### PR TITLE
perf: Optimize query hot paths from CPU profiling

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1763,3 +1763,50 @@ mem:fact-01kpm3sz8pxzakzcj4r8xx687v a mem:Fact ;
     mem:branch "misc/fixes" ;
     mem:createdAt "2026-04-20T00:14:22.486023+00:00"^^xsd:dateTime ;
     mem:rationale "This is a subtle semi-naive reasoning invariant; future restriction or chain work could easily reintroduce the bug by splitting lookups across delta and derived." .
+
+mem:fact-01ktcfc4gmhn2zh6xn29rskte8 a mem:Fact ;
+    mem:content "Query top-k is real but never truncates the upstream scan. apply_solution_modifiers (operator_tree.rs:2740) uses SortOperator::new_topk for ORDER BY+LIMIT, and even under DISTINCT does project-distinct-before-sort+top-k when ORDER BY refs only projected vars (can_project_distinct_before_sort :3011). But SortOperator is blocking: it drains the FULL child stream, building a per-row Vec<Binding> for every input row (sort.rs:589-622); only the final select_nth/heap is k-bounded. So rows_per_returned≫LIMIT is expected. BSBM Explore query1 also has a dedicated bypass: detect_star_const_numeric_label_order_limit→star_const_ordered_limit_operator (operator_tree.rs:280, :2440), tried before the generic tree." ;
+    mem:tag "bsbm" ;
+    mem:tag "distinct" ;
+    mem:tag "limit" ;
+    mem:tag "performance" ;
+    mem:tag "query" ;
+    mem:tag "sort" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "/Users/bplatz/fluree/db/fluree-db-query/src/execute/operator_tree.rs" ;
+    mem:artifactRef "/Users/bplatz/fluree/db/fluree-db-query/src/sort.rs" ;
+    mem:branch "refactor/column-caching" ;
+    mem:createdAt "2026-06-05T18:05:23.860294+00:00"^^xsd:dateTime ;
+    mem:rationale "Future perf sessions evaluating LIMIT pushdown must know top-k exists but doesn't truncate upstream scan, and query1 may bypass the generic path." .
+
+mem:fact-01ktcfd1te1wg10c1gxgmrk98c a mem:Fact ;
+    mem:content "Per-query IRI/Sid materialization is ALREADY cached. `Materializer` (one per query, materializer.rs:264-268) holds iri_cache: HashMap<u64,Arc<str>>, sid_cache, pid_cache; resolve_iri/resolve_sid/resolve_pid memoize on raw u64/u32 s_id/p_id so repeated subjects in star queries pay forward_pack lookup_str (allocating String per miss, forward_pack.rs:299) only ONCE per distinct id. BinaryGraphView::resolve_subject_sid/iri (binary_index_store.rs:1933/1979) are NOT cached — callers must cache. BinaryScanOperator also has its own sid_cache (binary_scan.rs:176) used only by resolve_s_id for repeated-var checks." ;
+    mem:tag "binding" ;
+    mem:tag "bsbm" ;
+    mem:tag "materialization" ;
+    mem:tag "performance" ;
+    mem:tag "query" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-binary-index/src/dict/forward_pack.rs" ;
+    mem:artifactRef "fluree-db-binary-index/src/read/binary_index_store.rs" ;
+    mem:artifactRef "fluree-db-query/src/binary_scan.rs" ;
+    mem:artifactRef "fluree-db-query/src/materializer.rs" ;
+    mem:branch "refactor/column-caching" ;
+    mem:createdAt "2026-06-05T18:05:53.870677+00:00"^^xsd:dateTime ;
+    mem:rationale "Candidate 4 (IRI/dict materialization) is largely solved; the lever is reducing residual lookups not adding a cache." .
+
+mem:fact-01ktcfdrpyfq8btp10mf75cmp5 a mem:Fact ;
+    mem:content "Batched star-join hot path already keys on raw u64, not full Binding: join.rs group_accumulator_by_subject/by_object (1490/1509) build FxHashMap<u64,Vec<usize>> from accumulator tuples (_,_,s_id) where s_id is the raw u64 extracted from EncodedSid at accumulate time. So eq/hash/clone ~6% is NOT join grouping (and NOT DISTINCT, which uses hashbrown raw-entry and only materializes a signature for genuinely-new rows). Residual binding overhead = scatter Vec<Vec<Vec<Binding>>> row assembly (join.rs:2049) + SortOperator per-row Vec<Binding> sort key. EncodedSid/EncodedLit late-materialization IS end-to-end (binary_scan.rs:1201)." ;
+    mem:tag "binding" ;
+    mem:tag "bsbm" ;
+    mem:tag "distinct" ;
+    mem:tag "join" ;
+    mem:tag "performance" ;
+    mem:tag "query" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-query/src/binary_scan.rs" ;
+    mem:artifactRef "fluree-db-query/src/binding.rs" ;
+    mem:artifactRef "fluree-db-query/src/join.rs" ;
+    mem:branch "refactor/column-caching" ;
+    mem:createdAt "2026-06-05T18:06:17.310296+00:00"^^xsd:dateTime ;
+    mem:rationale "Candidate 3 lever is scatter/sort assembly, not join grouping or DISTINCT which are already optimized." .

--- a/docs/query/output-formats.md
+++ b/docs/query/output-formats.md
@@ -419,10 +419,11 @@ fluree query --format typed-json --normalize-arrays '{"select": {"ex:alice": ["*
 
 ## Performance Considerations
 
+- **JSON string output is streamed** — when emitting a JSON **string** (the `format_results_string*` entry points used by the HTTP server), JSON-LD, SPARQL JSON, Typed JSON, and Agent JSON serialize directly into the output buffer, skipping the intermediate `serde_json::Value` DOM and its second serialization pass. Output is byte-identical to the DOM path (enforced by parity tests). The DOM path (`serde_json::Value`-returning `format_results*`) is still used for the programmatic `Value` API, for `pretty` output, and as the parity reference; `selectOne`, ASK, CONSTRUCT/DESCRIBE, and hydration also fall back to it.
 - **JSON-LD** is the most efficient format — inferable types skip the `@value`/`@type` wrapper
-- **Typed JSON** adds a constant-factor overhead per literal value (one extra JSON object allocation). Query execution is unaffected — only the formatting phase is slower.
+- **Typed JSON** adds a constant-factor overhead per literal value (the `@value`/`@type` wrapper). Query execution is unaffected — only the formatting phase is slower.
 - **normalize_arrays** adds zero overhead when disabled (default). When enabled, it skips the `len() == 1` check — no additional allocations beyond the array wrapper.
-- **TSV/CSV** bypass JSON DOM construction entirely for maximum throughput
+- **TSV/CSV** bypass JSON construction entirely for maximum throughput
 
 ## Best Practices
 

--- a/fluree-db-api/src/format/agent_json.rs
+++ b/fluree-db-api/src/format/agent_json.rs
@@ -12,6 +12,7 @@ use std::collections::{BTreeSet, HashMap};
 use serde_json::{json, Map, Value as JsonValue};
 
 use super::iri::IriCompactor;
+use super::json_write::{push_bool, push_i64, push_json_string, push_value};
 use super::Result;
 use crate::QueryResult;
 use fluree_db_query::binding::Binding;
@@ -115,50 +116,256 @@ pub fn format(
     if row_count == 0 {
         envelope.insert(
             "message".to_string(),
-            JsonValue::String(
-                "Query returned no results. The schema is empty because no rows were \
-                 available to infer types from. This does not necessarily indicate an \
-                 incorrect query — the data may not exist for the given constraints."
-                    .to_string(),
-            ),
+            JsonValue::String(NO_RESULTS_MESSAGE.to_string()),
         );
     }
 
     if has_more {
-        let budget_str = max_bytes.map(|b| b.to_string()).unwrap_or_default();
-        let mut msg = format!(
-            "Response truncated due to size limit of {budget_str} bytes. {row_count} of {total_row_hint} total rows included."
-        );
-
-        if let Some(ref ctx) = config.agent_json_context {
-            if ctx.from_count <= 1 {
-                if let (Some(ref sparql), Some(t)) = (&ctx.sparql_text, result.t) {
-                    if let Some(resume) =
-                        generate_resume_query(sparql, t, row_count, ctx.resume_limit)
-                    {
-                        msg = format!(
-                            "Response truncated due to size limit of {budget_str} bytes. \
-                             Use the query below to retrieve the next batch."
-                        );
-                        envelope.insert("resume".to_string(), JsonValue::String(resume));
-                    }
-                }
-            } else {
-                // Multi-ledger: advise using @iso: for time-pinning
-                if let Some(ref iso) = ctx.iso_timestamp {
-                    msg.push_str(&format!(
-                        " To retrieve the next batch, re-issue your query with \
-                         @iso:{} on each FROM clause and add OFFSET {} LIMIT {}.",
-                        iso, row_count, ctx.resume_limit
-                    ));
-                }
-            }
+        let (resume, msg) =
+            truncation_resume_and_message(config, result.t, row_count, total_row_hint, max_bytes);
+        if let Some(resume) = resume {
+            envelope.insert("resume".to_string(), JsonValue::String(resume));
         }
-
         envelope.insert("message".to_string(), JsonValue::String(msg));
     }
 
     Ok(JsonValue::Object(envelope))
+}
+
+/// Message used when a query returns zero rows.
+const NO_RESULTS_MESSAGE: &str =
+    "Query returned no results. The schema is empty because no rows were \
+     available to infer types from. This does not necessarily indicate an \
+     incorrect query — the data may not exist for the given constraints.";
+
+/// Build the `(resume, message)` pair for a size-truncated response.
+///
+/// Shared by the DOM and streaming envelopes so the wording and resume-query
+/// rules stay in lockstep. `resume` is `Some` only for the single-FROM,
+/// `@t:`-pinnable case.
+fn truncation_resume_and_message(
+    config: &super::config::FormatterConfig,
+    t: Option<i64>,
+    row_count: usize,
+    total_row_hint: usize,
+    max_bytes: Option<usize>,
+) -> (Option<String>, String) {
+    let budget_str = max_bytes.map(|b| b.to_string()).unwrap_or_default();
+    let mut msg = format!(
+        "Response truncated due to size limit of {budget_str} bytes. {row_count} of {total_row_hint} total rows included."
+    );
+    let mut resume = None;
+
+    if let Some(ref ctx) = config.agent_json_context {
+        if ctx.from_count <= 1 {
+            if let (Some(ref sparql), Some(t)) = (&ctx.sparql_text, t) {
+                if let Some(q) = generate_resume_query(sparql, t, row_count, ctx.resume_limit) {
+                    msg = format!(
+                        "Response truncated due to size limit of {budget_str} bytes. \
+                         Use the query below to retrieve the next batch."
+                    );
+                    resume = Some(q);
+                }
+            }
+        } else if let Some(ref iso) = ctx.iso_timestamp {
+            // Multi-ledger: advise using @iso: for time-pinning
+            msg.push_str(&format!(
+                " To retrieve the next batch, re-issue your query with \
+                 @iso:{} on each FROM clause and add OFFSET {} LIMIT {}.",
+                iso, row_count, ctx.resume_limit
+            ));
+        }
+    }
+
+    (resume, msg)
+}
+
+/// Stream the AgentJson envelope directly into a `String`, byte-identical to
+/// `serde_json::to_string(&format(...))`.
+///
+/// Rows stream into an inner buffer (no per-row `serde_json::Value`), the byte
+/// budget is measured from buffer-length deltas (no separate size-measuring
+/// serialization), and the schema / metadata envelope is assembled around the
+/// rows in serde's insertion order.
+pub fn format_string(
+    result: &QueryResult,
+    compactor: &IriCompactor,
+    config: &super::config::FormatterConfig,
+) -> Result<String> {
+    let select_vars = if result.output.is_wildcard() {
+        None
+    } else {
+        Some(result.output.projected_vars_or_empty())
+    };
+    let select_vars = select_vars.as_deref();
+
+    let max_bytes = config.max_bytes;
+    let total_row_hint = result
+        .batches
+        .iter()
+        .map(fluree_db_query::Batch::len)
+        .sum::<usize>();
+
+    let mut type_map: HashMap<VarId, BTreeSet<String>> = HashMap::new();
+    let mut cumulative_bytes: usize = 0;
+    let mut has_more = false;
+    let mut row_count: usize = 0;
+
+    // Stream the row objects (comma-separated) into their own buffer so the
+    // schema — computed from the same pass — can be written ahead of them.
+    //
+    // When a byte budget is set the buffer never exceeds `budget` (the running
+    // total is capped, and the one over-budget row is truncated away), so cap the
+    // preallocation at the budget rather than sizing for the full untruncated row
+    // count — otherwise a large result set with a small budget would still
+    // allocate megabytes up front, defeating the truncation path. Mirrors the DOM
+    // path's `total_row_hint.min(256)` guard.
+    let full_est = total_row_hint.saturating_mul(64).saturating_add(16);
+    let est_rows = match max_bytes {
+        Some(budget) => budget.saturating_add(64).min(full_est),
+        None => full_est,
+    };
+    let mut rows_buf = String::with_capacity(est_rows);
+
+    'outer: for batch in &result.batches {
+        let vars_to_scan = select_vars.unwrap_or_else(|| batch.schema());
+        for row_idx in 0..batch.len() {
+            let pre = rows_buf.len();
+            if row_count > 0 {
+                rows_buf.push(',');
+            }
+            let row_start = rows_buf.len();
+
+            // Formats the row AND records its types — done before the budget
+            // check, exactly as the DOM path does (so a budget-rejected row's
+            // types still contribute to the schema).
+            write_row_with_types(
+                &mut rows_buf,
+                result,
+                batch,
+                row_idx,
+                vars_to_scan,
+                &result.vars,
+                compactor,
+                &mut type_map,
+            )?;
+            let row_size = rows_buf.len() - row_start;
+
+            if let Some(budget) = max_bytes {
+                if cumulative_bytes + row_size > budget && row_count > 0 {
+                    has_more = true;
+                    rows_buf.truncate(pre); // drop the comma + rejected row
+                    break 'outer;
+                }
+                cumulative_bytes += row_size;
+            }
+
+            row_count += 1;
+        }
+    }
+
+    // Schema (built from the types collected above).
+    let schema = build_schema(&type_map, &result.vars);
+
+    let mut out = String::with_capacity(rows_buf.len() + 256);
+    out.push_str("{\"schema\":");
+    push_value(&mut out, &schema)?;
+    out.push_str(",\"rows\":[");
+    out.push_str(&rows_buf);
+    out.push_str("],\"rowCount\":");
+    push_i64(&mut out, row_count as i64);
+
+    if let Some(t) = result.t {
+        let include_t = match config.agent_json_context {
+            Some(ref ctx) => ctx.from_count <= 1,
+            None => true,
+        };
+        if include_t {
+            out.push_str(",\"t\":");
+            push_i64(&mut out, t);
+        }
+    }
+    if let Some(ref ctx) = config.agent_json_context {
+        if let Some(ref iso) = ctx.iso_timestamp {
+            out.push_str(",\"iso\":");
+            push_json_string(&mut out, iso);
+        }
+    }
+
+    out.push_str(",\"hasMore\":");
+    push_bool(&mut out, has_more);
+
+    if row_count == 0 {
+        out.push_str(",\"message\":");
+        push_json_string(&mut out, NO_RESULTS_MESSAGE);
+    }
+
+    if has_more {
+        let (resume, msg) =
+            truncation_resume_and_message(config, result.t, row_count, total_row_hint, max_bytes);
+        if let Some(resume) = resume {
+            out.push_str(",\"resume\":");
+            push_json_string(&mut out, &resume);
+        }
+        out.push_str(",\"message\":");
+        push_json_string(&mut out, &msg);
+    }
+
+    out.push('}');
+    Ok(out)
+}
+
+/// Stream one row object (`{"?v":value,...}`) into `out`, recording each cell's
+/// datatype label in `type_map`. Mirrors [`format_row_with_types`].
+#[allow(clippy::too_many_arguments)]
+fn write_row_with_types(
+    out: &mut String,
+    result: &QueryResult,
+    batch: &fluree_db_query::Batch,
+    row_idx: usize,
+    vars: &[VarId],
+    registry: &fluree_db_query::VarRegistry,
+    compactor: &IriCompactor,
+    type_map: &mut HashMap<VarId, BTreeSet<String>>,
+) -> Result<()> {
+    out.push('{');
+    let mut first = true;
+    for &var_id in vars {
+        let var_name = registry.name(var_id);
+        if var_name.starts_with("?__") {
+            continue;
+        }
+
+        // Resolve the cell to (value-source binding, type label). Encoded
+        // bindings are materialized once and reused for both, matching the DOM.
+        let binding = batch.get(row_idx, var_id);
+
+        if !first {
+            out.push(',');
+        }
+        first = false;
+        push_json_string(out, var_name);
+        out.push(':');
+
+        match binding {
+            None | Some(Binding::Unbound | Binding::Poisoned) => out.push_str("null"),
+            Some(b) if b.is_encoded() => {
+                let m = super::materialize::materialize_binding(result, b)?;
+                super::jsonld::write_value_with_result(out, result, &m, compactor)?;
+                if let Some(label) = binding_type_label(&m, compactor)? {
+                    type_map.entry(var_id).or_default().insert(label);
+                }
+            }
+            Some(b) => {
+                super::jsonld::write_value_with_result(out, result, b, compactor)?;
+                if let Some(label) = binding_type_label(b, compactor)? {
+                    type_map.entry(var_id).or_default().insert(label);
+                }
+            }
+        }
+    }
+    out.push('}');
+    Ok(())
 }
 
 /// Format a single row as a JSON object AND extract type info in one pass.
@@ -368,6 +575,190 @@ fn strip_clause(sparql: &str, keyword: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ------------------------------------------------------------------
+    // Streaming `format_string` parity with the DOM `format` + serde_json.
+    // ------------------------------------------------------------------
+
+    use crate::QueryResult;
+    use fluree_db_core::{FlakeValue, Sid};
+    use fluree_db_query::binding::Binding;
+    use fluree_db_query::var_registry::VarRegistry;
+    use std::collections::HashMap as StdHashMap;
+    use std::sync::Arc;
+
+    fn make_test_compactor() -> IriCompactor {
+        let mut namespaces = StdHashMap::new();
+        namespaces.insert(2, "http://www.w3.org/2001/XMLSchema#".to_string());
+        namespaces.insert(3, "http://www.w3.org/1999/02/22-rdf-syntax-ns#".to_string());
+        namespaces.insert(100, "http://example.org/".to_string());
+        IriCompactor::from_namespaces(Arc::new(namespaces))
+    }
+
+    fn make_result(var_names: &[&str], rows: Vec<Vec<Binding>>) -> QueryResult {
+        let mut vars = VarRegistry::new();
+        let var_ids: Vec<VarId> = var_names.iter().map(|&n| vars.get_or_insert(n)).collect();
+        let mut columns: Vec<Vec<Binding>> = vec![Vec::new(); var_ids.len()];
+        for row in rows {
+            for (col, b) in row.into_iter().enumerate() {
+                columns[col].push(b);
+            }
+        }
+        let batch = fluree_db_query::binding::Batch::new(
+            Arc::from(var_ids.clone().into_boxed_slice()),
+            columns,
+        )
+        .unwrap();
+        QueryResult {
+            vars,
+            t: Some(7),
+            novelty: None,
+            context: crate::ParsedContext::default(),
+            orig_context: None,
+            output: crate::QueryOutput::select_all(var_ids),
+            batches: vec![batch],
+            binary_graph: None,
+        }
+    }
+
+    fn assert_parity(result: &QueryResult, config: &super::super::config::FormatterConfig) {
+        let c = make_test_compactor();
+        let dom = format(result, &c, config).unwrap();
+        let want = serde_json::to_string(&dom).unwrap();
+        let got = format_string(result, &c, config).unwrap();
+        assert_eq!(got, want, "streaming AgentJson diverged from DOM");
+    }
+
+    #[test]
+    fn parity_basic_envelope() {
+        let r = make_result(
+            &["?s", "?n", "?d"],
+            vec![
+                vec![
+                    Binding::sid(Sid::new(100, "alice")),
+                    Binding::lit(
+                        FlakeValue::String("Alice & co".to_string()),
+                        Sid::new(2, "string"),
+                    ),
+                    Binding::lit(FlakeValue::Double(3.13), Sid::new(2, "double")),
+                ],
+                vec![
+                    Binding::sid(Sid::new(100, "bob")),
+                    Binding::lit(FlakeValue::Long(42), Sid::new(2, "long")),
+                    Binding::Unbound,
+                ],
+            ],
+        );
+        assert_parity(&r, &super::super::config::FormatterConfig::agent_json());
+    }
+
+    #[test]
+    fn parity_mixed_types_and_schema_array() {
+        // Same var carries two datatypes across rows -> schema becomes an array.
+        let r = make_result(
+            &["?v"],
+            vec![
+                vec![Binding::lit(FlakeValue::Long(1), Sid::new(2, "long"))],
+                vec![Binding::lit(
+                    FlakeValue::String("x".to_string()),
+                    Sid::new(2, "string"),
+                )],
+            ],
+        );
+        assert_parity(&r, &super::super::config::FormatterConfig::agent_json());
+    }
+
+    #[test]
+    fn parity_empty_results() {
+        let r = make_result(&["?s"], vec![]);
+        assert_parity(&r, &super::super::config::FormatterConfig::agent_json());
+    }
+
+    #[test]
+    fn parity_wildcard_and_grouped() {
+        let mut r = make_result(
+            &["?s", "?g"],
+            vec![vec![
+                Binding::sid(Sid::new(100, "a")),
+                Binding::Grouped(vec![
+                    Binding::lit(FlakeValue::Long(1), Sid::new(2, "long")),
+                    Binding::lit(FlakeValue::Long(2), Sid::new(2, "long")),
+                ]),
+            ]],
+        );
+        r.output = crate::QueryOutput::wildcard();
+        assert_parity(&r, &super::super::config::FormatterConfig::agent_json());
+    }
+
+    #[test]
+    fn parity_budget_truncation() {
+        // Small byte budget so the second/third rows are dropped (has_more).
+        let r = make_result(
+            &["?s", "?label"],
+            vec![
+                vec![
+                    Binding::sid(Sid::new(100, "a")),
+                    Binding::lit(
+                        FlakeValue::String("first row label".to_string()),
+                        Sid::new(2, "string"),
+                    ),
+                ],
+                vec![
+                    Binding::sid(Sid::new(100, "b")),
+                    Binding::lit(
+                        FlakeValue::String("second row label".to_string()),
+                        Sid::new(2, "string"),
+                    ),
+                ],
+                vec![
+                    Binding::sid(Sid::new(100, "c")),
+                    Binding::lit(
+                        FlakeValue::String("third row label".to_string()),
+                        Sid::new(2, "string"),
+                    ),
+                ],
+            ],
+        );
+        let mut config = super::super::config::FormatterConfig::agent_json();
+        config.max_bytes = Some(60);
+        assert_parity(&r, &config);
+    }
+
+    #[test]
+    fn parity_budget_truncation_with_resume() {
+        let r = make_result(
+            &["?s"],
+            vec![
+                vec![Binding::sid(Sid::new(100, "a"))],
+                vec![Binding::sid(Sid::new(100, "b"))],
+                vec![Binding::sid(Sid::new(100, "c"))],
+            ],
+        );
+        let mut config = super::super::config::FormatterConfig::agent_json();
+        config.max_bytes = Some(40);
+        config.agent_json_context = Some(super::super::config::AgentJsonContext {
+            sparql_text: Some("SELECT ?s FROM <mydb:main> WHERE { ?s ?p ?o }".to_string()),
+            from_count: 1,
+            iso_timestamp: Some("2026-03-26T14:30:00Z".to_string()),
+            resume_limit: 100,
+        });
+        assert_parity(&r, &config);
+    }
+
+    #[test]
+    fn parity_json_and_vector_cells() {
+        let r = make_result(
+            &["?j", "?v"],
+            vec![vec![
+                Binding::lit(
+                    FlakeValue::Json(r#"{"k":[1,2]}"#.to_string()),
+                    Sid::new(3, "JSON"),
+                ),
+                Binding::lit(FlakeValue::Vector(vec![1.0, -2.5]), Sid::new(2, "double")),
+            ]],
+        );
+        assert_parity(&r, &super::super::config::FormatterConfig::agent_json());
+    }
 
     #[test]
     fn test_generate_resume_basic() {

--- a/fluree-db-api/src/format/iri.rs
+++ b/fluree-db-api/src/format/iri.rs
@@ -11,7 +11,7 @@ use fluree_db_core::Sid;
 use fluree_graph_json_ld::{ContextCompactor, ParsedContext};
 use fluree_vocab::namespaces;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use super::{FormatError, Result};
 
@@ -49,7 +49,15 @@ pub struct IriCompactor {
 
     /// Auto-derived prefixes for namespaces not covered by the @context.
     /// Sorted longest-first for greedy matching (same strategy as ContextCompactor).
-    fallback_prefixes: Vec<(String, String)>,
+    ///
+    /// Built **lazily** on first display-compaction call. `build_fallback_prefixes`
+    /// iterates the entire DB namespace table (thousands of entries for datasets
+    /// like BSBM that mint a namespace per IRI path segment) and sorts it, but the
+    /// result is consumed *only* by the CLI / commit-builder display paths
+    /// (`compact_for_display`, `effective_prefixes`). The server query formatters
+    /// (SPARQL XML/JSON, TSV/CSV) never touch it, so they must not pay this
+    /// per-query construction cost — hence the `OnceLock`.
+    fallback_prefixes: OnceLock<Vec<(String, String)>>,
 }
 
 impl IriCompactor {
@@ -59,17 +67,19 @@ impl IriCompactor {
     /// `compact_vocab_iri` / `compact_id_iri` call is a pure lookup.
     ///
     /// For namespaces in `namespace_codes` that have no matching prefix in
-    /// the context, a short prefix is auto-derived from the namespace URI.
+    /// the context, a short prefix is auto-derived from the namespace URI — but
+    /// that table is built lazily on first display use (see `fallback_prefixes`),
+    /// so constructing a compactor for a query is independent of DB namespace count.
     pub fn new(namespace_codes: Arc<HashMap<u16, String>>, context: &ParsedContext) -> Self {
         let compactor = ContextCompactor::new(context);
         let reverse_terms = build_reverse_terms(context);
-        let fallback_prefixes = build_fallback_prefixes(&namespace_codes, context);
         Self {
             namespace_codes,
             context: context.clone(),
             compactor,
             reverse_terms,
-            fallback_prefixes,
+            // Lazily built on first display-compaction call — see field docs.
+            fallback_prefixes: OnceLock::new(),
         }
     }
 
@@ -85,8 +95,19 @@ impl IriCompactor {
             context: default_ctx,
             compactor,
             reverse_terms: HashMap::new(),
-            fallback_prefixes: Vec::new(),
+            // Empty default context → lazy build yields no fallbacks (unchanged behavior).
+            fallback_prefixes: OnceLock::new(),
         }
+    }
+
+    /// Lazily-built auto-derived fallback prefixes (see the `fallback_prefixes` field).
+    ///
+    /// Building this iterates the entire DB namespace table, so it is deferred
+    /// until a display-compaction path (`compact_for_display` / `effective_prefixes`)
+    /// actually needs it. The query result formatters never call this.
+    fn fallback_prefixes(&self) -> &[(String, String)] {
+        self.fallback_prefixes
+            .get_or_init(|| build_fallback_prefixes(&self.namespace_codes, &self.context))
     }
 
     /// Decode a Sid to a full IRI.
@@ -102,6 +123,24 @@ impl IriCompactor {
             .get(&sid.namespace_code)
             .ok_or(FormatError::UnknownNamespace(sid.namespace_code))?;
         Ok(format!("{}{}", prefix, sid.name))
+    }
+
+    /// Look up the namespace prefix for a Sid without allocating.
+    ///
+    /// Returns `Ok(Some(prefix))` for a registered namespace — the full IRI is
+    /// `prefix` followed by `sid.name`, which a formatter can stream directly
+    /// instead of paying [`decode_sid`](Self::decode_sid)'s `format!`
+    /// allocation. Returns `Ok(None)` for the EMPTY / OVERFLOW namespaces, where
+    /// `sid.name` is itself the verbatim IRI (and may be a `_:` blank-node
+    /// label). Errors on an unregistered namespace code, exactly as `decode_sid`.
+    pub fn namespace_prefix(&self, sid: &Sid) -> Result<Option<&str>> {
+        if sid.namespace_code == namespaces::EMPTY || sid.namespace_code == namespaces::OVERFLOW {
+            return Ok(None);
+        }
+        self.namespace_codes
+            .get(&sid.namespace_code)
+            .map(|p| Some(p.as_str()))
+            .ok_or(FormatError::UnknownNamespace(sid.namespace_code))
     }
 
     /// Compact a **forward** predicate / @type IRI using the @context (vocab rules).
@@ -255,7 +294,7 @@ impl IriCompactor {
         }
 
         // 2. Fallback prefixes (auto-derived for uncovered namespaces)
-        for (ns_iri, prefix_name) in &self.fallback_prefixes {
+        for (ns_iri, prefix_name) in self.fallback_prefixes() {
             map.entry(prefix_name.clone())
                 .or_insert_with(|| ns_iri.clone());
         }
@@ -265,7 +304,7 @@ impl IriCompactor {
 
     /// Try to compact an IRI using the auto-derived fallback prefixes.
     fn try_fallback(&self, iri: &str) -> Option<String> {
-        for (ns_iri, prefix_name) in &self.fallback_prefixes {
+        for (ns_iri, prefix_name) in self.fallback_prefixes() {
             if iri.starts_with(ns_iri.as_str()) {
                 let suffix = &iri[ns_iri.len()..];
                 return Some(format!("{prefix_name}:{suffix}"));

--- a/fluree-db-api/src/format/iri.rs
+++ b/fluree-db-api/src/format/iri.rs
@@ -133,6 +133,11 @@ impl IriCompactor {
     /// allocation. Returns `Ok(None)` for the EMPTY / OVERFLOW namespaces, where
     /// `sid.name` is itself the verbatim IRI (and may be a `_:` blank-node
     /// label). Errors on an unregistered namespace code, exactly as `decode_sid`.
+    ///
+    /// Blank-node caveat: the `BLANK_NODE` namespace is registered with the
+    /// `"_:"` prefix, so a blank node returns `Some("_:")` — NOT `None`. A
+    /// consumer that frames `Some(prefix)` as a `<uri>` / `@id` must special-case
+    /// the `"_:"` prefix (or `sid.namespace_code == namespaces::BLANK_NODE`).
     pub fn namespace_prefix(&self, sid: &Sid) -> Result<Option<&str>> {
         if sid.namespace_code == namespaces::EMPTY || sid.namespace_code == namespaces::OVERFLOW {
             return Ok(None);

--- a/fluree-db-api/src/format/json_write.rs
+++ b/fluree-db-api/src/format/json_write.rs
@@ -1,0 +1,254 @@
+//! Streaming JSON serialization primitives shared by the JSON result formatters.
+//!
+//! These write JSON tokens directly into a reusable `String` buffer, producing
+//! output that is **byte-identical** to `serde_json::to_string` (compact mode).
+//! The point is to avoid building a `serde_json::Value` DOM per result cell —
+//! no per-cell `Map`/`Vec`/`json!` allocation and no second serialization pass.
+//!
+//! ## Byte-identity contract
+//!
+//! The streaming formatters keep their DOM (`-> JsonValue`) counterparts as the
+//! reference implementation (used for the `JsonValue` API, `pretty` output, and
+//! `@json`/vector leaves). Every streaming formatter has a parity test asserting
+//! `stream(result) == serde_json::to_string(&dom(result))`. The primitives here
+//! carry their own parity tests against `serde_json` so a serde version bump that
+//! changes escaping or float formatting is caught immediately.
+//!
+//! Two facts make the streaming path tractable:
+//! - `serde_json` is built with `preserve_order`, so map keys serialize in
+//!   *insertion order*. Streaming writes keys in the same order the `json!`
+//!   macros list them — no key sorting required.
+//! - `serde_json`'s compact integer path is `itoa`, matched by [`push_i64`]; its
+//!   float path post-processes `ryu` output (e.g. it renders `1e30` as `1e+30`),
+//!   so [`push_f64`] reuses serde's own `CompactFormatter` rather than calling
+//!   `ryu` directly.
+
+use serde_json::Value as JsonValue;
+
+use super::Result;
+
+// JSON string escape codes (0 == no escape). Mirrors serde_json's ESCAPE table.
+const QU: u8 = 1; // `"`  -> \"
+const BS: u8 = 2; // `\`  -> \\
+const BB: u8 = 3; // 0x08 -> \b
+const TT: u8 = 4; // 0x09 -> \t
+const NN: u8 = 5; // 0x0A -> \n
+const FF: u8 = 6; // 0x0C -> \f
+const RR: u8 = 7; // 0x0D -> \r
+const UU: u8 = 8; // other control (< 0x20) -> \u00XX
+
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
+/// Per-byte escape table. Only `"`, `\`, and the C0 control bytes (< 0x20) need
+/// escaping; `serde_json` leaves `/`, DEL (0x7F), and all multi-byte UTF-8 bytes
+/// (>= 0x80) verbatim.
+const ESCAPE: [u8; 256] = build_escape_table();
+
+const fn build_escape_table() -> [u8; 256] {
+    let mut t = [0u8; 256];
+    // All C0 controls default to the \u00XX long form...
+    let mut i = 0usize;
+    while i < 0x20 {
+        t[i] = UU;
+        i += 1;
+    }
+    // ...except the five with short escapes.
+    t[0x08] = BB;
+    t[0x09] = TT;
+    t[0x0A] = NN;
+    t[0x0C] = FF;
+    t[0x0D] = RR;
+    t[b'"' as usize] = QU;
+    t[b'\\' as usize] = BS;
+    t
+}
+
+/// Append `s` as a quoted, escaped JSON string (including the surrounding
+/// quotes), byte-identical to `serde_json::to_string(&Value::String(s))`.
+pub(crate) fn push_json_string(out: &mut String, s: &str) {
+    out.push('"');
+    escape_json_into(out, s);
+    out.push('"');
+}
+
+/// Append the escaped *contents* of `s` (no surrounding quotes).
+///
+/// Bulk-copies runs of clean bytes with a single `push_str` and only handles the
+/// escape bytes individually — clean strings (the common case: IRIs, ASCII text)
+/// hit a single copy. Every escape byte is ASCII, so the `start..i` / `start..`
+/// slices always land on `char` boundaries.
+pub(crate) fn escape_json_into(out: &mut String, s: &str) {
+    let bytes = s.as_bytes();
+    let mut start = 0usize;
+    for (i, &b) in bytes.iter().enumerate() {
+        let esc = ESCAPE[b as usize];
+        if esc == 0 {
+            continue;
+        }
+        if start < i {
+            out.push_str(&s[start..i]);
+        }
+        match esc {
+            QU => out.push_str("\\\""),
+            BS => out.push_str("\\\\"),
+            BB => out.push_str("\\b"),
+            TT => out.push_str("\\t"),
+            NN => out.push_str("\\n"),
+            FF => out.push_str("\\f"),
+            RR => out.push_str("\\r"),
+            // Remaining C0 controls: \u00XX with lowercase hex (serde_json style).
+            _ => {
+                out.push_str("\\u00");
+                out.push(HEX[(b >> 4) as usize] as char);
+                out.push(HEX[(b & 0x0F) as usize] as char);
+            }
+        }
+        start = i + 1;
+    }
+    if start < bytes.len() {
+        out.push_str(&s[start..]);
+    }
+}
+
+/// Append an `i64` as a JSON number (via `itoa`, matching serde_json).
+pub(crate) fn push_i64(out: &mut String, n: i64) {
+    let mut buf = itoa::Buffer::new();
+    out.push_str(buf.format(n));
+}
+
+/// Append a **finite** `f64` as a JSON number, byte-identical to serde_json's
+/// compact number formatting.
+///
+/// Delegates to serde_json's own [`CompactFormatter`] rather than calling `ryu`
+/// directly: serde post-processes ryu's output (e.g. it renders `1e30` as
+/// `1e+30`), so reusing serde's formatter is the only way to stay byte-identical
+/// across serde versions. It writes straight into the buffer — no intermediate
+/// `Value` or `String`.
+///
+/// Callers must guarantee `d.is_finite()`. The result formatters render NaN/±INF
+/// as the string sentinels `"NaN"`/`"INF"`/`"-INF"` before reaching here, so a
+/// non-finite value is a caller bug — `serde_json` would have emitted `null`.
+pub(crate) fn push_f64(out: &mut String, d: f64) {
+    use serde_json::ser::{CompactFormatter, Formatter};
+    debug_assert!(d.is_finite(), "push_f64 requires a finite value");
+    // SAFETY: `write_f64` emits only ASCII bytes (digits, '.', 'e', '+', '-'),
+    // which are always valid UTF-8, so the String's invariant is preserved.
+    let buf = unsafe { out.as_mut_vec() };
+    CompactFormatter
+        .write_f64(buf, d)
+        .expect("writing to an in-memory buffer is infallible");
+}
+
+/// Append a boolean literal.
+pub(crate) fn push_bool(out: &mut String, b: bool) {
+    out.push_str(if b { "true" } else { "false" });
+}
+
+/// Append an already-built `serde_json::Value`, byte-identical to
+/// `serde_json::to_string(v)`.
+///
+/// Reserved for the rare "complex leaf" cells — embedding vectors and parsed
+/// `@json` values — where reconstructing serde's exact output by hand is not
+/// worth the risk. The hot scalar cells (string / uri / int / double / bool)
+/// stream directly and never call this.
+pub(crate) fn push_value(out: &mut String, v: &JsonValue) -> Result<()> {
+    out.push_str(&serde_json::to_string(v)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    /// Escape every string through both paths and require byte-equality with
+    /// serde_json's own string serialization.
+    fn assert_string_parity(s: &str) {
+        let mut got = String::new();
+        push_json_string(&mut got, s);
+        let want = serde_json::to_string(&Value::String(s.to_string())).unwrap();
+        assert_eq!(got, want, "string parity failed for {s:?}");
+    }
+
+    #[test]
+    fn string_escaping_matches_serde_json() {
+        for s in [
+            "",
+            "plain ascii",
+            "quote\"inside",
+            "back\\slash",
+            "tab\tand\nnewline\r",
+            "form\u{000C}feed\u{0008}back",
+            "controls\u{0000}\u{0001}\u{001F}",
+            "del\u{007F}kept",             // 0x7F is NOT escaped by serde_json
+            "slash/not/escaped",           // '/' is NOT escaped
+            "unicode é ü 端 😀 \u{1F600}", // multibyte passes through verbatim
+            "c1\u{0085}kept",              // C1 control (>= 0x80) passes through
+            "mixed \"a\"\t/b\\ é",
+        ] {
+            assert_string_parity(s);
+        }
+    }
+
+    #[test]
+    fn every_control_byte_matches_serde_json() {
+        // Exhaustively cover U+0000..=U+00FF so no control-char branch drifts.
+        for cp in 0u32..=0xFF {
+            let ch = char::from_u32(cp).unwrap();
+            let s: String = ch.to_string();
+            assert_string_parity(&s);
+        }
+    }
+
+    #[test]
+    fn i64_matches_serde_json() {
+        for n in [0i64, 1, -1, 42, -42, i64::MIN, i64::MAX, 1_000_000_000_000] {
+            let mut got = String::new();
+            push_i64(&mut got, n);
+            assert_eq!(got, serde_json::to_string(&json!(n)).unwrap(), "i64 {n}");
+        }
+    }
+
+    #[test]
+    fn f64_matches_serde_json() {
+        for d in [
+            0.0_f64,
+            -0.0,
+            1.0,
+            3.0,
+            3.13,
+            0.1,
+            -2.5,
+            1e30,
+            1e-7,
+            123_456_789.0,
+            2.5e-300,
+            9_007_199_254_740_993.0,
+            f64::MIN,
+            f64::MAX,
+            std::f64::consts::PI,
+        ] {
+            let mut got = String::new();
+            push_f64(&mut got, d);
+            // serde_json renders finite f64 via its compact formatter (ryu + post-processing).
+            assert_eq!(got, serde_json::to_string(&json!(d)).unwrap(), "f64 {d}");
+        }
+    }
+
+    #[test]
+    fn bool_matches_serde_json() {
+        for b in [true, false] {
+            let mut got = String::new();
+            push_bool(&mut got, b);
+            assert_eq!(got, serde_json::to_string(&json!(b)).unwrap());
+        }
+    }
+
+    #[test]
+    fn value_leaf_matches_serde_json() {
+        let v = json!({"name": "Alice", "nums": [1.0, 2.5, -3.0], "ok": true, "nested": {"a": 1}});
+        let mut got = String::new();
+        push_value(&mut got, &v).unwrap();
+        assert_eq!(got, serde_json::to_string(&v).unwrap());
+    }
+}

--- a/fluree-db-api/src/format/jsonld.rs
+++ b/fluree-db-api/src/format/jsonld.rs
@@ -12,7 +12,8 @@
 use super::config::FormatterConfig;
 use super::datatype::is_inferable_datatype;
 use super::iri::IriCompactor;
-use super::{FormatError, Result};
+use super::json_write::{push_bool, push_f64, push_i64, push_json_string, push_value};
+use super::{materialize, FormatError, Result};
 use crate::QueryResult;
 use fluree_db_core::FlakeValue;
 use fluree_db_query::binding::Binding;
@@ -67,6 +68,278 @@ pub fn format(
     } else {
         Ok(JsonValue::Array(rows))
     }
+}
+
+/// Stream JSON-LD Query results directly into a `String`, byte-identical to
+/// `serde_json::to_string(&format(...))` for the non-`select_one` case.
+///
+/// `select_one`, ASK, CONSTRUCT, and `pretty` are routed through the DOM path by
+/// the caller and never reach here.
+pub fn format_string(
+    result: &QueryResult,
+    compactor: &IriCompactor,
+    _config: &FormatterConfig,
+) -> Result<String> {
+    debug_assert!(
+        !result.output.is_select_one(),
+        "format_string is only for the non-select_one path; select_one routes through the DOM"
+    );
+
+    let is_wildcard = result.output.is_wildcard();
+    let select_vars = result.output.projected_vars_or_empty();
+    // Scalar flattening fires only for JSON-LD bare-string `select: "?x"` (one
+    // projected var). In that mode every row is a 1-element array and flattens to
+    // the bare value — see the DOM `format`'s `should_flatten_scalar` step.
+    let flatten = result.output.should_flatten_scalar() && select_vars.len() == 1;
+
+    let cols_hint = if is_wildcard {
+        result.batches.first().map_or(0, |b| b.schema().len())
+    } else {
+        select_vars.len()
+    };
+    let est = (result.row_count() + 1)
+        .saturating_mul(cols_hint.max(1))
+        .saturating_mul(40)
+        .saturating_add(16);
+    let mut out = String::with_capacity(est);
+
+    out.push('[');
+    let mut first_row = true;
+    for batch in &result.batches {
+        let cols: Vec<Option<usize>> = if is_wildcard {
+            Vec::new()
+        } else {
+            let schema = batch.schema();
+            select_vars
+                .iter()
+                .map(|&v| schema.iter().position(|&sv| sv == v))
+                .collect()
+        };
+
+        for row_idx in 0..batch.len() {
+            if !first_row {
+                out.push(',');
+            }
+            first_row = false;
+
+            if is_wildcard {
+                out.push('{');
+                let mut first = true;
+                for (col_idx, &var_id) in batch.schema().iter().enumerate() {
+                    let binding = batch.get_by_col(row_idx, col_idx);
+                    if matches!(binding, Binding::Unbound | Binding::Poisoned) {
+                        continue;
+                    }
+                    let name = result.vars.name(var_id);
+                    if name.starts_with("?__") {
+                        continue;
+                    }
+                    if !first {
+                        out.push(',');
+                    }
+                    first = false;
+                    push_json_string(&mut out, name);
+                    out.push(':');
+                    write_value_with_result(&mut out, result, binding, compactor)?;
+                }
+                out.push('}');
+            } else if flatten {
+                match cols[0] {
+                    Some(col) => write_value_with_result(
+                        &mut out,
+                        result,
+                        batch.get_by_col(row_idx, col),
+                        compactor,
+                    )?,
+                    None => out.push_str("null"),
+                }
+            } else {
+                out.push('[');
+                for (i, &col) in cols.iter().enumerate() {
+                    if i > 0 {
+                        out.push(',');
+                    }
+                    match col {
+                        Some(col) => write_value_with_result(
+                            &mut out,
+                            result,
+                            batch.get_by_col(row_idx, col),
+                            compactor,
+                        )?,
+                        None => out.push_str("null"),
+                    }
+                }
+                out.push(']');
+            }
+        }
+    }
+    out.push(']');
+    Ok(out)
+}
+
+/// Streaming counterpart of [`format_binding_with_result`]: materialize an
+/// encoded top binding, then stream it.
+///
+/// Exposed to `agent_json`, whose row cells use JSON-LD value shaping.
+pub(super) fn write_value_with_result(
+    out: &mut String,
+    result: &QueryResult,
+    binding: &Binding,
+    compactor: &IriCompactor,
+) -> Result<()> {
+    if binding.is_encoded() {
+        let materialized = materialize::materialize_binding(result, binding)?;
+        return write_value_with_result(out, result, &materialized, compactor);
+    }
+    write_value(out, binding, compactor)
+}
+
+/// Streaming counterpart of [`format_binding`] (no `QueryResult`): encoded
+/// bindings error here, exactly as the DOM path does. Grouped elements recurse
+/// through this same no-materialize path.
+fn write_value(out: &mut String, binding: &Binding, compactor: &IriCompactor) -> Result<()> {
+    match binding {
+        Binding::Unbound | Binding::Poisoned => out.push_str("null"),
+        // A reference is a bare compacted IRI string (not an `{"@id":...}` object).
+        Binding::Sid { sid, .. } => push_json_string(out, &compactor.compact_id_sid(sid)?),
+        Binding::IriMatch { iri, .. } => push_json_string(out, &compactor.compact_id_iri(iri)),
+        Binding::Iri(iri) => push_json_string(out, iri.as_ref()),
+        Binding::Lit { val, dtc, .. } => write_lit(out, val, dtc, compactor)?,
+        Binding::EncodedLit { .. } => {
+            return Err(FormatError::InvalidBinding(
+                "Internal error: format_binding called without QueryResult for EncodedLit"
+                    .to_string(),
+            ));
+        }
+        Binding::EncodedSid { .. } | Binding::EncodedPid { .. } => {
+            return Err(FormatError::InvalidBinding(
+                "Internal error: format_binding called without QueryResult for encoded IRI binding"
+                    .to_string(),
+            ));
+        }
+        Binding::Grouped(values) => {
+            out.push('[');
+            for (i, v) in values.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_value(out, v, compactor)?;
+            }
+            out.push(']');
+        }
+    }
+    Ok(())
+}
+
+/// Write a JSON-LD literal value, mirroring the DOM `format_binding` Lit arm:
+/// `@json` returns the parsed value bare, inferable datatypes emit a bare native
+/// value, and everything else wraps as `{"@value":...,"@type":<compact>}`.
+fn write_lit(
+    out: &mut String,
+    val: &FlakeValue,
+    dtc: &fluree_db_core::DatatypeConstraint,
+    compactor: &IriCompactor,
+) -> Result<()> {
+    let dt = dtc.datatype();
+    let dt_full = compactor.decode_sid(dt)?;
+    let dt_compact = compactor.compact_sid(dt)?;
+
+    // @json: emit the parsed value directly (accept Json or String, matching DOM).
+    if dt_full == rdf::JSON || dt_compact == "@json" {
+        return match val {
+            FlakeValue::Json(json_str) | FlakeValue::String(json_str) => {
+                let parsed: JsonValue = serde_json::from_str(json_str).map_err(|e| {
+                    FormatError::InvalidBinding(format!("Invalid JSON in @json value: {e}"))
+                })?;
+                push_value(out, &parsed)
+            }
+            _ => Err(FormatError::InvalidBinding(
+                "@json datatype must have FlakeValue::Json".to_string(),
+            )),
+        };
+    }
+
+    // Language-tagged strings: `{"@value":s,"@language":lang}`.
+    if let Some(lang_tag) = dtc.lang_tag() {
+        return match val {
+            FlakeValue::String(s) => {
+                out.push_str(r#"{"@value":"#);
+                push_json_string(out, s);
+                out.push_str(r#","@language":"#);
+                push_json_string(out, lang_tag);
+                out.push('}');
+                Ok(())
+            }
+            FlakeValue::Null => {
+                out.push_str("null");
+                Ok(())
+            }
+            FlakeValue::Ref(_) => Err(FormatError::InvalidBinding(
+                "Binding::Lit invariant violated: contains Ref".to_string(),
+            )),
+            _ => Err(FormatError::InvalidBinding(
+                "Language-tagged literals must be strings".to_string(),
+            )),
+        };
+    }
+
+    // Inferable datatypes emit a bare value (no @type wrapper).
+    if is_inferable_datatype(&dt_full) {
+        return write_scalar(out, val, false);
+    }
+
+    // Non-inferable: wrap with the compacted @type.
+    out.push_str(r#"{"@value":"#);
+    write_scalar(out, val, true)?;
+    out.push_str(r#","@type":"#);
+    push_json_string(out, &dt_compact);
+    out.push('}');
+    Ok(())
+}
+
+/// Write the bare scalar JSON for a literal value.
+///
+/// `json_as_string` distinguishes the two DOM contexts for `FlakeValue::Json`:
+/// in the inferable branch a stray `Json` is an internal error (it should have
+/// been caught by the `@json` check); in the non-inferable branch it is rendered
+/// as a plain string value.
+fn write_scalar(out: &mut String, val: &FlakeValue, json_as_string: bool) -> Result<()> {
+    match val {
+        FlakeValue::String(s) => push_json_string(out, s),
+        FlakeValue::Long(n) => push_i64(out, *n),
+        FlakeValue::Double(d) => {
+            if d.is_nan() {
+                push_json_string(out, "NaN");
+            } else if d.is_infinite() {
+                push_json_string(out, if d.is_sign_positive() { "INF" } else { "-INF" });
+            } else {
+                push_f64(out, *d);
+            }
+        }
+        FlakeValue::Boolean(b) => push_bool(out, *b),
+        FlakeValue::Vector(v) => push_value(out, &json!(v))?,
+        FlakeValue::Json(json_str) => {
+            if json_as_string {
+                push_json_string(out, json_str);
+            } else {
+                return Err(FormatError::InvalidBinding(
+                    "@json should have been handled above".to_string(),
+                ));
+            }
+        }
+        FlakeValue::Null => out.push_str("null"),
+        FlakeValue::Ref(_) => {
+            return Err(FormatError::InvalidBinding(
+                "Binding::Lit invariant violated: contains Ref".to_string(),
+            ));
+        }
+        FlakeValue::BigInt(n) => push_json_string(out, &n.to_string()),
+        FlakeValue::Decimal(d) => push_json_string(out, &d.to_string()),
+        // Temporal types + GeoPoint: original lexical string (FlakeValue Display
+        // delegates to the inner value's Display for these variants).
+        other => push_json_string(out, &other.to_string()),
+    }
+    Ok(())
 }
 
 /// Format a single binding to JSON-LD Query JSON
@@ -445,6 +718,194 @@ mod tests {
         ]);
         let result = format_binding(&binding, &compactor).unwrap();
         assert_eq!(result, json!([1, 2]));
+    }
+
+    // ------------------------------------------------------------------
+    // Streaming `format_string` parity with the DOM `format` + serde_json.
+    // ------------------------------------------------------------------
+
+    use fluree_db_query::var_registry::VarRegistry;
+    use std::sync::Arc;
+
+    fn make_result(var_names: &[&str], rows: Vec<Vec<Binding>>) -> QueryResult {
+        let mut vars = VarRegistry::new();
+        let var_ids: Vec<fluree_db_query::VarId> =
+            var_names.iter().map(|&n| vars.get_or_insert(n)).collect();
+        let mut columns: Vec<Vec<Binding>> = vec![Vec::new(); var_ids.len()];
+        for row in rows {
+            for (col, b) in row.into_iter().enumerate() {
+                columns[col].push(b);
+            }
+        }
+        let batch = fluree_db_query::binding::Batch::new(
+            Arc::from(var_ids.clone().into_boxed_slice()),
+            columns,
+        )
+        .unwrap();
+        QueryResult {
+            vars,
+            t: Some(0),
+            novelty: None,
+            context: crate::ParsedContext::default(),
+            orig_context: None,
+            output: crate::QueryOutput::select_all(var_ids),
+            batches: vec![batch],
+            binary_graph: None,
+        }
+    }
+
+    fn assert_parity(result: &QueryResult, compactor: &IriCompactor) {
+        let dom = format(result, compactor, &FormatterConfig::jsonld()).unwrap();
+        let want = serde_json::to_string(&dom).unwrap();
+        let got = format_string(result, compactor, &FormatterConfig::jsonld()).unwrap();
+        assert_eq!(got, want, "streaming JSON-LD diverged from DOM");
+    }
+
+    #[test]
+    fn parity_array_rows_and_scalars() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?ref", "?s", "?n", "?b", "?lang", "?date"],
+            vec![
+                vec![
+                    Binding::sid(Sid::new(100, "alice")),
+                    Binding::lit(
+                        FlakeValue::String("tab\there/slash".to_string()),
+                        Sid::new(2, "string"),
+                    ),
+                    Binding::lit(FlakeValue::Long(42), Sid::new(2, "long")),
+                    Binding::lit(FlakeValue::Boolean(true), Sid::new(2, "boolean")),
+                    Binding::lit_lang(FlakeValue::String("Salut".to_string()), "fr"),
+                    Binding::lit(
+                        FlakeValue::String("2024-01-15".to_string()),
+                        Sid::new(2, "date"),
+                    ),
+                ],
+                vec![
+                    Binding::Unbound,
+                    Binding::lit(FlakeValue::String("bob".to_string()), Sid::new(2, "string")),
+                    Binding::lit(FlakeValue::Long(-1), Sid::new(2, "long")),
+                    Binding::lit(FlakeValue::Boolean(false), Sid::new(2, "boolean")),
+                    Binding::Unbound,
+                    Binding::Unbound,
+                ],
+            ],
+        );
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_double_special_and_large() {
+        let c = make_test_compactor();
+        for d in [
+            3.13_f64,
+            1e30,
+            1e-7,
+            -0.0,
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ] {
+            let r = make_result(
+                &["?d"],
+                vec![vec![Binding::lit(
+                    FlakeValue::Double(d),
+                    Sid::new(2, "double"),
+                )]],
+            );
+            assert_parity(&r, &c);
+        }
+    }
+
+    #[test]
+    fn parity_json_and_vector() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?j", "?v"],
+            vec![vec![
+                Binding::lit(
+                    FlakeValue::Json(r#"{"k":[1,2.5],"s":"x"}"#.to_string()),
+                    Sid::new(3, "JSON"),
+                ),
+                Binding::lit(
+                    FlakeValue::Vector(vec![1.0, 2.5, -3.0]),
+                    Sid::new(2, "double"),
+                ),
+            ]],
+        );
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_wildcard_and_grouped() {
+        let c = make_test_compactor();
+        let mut r = make_result(
+            &["?s", "?g"],
+            vec![vec![
+                Binding::sid(Sid::new(100, "a")),
+                Binding::Grouped(vec![
+                    Binding::sid(Sid::new(100, "x")),
+                    Binding::lit(FlakeValue::Long(9), Sid::new(2, "long")),
+                ]),
+            ]],
+        );
+        r.output = crate::QueryOutput::wildcard();
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_scalar_flatten() {
+        use fluree_db_query::ir::projection::{Column, Projection};
+        let c = make_test_compactor();
+        let mut r = make_result(
+            &["?x"],
+            vec![
+                vec![Binding::sid(Sid::new(100, "a"))],
+                vec![Binding::lit(FlakeValue::Long(5), Sid::new(2, "long"))],
+                vec![Binding::Unbound],
+            ],
+        );
+        let x = r.vars.get_or_insert("?x");
+        r.output = fluree_db_query::ir::QueryOutput::Select {
+            projection: Projection::Scalar(Column::Var(x)),
+            restriction: None,
+        };
+        assert!(r.output.should_flatten_scalar());
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_empty() {
+        let c = make_test_compactor();
+        assert_parity(&make_result(&["?s", "?p"], vec![]), &c);
+    }
+
+    #[test]
+    fn parity_extended_value_types() {
+        use fluree_db_core::coerce::coerce_string_value;
+        use fluree_vocab::xsd;
+        let c = make_test_compactor();
+        // xsd:integer + xsd:decimal are inferable (bare value); xsd:dateTime is
+        // not (wrapped with @type). All funnel through the Display/.to_string()
+        // arms of write_scalar.
+        let r = make_result(
+            &["?big", "?dec", "?dt"],
+            vec![vec![
+                Binding::lit(
+                    coerce_string_value("99999999999999999999999999", xsd::INTEGER).unwrap(),
+                    Sid::new(2, "integer"),
+                ),
+                Binding::lit(
+                    coerce_string_value("3.14159265358979", xsd::DECIMAL).unwrap(),
+                    Sid::new(2, "decimal"),
+                ),
+                Binding::lit(
+                    coerce_string_value("2024-01-15T10:30:00Z", xsd::DATE_TIME).unwrap(),
+                    Sid::new(2, "dateTime"),
+                ),
+            ]],
+        );
+        assert_parity(&r, &c);
     }
 
     #[test]

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -46,6 +46,7 @@ pub mod datatype;
 pub mod delimited;
 mod hydration;
 pub mod iri;
+mod json_write;
 mod jsonld;
 mod materialize;
 mod rdf_xml;
@@ -165,6 +166,50 @@ pub fn format_results(
     }
 }
 
+/// True when the JSON **string** output for this result can be produced by the
+/// allocation-light streaming serializers instead of building (and then
+/// re-serializing) a `serde_json::Value` DOM.
+///
+/// The DOM path handles every excluded case identically and remains the
+/// reference implementation:
+/// - `pretty` — uses serde's pretty-printer
+/// - `select_one` — single-row output; per-format shaping quirks, and the win
+///   from streaming is negligible for one row
+/// - ASK — tiny boolean envelope
+/// - CONSTRUCT/DESCRIBE — coerced to a JSON-LD graph (`construct::format`)
+/// - hydration — async DB expansion during formatting
+fn json_stream_eligible(result: &QueryResult, config: &FormatterConfig) -> bool {
+    !config.pretty
+        && matches!(
+            config.format,
+            OutputFormat::JsonLd
+                | OutputFormat::SparqlJson
+                | OutputFormat::TypedJson
+                | OutputFormat::AgentJson
+        )
+        && !result.output.is_select_one()
+        && !result.output.is_ask()
+        && result.output.construct_template().is_none()
+        && !result.output.has_hydration()
+}
+
+/// Dispatch a stream-eligible result to the matching streaming JSON serializer.
+/// Each `format_string` is parity-tested to be byte-identical to
+/// `serde_json::to_string(&<dom format>(...))`.
+fn stream_json(
+    result: &QueryResult,
+    compactor: &IriCompactor,
+    config: &FormatterConfig,
+) -> Result<String> {
+    match config.format {
+        OutputFormat::JsonLd => jsonld::format_string(result, compactor, config),
+        OutputFormat::SparqlJson => sparql::format_string(result, compactor, config),
+        OutputFormat::TypedJson => typed::format_string(result, compactor, config),
+        OutputFormat::AgentJson => agent_json::format_string(result, compactor, config),
+        _ => unreachable!("stream_json only called for JSON formats (see json_stream_eligible)"),
+    }
+}
+
 /// Format query results to a JSON string
 ///
 /// Convenience function that formats and serializes in one step.
@@ -190,6 +235,13 @@ pub fn format_results_string(
             return rdf_xml::format(result, &compactor, config);
         }
         _ => {}
+    }
+
+    // Stream JSON straight to a String for the common SELECT case, skipping the
+    // serde_json::Value DOM and its second serialization pass.
+    if json_stream_eligible(result, config) {
+        let compactor = IriCompactor::new(snapshot.shared_namespaces(), context);
+        return stream_json(result, &compactor, config);
     }
 
     let value = format_results(result, context, snapshot, config)?;
@@ -428,6 +480,13 @@ pub async fn format_results_string_async(
         _ => {}
     }
 
+    // Stream JSON straight to a String for the common SELECT case (mirrors the
+    // compactor that `format_results_async` would build internally).
+    if json_stream_eligible(result, config) {
+        let compactor = IriCompactor::new(db.snapshot.shared_namespaces(), context);
+        return stream_json(result, &compactor, config);
+    }
+
     let value = format_results_async(result, context, db, config, policy, None).await?;
 
     if config.pretty {
@@ -465,6 +524,14 @@ pub async fn format_results_string_async_dataset(
             return rdf_xml::format(result, &compactor, config);
         }
         _ => {}
+    }
+
+    // Non-hydration JSON formats against the primary view, exactly as the DOM
+    // dataset path does — so the streaming compactor matches. Hydration is not
+    // stream-eligible and continues through the dataset-aware DOM path below.
+    if json_stream_eligible(result, config) {
+        let compactor = IriCompactor::new(primary_db.snapshot.shared_namespaces(), context);
+        return stream_json(result, &compactor, config);
     }
 
     let value = format_results_async_dataset(result, context, dataset, config, tracker).await?;
@@ -541,5 +608,214 @@ mod tests {
         let config = FormatterConfig::jsonld();
         let output = format_ask(&result, &config).unwrap().unwrap();
         assert_eq!(output, JsonValue::Bool(false));
+    }
+
+    // ====================================================================
+    // Manual perf harness: streaming `format_string` vs DOM `format` +
+    // `serde_json::to_string`, for each JSON format across number-heavy,
+    // string-heavy, and mixed result sets.
+    //
+    // Ignored by default (it's a benchmark, not an assertion). Run in RELEASE
+    // for meaningful numbers:
+    //
+    //   cargo test -p fluree-db-api --release --lib \
+    //     format::tests::bench_stream_vs_dom -- --ignored --nocapture
+    //
+    // It also asserts byte-identity at 10k rows, so it doubles as a
+    // large-scale parity check.
+    // ====================================================================
+
+    use fluree_db_core::{FlakeValue, Sid};
+    use fluree_db_query::binding::{Batch, Binding};
+    use std::hint::black_box;
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    fn bench_compactor() -> IriCompactor {
+        let mut ns = std::collections::HashMap::new();
+        ns.insert(2u16, "http://www.w3.org/2001/XMLSchema#".to_string());
+        ns.insert(100u16, "http://example.org/".to_string());
+        IriCompactor::from_namespaces(Arc::new(ns))
+    }
+
+    /// Build an `n`-row `QueryResult` for one of the data shapes.
+    fn bench_result(shape: &str, n: usize) -> QueryResult {
+        let mut vars = VarRegistry::new();
+        let xsd_long = Sid::new(2, "long");
+        let xsd_double = Sid::new(2, "double");
+        let xsd_string = Sid::new(2, "string");
+        let xsd_bool = Sid::new(2, "boolean");
+
+        let (names, cols): (Vec<&str>, Vec<Vec<Binding>>) = match shape {
+            // All numeric literals (Long + Double).
+            "numbers" => {
+                let names = vec!["?a", "?b", "?c"];
+                let a = (0..n)
+                    .map(|i| Binding::lit(FlakeValue::Long(i as i64), xsd_long.clone()))
+                    .collect();
+                let b = (0..n)
+                    .map(|i| Binding::lit(FlakeValue::Double(i as f64 * 1.5), xsd_double.clone()))
+                    .collect();
+                let c = (0..n)
+                    .map(|i| Binding::lit(FlakeValue::Long((i as i64) * 7 - 3), xsd_long.clone()))
+                    .collect();
+                (names, vec![a, b, c])
+            }
+            // An IRI ref + two string literals (short + longer).
+            "strings" => {
+                let names = vec!["?id", "?name", "?desc"];
+                let id = (0..n)
+                    .map(|i| Binding::sid(Sid::new(100, format!("item{i}"))))
+                    .collect();
+                let name = (0..n)
+                    .map(|i| {
+                        Binding::lit(FlakeValue::String(format!("Name {i}")), xsd_string.clone())
+                    })
+                    .collect();
+                let desc = (0..n)
+                    .map(|i| {
+                        Binding::lit(
+                            FlakeValue::String(format!(
+                                "A reasonably descriptive sentence for record number {i}."
+                            )),
+                            xsd_string.clone(),
+                        )
+                    })
+                    .collect();
+                (names, vec![id, name, desc])
+            }
+            // Mixed: ref + string + long + double + boolean.
+            _mixed => {
+                let names = vec!["?id", "?name", "?age", "?score", "?active"];
+                let id = (0..n)
+                    .map(|i| Binding::sid(Sid::new(100, format!("person{i}"))))
+                    .collect();
+                let name = (0..n)
+                    .map(|i| {
+                        Binding::lit(
+                            FlakeValue::String(format!("Person {i}")),
+                            xsd_string.clone(),
+                        )
+                    })
+                    .collect();
+                let age = (0..n)
+                    .map(|i| Binding::lit(FlakeValue::Long((i % 90) as i64), xsd_long.clone()))
+                    .collect();
+                let score = (0..n)
+                    .map(|i| Binding::lit(FlakeValue::Double((i as f64) / 3.0), xsd_double.clone()))
+                    .collect();
+                let active = (0..n)
+                    .map(|i| Binding::lit(FlakeValue::Boolean(i % 2 == 0), xsd_bool.clone()))
+                    .collect();
+                (names, vec![id, name, age, score, active])
+            }
+        };
+
+        let var_ids: Vec<fluree_db_query::VarId> =
+            names.iter().map(|&nm| vars.get_or_insert(nm)).collect();
+        let batch = Batch::new(Arc::from(var_ids.clone().into_boxed_slice()), cols).unwrap();
+        QueryResult {
+            vars,
+            t: Some(1),
+            novelty: None,
+            context: fluree_graph_json_ld::ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::select_all(var_ids),
+            batches: vec![batch],
+            binary_graph: None,
+        }
+    }
+
+    #[test]
+    #[ignore = "perf benchmark; run with --release --ignored --nocapture"]
+    fn bench_stream_vs_dom() {
+        type DomFn = fn(&QueryResult, &IriCompactor, &FormatterConfig) -> Result<JsonValue>;
+        type StreamFn = fn(&QueryResult, &IriCompactor, &FormatterConfig) -> Result<String>;
+
+        const ROWS: usize = 10_000;
+        const ITERS: usize = 100;
+
+        let compactor = bench_compactor();
+        let formats: [(&str, DomFn, StreamFn, FormatterConfig); 4] = [
+            (
+                "sparql_json",
+                sparql::format,
+                sparql::format_string,
+                FormatterConfig::sparql_json(),
+            ),
+            (
+                "typed_json",
+                typed::format,
+                typed::format_string,
+                FormatterConfig::typed_json(),
+            ),
+            (
+                "jsonld",
+                jsonld::format,
+                jsonld::format_string,
+                FormatterConfig::jsonld(),
+            ),
+            (
+                "agent_json",
+                agent_json::format,
+                agent_json::format_string,
+                FormatterConfig::agent_json(),
+            ),
+        ];
+
+        println!(
+            "\n{ROWS} rows, {ITERS} iters/measurement  (DOM = format + serde_json::to_string, STREAM = format_string)\n"
+        );
+        println!(
+            "{:<8} {:<12} {:>10} {:>11} {:>11} {:>9} {:>11}",
+            "shape", "format", "bytes", "dom µs/it", "strm µs/it", "speedup", "MB/s strm"
+        );
+        println!("{}", "-".repeat(80));
+
+        for shape in ["numbers", "strings", "mixed"] {
+            let result = bench_result(shape, ROWS);
+            for (name, dom, stream, cfg) in &formats {
+                // Correctness at scale: streaming must equal DOM-then-serialize.
+                let dom_once =
+                    serde_json::to_string(&dom(&result, &compactor, cfg).unwrap()).unwrap();
+                let stream_once = stream(&result, &compactor, cfg).unwrap();
+                assert_eq!(
+                    dom_once, stream_once,
+                    "parity mismatch at {ROWS} rows: shape={shape} format={name}"
+                );
+                let bytes = stream_once.len();
+
+                // Warm up.
+                for _ in 0..3 {
+                    black_box(
+                        serde_json::to_string(&dom(&result, &compactor, cfg).unwrap()).unwrap(),
+                    );
+                    black_box(stream(&result, &compactor, cfg).unwrap());
+                }
+
+                let t0 = Instant::now();
+                for _ in 0..ITERS {
+                    let v = dom(&result, &compactor, cfg).unwrap();
+                    black_box(serde_json::to_string(&v).unwrap().len());
+                }
+                let dom_elapsed = t0.elapsed();
+
+                let t1 = Instant::now();
+                for _ in 0..ITERS {
+                    black_box(stream(&result, &compactor, cfg).unwrap().len());
+                }
+                let stream_elapsed = t1.elapsed();
+
+                let dom_us = dom_elapsed.as_secs_f64() * 1e6 / ITERS as f64;
+                let strm_us = stream_elapsed.as_secs_f64() * 1e6 / ITERS as f64;
+                let speedup = dom_us / strm_us;
+                let mbps = (bytes as f64) / (strm_us / 1e6) / (1024.0 * 1024.0);
+
+                println!(
+                    "{shape:<8} {name:<12} {bytes:>10} {dom_us:>11.1} {strm_us:>11.1} {speedup:>8.2}x {mbps:>10.0}"
+                );
+            }
+        }
+        println!();
     }
 }

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -20,7 +20,8 @@
 use super::config::FormatterConfig;
 use super::datatype::is_inferable_datatype;
 use super::iri::IriCompactor;
-use super::{FormatError, Result};
+use super::json_write::{push_json_string, push_value};
+use super::{materialize, FormatError, Result};
 use crate::QueryResult;
 use fluree_db_core::FlakeValue;
 use fluree_db_query::binding::Binding;
@@ -33,44 +34,7 @@ pub fn format(
     compactor: &IriCompactor,
     _config: &FormatterConfig,
 ) -> Result<JsonValue> {
-    // Build head.vars from select list (without ? prefix).
-    // For wildcard, use the operator schema (all variables).
-    // Fall back to VarRegistry when batches are empty (W3C: exists-02 etc.).
-    let head_vars: Vec<fluree_db_query::VarId> = if result.output.is_wildcard() {
-        result
-            .batches
-            .first()
-            .map(|b| {
-                b.schema()
-                    .iter()
-                    .copied()
-                    // Skip internal variables (?__pp0, ?__s0, etc.) from wildcard output.
-                    .filter(|&vid| !result.vars.name(vid).starts_with("?__"))
-                    .collect()
-            })
-            .unwrap_or_else(|| {
-                // Empty result set: derive vars from the registry (all user-visible variables).
-                result
-                    .vars
-                    .iter()
-                    .filter(|(name, _)| !name.starts_with("?__"))
-                    .map(|(_, id)| id)
-                    .collect()
-            })
-    } else {
-        result.output.projected_vars_or_empty()
-    };
-
-    // Order head vars lexicographically by variable name (without '?').
-    // This also stabilizes output across planner reorderings.
-    let mut head_pairs: Vec<(String, fluree_db_query::VarId)> = head_vars
-        .iter()
-        .map(|&var_id| (strip_question_mark(result.vars.name(var_id)), var_id))
-        .collect();
-    head_pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-    let vars: Vec<String> = head_pairs.iter().map(|(name, _)| name.clone()).collect();
-    let head_vars: Vec<fluree_db_query::VarId> = head_pairs.into_iter().map(|(_, id)| id).collect();
+    let (vars, head_vars) = compute_head(result);
 
     let select_one = result.output.is_select_one();
     let mut bindings = Vec::new();
@@ -107,6 +71,289 @@ pub fn format(
         "head": {"vars": vars},
         "results": {"bindings": bindings}
     }))
+}
+
+/// Compute the `head.vars` names (without `?`) and the parallel `VarId` list,
+/// ordered lexicographically by name. Shared by the DOM and streaming paths so
+/// the head order can never drift between them.
+fn compute_head(result: &QueryResult) -> (Vec<String>, Vec<fluree_db_query::VarId>) {
+    // For wildcard, use the operator schema (all variables); fall back to the
+    // VarRegistry when batches are empty (W3C: exists-02 etc.).
+    let head_vars: Vec<fluree_db_query::VarId> = if result.output.is_wildcard() {
+        result
+            .batches
+            .first()
+            .map(|b| {
+                b.schema()
+                    .iter()
+                    .copied()
+                    // Skip internal variables (?__pp0, ?__s0, etc.) from wildcard output.
+                    .filter(|&vid| !result.vars.name(vid).starts_with("?__"))
+                    .collect()
+            })
+            .unwrap_or_else(|| {
+                result
+                    .vars
+                    .iter()
+                    .filter(|(name, _)| !name.starts_with("?__"))
+                    .map(|(_, id)| id)
+                    .collect()
+            })
+    } else {
+        result.output.projected_vars_or_empty()
+    };
+
+    // Order head vars lexicographically by name (stable across planner reorderings).
+    let mut head_pairs: Vec<(String, fluree_db_query::VarId)> = head_vars
+        .iter()
+        .map(|&var_id| (strip_question_mark(result.vars.name(var_id)), var_id))
+        .collect();
+    head_pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    let vars: Vec<String> = head_pairs.iter().map(|(name, _)| name.clone()).collect();
+    let head_vars: Vec<fluree_db_query::VarId> = head_pairs.into_iter().map(|(_, id)| id).collect();
+    (vars, head_vars)
+}
+
+/// Stream SPARQL 1.1 JSON results directly into a `String`, byte-identical to
+/// `serde_json::to_string(&format(...))` for the non-`select_one` SELECT case.
+///
+/// The common (non-grouped) row streams cell-by-cell with no per-cell
+/// `serde_json::Value` allocation. Grouped rows (GROUP BY without aggregation)
+/// are rare and reuse the proven [`disaggregate_row`] cartesian expansion,
+/// serialized leaf-wise via [`push_value`]. `select_one`, ASK, CONSTRUCT, and
+/// `pretty` are handled by the caller on the DOM path and never reach here.
+pub fn format_string(
+    result: &QueryResult,
+    compactor: &IriCompactor,
+    _config: &FormatterConfig,
+) -> Result<String> {
+    debug_assert!(
+        !result.output.is_select_one(),
+        "format_string is only for the non-select_one path; select_one routes through the DOM"
+    );
+
+    let (vars, head_vars) = compute_head(result);
+
+    // Pre-size: rows × cols × an estimated per-cell width plus envelope slack.
+    let est = (result.row_count() + 1)
+        .saturating_mul(head_vars.len().max(1))
+        .saturating_mul(64)
+        .saturating_add(64);
+    let mut out = String::with_capacity(est);
+
+    out.push_str("{\"head\":{\"vars\":[");
+    for (i, name) in vars.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        push_json_string(&mut out, name);
+    }
+    out.push_str("]},\"results\":{\"bindings\":[");
+
+    let mut first_binding = true;
+    for batch in &result.batches {
+        let schema = batch.schema();
+        // Map each head var to its column index in this batch once per batch.
+        let cols: Vec<Option<usize>> = head_vars
+            .iter()
+            .map(|&v| schema.iter().position(|&sv| sv == v))
+            .collect();
+
+        for row_idx in 0..batch.len() {
+            let has_grouped = cols.iter().any(|&c| {
+                matches!(
+                    c.map(|c| batch.get_by_col(row_idx, c)),
+                    Some(Binding::Grouped(_))
+                )
+            });
+
+            if has_grouped {
+                // Rare: cartesian-expand via the DOM disaggregator, then splice
+                // each fully-built binding object in verbatim.
+                let row_bindings: Vec<(fluree_db_query::VarId, &Binding)> = head_vars
+                    .iter()
+                    .map(|&var_id| {
+                        (
+                            var_id,
+                            batch.get(row_idx, var_id).unwrap_or(&Binding::Unbound),
+                        )
+                    })
+                    .collect();
+                let objs = disaggregate_row(result, &row_bindings, &result.vars, compactor)?;
+                for obj in &objs {
+                    if !first_binding {
+                        out.push(',');
+                    }
+                    first_binding = false;
+                    push_value(&mut out, obj)?;
+                }
+            } else {
+                if !first_binding {
+                    out.push(',');
+                }
+                first_binding = false;
+                out.push('{');
+                let mut first_cell = true;
+                for (k, &col) in cols.iter().enumerate() {
+                    if let Some(col) = col {
+                        let binding = batch.get_by_col(row_idx, col);
+                        write_cell(
+                            &mut out,
+                            result,
+                            binding,
+                            &vars[k],
+                            compactor,
+                            &mut first_cell,
+                        )?;
+                    }
+                }
+                out.push('}');
+            }
+        }
+    }
+
+    out.push_str("]}}");
+    Ok(out)
+}
+
+/// Write one `"name":{term}` cell, or nothing for Unbound/Poisoned/null literals
+/// (omitted per the SPARQL Results spec, matching [`format_binding`]).
+fn write_cell(
+    out: &mut String,
+    result: &QueryResult,
+    binding: &Binding,
+    name: &str,
+    compactor: &IriCompactor,
+    first_cell: &mut bool,
+) -> Result<()> {
+    // Late materialization: resolve encoded bindings to a concrete binding (the
+    // same step the DOM path takes), then stream the result.
+    if binding.is_encoded() {
+        let materialized = materialize::materialize_binding(result, binding)?;
+        return write_cell(out, result, &materialized, name, compactor, first_cell);
+    }
+
+    // Omitted cells produce no key at all.
+    match binding {
+        Binding::Unbound | Binding::Poisoned => return Ok(()),
+        Binding::Lit {
+            val: FlakeValue::Null,
+            ..
+        } => return Ok(()),
+        _ => {}
+    }
+
+    if !*first_cell {
+        out.push(',');
+    }
+    *first_cell = false;
+    push_json_string(out, name);
+    out.push(':');
+    write_term(out, binding, compactor)
+}
+
+/// Write the `{"type":...,"value":...}` term object for a (non-omitted) binding.
+fn write_term(out: &mut String, binding: &Binding, compactor: &IriCompactor) -> Result<()> {
+    match binding {
+        Binding::Sid { sid, .. } => write_node(out, &compactor.compact_id_sid(sid)?),
+        Binding::IriMatch { iri, .. } => write_node(out, &compactor.compact_id_iri(iri)),
+        Binding::Iri(iri) => write_node(out, iri.as_ref()),
+        Binding::Lit { val, dtc, .. } => {
+            let dt_iri = compactor.decode_sid(dtc.datatype())?;
+            write_literal(out, val, dtc.lang_tag(), &dt_iri)?;
+        }
+        Binding::Grouped(_) => {
+            return Err(FormatError::InvalidBinding(
+                "Binding::Grouped should be disaggregated before formatting".to_string(),
+            ));
+        }
+        Binding::EncodedLit { .. } | Binding::EncodedSid { .. } | Binding::EncodedPid { .. } => {
+            unreachable!("encoded bindings are materialized before write_term")
+        }
+        Binding::Unbound | Binding::Poisoned => unreachable!("omitted before write_term"),
+    }
+    Ok(())
+}
+
+/// Write a node reference as `{"type":"uri"|"bnode","value":...}`.
+fn write_node(out: &mut String, iri: &str) {
+    if let Some(label) = iri.strip_prefix("_:") {
+        out.push_str(r#"{"type":"bnode","value":"#);
+        push_json_string(out, label);
+    } else {
+        out.push_str(r#"{"type":"uri","value":"#);
+        push_json_string(out, iri);
+    }
+    out.push('}');
+}
+
+/// Write a literal term. SPARQL JSON encodes every literal value as a JSON
+/// string and carries the datatype for non-inferable / non-string types.
+fn write_literal(
+    out: &mut String,
+    val: &FlakeValue,
+    lang: Option<&str>,
+    dt_iri: &str,
+) -> Result<()> {
+    match val {
+        FlakeValue::String(s) => {
+            out.push_str(r#"{"type":"literal","value":"#);
+            push_json_string(out, s);
+            if let Some(lang) = lang {
+                out.push_str(r#","xml:lang":"#);
+                push_json_string(out, lang);
+            } else if !is_inferable_datatype(dt_iri) {
+                out.push_str(r#","datatype":"#);
+                push_json_string(out, dt_iri);
+            }
+            out.push('}');
+        }
+        FlakeValue::Ref(_) => {
+            return Err(FormatError::InvalidBinding(
+                "Binding::Lit invariant violated: contains Ref".to_string(),
+            ));
+        }
+        FlakeValue::Null => unreachable!("null literals are omitted before write_literal"),
+        // Every other value type is rendered as its string lexical form with the
+        // datatype attached (matching the DOM `format_binding`).
+        other => {
+            let value = scalar_lexical(other);
+            out.push_str(r#"{"type":"literal","value":"#);
+            push_json_string(out, &value);
+            out.push_str(r#","datatype":"#);
+            push_json_string(out, dt_iri);
+            out.push('}');
+        }
+    }
+    Ok(())
+}
+
+/// The lexical string form of a non-string literal value, matching the DOM
+/// `format_binding` value strings exactly.
+fn scalar_lexical(val: &FlakeValue) -> String {
+    match val {
+        FlakeValue::Long(n) => n.to_string(),
+        FlakeValue::Double(d) => {
+            if d.is_nan() {
+                "NaN".to_string()
+            } else if d.is_infinite() {
+                if d.is_sign_positive() {
+                    "INF".to_string()
+                } else {
+                    "-INF".to_string()
+                }
+            } else {
+                d.to_string()
+            }
+        }
+        FlakeValue::Boolean(b) => b.to_string(),
+        FlakeValue::Vector(v) => serde_json::to_string(v).unwrap_or_else(|_| "[]".to_string()),
+        FlakeValue::Json(json_str) => json_str.clone(),
+        FlakeValue::BigInt(n) => n.to_string(),
+        FlakeValue::Decimal(d) => d.to_string(),
+        other => other.to_string(),
+    }
 }
 
 /// Strip the leading '?' from a variable name
@@ -578,6 +825,212 @@ mod tests {
         let binding = Binding::Unbound;
         let formatted = format_binding(&result, &binding, &compactor).unwrap();
         assert!(formatted.is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // Streaming `format_string` parity with the DOM `format` + serde_json.
+    // ------------------------------------------------------------------
+
+    use fluree_db_query::var_registry::VarRegistry;
+    use std::sync::Arc;
+
+    fn make_result(var_names: &[&str], rows: Vec<Vec<Binding>>) -> QueryResult {
+        let mut vars = VarRegistry::new();
+        let var_ids: Vec<fluree_db_query::VarId> =
+            var_names.iter().map(|&n| vars.get_or_insert(n)).collect();
+        let mut columns: Vec<Vec<Binding>> = vec![Vec::new(); var_ids.len()];
+        for row in rows {
+            for (col, b) in row.into_iter().enumerate() {
+                columns[col].push(b);
+            }
+        }
+        let batch = fluree_db_query::binding::Batch::new(
+            Arc::from(var_ids.clone().into_boxed_slice()),
+            columns,
+        )
+        .unwrap();
+        QueryResult {
+            vars,
+            t: Some(0),
+            novelty: None,
+            context: crate::ParsedContext::default(),
+            orig_context: None,
+            output: crate::QueryOutput::select_all(var_ids),
+            batches: vec![batch],
+            binary_graph: None,
+        }
+    }
+
+    /// The streaming serializer must be byte-identical to compact-serializing the
+    /// DOM tree produced by `format`.
+    fn assert_parity(result: &QueryResult, compactor: &IriCompactor) {
+        let dom = format(result, compactor, &FormatterConfig::sparql_json()).unwrap();
+        let want = serde_json::to_string(&dom).unwrap();
+        let got = format_string(result, compactor, &FormatterConfig::sparql_json()).unwrap();
+        assert_eq!(got, want, "streaming SPARQL JSON diverged from DOM");
+    }
+
+    #[test]
+    fn parity_scalar_terms() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?uri", "?str", "?long", "?bool", "?lang", "?date"],
+            vec![vec![
+                Binding::sid(Sid::new(100, "alice")),
+                Binding::lit(
+                    FlakeValue::String("Alice & <Bob>".to_string()),
+                    Sid::new(2, "string"),
+                ),
+                Binding::lit(FlakeValue::Long(42), Sid::new(2, "long")),
+                Binding::lit(FlakeValue::Boolean(true), Sid::new(2, "boolean")),
+                Binding::lit_lang(FlakeValue::String("Bonjour".to_string()), "fr"),
+                Binding::lit(
+                    FlakeValue::String("2024-01-15".to_string()),
+                    Sid::new(2, "date"),
+                ),
+            ]],
+        );
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_double_special_and_normal() {
+        let c = make_test_compactor();
+        for d in [
+            3.13_f64,
+            1e30,
+            -0.0,
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ] {
+            let r = make_result(
+                &["?d"],
+                vec![vec![Binding::lit(
+                    FlakeValue::Double(d),
+                    Sid::new(2, "double"),
+                )]],
+            );
+            assert_parity(&r, &c);
+        }
+    }
+
+    #[test]
+    fn parity_blank_node_and_unbound() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?a", "?b", "?c"],
+            vec![vec![
+                Binding::sid(Sid::new(0, "_:b1")),
+                Binding::Unbound,
+                Binding::sid(Sid::new(100, "x")),
+            ]],
+        );
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_multi_row() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?s", "?n"],
+            vec![
+                vec![
+                    Binding::sid(Sid::new(100, "a")),
+                    Binding::lit(FlakeValue::Long(1), Sid::new(2, "long")),
+                ],
+                vec![
+                    Binding::sid(Sid::new(100, "b")),
+                    Binding::lit(FlakeValue::String("two".to_string()), Sid::new(2, "string")),
+                ],
+                vec![Binding::Unbound, Binding::Unbound],
+            ],
+        );
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_empty_results() {
+        let c = make_test_compactor();
+        let r = make_result(&["?s", "?p"], vec![]);
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_wildcard() {
+        let c = make_test_compactor();
+        let mut r = make_result(
+            &["?s", "?p"],
+            vec![vec![
+                Binding::sid(Sid::new(100, "a")),
+                Binding::lit(FlakeValue::Long(7), Sid::new(2, "long")),
+            ]],
+        );
+        r.output = crate::QueryOutput::select_all(vec![]); // wildcard
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_grouped_disaggregation() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?a", "?b"],
+            vec![vec![
+                Binding::Grouped(vec![
+                    Binding::lit(FlakeValue::Long(10), Sid::new(2, "long")),
+                    Binding::lit(FlakeValue::Long(20), Sid::new(2, "long")),
+                ]),
+                Binding::Grouped(vec![
+                    Binding::lit(FlakeValue::Long(1), Sid::new(2, "long")),
+                    Binding::lit(FlakeValue::Long(2), Sid::new(2, "long")),
+                ]),
+            ]],
+        );
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_json_and_vector_values() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?j", "?v"],
+            vec![vec![
+                Binding::lit(
+                    FlakeValue::Json(r#"{"k":1}"#.to_string()),
+                    Sid::new(3, "JSON"),
+                ),
+                Binding::lit(
+                    FlakeValue::Vector(vec![1.0, 2.5, -3.0]),
+                    Sid::new(2, "double"),
+                ),
+            ]],
+        );
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_extended_value_types() {
+        use fluree_db_core::coerce::coerce_string_value;
+        use fluree_vocab::xsd;
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?big", "?dec", "?dt"],
+            vec![vec![
+                Binding::lit(
+                    coerce_string_value("99999999999999999999999999", xsd::INTEGER).unwrap(),
+                    Sid::new(2, "integer"),
+                ),
+                Binding::lit(
+                    coerce_string_value("3.14159265358979", xsd::DECIMAL).unwrap(),
+                    Sid::new(2, "decimal"),
+                ),
+                Binding::lit(
+                    coerce_string_value("2024-01-15T10:30:00Z", xsd::DATE_TIME).unwrap(),
+                    Sid::new(2, "dateTime"),
+                ),
+            ]],
+        );
+        assert_parity(&r, &c);
     }
 
     #[test]

--- a/fluree-db-api/src/format/sparql_xml.rs
+++ b/fluree-db-api/src/format/sparql_xml.rs
@@ -13,16 +13,22 @@ use crate::QueryResult;
 use super::config::FormatterConfig;
 use super::datatype::is_inferable_datatype;
 use super::iri::IriCompactor;
+use super::xml_escape::{escape_attr_into, escape_text_into};
 use super::{materialize, FormatError, Result};
 
-use fluree_db_core::FlakeValue;
+use fluree_db_binary_index::BinaryGraphView;
+use fluree_db_core::{DatatypeConstraint, FlakeValue, Sid};
 use fluree_db_query::binding::Binding;
-use fluree_db_query::VarRegistry;
-use rustc_hash::FxHashMap;
+use fluree_db_query::VarId;
 
 const SPARQL_XML_NS: &str = "http://www.w3.org/2005/sparql-results#";
 
 /// Format query results as SPARQL Results XML.
+///
+/// Writes directly into one pre-sized output buffer: no per-cell `String`, no
+/// per-row hash map, and no binding clones on the common (non-grouped) path.
+/// Encoded subject/predicate refs are resolved inline (no materialize
+/// re-encode round-trip); only grouped rows fall back to cartesian expansion.
 pub fn format(
     result: &QueryResult,
     compactor: &IriCompactor,
@@ -48,7 +54,7 @@ pub fn format(
     // Build head.vars from select list (without ? prefix).
     // For wildcard, use the operator schema (all variables).
     // Fall back to VarRegistry when batches are empty.
-    let head_vars: Vec<fluree_db_query::VarId> = if result.output.is_wildcard() {
+    let head_vars: Vec<VarId> = if result.output.is_wildcard() {
         result
             .batches
             .first()
@@ -72,19 +78,24 @@ pub fn format(
     };
 
     // Order head vars lexicographically by variable name (without '?') for stability.
-    let mut head_pairs: Vec<(String, fluree_db_query::VarId)> = head_vars
+    let mut head_pairs: Vec<(String, VarId)> = head_vars
         .iter()
         .map(|&var_id| (strip_question_mark(result.vars.name(var_id)), var_id))
         .collect();
     head_pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
 
     let head_names: Vec<String> = head_pairs.iter().map(|(name, _)| name.clone()).collect();
-    let head_vars: Vec<fluree_db_query::VarId> = head_pairs.into_iter().map(|(_, id)| id).collect();
+    let head_vars: Vec<VarId> = head_pairs.into_iter().map(|(_, id)| id).collect();
 
     let select_one = result.output.is_select_one();
+    let gv = result.binary_graph.as_ref();
 
-    // Pre-allocate output (best-effort).
-    let mut out = String::new();
+    // Pre-size: rows × cols × an estimated per-cell width, plus envelope slack.
+    let est = (result.row_count() + 1)
+        .saturating_mul(head_vars.len().max(1))
+        .saturating_mul(96)
+        .saturating_add(128);
+    let mut out = String::with_capacity(est);
     out.push_str(r#"<?xml version="1.0" encoding="UTF-8"?>"#);
     out.push_str(r#"<sparql xmlns=""#);
     out.push_str(SPARQL_XML_NS);
@@ -102,38 +113,62 @@ pub fn format(
     // results
     out.push_str("<results>");
 
-    for batch in &result.batches {
+    'outer: for batch in &result.batches {
+        // Map each head var to its column index in this batch once per batch
+        // (None = absent → treated as Unbound and omitted).
+        let schema = batch.schema();
+        let cols: Vec<Option<usize>> = head_vars
+            .iter()
+            .map(|&v| schema.iter().position(|&sv| sv == v))
+            .collect();
+
         for row_idx in 0..batch.len() {
-            let row_bindings: Vec<_> = head_vars
-                .iter()
-                .map(|&var_id| {
-                    let binding = batch.get(row_idx, var_id).unwrap_or(&Binding::Unbound);
-                    (var_id, binding)
-                })
-                .collect();
+            let has_grouped = cols.iter().any(|&c| {
+                matches!(
+                    c.map(|c| batch.get_by_col(row_idx, c)),
+                    Some(Binding::Grouped(_))
+                )
+            });
 
-            let disaggregated =
-                disaggregate_row(&row_bindings).map_err(FormatError::InvalidBinding)?;
-
-            if select_one {
-                if let Some(first) = disaggregated.into_iter().next() {
-                    append_result_row(
-                        result,
-                        &first,
-                        &head_vars,
-                        &result.vars,
-                        compactor,
-                        &mut out,
-                    )?;
+            if has_grouped {
+                // Rare path: cartesian-expand grouped columns into multiple rows.
+                let cells: Vec<Option<&Binding>> = cols
+                    .iter()
+                    .map(|&c| c.map(|c| batch.get_by_col(row_idx, c)))
+                    .collect();
+                let wrote = write_grouped_rows(
+                    &mut out,
+                    result,
+                    &cells,
+                    &head_names,
+                    compactor,
+                    gv,
+                    select_one,
+                )?;
+                if select_one && wrote {
+                    break 'outer;
                 }
-                break;
+            } else {
+                // Fast path: stream the row straight into the buffer.
+                out.push_str("<result>");
+                for (k, &col) in cols.iter().enumerate() {
+                    if let Some(col) = col {
+                        let binding = batch.get_by_col(row_idx, col);
+                        write_binding_cell(
+                            &mut out,
+                            result,
+                            binding,
+                            &head_names[k],
+                            compactor,
+                            gv,
+                        )?;
+                    }
+                }
+                out.push_str("</result>");
+                if select_one {
+                    break 'outer;
+                }
             }
-            for row in disaggregated {
-                append_result_row(result, &row, &head_vars, &result.vars, compactor, &mut out)?;
-            }
-        }
-        if select_one {
-            break;
         }
     }
 
@@ -142,195 +177,260 @@ pub fn format(
     Ok(out)
 }
 
-fn append_result_row(
-    result: &QueryResult,
-    row: &[(fluree_db_query::VarId, Binding)],
-    head_vars: &[fluree_db_query::VarId],
-    vars: &VarRegistry,
-    compactor: &IriCompactor,
+/// Write a `<binding name="…">term</binding>` element, or nothing for
+/// Unbound/Poisoned (omitted per the SPARQL Results spec).
+fn write_binding_cell(
     out: &mut String,
+    result: &QueryResult,
+    binding: &Binding,
+    name: &str,
+    compactor: &IriCompactor,
+    gv: Option<&BinaryGraphView>,
 ) -> Result<()> {
-    let mut map: FxHashMap<fluree_db_query::VarId, &Binding> = FxHashMap::default();
-    for (vid, b) in row {
-        map.insert(*vid, b);
+    if matches!(binding, Binding::Unbound | Binding::Poisoned) {
+        return Ok(());
     }
-
-    out.push_str("<result>");
-    for &var_id in head_vars {
-        let binding = map.get(&var_id).copied().unwrap_or(&Binding::Unbound);
-        if let Some(term_xml) = format_binding_xml(result, binding, compactor)? {
-            out.push_str(r#"<binding name=""#);
-            escape_attr_into(&strip_question_mark(vars.name(var_id)), out);
-            out.push_str(r#"">"#);
-            out.push_str(&term_xml);
-            out.push_str("</binding>");
-        }
-    }
-    out.push_str("</result>");
+    out.push_str(r#"<binding name=""#);
+    escape_attr_into(name, out);
+    out.push_str(r#"">"#);
+    write_term(out, result, binding, compactor, gv)?;
+    out.push_str("</binding>");
     Ok(())
 }
 
-/// Disaggregate grouped bindings into multiple rows (cartesian product).
-///
-/// Returns a vector of rows where each row contains owned bindings.
-fn disaggregate_row(
-    bindings: &[(fluree_db_query::VarId, &Binding)],
-) -> std::result::Result<Vec<Vec<(fluree_db_query::VarId, Binding)>>, String> {
-    let mut grouped_cols: Vec<(fluree_db_query::VarId, Vec<Binding>)> = Vec::new();
-    let mut scalars: Vec<(fluree_db_query::VarId, Binding)> = Vec::new();
-
-    for &(var_id, binding) in bindings {
-        match binding {
-            Binding::Grouped(values) => grouped_cols.push((var_id, values.to_vec())),
-            _ => scalars.push((var_id, binding.clone())),
-        }
-    }
-
-    let mut results: Vec<Vec<(fluree_db_query::VarId, Binding)>> = vec![scalars];
-    for (var_id, values) in grouped_cols {
-        let mut new_results = Vec::new();
-        for row in results {
-            for val in &values {
-                let mut new_row = row.clone();
-                new_row.push((var_id, val.clone()));
-                new_results.push(new_row);
-            }
-        }
-        results = new_results;
-    }
-    Ok(results)
-}
-
-fn format_binding_xml(
+/// Write the `<uri>`/`<bnode>`/`<literal>` term for a (non-unbound) binding.
+fn write_term(
+    out: &mut String,
     result: &QueryResult,
     binding: &Binding,
     compactor: &IriCompactor,
-) -> Result<Option<String>> {
-    // Late materialization for encoded bindings.
-    if binding.is_encoded() {
-        let materialized = materialize::materialize_binding(result, binding)?;
-        return format_binding_xml(result, &materialized, compactor);
-    }
-
+    gv: Option<&BinaryGraphView>,
+) -> Result<()> {
     match binding {
-        Binding::Unbound | Binding::Poisoned => Ok(None),
+        Binding::Sid { sid, .. } => write_sid_ref(out, compactor, sid)?,
+        Binding::IriMatch { iri, .. } => write_iri_ref(out, iri.as_ref()),
+        Binding::Iri(iri) => write_iri_ref(out, iri.as_ref()),
+        Binding::Lit { val, dtc, .. } => write_literal(out, compactor, val, dtc)?,
 
-        Binding::Sid { sid, .. } => {
-            let iri = compactor.decode_sid(sid)?;
-            Ok(Some(if iri.starts_with("_:") {
-                let mut s = String::from("<bnode>");
-                escape_text_into(iri.strip_prefix("_:").unwrap_or(&iri), &mut s);
-                s.push_str("</bnode>");
-                s
-            } else {
-                let mut s = String::from("<uri>");
-                escape_text_into(&iri, &mut s);
-                s.push_str("</uri>");
-                s
-            }))
+        // Encoded subject/predicate refs resolve directly to their full IRI —
+        // no materialize re-encode round-trip (XML never compacts node IRIs).
+        Binding::EncodedSid { .. } | Binding::EncodedPid { .. } => {
+            let gv = gv.ok_or_else(|| {
+                FormatError::InvalidBinding(
+                    "Encountered encoded binding during SPARQL XML formatting but QueryResult \
+                     has no binary_graph"
+                        .to_string(),
+                )
+            })?;
+            write_encoded_ref(out, binding, gv)?;
+        }
+        // Encoded literals: decode via the shared materializer (its value decode
+        // is not a wasted round-trip), then write the concrete value.
+        Binding::EncodedLit { .. } => {
+            let materialized = materialize::materialize_binding(result, binding)?;
+            write_term(out, result, &materialized, compactor, gv)?;
         }
 
-        Binding::IriMatch { iri, .. } => Ok(Some({
-            let iri = iri.as_ref();
-            if iri.starts_with("_:") {
-                let mut s = String::from("<bnode>");
-                escape_text_into(iri.strip_prefix("_:").unwrap_or(iri), &mut s);
-                s.push_str("</bnode>");
-                s
-            } else {
-                let mut s = String::from("<uri>");
-                escape_text_into(iri, &mut s);
-                s.push_str("</uri>");
-                s
-            }
-        })),
-
-        Binding::Iri(iri) => Ok(Some({
-            let iri = iri.as_ref();
-            if iri.starts_with("_:") {
-                let mut s = String::from("<bnode>");
-                escape_text_into(iri.strip_prefix("_:").unwrap_or(iri), &mut s);
-                s.push_str("</bnode>");
-                s
-            } else {
-                let mut s = String::from("<uri>");
-                escape_text_into(iri, &mut s);
-                s.push_str("</uri>");
-                s
-            }
-        })),
-
-        Binding::Lit { val, dtc, .. } => {
-            let dt = dtc.datatype();
-            let dt_iri = compactor.decode_sid(dt)?;
-
-            let mut s = String::from("<literal");
-
-            if let Some(lang) = dtc.lang_tag() {
-                s.push_str(r#" xml:lang=""#);
-                escape_attr_into(lang, &mut s);
-                s.push('"');
-            } else if !is_inferable_datatype(&dt_iri) {
-                s.push_str(r#" datatype=""#);
-                escape_attr_into(&dt_iri, &mut s);
-                s.push('"');
-            }
-
-            s.push('>');
-
-            match val {
-                FlakeValue::String(v) => escape_text_into(v, &mut s),
-                FlakeValue::Long(n) => s.push_str(&n.to_string()),
-                FlakeValue::Double(d) => {
-                    let value_str = if d.is_nan() {
-                        "NaN".to_string()
-                    } else if d.is_infinite() {
-                        if d.is_sign_positive() {
-                            "INF".to_string()
-                        } else {
-                            "-INF".to_string()
-                        }
-                    } else {
-                        d.to_string()
-                    };
-                    s.push_str(&value_str);
-                }
-                FlakeValue::Boolean(b) => s.push_str(&b.to_string()),
-                FlakeValue::Vector(v) => {
-                    let value = serde_json::to_string(v).unwrap_or_else(|_| "[]".to_string());
-                    escape_text_into(&value, &mut s);
-                }
-                FlakeValue::Json(json_str) => escape_text_into(json_str, &mut s),
-                FlakeValue::Ref(_) => {
-                    return Err(FormatError::InvalidBinding(
-                        "Lit cannot contain Ref - expected Binding::Sid".to_string(),
-                    ));
-                }
-                // Temporal / other scalar values: use Display + keep datatype.
-                other => escape_text_into(&other.to_string(), &mut s),
-            }
-
-            s.push_str("</literal>");
-            Ok(Some(s))
+        Binding::Grouped(_) => {
+            return Err(FormatError::InvalidBinding(
+                "Binding::Grouped should be disaggregated before SPARQL XML formatting".to_string(),
+            ));
         }
+        // Skipped by the caller; unreachable here.
+        Binding::Unbound | Binding::Poisoned => {}
+    }
+    Ok(())
+}
 
-        Binding::Grouped(_) => Err(FormatError::InvalidBinding(
-            "Binding::Grouped should be disaggregated before SPARQL XML formatting".to_string(),
-        )),
+/// Write a `Sid` reference, streaming `prefix` + `name` without `decode_sid`'s
+/// intermediate `format!` allocation for the common registered-namespace case.
+fn write_sid_ref(out: &mut String, compactor: &IriCompactor, sid: &Sid) -> Result<()> {
+    match compactor.namespace_prefix(sid)? {
+        // The BLANK_NODE namespace is registered with the `"_:"` prefix, so a
+        // blank node arrives here as `Some("_:")` (not via the EMPTY `None`
+        // branch). Frame it as `<bnode>` with the bare label, matching
+        // `decode_sid` + `starts_with("_:")` in the pre-rewrite formatter.
+        Some("_:") => {
+            out.push_str("<bnode>");
+            escape_text_into(sid.name.as_ref(), out);
+            out.push_str("</bnode>");
+        }
+        Some(prefix) => {
+            // Any other registered prefix is an absolute IRI, so the joined form
+            // is never a blank node — emit `<uri>` directly.
+            out.push_str("<uri>");
+            escape_text_into(prefix, out);
+            escape_text_into(sid.name.as_ref(), out);
+            out.push_str("</uri>");
+        }
+        // EMPTY / OVERFLOW: the name is the verbatim IRI (possibly a `_:` label).
+        None => write_iri_ref(out, sid.name.as_ref()),
+    }
+    Ok(())
+}
 
-        Binding::EncodedLit { .. } | Binding::EncodedSid { .. } | Binding::EncodedPid { .. } => {
-            unreachable!(
-                "Encoded bindings should have been materialized before SPARQL XML formatting"
-            )
+/// Write a full IRI string as `<uri>` (or `<bnode>` when it is a `_:` label).
+fn write_iri_ref(out: &mut String, iri: &str) {
+    if let Some(label) = iri.strip_prefix("_:") {
+        out.push_str("<bnode>");
+        escape_text_into(label, out);
+        out.push_str("</bnode>");
+    } else {
+        out.push_str("<uri>");
+        escape_text_into(iri, out);
+        out.push_str("</uri>");
+    }
+}
+
+/// Resolve an `EncodedSid`/`EncodedPid` to its full IRI and write it.
+fn write_encoded_ref(out: &mut String, binding: &Binding, gv: &BinaryGraphView) -> Result<()> {
+    let store = gv.store();
+    match binding {
+        Binding::EncodedSid { s_id, .. } => {
+            let iri = store.resolve_subject_iri(*s_id).map_err(|e| {
+                FormatError::InvalidBinding(format!(
+                    "Failed to resolve subject IRI for s_id {s_id}: {e}"
+                ))
+            })?;
+            write_iri_ref(out, &iri);
+        }
+        Binding::EncodedPid { p_id } => {
+            let iri = store.resolve_predicate_iri(*p_id).ok_or_else(|| {
+                FormatError::InvalidBinding(format!(
+                    "Failed to resolve predicate IRI for p_id {p_id}"
+                ))
+            })?;
+            write_iri_ref(out, iri);
+        }
+        _ => unreachable!("write_encoded_ref only handles EncodedSid/EncodedPid"),
+    }
+    Ok(())
+}
+
+/// Write a `<literal>` element with lang/datatype attributes and value text.
+fn write_literal(
+    out: &mut String,
+    compactor: &IriCompactor,
+    val: &FlakeValue,
+    dtc: &DatatypeConstraint,
+) -> Result<()> {
+    out.push_str("<literal");
+    if let Some(lang) = dtc.lang_tag() {
+        // A language tag short-circuits the datatype, so don't decode it at all
+        // (avoids an allocation — and a spurious decode error — per lang literal).
+        out.push_str(r#" xml:lang=""#);
+        escape_attr_into(lang, out);
+        out.push('"');
+    } else {
+        let dt_iri = compactor.decode_sid(dtc.datatype())?;
+        if !is_inferable_datatype(&dt_iri) {
+            out.push_str(r#" datatype=""#);
+            escape_attr_into(&dt_iri, out);
+            out.push('"');
         }
     }
+    out.push('>');
+
+    match val {
+        FlakeValue::String(v) => escape_text_into(v, out),
+        FlakeValue::Long(n) => {
+            let mut buf = itoa::Buffer::new();
+            out.push_str(buf.format(*n));
+        }
+        FlakeValue::Double(d) => write_double(out, *d),
+        FlakeValue::Boolean(b) => out.push_str(if *b { "true" } else { "false" }),
+        FlakeValue::Vector(v) => {
+            let value = serde_json::to_string(v).unwrap_or_else(|_| "[]".to_string());
+            escape_text_into(&value, out);
+        }
+        FlakeValue::Json(json_str) => escape_text_into(json_str, out),
+        FlakeValue::Ref(_) => {
+            return Err(FormatError::InvalidBinding(
+                "Lit cannot contain Ref - expected Binding::Sid".to_string(),
+            ));
+        }
+        // Temporal / other scalar values: use Display + keep datatype.
+        other => escape_text_into(&other.to_string(), out),
+    }
+
+    out.push_str("</literal>");
+    Ok(())
+}
+
+/// Write an `xsd:double` lexical value, preserving the special-value spellings.
+fn write_double(out: &mut String, d: f64) {
+    if d.is_nan() {
+        out.push_str("NaN");
+    } else if d.is_infinite() {
+        out.push_str(if d.is_sign_positive() { "INF" } else { "-INF" });
+    } else {
+        out.push_str(&d.to_string());
+    }
+}
+
+/// Cartesian-expand a row containing `Grouped` columns into multiple `<result>`
+/// elements (one per combination), preserving the original disaggregation order
+/// where the first grouped column varies slowest. Returns whether any row was
+/// written (an empty grouped column drops the source row, matching prior
+/// behavior). `cells` is aligned with `head_names`; `None` entries are omitted.
+fn write_grouped_rows(
+    out: &mut String,
+    result: &QueryResult,
+    cells: &[Option<&Binding>],
+    head_names: &[String],
+    compactor: &IriCompactor,
+    gv: Option<&BinaryGraphView>,
+    select_one: bool,
+) -> Result<bool> {
+    // Collect grouped columns; an empty group means zero output rows.
+    let mut grouped: Vec<&[Binding]> = Vec::new();
+    for cell in cells {
+        if let Some(Binding::Grouped(values)) = cell {
+            if values.is_empty() {
+                return Ok(false);
+            }
+            grouped.push(values.as_slice());
+        }
+    }
+
+    let total: usize = grouped.iter().map(|v| v.len()).product();
+    let combos = if select_one { total.min(1) } else { total };
+
+    for combo in 0..combos {
+        // Mixed-radix decode: last grouped column varies fastest so the first
+        // varies slowest, matching the original nested-loop expansion order.
+        let mut picks = vec![0usize; grouped.len()];
+        let mut rem = combo;
+        for gi in (0..grouped.len()).rev() {
+            let r = grouped[gi].len();
+            picks[gi] = rem % r;
+            rem /= r;
+        }
+
+        out.push_str("<result>");
+        let mut gi = 0usize;
+        for (k, cell) in cells.iter().enumerate() {
+            match cell {
+                Some(Binding::Grouped(_)) => {
+                    let chosen = &grouped[gi][picks[gi]];
+                    gi += 1;
+                    write_binding_cell(out, result, chosen, &head_names[k], compactor, gv)?;
+                }
+                Some(binding) => {
+                    write_binding_cell(out, result, binding, &head_names[k], compactor, gv)?;
+                }
+                None => {} // absent column → Unbound → omitted
+            }
+        }
+        out.push_str("</result>");
+    }
+
+    Ok(combos > 0)
 }
 
 fn strip_question_mark(var_name: &str) -> String {
     var_name.strip_prefix('?').unwrap_or(var_name).to_string()
 }
-
-use super::xml_escape::{escape_attr_into, escape_text_into};
 
 #[cfg(test)]
 mod tests {
@@ -345,6 +445,9 @@ mod tests {
         let mut namespaces = HashMap::new();
         namespaces.insert(100, "http://example.org/".to_string());
         namespaces.insert(2, "http://www.w3.org/2001/XMLSchema#".to_string());
+        // BLANK_NODE (code 10) is registered with the "_:" prefix in production
+        // (default_namespace_codes); mirror that so blank-node Sids resolve.
+        namespaces.insert(fluree_vocab::namespaces::BLANK_NODE, "_:".to_string());
         IriCompactor::from_namespaces(std::sync::Arc::new(namespaces))
     }
 
@@ -390,5 +493,276 @@ mod tests {
         assert!(xml.contains(r#"<variable name="s"/>"#), "{xml}");
         assert!(xml.contains(r#"<binding name="s">"#), "{xml}");
         assert!(xml.contains("<uri>http://example.org/alice</uri>"), "{xml}");
+    }
+
+    // ------------------------------------------------------------------
+    // Direct-write rewrite coverage (previously untested invariants).
+    // ------------------------------------------------------------------
+
+    use std::sync::Arc;
+
+    fn make_result(var_names: &[&str], rows: Vec<Vec<Binding>>) -> QueryResult {
+        let mut vars = VarRegistry::new();
+        let var_ids: Vec<fluree_db_query::VarId> =
+            var_names.iter().map(|&n| vars.get_or_insert(n)).collect();
+        let mut columns: Vec<Vec<Binding>> = vec![Vec::new(); var_ids.len()];
+        for row in rows {
+            for (col, b) in row.into_iter().enumerate() {
+                columns[col].push(b);
+            }
+        }
+        let batch = Batch::new(Arc::from(var_ids.clone().into_boxed_slice()), columns).unwrap();
+        QueryResult {
+            vars,
+            t: Some(0),
+            novelty: None,
+            context: fluree_graph_json_ld::ParsedContext::default(),
+            orig_context: None,
+            output: fluree_db_query::ir::QueryOutput::select_all(var_ids),
+            batches: vec![batch],
+            binary_graph: None,
+        }
+    }
+
+    fn fmt(result: &QueryResult, compactor: &IriCompactor) -> String {
+        format(result, compactor, &FormatterConfig::sparql_xml()).unwrap()
+    }
+
+    #[test]
+    fn inferable_datatype_omitted_string() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?v"],
+            vec![vec![Binding::lit(
+                FlakeValue::String("Alice".to_string()),
+                Sid::new(2, "string"),
+            )]],
+        );
+        let xml = fmt(&r, &c);
+        // xsd:string is inferable → no datatype attribute, just the value.
+        assert!(xml.contains("<literal>Alice</literal>"), "{xml}");
+    }
+
+    #[test]
+    fn inferable_datatype_omitted_long() {
+        let c = make_test_compactor();
+        // xsd:long is inferable, so XML omits the datatype (value-type agnostic,
+        // unlike SPARQL-JSON which always carries datatype on numerics).
+        let r = make_result(
+            &["?v"],
+            vec![vec![Binding::lit(
+                FlakeValue::Long(42),
+                Sid::new(2, "long"),
+            )]],
+        );
+        let xml = fmt(&r, &c);
+        assert!(xml.contains("<literal>42</literal>"), "{xml}");
+    }
+
+    #[test]
+    fn non_inferable_datatype_present_date() {
+        let c = make_test_compactor();
+        // xsd:date is NOT inferable → the datatype attribute must be emitted.
+        let r = make_result(
+            &["?v"],
+            vec![vec![Binding::lit(
+                FlakeValue::String("2024-01-15".to_string()),
+                Sid::new(2, "date"),
+            )]],
+        );
+        let xml = fmt(&r, &c);
+        assert!(
+            xml.contains(
+                r#"<literal datatype="http://www.w3.org/2001/XMLSchema#date">2024-01-15</literal>"#
+            ),
+            "{xml}"
+        );
+    }
+
+    #[test]
+    fn language_tag_wins_over_datatype() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?v"],
+            vec![vec![Binding::lit_lang(
+                FlakeValue::String("Bonjour".to_string()),
+                "fr",
+            )]],
+        );
+        let xml = fmt(&r, &c);
+        assert!(
+            xml.contains(r#"<literal xml:lang="fr">Bonjour</literal>"#),
+            "{xml}"
+        );
+        assert!(!xml.contains("datatype="), "{xml}");
+    }
+
+    #[test]
+    fn blank_node_stripped_and_framed() {
+        let c = make_test_compactor();
+        // EMPTY namespace (code 0) carries the verbatim IRI, here a `_:` label.
+        let r = make_result(&["?v"], vec![vec![Binding::sid(Sid::new(0, "_:b1"))]]);
+        let xml = fmt(&r, &c);
+        assert!(xml.contains("<bnode>b1</bnode>"), "{xml}");
+        assert!(!xml.contains("<uri>"), "{xml}");
+    }
+
+    #[test]
+    fn blank_node_registered_namespace_code() {
+        // The real encoding: a blank node lands in the registered BLANK_NODE
+        // namespace (prefix "_:"), so `namespace_prefix` returns Some("_:").
+        // This must still frame as <bnode>, not <uri>.
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?v"],
+            vec![vec![Binding::sid(Sid::new(
+                fluree_vocab::namespaces::BLANK_NODE,
+                "b1",
+            ))]],
+        );
+        let xml = fmt(&r, &c);
+        assert!(xml.contains("<bnode>b1</bnode>"), "{xml}");
+        assert!(!xml.contains("<uri>"), "{xml}");
+    }
+
+    #[test]
+    fn double_special_values() {
+        let c = make_test_compactor();
+        for (d, expected) in [
+            (f64::NAN, "NaN"),
+            (f64::INFINITY, "INF"),
+            (f64::NEG_INFINITY, "-INF"),
+        ] {
+            let r = make_result(
+                &["?v"],
+                vec![vec![Binding::lit(
+                    FlakeValue::Double(d),
+                    Sid::new(2, "double"),
+                )]],
+            );
+            let xml = fmt(&r, &c);
+            assert!(xml.contains(&format!(">{expected}</literal>")), "{xml}");
+        }
+    }
+
+    #[test]
+    fn unbound_binding_is_omitted() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?a", "?b"],
+            vec![vec![Binding::sid(Sid::new(100, "x")), Binding::Unbound]],
+        );
+        let xml = fmt(&r, &c);
+        assert!(xml.contains(r#"<binding name="a">"#), "{xml}");
+        // Unbound ?b must not produce a <binding> element.
+        assert!(!xml.contains(r#"<binding name="b">"#), "{xml}");
+    }
+
+    #[test]
+    fn head_vars_sorted_lexicographically() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?zebra", "?apple"],
+            vec![vec![
+                Binding::sid(Sid::new(100, "z")),
+                Binding::sid(Sid::new(100, "a")),
+            ]],
+        );
+        let xml = fmt(&r, &c);
+        let apple = xml.find(r#"<variable name="apple"/>"#).unwrap();
+        let zebra = xml.find(r#"<variable name="zebra"/>"#).unwrap();
+        assert!(apple < zebra, "head vars must be sorted: {xml}");
+    }
+
+    #[test]
+    fn xml_special_chars_escaped_in_value() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?v"],
+            vec![vec![Binding::lit(
+                FlakeValue::String("a & b < c > d".to_string()),
+                Sid::new(2, "string"),
+            )]],
+        );
+        let xml = fmt(&r, &c);
+        assert!(xml.contains("a &amp; b &lt; c &gt; d"), "{xml}");
+    }
+
+    #[test]
+    fn grouped_disaggregates_in_cartesian_order() {
+        let c = make_test_compactor();
+        // Two grouped columns; first (sorted) var must vary slowest.
+        let r = make_result(
+            &["?a", "?b"],
+            vec![vec![
+                Binding::Grouped(vec![
+                    Binding::lit(FlakeValue::Long(10), Sid::new(2, "long")),
+                    Binding::lit(FlakeValue::Long(20), Sid::new(2, "long")),
+                ]),
+                Binding::Grouped(vec![
+                    Binding::lit(FlakeValue::Long(1), Sid::new(2, "long")),
+                    Binding::lit(FlakeValue::Long(2), Sid::new(2, "long")),
+                ]),
+            ]],
+        );
+        let xml = fmt(&r, &c);
+        // Expect 4 <result> rows in order (a=10,b=1),(a=10,b=2),(a=20,b=1),(a=20,b=2).
+        assert_eq!(xml.matches("<result>").count(), 4, "{xml}");
+        let results_section = &xml[xml.find("<results>").unwrap()..];
+        let blocks: Vec<&str> = results_section
+            .split("<result>")
+            .skip(1)
+            .map(|s| s.split("</result>").next().unwrap())
+            .collect();
+        assert_eq!(blocks.len(), 4);
+        let pairs: Vec<(i64, i64)> = blocks
+            .iter()
+            .map(|blk| (seg_val(blk, "a"), seg_val(blk, "b")))
+            .collect();
+        assert_eq!(pairs, vec![(10, 1), (10, 2), (20, 1), (20, 2)], "{xml}");
+    }
+
+    /// Extract the integer literal value of `<binding name="{name}">…</binding>`.
+    fn seg_val(blk: &str, name: &str) -> i64 {
+        let start = blk.find(&format!(r#"<binding name="{name}">"#)).unwrap();
+        let seg = &blk[start..];
+        // Skip to the end of the <literal ...> opening tag, then read until '<'.
+        let lit = &seg[seg.find("<literal").unwrap()..];
+        let val_start = &lit[lit.find('>').unwrap() + 1..];
+        let val_end = val_start.find('<').unwrap();
+        val_start[..val_end].parse().unwrap()
+    }
+
+    #[test]
+    fn select_one_emits_single_result() {
+        let c = make_test_compactor();
+        let mut r = make_result(
+            &["?s"],
+            vec![
+                vec![Binding::sid(Sid::new(100, "a"))],
+                vec![Binding::sid(Sid::new(100, "b"))],
+                vec![Binding::sid(Sid::new(100, "c"))],
+            ],
+        );
+        let s_var = r.vars.get_or_insert("?s");
+        r.output = fluree_db_query::ir::QueryOutput::select_one(vec![s_var]);
+        let xml = fmt(&r, &c);
+        assert_eq!(xml.matches("<result>").count(), 1, "{xml}");
+        assert!(xml.contains("<uri>http://example.org/a</uri>"), "{xml}");
+    }
+
+    #[test]
+    fn iri_binding_full_iri_no_compaction() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?g"],
+            vec![vec![Binding::Iri(Arc::from("http://example.org/graph1"))]],
+        );
+        let xml = fmt(&r, &c);
+        // XML uses the full IRI (no @vocab/@base compaction).
+        assert!(
+            xml.contains("<uri>http://example.org/graph1</uri>"),
+            "{xml}"
+        );
     }
 }

--- a/fluree-db-api/src/format/typed.rs
+++ b/fluree-db-api/src/format/typed.rs
@@ -17,7 +17,8 @@
 
 use super::config::FormatterConfig;
 use super::iri::IriCompactor;
-use super::{FormatError, Result};
+use super::json_write::{push_bool, push_f64, push_i64, push_json_string, push_value};
+use super::{materialize, FormatError, Result};
 use crate::QueryResult;
 use fluree_db_core::FlakeValue;
 use fluree_db_query::binding::Binding;
@@ -63,6 +64,242 @@ pub fn format(
         Ok(rows.into_iter().next().unwrap_or(JsonValue::Null))
     } else {
         Ok(JsonValue::Array(rows))
+    }
+}
+
+/// Stream TypedJson directly into a `String`, byte-identical to
+/// `serde_json::to_string(&format(...))` for the non-`select_one` SELECT case.
+///
+/// `select_one`, ASK, CONSTRUCT, and `pretty` are routed through the DOM path by
+/// the caller and never reach here.
+pub fn format_string(
+    result: &QueryResult,
+    compactor: &IriCompactor,
+    _config: &FormatterConfig,
+) -> Result<String> {
+    debug_assert!(
+        !result.output.is_select_one(),
+        "format_string is only for the non-select_one path; select_one routes through the DOM"
+    );
+
+    let is_wildcard = result.output.is_wildcard();
+    let select_vars = result.output.projected_vars_or_empty();
+
+    let cols_hint = if is_wildcard {
+        result.batches.first().map_or(0, |b| b.schema().len())
+    } else {
+        select_vars.len()
+    };
+    let est = (result.row_count() + 1)
+        .saturating_mul(cols_hint.max(1))
+        .saturating_mul(48)
+        .saturating_add(16);
+    let mut out = String::with_capacity(est);
+
+    out.push('[');
+    let mut first_row = true;
+    for batch in &result.batches {
+        // Precompute the column index for each projected var once per batch.
+        let cols: Vec<Option<usize>> = if is_wildcard {
+            Vec::new()
+        } else {
+            let schema = batch.schema();
+            select_vars
+                .iter()
+                .map(|&v| schema.iter().position(|&sv| sv == v))
+                .collect()
+        };
+
+        for row_idx in 0..batch.len() {
+            if !first_row {
+                out.push(',');
+            }
+            first_row = false;
+
+            out.push('{');
+            if is_wildcard {
+                let mut first = true;
+                for (col_idx, &var_id) in batch.schema().iter().enumerate() {
+                    let binding = batch.get_by_col(row_idx, col_idx);
+                    if matches!(binding, Binding::Unbound | Binding::Poisoned) {
+                        continue;
+                    }
+                    let name = result.vars.name(var_id);
+                    if name.starts_with("?__") {
+                        continue;
+                    }
+                    if !first {
+                        out.push(',');
+                    }
+                    first = false;
+                    push_json_string(&mut out, name);
+                    out.push(':');
+                    write_value(&mut out, result, binding, compactor)?;
+                }
+            } else {
+                for (i, &var_id) in select_vars.iter().enumerate() {
+                    if i > 0 {
+                        out.push(',');
+                    }
+                    push_json_string(&mut out, result.vars.name(var_id));
+                    out.push(':');
+                    match cols[i] {
+                        Some(col) => write_value(
+                            &mut out,
+                            result,
+                            batch.get_by_col(row_idx, col),
+                            compactor,
+                        )?,
+                        None => out.push_str("null"),
+                    }
+                }
+            }
+            out.push('}');
+        }
+    }
+    out.push(']');
+    Ok(out)
+}
+
+/// Write a single TypedJson value (the per-cell `{...}` / `null` / `[...]`),
+/// matching [`format_binding`] but streamed into `out`.
+fn write_value(
+    out: &mut String,
+    result: &QueryResult,
+    binding: &Binding,
+    compactor: &IriCompactor,
+) -> Result<()> {
+    if binding.is_encoded() {
+        let materialized = materialize::materialize_binding(result, binding)?;
+        return write_value(out, result, &materialized, compactor);
+    }
+
+    match binding {
+        Binding::Unbound | Binding::Poisoned => out.push_str("null"),
+        Binding::Sid { sid, .. } => {
+            out.push_str(r#"{"@id":"#);
+            push_json_string(out, &compactor.compact_id_sid(sid)?);
+            out.push('}');
+        }
+        Binding::IriMatch { iri, .. } => {
+            out.push_str(r#"{"@id":"#);
+            push_json_string(out, &compactor.compact_id_iri(iri));
+            out.push('}');
+        }
+        Binding::Iri(iri) => {
+            out.push_str(r#"{"@id":"#);
+            push_json_string(out, iri.as_ref());
+            out.push('}');
+        }
+        Binding::Lit { val, dtc, .. } => write_lit(out, val, dtc, compactor)?,
+        Binding::Grouped(values) => {
+            out.push('[');
+            for (i, v) in values.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_value(out, result, v, compactor)?;
+            }
+            out.push(']');
+        }
+        Binding::EncodedLit { .. } | Binding::EncodedSid { .. } | Binding::EncodedPid { .. } => {
+            unreachable!("encoded bindings are materialized before write_value")
+        }
+    }
+    Ok(())
+}
+
+/// Write a TypedJson literal value. Mirrors the DOM `format_binding` Lit arm,
+/// including computing the compacted datatype up front (so a decode error
+/// surfaces even on the `@json` / null paths, exactly as the DOM does).
+fn write_lit(
+    out: &mut String,
+    val: &FlakeValue,
+    dtc: &fluree_db_core::DatatypeConstraint,
+    compactor: &IriCompactor,
+) -> Result<()> {
+    let dt_iri = compactor.compact_sid(dtc.datatype())?;
+
+    match val {
+        FlakeValue::String(s) => {
+            out.push_str(r#"{"@value":"#);
+            push_json_string(out, s);
+            if let Some(lang) = dtc.lang_tag() {
+                out.push_str(r#","@language":"#);
+                push_json_string(out, lang);
+            } else {
+                out.push_str(r#","@type":"#);
+                push_json_string(out, &dt_iri);
+            }
+            out.push('}');
+        }
+        FlakeValue::Long(n) => {
+            out.push_str(r#"{"@value":"#);
+            push_i64(out, *n);
+            out.push_str(r#","@type":"#);
+            push_json_string(out, &dt_iri);
+            out.push('}');
+        }
+        FlakeValue::Double(d) => {
+            out.push_str(r#"{"@value":"#);
+            if d.is_nan() {
+                push_json_string(out, "NaN");
+            } else if d.is_infinite() {
+                push_json_string(out, if d.is_sign_positive() { "INF" } else { "-INF" });
+            } else {
+                push_f64(out, *d);
+            }
+            out.push_str(r#","@type":"#);
+            push_json_string(out, &dt_iri);
+            out.push('}');
+        }
+        FlakeValue::Boolean(b) => {
+            out.push_str(r#"{"@value":"#);
+            push_bool(out, *b);
+            out.push_str(r#","@type":"#);
+            push_json_string(out, &dt_iri);
+            out.push('}');
+        }
+        FlakeValue::Vector(v) => {
+            // Rare leaf: serialize the float array via serde for exact parity.
+            out.push_str(r#"{"@value":"#);
+            push_value(out, &json!(v))?;
+            out.push_str(r#","@type":"#);
+            push_json_string(out, &dt_iri);
+            out.push('}');
+        }
+        FlakeValue::Json(json_str) => {
+            let json_val: JsonValue = serde_json::from_str(json_str).map_err(|e| {
+                FormatError::InvalidBinding(format!("Invalid JSON in @json value: {e}"))
+            })?;
+            out.push_str(r#"{"@value":"#);
+            push_value(out, &json_val)?;
+            out.push_str(r#","@type":"@json"}"#);
+        }
+        FlakeValue::Null => out.push_str("null"),
+        FlakeValue::Ref(_) => {
+            return Err(FormatError::InvalidBinding(
+                "Binding::Lit invariant violated: contains Ref".to_string(),
+            ));
+        }
+        // Extended numeric + temporal types: stringified value with @type.
+        other => {
+            out.push_str(r#"{"@value":"#);
+            push_json_string(out, &stringified(other));
+            out.push_str(r#","@type":"#);
+            push_json_string(out, &dt_iri);
+            out.push('}');
+        }
+    }
+    Ok(())
+}
+
+/// The `.to_string()` lexical form the DOM uses for BigInt/Decimal/temporal/Geo.
+fn stringified(val: &FlakeValue) -> String {
+    match val {
+        FlakeValue::BigInt(n) => n.to_string(),
+        FlakeValue::Decimal(d) => d.to_string(),
+        other => other.to_string(),
     }
 }
 
@@ -466,6 +703,171 @@ mod tests {
                 {"@value": 2, "@type": "http://www.w3.org/2001/XMLSchema#long"}
             ])
         );
+    }
+
+    // ------------------------------------------------------------------
+    // Streaming `format_string` parity with the DOM `format` + serde_json.
+    // ------------------------------------------------------------------
+
+    use fluree_db_query::var_registry::VarRegistry;
+    use std::sync::Arc;
+
+    fn make_result(var_names: &[&str], rows: Vec<Vec<Binding>>) -> QueryResult {
+        let mut vars = VarRegistry::new();
+        let var_ids: Vec<fluree_db_query::VarId> =
+            var_names.iter().map(|&n| vars.get_or_insert(n)).collect();
+        let mut columns: Vec<Vec<Binding>> = vec![Vec::new(); var_ids.len()];
+        for row in rows {
+            for (col, b) in row.into_iter().enumerate() {
+                columns[col].push(b);
+            }
+        }
+        let batch = fluree_db_query::binding::Batch::new(
+            Arc::from(var_ids.clone().into_boxed_slice()),
+            columns,
+        )
+        .unwrap();
+        QueryResult {
+            vars,
+            t: Some(0),
+            novelty: None,
+            context: crate::ParsedContext::default(),
+            orig_context: None,
+            output: crate::QueryOutput::select_all(var_ids),
+            batches: vec![batch],
+            binary_graph: None,
+        }
+    }
+
+    fn assert_parity(result: &QueryResult, compactor: &IriCompactor) {
+        let dom = format(result, compactor, &FormatterConfig::typed_json()).unwrap();
+        let want = serde_json::to_string(&dom).unwrap();
+        let got = format_string(result, compactor, &FormatterConfig::typed_json()).unwrap();
+        assert_eq!(got, want, "streaming TypedJson diverged from DOM");
+    }
+
+    #[test]
+    fn parity_scalar_terms() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?id", "?s", "?n", "?d", "?b", "?lang", "?date"],
+            vec![vec![
+                Binding::sid(Sid::new(100, "alice")),
+                Binding::lit(
+                    FlakeValue::String("A \"quoted\"\tval".to_string()),
+                    Sid::new(2, "string"),
+                ),
+                Binding::lit(FlakeValue::Long(-42), Sid::new(2, "long")),
+                Binding::lit(FlakeValue::Double(3.13), Sid::new(2, "double")),
+                Binding::lit(FlakeValue::Boolean(false), Sid::new(2, "boolean")),
+                Binding::lit_lang(FlakeValue::String("Hola".to_string()), "es"),
+                Binding::lit(
+                    FlakeValue::String("2024-01-15".to_string()),
+                    Sid::new(2, "date"),
+                ),
+            ]],
+        );
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_double_special_and_large() {
+        let c = make_test_compactor();
+        for d in [
+            3.13_f64,
+            1e30,
+            1e-7,
+            -0.0,
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ] {
+            let r = make_result(
+                &["?d"],
+                vec![vec![Binding::lit(
+                    FlakeValue::Double(d),
+                    Sid::new(2, "double"),
+                )]],
+            );
+            assert_parity(&r, &c);
+        }
+    }
+
+    #[test]
+    fn parity_unbound_emits_null_and_multi_row() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?a", "?b"],
+            vec![
+                vec![Binding::sid(Sid::new(100, "a")), Binding::Unbound],
+                vec![
+                    Binding::Unbound,
+                    Binding::lit(FlakeValue::Long(2), Sid::new(2, "long")),
+                ],
+            ],
+        );
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_wildcard_and_grouped() {
+        let c = make_test_compactor();
+        let mut r = make_result(
+            &["?s", "?g"],
+            vec![vec![
+                Binding::sid(Sid::new(100, "a")),
+                Binding::Grouped(vec![
+                    Binding::lit(FlakeValue::Long(1), Sid::new(2, "long")),
+                    Binding::lit(FlakeValue::Long(2), Sid::new(2, "long")),
+                ]),
+            ]],
+        );
+        r.output = crate::QueryOutput::select_all(vec![]); // wildcard
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_json_and_vector() {
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?j", "?v"],
+            vec![vec![
+                Binding::lit(
+                    FlakeValue::Json(r#"{"k":[1,2],"s":"x"}"#.to_string()),
+                    Sid::new(3, "JSON"),
+                ),
+                Binding::lit(
+                    FlakeValue::Vector(vec![1.0, 2.5, -3.0]),
+                    Sid::new(2, "double"),
+                ),
+            ]],
+        );
+        assert_parity(&r, &c);
+    }
+
+    #[test]
+    fn parity_extended_value_types() {
+        use fluree_db_core::coerce::coerce_string_value;
+        use fluree_vocab::xsd;
+        let c = make_test_compactor();
+        let r = make_result(
+            &["?big", "?dec", "?dt"],
+            vec![vec![
+                Binding::lit(
+                    coerce_string_value("99999999999999999999999999", xsd::INTEGER).unwrap(),
+                    Sid::new(2, "integer"),
+                ),
+                Binding::lit(
+                    coerce_string_value("3.14159265358979", xsd::DECIMAL).unwrap(),
+                    Sid::new(2, "decimal"),
+                ),
+                Binding::lit(
+                    coerce_string_value("2024-01-15T10:30:00Z", xsd::DATE_TIME).unwrap(),
+                    Sid::new(2, "dateTime"),
+                ),
+            ]],
+        );
+        assert_parity(&r, &c);
     }
 
     #[test]

--- a/fluree-db-api/src/format/xml_escape.rs
+++ b/fluree-db-api/src/format/xml_escape.rs
@@ -4,49 +4,70 @@
 //! All other control characters (U+0000–U+001F, U+007F, U+0080–U+009F minus
 //! the three allowed) are silently stripped to produce valid XML output.
 
-/// Returns `true` if `ch` is allowed in XML 1.0 character data.
-///
-/// Per XML 1.0 §2.2: `#x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]`
-#[inline]
-fn is_xml_char(ch: char) -> bool {
-    matches!(ch,
-        '\u{09}' | '\u{0A}' | '\u{0D}' |
-        '\u{20}'..='\u{D7FF}' |
-        '\u{E000}'..='\u{FFFD}' |
-        '\u{10000}'..='\u{10FFFF}'
-    )
-}
-
 /// Escape text content for XML elements (`&`, `<`, `>`).
 ///
 /// Forbidden XML 1.0 control characters are silently stripped.
 pub fn escape_text_into(input: &str, out: &mut String) {
-    for ch in input.chars() {
-        match ch {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            _ if is_xml_char(ch) => out.push(ch),
-            _ => {} // strip forbidden control characters
-        }
-    }
+    escape_into(input, out, false);
 }
 
 /// Escape attribute values for XML (`&`, `<`, `>`, `"`, `'`).
 ///
 /// Forbidden XML 1.0 control characters are silently stripped.
 pub fn escape_attr_into(input: &str, out: &mut String) {
-    for ch in input.chars() {
-        match ch {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&apos;"),
-            _ if is_xml_char(ch) => out.push(ch),
-            _ => {} // strip forbidden control characters
-        }
+    escape_into(input, out, true);
+}
+
+/// Byte-scan escaper shared by text and attribute escaping.
+///
+/// Runs of bytes that need neither escaping nor stripping are bulk-copied with a
+/// single `push_str` rather than decoded and re-pushed char-by-char. Every UTF-8
+/// continuation/lead byte (`>= 0x80`) falls into that common path, so multibyte
+/// characters are copied verbatim without per-char decoding — only the handful of
+/// ASCII metacharacters and the forbidden control points are handled specially.
+///
+/// The set of stripped code points exactly matches the previous `is_xml_char`
+/// gate (XML 1.0 §2.2 `#x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] |
+/// [#x10000-#x10FFFF]`):
+/// - C0 controls other than tab/LF/CR (`0x00-0x08`, `0x0B`, `0x0C`, `0x0E-0x1F`).
+/// - The non-characters U+FFFE / U+FFFF (`EF BF BE` / `EF BF BF`) — the only
+///   non-ASCII scalar values the production rejects. (C1 controls U+0080-U+009F
+///   and DEL U+007F are *valid* in XML 1.0 and are kept verbatim.)
+#[inline]
+fn escape_into(input: &str, out: &mut String, escape_quotes: bool) {
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    out.reserve(len);
+    let mut clean_start = 0usize;
+    let mut i = 0usize;
+    while i < len {
+        // `(advance, replacement)`: how many bytes the special run consumes and
+        // what to emit in its place (empty string = strip).
+        let (advance, replacement): (usize, &str) = match bytes[i] {
+            b'&' => (1, "&amp;"),
+            b'<' => (1, "&lt;"),
+            b'>' => (1, "&gt;"),
+            b'"' if escape_quotes => (1, "&quot;"),
+            b'\'' if escape_quotes => (1, "&apos;"),
+            // C0 controls except tab/LF/CR are forbidden in XML 1.0 → strip.
+            0x00..=0x08 | 0x0B | 0x0C | 0x0E..=0x1F => (1, ""),
+            // U+FFFE / U+FFFF → strip (valid UTF-8 always has the two
+            // continuation bytes, so the bounds check only guards truncation).
+            0xEF if i + 2 < len && bytes[i + 1] == 0xBF && matches!(bytes[i + 2], 0xBE | 0xBF) => {
+                (3, "")
+            }
+            // Everything else (incl. all multibyte UTF-8) is copied verbatim.
+            _ => {
+                i += 1;
+                continue;
+            }
+        };
+        out.push_str(&input[clean_start..i]);
+        out.push_str(replacement);
+        i += advance;
+        clean_start = i;
     }
+    out.push_str(&input[clean_start..]);
 }
 
 #[cfg(test)]
@@ -80,5 +101,76 @@ mod tests {
         let mut out = String::new();
         escape_attr_into("a\"b'c", &mut out);
         assert_eq!(out, "a&quot;b&apos;c");
+    }
+
+    #[test]
+    fn keeps_multibyte_and_c1_and_del() {
+        // Multibyte (é, €, 𝄞), C1 control (U+0085 NEL), and DEL (U+007F) are all
+        // valid XML 1.0 and must pass through unescaped and unstripped.
+        let input = "é€𝄞\u{0085}\u{007F}x";
+        let mut out = String::new();
+        escape_text_into(input, &mut out);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn strips_only_fffe_ffff_noncharacters() {
+        // U+FFFE and U+FFFF are the only non-ASCII scalar values XML 1.0 rejects.
+        let mut out = String::new();
+        escape_text_into("a\u{FFFE}b\u{FFFF}c", &mut out);
+        assert_eq!(out, "abc");
+        // ...but the adjacent valid non-character U+FFFD (replacement char) stays.
+        let mut out2 = String::new();
+        escape_text_into("a\u{FFFD}b", &mut out2);
+        assert_eq!(out2, "a\u{FFFD}b");
+    }
+
+    #[test]
+    fn escape_into_matches_legacy_char_scan() {
+        // Property check: the byte-scan must agree with the original per-char
+        // implementation across a tricky mix of specials, controls, and multibyte.
+        fn legacy(input: &str, escape_quotes: bool) -> String {
+            fn is_xml_char(ch: char) -> bool {
+                matches!(ch,
+                    '\u{09}' | '\u{0A}' | '\u{0D}'
+                    | '\u{20}'..='\u{D7FF}'
+                    | '\u{E000}'..='\u{FFFD}'
+                    | '\u{10000}'..='\u{10FFFF}')
+            }
+            let mut out = String::new();
+            for ch in input.chars() {
+                match ch {
+                    '&' => out.push_str("&amp;"),
+                    '<' => out.push_str("&lt;"),
+                    '>' => out.push_str("&gt;"),
+                    '"' if escape_quotes => out.push_str("&quot;"),
+                    '\'' if escape_quotes => out.push_str("&apos;"),
+                    _ if is_xml_char(ch) => out.push(ch),
+                    _ => {}
+                }
+            }
+            out
+        }
+
+        let samples = [
+            "plain http://example.org/Path#frag",
+            "a&b<c>d\"e'f",
+            "tabs\tand\nnewlines\r\u{0B}vtab\u{0C}ff\u{1F}us",
+            "null\u{0}byte\u{8}bs",
+            "unicode é € 𝄞 \u{0085} \u{007F} \u{00A0}",
+            "noncharacter \u{FFFE}\u{FFFF} and \u{FFFD}",
+            "",
+        ];
+        for s in samples {
+            for eq in [false, true] {
+                let mut got = String::new();
+                escape_into(s, &mut got, eq);
+                assert_eq!(
+                    got,
+                    legacy(s, eq),
+                    "mismatch for {s:?} (escape_quotes={eq})"
+                );
+            }
+        }
     }
 }

--- a/fluree-db-api/src/view/types.rs
+++ b/fluree-db-api/src/view/types.rs
@@ -514,8 +514,11 @@ impl GraphDb {
     /// Returns `None` if no binary store is attached.
     pub fn binary_graph(&self) -> Option<BinaryGraphView> {
         self.binary_store.as_ref().map(|store| {
+            // `namespaces_arc()` is a refcount bump on the snapshot's already-Arc
+            // namespace table; `namespaces().clone()` would deep-copy the whole map
+            // on every query (a dominant per-query cost on large ledgers).
             BinaryGraphView::new(store.clone(), self.graph_id)
-                .with_namespace_codes_fallback(Some(Arc::new(self.snapshot.namespaces().clone())))
+                .with_namespace_codes_fallback(Some(self.snapshot.namespaces_arc()))
         })
     }
 }

--- a/fluree-db-api/tests/it_query_datatype.rs
+++ b/fluree-db-api/tests/it_query_datatype.rs
@@ -10,7 +10,7 @@
 
 mod support;
 
-use fluree_db_api::FlureeBuilder;
+use fluree_db_api::{FlureeBuilder, QueryInput};
 use serde_json::{json, Value as JsonValue};
 use support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
@@ -1351,5 +1351,111 @@ async fn float_typed_integer_values_survive_indexing() {
     assert!(
         (revenue2 - 2_500_000.75).abs() < 0.01,
         "revenue2 should be 2500000.75, got {revenue2}"
+    );
+}
+
+/// Inline `xsd:integer` / `xsd:double` objects are emitted as
+/// `EncodedLit(NUM_INT/NUM_F64)` on the binary-scan path (commit 2f45f10f3),
+/// not materialized `Lit`. This test drives the INDEXED path (so the
+/// binary-scan / batched-join decode runs, not the novelty path) and checks the
+/// encoded values still round-trip through projection, DISTINCT (dedup), numeric
+/// FILTER, SUM, and DATATYPE.
+#[tokio::test]
+async fn indexed_inline_numerics_roundtrip_through_distinct_filter_sum() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "nums:main");
+    let ctx = ctx_datatype();
+    fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx,
+                "@graph": [
+                    {"@id":"ex:a","ex:age":10,"ex:score":1.5},
+                    {"@id":"ex:b","ex:age":10,"ex:score":2.5},
+                    {"@id":"ex:c","ex:age":20,"ex:score":1.5},
+                    {"@id":"ex:d","ex:age":30,"ex:score":3.5}
+                ]
+            }),
+        )
+        .await
+        .expect("insert");
+    // Build + publish the binary index, then open the indexed view so queries
+    // take the binary-scan path rather than pure novelty.
+    support::rebuild_and_publish_index(&fluree, "nums:main").await;
+    let view = fluree.db("nums:main").await.expect("indexed view");
+
+    async fn rows(
+        fluree: &MemoryFluree,
+        view: &fluree_db_api::GraphDb,
+        sparql: &str,
+    ) -> Vec<JsonValue> {
+        let res = fluree
+            .query(view, QueryInput::Sparql(sparql))
+            .await
+            .expect("sparql query");
+        normalize_rows(&res.to_jsonld(&view.snapshot).expect("to_jsonld"))
+    }
+    const P: &str = "PREFIX ex: <http://example.org/ns/>\n";
+
+    // Projection: integer values decode correctly (with the duplicate present).
+    assert_eq!(
+        rows(
+            &fluree,
+            &view,
+            &format!("{P} SELECT ?age WHERE {{ ?s ex:age ?age }} ORDER BY ?age")
+        )
+        .await,
+        normalize_rows(&json!([[10], [10], [20], [30]]))
+    );
+    // DISTINCT dedups the duplicate integer (EncodedLit hash/eq on o_key).
+    assert_eq!(
+        rows(
+            &fluree,
+            &view,
+            &format!("{P} SELECT DISTINCT ?age WHERE {{ ?s ex:age ?age }} ORDER BY ?age")
+        )
+        .await,
+        normalize_rows(&json!([[10], [20], [30]]))
+    );
+    // Numeric FILTER over the encoded value.
+    assert_eq!(
+        rows(
+            &fluree,
+            &view,
+            &format!("{P} SELECT ?age WHERE {{ ?s ex:age ?age FILTER(?age > 15) }} ORDER BY ?age")
+        )
+        .await,
+        normalize_rows(&json!([[20], [30]]))
+    );
+    // SUM aggregate (10 + 10 + 20 + 30).
+    assert_eq!(
+        rows(
+            &fluree,
+            &view,
+            &format!("{P} SELECT (SUM(?age) AS ?t) WHERE {{ ?s ex:age ?age }}")
+        )
+        .await,
+        normalize_rows(&json!([[70]]))
+    );
+    // DATATYPE round-trips to xsd:integer (dt_id resolves back to the o_type).
+    assert_eq!(
+        rows(
+            &fluree,
+            &view,
+            &format!("{P} SELECT DISTINCT (DATATYPE(?age) AS ?dt) WHERE {{ ?s ex:age ?age }}")
+        )
+        .await,
+        normalize_rows(&json!([["xsd:integer"]]))
+    );
+    // Inline doubles encode (NUM_F64) and DISTINCT-dedup too.
+    assert_eq!(
+        rows(
+            &fluree,
+            &view,
+            &format!("{P} SELECT DISTINCT ?score WHERE {{ ?s ex:score ?score }} ORDER BY ?score")
+        )
+        .await,
+        normalize_rows(&json!([[1.5], [2.5], [3.5]]))
     );
 }

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -52,7 +52,9 @@ pub mod scan_stats {
 
     /// Reset all counters (e.g. before measuring a specific workload).
     pub fn reset() {
-        for c in [&CALLS, &VISITED, &SKIPPED, &EMPTY, &RETURNED, &ROWS, &FILTERED] {
+        for c in [
+            &CALLS, &VISITED, &SKIPPED, &EMPTY, &RETURNED, &ROWS, &FILTERED,
+        ] {
             c.store(0, Relaxed);
         }
         NEXT_LOG_AT.store(1 << 18, Relaxed);

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -27,84 +27,6 @@ use super::replay::{batch_has_rows_above_t, replay_leaflet};
 use crate::format::column_block::ColumnId;
 
 // ============================================================================
-// Scan loop diagnostics
-// ============================================================================
-
-/// Process-cumulative counters for the per-leaflet scan loop ([`BinaryCursor::next_batch`]).
-///
-/// `next_batch`'s flamegraph self-time dominates Explore but has no informative
-/// child frames, so inference can't say whether it's leaflet **breadth**
-/// (visited ≫ returned), row **volume** (rows/returned), **filtering**, or
-/// per-call **overhead** (returned/calls). These ratios disambiguate it directly.
-/// Relaxed atomics; logged on a doubling `visited` schedule so it surfaces a
-/// handful of times per run without spamming.
-pub mod scan_stats {
-    use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
-
-    pub static CALLS: AtomicU64 = AtomicU64::new(0);
-    pub static VISITED: AtomicU64 = AtomicU64::new(0);
-    pub static SKIPPED: AtomicU64 = AtomicU64::new(0);
-    pub static EMPTY: AtomicU64 = AtomicU64::new(0);
-    pub static RETURNED: AtomicU64 = AtomicU64::new(0);
-    pub static ROWS: AtomicU64 = AtomicU64::new(0);
-    pub static FILTERED: AtomicU64 = AtomicU64::new(0);
-    static NEXT_LOG_AT: AtomicU64 = AtomicU64::new(1 << 18);
-
-    /// Reset all counters (e.g. before measuring a specific workload).
-    pub fn reset() {
-        for c in [
-            &CALLS, &VISITED, &SKIPPED, &EMPTY, &RETURNED, &ROWS, &FILTERED,
-        ] {
-            c.store(0, Relaxed);
-        }
-        NEXT_LOG_AT.store(1 << 18, Relaxed);
-    }
-
-    /// `(calls, visited, returned, rows, skipped, empty, filtered)`.
-    pub fn snapshot() -> (u64, u64, u64, u64, u64, u64, u64) {
-        (
-            CALLS.load(Relaxed),
-            VISITED.load(Relaxed),
-            RETURNED.load(Relaxed),
-            ROWS.load(Relaxed),
-            SKIPPED.load(Relaxed),
-            EMPTY.load(Relaxed),
-            FILTERED.load(Relaxed),
-        )
-    }
-
-    /// Log the ratios once `visited` crosses the next doubling threshold.
-    #[inline]
-    pub(super) fn maybe_log() {
-        let visited = VISITED.load(Relaxed);
-        let at = NEXT_LOG_AT.load(Relaxed);
-        if visited < at
-            || NEXT_LOG_AT
-                .compare_exchange(at, at.saturating_mul(2), Relaxed, Relaxed)
-                .is_err()
-        {
-            return;
-        }
-        let (calls, _v, ret, rows, skip, empty, filt) = snapshot();
-        let r = |a: u64, b: u64| if b == 0 { 0.0 } else { a as f64 / b as f64 };
-        tracing::info!(
-            target: "fluree_db_binary_index::scan",
-            calls,
-            visited,
-            returned = ret,
-            rows,
-            skipped = skip,
-            empty,
-            filtered = filt,
-            visited_per_returned = r(visited, ret),
-            rows_per_returned = r(rows, ret),
-            returned_per_call = r(ret, calls),
-            "binary scan leaflet-loop stats"
-        );
-    }
-}
-
-// ============================================================================
 // BinaryCursor
 // ============================================================================
 
@@ -342,8 +264,6 @@ impl BinaryCursor {
     /// Returns `None` when all leaflets in all leaves are exhausted
     /// (and overlay-only ops have been emitted).
     pub fn next_batch(&mut self) -> io::Result<Option<ColumnBatch>> {
-        use std::sync::atomic::Ordering::Relaxed;
-        scan_stats::CALLS.fetch_add(1, Relaxed);
         loop {
             if self.exhausted {
                 return Ok(None);
@@ -355,13 +275,11 @@ impl BinaryCursor {
                 while self.current_leaflet_idx < leaf.handle.dir().entries.len() {
                     let entry = &leaf.handle.dir().entries[self.current_leaflet_idx];
                     self.current_leaflet_idx += 1;
-                    scan_stats::VISITED.fetch_add(1, Relaxed);
 
                     // Pre-skip by directory metadata (only when no overlay —
                     // overlay merge may add rows to otherwise-skippable leaflets).
                     let has_ov = self.has_overlay();
                     if !has_ov && self.filter.skip_leaflet(entry.p_const, entry.o_type_const) {
-                        scan_stats::SKIPPED.fetch_add(1, Relaxed);
                         continue;
                     }
                     // An empty-after-retract leaflet (`row_count == 0`) is preserved
@@ -373,7 +291,6 @@ impl BinaryCursor {
                         && entry.history_len > 0
                         && entry.history_max_t > to_t_u32;
                     if entry.row_count == 0 && !has_ov && !needs_history_replay {
-                        scan_stats::EMPTY.fetch_add(1, Relaxed);
                         continue;
                     }
 
@@ -390,7 +307,6 @@ impl BinaryCursor {
                             &entry.last_key,
                         )
                     {
-                        scan_stats::SKIPPED.fetch_add(1, Relaxed);
                         continue;
                     }
 
@@ -458,7 +374,6 @@ impl BinaryCursor {
                     let batch = if self.filter.is_empty() || batch.is_empty() {
                         batch
                     } else {
-                        scan_stats::FILTERED.fetch_add(1, Relaxed);
                         filter_batch(&self.filter, &batch)
                     };
 
@@ -475,7 +390,6 @@ impl BinaryCursor {
                     };
 
                     if batch.is_empty() {
-                        scan_stats::EMPTY.fetch_add(1, Relaxed);
                         continue;
                     }
 
@@ -491,9 +405,6 @@ impl BinaryCursor {
                     }
 
                     // Put the leaf back before returning.
-                    scan_stats::RETURNED.fetch_add(1, Relaxed);
-                    scan_stats::ROWS.fetch_add(batch.row_count as u64, Relaxed);
-                    scan_stats::maybe_log();
                     self.current_leaf = Some(leaf);
                     return Ok(Some(batch));
                 }

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -22,7 +22,7 @@ use crate::read::types::{cmp_row_vs_overlay, OverlayOp};
 
 use super::binary_index_store::BinaryIndexStore;
 use super::column_loader::load_columns_cached_via_handle;
-use super::column_types::{BinaryFilter, ColumnBatch, ColumnData, ColumnProjection};
+use super::column_types::{BinaryFilter, ColumnBatch, ColumnData, ColumnProjection, ColumnSet};
 use super::replay::{batch_has_rows_above_t, replay_leaflet};
 use crate::format::column_block::ColumnId;
 
@@ -198,6 +198,38 @@ impl BinaryCursor {
         self.to_t < self.store.max_t()
     }
 
+    /// Columns to decode for the current leaflet (projection-aware).
+    ///
+    /// Trusts the cursor's `projection` (which already carries output + internal
+    /// filter/order columns, exactly as the no-cache decode path consumes it),
+    /// but widens it defensively so a narrowed decode can never starve a
+    /// downstream read:
+    /// - `has_ov`: the overlay merge reads every base column → decode ALL.
+    /// - non-empty filter: `filter_batch` reads s/p/o_type/o_key/o_i (mostly
+    ///   `Const`/absent, so free to include).
+    /// - `need_replay`: leaflet replay reads `t`.
+    ///
+    /// For a plain current-time scan this drops `t` (and any other unprojected
+    /// column), so its `Block` is neither decoded nor allocated. The leaflet
+    /// cache keys on this set, keeping narrow and full batches distinct.
+    fn leaflet_decode_set(&self, has_ov: bool) -> ColumnSet {
+        if has_ov {
+            return ColumnSet::ALL;
+        }
+        let mut set = self.projection.effective();
+        if !self.filter.is_empty() {
+            set.insert(ColumnId::SId);
+            set.insert(ColumnId::OKey);
+            set.insert(ColumnId::PId);
+            set.insert(ColumnId::OType);
+            set.insert(ColumnId::OI);
+        }
+        if self.need_replay() {
+            set.insert(ColumnId::T);
+        }
+        set
+    }
+
     /// Whether any overlay ops remain globally (for overlay-only path).
     fn has_any_overlay(&self) -> bool {
         self.overlay_pos < self.overlay_ops.len()
@@ -265,22 +297,28 @@ impl BinaryCursor {
                     // Load columns via LeafHandle (cached when LeafletCache is available).
                     let mut batch = if entry.row_count > 0 {
                         let leaflet_idx = self.current_leaflet_idx - 1;
+                        let decode_set = self.leaflet_decode_set(has_ov);
                         if let Some(cache) = self.store.leaflet_cache() {
                             load_columns_cached_via_handle(
                                 leaf.handle.as_ref(),
-                                leaflet_idx,
-                                self.order,
                                 cache,
-                                leaf.handle.leaf_id(),
-                                u32::try_from(leaflet_idx).map_err(|_| {
-                                    std::io::Error::other(format!(
-                                        "leaflet index {leaflet_idx} exceeds u32::MAX"
-                                    ))
-                                })?,
+                                super::column_loader::LeafletDecodeSpec {
+                                    leaf_id: leaf.handle.leaf_id(),
+                                    leaflet_idx: u32::try_from(leaflet_idx).map_err(|_| {
+                                        std::io::Error::other(format!(
+                                            "leaflet index {leaflet_idx} exceeds u32::MAX"
+                                        ))
+                                    })?,
+                                    order: self.order,
+                                    decode_set,
+                                },
                             )?
                         } else {
-                            leaf.handle
-                                .load_columns(leaflet_idx, &self.projection, self.order)?
+                            let proj = ColumnProjection {
+                                output: decode_set,
+                                internal: ColumnSet::EMPTY,
+                            };
+                            leaf.handle.load_columns(leaflet_idx, &proj, self.order)?
                         }
                     } else {
                         ColumnBatch::empty()

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -27,6 +27,74 @@ use super::replay::{batch_has_rows_above_t, replay_leaflet};
 use crate::format::column_block::ColumnId;
 
 // ============================================================================
+// Scan loop diagnostics
+// ============================================================================
+
+/// Process-cumulative counters for the per-leaflet scan loop ([`BinaryCursor::next_batch`]).
+///
+/// `next_batch`'s flamegraph self-time dominates Explore but has no informative
+/// child frames, so inference can't say whether it's leaflet **breadth**
+/// (visited ≫ returned), row **volume** (rows/returned), **filtering**, or
+/// per-call **overhead** (returned/calls). These ratios disambiguate it directly.
+/// Relaxed atomics; logged on a doubling `visited` schedule so it surfaces a
+/// handful of times per run without spamming.
+pub mod scan_stats {
+    use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+
+    pub static CALLS: AtomicU64 = AtomicU64::new(0);
+    pub static VISITED: AtomicU64 = AtomicU64::new(0);
+    pub static SKIPPED: AtomicU64 = AtomicU64::new(0);
+    pub static EMPTY: AtomicU64 = AtomicU64::new(0);
+    pub static RETURNED: AtomicU64 = AtomicU64::new(0);
+    pub static ROWS: AtomicU64 = AtomicU64::new(0);
+    pub static FILTERED: AtomicU64 = AtomicU64::new(0);
+    static NEXT_LOG_AT: AtomicU64 = AtomicU64::new(1 << 26);
+
+    /// `(calls, visited, returned, rows, skipped, empty, filtered)`.
+    pub fn snapshot() -> (u64, u64, u64, u64, u64, u64, u64) {
+        (
+            CALLS.load(Relaxed),
+            VISITED.load(Relaxed),
+            RETURNED.load(Relaxed),
+            ROWS.load(Relaxed),
+            SKIPPED.load(Relaxed),
+            EMPTY.load(Relaxed),
+            FILTERED.load(Relaxed),
+        )
+    }
+
+    /// Log the ratios once `visited` crosses the next doubling threshold.
+    #[inline]
+    pub(super) fn maybe_log() {
+        let visited = VISITED.load(Relaxed);
+        let at = NEXT_LOG_AT.load(Relaxed);
+        if visited < at
+            || NEXT_LOG_AT
+                .compare_exchange(at, at.saturating_mul(2), Relaxed, Relaxed)
+                .is_err()
+        {
+            return;
+        }
+        let (calls, _v, ret, rows, skip, empty, filt) = snapshot();
+        let r = |a: u64, b: u64| if b == 0 { 0.0 } else { a as f64 / b as f64 };
+        tracing::info!(
+            target: "fluree_db_binary_index::scan",
+            calls,
+            visited,
+            returned = ret,
+            rows,
+            skipped = skip,
+            empty,
+            filtered = filt,
+            visited_per_returned = r(visited, ret),
+            rows_per_returned = r(rows, ret),
+            returned_per_call = r(ret, calls),
+            "binary scan leaflet-loop stats"
+        );
+    }
+}
+
+// ============================================================================
 // BinaryCursor
 // ============================================================================
 
@@ -264,6 +332,8 @@ impl BinaryCursor {
     /// Returns `None` when all leaflets in all leaves are exhausted
     /// (and overlay-only ops have been emitted).
     pub fn next_batch(&mut self) -> io::Result<Option<ColumnBatch>> {
+        use std::sync::atomic::Ordering::Relaxed;
+        scan_stats::CALLS.fetch_add(1, Relaxed);
         loop {
             if self.exhausted {
                 return Ok(None);
@@ -275,11 +345,13 @@ impl BinaryCursor {
                 while self.current_leaflet_idx < leaf.handle.dir().entries.len() {
                     let entry = &leaf.handle.dir().entries[self.current_leaflet_idx];
                     self.current_leaflet_idx += 1;
+                    scan_stats::VISITED.fetch_add(1, Relaxed);
 
                     // Pre-skip by directory metadata (only when no overlay —
                     // overlay merge may add rows to otherwise-skippable leaflets).
                     let has_ov = self.has_overlay();
                     if !has_ov && self.filter.skip_leaflet(entry.p_const, entry.o_type_const) {
+                        scan_stats::SKIPPED.fetch_add(1, Relaxed);
                         continue;
                     }
                     // An empty-after-retract leaflet (`row_count == 0`) is preserved
@@ -291,6 +363,7 @@ impl BinaryCursor {
                         && entry.history_len > 0
                         && entry.history_max_t > to_t_u32;
                     if entry.row_count == 0 && !has_ov && !needs_history_replay {
+                        scan_stats::EMPTY.fetch_add(1, Relaxed);
                         continue;
                     }
 
@@ -358,6 +431,7 @@ impl BinaryCursor {
                     let batch = if self.filter.is_empty() || batch.is_empty() {
                         batch
                     } else {
+                        scan_stats::FILTERED.fetch_add(1, Relaxed);
                         filter_batch(&self.filter, &batch)
                     };
 
@@ -374,6 +448,7 @@ impl BinaryCursor {
                     };
 
                     if batch.is_empty() {
+                        scan_stats::EMPTY.fetch_add(1, Relaxed);
                         continue;
                     }
 
@@ -389,6 +464,9 @@ impl BinaryCursor {
                     }
 
                     // Put the leaf back before returning.
+                    scan_stats::RETURNED.fetch_add(1, Relaxed);
+                    scan_stats::ROWS.fetch_add(batch.row_count as u64, Relaxed);
+                    scan_stats::maybe_log();
                     self.current_leaf = Some(leaf);
                     return Ok(Some(batch));
                 }

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -48,7 +48,15 @@ pub mod scan_stats {
     pub static RETURNED: AtomicU64 = AtomicU64::new(0);
     pub static ROWS: AtomicU64 = AtomicU64::new(0);
     pub static FILTERED: AtomicU64 = AtomicU64::new(0);
-    static NEXT_LOG_AT: AtomicU64 = AtomicU64::new(1 << 26);
+    static NEXT_LOG_AT: AtomicU64 = AtomicU64::new(1 << 18);
+
+    /// Reset all counters (e.g. before measuring a specific workload).
+    pub fn reset() {
+        for c in [&CALLS, &VISITED, &SKIPPED, &EMPTY, &RETURNED, &ROWS, &FILTERED] {
+            c.store(0, Relaxed);
+        }
+        NEXT_LOG_AT.store(1 << 18, Relaxed);
+    }
 
     /// `(calls, visited, returned, rows, skipped, empty, filtered)`.
     pub fn snapshot() -> (u64, u64, u64, u64, u64, u64, u64) {

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -375,6 +375,23 @@ impl BinaryCursor {
                         continue;
                     }
 
+                    // Key-range pre-skip: drop leaflets whose [first_key, last_key]
+                    // provably cannot contain a row matching the filter's bound
+                    // order-leading prefix, before paying any decode + per-row
+                    // filter. Same safety guards as the metadata skip above
+                    // (no overlay merge; no time-travel history replay).
+                    if !has_ov
+                        && !needs_history_replay
+                        && self.filter.leaflet_out_of_range(
+                            self.order,
+                            &entry.first_key,
+                            &entry.last_key,
+                        )
+                    {
+                        scan_stats::SKIPPED.fetch_add(1, Relaxed);
+                        continue;
+                    }
+
                     // Load columns via LeafHandle (cached when LeafletCache is available).
                     let mut batch = if entry.row_count > 0 {
                         let leaflet_idx = self.current_leaflet_idx - 1;

--- a/fluree-db-binary-index/src/read/column_loader.rs
+++ b/fluree-db-binary-index/src/read/column_loader.rs
@@ -7,7 +7,7 @@
 use std::io;
 use std::sync::Arc;
 
-use super::column_types::{ColumnBatch, ColumnData, ColumnProjection};
+use super::column_types::{ColumnBatch, ColumnData, ColumnProjection, ColumnSet};
 use crate::format::column_block::{
     decode_column_u16, decode_column_u32, decode_column_u64, ColumnBlockRef, ColumnId,
 };
@@ -192,37 +192,70 @@ pub fn load_leaflet_columns(
     })
 }
 
+/// Identity + decode policy for a cached leaflet column load.
+///
+/// Bundles the content-addressed key components (`leaf_id`, `leaflet_idx`, and
+/// the `decode_set` column bitmask), the leaf's sort order, and which columns to
+/// decode — keeping the loader signatures small. Distinct `decode_set`s cache
+/// under distinct keys, so a narrow batch is never served where a wider one is
+/// needed.
+#[derive(Clone, Copy)]
+pub struct LeafletDecodeSpec {
+    /// `xxh3_128(leaf_cid)` — content-addressed, self-invalidating.
+    pub leaf_id: u128,
+    /// Leaflet slot within the leaf.
+    pub leaflet_idx: u32,
+    /// Sort order of the leaf being decoded.
+    pub order: RunSortOrder,
+    /// Columns to decode (and the cache-key column dimension). Must cover
+    /// everything applied downstream — output projection, filter columns, `t`
+    /// for replay, and ALL when an overlay merge will run.
+    pub decode_set: ColumnSet,
+}
+
+impl LeafletDecodeSpec {
+    #[inline]
+    fn key(&self) -> super::leaflet_cache::V3BatchCacheKey {
+        super::leaflet_cache::V3BatchCacheKey {
+            leaf_id: self.leaf_id,
+            leaflet_idx: self.leaflet_idx,
+            columns: self.decode_set.0,
+        }
+    }
+
+    #[inline]
+    fn projection(&self) -> ColumnProjection {
+        ColumnProjection {
+            output: self.decode_set,
+            internal: ColumnSet::EMPTY,
+        }
+    }
+}
+
 /// Load columns from a V3 leaflet with `LeafletCache` support.
 ///
 /// On cache hit, returns the previously decoded `ColumnBatch` directly (zero
-/// decompress cost). On miss, calls `load_leaflet_columns`, inserts the result
-/// into the cache, and returns it.
-///
-/// The cache key uses `(leaf_id, leaflet_idx)` — base columns are immutable
-/// (content-addressed leaf CID), so no `to_t`/`epoch` dimension is needed.
-/// Overlay merge and time-travel replay are applied downstream.
-///
-/// **Important**: this always decodes ALL columns (projection=all) so the cached
-/// batch can serve any subsequent projection. The per-column `ColumnData::Block`
-/// values are `Arc<[T]>` and cheap to clone.
+/// decompress cost). On miss, decodes only `spec.decode_set`, inserts the
+/// result, and returns it. The per-column `ColumnData::Block` values are
+/// `Arc<[T]>` and cheap to clone. The cache key carries the column set, so a
+/// query needing more columns misses and decodes its own wider entry rather
+/// than being served a narrow batch. Overlay merge and time-travel replay are
+/// applied downstream (callers must widen `decode_set` accordingly).
 pub fn load_leaflet_columns_cached(
     leaf_bytes: &[u8],
     entry: &LeafletDirEntryV3,
     payload_base: usize,
-    order: RunSortOrder,
     cache: &super::leaflet_cache::LeafletCache,
-    leaf_id: u128,
-    leaflet_idx: u32,
+    spec: LeafletDecodeSpec,
 ) -> io::Result<ColumnBatch> {
-    let key = super::leaflet_cache::V3BatchCacheKey {
-        leaf_id,
-        leaflet_idx,
-    };
-
-    cache.try_get_or_decode_v3_batch(key, || {
-        // Cache miss: decode ALL columns so the cached batch serves any projection.
-        let all = ColumnProjection::all();
-        load_leaflet_columns(leaf_bytes, entry, payload_base, &all, order)
+    cache.try_get_or_decode_v3_batch(spec.key(), || {
+        load_leaflet_columns(
+            leaf_bytes,
+            entry,
+            payload_base,
+            &spec.projection(),
+            spec.order,
+        )
     })
 }
 
@@ -232,24 +265,15 @@ pub fn load_leaflet_columns_cached(
 /// [`LeafHandle::load_columns()`] on cache miss. This works transparently for
 /// both local (`FullBlobLeafHandle`) and remote (`RangeReadLeafHandle`) access.
 ///
-/// Always decodes ALL columns on miss so the cached batch serves any projection.
+/// Projection-aware via `spec.decode_set` (see [`LeafletDecodeSpec`]).
 pub fn load_columns_cached_via_handle(
     handle: &dyn super::leaf_access::LeafHandle,
-    leaflet_idx: usize,
-    order: RunSortOrder,
     cache: &super::leaflet_cache::LeafletCache,
-    leaf_id: u128,
-    leaflet_idx_u32: u32,
+    spec: LeafletDecodeSpec,
 ) -> io::Result<ColumnBatch> {
-    let key = super::leaflet_cache::V3BatchCacheKey {
-        leaf_id,
-        leaflet_idx: leaflet_idx_u32,
-    };
-    let batch = cache.try_get_or_decode_v3_batch(key, || {
-        let all = ColumnProjection::all();
-        handle.load_columns(leaflet_idx, &all, order)
-    })?;
-    Ok(batch)
+    cache.try_get_or_decode_v3_batch(spec.key(), || {
+        handle.load_columns(spec.leaflet_idx as usize, &spec.projection(), spec.order)
+    })
 }
 
 // Re-export for convenience: callers use decode_leaf_dir_v3_with_base to get
@@ -470,9 +494,17 @@ mod tests {
         let handle = FullBlobLeafHandle::new(leaf_bytes, None, 123).unwrap();
         let cache = LeafletCache::with_max_mb(16);
 
-        let batch =
-            load_columns_cached_via_handle(&handle, 256, RunSortOrder::Post, &cache, 123, 256)
-                .unwrap();
+        let batch = load_columns_cached_via_handle(
+            &handle,
+            &cache,
+            LeafletDecodeSpec {
+                leaf_id: 123,
+                leaflet_idx: 256,
+                order: RunSortOrder::Post,
+                decode_set: ColumnSet::ALL,
+            },
+        )
+        .unwrap();
 
         assert_eq!(batch.row_count, 1);
         assert_eq!(batch.s_id.get(0), 257);
@@ -483,6 +515,7 @@ mod tests {
             .get_v3_batch(&crate::read::leaflet_cache::V3BatchCacheKey {
                 leaf_id: 123,
                 leaflet_idx: 256,
+                columns: ColumnSet::ALL.0,
             })
             .expect("cached batch for leaflet 256");
         assert_eq!(cached.s_id.get(0), 257);

--- a/fluree-db-binary-index/src/read/column_types.rs
+++ b/fluree-db-binary-index/src/read/column_types.rs
@@ -332,30 +332,34 @@ impl BinaryFilter {
         first_key: &[u8; ORDERED_KEY_V2_SIZE],
         last_key: &[u8; ORDERED_KEY_V2_SIZE],
     ) -> bool {
-        // Sort-column sequence per order (`o_type` precedes `o_key`; `t` and the
-        // identity tiebreaks are never bound, so they are not consulted).
+        // Sort-column sequence per order (`o_type` precedes `o_key`; `t` is not
+        // part of the V3 ordered key and is never consulted).
         let fields: &[SortField] = match order {
             RunSortOrder::Spot => &[
                 SortField::S,
                 SortField::P,
                 SortField::OType,
                 SortField::OKey,
+                SortField::OI,
             ],
             RunSortOrder::Psot => &[
                 SortField::P,
                 SortField::S,
                 SortField::OType,
                 SortField::OKey,
+                SortField::OI,
             ],
             RunSortOrder::Post => &[
                 SortField::P,
                 SortField::OType,
                 SortField::OKey,
+                SortField::OI,
                 SortField::S,
             ],
             RunSortOrder::Opst => &[
                 SortField::OType,
                 SortField::OKey,
+                SortField::OI,
                 SortField::P,
                 SortField::S,
             ],
@@ -368,11 +372,14 @@ impl BinaryFilter {
         let first = read_ordered_key_v2(order, first_key);
         let last = read_ordered_key_v2(order, last_key);
         for &f in fields {
-            let Some(v) = self.bound_value(f) else {
-                return false; // unbound column → deeper columns not range-bounded
-            };
             let fv = field_value(&first, f);
             let lv = field_value(&last, f);
+            let Some(v) = self.bound_value(f) else {
+                if fv != lv {
+                    return false; // unbound varying column → deeper columns not range-bounded
+                }
+                continue; // unbound but constant across this leaflet → safe to descend
+            };
             if v < fv || v > lv {
                 return true; // bound value outside the leaflet's range for this column
             }
@@ -391,17 +398,19 @@ impl BinaryFilter {
             SortField::P => self.p_id.map(u64::from),
             SortField::OType => self.o_type.map(u64::from),
             SortField::OKey => self.o_key,
+            SortField::OI => self.o_i.map(u64::from),
         }
     }
 }
 
-/// A primary sort column (the permutation members; `t`/identity tiebreaks excluded).
+/// A V3 ordered-key sort column (`t` excluded).
 #[derive(Clone, Copy)]
 enum SortField {
     S,
     P,
     OType,
     OKey,
+    OI,
 }
 
 #[inline]
@@ -411,6 +420,7 @@ fn field_value(rec: &RunRecordV2, f: SortField) -> u64 {
         SortField::P => u64::from(rec.p_id),
         SortField::OType => u64::from(rec.o_type),
         SortField::OKey => rec.o_key,
+        SortField::OI => u64::from(rec.o_i),
     }
 }
 
@@ -442,6 +452,8 @@ impl ColumnProjection {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::format::run_record_v2::write_ordered_key_v2;
+    use fluree_db_core::subject_id::SubjectId;
 
     #[test]
     fn column_data_const() {
@@ -517,5 +529,85 @@ mod tests {
         assert!(filter.skip_leaflet(Some(6), None));
         // no p_const → can't skip
         assert!(!filter.skip_leaflet(None, None));
+    }
+
+    fn ordered_key(
+        order: RunSortOrder,
+        s_id: u64,
+        p_id: u32,
+        o_type: u16,
+        o_key: u64,
+        o_i: u32,
+    ) -> [u8; ORDERED_KEY_V2_SIZE] {
+        let rec = RunRecordV2 {
+            s_id: SubjectId(s_id),
+            o_key,
+            p_id,
+            t: 0,
+            o_i,
+            o_type,
+            g_id: 0,
+        };
+        let mut key = [0u8; ORDERED_KEY_V2_SIZE];
+        write_ordered_key_v2(order, &rec, &mut key);
+        key
+    }
+
+    #[test]
+    fn leaflet_range_post_stops_before_subject_when_unbound_oi_varies() {
+        let first_key = ordered_key(RunSortOrder::Post, 100, 5, 7, 11, 0);
+        let last_key = ordered_key(RunSortOrder::Post, 1, 5, 7, 11, 1);
+        let filter = BinaryFilter {
+            p_id: Some(5),
+            o_type: Some(7),
+            o_key: Some(11),
+            s_id: Some(1),
+            ..Default::default()
+        };
+
+        assert!(!filter.leaflet_out_of_range(RunSortOrder::Post, &first_key, &last_key));
+    }
+
+    #[test]
+    fn leaflet_range_opst_stops_before_predicate_when_unbound_oi_varies() {
+        let first_key = ordered_key(RunSortOrder::Opst, 100, 100, 7, 11, 0);
+        let last_key = ordered_key(RunSortOrder::Opst, 1, 1, 7, 11, 1);
+        let filter = BinaryFilter {
+            o_type: Some(7),
+            o_key: Some(11),
+            p_id: Some(1),
+            ..Default::default()
+        };
+
+        assert!(!filter.leaflet_out_of_range(RunSortOrder::Opst, &first_key, &last_key));
+    }
+
+    #[test]
+    fn leaflet_range_post_descends_past_constant_unbound_oi() {
+        let first_key = ordered_key(RunSortOrder::Post, 10, 5, 7, 11, u32::MAX);
+        let last_key = ordered_key(RunSortOrder::Post, 20, 5, 7, 11, u32::MAX);
+        let filter = BinaryFilter {
+            p_id: Some(5),
+            o_type: Some(7),
+            o_key: Some(11),
+            s_id: Some(30),
+            ..Default::default()
+        };
+
+        assert!(filter.leaflet_out_of_range(RunSortOrder::Post, &first_key, &last_key));
+    }
+
+    #[test]
+    fn leaflet_range_opst_descends_past_constant_unbound_oi() {
+        let first_key = ordered_key(RunSortOrder::Opst, 10, 10, 7, 11, u32::MAX);
+        let last_key = ordered_key(RunSortOrder::Opst, 20, 20, 7, 11, u32::MAX);
+        let filter = BinaryFilter {
+            o_type: Some(7),
+            o_key: Some(11),
+            p_id: Some(30),
+            ..Default::default()
+        };
+
+        assert!(filter.leaflet_out_of_range(RunSortOrder::Opst, &first_key, &last_key));
     }
 }

--- a/fluree-db-binary-index/src/read/column_types.rs
+++ b/fluree-db-binary-index/src/read/column_types.rs
@@ -335,10 +335,30 @@ impl BinaryFilter {
         // Sort-column sequence per order (`o_type` precedes `o_key`; `t` and the
         // identity tiebreaks are never bound, so they are not consulted).
         let fields: &[SortField] = match order {
-            RunSortOrder::Spot => &[SortField::S, SortField::P, SortField::OType, SortField::OKey],
-            RunSortOrder::Psot => &[SortField::P, SortField::S, SortField::OType, SortField::OKey],
-            RunSortOrder::Post => &[SortField::P, SortField::OType, SortField::OKey, SortField::S],
-            RunSortOrder::Opst => &[SortField::OType, SortField::OKey, SortField::P, SortField::S],
+            RunSortOrder::Spot => &[
+                SortField::S,
+                SortField::P,
+                SortField::OType,
+                SortField::OKey,
+            ],
+            RunSortOrder::Psot => &[
+                SortField::P,
+                SortField::S,
+                SortField::OType,
+                SortField::OKey,
+            ],
+            RunSortOrder::Post => &[
+                SortField::P,
+                SortField::OType,
+                SortField::OKey,
+                SortField::S,
+            ],
+            RunSortOrder::Opst => &[
+                SortField::OType,
+                SortField::OKey,
+                SortField::P,
+                SortField::S,
+            ],
         };
         // Cheap bail before decoding the keys: nothing to prune if the leading
         // sort column is unbound.

--- a/fluree-db-binary-index/src/read/column_types.rs
+++ b/fluree-db-binary-index/src/read/column_types.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use crate::format::column_block::ColumnId;
 use crate::format::run_record::RunSortOrder;
+use crate::format::run_record_v2::{read_ordered_key_v2, RunRecordV2, ORDERED_KEY_V2_SIZE};
 
 // ============================================================================
 // ColumnData — per-column representation
@@ -304,6 +305,92 @@ impl BinaryFilter {
             }
         }
         false
+    }
+
+    /// True if a leaflet whose key range is `[first_key, last_key]` (encoded in
+    /// `order`) provably contains no row matching this filter — so it can be
+    /// skipped without decoding/loading.
+    ///
+    /// Sound pruning on the **order-leading contiguous bound prefix**: it walks
+    /// the order's sort columns and, for each *bound* column, requires the bound
+    /// value to fall within the leaflet's `[first, last]` range for that column
+    /// — but only while the higher columns are constant across the leaflet
+    /// (`first == last`), since a column is monotonic within the leaflet only
+    /// then. It stops at the first **unbound** sort column (deeper columns are
+    /// not range-bounded). This generalizes the OPST star-probe's
+    /// `first_key`/`last_key` reject to every order, and `o_type` precedes
+    /// `o_key` in all orders — so a bound `o_key` with a *wild* `o_type` (e.g.
+    /// untyped strings) prunes nothing beyond `skip_leaflet`, which is correct.
+    ///
+    /// CALLER CONTRACT: only invoke when `!has_overlay` (overlay asserts can add
+    /// rows to an otherwise-out-of-range base leaflet) and `!needs_history_replay`
+    /// (a row-count-0 leaflet's keys don't bound its time-travel rows). These are
+    /// the same guards `skip_leaflet` relies on.
+    pub fn leaflet_out_of_range(
+        &self,
+        order: RunSortOrder,
+        first_key: &[u8; ORDERED_KEY_V2_SIZE],
+        last_key: &[u8; ORDERED_KEY_V2_SIZE],
+    ) -> bool {
+        // Sort-column sequence per order (`o_type` precedes `o_key`; `t` and the
+        // identity tiebreaks are never bound, so they are not consulted).
+        let fields: &[SortField] = match order {
+            RunSortOrder::Spot => &[SortField::S, SortField::P, SortField::OType, SortField::OKey],
+            RunSortOrder::Psot => &[SortField::P, SortField::S, SortField::OType, SortField::OKey],
+            RunSortOrder::Post => &[SortField::P, SortField::OType, SortField::OKey, SortField::S],
+            RunSortOrder::Opst => &[SortField::OType, SortField::OKey, SortField::P, SortField::S],
+        };
+        // Cheap bail before decoding the keys: nothing to prune if the leading
+        // sort column is unbound.
+        if self.bound_value(fields[0]).is_none() {
+            return false;
+        }
+        let first = read_ordered_key_v2(order, first_key);
+        let last = read_ordered_key_v2(order, last_key);
+        for &f in fields {
+            let Some(v) = self.bound_value(f) else {
+                return false; // unbound column → deeper columns not range-bounded
+            };
+            let fv = field_value(&first, f);
+            let lv = field_value(&last, f);
+            if v < fv || v > lv {
+                return true; // bound value outside the leaflet's range for this column
+            }
+            if fv != lv {
+                return false; // column varies in the leaflet → cannot prune deeper
+            }
+            // column is constant at the bound value → descend to the next column
+        }
+        false
+    }
+
+    #[inline]
+    fn bound_value(&self, f: SortField) -> Option<u64> {
+        match f {
+            SortField::S => self.s_id,
+            SortField::P => self.p_id.map(u64::from),
+            SortField::OType => self.o_type.map(u64::from),
+            SortField::OKey => self.o_key,
+        }
+    }
+}
+
+/// A primary sort column (the permutation members; `t`/identity tiebreaks excluded).
+#[derive(Clone, Copy)]
+enum SortField {
+    S,
+    P,
+    OType,
+    OKey,
+}
+
+#[inline]
+fn field_value(rec: &RunRecordV2, f: SortField) -> u64 {
+    match f {
+        SortField::S => rec.s_id.as_u64(),
+        SortField::P => u64::from(rec.p_id),
+        SortField::OType => u64::from(rec.o_type),
+        SortField::OKey => rec.o_key,
     }
 }
 

--- a/fluree-db-binary-index/src/read/leaflet_cache.rs
+++ b/fluree-db-binary-index/src/read/leaflet_cache.rs
@@ -332,10 +332,6 @@ impl CachedEntry {
 /// `CacheKey` variants, so inserting R1 never evicts or implies R2.
 pub struct LeafletCache {
     inner: Cache<CacheKey, CachedEntry>,
-    /// V3 batch cache hit / miss counters (process-cumulative) for diagnosing
-    /// scan-bound workloads — is the scan thrashing the leaflet cache?
-    v3_hits: std::sync::atomic::AtomicU64,
-    v3_misses: std::sync::atomic::AtomicU64,
 }
 
 /// Run a moka single-flight call (`get_with`/`try_get_with`) under a Tokio
@@ -421,20 +417,7 @@ impl LeafletCache {
             .max_capacity(max_bytes)
             .build();
 
-        Self {
-            inner,
-            v3_hits: std::sync::atomic::AtomicU64::new(0),
-            v3_misses: std::sync::atomic::AtomicU64::new(0),
-        }
-    }
-
-    /// V3 batch cache `(hits, misses)` since process start. Hit rate =
-    /// `hits / (hits + misses)`; a low rate on a scan workload means the
-    /// working set exceeds the cache (thrashing) — decode cost is then a
-    /// capacity problem, not a per-decode one.
-    pub fn v3_hit_miss(&self) -> (u64, u64) {
-        use std::sync::atomic::Ordering::Relaxed;
-        (self.v3_hits.load(Relaxed), self.v3_misses.load(Relaxed))
+        Self { inner }
     }
 
     /// Create a new cache with the given maximum megabyte budget.
@@ -658,27 +641,9 @@ impl LeafletCache {
     where
         F: FnOnce() -> io::Result<super::column_types::ColumnBatch>,
     {
-        use std::sync::atomic::Ordering::Relaxed;
         // Fast path: a plain hit must not pay the block_in_place cost.
         if let Some(batch) = self.get_v3_batch(&key) {
-            self.v3_hits.fetch_add(1, Relaxed);
             return Ok(batch);
-        }
-        // Miss. (Counts lookups, not decodes: concurrent waiters on the same key
-        // single-flight one decode but each records a miss — fine for hit rate.)
-        let misses = self.v3_misses.fetch_add(1, Relaxed) + 1;
-        if misses.is_multiple_of(1_000_000) {
-            let hits = self.v3_hits.load(Relaxed);
-            let total = hits + misses;
-            tracing::info!(
-                target: "fluree_db_binary_index::leaflet_cache",
-                v3_hits = hits,
-                v3_misses = misses,
-                hit_rate_pct = 100.0 * hits as f64 / total as f64,
-                entries = self.inner.entry_count(),
-                weighted_bytes = self.inner.weighted_size(),
-                "leaflet v3 batch cache stats"
-            );
         }
         // Run the single-flight wait/init in a blocking region so a
         // waiter promotes a replacement worker (see in_blocking_region).

--- a/fluree-db-binary-index/src/read/leaflet_cache.rs
+++ b/fluree-db-binary-index/src/read/leaflet_cache.rs
@@ -202,6 +202,11 @@ pub struct V3BatchCacheKey {
     pub leaf_id: u128,
     /// Leaflet slot within the leaf (0..leaflet_count).
     pub leaflet_idx: u32,
+    /// `ColumnSet` bitmask of the columns decoded into this cached batch.
+    /// Projection-aware: a narrow batch (e.g. one decoded without the `t`
+    /// column for a current-time scan) caches under a different key than a full
+    /// decode, so it is never served to a query that needs the omitted column.
+    pub columns: u16,
 }
 
 // ============================================================================
@@ -327,6 +332,10 @@ impl CachedEntry {
 /// `CacheKey` variants, so inserting R1 never evicts or implies R2.
 pub struct LeafletCache {
     inner: Cache<CacheKey, CachedEntry>,
+    /// V3 batch cache hit / miss counters (process-cumulative) for diagnosing
+    /// scan-bound workloads — is the scan thrashing the leaflet cache?
+    v3_hits: std::sync::atomic::AtomicU64,
+    v3_misses: std::sync::atomic::AtomicU64,
 }
 
 /// Run a moka single-flight call (`get_with`/`try_get_with`) under a Tokio
@@ -412,7 +421,20 @@ impl LeafletCache {
             .max_capacity(max_bytes)
             .build();
 
-        Self { inner }
+        Self {
+            inner,
+            v3_hits: std::sync::atomic::AtomicU64::new(0),
+            v3_misses: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// V3 batch cache `(hits, misses)` since process start. Hit rate =
+    /// `hits / (hits + misses)`; a low rate on a scan workload means the
+    /// working set exceeds the cache (thrashing) — decode cost is then a
+    /// capacity problem, not a per-decode one.
+    pub fn v3_hit_miss(&self) -> (u64, u64) {
+        use std::sync::atomic::Ordering::Relaxed;
+        (self.v3_hits.load(Relaxed), self.v3_misses.load(Relaxed))
     }
 
     /// Create a new cache with the given maximum megabyte budget.
@@ -636,11 +658,29 @@ impl LeafletCache {
     where
         F: FnOnce() -> io::Result<super::column_types::ColumnBatch>,
     {
+        use std::sync::atomic::Ordering::Relaxed;
         // Fast path: a plain hit must not pay the block_in_place cost.
         if let Some(batch) = self.get_v3_batch(&key) {
+            self.v3_hits.fetch_add(1, Relaxed);
             return Ok(batch);
         }
-        // Miss: run the single-flight wait/init in a blocking region so a
+        // Miss. (Counts lookups, not decodes: concurrent waiters on the same key
+        // single-flight one decode but each records a miss — fine for hit rate.)
+        let misses = self.v3_misses.fetch_add(1, Relaxed) + 1;
+        if misses.is_multiple_of(1_000_000) {
+            let hits = self.v3_hits.load(Relaxed);
+            let total = hits + misses;
+            tracing::info!(
+                target: "fluree_db_binary_index::leaflet_cache",
+                v3_hits = hits,
+                v3_misses = misses,
+                hit_rate_pct = 100.0 * hits as f64 / total as f64,
+                entries = self.inner.entry_count(),
+                weighted_bytes = self.inner.weighted_size(),
+                "leaflet v3 batch cache stats"
+            );
+        }
+        // Run the single-flight wait/init in a blocking region so a
         // waiter promotes a replacement worker (see in_blocking_region).
         let result = in_blocking_region(|| {
             self.inner.try_get_with(CacheKey::V3Batch(key), || {

--- a/fluree-db-query/src/context.rs
+++ b/fluree-db-query/src/context.rs
@@ -749,6 +749,25 @@ impl<'a> ExecutionContext<'a> {
         dt_id: u16,
         lang_id: u16,
     ) -> Option<std::io::Result<fluree_db_core::FlakeValue>> {
+        use fluree_db_core::ids::DatatypeDictId;
+        use fluree_db_core::value_id::{ObjKey, ObjKind};
+        use fluree_db_core::FlakeValue;
+        // Inline numerics are self-contained in `o_key` — decode them directly
+        // rather than building a fresh BinaryGraphView per call (a per-row cost
+        // when filters/arithmetic touch encoded numeric literals). Gated on the
+        // standard integer/double dt_ids; other shapes (e.g. an integer-valued
+        // double stored as NUM_INT by novelty) fall through to the view path.
+        let okind = ObjKind::from_u8(o_kind);
+        if okind == ObjKind::NUM_INT
+            && (dt_id == DatatypeDictId::INTEGER.as_u16() || dt_id == DatatypeDictId::LONG.as_u16())
+        {
+            return Some(Ok(FlakeValue::Long(ObjKey::from_u64(o_key).decode_i64())));
+        }
+        if okind == ObjKind::NUM_F64
+            && (dt_id == DatatypeDictId::DOUBLE.as_u16() || dt_id == DatatypeDictId::FLOAT.as_u16())
+        {
+            return Some(Ok(FlakeValue::Double(ObjKey::from_u64(o_key).decode_f64())));
+        }
         let gv = self.graph_view()?;
         Some(gv.decode_value_from_kind(o_kind, o_key, p_id, dt_id, lang_id))
     }

--- a/fluree-db-query/src/context.rs
+++ b/fluree-db-query/src/context.rs
@@ -38,6 +38,14 @@ pub enum ConstSidKey {
     Iri(Box<str>),
     /// A constant SID: namespace code + name.
     Sid(u16, Box<str>),
+    /// Identity (address) of a variable-free operand expression, so its s_id can
+    /// be resolved once and reused without re-evaluating/re-encoding it per row.
+    ///
+    /// Safe as a key only because this memo lives exactly as long as the query
+    /// (and the expression tree it points into): the pointer is stable across
+    /// rows and the memo is dropped before any expression could be freed, so a
+    /// stale/reused address can never be observed.
+    ExprPtr(usize),
 }
 
 /// Per-query memo for constant subject-id resolution (see [`ConstSidKey`]).

--- a/fluree-db-query/src/context.rs
+++ b/fluree-db-query/src/context.rs
@@ -911,7 +911,14 @@ impl<'a> ExecutionContext<'a> {
             multi_ledger: false,
             eager_materialization: self.eager_materialization,
             original_snapshot: self.original_snapshot,
-            const_sid_cache: self.const_sid_cache.clone(),
+            // This per-graph context switches to `graph`'s own store/snapshot
+            // (see `binary_store`/`active_snapshot` above) while clearing
+            // `multi_ledger`, so the single-ledger const→s_id fast path DOES run
+            // here — against a different store than the parent. A fresh memo is
+            // mandatory: sharing the parent's would alias an s_id resolved in one
+            // graph/store into another. (`with_active_graph`/`with_default_graph`
+            // keep the same store, so they correctly share the parent's memo.)
+            const_sid_cache: ConstSidCache::default(),
         }
     }
 

--- a/fluree-db-query/src/context.rs
+++ b/fluree-db-query/src/context.rs
@@ -22,8 +22,30 @@ use crate::binary_range::BinaryRangeProvider;
 use fluree_db_spatial::SpatialIndexProvider;
 use fluree_vocab::namespaces::{FLUREE_DB, JSON_LD, OGC_GEO, RDF, XSD};
 use fluree_vocab::{geo_names, xsd_names};
+use rustc_hash::FxHashMap;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+
+/// Key for the per-query constant→`s_id` memo.
+///
+/// A FILTER like `<iri> != ?var` (or `sid != ?var`) resolves the constant side
+/// to an internal subject id via a dictionary reverse-lookup. That result is
+/// invariant across rows, so it is memoized once per query rather than redone
+/// per row (a dominant cost on selective-filter workloads such as BSBM Explore).
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum ConstSidKey {
+    /// A constant full IRI.
+    Iri(Box<str>),
+    /// A constant SID: namespace code + name.
+    Sid(u16, Box<str>),
+}
+
+/// Per-query memo for constant subject-id resolution (see [`ConstSidKey`]).
+///
+/// Owned by the [`ExecutionContext`], which holds exactly one store/snapshot, so
+/// the memo is correctly scoped — no cross-ledger aliasing. `Arc<Mutex<…>>` so
+/// derived per-graph contexts can share it and the context stays `Send + Sync`.
+pub type ConstSidCache = Arc<Mutex<FxHashMap<ConstSidKey, Option<u64>>>>;
 
 /// Map from `(graph_id, predicate_id, lang_id)` to fulltext BoW arenas used
 /// by `fulltext()` BM25 scoring.
@@ -162,6 +184,9 @@ pub struct ExecutionContext<'a> {
     /// SIDs — encoded in the original namespace space — can be decoded
     /// correctly (see `reencode_sid` in `build_match_val_for_snapshot`).
     pub original_snapshot: &'a LedgerSnapshot,
+    /// Per-query memo: constant filter operands → internal subject id, so a
+    /// `<const> != ?var` FILTER resolves the constant once, not per row.
+    pub const_sid_cache: ConstSidCache,
 }
 
 impl<'a> ExecutionContext<'a> {
@@ -197,6 +222,7 @@ impl<'a> ExecutionContext<'a> {
             multi_ledger: false,
             eager_materialization: false,
             original_snapshot: snapshot,
+            const_sid_cache: ConstSidCache::default(),
         }
     }
 
@@ -244,6 +270,7 @@ impl<'a> ExecutionContext<'a> {
             multi_ledger: false,
             eager_materialization: db.eager,
             original_snapshot: db.snapshot,
+            const_sid_cache: ConstSidCache::default(),
         }
     }
 
@@ -295,6 +322,7 @@ impl<'a> ExecutionContext<'a> {
             multi_ledger: false,
             eager_materialization: db.eager,
             original_snapshot: db.snapshot,
+            const_sid_cache: ConstSidCache::default(),
         }
     }
 
@@ -335,6 +363,7 @@ impl<'a> ExecutionContext<'a> {
             multi_ledger: false,
             eager_materialization: false,
             original_snapshot: snapshot,
+            const_sid_cache: ConstSidCache::default(),
         }
     }
 
@@ -374,6 +403,7 @@ impl<'a> ExecutionContext<'a> {
             multi_ledger: false,
             eager_materialization: false,
             original_snapshot: snapshot,
+            const_sid_cache: ConstSidCache::default(),
         }
     }
 
@@ -415,6 +445,7 @@ impl<'a> ExecutionContext<'a> {
             multi_ledger: false,
             eager_materialization: false,
             original_snapshot: snapshot,
+            const_sid_cache: ConstSidCache::default(),
         }
     }
 
@@ -782,6 +813,7 @@ impl<'a> ExecutionContext<'a> {
             multi_ledger,
             eager_materialization: self.eager_materialization,
             original_snapshot: self.original_snapshot,
+            const_sid_cache: self.const_sid_cache.clone(),
         }
     }
 
@@ -832,6 +864,7 @@ impl<'a> ExecutionContext<'a> {
             multi_ledger: Self::compute_multi_ledger(self.dataset, &ActiveGraph::Default),
             eager_materialization: self.eager_materialization,
             original_snapshot: self.original_snapshot,
+            const_sid_cache: self.const_sid_cache.clone(),
         }
     }
 
@@ -878,6 +911,7 @@ impl<'a> ExecutionContext<'a> {
             multi_ledger: false,
             eager_materialization: self.eager_materialization,
             original_snapshot: self.original_snapshot,
+            const_sid_cache: self.const_sid_cache.clone(),
         }
     }
 

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -2737,11 +2737,13 @@ fn execute_chain(
                         })?;
                         load_columns_cached_via_handle(
                             handle.as_ref(),
-                            idx,
-                            RunSortOrder::Psot,
                             cache,
-                            handle.leaf_id(),
-                            idx_u32,
+                            fluree_db_binary_index::read::column_loader::LeafletDecodeSpec {
+                                leaf_id: handle.leaf_id(),
+                                leaflet_idx: idx_u32,
+                                order: RunSortOrder::Psot,
+                                decode_set: fluree_db_binary_index::ColumnSet::ALL,
+                            },
                         )
                         .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
                     } else {

--- a/fluree-db-query/src/eval/compare.rs
+++ b/fluree-db-query/src/eval/compare.rs
@@ -75,18 +75,17 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
             return Ok(Some(false));
         };
 
-        // Single-ledger fast path: when both sides are subjects encoded by the
-        // binary index, their internal `s_id`s are directly comparable within a
-        // single ledger — so compare the ids and skip resolving EITHER side to
-        // an IRI string (and skip materializing the other side at all). This is
-        // the dominant cost of this fn (`resolve_subject_iri`). Cross-ledger
-        // `s_id`s are NOT comparable, so it is gated on `!is_multi_ledger`; all
-        // other shapes fall through to the IRI-string path below unchanged.
+        // Single-ledger fast path: when the bound side is a subject encoded by
+        // the binary index, its internal `s_id` is directly comparable to the
+        // other side's `s_id` within a single ledger — so compare ids and skip
+        // resolving to IRI strings. Cross-ledger `s_id`s are NOT comparable, so
+        // gated on `!is_multi_ledger`; everything else falls through unchanged.
         if !ctx.is_multi_ledger() {
-            if let Binding::EncodedSid { s_id: lhs_s_id, .. } = binding {
+            if let Binding::EncodedSid { s_id, .. } = binding {
+                // var = var: both sides EncodedSid → compare raw s_ids directly.
                 if let Expression::Var(ov) = other_expr {
                     if let Some(Binding::EncodedSid { s_id: rhs_s_id, .. }) = row.get(*ov) {
-                        let eq = lhs_s_id == rhs_s_id;
+                        let eq = s_id == rhs_s_id;
                         let out = match op {
                             CompareOp::Eq => eq,
                             CompareOp::Ne => !eq,
@@ -96,6 +95,55 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
                         return Ok(Some(out));
                     }
                 }
+
+                // var = const: a variable-free operand resolves to the same s_id
+                // on every row, so resolve it once and memoize by the operand
+                // expression's identity — skipping the per-row eval_to_comparable
+                // and IRI re-encode (`canonical_split` / namespace lookup). The
+                // memo is consulted by pointer first, so the (cheap) variable-free
+                // check only runs on the first row for each operand.
+                let key =
+                    crate::context::ConstSidKey::ExprPtr(other_expr as *const Expression as usize);
+                let resolved: Option<Option<u64>> = {
+                    let cached = ctx
+                        .const_sid_cache
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .get(&key)
+                        .copied();
+                    match cached {
+                        Some(v) => Some(v),
+                        None if other_expr.referenced_vars().is_empty() => {
+                            let v = match other_expr.eval_to_comparable(row, Some(ctx))? {
+                                Some(ComparableValue::Sid(sid)) => {
+                                    subject_ref_to_s_id(ctx.active_snapshot, store, &Ref::Sid(sid))?
+                                }
+                                Some(ComparableValue::Iri(iri)) => {
+                                    subject_ref_to_s_id(ctx.active_snapshot, store, &Ref::Iri(iri))?
+                                }
+                                _ => None,
+                            };
+                            ctx.const_sid_cache
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .insert(key, v);
+                            Some(v)
+                        }
+                        None => None,
+                    }
+                };
+                if let Some(Some(rhs_s_id)) = resolved {
+                    let eq = *s_id == rhs_s_id;
+                    let out = match op {
+                        CompareOp::Eq => eq,
+                        CompareOp::Ne => !eq,
+                        _ => unreachable!(),
+                    };
+                    log_fastpath_hit_once("EncodedSid-const");
+                    return Ok(Some(out));
+                }
+                // `Some(None)` (constant not an indexed subject) or `None`
+                // (operand has variables) both fall through to the paths below.
             }
         }
 

--- a/fluree-db-query/src/eval/compare.rs
+++ b/fluree-db-query/src/eval/compare.rs
@@ -17,7 +17,8 @@ use crate::binding::Binding;
 use crate::binding::RowAccess;
 use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
-use crate::ir::{CompareOp, Expression};
+use crate::fast_path_common::subject_ref_to_s_id;
+use crate::ir::{CompareOp, Expression, Ref};
 use fluree_db_core::FlakeValue;
 use std::cmp::Ordering;
 
@@ -104,6 +105,34 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
 
         match binding {
             Binding::EncodedSid { s_id, .. } => {
+                // Single-ledger fast path for `?var = <const IRI>` / `?var = Sid`
+                // (e.g. BSBM's `FILTER (<product> != ?p)`): reduce the constant
+                // side to its internal `s_id` and compare u64s, skipping the
+                // costly `resolve_subject_iri` string materialization of the
+                // bound side. Cross-ledger `s_id`s aren't comparable, so gate on
+                // `!is_multi_ledger`. A `None` reduction (subject not indexed, or
+                // an IRI-normalization mismatch) falls through to the IRI-string
+                // path below, which stays conservative.
+                if !ctx.is_multi_ledger() {
+                    let other_ref = match &other {
+                        ComparableValue::Sid(sid) => Some(Ref::Sid(sid.clone())),
+                        ComparableValue::Iri(iri) => Some(Ref::Iri(iri.clone())),
+                        _ => None,
+                    };
+                    if let Some(r) = other_ref {
+                        if let Some(rhs_s_id) = subject_ref_to_s_id(ctx.active_snapshot, store, &r)? {
+                            let eq = *s_id == rhs_s_id;
+                            let out = match op {
+                                CompareOp::Eq => eq,
+                                CompareOp::Ne => !eq,
+                                _ => unreachable!(),
+                            };
+                            log_fastpath_hit_once("EncodedSid-id");
+                            return Ok(Some(out));
+                        }
+                    }
+                }
+
                 let Some(lhs_iri) = ctx
                     .resolve_subject_iri(*s_id)
                     .transpose()

--- a/fluree-db-query/src/eval/compare.rs
+++ b/fluree-db-query/src/eval/compare.rs
@@ -74,6 +74,30 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
             return Ok(Some(false));
         };
 
+        // Single-ledger fast path: when both sides are subjects encoded by the
+        // binary index, their internal `s_id`s are directly comparable within a
+        // single ledger — so compare the ids and skip resolving EITHER side to
+        // an IRI string (and skip materializing the other side at all). This is
+        // the dominant cost of this fn (`resolve_subject_iri`). Cross-ledger
+        // `s_id`s are NOT comparable, so it is gated on `!is_multi_ledger`; all
+        // other shapes fall through to the IRI-string path below unchanged.
+        if !ctx.is_multi_ledger() {
+            if let Binding::EncodedSid { s_id: lhs_s_id, .. } = binding {
+                if let Expression::Var(ov) = other_expr {
+                    if let Some(Binding::EncodedSid { s_id: rhs_s_id, .. }) = row.get(*ov) {
+                        let eq = lhs_s_id == rhs_s_id;
+                        let out = match op {
+                            CompareOp::Eq => eq,
+                            CompareOp::Ne => !eq,
+                            _ => unreachable!(),
+                        };
+                        log_fastpath_hit_once("EncodedSid-id");
+                        return Ok(Some(out));
+                    }
+                }
+            }
+        }
+
         let Some(other) = other_expr.eval_to_comparable(row, Some(ctx))? else {
             return Ok(Some(false));
         };

--- a/fluree-db-query/src/eval/compare.rs
+++ b/fluree-db-query/src/eval/compare.rs
@@ -120,7 +120,8 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
                         _ => None,
                     };
                     if let Some(r) = other_ref {
-                        if let Some(rhs_s_id) = subject_ref_to_s_id(ctx.active_snapshot, store, &r)? {
+                        if let Some(rhs_s_id) = subject_ref_to_s_id(ctx.active_snapshot, store, &r)?
+                        {
                             let eq = *s_id == rhs_s_id;
                             let out = match op {
                                 CompareOp::Eq => eq,

--- a/fluree-db-query/src/eval/compare.rs
+++ b/fluree-db-query/src/eval/compare.rs
@@ -25,19 +25,6 @@ use std::cmp::Ordering;
 use super::helpers::check_min_arity;
 use super::value::{ComparableValue, ComparisonError};
 
-fn log_fastpath_hit_once(kind: &'static str) {
-    if !tracing::enabled!(tracing::Level::DEBUG) {
-        return;
-    }
-    static HIT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-    if !HIT.swap(true, std::sync::atomic::Ordering::Relaxed) {
-        tracing::debug!(
-            kind,
-            "FILTER: used encoded-id equality fast path (logged once)"
-        );
-    }
-}
-
 fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
     op: CompareOp,
     args: &[Expression],
@@ -91,7 +78,6 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
                             CompareOp::Ne => !eq,
                             _ => unreachable!(),
                         };
-                        log_fastpath_hit_once("EncodedSid-id");
                         return Ok(Some(out));
                     }
                 }
@@ -139,7 +125,6 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
                         CompareOp::Ne => !eq,
                         _ => unreachable!(),
                     };
-                    log_fastpath_hit_once("EncodedSid-const");
                     return Ok(Some(out));
                 }
                 // `Some(None)` (constant not an indexed subject) or `None`
@@ -204,7 +189,6 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
                                 CompareOp::Ne => !eq,
                                 _ => unreachable!(),
                             };
-                            log_fastpath_hit_once("EncodedSid-id");
                             return Ok(Some(out));
                         }
                     }
@@ -227,7 +211,6 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
                     CompareOp::Ne => !eq,
                     _ => unreachable!(),
                 };
-                log_fastpath_hit_once("EncodedSid");
                 Ok(Some(out))
             }
             Binding::Sid { sid, .. } => {
@@ -257,7 +240,6 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
                     CompareOp::Ne => !eq,
                     _ => unreachable!(),
                 };
-                log_fastpath_hit_once("Sid");
                 Ok(Some(out))
             }
             Binding::Iri(iri) | Binding::IriMatch { iri, .. } => {
@@ -276,7 +258,6 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
                     CompareOp::Ne => !eq,
                     _ => unreachable!(),
                 };
-                log_fastpath_hit_once("Iri");
                 Ok(Some(out))
             }
             Binding::EncodedPid { p_id } => {
@@ -292,7 +273,6 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
                     CompareOp::Ne => !eq,
                     _ => unreachable!(),
                 };
-                log_fastpath_hit_once("EncodedPid");
                 Ok(Some(out))
             }
             _ => Ok(None),

--- a/fluree-db-query/src/eval/compare.rs
+++ b/fluree-db-query/src/eval/compare.rs
@@ -120,8 +120,36 @@ fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
                         _ => None,
                     };
                     if let Some(r) = other_ref {
-                        if let Some(rhs_s_id) = subject_ref_to_s_id(ctx.active_snapshot, store, &r)?
-                        {
+                        // The constant operand resolves to the same `s_id` on
+                        // every row, so memoize it per query instead of doing a
+                        // dictionary reverse-lookup (`find_subject_id_by_parts`)
+                        // per row — the dominant cost of this filter at scale.
+                        let key = match &r {
+                            Ref::Iri(iri) => crate::context::ConstSidKey::Iri(iri.as_ref().into()),
+                            Ref::Sid(sid) => crate::context::ConstSidKey::Sid(
+                                sid.namespace_code,
+                                sid.name.as_ref().into(),
+                            ),
+                            Ref::Var(_) => unreachable!("other_ref is never a Var"),
+                        };
+                        let cached = ctx
+                            .const_sid_cache
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .get(&key)
+                            .copied();
+                        let rhs = match cached {
+                            Some(v) => v,
+                            None => {
+                                let v = subject_ref_to_s_id(ctx.active_snapshot, store, &r)?;
+                                ctx.const_sid_cache
+                                    .lock()
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                    .insert(key, v);
+                                v
+                            }
+                        };
+                        if let Some(rhs_s_id) = rhs {
                             let eq = *s_id == rhs_s_id;
                             let out = match op {
                                 CompareOp::Eq => eq,

--- a/fluree-db-query/src/eval/helpers.rs
+++ b/fluree-db-query/src/eval/helpers.rs
@@ -233,7 +233,36 @@ fn eval_cached_bool_predicate_with_spec<R: RowAccess>(
     Ok(Some(pass))
 }
 
+/// Cheap, hash-free variable-usage walk used to pre-filter cacheable predicates.
+///
+/// The encoded-bool-predicate cache only applies to single-variable predicates,
+/// but `analyze_bool_cache` computes a SipHash of the whole expression tree as it
+/// walks. For the common multi-variable predicate (e.g. `?a < ?b + k`) that hash
+/// is pure waste — recomputed per row only to be discarded. This walk decides
+/// single-vs-multi without hashing and short-circuits on the second distinct var.
+fn bool_predicate_var_usage(expr: &Expression) -> VarUsage {
+    match expr {
+        Expression::Var(v) => VarUsage::Single(*v),
+        Expression::Const(_) | Expression::Exists { .. } => VarUsage::None,
+        Expression::Call { args, .. } => {
+            let mut vars = VarUsage::None;
+            for arg in args {
+                vars = merge_var_usage(vars, bool_predicate_var_usage(arg));
+                if matches!(vars, VarUsage::Multiple) {
+                    return VarUsage::Multiple;
+                }
+            }
+            vars
+        }
+    }
+}
+
 fn analyze_cacheable_bool_predicate(expr: &Expression) -> Option<CacheableBoolPredicate> {
+    // Bail before the (SipHash) structural+hash walk when the predicate isn't a
+    // single-variable shape — the only shape the cache can serve.
+    if !matches!(bool_predicate_var_usage(expr), VarUsage::Single(_)) {
+        return None;
+    }
     let analysis = analyze_bool_cache(expr);
     let VarUsage::Single(input_var) = analysis.vars else {
         return None;

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -545,10 +545,13 @@ fn load_v6_batch(
             leaf_bytes,
             entry,
             payload_base,
-            order,
             c,
-            leaf_id,
-            leaflet_idx,
+            fluree_db_binary_index::read::column_loader::LeafletDecodeSpec {
+                leaf_id,
+                leaflet_idx,
+                order,
+                decode_set: ColumnSet::ALL,
+            },
         )
         .map_err(|e| QueryError::Internal(format!("load columns: {e}")))
     } else {

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -672,11 +672,13 @@ impl<'a> PsotSubjectCountIter<'a> {
                         .map_err(|_| QueryError::Internal("leaflet idx exceeds u32".to_string()))?;
                     load_columns_cached_via_handle(
                         handle.as_ref(),
-                        idx,
-                        RunSortOrder::Psot,
                         cache,
-                        handle.leaf_id(),
-                        idx_u32,
+                        fluree_db_binary_index::read::column_loader::LeafletDecodeSpec {
+                            leaf_id: handle.leaf_id(),
+                            leaflet_idx: idx_u32,
+                            order: RunSortOrder::Psot,
+                            decode_set: ColumnSet::ALL,
+                        },
                     )
                     .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
                 } else {
@@ -862,11 +864,13 @@ impl<'a> PsotSubjectSeek<'a> {
                         .map_err(|_| QueryError::Internal("leaflet idx exceeds u32".to_string()))?;
                     load_columns_cached_via_handle(
                         handle.as_ref(),
-                        idx,
-                        RunSortOrder::Psot,
                         cache,
-                        handle.leaf_id(),
-                        idx_u32,
+                        fluree_db_binary_index::read::column_loader::LeafletDecodeSpec {
+                            leaf_id: handle.leaf_id(),
+                            leaflet_idx: idx_u32,
+                            order: RunSortOrder::Psot,
+                            decode_set: ColumnSet::ALL,
+                        },
                     )
                     .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
                 } else {
@@ -1024,11 +1028,13 @@ impl<'a> PostObjectGroupCountIter<'a> {
                         .map_err(|_| QueryError::Internal("leaflet idx exceeds u32".to_string()))?;
                     load_columns_cached_via_handle(
                         handle.as_ref(),
-                        idx,
-                        RunSortOrder::Post,
                         cache,
-                        handle.leaf_id(),
-                        idx_u32,
+                        fluree_db_binary_index::read::column_loader::LeafletDecodeSpec {
+                            leaf_id: handle.leaf_id(),
+                            leaflet_idx: idx_u32,
+                            order: RunSortOrder::Post,
+                            decode_set: ColumnSet::ALL,
+                        },
                     )
                     .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
                 } else {
@@ -1249,11 +1255,13 @@ impl<'a> PsotSubjectWeightedSumIter<'a> {
                         .map_err(|_| QueryError::Internal("leaflet idx exceeds u32".to_string()))?;
                     load_columns_cached_via_handle(
                         handle.as_ref(),
-                        idx,
-                        RunSortOrder::Psot,
                         cache,
-                        handle.leaf_id(),
-                        idx_u32,
+                        fluree_db_binary_index::read::column_loader::LeafletDecodeSpec {
+                            leaf_id: handle.leaf_id(),
+                            leaflet_idx: idx_u32,
+                            order: RunSortOrder::Psot,
+                            decode_set: ColumnSet::ALL,
+                        },
                     )
                     .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
                 } else {

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -1627,12 +1627,15 @@ impl NestedLoopJoinOperator {
                         &leaf_bytes,
                         entry,
                         dir.payload_base,
-                        header.order,
                         c,
-                        leaf_id,
-                        u32::try_from(leaflet_idx).map_err(|_| {
-                            QueryError::Internal("leaflet idx exceeds u32".to_string())
-                        })?,
+                        fluree_db_binary_index::read::column_loader::LeafletDecodeSpec {
+                            leaf_id,
+                            leaflet_idx: u32::try_from(leaflet_idx).map_err(|_| {
+                                QueryError::Internal("leaflet idx exceeds u32".to_string())
+                            })?,
+                            order: header.order,
+                            decode_set: fluree_db_binary_index::ColumnSet::ALL,
+                        },
                     )
                     .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
                 } else {
@@ -2217,24 +2220,24 @@ impl NestedLoopJoinOperator {
                 let batch = if entry.row_count == 0 {
                     fluree_db_binary_index::ColumnBatch::empty()
                 } else if let Some(c) = &cache {
-                    let key = fluree_db_binary_index::read::leaflet_cache::V3BatchCacheKey {
-                        leaf_id,
-                        leaflet_idx: u32::try_from(leaflet_idx).map_err(|_| {
-                            QueryError::Internal("leaflet idx exceeds u32".to_string())
-                        })?,
-                    };
-                    if let Some(cached) = c.get_v3_batch(&key) {
-                        cached
-                    } else {
-                        load_leaflet_columns(
-                            &leaf_bytes,
-                            entry,
-                            dir.payload_base,
-                            &proj,
-                            header.order,
-                        )
-                        .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
-                    }
+                    let leaflet_idx_u32 = u32::try_from(leaflet_idx)
+                        .map_err(|_| QueryError::Internal("leaflet idx exceeds u32".to_string()))?;
+                    // Projection-aware + inserting: caches under the decoded
+                    // column set (CORE, or ALL for replay) so repeat probes hit
+                    // instead of re-decoding, and never collides with a wider entry.
+                    fluree_db_binary_index::read::column_loader::load_leaflet_columns_cached(
+                        &leaf_bytes,
+                        entry,
+                        dir.payload_base,
+                        c,
+                        fluree_db_binary_index::read::column_loader::LeafletDecodeSpec {
+                            leaf_id,
+                            leaflet_idx: leaflet_idx_u32,
+                            order: header.order,
+                            decode_set: proj.effective(),
+                        },
+                    )
+                    .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
                 } else {
                     load_leaflet_columns(&leaf_bytes, entry, dir.payload_base, &proj, header.order)
                         .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
@@ -2672,11 +2675,15 @@ pub(crate) fn batched_subject_probe_binary(
                     &leaf_bytes,
                     entry,
                     dir.payload_base,
-                    header.order,
                     c,
-                    leaf_id,
-                    u32::try_from(leaflet_idx)
-                        .map_err(|_| QueryError::Internal("leaflet idx exceeds u32".to_string()))?,
+                    fluree_db_binary_index::read::column_loader::LeafletDecodeSpec {
+                        leaf_id,
+                        leaflet_idx: u32::try_from(leaflet_idx).map_err(|_| {
+                            QueryError::Internal("leaflet idx exceeds u32".to_string())
+                        })?,
+                        order: header.order,
+                        decode_set: fluree_db_binary_index::ColumnSet::ALL,
+                    },
                 )
                 .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
             } else {
@@ -2876,11 +2883,15 @@ pub(crate) fn batched_subject_star_spot(
                     &leaf_bytes,
                     entry,
                     dir.payload_base,
-                    header.order,
                     c,
-                    leaf_id,
-                    u32::try_from(leaflet_idx)
-                        .map_err(|_| QueryError::Internal("leaflet idx exceeds u32".to_string()))?,
+                    fluree_db_binary_index::read::column_loader::LeafletDecodeSpec {
+                        leaf_id,
+                        leaflet_idx: u32::try_from(leaflet_idx).map_err(|_| {
+                            QueryError::Internal("leaflet idx exceeds u32".to_string())
+                        })?,
+                        order: header.order,
+                        decode_set: fluree_db_binary_index::ColumnSet::ALL,
+                    },
                 )
                 .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?
             } else {

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -1871,65 +1871,82 @@ impl NestedLoopJoinOperator {
                                     }
                                 }
                                 _ => {
-                                    // Fallback: decode eagerly, using DictOverlay for
-                                    // novelty-aware resolution of string/subject IDs.
-                                    use fluree_db_core::o_type::{DecodeKind, OType as OT};
-                                    let ot = OT::from_u16(o_type_val);
-                                    let val: fluree_db_core::FlakeValue =
-                                        match (ot.decode_kind(), dict_overlay.as_ref()) {
-                                            (DecodeKind::IriRef, Some(ov)) => {
-                                                let iri = ov
-                                                    .resolve_subject_iri(o_key_val)
+                                    // Inline numerics with a reserved dict id stay encoded
+                                    // (cheap through DISTINCT/joins, materialized at projection);
+                                    // everything else decodes eagerly via DictOverlay.
+                                    if let Some(encoded) =
+                                        crate::object_binding::inline_numeric_encoded_lit(
+                                            o_type_val, o_key_val, p_id, o_i, t,
+                                        )
+                                    {
+                                        encoded
+                                    } else {
+                                        // Fallback: decode eagerly, using DictOverlay for
+                                        // novelty-aware resolution of string/subject IDs.
+                                        use fluree_db_core::o_type::{DecodeKind, OType as OT};
+                                        let ot = OT::from_u16(o_type_val);
+                                        let val: fluree_db_core::FlakeValue =
+                                            match (ot.decode_kind(), dict_overlay.as_ref()) {
+                                                (DecodeKind::IriRef, Some(ov)) => {
+                                                    let iri = ov
+                                                        .resolve_subject_iri(o_key_val)
+                                                        .map_err(|e| {
+                                                            crate::error::QueryError::Internal(
+                                                                format!(
+                                                        "resolve_subject_iri (batched join): {e}"
+                                                    ),
+                                                            )
+                                                        })?;
+                                                    fluree_db_core::FlakeValue::Ref(
+                                                        store.encode_iri(&iri),
+                                                    )
+                                                }
+                                                (DecodeKind::StringDict, Some(ov)) => {
+                                                    let s = ov
+                                                        .resolve_string_value(o_key_val as u32)
+                                                        .map_err(|e| {
+                                                            crate::error::QueryError::Internal(
+                                                                format!(
+                                                        "resolve_string_value (batched join): {e}"
+                                                    ),
+                                                            )
+                                                        })?;
+                                                    fluree_db_core::FlakeValue::String(s)
+                                                }
+                                                (DecodeKind::JsonArena, Some(ov)) => {
+                                                    let s = ov
+                                                        .resolve_string_value(o_key_val as u32)
+                                                        .map_err(|e| {
+                                                            crate::error::QueryError::Internal(
+                                                                format!(
+                                                    "resolve_string_value (batched join json): {e}"
+                                                ),
+                                                            )
+                                                        })?;
+                                                    fluree_db_core::FlakeValue::Json(s)
+                                                }
+                                                _ => store
+                                                    .decode_value_v3(
+                                                        o_type_val,
+                                                        o_key_val,
+                                                        p_id,
+                                                        ctx.binary_g_id,
+                                                    )
                                                     .map_err(|e| {
                                                         crate::error::QueryError::Internal(format!(
-                                                        "resolve_subject_iri (batched join): {e}"
-                                                    ))
-                                                    })?;
-                                                fluree_db_core::FlakeValue::Ref(
-                                                    store.encode_iri(&iri),
-                                                )
-                                            }
-                                            (DecodeKind::StringDict, Some(ov)) => {
-                                                let s = ov
-                                                    .resolve_string_value(o_key_val as u32)
-                                                    .map_err(|e| {
-                                                    crate::error::QueryError::Internal(format!(
-                                                        "resolve_string_value (batched join): {e}"
-                                                    ))
-                                                })?;
-                                                fluree_db_core::FlakeValue::String(s)
-                                            }
-                                            (DecodeKind::JsonArena, Some(ov)) => {
-                                                let s = ov
-                                                    .resolve_string_value(o_key_val as u32)
-                                                    .map_err(|e| {
-                                                    crate::error::QueryError::Internal(format!(
-                                                    "resolve_string_value (batched join json): {e}"
-                                                ))
-                                                })?;
-                                                fluree_db_core::FlakeValue::Json(s)
-                                            }
-                                            _ => store
-                                                .decode_value_v3(
-                                                    o_type_val,
-                                                    o_key_val,
-                                                    p_id,
-                                                    ctx.binary_g_id,
-                                                )
-                                                .map_err(|e| {
-                                                    crate::error::QueryError::Internal(format!(
-                                                        "decode_value_v3 (batched join): {e}"
-                                                    ))
-                                                })?,
-                                        };
-                                    materialized_object_binding(
-                                        store,
-                                        o_type_val,
-                                        p_id,
-                                        val,
-                                        Some(t),
-                                        None,
-                                    )
+                                                            "decode_value_v3 (batched join): {e}"
+                                                        ))
+                                                    })?,
+                                            };
+                                        materialized_object_binding(
+                                            store,
+                                            o_type_val,
+                                            p_id,
+                                            val,
+                                            Some(t),
+                                            None,
+                                        )
+                                    }
                                 }
                             }
                         };

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -20,7 +20,8 @@ use async_trait::async_trait;
 use fluree_db_binary_index::{BinaryGraphView, BinaryIndexStore};
 use fluree_db_core::subject_id::SubjectId;
 use fluree_db_core::{GraphId, IndexType, ObjectBounds, Sid, BATCHED_JOIN_SIZE};
-use std::collections::{HashMap, HashSet, VecDeque};
+use rustc_hash::{FxBuildHasher, FxHashMap};
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::Instrument;
@@ -1486,9 +1487,13 @@ impl NestedLoopJoinOperator {
     ///
     /// Returns `(s_id → accumulator indices, sorted unique s_ids)`.
     /// The s_ids are already stored as raw u64 in the accumulator — no dictionary lookup needed.
-    fn group_accumulator_by_subject(&self) -> (HashMap<u64, Vec<usize>>, Vec<u64>) {
-        let mut s_id_to_accum: HashMap<u64, Vec<usize>> = HashMap::new();
-        let mut unique_s_ids: Vec<u64> = Vec::new();
+    fn group_accumulator_by_subject(&self) -> (FxHashMap<u64, Vec<usize>>, Vec<u64>) {
+        // Keyed on raw u64 subject IDs and rebuilt every flush, so use a fast
+        // integer hash and pre-size to the accumulator length to avoid SipHash
+        // and repeated rehash growth (a top self-time cost on star-join workloads).
+        let mut s_id_to_accum: FxHashMap<u64, Vec<usize>> =
+            FxHashMap::with_capacity_and_hasher(self.batched_accumulator.len(), FxBuildHasher);
+        let mut unique_s_ids: Vec<u64> = Vec::with_capacity(self.batched_accumulator.len());
         for (accum_idx, (_, _, s_id)) in self.batched_accumulator.iter().enumerate() {
             s_id_to_accum.entry(*s_id).or_default().push(accum_idx);
             unique_s_ids.push(*s_id);
@@ -1501,8 +1506,9 @@ impl NestedLoopJoinOperator {
     /// Group accumulator entries by object ID.
     ///
     /// Returns `(o_s_id → accumulator indices, (min_o, max_o))`.
-    fn group_accumulator_by_object(&self) -> (HashMap<u64, Vec<usize>>, u64, u64) {
-        let mut o_to_accum: HashMap<u64, Vec<usize>> = HashMap::new();
+    fn group_accumulator_by_object(&self) -> (FxHashMap<u64, Vec<usize>>, u64, u64) {
+        let mut o_to_accum: FxHashMap<u64, Vec<usize>> =
+            FxHashMap::with_capacity_and_hasher(self.batched_accumulator.len(), FxBuildHasher);
         let mut min_o: u64 = u64::MAX;
         let mut max_o: u64 = 0;
         for (accum_idx, (_, _, o_s_id)) in self.batched_accumulator.iter().enumerate() {
@@ -1569,7 +1575,7 @@ impl NestedLoopJoinOperator {
         leaf_range: std::ops::Range<usize>,
         p_id: u32,
         unique_s_ids: &[u64],
-        s_id_to_accum: &HashMap<u64, Vec<usize>>,
+        s_id_to_accum: &FxHashMap<u64, Vec<usize>>,
         scatter: &mut [Vec<Vec<Binding>>],
         dict_overlay: &Option<crate::dict_overlay::DictOverlay>,
     ) -> Result<()> {
@@ -2798,7 +2804,8 @@ pub(crate) fn batched_subject_star_spot(
         return Ok(Vec::new());
     }
 
-    let mut predicates_by_id: HashMap<u32, &SpotStarPredicateParams<'_>> = HashMap::new();
+    let mut predicates_by_id: FxHashMap<u32, &SpotStarPredicateParams<'_>> =
+        FxHashMap::with_capacity_and_hasher(predicates.len(), FxBuildHasher);
     for predicate in predicates {
         let Some(p_id) = store.sid_to_p_id(&predicate.pred_sid) else {
             continue;

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -1731,9 +1731,6 @@ impl NestedLoopJoinOperator {
 
                 let row_count = batch.row_count;
 
-                // Collect matching row indices using PSOT's `(p_id, s_id, ...)` ordering.
-                let mut matches: Vec<(usize, u64)> = Vec::with_capacity(64);
-
                 // For PSOT, leaflets are sorted by p_id then s_id.
                 // Find the contiguous segment for our p_id.
                 let p_start = (0..row_count)
@@ -1755,192 +1752,188 @@ impl NestedLoopJoinOperator {
                     continue;
                 }
 
+                // Stream matched rows straight into the object-decode + on_match
+                // path in PSOT `(p_id, s_id, ...)` order — no per-leaflet `matches`
+                // Vec to allocate, grow, and replay.
                 for &s_id in &unique_s_ids[subj_start..subj_end] {
-                    if !s_id_to_accum.contains_key(&s_id) {
+                    let Some(accum_indices) = s_id_to_accum.get(&s_id) else {
                         continue;
-                    }
+                    };
                     let row_start = lower_bound_s_id(&batch, p_start, p_end, s_id);
                     let row_end = upper_bound_s_id(&batch, p_start, p_end, s_id);
                     if row_start == row_end {
                         continue;
                     }
                     for row in row_start..row_end {
-                        matches.push((row, s_id));
-                    }
-                }
+                        matched_rows += 1;
+                        let o_type_val = entry
+                            .o_type_const
+                            .unwrap_or_else(|| batch.o_type.get_or(row, 0));
+                        let o_key_val = batch.o_key.get(row);
+                        if !self.batched_row_matches_object_bounds(
+                            store,
+                            ctx.binary_g_id,
+                            p_id,
+                            o_type_val,
+                            o_key_val,
+                        )? {
+                            continue;
+                        }
 
-                if matches.is_empty() {
-                    continue;
-                }
-                matched_rows += matches.len() as u64;
+                        let obj_binding = if o_type_val == OType::IRI_REF.as_u16()
+                            || o_type_val == OType::BLANK_NODE.as_u16()
+                        {
+                            Binding::encoded_sid(o_key_val)
+                        } else {
+                            let p_id = entry.p_const.unwrap_or_else(|| batch.p_id.get_or(row, 0));
+                            let o_i = batch.o_i.get_or(row, u32::MAX);
+                            let t = batch.t.get_or(row, 0) as i64;
+                            let ot = OType::from_u16(o_type_val);
 
-                for (row, s_id) in matches {
-                    let o_type_val = entry
-                        .o_type_const
-                        .unwrap_or_else(|| batch.o_type.get_or(row, 0));
-                    let o_key_val = batch.o_key.get(row);
-                    if !self.batched_row_matches_object_bounds(
-                        store,
-                        ctx.binary_g_id,
-                        p_id,
-                        o_type_val,
-                        o_key_val,
-                    )? {
-                        continue;
-                    }
+                            // Prefer a stable EncodedLit representation when possible so that
+                            // formatters can materialize using the root's canonical datatype table.
+                            match ot.decode_kind() {
+                                fluree_db_core::o_type::DecodeKind::StringDict => {
+                                    use fluree_db_core::ids::DatatypeDictId;
+                                    use fluree_db_core::value_id::ObjKind;
 
-                    let obj_binding = if o_type_val == OType::IRI_REF.as_u16()
-                        || o_type_val == OType::BLANK_NODE.as_u16()
-                    {
-                        Binding::encoded_sid(o_key_val)
-                    } else {
-                        let p_id = entry.p_const.unwrap_or_else(|| batch.p_id.get_or(row, 0));
-                        let o_i = batch.o_i.get_or(row, u32::MAX);
-                        let t = batch.t.get_or(row, 0) as i64;
-                        let ot = OType::from_u16(o_type_val);
-
-                        // Prefer a stable EncodedLit representation when possible so that
-                        // formatters can materialize using the root's canonical datatype table.
-                        match ot.decode_kind() {
-                            fluree_db_core::o_type::DecodeKind::StringDict => {
-                                use fluree_db_core::ids::DatatypeDictId;
-                                use fluree_db_core::value_id::ObjKind;
-
-                                let (dt_id, lang_id) = if ot.is_lang_string() {
-                                    (DatatypeDictId::LANG_STRING.as_u16(), ot.payload())
-                                } else if o_type_val == OType::FULLTEXT.as_u16() {
-                                    (DatatypeDictId::FULL_TEXT.as_u16(), 0)
-                                } else {
-                                    (DatatypeDictId::STRING.as_u16(), 0)
-                                };
-
-                                Binding::EncodedLit {
-                                    o_kind: ObjKind::LEX_ID.as_u8(),
-                                    o_key: o_key_val,
-                                    p_id,
-                                    dt_id,
-                                    lang_id,
-                                    i_val: if o_i == u32::MAX {
-                                        i32::MIN
+                                    let (dt_id, lang_id) = if ot.is_lang_string() {
+                                        (DatatypeDictId::LANG_STRING.as_u16(), ot.payload())
+                                    } else if o_type_val == OType::FULLTEXT.as_u16() {
+                                        (DatatypeDictId::FULL_TEXT.as_u16(), 0)
                                     } else {
-                                        o_i as i32
-                                    },
-                                    t,
+                                        (DatatypeDictId::STRING.as_u16(), 0)
+                                    };
+
+                                    Binding::EncodedLit {
+                                        o_kind: ObjKind::LEX_ID.as_u8(),
+                                        o_key: o_key_val,
+                                        p_id,
+                                        dt_id,
+                                        lang_id,
+                                        i_val: if o_i == u32::MAX {
+                                            i32::MIN
+                                        } else {
+                                            o_i as i32
+                                        },
+                                        t,
+                                    }
                                 }
-                            }
-                            fluree_db_core::o_type::DecodeKind::JsonArena => {
-                                use fluree_db_core::ids::DatatypeDictId;
-                                use fluree_db_core::value_id::ObjKind;
-                                Binding::EncodedLit {
-                                    o_kind: ObjKind::JSON_ID.as_u8(),
-                                    o_key: o_key_val,
-                                    p_id,
-                                    dt_id: DatatypeDictId::JSON.as_u16(),
-                                    lang_id: 0,
-                                    i_val: if o_i == u32::MAX {
-                                        i32::MIN
-                                    } else {
-                                        o_i as i32
-                                    },
-                                    t,
+                                fluree_db_core::o_type::DecodeKind::JsonArena => {
+                                    use fluree_db_core::ids::DatatypeDictId;
+                                    use fluree_db_core::value_id::ObjKind;
+                                    Binding::EncodedLit {
+                                        o_kind: ObjKind::JSON_ID.as_u8(),
+                                        o_key: o_key_val,
+                                        p_id,
+                                        dt_id: DatatypeDictId::JSON.as_u16(),
+                                        lang_id: 0,
+                                        i_val: if o_i == u32::MAX {
+                                            i32::MIN
+                                        } else {
+                                            o_i as i32
+                                        },
+                                        t,
+                                    }
                                 }
-                            }
-                            fluree_db_core::o_type::DecodeKind::VectorArena => {
-                                use fluree_db_core::ids::DatatypeDictId;
-                                use fluree_db_core::value_id::ObjKind;
-                                Binding::EncodedLit {
-                                    o_kind: ObjKind::VECTOR_ID.as_u8(),
-                                    o_key: o_key_val,
-                                    p_id,
-                                    dt_id: DatatypeDictId::VECTOR.as_u16(),
-                                    lang_id: 0,
-                                    i_val: if o_i == u32::MAX {
-                                        i32::MIN
-                                    } else {
-                                        o_i as i32
-                                    },
-                                    t,
+                                fluree_db_core::o_type::DecodeKind::VectorArena => {
+                                    use fluree_db_core::ids::DatatypeDictId;
+                                    use fluree_db_core::value_id::ObjKind;
+                                    Binding::EncodedLit {
+                                        o_kind: ObjKind::VECTOR_ID.as_u8(),
+                                        o_key: o_key_val,
+                                        p_id,
+                                        dt_id: DatatypeDictId::VECTOR.as_u16(),
+                                        lang_id: 0,
+                                        i_val: if o_i == u32::MAX {
+                                            i32::MIN
+                                        } else {
+                                            o_i as i32
+                                        },
+                                        t,
+                                    }
                                 }
-                            }
-                            fluree_db_core::o_type::DecodeKind::NumBigArena => {
-                                use fluree_db_core::ids::DatatypeDictId;
-                                use fluree_db_core::value_id::ObjKind;
-                                Binding::EncodedLit {
-                                    o_kind: ObjKind::NUM_BIG.as_u8(),
-                                    o_key: o_key_val,
-                                    p_id,
-                                    dt_id: DatatypeDictId::DECIMAL.as_u16(),
-                                    lang_id: 0,
-                                    i_val: if o_i == u32::MAX {
-                                        i32::MIN
-                                    } else {
-                                        o_i as i32
-                                    },
-                                    t,
+                                fluree_db_core::o_type::DecodeKind::NumBigArena => {
+                                    use fluree_db_core::ids::DatatypeDictId;
+                                    use fluree_db_core::value_id::ObjKind;
+                                    Binding::EncodedLit {
+                                        o_kind: ObjKind::NUM_BIG.as_u8(),
+                                        o_key: o_key_val,
+                                        p_id,
+                                        dt_id: DatatypeDictId::DECIMAL.as_u16(),
+                                        lang_id: 0,
+                                        i_val: if o_i == u32::MAX {
+                                            i32::MIN
+                                        } else {
+                                            o_i as i32
+                                        },
+                                        t,
+                                    }
                                 }
-                            }
-                            _ => {
-                                // Fallback: decode eagerly, using DictOverlay for
-                                // novelty-aware resolution of string/subject IDs.
-                                use fluree_db_core::o_type::{DecodeKind, OType as OT};
-                                let ot = OT::from_u16(o_type_val);
-                                let val: fluree_db_core::FlakeValue =
-                                    match (ot.decode_kind(), dict_overlay.as_ref()) {
-                                        (DecodeKind::IriRef, Some(ov)) => {
-                                            let iri =
-                                                ov.resolve_subject_iri(o_key_val).map_err(|e| {
-                                                    crate::error::QueryError::Internal(format!(
+                                _ => {
+                                    // Fallback: decode eagerly, using DictOverlay for
+                                    // novelty-aware resolution of string/subject IDs.
+                                    use fluree_db_core::o_type::{DecodeKind, OType as OT};
+                                    let ot = OT::from_u16(o_type_val);
+                                    let val: fluree_db_core::FlakeValue =
+                                        match (ot.decode_kind(), dict_overlay.as_ref()) {
+                                            (DecodeKind::IriRef, Some(ov)) => {
+                                                let iri = ov
+                                                    .resolve_subject_iri(o_key_val)
+                                                    .map_err(|e| {
+                                                        crate::error::QueryError::Internal(format!(
                                                         "resolve_subject_iri (batched join): {e}"
                                                     ))
-                                                })?;
-                                            fluree_db_core::FlakeValue::Ref(store.encode_iri(&iri))
-                                        }
-                                        (DecodeKind::StringDict, Some(ov)) => {
-                                            let s = ov
-                                                .resolve_string_value(o_key_val as u32)
-                                                .map_err(|e| {
+                                                    })?;
+                                                fluree_db_core::FlakeValue::Ref(
+                                                    store.encode_iri(&iri),
+                                                )
+                                            }
+                                            (DecodeKind::StringDict, Some(ov)) => {
+                                                let s = ov
+                                                    .resolve_string_value(o_key_val as u32)
+                                                    .map_err(|e| {
                                                     crate::error::QueryError::Internal(format!(
                                                         "resolve_string_value (batched join): {e}"
                                                     ))
                                                 })?;
-                                            fluree_db_core::FlakeValue::String(s)
-                                        }
-                                        (DecodeKind::JsonArena, Some(ov)) => {
-                                            let s = ov
-                                                .resolve_string_value(o_key_val as u32)
-                                                .map_err(|e| {
+                                                fluree_db_core::FlakeValue::String(s)
+                                            }
+                                            (DecodeKind::JsonArena, Some(ov)) => {
+                                                let s = ov
+                                                    .resolve_string_value(o_key_val as u32)
+                                                    .map_err(|e| {
                                                     crate::error::QueryError::Internal(format!(
                                                     "resolve_string_value (batched join json): {e}"
                                                 ))
                                                 })?;
-                                            fluree_db_core::FlakeValue::Json(s)
-                                        }
-                                        _ => store
-                                            .decode_value_v3(
-                                                o_type_val,
-                                                o_key_val,
-                                                p_id,
-                                                ctx.binary_g_id,
-                                            )
-                                            .map_err(|e| {
-                                                crate::error::QueryError::Internal(format!(
-                                                    "decode_value_v3 (batched join): {e}"
-                                                ))
-                                            })?,
-                                    };
-                                materialized_object_binding(
-                                    store,
-                                    o_type_val,
-                                    p_id,
-                                    val,
-                                    Some(t),
-                                    None,
-                                )
+                                                fluree_db_core::FlakeValue::Json(s)
+                                            }
+                                            _ => store
+                                                .decode_value_v3(
+                                                    o_type_val,
+                                                    o_key_val,
+                                                    p_id,
+                                                    ctx.binary_g_id,
+                                                )
+                                                .map_err(|e| {
+                                                    crate::error::QueryError::Internal(format!(
+                                                        "decode_value_v3 (batched join): {e}"
+                                                    ))
+                                                })?,
+                                        };
+                                    materialized_object_binding(
+                                        store,
+                                        o_type_val,
+                                        p_id,
+                                        val,
+                                        Some(t),
+                                        None,
+                                    )
+                                }
                             }
-                        }
-                    };
+                        };
 
-                    if let Some(accum_indices) = s_id_to_accum.get(&s_id) {
                         on_match(accum_indices, &obj_binding)?;
                     }
                 }

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -5,7 +5,7 @@
 //! vars between left and right must match exactly.
 
 use crate::binary_scan::EmitMask;
-use crate::binding::{Batch, Binding};
+use crate::binding::{Batch, Binding, RowAccess};
 use crate::context::ExecutionContext;
 use crate::dataset::ActiveGraphs;
 use crate::error::{QueryError, Result};
@@ -32,7 +32,7 @@ const BATCHED_EXISTS_DEBUG_MIN_ACCUM: usize = 8;
 const BATCHED_EXISTS_DEBUG_MIN_MS: u64 = 10;
 
 /// Prepared per-leaf inputs shared by every batched-probe path
-/// (`scan_leaves_into_scatter`, `flush_batched_object_accumulator_binary`,
+/// (`scan_matches`, `flush_batched_object_accumulator_binary`,
 /// `batched_subject_probe_binary`, `batched_subject_star_spot`). Owns the
 /// leaf blob, decoded header/dir, the leaf-id hash, and the optional
 /// sidecar bytes — the leaflet loop body destructures this and proceeds
@@ -46,6 +46,62 @@ struct LeafScan {
     /// leaflet alone is authoritative); always fetched when `need_replay`
     /// is true so `replay_leaflet_at_t` can reconstruct historical state.
     sidecar_bytes: Option<Vec<u8>>,
+}
+
+/// Read-only view of a single joined row — a stored left-batch row plus the
+/// right-scan tail bindings — addressed through `combined_schema`. Lets the
+/// batched-join fast path evaluate inline FILTERs without materializing a
+/// `combined: Vec<Binding>` per match.
+///
+/// Column layout matches `combined_schema = left_schema ++ right_new_vars`:
+/// positions `< left_len` resolve against the left batch (whose schema is
+/// exactly `left_schema`, so a combined position is also the left column index);
+/// positions `>= left_len` index into the right tail.
+struct CombinedRowView<'a> {
+    left_batch: &'a Batch,
+    left_row: usize,
+    left_len: usize,
+    right: &'a [Binding],
+    schema: &'a [VarId],
+}
+
+impl RowAccess for CombinedRowView<'_> {
+    fn get(&self, var: VarId) -> Option<&Binding> {
+        let pos = self.schema.iter().position(|&v| v == var)?;
+        if pos < self.left_len {
+            Some(self.left_batch.get_by_col(self.left_row, pos))
+        } else {
+            self.right.get(pos - self.left_len)
+        }
+    }
+}
+
+/// Apply inline FILTER operators against a joined row view.
+///
+/// Only valid when `ops` contains no `Bind` — the batched-join fast path is
+/// gated on that, since a Bind would need to append/clobber a column on a
+/// materialized row.
+fn apply_inline_filters_view<R: RowAccess>(
+    ops: &[InlineOperator],
+    row: &R,
+    ctx: &ExecutionContext<'_>,
+) -> Result<bool> {
+    for op in ops {
+        match op {
+            InlineOperator::Filter(expr) => {
+                if !expr.eval_to_bool_non_strict(row, Some(ctx))? {
+                    return Ok(false);
+                }
+            }
+            InlineOperator::Bind { .. } => {
+                return Err(QueryError::Internal(
+                    "apply_inline_filters_view: Bind not supported on the batched-join fast path"
+                        .into(),
+                ));
+            }
+        }
+    }
+    Ok(true)
 }
 
 fn prepare_leaf_for_scan(
@@ -1561,13 +1617,16 @@ impl NestedLoopJoinOperator {
         branch.find_leaves_in_range(&min_key, &max_key, cmp)
     }
 
-    /// Phase 4: Scan PSOT leaves, matching accumulated subjects and scattering results.
+    /// Phase 4: Scan PSOT leaves, matching accumulated subjects and invoking
+    /// `on_match` per matched (left-row group, object) pair.
     ///
     /// Uses V3 column-based leaf loading via `get_leaf_bytes_sync` + `load_leaflet_columns_cached`,
-    /// binary-searches for matching subjects within each leaflet's p_id segment, builds
-    /// late-materialized bindings, and scatters them to accumulator positions.
+    /// binary-searches for matching subjects within each leaflet's p_id segment, and builds the
+    /// late-materialized object binding. The decoded object plus the accumulator indices that
+    /// share the matched subject are handed to `on_match`, which owns the scatter representation
+    /// (full combined rows for the Bind path, right-only tails for the fast path).
     #[allow(clippy::too_many_arguments)]
-    fn scan_leaves_into_scatter(
+    fn scan_matches(
         &self,
         ctx: &ExecutionContext<'_>,
         store: &BinaryIndexStore,
@@ -1576,8 +1635,8 @@ impl NestedLoopJoinOperator {
         p_id: u32,
         unique_s_ids: &[u64],
         s_id_to_accum: &FxHashMap<u64, Vec<usize>>,
-        scatter: &mut [Vec<Vec<Binding>>],
         dict_overlay: &Option<crate::dict_overlay::DictOverlay>,
+        on_match: &mut dyn FnMut(&[usize], &Binding) -> Result<()>,
     ) -> Result<()> {
         use fluree_db_binary_index::read::column_loader::load_leaflet_columns_cached;
         use fluree_db_core::o_type::OType;
@@ -1882,34 +1941,7 @@ impl NestedLoopJoinOperator {
                     };
 
                     if let Some(accum_indices) = s_id_to_accum.get(&s_id) {
-                        for &accum_idx in accum_indices {
-                            let (batch_idx, row_idx, _) = &self.batched_accumulator[accum_idx];
-                            let left_batch = &self.stored_left_batches[*batch_idx];
-                            let mut right_bindings = Vec::with_capacity(self.right_new_vars.len());
-                            for _ in &self.right_new_vars {
-                                right_bindings.push(obj_binding.clone());
-                            }
-                            if !self.apply_right_scan_inline_ops(ctx, &mut right_bindings)? {
-                                continue;
-                            }
-
-                            let mut combined = Vec::with_capacity(self.combined_schema.len());
-                            for col in 0..self.left_schema.len() {
-                                combined.push(left_batch.get_by_col(*row_idx, col).clone());
-                            }
-                            combined.extend(right_bindings);
-
-                            if !apply_inline(
-                                &self.inline_ops,
-                                &self.combined_schema,
-                                &mut combined,
-                                Some(ctx),
-                            )? {
-                                continue;
-                            }
-
-                            scatter[accum_idx].push(combined);
-                        }
+                        on_match(accum_indices, &obj_binding)?;
                     }
                 }
             }
@@ -1995,6 +2027,77 @@ impl NestedLoopJoinOperator {
         Ok(())
     }
 
+    /// Whether any inline operator is a `Bind` (which appends or clobbers a
+    /// column and therefore requires a materialized combined row).
+    fn inline_has_bind(&self) -> bool {
+        self.inline_ops
+            .iter()
+            .any(|op| matches!(op, InlineOperator::Bind { .. }))
+    }
+
+    /// Phase 5 (fast path): assemble a right-only flat scatter into output
+    /// batches in left-row order.
+    ///
+    /// `scatter[accum_idx]` holds the right-side tails of every match for that
+    /// accumulator slot, concatenated (each tail is `right_width` bindings). The
+    /// left columns are reconstructed from the stored left batch via the
+    /// accumulator's `(batch_idx, row_idx)` and written directly into the output
+    /// columns — no per-match `combined` Vec and no transpose. Only used when
+    /// `right_width >= 1`, so `combined_schema` is never empty here.
+    fn emit_right_scatter_to_output(
+        &mut self,
+        scatter: Vec<Vec<Binding>>,
+        right_width: usize,
+        batch_size: usize,
+    ) -> Result<()> {
+        let num_cols = self.combined_schema.len();
+        let left_len = self.left_schema.len();
+        let mut output_columns: Vec<Vec<Binding>> = (0..num_cols)
+            .map(|_| Vec::with_capacity(batch_size))
+            .collect();
+        let mut rows_added = 0usize;
+
+        for (accum_idx, tails) in scatter.into_iter().enumerate() {
+            if tails.is_empty() {
+                continue;
+            }
+            let (batch_idx, row_idx, _) = self.batched_accumulator[accum_idx];
+            let n_matches = tails.len() / right_width;
+            let mut tail_iter = tails.into_iter();
+            for _ in 0..n_matches {
+                for (col, out_col) in output_columns.iter_mut().enumerate().take(left_len) {
+                    out_col.push(
+                        self.stored_left_batches[batch_idx]
+                            .get_by_col(row_idx, col)
+                            .clone(),
+                    );
+                }
+                for off in 0..right_width {
+                    // `tails.len()` is a multiple of `right_width` by construction.
+                    output_columns[left_len + off].push(tail_iter.next().unwrap());
+                }
+                rows_added += 1;
+
+                if rows_added >= batch_size {
+                    let batch = Batch::new(self.combined_schema.clone(), output_columns)?;
+                    self.batched_output.push_back(batch);
+                    output_columns = (0..num_cols)
+                        .map(|_| Vec::with_capacity(batch_size))
+                        .collect();
+                    rows_added = 0;
+                }
+            }
+        }
+
+        if rows_added > 0 {
+            let batch = Batch::new(self.combined_schema.clone(), output_columns)?;
+            self.batched_output.push_back(batch);
+        }
+
+        self.clear_batched_state();
+        Ok(())
+    }
+
     /// Binary-index batched scan orchestrator.
     ///
     /// Implements a true batched scan over PSOT leaf files:
@@ -2045,22 +2148,114 @@ impl NestedLoopJoinOperator {
             *unique_s_ids.last().unwrap(),
         );
 
-        // Phase 4: Scan leaves → scatter buffer
-        let mut scatter: Vec<Vec<Vec<Binding>>> = vec![Vec::new(); self.batched_accumulator.len()];
-        self.scan_leaves_into_scatter(
-            ctx,
-            &store,
-            branch,
-            leaf_range,
-            p_id,
-            &unique_s_ids,
-            &s_id_to_accum,
-            &mut scatter,
-            &dict_overlay,
-        )?;
+        // Phase 4+5: Scan leaves, scatter matches by accumulator position, emit
+        // output batches in left-row order. Two scatter representations:
+        //
+        //  * Fast path (`right_width >= 1` and no `Bind` inline ops): a right-only
+        //    flat scatter (`Vec<Vec<Binding>>`, the right-side tails concatenated
+        //    per accumulator slot). Inline FILTERs run against a `CombinedRowView`
+        //    over the stored left row + right tail — no per-match `combined` Vec.
+        //    `emit_right_scatter_to_output` writes left columns (cloned once) and
+        //    right tails directly into the output columns.
+        //  * Bind/general path: full combined rows scattered into
+        //    `Vec<Vec<Vec<Binding>>>`, then transposed by `emit_scatter_to_output`.
+        //    Binds may append or clobber columns, so the row must be materialized.
+        let right_width = self.combined_schema.len() - self.left_schema.len();
+        if right_width >= 1 && !self.inline_has_bind() {
+            let left_len = self.left_schema.len();
+            let combined_schema = self.combined_schema.clone();
+            let mut scatter: Vec<Vec<Binding>> = vec![Vec::new(); self.batched_accumulator.len()];
+            {
+                let mut on_match = |accum_indices: &[usize], obj: &Binding| -> Result<()> {
+                    // Right-side tail (object + any right-scan inline outputs) is
+                    // independent of the left row, so build it once per match.
+                    let mut right_bindings = Vec::with_capacity(self.right_new_vars.len());
+                    for _ in 0..self.right_new_vars.len() {
+                        right_bindings.push(obj.clone());
+                    }
+                    if !self.apply_right_scan_inline_ops(ctx, &mut right_bindings)? {
+                        return Ok(());
+                    }
+                    for &accum_idx in accum_indices {
+                        let (batch_idx, row_idx, _) = self.batched_accumulator[accum_idx];
+                        if !self.inline_ops.is_empty() {
+                            let view = CombinedRowView {
+                                left_batch: &self.stored_left_batches[batch_idx],
+                                left_row: row_idx,
+                                left_len,
+                                right: &right_bindings,
+                                schema: &combined_schema,
+                            };
+                            if !apply_inline_filters_view(&self.inline_ops, &view, ctx)? {
+                                continue;
+                            }
+                        }
+                        scatter[accum_idx].extend(right_bindings.iter().cloned());
+                    }
+                    Ok(())
+                };
+                self.scan_matches(
+                    ctx,
+                    &store,
+                    branch,
+                    leaf_range,
+                    p_id,
+                    &unique_s_ids,
+                    &s_id_to_accum,
+                    &dict_overlay,
+                    &mut on_match,
+                )?;
+            }
+            self.emit_right_scatter_to_output(scatter, right_width, ctx.batch_size)?;
+        } else {
+            let mut scatter: Vec<Vec<Vec<Binding>>> =
+                vec![Vec::new(); self.batched_accumulator.len()];
+            {
+                let mut on_match = |accum_indices: &[usize], obj: &Binding| -> Result<()> {
+                    for &accum_idx in accum_indices {
+                        let (batch_idx, row_idx, _) = &self.batched_accumulator[accum_idx];
+                        let left_batch = &self.stored_left_batches[*batch_idx];
+                        let mut right_bindings = Vec::with_capacity(self.right_new_vars.len());
+                        for _ in &self.right_new_vars {
+                            right_bindings.push(obj.clone());
+                        }
+                        if !self.apply_right_scan_inline_ops(ctx, &mut right_bindings)? {
+                            continue;
+                        }
 
-        // Phase 5: Emit output batches
-        self.emit_scatter_to_output(scatter, ctx.batch_size)?;
+                        let mut combined = Vec::with_capacity(self.combined_schema.len());
+                        for col in 0..self.left_schema.len() {
+                            combined.push(left_batch.get_by_col(*row_idx, col).clone());
+                        }
+                        combined.extend(right_bindings);
+
+                        if !apply_inline(
+                            &self.inline_ops,
+                            &self.combined_schema,
+                            &mut combined,
+                            Some(ctx),
+                        )? {
+                            continue;
+                        }
+
+                        scatter[accum_idx].push(combined);
+                    }
+                    Ok(())
+                };
+                self.scan_matches(
+                    ctx,
+                    &store,
+                    branch,
+                    leaf_range,
+                    p_id,
+                    &unique_s_ids,
+                    &s_id_to_accum,
+                    &dict_overlay,
+                    &mut on_match,
+                )?;
+            }
+            self.emit_scatter_to_output(scatter, ctx.batch_size)?;
+        }
 
         tracing::debug!(
             total_ms = (overall_start.elapsed().as_secs_f64() * 1000.0) as u64,

--- a/fluree-db-query/src/object_binding.rs
+++ b/fluree-db-query/src/object_binding.rs
@@ -14,6 +14,50 @@ fn encoded_i_val(o_i: u32) -> i32 {
     }
 }
 
+/// Encoded representation for an inline numeric o_type, or `None` if the type
+/// has no well-known `dt_id` and must stay on the materialized path.
+///
+/// Returns `(o_kind, dt_id)` for `EncodedLit`. The `dt_id` is the well-known
+/// `DatatypeDictId` whose registry slot maps back to exactly this o_type
+/// (`resolve(o_kind, dt_id, 0) == o_type`), so `DATATYPE()` and terminal
+/// materialization reconstruct the correct datatype. Restricted to the four
+/// numeric types with reserved dict ids — xsd:int / xsd:short / etc. have no
+/// well-known id and fall through to materialization unchanged.
+fn inline_numeric_encoding(o_type: u16) -> Option<(u8, u16)> {
+    let ot = OType::from_u16(o_type);
+    if ot == OType::XSD_INTEGER {
+        Some((ObjKind::NUM_INT.as_u8(), DatatypeDictId::INTEGER.as_u16()))
+    } else if ot == OType::XSD_LONG {
+        Some((ObjKind::NUM_INT.as_u8(), DatatypeDictId::LONG.as_u16()))
+    } else if ot == OType::XSD_DOUBLE {
+        Some((ObjKind::NUM_F64.as_u8(), DatatypeDictId::DOUBLE.as_u16()))
+    } else if ot == OType::XSD_FLOAT {
+        Some((ObjKind::NUM_F64.as_u8(), DatatypeDictId::FLOAT.as_u16()))
+    } else {
+        None
+    }
+}
+
+/// Build an `EncodedLit` for an inline numeric, or `None` for types that must
+/// stay materialized (see [`inline_numeric_encoding`]).
+pub(crate) fn inline_numeric_encoded_lit(
+    o_type: u16,
+    o_key: u64,
+    p_id: u32,
+    o_i: u32,
+    t: i64,
+) -> Option<Binding> {
+    inline_numeric_encoding(o_type).map(|(o_kind, dt_id)| Binding::EncodedLit {
+        o_kind,
+        o_key,
+        p_id,
+        dt_id,
+        lang_id: 0,
+        i_val: encoded_i_val(o_i),
+        t,
+    })
+}
+
 /// Build a late-materialized object binding for the binary scan path.
 ///
 /// `op` is `Some(true|false)` only in history mode (assert/retract) — it
@@ -85,6 +129,14 @@ pub(crate) fn late_materialized_object_binding(
             i_val: encoded_i_val(o_i),
             t,
         }),
+        // Inline integer/float values whose datatype has a reserved dict id:
+        // keep them encoded so they hash/compare/clone as cheap ints through
+        // DISTINCT and joins, with materialization deferred to projection. Other
+        // inline kinds (and unsupported numeric subtypes) fall through to `None`,
+        // and the caller materializes them as before.
+        DecodeKind::I64 | DecodeKind::F64 => {
+            inline_numeric_encoded_lit(o_type, o_key, p_id, o_i, t)
+        }
         _ => None,
     }
 }

--- a/fluree-db-server/Cargo.toml
+++ b/fluree-db-server/Cargo.toml
@@ -55,7 +55,6 @@ fluree-db-nameservice = { path = "../fluree-db-nameservice" }
 fluree-db-nameservice-sync = { path = "../fluree-db-nameservice-sync" }
 fluree-db-peer = { path = "../fluree-db-peer" }
 fluree-db-query = { path = "../fluree-db-query" }
-fluree-db-binary-index = { path = "../fluree-db-binary-index" }
 fluree-db-sparql = { path = "../fluree-db-sparql" }
 fluree-sse = { path = "../fluree-sse" }
 fluree-vocab = { path = "../fluree-vocab" }

--- a/fluree-db-server/Cargo.toml
+++ b/fluree-db-server/Cargo.toml
@@ -55,6 +55,7 @@ fluree-db-nameservice = { path = "../fluree-db-nameservice" }
 fluree-db-nameservice-sync = { path = "../fluree-db-nameservice-sync" }
 fluree-db-peer = { path = "../fluree-db-peer" }
 fluree-db-query = { path = "../fluree-db-query" }
+fluree-db-binary-index = { path = "../fluree-db-binary-index" }
 fluree-db-sparql = { path = "../fluree-db-sparql" }
 fluree-sse = { path = "../fluree-sse" }
 fluree-vocab = { path = "../fluree-vocab" }

--- a/fluree-db-server/src/routes/admin.rs
+++ b/fluree-db-server/src/routes/admin.rs
@@ -32,6 +32,64 @@ pub async fn health() -> Json<HealthResponse> {
     })
 }
 
+/// Binary-scan leaflet-loop diagnostic counters (see
+/// `fluree_db_binary_index::read::binary_cursor::scan_stats`).
+#[derive(Serialize)]
+pub struct ScanStatsResponse {
+    pub calls: u64,
+    pub visited: u64,
+    pub returned: u64,
+    pub rows: u64,
+    pub skipped: u64,
+    pub empty: u64,
+    pub filtered: u64,
+    /// Leaflet breadth: leaflets examined per leaflet returned (≫1 ⇒ over-scan).
+    pub visited_per_returned: f64,
+    /// Row volume per returned leaflet (small ⇒ per-leaflet/per-call overhead).
+    pub rows_per_returned: f64,
+    /// How often the per-row filter runs (per returned leaflet).
+    pub filtered_per_returned: f64,
+    /// Leaflets yielded per `next_batch` call.
+    pub returned_per_call: f64,
+}
+
+#[derive(serde::Deserialize, Default)]
+pub struct ScanStatsQuery {
+    /// `?reset=true` zeroes the counters after reading (to scope a workload).
+    #[serde(default)]
+    pub reset: bool,
+}
+
+/// Binary-scan leaflet-loop counters endpoint.
+///
+/// GET /debug/scan-stats[?reset=true]
+///
+/// On-demand readout of the per-leaflet scan loop counters so the Explore
+/// `next_batch` hotspot can be localized without waiting for the periodic log.
+pub async fn scan_stats(
+    axum::extract::Query(q): axum::extract::Query<ScanStatsQuery>,
+) -> Json<ScanStatsResponse> {
+    use fluree_db_binary_index::read::binary_cursor::scan_stats as s;
+    let (calls, visited, returned, rows, skipped, empty, filtered) = s::snapshot();
+    if q.reset {
+        s::reset();
+    }
+    let r = |a: u64, b: u64| if b == 0 { 0.0 } else { a as f64 / b as f64 };
+    Json(ScanStatsResponse {
+        calls,
+        visited,
+        returned,
+        rows,
+        skipped,
+        empty,
+        filtered,
+        visited_per_returned: r(visited, returned),
+        rows_per_returned: r(rows, returned),
+        filtered_per_returned: r(filtered, returned),
+        returned_per_call: r(returned, calls),
+    })
+}
+
 /// Server statistics response
 #[derive(Serialize)]
 pub struct StatsResponse {

--- a/fluree-db-server/src/routes/admin.rs
+++ b/fluree-db-server/src/routes/admin.rs
@@ -32,64 +32,6 @@ pub async fn health() -> Json<HealthResponse> {
     })
 }
 
-/// Binary-scan leaflet-loop diagnostic counters (see
-/// `fluree_db_binary_index::read::binary_cursor::scan_stats`).
-#[derive(Serialize)]
-pub struct ScanStatsResponse {
-    pub calls: u64,
-    pub visited: u64,
-    pub returned: u64,
-    pub rows: u64,
-    pub skipped: u64,
-    pub empty: u64,
-    pub filtered: u64,
-    /// Leaflet breadth: leaflets examined per leaflet returned (≫1 ⇒ over-scan).
-    pub visited_per_returned: f64,
-    /// Row volume per returned leaflet (small ⇒ per-leaflet/per-call overhead).
-    pub rows_per_returned: f64,
-    /// How often the per-row filter runs (per returned leaflet).
-    pub filtered_per_returned: f64,
-    /// Leaflets yielded per `next_batch` call.
-    pub returned_per_call: f64,
-}
-
-#[derive(serde::Deserialize, Default)]
-pub struct ScanStatsQuery {
-    /// `?reset=true` zeroes the counters after reading (to scope a workload).
-    #[serde(default)]
-    pub reset: bool,
-}
-
-/// Binary-scan leaflet-loop counters endpoint.
-///
-/// GET /debug/scan-stats[?reset=true]
-///
-/// On-demand readout of the per-leaflet scan loop counters so the Explore
-/// `next_batch` hotspot can be localized without waiting for the periodic log.
-pub async fn scan_stats(
-    axum::extract::Query(q): axum::extract::Query<ScanStatsQuery>,
-) -> Json<ScanStatsResponse> {
-    use fluree_db_binary_index::read::binary_cursor::scan_stats as s;
-    let (calls, visited, returned, rows, skipped, empty, filtered) = s::snapshot();
-    if q.reset {
-        s::reset();
-    }
-    let r = |a: u64, b: u64| if b == 0 { 0.0 } else { a as f64 / b as f64 };
-    Json(ScanStatsResponse {
-        calls,
-        visited,
-        returned,
-        rows,
-        skipped,
-        empty,
-        filtered,
-        visited_per_returned: r(visited, returned),
-        rows_per_returned: r(rows, returned),
-        filtered_per_returned: r(filtered, returned),
-        returned_per_call: r(returned, calls),
-    })
-}
-
 /// Server statistics response
 #[derive(Serialize)]
 pub struct StatsResponse {

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -139,6 +139,8 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     let mut router = Router::new()
         // Health check
         .route("/health", get(admin::health))
+        // Diagnostic: binary-scan leaflet-loop counters (GET, ?reset=true to zero)
+        .route("/debug/scan-stats", get(admin::scan_stats))
         // Auth discovery (CLI auto-configuration)
         .route("/.well-known/fluree.json", get(admin::discovery))
         // Versioned API

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -140,7 +140,6 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // Health check
         .route("/health", get(admin::health))
         // Diagnostic: binary-scan leaflet-loop counters (GET, ?reset=true to zero)
-        .route("/debug/scan-stats", get(admin::scan_stats))
         // Auth discovery (CLI auto-configuration)
         .route("/.well-known/fluree.json", get(admin::discovery))
         // Versioned API

--- a/testsuite-sparql/Cargo.lock
+++ b/testsuite-sparql/Cargo.lock
@@ -635,7 +635,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-db-api"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "bigdecimal 0.4.10",
  "chrono",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "base64",
  "bs58",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -913,6 +913,7 @@ dependencies = [
  "percent-encoding",
  "postcard",
  "rand 0.8.5",
+ "rayon",
  "regex",
  "rustc-hash",
  "serde",
@@ -930,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -946,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -960,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -975,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -1003,14 +1004,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1048,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-graph-ir",
  "serde",
@@ -1058,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-vocab",
  "serde",
@@ -1068,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1079,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1092,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.0.4"
+version = "4.0.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1101,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-vocab"
-version = "4.0.4"
+version = "4.0.5"
 
 [[package]]
 name = "foldhash"


### PR DESCRIPTION
This branch improves query throughput by using CPU-profile-guided optimizations across serialization, binary index scanning, batched joins, filter evaluation, and late materialization.

The largest wins come from removing repeated loop-invariant work from hot paths, reducing binary scan work before decoding, and keeping values encoded longer so joins and DISTINCT process cheaper integer-backed bindings instead of materialized values.

## Key Changes

- Improved SPARQL XML serialization by reducing per-cell allocation, bulk-copying escaped XML spans, and lazily building IRI compaction fallback prefixes.
- Added binary scan diagnostics and a scan-stats endpoint to make CPU profiles easier to localize.
- Made binary leaflet loading projection-aware and cache-keyed by decoded column set, reducing unnecessary column decode and cache pressure.
- Added key-range pre-skip in the binary cursor so leaflets outside the bound key range are skipped before decode/filter work.
- Reduced batched join overhead by using faster hash maps, pre-sizing grouping maps, streaming matched rows directly, and emitting batched subject-join results column-wise.
- Added single-ledger encoded-ID fast paths for IRI equality/inequality filters, including constant-IRI comparisons.
- Hoisted repeated per-row filter work by memoizing constant operand resolution to internal subject IDs.
- Removed expensive namespace table deep clones by sharing namespace data in binary graph views.
- Kept inline integer/double values encoded through binary scans and joins, reducing Binding hash/eq/clone/drop cost through DISTINCT and join pipelines.
- Added direct decode for inline numeric encoded literals without rebuilding a graph view per row.
- Added regression coverage for indexed inline numerics through projection, DISTINCT, filter evaluation, SUM, and DATATYPE.
- Streamed JSON result serialization (JSON-LD, SPARQL JSON, Typed JSON, Agent JSON) directly into the output buffer, eliminating the per-cell serde_json::Value DOM and its second serialization pass on the hot query string path; output stays byte-identical (enforced by parity tests), with the object-heavy SPARQL JSON and Typed JSON formats formatting large result sets roughly 7–9× and ~4× faster respectively.
- Centralized the byte-identical JSON-writing primitives (string escaping, integer/float formatting) in one parity-tested module, and dropped Agent JSON's per-row double serialization under a byte budget by measuring row size from output-buffer length deltas instead of re-serializing each row.

## Performance Notes

CPU profiling showed repeated low-level costs were often caused by loop-invariant work happening per row or per call. This branch addresses those cases directly: namespace cloning, constant IRI-to-subject-ID lookup, graph-view reconstruction for inline numeric decode, avoidable binary leaf scans, and materializing numeric values too early.

On the benchmark workload used during development, these changes produced substantial throughput improvements across single-client and high-concurrency runs.
