### PR TITLE
Phase 0.0 perf guardrails: baseline capture/compare, allocation tracking, overlay-matrix bench

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1108,6 +1108,24 @@ mem:fact-01kp4g1wa8yyty4sd2p03k6bg9 a mem:Fact ;
     mem:artifactRef "fluree-graph-json-ld/src/expand.rs" ;
     mem:createdAt "2026-04-13T22:40:33.608461+00:00"^^xsd:dateTime .
 
+mem:fact-01ktwg9z9hkvq603ape6c4wbah a mem:Fact ;
+    mem:content "Perf guardrails (audit Phase 0.0) implemented on branch bench/phase0-baseline-guardrails: bench-baseline bin (capture/compare against regression-budget.json, exit 1 on breach, --only for PR-scoped subsets), fluree-bench-alloc tracking allocator (separate crate so bench-support keeps forbid(unsafe_code)), mem sidecars merged into baselines, and query_overlay_matrix bench (count/star/groupby × base/overlay/novelty conditions). First overlay-lane measurements (tiny, 100 products, quick profile): base→overlay penalties are count 31µs→273µs (~9×), star 63µs→911µs (~14×), groupby 154µs→19.8ms (~128×) — large improvement headroom for the Phase 1 overlay-merge refactor. Novelty condition skipped at large scale by design." ;
+    mem:tag "audit" ;
+    mem:tag "baseline" ;
+    mem:tag "benchmarking" ;
+    mem:tag "guardrails" ;
+    mem:tag "overlay" ;
+    mem:tag "query-perf" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "BENCHMARKING.md" ;
+    mem:artifactRef "fluree-bench-alloc/src/lib.rs" ;
+    mem:artifactRef "fluree-bench-support/src/baseline.rs" ;
+    mem:artifactRef "fluree-bench-support/src/bin/bench_baseline.rs" ;
+    mem:artifactRef "fluree-db-api/benches/query_overlay_matrix.rs" ;
+    mem:branch "bench/phase0-baseline-guardrails" ;
+    mem:createdAt "2026-06-11T23:29:32.465491+00:00"^^xsd:dateTime ;
+    mem:rationale "Phase gates for all audit roadmap phases run through this tooling; the overlay-penalty numbers are the pre-refactor reference for judging Phase 1 outcomes." .
+
 mem:decision-01kkymgaynzn5mrgy21pw22tf6 a mem:Decision ;
     mem:content "CLI write command naming: \"transact\" is the umbrella (API builder, HTTP endpoint), while specific operations are \"insert\", \"upsert\", and \"update\". The CLI command is `fluree update` (not `transact`) matching the API's `.transact().update()` pattern. Code: Commands::Update, commands::update::run(), UpdateFormat enum. Remote: update_jsonld()/update_sparql() both route to HTTP /transact. Internal types use \"transact\" for the generic write concept (TransactCore, GraphTransactBuilder, fluree-db-transact crate)." ;
     mem:tag "api-alignment" ;

--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1464,6 +1464,37 @@ mem:fact-01ks1m2nn2exrjt7tjkmzgqtg2 a mem:Fact ;
     mem:createdAt "2026-05-20T02:40:16.034976+00:00"^^xsd:dateTime ;
     mem:rationale "Pre-fix the extractors only handled Long/Double/Boolean and silently dropped FlakeValue::Decimal, causing SUM(decimal)=0 and AVG(decimal)=Unbound. The shared NumericAcc keeps the streaming and non-streaming paths in sync and prevents future drift between them." .
 
+mem:fact-01ktwep3pg2dxz9r44083zdrxy a mem:Fact ;
+    mem:content "Comprehensive architecture audit (2026-06-11) written to docs/audit/2026-06-architecture-audit.md. Thesis: the three chronic-bug contracts are convention-enforced, not type-enforced: (1) overlay→binary translation/merge has 5 merge impls + per-callsite failure policies; (2) LedgerState coherence spans 4 pub Arc fields with Arc-IDENTITY dependency (BinaryRangeProvider must share state.dict_novelty Arc); (3) fast-path gates (fast_path_store vs allow_cursor_fast_path) chosen per-operator — all 12 currently correct but unguarded. Roadmap phases: 0 newtypes+differential tests, 1 overlay chokepoint, 2 CoherentLedgerState/ArcSwap, 3 PlanCapabilities registry, 4 crate carve-outs." ;
+    mem:tag "architecture" ;
+    mem:tag "audit" ;
+    mem:tag "fast-path" ;
+    mem:tag "lifecycle" ;
+    mem:tag "overlay" ;
+    mem:tag "refactor-plan" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "docs/audit/2026-06-architecture-audit.md" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-06-11T23:01:13.040806+00:00"^^xsd:dateTime ;
+    mem:rationale "Anchor document for any future refactor work; recall before structural changes to query/ledger/binary-index." .
+
+mem:fact-01ktwepk8ernqdycdrns8e8kyq a mem:Fact ;
+    mem:content "Audit flagged unconfirmed lifecycle/correctness candidates — verify before fixing: (1) apply_loaded_db (~ledger lib.rs:606-622) merges old namespace codes but may not replay graph_registry deltas from remaining novelty; (2) apply_index_v2 (~ledger_manager.rs:351) doesn't call sync_binary_store_from_state before releasing state lock (snapshot/store TOCTOU); (3) reload swap condition new_state.t() >= current.t() (~ledger_manager.rs:1157) races concurrent commits; (4) export translate path WARN-drops non-Unsupported translation errors (binary_scan.rs:2238-2242) — same silent-drop class fixed earlier in graph crawl. Also: DecodedRow.dt u32 vs OverlayOp/RunRecord.dt u16; GraphId is bare u16 alias." ;
+    mem:tag "audit" ;
+    mem:tag "bug-candidates" ;
+    mem:tag "id-space" ;
+    mem:tag "lifecycle" ;
+    mem:tag "overlay" ;
+    mem:tag "verification-needed" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/src/ledger_manager.rs" ;
+    mem:artifactRef "fluree-db-binary-index/src/types.rs" ;
+    mem:artifactRef "fluree-db-ledger/src/lib.rs" ;
+    mem:artifactRef "fluree-db-query/src/binary_scan.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-06-11T23:01:28.974709+00:00"^^xsd:dateTime ;
+    mem:rationale "Read-level findings from exploration agents, not reproduced bugs; each needs confirmation (test or trace) before being treated as fact." .
+
 mem:constraint-01kp8yczz09ndt54ztchbheeyb a mem:Constraint ;
     mem:content "JSON-LD transaction parsing does NOT auto-promote bare string values to IRI references. User data becomes an IRI only when wrapped in `{\"@id\": \"...\"}` or when the property has `@type: \"@id\"` in `@context`. The former `looks_like_iri` heuristic (three sites in parse/jsonld.rs) was removed — it silently promoted strings starting with `http://`/`https://`/`did:`/`fluree:`/`urn:` to IRIs, which violated the JSON-LD spec (especially for `{\"@value\": \"...\"}`, explicitly a literal)." ;
     mem:tag "iri" ;

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -60,6 +60,7 @@ Hand-maintained; add new entries when introducing a bench file.
 | `fluree-db-api` | `reindex_incremental.rs` | Orchestrator's incremental path via `Fluree::trigger_index(...)` over delta novelty |
 | `fluree-db-api` | `novelty_replay.rs` | Cold reload with `without_indexing()` so populate stays in novelty; scaled by commit count |
 | `fluree-db-api` | `query_hot_bsbm.rs` | Warm-cache SPARQL: BSBM-shape Q3/Q5/Q9 against a reindexed ledger |
+| `fluree-db-api` | `query_overlay_matrix.rs` | Same query shapes at three ledger conditions — `base` (indexed, epoch 0), `overlay` (indexed + trailing novelty), `novelty` (no index) — with per-scenario memory metrics. The overlay-merge regression gate. |
 | `fluree-db-query` | `vector_math.rs` | SIMD vs scalar dot/L2/cosine micro-bench |
 | `fluree-db-spatial` | `spatial_bench.rs` | S2 covering build + within/intersects/radius latency |
 
@@ -116,6 +117,86 @@ The gate runs in two phases, defined separately in CI:
 
 To intentionally accept a regression (or tighten a budget), edit
 `regression-budget.json` in the same PR and explain in the PR body.
+
+## Baselines: capture & compare
+
+`bench-baseline` (a bin in `fluree-bench-support`) turns "benchmark before
+and after a change" into a mechanical workflow. It backs the per-phase
+performance gate defined in
+[`docs/audit/2026-06-architecture-audit.md`](docs/audit/2026-06-architecture-audit.md)
+(Phase 0.0): capture a labeled baseline **before** starting a refactor
+phase, compare against it on every PR in the phase, and validate at phase
+close.
+
+```bash
+# 1. Run the benches you care about (criterion writes target/criterion/):
+FLUREE_BENCH_SCALE=small cargo bench -p fluree-db-api --bench query_overlay_matrix
+
+# 2. Capture a labeled, git-stamped baseline:
+cargo run -p fluree-bench-support --bin bench-baseline -- \
+    capture --label phase-1-pre --out bench-baselines/phase-1-pre.json
+
+# 3. ...make changes, rerun the same benches under the same env knobs...
+
+# 4. Compare. Prints regressions AND improvements; exits 1 on any breach:
+cargo run -p fluree-bench-support --bin bench-baseline -- \
+    compare --baseline bench-baselines/phase-1-pre.json
+
+# PR-scoped subset (only scenario IDs containing the filter):
+cargo run -p fluree-bench-support --bin bench-baseline -- \
+    compare --baseline bench-baselines/phase-1-pre.json --only query_overlay_matrix
+```
+
+Details:
+
+- Scenario IDs are criterion's layout joined with `/` —
+  `<group>/<function>/<scale>` — and the scale segment maps comparisons
+  onto `regression-budget.json` budgets via the same machinery as
+  `budget::check()`.
+- Baselines record provenance (label, short git sha, timestamp, profile
+  and scale env at capture time). Compare like against like: same
+  profile, same scale, same machine class. `quick` profile for direction,
+  `full` for decisions.
+- Scenarios in the baseline but not rerun are reported as "not rerun" and
+  do **not** fail the gate — subset runs are expected on PRs. Breaches
+  fail with exit 1.
+- Phase reference baselines live in `bench-baselines/` and are committed
+  with the first PR of a phase so reviewers and CI share the reference.
+  Improvements found at phase close get banked by tightening the budget
+  in `regression-budget.json` in the closing PR.
+
+## Memory metrics
+
+Criterion measures wall-clock only. Benches that also want allocation
+metrics install the tracking allocator from `fluree-bench-alloc` (a
+dedicated crate so `fluree-bench-support` keeps `#![forbid(unsafe_code)]`)
+and record per-scenario peak / total allocation:
+
+```rust
+use fluree_bench_alloc::TrackingAllocator;
+
+#[global_allocator]
+static ALLOC: TrackingAllocator = TrackingAllocator::new();
+
+// around a scenario:
+fluree_bench_alloc::reset_peak();
+group.bench_with_input(/* ... */);
+let m = fluree_bench_alloc::snapshot();
+fluree_bench_support::mem::record_scenario("my_bench", "my_bench/q1/small",
+    MemMetrics { peak_bytes: m.peak_bytes as u64,
+                 total_allocated_bytes: m.total_allocated_bytes as u64 });
+```
+
+Metrics land in `target/fluree-bench-mem/<bench>.json` sidecars;
+`bench-baseline capture` merges them into the baseline and `compare`
+gates `peak_mem` with the same per-bench budgets as time.
+`total_allocated_bytes` (churn) is recorded for analysis but not gated —
+it scales with criterion's adaptive iteration counts. The tracker costs
+two relaxed atomics per alloc; that overhead is identical between a
+baseline and a comparison run of the same bench, so deltas stay valid —
+but don't compare a tracking bench's absolute times against a
+non-tracking bench. `query_overlay_matrix` is the first memory-aware
+bench; opt others in as needed.
 
 ### Why two phases
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
+name = "fluree-bench-alloc"
+version = "4.0.5"
+
+[[package]]
 name = "fluree-bench-support"
 version = "4.0.5"
 dependencies = [
@@ -2321,6 +2325,7 @@ dependencies = [
  "dirs 5.0.1",
  "ed25519-dalek",
  "flate2",
+ "fluree-bench-alloc",
  "fluree-bench-support",
  "fluree-db-binary-index",
  "fluree-db-connection",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "fluree-db-cli",
     "fluree-db-memory",
     "fluree-bench-support",
+    "fluree-bench-alloc",
 ]
 exclude = ["testsuite-sparql"]
 

--- a/bench-baselines/README.md
+++ b/bench-baselines/README.md
@@ -1,0 +1,27 @@
+# bench-baselines
+
+Committed performance reference points for the phase gate described in
+[`BENCHMARKING.md`](../BENCHMARKING.md) ("Baselines: capture & compare")
+and [`docs/audit/2026-06-architecture-audit.md`](../docs/audit/2026-06-architecture-audit.md)
+(Phase 0.0).
+
+Conventions:
+
+- `phase-<N>-pre.json` — captured on the commit a refactor phase branches
+  from, committed with the phase's first PR. Every PR in the phase runs
+  `bench-baseline compare` against it.
+- `phase-<N>-post.json` — captured at phase close on the same hardware
+  class and env knobs (`FLUREE_BENCH_PROFILE`, `FLUREE_BENCH_SCALE`) as
+  the pre-baseline. All tuples must be within budget vs pre;
+  improvements are banked by tightening `regression-budget.json` in the
+  closing PR.
+- Ad-hoc local baselines (validation runs, experiments) should live
+  outside the repo or be cleaned up before merge — only phase reference
+  points belong here.
+
+Capture:
+
+```bash
+cargo run -p fluree-bench-support --bin bench-baseline -- \
+    capture --label phase-1-pre --out bench-baselines/phase-1-pre.json
+```

--- a/docs/audit/2026-06-architecture-audit.md
+++ b/docs/audit/2026-06-architecture-audit.md
@@ -1,0 +1,230 @@
+# Fluree DB — Architecture & Rust-Practice Audit
+
+**Date:** 2026-06-11
+**Scope:** Full workspace (38 crates, ~460k lines of non-test Rust; ~594k total). Seven parallel deep-explorations: crate layering, core data model & ID spaces, binary-index/overlay contract, query engine organization, state lifecycle, write path, and a metrics-driven hygiene sweep. Load-bearing claims were verified directly against source.
+
+---
+
+## 1. Executive summary
+
+**The performance architecture is sound and the engineering discipline is real.** Workspace-wide `thiserror`, CI `-D warnings`, newtypes already in place for most ID spaces (`PredicateId`, `StringId`, `LangId`, `DatatypeDictId`, `TxnT`), a shared `fast_path_common.rs` that already deduplicated ~1.1k LOC, regression tests pinned to past bugs, and genuinely good design docs (`docs/design/query-execution.md`). The hygiene sweep grades the codebase **B+**: issues are incidental, not systemic rot.
+
+**The systemic risk is precisely the one you named.** The three most important contracts in the system are enforced by *convention and runtime discipline* rather than *by construction*:
+
+1. **The row↔columnar translation contract** — overlay `Flake`s (row world, `Sid`-based) translated into binary-index integer-ID space (`s_id`/`p_id`/`o_key`). There are **5 distinct merge implementations** and **2 translation wrappers** with subtly different fact-identity definitions and failure behaviors.
+2. **The ledger-state coherence contract** — `LedgerState` is four independently mutable `pub Arc` fields (`snapshot`, `novelty`, `dict_novelty`, `runtime_small_dicts`) whose consistency, plus the *Arc-pointer-identity* of `dict_novelty` inside `BinaryRangeProvider`, is maintained by hand at every mutation site.
+3. **The fast-path eligibility contract** — 33 shape detectors and 13 specialized operators each independently choose one of two overlay-safety gates; a wrong choice produces silently wrong results, not an error.
+
+Every chronic stateful bug class in project memory (disappearing properties on failed overlay translation, namespace-code drift after index attach, stale `DictNovelty` after refresh, lost graph-registry deltas) maps onto one of these three conventions. **The audit found the conventions are currently held everywhere checked** — all 12 fast-path gates are correctly applied today — but nothing except review discipline keeps them held.
+
+The plan in §4 converts each convention into a compile-time or single-chokepoint guarantee **without touching the hot inner loops**: newtypes are `#[repr(transparent)]` (zero cost), the merge chokepoint is a refactor of dispatch not of kernels, and the coherent-state swap (`ArcSwap`) is *cheaper* on the read path than the current `RwLock`.
+
+---
+
+## 2. How the system coheres today
+
+The implicit layering is healthy and close to what `docs/reference/crate-map.md` claims:
+
+```
+server / cli
+   └─ api  (facade + orchestration: ledger_manager, import/export, formatting, datasets, cross-ledger)
+       ├─ query ←─ sparql (lowering)        ├─ transact (write pipeline orchestrator)
+       │    └─ policy / reasoner             │
+       ├─ ledger (snapshot + novelty state)  ├─ shacl
+       ├─ indexer (build) / binary-index (read)
+       ├─ novelty / connection / nameservice
+       └─ core (Flake, Sid, ContentId, range, LedgerSnapshot) ── vocab
+```
+
+Verified deviations from the ideal:
+
+- **[LAYERING]** `fluree-db-indexer` optionally depends *upward* on `fluree-db-ledger` via the `embedded-orchestrator` feature (`fluree-db-indexer/Cargo.toml:12,19`), used only by `orchestrator.rs`. Orchestration belongs above the index builder, not inside it.
+- **[TYPE-ERASURE]** `TypeErasedStore(pub Arc<dyn Any + Send + Sync>)` (`fluree-db-ledger/src/lib.rs:53`) exists so `LedgerState` can carry a `BinaryIndexStore` without `ledger → indexer`/`binary-index` coupling, downcast in `fluree-db-api/src/ledger_manager.rs`. It is a *deliberate* dependency inversion — but it is also a hole in the type system at the exact point where the state-coherence bugs live. A small `ledger-state` trait crate (or moving the store handle into a typed field once Phase 2 lands) would retire it.
+- **[GOD-CRATE]** `fluree-db-api` (77k lines, 110 files) is a legitimate facade that has accreted non-facade business logic: `import.rs` alone is **5,880 lines**, plus `format/` (~16 output formats), `cross_ledger/`, `ledger_manager.rs`, `export.rs`. The crate name says "API"; the content says "API + ETL + formatting + state cache + governance."
+- **No duplicate domain types across crates** — `Flake`, `Commit`, `ContentId` are defined once. Duplication lives *within* the query crate (§3.4), not across crate boundaries.
+
+---
+
+## 3. Findings by area
+
+### 3.1 ID spaces and core types — good bones, three holes
+
+The core types are mostly newtyped. The exceptions are exactly where past bugs happened:
+
+| Finding | Evidence | Why it matters |
+|---|---|---|
+| `GraphId` is a bare alias: `pub type GraphId = u16` | `fluree-db-core/src/ids.rs:73` | Freely cross-assignable with namespace codes (also bare `u16`). Graph scoping and namespace encoding are both pervasive `u16`s in the same functions. |
+| Namespace codes are bare `u16` everywhere, and there are **two distinct namespace spaces** (snapshot-space vs binary-store-space) carried in the same type | `ns_encoding.rs`, `binary_scan.rs`; past bug fixed in `it_namespace_new_after_index.rs` | The "new namespace after index attach" bug was precisely a cross-space confusion. The fix is convention ("keep bound SIDs in snapshot space, decode→re-encode for store filters") that the type system cannot see. |
+| Datatype code width disagreement: `DecodedRow.dt: u32` vs `OverlayOp.dt: u16` vs `RunRecord.dt: u16` | `fluree-db-binary-index/src/types.rs:72,100`; `format/run_record.rs:83` | Same semantic value, three widths, implicit widening/narrowing across the overlay-translation pipeline — the system's most bug-prone seam. |
+| `LedgerSnapshot` exposes coupled `pub` fields: `t`/`base_t`, `subject_watermarks`/`string_watermark` (must mirror `DictNovelty` watermarks), `graph_registry` (must mirror commit envelope deltas) | `fluree-db-core/src/db.rs:64-134` | Any caller can break the pairing; the invariants are stated in comments, enforced nowhere. |
+| `DictNovelty` guards initialization with an unconditional runtime panic, and its correctness depends on being **the same Arc instance** shared with `BinaryRangeProvider` | `fluree-db-core/src/dict_novelty.rs:25,63,136`; `fluree-db-api/src/ledger_manager.rs:341-347` | Arc *identity* (not value) as a correctness requirement is invisible to the compiler, to clippy, and to most reviewers. |
+
+The bright side: `namespace_codes`/`namespace_reverse` are already private with mutation funneled through methods — the pattern to extend, not invent.
+
+### 3.2 The overlay merge contract — one concept, five implementations
+
+Distinct implementations of "merge columnar base with row overlay," each with its own fact-identity and tie-breaking:
+
+| # | Site | Semantics |
+|---|---|---|
+| 1 | `BinaryCursor::merge_overlay_into_batch` — `fluree-db-binary-index/src/read/binary_cursor.rs:457-612` | Two-pointer merge on V3 identity `(s_id, p_id, o_type, o_key, o_i)`; overlay replaces/suppresses base on equal identity |
+| 2 | `fast_post_order_limit::collect_post_desc_topk_overlay` — `fluree-db-query/src/fast_post_order_limit.rs:512-678` | Descending row-set merge; asserts sorted DESC, retracts as hash set |
+| 3 | `count_predicate_overlay_delta` — `fluree-db-query/src/fast_path_common.rs:2291-2396` | Arithmetic: `base_total − base(touched) + merged(touched)` per leaf |
+| 4 | Export/graph-crawl raw-flake post-pass — `fluree-db-api/src/export.rs:79-122`, `format/graph_crawl.rs` | Parallel translated + *untranslated raw Flake* streams; dedup by `FlakeValue` identity (NOT the V3 tuple); latest-t-wins, tie prefers retract |
+| 5 | `range_with_overlay` — `fluree-db-core/src/range.rs:68-142` | Trait-delegated; the generic fallback everyone else must agree with |
+
+Translation (`Flake → OverlayOp`) is funneled through `translate_one_flake_v3_pub` (`fluree-db-query/src/binary_scan.rs:2268-2360`) but its **failure handling differs per call site**: `Ok(None)`-fallback at one (`:1811→:1844`), untranslated-list at another, and **WARN-and-drop for non-`Unsupported` errors in the export path** (`binary_scan.rs:2238-2242`) — a residual instance of the exact bug class (silent data drop) that was previously fixed in graph crawl.
+
+The gating contract (`fast_path_common.rs:2663-2705`): strategy (a) `fast_path_store`/`allow_fast_path` (bail when *any* overlay/time-travel/policy/multi-ledger), strategy (b) `allow_cursor_fast_path` (admit overlay because the cursor merges it). **All 12 fast paths were verified to use a correct gate today.** But the gate choice is one function call in each operator's `open()`; nothing structural prevents the 14th fast path from picking wrong, and a wrong pick is silently wrong results.
+
+### 3.3 State lifecycle — the torn-state machine
+
+A ledger's in-memory life is an implicit state machine (genesis → indexed → indexed+trailing-novelty → mid-refresh → reloading) spread across `LedgerHandle { RwLock<LedgerState>, RwLock<Option<Arc<BinaryIndexStore>>> }` (`fluree-db-api/src/ledger_manager.rs:102-135`) and four CoW Arc fields in `LedgerState` (`fluree-db-ledger/src/lib.rs:81-125`).
+
+Highest-confidence findings (flagged by the lifecycle audit; **confirm before fixing**, they are read-level analyses, not reproduced bugs):
+
+- **[ARC-IDENTITY]** `apply_index_v2` builds `BinaryRangeProvider` with `Arc::clone(&state.dict_novelty)` (`ledger_manager.rs:341-347`). A later commit's `Arc::make_mut` on `state.dict_novelty` (CoW because the provider holds a ref) detaches the provider's copy → overlay translation misses post-refresh novelty IDs. This is the same family as the gotcha already recorded in project memory; the audit suggests the *structural* exposure is still present.
+- **[TORN-STATE]** `apply_loaded_db` (`fluree-db-ledger/src/lib.rs:548`) merges old namespace codes into the new snapshot (`:606-622`) but does **not** replay graph-registry deltas from remaining novelty commits — candidate for graph-IRI loss after refresh.
+- **[RACE]** Reload swap condition `new_state.t() >= current.t()` (`ledger_manager.rs:~1157`) compares a max(novelty, snapshot) watermark that a concurrent commit can move mid-load.
+- **[LOCKING]** `state`-before-`binary_store` lock ordering is documented (`ledger_manager.rs:116`) but convention-only, and `sync_binary_store_from_state` (`:187-200`) — written to close the snapshot/store TOCTOU — is not invoked in `apply_index_v2` (`:351`).
+- **[TEST-GAP]** No test exercises refresh-while-querying, commit-during-refresh, or reload-vs-commit. The one regression test (`it_dict_novelty_apply_loaded_db.rs`) validates sequential behavior only.
+
+### 3.4 Query engine — phenomenal machinery, organizational debt
+
+- **[FAST-PATH-SPRAWL]** 33 `detect_*` shape recognizers (verified) dispatching to 13 `fast_*.rs` operator files (~10k LOC). `operator_tree.rs` (3,692 lines) runs them as a 600+-line sequential if-chain, each arm recursively building the generic tree as `fallback`. The *operators* are well-built; the *dispatch and gating* are the sprawl.
+- **[PLANNER-MONOLITH]** `where_plan.rs` (3,570 lines) interleaves pattern reordering, filter-pushdown analysis, OPTIONAL coalescing, star fusion, and operator construction. Variable-readiness logic is implemented three times (`partition_eligible_filters` `:697`, `apply_eligible_binds` `:725`, `inline_eligible_filters` `:979`).
+- **[EXPLAIN-GAP]** When a fast path bails at runtime (`Ok(None)` → fallback), EXPLAIN still shows the *planned* operator. For a system whose contributor-facing question is "which path did my query take," this is the single cheapest comprehension win available.
+- **[BINDING-STATES]** `Binding` has 11 variants spanning three regimes (decoded, late-materialized `Encoded*`, control-flow `Poisoned`). Two latent contracts are doc-comment-only: `Poisoned` must block matching (documented at `binding.rs:35-37`), and `EncodedSid` is single-ledger-only (raw `s_id` comparison is wrong cross-ledger; currently prevented by construction in `DatasetOperator`, enforced nowhere).
+- Error/panic style inside operators is disciplined: invariant-guarded unwraps, `catch_unwind` around parallel workers. `join.rs` (3,755 lines) carries ~20 such unwraps without invariant comments.
+
+### 3.5 Write path — clean pipeline, opt-in safety
+
+The transact pipeline is a clear 10-stage sequence (parse → WHERE resolve → instantiate/cancel → policy → SHACL → commit build → CAS publish → novelty apply → index trigger) and **reuses the query engine for WHERE resolution — no read/write duplication**. Crash-consistency is sound by design (commit blob + nameservice CAS durable; novelty volatile and rebuilt by replay). Three structural notes:
+
+- **[VALIDATION-BYPASS]** Policy enforcement is `policy_ctx: Option<&PolicyContext>` threaded per call (`fluree-db-transact/src/stage.rs:80,382-398`). The default `transact()` path passes `None`. Whether writes are policy-checked is a property of the *call site*, not the *ledger*. Same opt-in shape for SHACL.
+- **[VALIDATION-TIMING]** SHACL validates pre-state + staged flakes, never final post-state; a transaction that deletes the last `:name` of a `Person` passes a min-count shape.
+- **[PARTIAL-FAILURE]** Lost CAS race leaves a durable, unreferenced commit blob with no GC path.
+
+### 3.6 Hygiene metrics (workspace-wide)
+
+| Metric | Value | Read |
+|---|---|---|
+| `.unwrap()` / `.expect()` (incl. tests) | ~9.2k / ~5.3k | Sampled hot-path instances are invariant-guarded but undocumented |
+| `unsafe` blocks | 46 (~20 without `SAFETY:`) | Mostly justified (UTF-8 post-validation, libc in CLI); docs missing |
+| Error style | `thiserror` in 36/37 crates | Coherent but shallow: `Other(String)`/`Storage(String)` catch-alls in `fluree-db-core/src/error.rs:10-54` |
+| Lints/CI | 26 workspace deny rules, clippy `-D warnings` | Strong |
+| Files >3k lines | `import.rs` 5,880 · `lib.rs`(api) 4,268 · `join.rs` 3,755 · `operator_tree.rs` 3,692 · `where_plan.rs` 3,570 · `count_plan_exec.rs` 2,965 | The split candidates are §4 Phase 4 |
+| Integration tests | api: 146 files · query: **5 files** (plus inline units) | Query correctness is mostly tested *through* the api crate; planner/operator regressions surface late and far from cause |
+| Async | 1 intentional `block_on` bridge; no lock-across-await anti-patterns found | Healthy |
+
+---
+
+## 4. First principles, then the roadmap
+
+### Design principles (what "good" looks like for this codebase)
+
+1. **One coherent state, swapped atomically.** Readers receive an immutable, internally consistent bundle; writers build the next bundle and swap. No observable intermediate states, no Arc-identity contracts.
+2. **An ID is a type, not an integer.** Two values that must never be cross-assigned get two types; where the same number exists in two coordinate systems (snapshot-ns vs store-ns), the *space* is part of the type.
+3. **One chokepoint per contract.** Overlay translation and overlay merge each get exactly one entry point with an explicit, typed outcome — variants (`RowMerge`, `OrderedMerge`, `CountDelta`, `RawPostPass`) are strategies behind it, not parallel implementations.
+4. **Capabilities, not scattered booleans.** A query's plan-time environment (`history`, `overlay-epoch`, `policy`, `multi-ledger`, `time-travel`, index features) is computed once into a capability set; fast paths *declare* requirements and a registry matches them. Adding a feature means adding a capability, and the compiler/registry — not 33 detectors — decides who is disabled.
+5. **Fallback is architecture — keep it, but type it.** The `Ok(None) ⇒ run fallback` philosophy is genuinely good (correctness never depends on flawless translation). Promote it from convention to a `FastPathOutcome::{Proceed, Fallback(reason)}` that EXPLAIN and metrics can observe.
+6. **Validation is a ledger property, not a call-site argument.**
+
+### Phase 0.0 — Performance guardrails *(the precondition for every phase below)*
+
+Correctness guardrails (the differential harness, 0.7) tell us a refactor didn't change *answers*; these tell us it didn't change *speed or memory*. The rule for the whole roadmap: **no phase begins until its pre-baseline is captured, and no phase closes until the post-baseline shows every tuple within budget — with improvements recorded and budgets tightened where they appear.**
+
+What exists today: a criterion chassis (`fluree-bench-support`) with scale (`tiny`→`large`) and profile (`quick`/`full`) knobs, `regression-budget.json` with per-`(crate, bench, scale)` budgets, and a CI smoke gate. What's missing, and what this phase adds:
+
+| # | Item | Gap it closes |
+|---|---|---|
+| G1 | **Baseline capture & compare tool** (`bench-baseline` bin in `fluree-bench-support`): `capture` walks criterion's `estimates.json` output into a labeled, git-stamped `bench-baselines/<label>.json`; `compare` re-walks current results against a named baseline using `regression-budget.json` budgets, prints a per-scenario table (regressions *and* improvements), exits nonzero on breach | Budget comparison was aspirational — budgets existed but no baseline file, no capture workflow, no compare command anyone can run locally before/after a change |
+| G2 | **Memory metrics** (`fluree-bench-alloc` tracking allocator + `mem` sidecar recording in bench-support): per-scenario peak and net allocated bytes recorded alongside time, merged into the same baseline file, compared with the same budget machinery | Criterion measures time only; an allocation regression (e.g., a refactor that clones where it borrowed) was invisible |
+| G3 | **Condition-matrix bench** (`query_overlay_matrix`): the same query shapes run at `base` (indexed, epoch 0), `overlay` (indexed + trailing novelty), and `novelty` (no index) conditions, × scales | Every existing hot-path bench runs at epoch 0 — the overlay-merge lane, which Phases 1–2 refactor directly, had zero benchmark coverage; a regression confined to the overlay lane would have passed every gate |
+| G4 | **Per-phase protocol** (below) | "Benchmark before and after" was implicit; now it is a written, mechanical procedure |
+
+**Per-phase protocol (G4):**
+
+1. **Pre-baseline.** On the commit a phase branches from: `quick` profile at `tiny`+`small` for fast iteration, `full` profile at `small`+`medium` for the gate, `large` where the phase touches scan/merge paths. Capture → `bench-baselines/phase-<N>-pre.json`, committed with the phase's first PR so reviewers and CI share the reference.
+2. **In-flight.** Every PR in the phase runs `compare` against the pre-baseline for the bench subset its diff can affect (at minimum: `query_overlay_matrix` for Phases 1–2, `query_hot_bsbm` for Phase 3, `transact_commit`/`novelty_replay` for write-path changes).
+3. **Post-validate.** At phase close, capture `phase-<N>-post.json` under the same profile/scale matrix on the same hardware class; every tuple must be ≤ budget vs pre. Improvements are recorded in the phase's closing PR and budgets tightened to bank them (a banked improvement can't silently erode later).
+4. **Noise discipline.** Local runs use `quick` for direction, `full` for decisions; the budget JSON keeps per-scale slack (10% tiny, 5% small/medium, 3% where we've banked wins) because small scales flap more.
+
+Scale-tier honesty: `tiny`/`small`/`medium` run in CI and locally; `large` and the BSBM-100M-class datasets in project memory are nightly/manual — phases that touch leaf-walk or merge kernels (1, 2) require at least one manual `large` validation before close, recorded in the closing PR.
+
+### Phase 0 — Make invariants visible and tested *(days–2 weeks each, LOW risk, HIGH leverage)*
+
+| # | Item | Impact / Risk |
+|---|---|---|
+| 0.1 | Newtype `GraphId(u16)` and `NsCode(u16)`; optionally phantom-tag namespace space (`NsCode<Snapshot>` vs `NsCode<Store>`) at the binary_scan boundary where the past bug lived | High / Low — `#[repr(transparent)]`, zero runtime cost, mechanical |
+| 0.2 | Unify datatype code to one `DtCode(u16)` across `DecodedRow`/`OverlayOp`/`RunRecord` | High / Low–Med |
+| 0.3 | **Confirm-then-fix** the three lifecycle flags: graph-registry replay in `apply_loaded_db`; call `sync_binary_store_from_state` inside `apply_index_v2` before releasing the state lock; reload `t()` swap race | High / Low once confirmed |
+| 0.4 | Concurrency regression tests: query-during-refresh, commit-during-refresh, reload-vs-commit, detached-`dict_novelty` detection | High / None — pure test investment, and the safety net for Phases 1–2 |
+| 0.5 | Fix export-path WARN-and-drop on non-`Unsupported` translation errors (`binary_scan.rs:2238-2242`) — route through the raw-flake post-pass like graph crawl | Med / Low |
+| 0.6 | `# Invariants` rustdoc on `LedgerSnapshot`, `LedgerState`, `DictNovelty`, `Binding`; `SAFETY:`/invariant comments on the ~20 undocumented unsafes and `join.rs` unwraps | Med / None |
+| 0.7 | **Differential test harness**: property tests asserting fast-path ≡ generic-path results under randomized base+overlay+time-travel. This is the single highest-ROI test artifact for this codebase and the gate for everything below | Very High / None |
+
+### Phase 1 — One overlay contract *(3–6 weeks, MED risk, the highest correctness ROI)*
+
+Create an `overlay` module (likely in `fluree-db-binary-index` or a thin `fluree-db-overlay`) owning:
+- **One canonical `FactKey`** (the V3 identity tuple) — today export dedups by `FlakeValue`, cursors by the V3 tuple; pick one, convert at the edge.
+- **One translation entry** returning `enum Translation { Ok(OverlayOp), Untranslated(Flake, Reason), Fatal(Error) }` — callers choose *policy* (fallback / raw post-pass / error) but can no longer silently drop.
+- **Merge strategies behind one trait/enum**: `RowMerge` (cursor two-pointer), `OrderedMerge` (desc top-k), `CountDelta`, `RawPostPass` (lifecycle resolution: latest-t-wins, tie prefers retract — written once).
+
+Migrate the five implementations one at a time, each landing behind the Phase 0.7 differential harness and the `regression-budget.json` benchmark gate. The inner kernels (two-pointer merge, leaflet arithmetic) move, not change.
+
+### Phase 2 — Coherent ledger state *(4–8 weeks, MED-HIGH risk, kills the bug class structurally)*
+
+```rust
+pub struct CoherentLedgerState {       // all fields private
+    snapshot: Arc<LedgerSnapshot>,
+    novelty: Arc<Novelty>,
+    dict_novelty: Arc<DictNovelty>,
+    runtime_small_dicts: Arc<RuntimeSmallDicts>,
+    index: Option<AttachedIndex>,      // store + provider built together, typed (retires TypeErasedStore)
+}
+// LedgerHandle: ArcSwap<CoherentLedgerState>; transitions are methods returning a NEW bundle:
+// .with_commit(...), .with_index_applied(...), .trimmed_to(...)
+```
+
+- Readers: one atomic `load()` — strictly cheaper than today's `RwLock` read; no torn states by construction.
+- Writers: build-then-swap; the `BinaryRangeProvider` is constructed *inside* the transition from the same bundle, so Arc-identity coupling cannot recur.
+- Sequencing of writers stays as-is (commits already serialize via nameservice CAS).
+- This phase retires: both lifecycle `RwLock`s' ordering convention, `sync_binary_store_from_state`, the detached-Arc class, and `TypeErasedStore`.
+
+### Phase 3 — Capability-gated planning *(2–4 weeks, LOW-MED risk)*
+
+- `PlanCapabilities` computed once from `ExecutionContext` (overlay epoch, to_t vs index_t, from_t, policy, multi-ledger, history, index features like `lex_sorted_string_ids`, leaflet-FIRST availability).
+- `FastPathRegistry`: table of `{ detector, builder, required_capabilities }` replacing the if-chain in `operator_tree.rs:2073-2700`. Gate strategies (a)/(b) become *declared data* (`requires: NoOverlay` vs `requires: CursorMergeable`) instead of a per-operator function call.
+- EXPLAIN records **actual** path: when an operator falls back at `open()`, stamp `FastPathOutcome::Fallback(reason)` into the execution context so explain/tracing show planned *and* executed. (This piece alone is shippable in days and is the best contributor-experience win per line changed.)
+
+### Phase 4 — Organizational refactors *(incremental, LOW risk each, schedule opportunistically)*
+
+1. Split `where_plan.rs` into `plan` (pure analysis → a serializable `WherePlan` struct) and `build` (plan → operators); consolidate the 3× variable-readiness logic. Unit-test planning without executing.
+2. Extract `fluree-db-api/src/format/` → its own crate; split `import.rs` (5,880 lines) into parse/resolve/build stages; consider `ledger_manager` → `fluree-db-connection` once Phase 2 reshapes it.
+3. Move indexer orchestration out of `fluree-db-indexer` (drop the `embedded-orchestrator` upward dep).
+4. Make policy/SHACL enforcement a ledger-level configuration checked at the commit chokepoint (one place all commit-building paths must pass), with explicit `root`/`system` bypass — not an `Option` parameter. Offer post-state SHACL as a config mode (validate after novelty apply against the new bundle from Phase 2, reject by not swapping).
+5. Structured error variants for the cross-crate seams that matter (translation, state transitions) — leave user-facing `String` variants alone.
+6. `fluree-db-query/tests/` integration suite (planner shapes, operator correctness, fast-path/fallback parity) so query bugs stop being discovered through `fluree-db-api`'s 146 test files.
+
+### Explicitly deferred / not recommended
+
+- **Phantom-typed `Binding<Maturity>`**: real safety, but it makes every operator generic — viral complexity for a contract better held by the registry + a debug-assert at batch boundaries. Revisit only if Poisoned/Encoded leaks actually occur.
+- **Per-ledger commit queue**: CAS + retry is correct and scales; don't serialize writes harder than the nameservice already does.
+- **Detector DSL/macro for query shapes**: appealing, but a registry of plain functions gets 90% of the benefit without a new meta-language to maintain.
+
+---
+
+## 5. What must not change
+
+The audit's job was also to mark the load-bearing performance walls:
+
+- The 13 fast-path operator **kernels** (leaflet-FIRST boundary tricks, POST tail walks, per-leaf count arithmetic, `ColumnSet::CORE`-only decoding, binary-searched o_key runs) — these are the measured wins (BSBM Q5 ~27%, ORDER BY ~200×). Phases 1/3 move their *dispatch and gating*, never their loops.
+- The columnar/row dual representation itself — it is the right design; the goal is one *contract* between the worlds, not one representation.
+- Late materialization (`Encoded*` bindings) and the streaming batch model.
+- The fallback-over-failure philosophy (`Ok(None)` ⇒ slower correct path) — formalized, not removed.
+- Landing rule for every phase: differential tests green (Phase 0.7), baseline compare green per the Phase 0.0 protocol (time *and* memory, including the overlay-condition lanes), one migration per PR.
+
+## 6. Sequencing rationale
+
+Phase 0.0 comes first because it is the measurement substrate every later claim depends on — "no regression" is only meaningful against a captured baseline, and the overlay-condition lane must be benchmarked *before* the phases that refactor it. Phase 0 is pure insurance and takes effect immediately. Phase 1 attacks the seam where every historical data-correctness bug originated, with the differential harness making it safe. Phase 2 is the structural kill of the stateful-condition class you called out — it is the riskiest, which is why it comes *after* the test harness and the confirmed point-fixes have stabilized the ground. Phase 3 is leverage for future contributors (every new optimization slots into a registry instead of a 600-line if-chain). Phase 4 is steady-state hygiene that can interleave with feature work indefinitely.

--- a/fluree-bench-alloc/Cargo.toml
+++ b/fluree-bench-alloc/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fluree-bench-alloc"
+description = "Tracking global allocator for Fluree DB benchmarks: per-scenario peak / net allocation metrics with two relaxed atomics of overhead per alloc"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# This crate exists separately from fluree-bench-support so that crate can
+# keep `#![forbid(unsafe_code)]`: implementing `GlobalAlloc` requires one
+# well-understood `unsafe impl`, which is quarantined here. Benches that
+# want memory metrics depend on this crate directly and install the
+# allocator in their own binary; nothing in the production dependency
+# graph references it.
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/fluree-bench-alloc/src/lib.rs
+++ b/fluree-bench-alloc/src/lib.rs
@@ -1,0 +1,185 @@
+//! Tracking global allocator for benchmarks.
+//!
+//! Wraps [`std::alloc::System`] and maintains three counters with two
+//! `Relaxed` atomic operations per allocation/deallocation:
+//!
+//! - **current** — live bytes right now,
+//! - **peak** — high-water mark of `current` since the last [`reset_peak`],
+//! - **total** — cumulative bytes allocated since the last [`reset_peak`]
+//!   (deallocations don't decrease it; a measure of allocator churn).
+//!
+//! ## Usage in a bench
+//!
+//! ```ignore
+//! use fluree_bench_alloc::TrackingAllocator;
+//!
+//! #[global_allocator]
+//! static ALLOC: TrackingAllocator = TrackingAllocator::new();
+//!
+//! // around a scenario:
+//! fluree_bench_alloc::reset_peak();
+//! run_scenario();
+//! let m = fluree_bench_alloc::snapshot();
+//! eprintln!("peak={}B churn={}B", m.peak_bytes, m.total_allocated_bytes);
+//! ```
+//!
+//! ## Measurement honesty
+//!
+//! The counters add a small constant overhead to every allocation. That
+//! overhead is identical between a baseline run and a comparison run of the
+//! same bench binary, so *deltas* remain valid; absolute numbers from a
+//! tracking bench should not be compared against a non-tracking bench.
+//! Benches that install this allocator say so in their module docs.
+//!
+//! Peak tracking uses a `Relaxed` compare-exchange loop; under multi-threaded
+//! allocation the recorded peak can momentarily lag the true peak by the
+//! window of a racing update, which is well inside bench noise. Counters are
+//! process-wide: reset before each scenario and read after it, and don't run
+//! scenarios concurrently (criterion doesn't).
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static CURRENT: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+static TOTAL: AtomicUsize = AtomicUsize::new(0);
+
+/// A `GlobalAlloc` wrapper around [`System`] that maintains the module's
+/// current / peak / total counters.
+pub struct TrackingAllocator;
+
+impl TrackingAllocator {
+    #[must_use]
+    pub const fn new() -> Self {
+        TrackingAllocator
+    }
+}
+
+impl Default for TrackingAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn on_alloc(size: usize) {
+    TOTAL.fetch_add(size, Ordering::Relaxed);
+    let cur = CURRENT.fetch_add(size, Ordering::Relaxed) + size;
+    // Lock-free high-water mark. Relaxed is fine: we only need the peak to
+    // be observable after the scenario's allocations have happened-before
+    // the read, which the bench harness's own synchronization provides.
+    let mut peak = PEAK.load(Ordering::Relaxed);
+    while cur > peak {
+        match PEAK.compare_exchange_weak(peak, cur, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(observed) => peak = observed,
+        }
+    }
+}
+
+fn on_dealloc(size: usize) {
+    CURRENT.fetch_sub(size, Ordering::Relaxed);
+}
+
+// SAFETY: delegates every allocation verbatim to `System`, which upholds the
+// `GlobalAlloc` contract; the counter updates around the delegation never
+// touch the returned memory and cannot panic (atomics only).
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            on_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        on_dealloc(layout.size());
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc_zeroed(layout);
+        if !ptr.is_null() {
+            on_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = System.realloc(ptr, layout, new_size);
+        if !new_ptr.is_null() {
+            // Model as dealloc(old) + alloc(new) so `current` stays exact.
+            on_dealloc(layout.size());
+            on_alloc(new_size);
+        }
+        new_ptr
+    }
+}
+
+/// A point-in-time reading of the allocator counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AllocSnapshot {
+    /// Live bytes at the time of the snapshot.
+    pub current_bytes: usize,
+    /// High-water mark of live bytes since the last [`reset_peak`].
+    pub peak_bytes: usize,
+    /// Cumulative bytes allocated since the last [`reset_peak`] (churn).
+    pub total_allocated_bytes: usize,
+}
+
+/// Reset `peak` to the current live size and `total` to zero. Call before
+/// the measured region of a scenario.
+pub fn reset_peak() {
+    let cur = CURRENT.load(Ordering::Relaxed);
+    PEAK.store(cur, Ordering::Relaxed);
+    TOTAL.store(0, Ordering::Relaxed);
+}
+
+/// Read the counters. Call after the measured region of a scenario.
+#[must_use]
+pub fn snapshot() -> AllocSnapshot {
+    AllocSnapshot {
+        current_bytes: CURRENT.load(Ordering::Relaxed),
+        peak_bytes: PEAK.load(Ordering::Relaxed),
+        total_allocated_bytes: TOTAL.load(Ordering::Relaxed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // NOTE: these tests exercise the counter arithmetic directly rather than
+    // installing the allocator (a test binary can't conditionally install a
+    // global allocator, and installing it for the whole test binary would
+    // make assertions racy against the test harness's own allocations).
+    // The counters are process-global, so the tests serialize on a lock.
+
+    static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn alloc_dealloc_counter_arithmetic() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_peak();
+        let before = snapshot();
+        on_alloc(1000);
+        on_alloc(500);
+        on_dealloc(500);
+        let after = snapshot();
+        assert_eq!(after.current_bytes, before.current_bytes + 1000);
+        assert!(after.peak_bytes >= before.current_bytes + 1500);
+        assert!(after.total_allocated_bytes >= 1500);
+        on_dealloc(1000);
+    }
+
+    #[test]
+    fn reset_peak_rebases_to_current() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        on_alloc(2048);
+        reset_peak();
+        let s = snapshot();
+        assert_eq!(s.peak_bytes, s.current_bytes);
+        assert_eq!(s.total_allocated_bytes, 0);
+        on_dealloc(2048);
+    }
+}

--- a/fluree-bench-support/Cargo.toml
+++ b/fluree-bench-support/Cargo.toml
@@ -6,8 +6,14 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
-# Library only. No bins, no benches in this crate — see <workspace>/BENCHMARKING.md
-# for the chassis design and per-crate `benches/` for the actual benches.
+# Library + one small CLI (`bench-baseline`, for baseline capture/compare —
+# see BENCHMARKING.md "Baselines"). No benches in this crate — see
+# <workspace>/BENCHMARKING.md for the chassis design and per-crate
+# `benches/` for the actual benches.
+
+[[bin]]
+name = "bench-baseline"
+path = "src/bin/bench_baseline.rs"
 
 [features]
 default = []

--- a/fluree-bench-support/src/baseline.rs
+++ b/fluree-bench-support/src/baseline.rs
@@ -1,0 +1,476 @@
+//! Baseline capture and comparison for the per-phase performance gate.
+//!
+//! `BENCHMARKING.md` ("Baselines: capture & compare") documents the
+//! workflow; `docs/audit/2026-06-architecture-audit.md` Phase 0.0 documents
+//! the protocol this implements. In short:
+//!
+//! 1. Run benches (`cargo bench ...`). Criterion writes per-scenario
+//!    estimates under `target/criterion/<group>/<fn>/<param>/new/estimates.json`;
+//!    memory-aware benches additionally write sidecars under
+//!    `target/fluree-bench-mem/` (see [`crate::mem`]).
+//! 2. `bench-baseline capture --label phase-1-pre --out bench-baselines/phase-1-pre.json`
+//!    walks both outputs into one git-stamped [`BaselineFile`].
+//! 3. After a change, rerun the benches and
+//!    `bench-baseline compare --baseline bench-baselines/phase-1-pre.json`.
+//!    Each scenario present in both runs is compared against
+//!    `baseline × (1 + budget_pct/100)` using `regression-budget.json`
+//!    budgets (same machinery as [`crate::budget::check`]); the command
+//!    prints a table of regressions *and* improvements and exits nonzero
+//!    on any budget breach.
+//!
+//! Scenario IDs are criterion's directory layout joined with `/` —
+//! `"<group>/<function>/<parameter>"` — and benches put the scale in the
+//! parameter slot (`BenchScale::as_str()`), so budget lookup can recover
+//! `(bench, scale)` from the ID's first and last segments.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::budget::RegressionBudget;
+use crate::mem::MemMetrics;
+use crate::runtime::BenchScale;
+
+pub const BASELINE_SCHEMA_VERSION: u32 = 1;
+
+/// One scenario's captured measurements.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BaselineEntry {
+    /// Criterion `mean.point_estimate`, nanoseconds.
+    pub mean_ns: f64,
+    /// Criterion `median.point_estimate`, nanoseconds.
+    pub median_ns: f64,
+    /// Allocation metrics, when the bench records them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mem: Option<MemMetrics>,
+}
+
+/// A captured baseline: scenario ID → measurements, plus provenance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaselineFile {
+    pub schema_version: u32,
+    /// Human label, e.g. `phase-1-pre`.
+    pub label: String,
+    /// `git rev-parse --short HEAD` at capture time, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git_sha: Option<String>,
+    /// RFC 3339 capture timestamp.
+    pub captured_at: String,
+    /// `FLUREE_BENCH_PROFILE` / `FLUREE_BENCH_SCALE` at capture time —
+    /// informational; compare against a baseline captured under the same
+    /// knobs.
+    pub profile: String,
+    pub scale: String,
+    pub entries: BTreeMap<String, BaselineEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Capture
+// ---------------------------------------------------------------------------
+
+/// Walk a criterion output directory and collect
+/// `scenario_id → (mean_ns, median_ns)` from every `*/new/estimates.json`.
+///
+/// Criterion's own `report/` directories contain no `new/estimates.json`,
+/// so they fall out naturally.
+pub fn collect_criterion_entries(criterion_dir: &Path) -> BTreeMap<String, BaselineEntry> {
+    let mut out = BTreeMap::new();
+    walk(criterion_dir, criterion_dir, &mut out);
+    out
+}
+
+fn walk(root: &Path, dir: &Path, out: &mut BTreeMap<String, BaselineEntry>) {
+    let estimates = dir.join("new").join("estimates.json");
+    if estimates.is_file() {
+        if let Some(entry) = parse_estimates(&estimates) {
+            let id = dir
+                .strip_prefix(root)
+                .unwrap_or(dir)
+                .components()
+                .map(|c| c.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/");
+            if !id.is_empty() {
+                out.insert(id, entry);
+            }
+        }
+        // A scenario dir can't also contain nested scenario dirs.
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in entries.flatten() {
+        let path = e.path();
+        if path.is_dir() {
+            walk(root, &path, out);
+        }
+    }
+}
+
+fn parse_estimates(path: &Path) -> Option<BaselineEntry> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let point = |stat: &str| -> Option<f64> { v.get(stat)?.get("point_estimate")?.as_f64() };
+    Some(BaselineEntry {
+        mean_ns: point("mean")?,
+        median_ns: point("median").or_else(|| point("mean"))?,
+        mem: None,
+    })
+}
+
+/// Capture a baseline from criterion output plus memory sidecars.
+pub fn capture(
+    label: &str,
+    criterion_dir: &Path,
+    mem_dir: &Path,
+    git_sha: Option<String>,
+    captured_at: String,
+) -> BaselineFile {
+    let mut entries = collect_criterion_entries(criterion_dir);
+    for (id, metrics) in crate::mem::read_all_sidecars(mem_dir) {
+        entries
+            .entry(id)
+            .and_modify(|e| e.mem = Some(metrics))
+            .or_insert(BaselineEntry {
+                mean_ns: 0.0,
+                median_ns: 0.0,
+                mem: Some(metrics),
+            });
+    }
+    BaselineFile {
+        schema_version: BASELINE_SCHEMA_VERSION,
+        label: label.to_string(),
+        git_sha,
+        captured_at,
+        profile: std::env::var("FLUREE_BENCH_PROFILE").unwrap_or_else(|_| "quick".into()),
+        scale: std::env::var("FLUREE_BENCH_SCALE").unwrap_or_else(|_| "small".into()),
+        entries,
+    }
+}
+
+pub fn load_baseline(path: &Path) -> Result<BaselineFile, String> {
+    let raw = std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    serde_json::from_str(&raw).map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+pub fn save_baseline(file: &BaselineFile, path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(file).map_err(|e| format!("serialize: {e}"))?;
+    std::fs::write(path, json).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Compare
+// ---------------------------------------------------------------------------
+
+/// Outcome of one scenario × one metric comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompareStatus {
+    /// Faster / smaller than baseline by more than 1%.
+    Improved,
+    /// Within the budget envelope.
+    Within,
+    /// Over `baseline × (1 + budget_pct/100)` — fails the gate.
+    Exceeded,
+}
+
+#[derive(Debug, Clone)]
+pub struct Comparison {
+    pub id: String,
+    /// `"time"` or `"peak_mem"`.
+    pub metric: &'static str,
+    pub baseline: f64,
+    pub observed: f64,
+    pub change_pct: f64,
+    pub budget_pct: f64,
+    pub status: CompareStatus,
+}
+
+#[derive(Debug, Default)]
+pub struct CompareReport {
+    pub comparisons: Vec<Comparison>,
+    /// Scenario IDs in the baseline with no current measurement (bench not
+    /// rerun — informational, not a failure: PR-scoped runs compare subsets).
+    pub missing: Vec<String>,
+    /// Scenario IDs measured now but absent from the baseline.
+    pub new_scenarios: Vec<String>,
+}
+
+impl CompareReport {
+    pub fn breaches(&self) -> impl Iterator<Item = &Comparison> {
+        self.comparisons
+            .iter()
+            .filter(|c| c.status == CompareStatus::Exceeded)
+    }
+    pub fn passed(&self) -> bool {
+        self.breaches().next().is_none()
+    }
+}
+
+/// Recover `(bench, scale)` from a scenario ID and find its budget.
+///
+/// The bench name is the criterion group (first segment); the scale is the
+/// last segment when it parses as a [`BenchScale`]. The owning crate is
+/// found by scanning the budget's crate map for the bench name — bench
+/// names are unique across the workspace (the `workspace_reconcile` test
+/// keys budgets by them).
+fn budget_for_id(budget: &RegressionBudget, id: &str) -> f64 {
+    let mut parts = id.split('/');
+    let bench = parts.next().unwrap_or(id);
+    let scale = id
+        .rsplit('/')
+        .next()
+        .and_then(parse_scale)
+        .unwrap_or(BenchScale::Small);
+    for (crate_name, benches) in &budget.crates {
+        if benches.contains_key(bench) {
+            return budget.budget_pct(crate_name, bench, scale);
+        }
+    }
+    budget.default_budget_pct
+}
+
+fn parse_scale(s: &str) -> Option<BenchScale> {
+    match s {
+        "tiny" => Some(BenchScale::Tiny),
+        "small" => Some(BenchScale::Small),
+        "medium" => Some(BenchScale::Medium),
+        "large" => Some(BenchScale::Large),
+        _ => None,
+    }
+}
+
+fn classify(baseline: f64, observed: f64, budget_pct: f64) -> (f64, CompareStatus) {
+    if baseline <= 0.0 {
+        return (0.0, CompareStatus::Within);
+    }
+    let change_pct = (observed - baseline) / baseline * 100.0;
+    let status = if observed > baseline * (1.0 + budget_pct / 100.0) {
+        CompareStatus::Exceeded
+    } else if change_pct < -1.0 {
+        CompareStatus::Improved
+    } else {
+        CompareStatus::Within
+    };
+    (change_pct, status)
+}
+
+/// Compare current entries against a baseline under the given budgets.
+///
+/// `only` restricts the comparison to scenario IDs containing the given
+/// substring (PR-scoped subset runs).
+pub fn compare(
+    baseline: &BaselineFile,
+    current: &BTreeMap<String, BaselineEntry>,
+    budget: &RegressionBudget,
+    only: Option<&str>,
+) -> CompareReport {
+    let selected = |id: &str| only.is_none_or(|f| id.contains(f));
+    let mut report = CompareReport::default();
+
+    for (id, base) in &baseline.entries {
+        if !selected(id) {
+            continue;
+        }
+        let Some(cur) = current.get(id) else {
+            report.missing.push(id.clone());
+            continue;
+        };
+        let budget_pct = budget_for_id(budget, id);
+
+        if base.mean_ns > 0.0 && cur.mean_ns > 0.0 {
+            let (change_pct, status) = classify(base.mean_ns, cur.mean_ns, budget_pct);
+            report.comparisons.push(Comparison {
+                id: id.clone(),
+                metric: "time",
+                baseline: base.mean_ns,
+                observed: cur.mean_ns,
+                change_pct,
+                budget_pct,
+                status,
+            });
+        }
+        if let (Some(bm), Some(cm)) = (base.mem, cur.mem) {
+            let (change_pct, status) =
+                classify(bm.peak_bytes as f64, cm.peak_bytes as f64, budget_pct);
+            report.comparisons.push(Comparison {
+                id: id.clone(),
+                metric: "peak_mem",
+                baseline: bm.peak_bytes as f64,
+                observed: cm.peak_bytes as f64,
+                change_pct,
+                budget_pct,
+                status,
+            });
+        }
+    }
+
+    for id in current.keys() {
+        if selected(id) && !baseline.entries.contains_key(id) {
+            report.new_scenarios.push(id.clone());
+        }
+    }
+    report
+}
+
+/// Default locations, resolved from the workspace root.
+pub fn default_criterion_dir() -> PathBuf {
+    crate::budget::workspace_root()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("target")
+        .join("criterion")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(mean: f64) -> BaselineEntry {
+        BaselineEntry {
+            mean_ns: mean,
+            median_ns: mean,
+            mem: None,
+        }
+    }
+
+    fn baseline_with(entries: Vec<(&str, BaselineEntry)>) -> BaselineFile {
+        BaselineFile {
+            schema_version: BASELINE_SCHEMA_VERSION,
+            label: "test".into(),
+            git_sha: None,
+            captured_at: "2026-01-01T00:00:00Z".into(),
+            profile: "quick".into(),
+            scale: "small".into(),
+            entries: entries
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn collect_walks_criterion_layout() {
+        let dir = std::env::temp_dir().join(format!(
+            "fluree-baseline-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let scenario = dir.join("my_group").join("q1").join("small").join("new");
+        std::fs::create_dir_all(&scenario).unwrap();
+        std::fs::write(
+            scenario.join("estimates.json"),
+            r#"{"mean":{"point_estimate":1500.0},"median":{"point_estimate":1400.0}}"#,
+        )
+        .unwrap();
+        // report dirs must be ignored (no new/estimates.json inside).
+        std::fs::create_dir_all(dir.join("my_group").join("report")).unwrap();
+
+        let entries = collect_criterion_entries(&dir);
+        assert_eq!(entries.len(), 1);
+        let e = &entries["my_group/q1/small"];
+        assert_eq!(e.mean_ns, 1500.0);
+        assert_eq!(e.median_ns, 1400.0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn compare_classifies_improvement_within_and_breach() {
+        let base = baseline_with(vec![
+            ("g/q1/small", entry(1000.0)),
+            ("g/q2/small", entry(1000.0)),
+            ("g/q3/small", entry(1000.0)),
+        ]);
+        let mut current = BTreeMap::new();
+        current.insert("g/q1/small".to_string(), entry(900.0)); // -10%
+        current.insert("g/q2/small".to_string(), entry(1030.0)); // +3%
+        current.insert("g/q3/small".to_string(), entry(1100.0)); // +10%
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, None);
+        assert!(!report.passed());
+        let by_id = |id: &str| {
+            report
+                .comparisons
+                .iter()
+                .find(|c| c.id == id)
+                .unwrap()
+                .status
+        };
+        assert_eq!(by_id("g/q1/small"), CompareStatus::Improved);
+        assert_eq!(by_id("g/q2/small"), CompareStatus::Within);
+        assert_eq!(by_id("g/q3/small"), CompareStatus::Exceeded);
+    }
+
+    #[test]
+    fn compare_subset_filter_and_missing() {
+        let base = baseline_with(vec![
+            ("g/q1/small", entry(1000.0)),
+            ("h/q1/small", entry(1000.0)),
+        ]);
+        let mut current = BTreeMap::new();
+        current.insert("g/q1/small".to_string(), entry(1000.0));
+        let budget = RegressionBudget::empty(5.0);
+
+        // Unfiltered: h/q1 is missing (informational, not a failure).
+        let report = compare(&base, &current, &budget, None);
+        assert!(report.passed());
+        assert_eq!(report.missing, vec!["h/q1/small".to_string()]);
+
+        // Filtered to g/: nothing missing.
+        let report = compare(&base, &current, &budget, Some("g/"));
+        assert!(report.missing.is_empty());
+        assert_eq!(report.comparisons.len(), 1);
+    }
+
+    #[test]
+    fn compare_includes_memory_metric() {
+        let mem = |peak: u64| MemMetrics {
+            peak_bytes: peak,
+            total_allocated_bytes: peak * 2,
+        };
+        let mut base_entry = entry(1000.0);
+        base_entry.mem = Some(mem(1_000_000));
+        let base = baseline_with(vec![("g/q1/small", base_entry)]);
+
+        let mut cur_entry = entry(1000.0);
+        cur_entry.mem = Some(mem(2_000_000)); // +100% peak
+        let mut current = BTreeMap::new();
+        current.insert("g/q1/small".to_string(), cur_entry);
+
+        let budget = RegressionBudget::empty(5.0);
+        let report = compare(&base, &current, &budget, None);
+        assert!(!report.passed());
+        let breach = report.breaches().next().unwrap();
+        assert_eq!(breach.metric, "peak_mem");
+    }
+
+    #[test]
+    fn budget_lookup_recovers_bench_and_scale() {
+        let mut budget = RegressionBudget::empty(5.0);
+        budget
+            .crates
+            .entry("fluree-db-api".into())
+            .or_default()
+            .entry("query_overlay_matrix".into())
+            .or_default()
+            .insert("tiny".into(), 12.0);
+        assert_eq!(
+            budget_for_id(&budget, "query_overlay_matrix/count_base/tiny"),
+            12.0
+        );
+        // Unknown bench falls back to default.
+        assert_eq!(budget_for_id(&budget, "nope/x/small"), 5.0);
+    }
+
+    #[test]
+    fn baseline_file_round_trips() {
+        let base = baseline_with(vec![("g/q1/small", entry(42.0))]);
+        let json = serde_json::to_string(&base).unwrap();
+        let read: BaselineFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(read.entries["g/q1/small"].mean_ns, 42.0);
+    }
+}

--- a/fluree-bench-support/src/bin/bench_baseline.rs
+++ b/fluree-bench-support/src/bin/bench_baseline.rs
@@ -1,0 +1,334 @@
+//! `bench-baseline` — capture and compare performance baselines.
+//!
+//! Backs the per-phase performance gate described in BENCHMARKING.md
+//! ("Baselines: capture & compare") and the Phase 0.0 protocol in
+//! `docs/audit/2026-06-architecture-audit.md`.
+//!
+//! ```bash
+//! # 1. Run the benches you care about:
+//! cargo bench -p fluree-db-api --bench query_overlay_matrix
+//!
+//! # 2. Capture a labeled, git-stamped baseline:
+//! cargo run -p fluree-bench-support --bin bench-baseline -- \
+//!     capture --label phase-1-pre --out bench-baselines/phase-1-pre.json
+//!
+//! # 3. ...make changes, rerun the benches...
+//!
+//! # 4. Compare (exit 1 on any budget breach):
+//! cargo run -p fluree-bench-support --bin bench-baseline -- \
+//!     compare --baseline bench-baselines/phase-1-pre.json
+//!
+//! # PR-scoped subset (only scenarios whose ID contains the filter):
+//! cargo run -p fluree-bench-support --bin bench-baseline -- \
+//!     compare --baseline bench-baselines/phase-1-pre.json --only query_overlay_matrix
+//! ```
+//!
+//! Argument parsing is hand-rolled (std only) to keep clap out of every
+//! bench's dev-dependency tree.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use fluree_bench_support::baseline::{
+    capture, compare, default_criterion_dir, load_baseline, save_baseline, BaselineEntry,
+    CompareStatus,
+};
+use fluree_bench_support::budget;
+use fluree_bench_support::mem;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        Some("capture") => run_capture(&args[1..]),
+        Some("compare") => run_compare(&args[1..]),
+        Some("help" | "--help" | "-h") | None => {
+            print_usage();
+            ExitCode::SUCCESS
+        }
+        Some(other) => {
+            eprintln!("unknown subcommand: {other}\n");
+            print_usage();
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        "bench-baseline — capture and compare performance baselines\n\n\
+         USAGE:\n  \
+         bench-baseline capture --label <name> --out <file> [--criterion-dir <dir>] [--mem-dir <dir>] [--clean-mem]\n  \
+         bench-baseline compare --baseline <file> [--criterion-dir <dir>] [--mem-dir <dir>] [--budget <file>] [--only <substr>]\n\n\
+         Run the benches first (`cargo bench ...`); this tool reads criterion's\n\
+         output from target/criterion and memory sidecars from\n\
+         target/fluree-bench-mem. See BENCHMARKING.md (\"Baselines\")."
+    );
+}
+
+/// Minimal `--flag value` / `--flag` parser. Unknown flags are an error so
+/// typos can't silently change what a gate run measures.
+fn parse_flags(
+    args: &[String],
+    value_flags: &[&str],
+    bool_flags: &[&str],
+) -> Result<BTreeMap<String, String>, String> {
+    let mut out = BTreeMap::new();
+    let mut i = 0;
+    while i < args.len() {
+        let flag = args[i].as_str();
+        if bool_flags.contains(&flag) {
+            out.insert(flag.to_string(), "true".to_string());
+            i += 1;
+        } else if value_flags.contains(&flag) {
+            let value = args
+                .get(i + 1)
+                .ok_or_else(|| format!("{flag} requires a value"))?;
+            out.insert(flag.to_string(), value.clone());
+            i += 2;
+        } else {
+            return Err(format!("unknown flag: {flag}"));
+        }
+    }
+    Ok(out)
+}
+
+fn criterion_dir(flags: &BTreeMap<String, String>) -> PathBuf {
+    flags
+        .get("--criterion-dir")
+        .map(PathBuf::from)
+        .unwrap_or_else(default_criterion_dir)
+}
+
+fn mem_dir(flags: &BTreeMap<String, String>) -> PathBuf {
+    flags
+        .get("--mem-dir")
+        .map(PathBuf::from)
+        .unwrap_or_else(mem::sidecar_dir)
+}
+
+fn git_short_sha() -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    (!sha.is_empty()).then_some(sha)
+}
+
+fn run_capture(args: &[String]) -> ExitCode {
+    let flags = match parse_flags(
+        args,
+        &["--label", "--out", "--criterion-dir", "--mem-dir"],
+        &["--clean-mem"],
+    ) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("{e}\n");
+            print_usage();
+            return ExitCode::FAILURE;
+        }
+    };
+    let Some(label) = flags.get("--label") else {
+        eprintln!("capture requires --label <name>");
+        return ExitCode::FAILURE;
+    };
+    let Some(out_path) = flags.get("--out").map(PathBuf::from) else {
+        eprintln!("capture requires --out <file>");
+        return ExitCode::FAILURE;
+    };
+
+    let crit = criterion_dir(&flags);
+    let mem_d = mem_dir(&flags);
+    if !crit.is_dir() {
+        eprintln!(
+            "criterion dir {} not found — run `cargo bench ...` first",
+            crit.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let file = capture(
+        label,
+        &crit,
+        &mem_d,
+        git_short_sha(),
+        chrono::Utc::now().to_rfc3339(),
+    );
+    if file.entries.is_empty() {
+        eprintln!("no scenarios found under {}", crit.display());
+        return ExitCode::FAILURE;
+    }
+    if let Err(e) = save_baseline(&file, &out_path) {
+        eprintln!("{e}");
+        return ExitCode::FAILURE;
+    }
+    let with_mem = file.entries.values().filter(|e| e.mem.is_some()).count();
+    println!(
+        "captured {} scenarios ({} with memory metrics) → {} [label={} sha={} profile={} scale={}]",
+        file.entries.len(),
+        with_mem,
+        out_path.display(),
+        file.label,
+        file.git_sha.as_deref().unwrap_or("?"),
+        file.profile,
+        file.scale,
+    );
+    if flags.contains_key("--clean-mem") {
+        mem::clear_sidecars(&mem_d);
+    }
+    ExitCode::SUCCESS
+}
+
+fn run_compare(args: &[String]) -> ExitCode {
+    let flags = match parse_flags(
+        args,
+        &[
+            "--baseline",
+            "--criterion-dir",
+            "--mem-dir",
+            "--budget",
+            "--only",
+        ],
+        &[],
+    ) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("{e}\n");
+            print_usage();
+            return ExitCode::FAILURE;
+        }
+    };
+    let Some(baseline_path) = flags.get("--baseline").map(PathBuf::from) else {
+        eprintln!("compare requires --baseline <file>");
+        return ExitCode::FAILURE;
+    };
+
+    let baseline = match load_baseline(&baseline_path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let budgets = match flags.get("--budget") {
+        Some(p) => budget::load_from(PathBuf::from(p).as_path()),
+        None => budget::load(),
+    };
+    let budgets = match budgets {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("budget load failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Collect current measurements the same way capture does.
+    let crit = criterion_dir(&flags);
+    let mem_d = mem_dir(&flags);
+    let current_file = capture("current", &crit, &mem_d, None, String::new());
+    let current: BTreeMap<String, BaselineEntry> = current_file.entries;
+
+    let report = compare(
+        &baseline,
+        &current,
+        &budgets,
+        flags.get("--only").map(String::as_str),
+    );
+
+    println!(
+        "comparing against '{}' (sha={} captured={} profile={} scale={})",
+        baseline.label,
+        baseline.git_sha.as_deref().unwrap_or("?"),
+        baseline.captured_at,
+        baseline.profile,
+        baseline.scale,
+    );
+    println!();
+    println!(
+        "{:<55} {:>9} {:>14} {:>14} {:>8} {:>8}",
+        "scenario [metric]", "status", "baseline", "observed", "Δ%", "budget%"
+    );
+    for c in &report.comparisons {
+        let status = match c.status {
+            CompareStatus::Improved => "improved",
+            CompareStatus::Within => "ok",
+            CompareStatus::Exceeded => "EXCEEDED",
+        };
+        let (baseline_s, observed_s) = if c.metric == "time" {
+            (format_ns(c.baseline), format_ns(c.observed))
+        } else {
+            (format_bytes(c.baseline), format_bytes(c.observed))
+        };
+        println!(
+            "{:<55} {:>9} {:>14} {:>14} {:>+8.2} {:>8.1}",
+            format!("{} [{}]", c.id, c.metric),
+            status,
+            baseline_s,
+            observed_s,
+            c.change_pct,
+            c.budget_pct,
+        );
+    }
+    if !report.missing.is_empty() {
+        println!(
+            "\nnot rerun (in baseline, no current measurement): {}",
+            report.missing.join(", ")
+        );
+    }
+    if !report.new_scenarios.is_empty() {
+        println!(
+            "new scenarios (no baseline entry): {}",
+            report.new_scenarios.join(", ")
+        );
+    }
+
+    let improved = report
+        .comparisons
+        .iter()
+        .filter(|c| c.status == CompareStatus::Improved)
+        .count();
+    let breaches: Vec<_> = report.breaches().collect();
+    println!(
+        "\n{} compared, {} improved, {} breached",
+        report.comparisons.len(),
+        improved,
+        breaches.len()
+    );
+    if breaches.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        eprintln!(
+            "FAIL: budget exceeded for {} scenario metric(s)",
+            breaches.len()
+        );
+        ExitCode::FAILURE
+    }
+}
+
+fn format_ns(ns: f64) -> String {
+    if ns >= 1e9 {
+        format!("{:.3} s", ns / 1e9)
+    } else if ns >= 1e6 {
+        format!("{:.3} ms", ns / 1e6)
+    } else if ns >= 1e3 {
+        format!("{:.3} µs", ns / 1e3)
+    } else {
+        format!("{ns:.0} ns")
+    }
+}
+
+fn format_bytes(b: f64) -> String {
+    if b >= 1024.0 * 1024.0 * 1024.0 {
+        format!("{:.2} GiB", b / (1024.0 * 1024.0 * 1024.0))
+    } else if b >= 1024.0 * 1024.0 {
+        format!("{:.2} MiB", b / (1024.0 * 1024.0))
+    } else if b >= 1024.0 {
+        format!("{:.2} KiB", b / 1024.0)
+    } else {
+        format!("{b:.0} B")
+    }
+}

--- a/fluree-bench-support/src/lib.rs
+++ b/fluree-bench-support/src/lib.rs
@@ -26,13 +26,19 @@
 //! - [`fixtures`] — vendored / fetched fixture loaders.
 //! - [`budget`] — regression-budget loader and validator.
 //! - [`report`] — opt-in human-readable end-of-run summary tables.
+//! - [`baseline`] — labeled baseline capture/compare (backs the
+//!   `bench-baseline` bin; see BENCHMARKING.md "Baselines").
+//! - [`mem`] — per-scenario memory-metric sidecars (pairs with the
+//!   `fluree-bench-alloc` tracking allocator).
 
 #![forbid(unsafe_code)]
 
+pub mod baseline;
 pub mod budget;
 pub mod fixtures;
 pub mod gen;
 pub mod ledger;
+pub mod mem;
 pub mod report;
 pub mod runtime;
 pub mod tracing;

--- a/fluree-bench-support/src/mem.rs
+++ b/fluree-bench-support/src/mem.rs
@@ -1,0 +1,149 @@
+//! Per-scenario memory metric recording.
+//!
+//! Criterion measures wall-clock only. Benches that also want allocation
+//! metrics install the tracking allocator from `fluree-bench-alloc` in
+//! their own binary, then record a [`MemMetrics`] per scenario via
+//! [`record_scenario`]. Metrics land as JSON sidecar files under
+//! `target/fluree-bench-mem/<bench>.json`, keyed by the same
+//! `<group>/<function>/<scale>` ID criterion uses, so the
+//! `bench-baseline` tool can merge them into the captured baseline and
+//! compare them with the same budget machinery as time.
+//!
+//! This module is pure-safe-Rust (file IO + serde); the one `unsafe impl`
+//! the allocator needs lives in `fluree-bench-alloc`, keeping this crate's
+//! `#![forbid(unsafe_code)]` intact.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Memory metrics for one bench scenario.
+///
+/// `peak_bytes` is the live-bytes high-water mark across the scenario's
+/// measured iterations; `total_allocated_bytes` is cumulative allocation
+/// (churn). Both come from `fluree_bench_alloc::snapshot()` semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemMetrics {
+    pub peak_bytes: u64,
+    pub total_allocated_bytes: u64,
+}
+
+/// Sidecar directory under the cargo target dir.
+///
+/// Resolved relative to the workspace root (same discovery as
+/// `budget::workspace_root()`), or `target/` under the current dir as a
+/// fallback so the helper still works outside the workspace.
+pub fn sidecar_dir() -> PathBuf {
+    let base = crate::budget::workspace_root()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("target");
+    base.join("fluree-bench-mem")
+}
+
+/// Record metrics for one scenario of `bench`, merging into the bench's
+/// sidecar file. `scenario_id` must match the criterion ID path for the
+/// scenario — `"<group>/<function>/<scale>"` — so baseline capture can
+/// join time and memory rows.
+///
+/// Best-effort by design: bench output must not fail because a sidecar
+/// write did. IO errors are reported to stderr and swallowed.
+pub fn record_scenario(bench: &str, scenario_id: &str, metrics: MemMetrics) {
+    let dir = sidecar_dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("  [bench-mem] create {}: {e}", dir.display());
+        return;
+    }
+    let path = dir.join(format!("{bench}.json"));
+    let mut entries = read_sidecar(&path).unwrap_or_default();
+    entries.insert(scenario_id.to_string(), metrics);
+    match serde_json::to_string_pretty(&entries) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(&path, json) {
+                eprintln!("  [bench-mem] write {}: {e}", path.display());
+            }
+        }
+        Err(e) => eprintln!("  [bench-mem] serialize {}: {e}", path.display()),
+    }
+}
+
+/// Read one sidecar file. Returns `None` when missing or unparsable.
+pub fn read_sidecar(path: &Path) -> Option<BTreeMap<String, MemMetrics>> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Read every sidecar in [`sidecar_dir`] (or the given dir), merged into a
+/// single scenario-ID → metrics map. Used by `bench-baseline capture`.
+pub fn read_all_sidecars(dir: &Path) -> BTreeMap<String, MemMetrics> {
+    let mut merged = BTreeMap::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return merged;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            if let Some(map) = read_sidecar(&path) {
+                merged.extend(map);
+            }
+        }
+    }
+    merged
+}
+
+/// Remove all sidecar files so a fresh bench run starts clean. Called by
+/// `bench-baseline capture --clean-mem` and useful at the top of scripted
+/// baseline runs; stale sidecars from an earlier run would otherwise be
+/// merged into the new baseline.
+pub fn clear_sidecars(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidecar_round_trip() {
+        let dir = std::env::temp_dir().join(format!(
+            "fluree-bench-mem-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("some_bench.json");
+
+        let mut entries: BTreeMap<String, MemMetrics> = BTreeMap::new();
+        entries.insert(
+            "some_bench/q1/small".into(),
+            MemMetrics {
+                peak_bytes: 1024,
+                total_allocated_bytes: 4096,
+            },
+        );
+        std::fs::write(&path, serde_json::to_string(&entries).unwrap()).unwrap();
+
+        let read = read_sidecar(&path).unwrap();
+        assert_eq!(read["some_bench/q1/small"].peak_bytes, 1024);
+
+        let all = read_all_sidecars(&dir);
+        assert_eq!(all.len(), 1);
+
+        clear_sidecars(&dir);
+        assert!(read_all_sidecars(&dir).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_sidecar_is_none() {
+        assert!(read_sidecar(Path::new("/nonexistent/x.json")).is_none());
+    }
+}

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -119,6 +119,7 @@ num-bigdecimal = { package = "bigdecimal", version = "0.4" }
 ed25519-dalek = "2.1"
 criterion = "0.5"
 fluree-bench-support = { path = "../fluree-bench-support" }
+fluree-bench-alloc = { path = "../fluree-bench-alloc" }
 rand = { workspace = true }
 fluree-db-nameservice-sync = { path = "../fluree-db-nameservice-sync" }
 
@@ -180,6 +181,10 @@ harness = false
 
 [[bench]]
 name = "query_hot_bsbm"
+harness = false
+
+[[bench]]
+name = "query_overlay_matrix"
 harness = false
 
 [lints]

--- a/fluree-db-api/benches/query_overlay_matrix.rs
+++ b/fluree-db-api/benches/query_overlay_matrix.rs
@@ -1,0 +1,305 @@
+//! Query latency across the base / overlay / novelty condition matrix.
+//!
+//! Every other hot-path query bench (`query_hot_bsbm`) measures the
+//! epoch-0 case: all data behind the binary columnar index, no trailing
+//! novelty. But the system's chronic-bug seam — and the target of the
+//! audit roadmap's Phases 1–2 (`docs/audit/2026-06-architecture-audit.md`)
+//! — is the **overlay merge**: columnar base combined with row-based
+//! novelty. This bench runs the same query shapes at three ledger
+//! conditions so a refactor of the merge/translation paths cannot regress
+//! a lane that has no benchmark coverage:
+//!
+//! 1. **`base`** — populate, reindex; epoch 0. Strategy-(a) *and* -(b)
+//!    fast paths eligible (`fast_path_common.rs` gates).
+//! 2. **`overlay`** — populate, reindex, then commit a ~10% data delta
+//!    with indexing thresholds set high so it stays in novelty. Exercises
+//!    overlay→binary translation and cursor-merge (strategy (b)); bails
+//!    strategy-(a) paths.
+//! 3. **`novelty`** — populate with indexing disabled; no binary index at
+//!    all. Pure novelty/range path. (Skipped at `large` scale — a
+//!    multi-million-triple pure-novelty scan is a pathological shape we
+//!    don't gate on.)
+//!
+//! ## Query shapes
+//!
+//! - **`count`** — `COUNT(?s)` over a bound class: the fast-count operator
+//!   family (leaflet-FIRST skipping, overlay count-delta simulation).
+//! - **`star`** — Q5-shape same-subject star join + range filter +
+//!   ORDER BY + LIMIT: property-join/star-fusion and ordered access.
+//! - **`groupby`** — Q9-shape GROUP BY + COUNT + HAVING + ORDER BY DESC:
+//!   group-count fast paths.
+//!
+//! ## Memory metrics
+//!
+//! This bench installs the `fluree-bench-alloc` tracking allocator and
+//! records per-scenario peak / total allocation to
+//! `target/fluree-bench-mem/` (see `fluree-bench-support::mem`), which
+//! `bench-baseline capture` merges into the baseline. The tracking adds a
+//! small constant overhead to every allocation — identical between a
+//! baseline run and a comparison run, so deltas stay valid; don't compare
+//! this bench's absolute times against a non-tracking bench.
+//!
+//! ## Matrix
+//!
+//!   inputs:    BenchScale → n_products (Tiny=100, Small=1k, Medium=10k,
+//!              Large=100k); overlay delta = n_products / 10.
+//!   scenarios: {count, star, groupby} × {base, overlay, novelty}
+//!   metric:    ns/query (criterion), peak/total alloc bytes (sidecar)
+//!
+//! ## Running
+//!
+//!   cargo bench -p fluree-db-api --bench query_overlay_matrix
+//!   cargo bench -p fluree-db-api --bench query_overlay_matrix -- --test
+//!   FLUREE_BENCH_SCALE=medium cargo bench -p fluree-db-api --bench query_overlay_matrix
+//!
+//! Then capture / compare via `bench-baseline` (BENCHMARKING.md
+//! "Baselines: capture & compare").
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use fluree_bench_alloc::TrackingAllocator;
+use fluree_bench_support::gen::bsbm::{bsbm_data_to_turtle, generate_dataset, BsbmData};
+use fluree_bench_support::mem::{record_scenario, MemMetrics};
+use fluree_bench_support::{
+    bench_runtime, current_profile, current_scale, init_tracing_for_bench, next_ledger_alias,
+    BenchScale,
+};
+use fluree_db_api::admin::ReindexOptions;
+use fluree_db_api::{CommitOpts, Fluree, FlureeBuilder, IndexConfig, TxnOpts};
+
+#[global_allocator]
+static ALLOC: TrackingAllocator = TrackingAllocator::new();
+
+const GROUP: &str = "query_overlay_matrix";
+
+fn scale_n_products(scale: BenchScale) -> usize {
+    match scale {
+        BenchScale::Tiny => 100,
+        BenchScale::Small => 1_000,
+        BenchScale::Medium => 10_000,
+        BenchScale::Large => 100_000,
+    }
+}
+
+const Q_COUNT: &str = r"
+PREFIX bsbm: <http://example.org/bsbm/>
+SELECT (COUNT(?s) AS ?c) WHERE { ?s a bsbm:Product }
+";
+
+const Q_STAR: &str = r"
+PREFIX bsbm: <http://example.org/bsbm/>
+SELECT ?product ?label ?vendorLabel ?price WHERE {
+  ?product a bsbm:Product ;
+           bsbm:label ?label ;
+           bsbm:vendor ?vendor ;
+           bsbm:price ?price .
+  ?vendor bsbm:label ?vendorLabel .
+  FILTER(?price >= 5000 && ?price <= 25000)
+}
+ORDER BY ?price
+LIMIT 10
+";
+
+const Q_GROUPBY: &str = r"
+PREFIX bsbm: <http://example.org/bsbm/>
+SELECT ?product (COUNT(?review) AS ?nReviews) WHERE {
+  ?product a bsbm:Product .
+  ?review bsbm:reviewFor ?product .
+}
+GROUP BY ?product
+HAVING (COUNT(?review) >= 3)
+ORDER BY DESC(?nReviews)
+LIMIT 25
+";
+
+/// Indexing thresholds high enough that populate/delta commits never
+/// trigger foreground or background indexing on their own.
+fn no_auto_index() -> IndexConfig {
+    IndexConfig {
+        reindex_min_bytes: 5_000_000_000,
+        reindex_max_bytes: 5_000_000_000,
+    }
+}
+
+/// The ~10% data delta committed on top of the indexed base for the
+/// `overlay` condition. Generated from the deterministic generator's tail:
+/// products `[n, n + n/10)` plus their reviews. Vendors and persons from
+/// the larger dataset are included wholesale — re-asserting facts that are
+/// already indexed is itself a realistic overlay shape (novelty set
+/// semantics dedup them) and keeps this slice robust to generator-internal
+/// count derivations.
+fn overlay_delta(n_products: usize) -> BsbmData {
+    let delta = std::cmp::max(1, n_products / 10);
+    let full = generate_dataset(n_products + delta);
+    BsbmData {
+        vendors: full.vendors.clone(),
+        persons: full.persons.clone(),
+        products: full.products[n_products..].to_vec(),
+        reviews: full.reviews[n_products * 3..].to_vec(),
+    }
+}
+
+/// Populate `alias` with the base dataset; optionally reindex (binary
+/// index attached, epoch 0); optionally commit the overlay delta in two
+/// further commits that stay in novelty.
+async fn setup(
+    n_products: usize,
+    index: bool,
+    overlay: bool,
+) -> (tempfile::TempDir, Fluree, String) {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let mut builder = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string());
+    if !index {
+        builder = builder.without_indexing();
+    }
+    let fluree = builder.build().expect("build file-backed Fluree");
+
+    let alias = next_ledger_alias("query-overlay-matrix");
+    let ledger = fluree.create_ledger(&alias).await.expect("create_ledger");
+
+    let turtle = bsbm_data_to_turtle(&generate_dataset(n_products));
+    let r = fluree
+        .insert_turtle_with_opts(
+            ledger,
+            &turtle,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &no_auto_index(),
+        )
+        .await
+        .expect("populate insert");
+    let mut ledger = r.ledger;
+
+    if index {
+        let _ = fluree
+            .reindex(&alias, ReindexOptions::default())
+            .await
+            .expect("reindex");
+    }
+
+    if overlay {
+        let delta = overlay_delta(n_products);
+        // Two commits so the trailing novelty has a multi-commit t-order,
+        // like production overlay state: entities first, reviews second.
+        let entities = BsbmData {
+            reviews: Vec::new(),
+            ..delta.clone()
+        };
+        let reviews = BsbmData {
+            vendors: Vec::new(),
+            persons: Vec::new(),
+            products: Vec::new(),
+            reviews: delta.reviews,
+        };
+        for part in [entities, reviews] {
+            // Reload the post-reindex ledger state through a fresh handle:
+            // insert returns the updated handle each time.
+            let r = fluree
+                .insert_turtle_with_opts(
+                    ledger,
+                    &bsbm_data_to_turtle(&part),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &no_auto_index(),
+                )
+                .await
+                .expect("overlay delta insert");
+            ledger = r.ledger;
+        }
+    }
+    let _ = ledger;
+
+    (db_dir, fluree, alias)
+}
+
+fn bench_query_overlay_matrix(c: &mut Criterion) {
+    init_tracing_for_bench();
+    let rt = bench_runtime();
+    let scale = current_scale();
+    let profile = current_profile();
+    let n_products = scale_n_products(scale);
+
+    eprintln!(
+        "  [query_overlay_matrix] scale={} n_products={} overlay_delta={}",
+        scale.as_str(),
+        n_products,
+        std::cmp::max(1, n_products / 10),
+    );
+
+    let mut group = c.benchmark_group(GROUP);
+    group.sample_size(profile.sample_size());
+    group.sampling_mode(criterion::SamplingMode::Flat);
+
+    // One scenario: time the query via criterion, then record the
+    // allocation peak observed across its iterations to the mem sidecar
+    // under the same `<group>/<fn_id>/<scale>` ID the baseline tool uses.
+    macro_rules! scenario {
+        ($snapshot:expr, $fn_id:expr, $query:expr) => {{
+            fluree_bench_alloc::reset_peak();
+            group.bench_with_input(BenchmarkId::new($fn_id, scale.as_str()), &(), |b, ()| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let result = $snapshot
+                            .query()
+                            .sparql($query)
+                            .execute()
+                            .await
+                            .expect("query execute");
+                        black_box(result);
+                    });
+                });
+            });
+            let m = fluree_bench_alloc::snapshot();
+            record_scenario(
+                GROUP,
+                &format!("{GROUP}/{}/{}", $fn_id, scale.as_str()),
+                MemMetrics {
+                    peak_bytes: m.peak_bytes as u64,
+                    total_allocated_bytes: m.total_allocated_bytes as u64,
+                },
+            );
+        }};
+    }
+
+    // --- condition: base (indexed, epoch 0) ---
+    {
+        let (_db_dir, fluree, alias) = rt.block_on(setup(n_products, true, false));
+        let snapshot =
+            rt.block_on(async { fluree.graph(&alias).load().await.expect("graph load") });
+        scenario!(snapshot, "count_base", Q_COUNT);
+        scenario!(snapshot, "star_base", Q_STAR);
+        scenario!(snapshot, "groupby_base", Q_GROUPBY);
+        drop(snapshot);
+        drop(fluree);
+    }
+
+    // --- condition: overlay (indexed + trailing novelty) ---
+    {
+        let (_db_dir, fluree, alias) = rt.block_on(setup(n_products, true, true));
+        let snapshot =
+            rt.block_on(async { fluree.graph(&alias).load().await.expect("graph load") });
+        scenario!(snapshot, "count_overlay", Q_COUNT);
+        scenario!(snapshot, "star_overlay", Q_STAR);
+        scenario!(snapshot, "groupby_overlay", Q_GROUPBY);
+        drop(snapshot);
+        drop(fluree);
+    }
+
+    // --- condition: novelty (no index at all) ---
+    if scale == BenchScale::Large {
+        eprintln!("  [query_overlay_matrix] skipping novelty condition at large scale");
+    } else {
+        let (_db_dir, fluree, alias) = rt.block_on(setup(n_products, false, false));
+        let snapshot =
+            rt.block_on(async { fluree.graph(&alias).load().await.expect("graph load") });
+        scenario!(snapshot, "count_novelty", Q_COUNT);
+        scenario!(snapshot, "star_novelty", Q_STAR);
+        scenario!(snapshot, "groupby_novelty", Q_GROUPBY);
+        drop(snapshot);
+        drop(fluree);
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_query_overlay_matrix);
+criterion_main!(benches);

--- a/regression-budget.json
+++ b/regression-budget.json
@@ -48,6 +48,11 @@
         "tiny": 10.0,
         "small": 5.0,
         "medium": 3.0
+      },
+      "query_overlay_matrix": {
+        "tiny": 10.0,
+        "small": 5.0,
+        "medium": 5.0
       }
     },
     "fluree-db-query": {


### PR DESCRIPTION
## Summary

First PR of the architecture-audit roadmap (`docs/audit/2026-06-architecture-audit.md`, included here). Implements **Phase 0.0 — performance guardrails**: the measurement substrate every later refactor phase gates on, so "no regression, ideally improvement" is a mechanical check (time **and** memory, across scales and ledger conditions) instead of a hope.

## What's included

1. **Architecture audit + roadmap** (`docs/audit/2026-06-architecture-audit.md`) — full-workspace audit; core finding is that the three chronic-bug contracts (overlay translation/merge, LedgerState coherence, fast-path gating) are convention-enforced rather than type-enforced. Phases 0–4 convert them to compile-time / single-chokepoint guarantees without touching hot kernels. Phase 0.0 defines the per-phase baseline protocol this PR implements.
2. **`bench-baseline`** (bin in `fluree-bench-support`) — `capture` walks criterion estimates + memory sidecars into a labeled, git-stamped `bench-baselines/<label>.json`; `compare` checks a later run against it using `regression-budget.json` budgets, prints regressions *and* improvements, exits 1 on breach. `--only` scopes PR-level subset runs. See BENCHMARKING.md "Baselines: capture & compare".
3. **`fluree-bench-alloc`** — tracking `GlobalAlloc` wrapper (current/peak/total; two relaxed atomics per alloc) in its own crate so `fluree-bench-support` keeps `#![forbid(unsafe_code)]`. New `mem` module records per-scenario sidecars; `compare` gates `peak_mem` with the same budgets as time.
4. **`query_overlay_matrix` bench** — count / star-join / group-by shapes at three ledger conditions: `base` (indexed, epoch 0), `overlay` (indexed + ~10% trailing novelty), `novelty` (no index). Closes the coverage gap where every existing hot-path bench ran at epoch 0 — i.e. the overlay-merge lane the roadmap's Phases 1–2 refactor had **zero** benchmark coverage.

## Why the matrix matters — first measurements

Tiny scale (100 products, quick profile), base → overlay:

| shape | base | overlay | penalty |
|---|---|---|---|
| count | 31 µs | 273 µs | ~9× |
| star | 63 µs | 911 µs | ~14× |
| groupby | 154 µs | 19.8 ms | ~128× |

These are the pre-refactor reference numbers for Phase 1 (overlay-merge chokepoint) — significant measured headroom in exactly the lane it consolidates.

## Validation

- 55 unit tests pass (`fluree-bench-support`, `fluree-bench-alloc`) incl. the `workspace_reconcile` gate with the new bench + budget entries
- All 9 bench scenarios smoke-pass (`-- --test`) and run measured at tiny scale
- Round-trip proven: capture (9 scenarios, 9 with memory) → compare vs self exits 0 → doctored baseline correctly fails with exit 1
- Clippy clean on touched crates (the `graph_iris` dead-code warning pre-exists on main; verified via stash)