### PR TITLE
release v4.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,7 +2293,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-bench-support"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "chrono",
  "rand 0.8.5",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-api"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cli"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-iceberg"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-memory"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "chrono",
  "fluree-db-api",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice-sync"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-peer"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-server"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-aws"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-ipfs"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "cid",
@@ -3004,14 +3004,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "fluree-vocab",
  "pretty_assertions",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-httpd"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-service"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3153,14 +3153,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-sse"
-version = "4.0.5"
+version = "4.0.6"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-vocab"
-version = "4.0.5"
+version = "4.0.6"
 
 [[package]]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 exclude = ["testsuite-sparql"]
 
 [workspace.package]
-version = "4.0.5"
+version = "4.0.6"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/fluree/db"


### PR DESCRIPTION
Bumps the workspace version to 4.0.6 (`Cargo.toml` + `cargo update --workspace` lockfile refresh).

Stacked on #1308; once the chain is merged to main, the release will be tagged `v4.0.6` per `docs/contributing/releasing.md`, triggering cargo-dist to build binaries and publish the GitHub Release with auto-generated notes.
