### PR TITLE
fix(api): resolve novelty-allocated encoded IDs in result formatting

### DIFF
--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -386,8 +386,7 @@ fn write_binding_cell(
         }
         Binding::EncodedSid { s_id, .. } => {
             let gv = require_graph_view(gv)?;
-            let store = gv.store();
-            let iri = store.resolve_subject_iri(*s_id).map_err(|e| {
+            let iri = gv.resolve_subject_iri(*s_id).map_err(|e| {
                 FormatError::InvalidBinding(format!(
                     "Failed to resolve subject IRI for s_id {s_id}: {e}"
                 ))
@@ -417,15 +416,21 @@ fn write_binding_cell(
             let gv = require_graph_view(gv)?;
             let store = gv.store();
             if *o_kind == ObjKind::LEX_ID.as_u8() || *o_kind == ObjKind::JSON_ID.as_u8() {
-                store
-                    .write_string_value_bytes(*o_key as u32, cell)
-                    .map_err(|e| {
-                        FormatError::InvalidBinding(format!(
-                            "Failed to resolve string (kind={o_kind}, key={o_key}): {e}"
-                        ))
-                    })?;
+                // Zero-copy persisted lookup first; novelty string IDs sit above
+                // the pack watermark so the store lookup fails cleanly (without
+                // writing) and the novelty-aware decode takes over.
+                if store.write_string_value_bytes(*o_key as u32, cell).is_err() {
+                    let val = gv
+                        .decode_value_from_kind(*o_kind, *o_key, *p_id, *dt_id, *lang_id)
+                        .map_err(|e| {
+                            FormatError::InvalidBinding(format!(
+                                "Failed to resolve string (kind={o_kind}, key={o_key}): {e}"
+                            ))
+                        })?;
+                    write_flake_value(cell, &val, compactor);
+                }
             } else if *o_kind == ObjKind::REF_ID.as_u8() {
-                let iri = store.resolve_subject_iri(*o_key).map_err(|e| {
+                let iri = gv.resolve_subject_iri(*o_key).map_err(|e| {
                     FormatError::InvalidBinding(format!(
                         "Failed to resolve ref IRI for s_id {o_key}: {e}"
                     ))

--- a/fluree-db-api/src/format/materialize.rs
+++ b/fluree-db-api/src/format/materialize.rs
@@ -41,9 +41,10 @@ fn materialize_encoded_binding(
 ) -> std::io::Result<Binding> {
     let store = gv.store();
     match binding {
+        // Novelty-aware: subjects first seen after the index snapshot resolve
+        // from DictNovelty (watermark routing), not the persisted packs.
         Binding::EncodedSid { s_id, .. } => {
-            let iri = store.resolve_subject_iri(*s_id)?;
-            let sid = store.encode_iri(&iri);
+            let sid = gv.resolve_subject_sid(*s_id)?;
             Ok(Binding::sid(sid))
         }
         Binding::EncodedPid { p_id } => match store.resolve_predicate_iri(*p_id) {

--- a/fluree-db-api/src/format/sparql_xml.rs
+++ b/fluree-db-api/src/format/sparql_xml.rs
@@ -284,10 +284,9 @@ fn write_iri_ref(out: &mut String, iri: &str) {
 
 /// Resolve an `EncodedSid`/`EncodedPid` to its full IRI and write it.
 fn write_encoded_ref(out: &mut String, binding: &Binding, gv: &BinaryGraphView) -> Result<()> {
-    let store = gv.store();
     match binding {
         Binding::EncodedSid { s_id, .. } => {
-            let iri = store.resolve_subject_iri(*s_id).map_err(|e| {
+            let iri = gv.resolve_subject_iri(*s_id).map_err(|e| {
                 FormatError::InvalidBinding(format!(
                     "Failed to resolve subject IRI for s_id {s_id}: {e}"
                 ))
@@ -295,7 +294,7 @@ fn write_encoded_ref(out: &mut String, binding: &Binding, gv: &BinaryGraphView) 
             write_iri_ref(out, &iri);
         }
         Binding::EncodedPid { p_id } => {
-            let iri = store.resolve_predicate_iri(*p_id).ok_or_else(|| {
+            let iri = gv.store().resolve_predicate_iri(*p_id).ok_or_else(|| {
                 FormatError::InvalidBinding(format!(
                     "Failed to resolve predicate IRI for p_id {p_id}"
                 ))

--- a/fluree-db-api/src/view/types.rs
+++ b/fluree-db-api/src/view/types.rs
@@ -552,13 +552,16 @@ impl GraphDb {
 
     /// Build a `BinaryGraphView` combining the binary store with the view's graph ID.
     ///
-    /// Returns `None` if no binary store is attached.
+    /// Returns `None` if no binary store is attached. The view carries
+    /// `dict_novelty` so encoded IDs allocated after the index snapshot
+    /// (novelty-only subjects/strings) resolve via watermark routing instead
+    /// of failing against the persisted forward packs.
     pub fn binary_graph(&self) -> Option<BinaryGraphView> {
         self.binary_store.as_ref().map(|store| {
             // `shared_namespaces()` is a refcount bump on the snapshot's already-Arc
             // namespace table; `namespaces().clone()` would deep-copy the whole map
             // on every query (a dominant per-query cost on large ledgers).
-            BinaryGraphView::new(store.clone(), self.graph_id)
+            BinaryGraphView::with_novelty(store.clone(), self.graph_id, self.dict_novelty.clone())
                 .with_namespace_codes_fallback(Some(self.snapshot.shared_namespaces()))
         })
     }

--- a/fluree-db-api/tests/it_values_type_deleted_repro.rs
+++ b/fluree-db-api/tests/it_values_type_deleted_repro.rs
@@ -196,6 +196,71 @@ async fn values_bound_type_after_delete_indexed_before_delete() {
     assert_shapes_agree(&fluree, &receipt2.ledger, 5, "post-reinsert").await;
 }
 
+/// Production-like timeline: incremental index builds interleaved with the
+/// delete and re-insert (the server's background indexer path), plus an RDFS
+/// schema transacted after the re-insert as in the original report.
+#[tokio::test]
+async fn values_bound_type_after_delete_incremental_index_timeline() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let alias = "values-deleted/incremental:main";
+    let ledger0 = fluree.create_ledger(alias).await.expect("create");
+
+    // Populate across two commits, then index.
+    let r1 = fluree
+        .insert(ledger0, &parts_graph("olda", 20))
+        .await
+        .expect("insert 1");
+    let r2 = fluree
+        .insert(r1.ledger, &parts_graph("oldb", 20))
+        .await
+        .expect("insert 2");
+    support::build_and_publish_index(&fluree, alias).await;
+    let ledger = fluree.ledger(alias).await.expect("reload");
+    assert_shapes_agree(&fluree, &ledger, 40, "pre-delete indexed").await;
+    let _ = r2;
+
+    // Wipe, then fold the retractions into the index incrementally.
+    let wiped = wipe_ledger(&fluree, ledger).await;
+    support::build_and_publish_index(&fluree, alias).await;
+    let ledger = fluree.ledger(alias).await.expect("reload post-delete");
+    assert_shapes_agree(&fluree, &ledger, 0, "post-delete indexed").await;
+    let _ = wiped;
+
+    // Re-insert a smaller set, then transact an RDFS schema (the affected
+    // production ledger carried rdfs:domain/range/Class declarations).
+    let r3 = fluree
+        .insert(ledger, &parts_graph("new", 5))
+        .await
+        .expect("re-insert");
+    let schema = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        "@graph": [
+            { "@id": "ex:Part", "@type": "rdfs:Class", "rdfs:label": "Part" },
+            {
+                "@id": "ex:name",
+                "rdfs:domain": { "@id": "ex:Part" },
+                "rdfs:range": { "@id": "rdfs:Literal" }
+            }
+        ]
+    });
+    let r4 = fluree
+        .insert(r3.ledger, &schema)
+        .await
+        .expect("schema insert");
+    assert_shapes_agree(&fluree, &r4.ledger, 5, "post-reinsert novelty").await;
+
+    // Fold the re-insert into the index and check the steady state.
+    support::build_and_publish_index(&fluree, alias).await;
+    let ledger = fluree.ledger(alias).await.expect("reload post-reinsert");
+    assert_shapes_agree(&fluree, &ledger, 5, "post-reinsert indexed").await;
+}
+
 /// Binary index rebuilt after the delete + re-insert (fully indexed state).
 #[tokio::test]
 async fn values_bound_type_after_delete_indexed_after_reinsert() {

--- a/fluree-db-api/tests/it_values_type_deleted_repro.rs
+++ b/fluree-db-api/tests/it_values_type_deleted_repro.rs
@@ -1,0 +1,227 @@
+//! Regression test for fluree/db#1310: a `VALUES`-bound `rdf:type` pattern
+//! must not resurface logically deleted (retracted) subjects.
+//!
+//! Repro shape: populate a ledger, wildcard-DELETE everything, re-insert a
+//! smaller set. Counting class members with a constant class IRI and with the
+//! class bound via `VALUES` must agree.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::{FlureeBuilder, LedgerState, ReindexOptions};
+use serde_json::json;
+
+fn parts_graph(prefix: &str, n: usize) -> serde_json::Value {
+    let nodes: Vec<serde_json::Value> = (0..n)
+        .map(|i| {
+            json!({
+                "@id": format!("ex:{prefix}{i}"),
+                "@type": "ex:Part",
+                "ex:name": format!("{prefix} {i}")
+            })
+        })
+        .collect();
+    json!({
+        "@context": { "ex": "http://example.org/" },
+        "@graph": nodes
+    })
+}
+
+async fn count_constant(fluree: &fluree_db_api::Fluree, ledger: &LedgerState) -> i64 {
+    let q = r"
+        PREFIX ex: <http://example.org/>
+        SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE { ?s a ex:Part }
+    ";
+    extract_count(fluree, ledger, q).await
+}
+
+async fn count_values(fluree: &fluree_db_api::Fluree, ledger: &LedgerState) -> i64 {
+    let q = r"
+        PREFIX ex: <http://example.org/>
+        SELECT (COUNT(DISTINCT ?s) AS ?n)
+        WHERE { VALUES ?c { ex:Part } ?s a ?c }
+    ";
+    extract_count(fluree, ledger, q).await
+}
+
+async fn list_constant_subjects(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &LedgerState,
+) -> Vec<String> {
+    let q = r"
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?s WHERE { ?s a ex:Part }
+    ";
+    list_subjects(fluree, ledger, q).await
+}
+
+async fn list_values_subjects(fluree: &fluree_db_api::Fluree, ledger: &LedgerState) -> Vec<String> {
+    let q = r"
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?s WHERE { ?s a ?c . VALUES ?c { ex:Part } }
+    ";
+    list_subjects(fluree, ledger, q).await
+}
+
+async fn list_subjects(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &LedgerState,
+    q: &str,
+) -> Vec<String> {
+    let result = support::query_sparql(fluree, ledger, q)
+        .await
+        .expect("VALUES list query");
+    let sparql_json = result
+        .to_sparql_json(&ledger.snapshot)
+        .expect("to_sparql_json");
+    let mut subjects: Vec<String> = sparql_json["results"]["bindings"]
+        .as_array()
+        .expect("bindings array")
+        .iter()
+        .map(|b| b["s"]["value"].as_str().expect("iri").to_string())
+        .collect();
+    subjects.sort();
+    subjects
+}
+
+async fn extract_count(fluree: &fluree_db_api::Fluree, ledger: &LedgerState, q: &str) -> i64 {
+    let result = support::query_sparql(fluree, ledger, q)
+        .await
+        .expect("count query");
+    let sparql_json = result
+        .to_sparql_json(&ledger.snapshot)
+        .expect("to_sparql_json");
+    let bindings = sparql_json["results"]["bindings"]
+        .as_array()
+        .expect("bindings array");
+    assert_eq!(bindings.len(), 1, "single aggregate row: {sparql_json}");
+    bindings[0]["n"]["value"]
+        .as_str()
+        .expect("count literal")
+        .parse()
+        .expect("count parses")
+}
+
+async fn wipe_ledger(fluree: &fluree_db_api::Fluree, ledger: LedgerState) -> LedgerState {
+    let delete_all = json!({
+        "@context": { "ex": "http://example.org/" },
+        "where":  { "@id": "?s", "?p": "?o" },
+        "delete": { "@id": "?s", "?p": "?o" }
+    });
+    fluree
+        .update(ledger, &delete_all)
+        .await
+        .expect("wildcard delete")
+        .ledger
+}
+
+async fn assert_shapes_agree(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &LedgerState,
+    expected: i64,
+    label: &str,
+) {
+    let constant = count_constant(fluree, ledger).await;
+    let values = count_values(fluree, ledger).await;
+    let listed_constant = list_constant_subjects(fluree, ledger).await;
+    let listed_values = list_values_subjects(fluree, ledger).await;
+    assert_eq!(constant, expected, "[{label}] constant-class count");
+    assert_eq!(
+        values, expected,
+        "[{label}] VALUES-bound class count diverged (constant={constant}); \
+         VALUES subjects: {listed_values:?}"
+    );
+    assert_eq!(
+        listed_constant, listed_values,
+        "[{label}] constant and VALUES shapes must list the same subjects"
+    );
+}
+
+/// Novelty-only ledger (no binary index at any point).
+#[tokio::test]
+async fn values_bound_type_after_delete_novelty_only() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = fluree
+        .create_ledger("values-deleted/novelty:main")
+        .await
+        .expect("create");
+
+    let receipt = fluree
+        .insert(ledger0, &parts_graph("old", 40))
+        .await
+        .expect("initial insert");
+    assert_shapes_agree(&fluree, &receipt.ledger, 40, "pre-delete").await;
+
+    let wiped = wipe_ledger(&fluree, receipt.ledger).await;
+    assert_shapes_agree(&fluree, &wiped, 0, "post-delete").await;
+
+    let receipt2 = fluree
+        .insert(wiped, &parts_graph("new", 5))
+        .await
+        .expect("re-insert");
+    assert_shapes_agree(&fluree, &receipt2.ledger, 5, "post-reinsert").await;
+}
+
+/// Binary index built from the initial population; delete + re-insert live in
+/// novelty on top of the indexed (pre-delete) state.
+#[tokio::test]
+async fn values_bound_type_after_delete_indexed_before_delete() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let alias = "values-deleted/indexed-pre:main";
+    let ledger0 = fluree.create_ledger(alias).await.expect("create");
+
+    let receipt = fluree
+        .insert(ledger0, &parts_graph("old", 40))
+        .await
+        .expect("initial insert");
+    fluree
+        .reindex(alias, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let ledger = fluree.ledger(alias).await.expect("reload");
+    assert_shapes_agree(&fluree, &ledger, 40, "pre-delete indexed").await;
+
+    let wiped = wipe_ledger(&fluree, ledger).await;
+    assert_shapes_agree(&fluree, &wiped, 0, "post-delete").await;
+
+    let receipt2 = fluree
+        .insert(wiped, &parts_graph("new", 5))
+        .await
+        .expect("re-insert");
+    let _ = receipt;
+    assert_shapes_agree(&fluree, &receipt2.ledger, 5, "post-reinsert").await;
+}
+
+/// Binary index rebuilt after the delete + re-insert (fully indexed state).
+#[tokio::test]
+async fn values_bound_type_after_delete_indexed_after_reinsert() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let alias = "values-deleted/indexed-post:main";
+    let ledger0 = fluree.create_ledger(alias).await.expect("create");
+
+    let receipt = fluree
+        .insert(ledger0, &parts_graph("old", 40))
+        .await
+        .expect("initial insert");
+
+    let wiped = wipe_ledger(&fluree, receipt.ledger).await;
+    let receipt2 = fluree
+        .insert(wiped, &parts_graph("new", 5))
+        .await
+        .expect("re-insert");
+    let _ = receipt2;
+
+    fluree
+        .reindex(alias, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let ledger = fluree.ledger(alias).await.expect("reload");
+    assert_shapes_agree(&fluree, &ledger, 5, "post-reinsert indexed").await;
+}


### PR DESCRIPTION
Closes #1310

## Problem

On a ledger that was emptied with a wildcard DELETE and re-populated, the `VALUES ?c { <iri> } ?s a ?c` query shape misbehaved while the constant-IRI shape `?s a <iri>` was correct.

Two layers:

1. **v4.0.5 (as reported):** the batched-object join lane didn't merge the novelty overlay — post-delete it returned every deleted subject still in the index (the reported 53-vs-5 divergence) and post-reinsert it dropped novelty-only subjects. Already fixed on main by the `ObjectProbeOps` overlay-merge work (unreleased).
2. **Still broken at HEAD:** that lane emits novelty subjects as `EncodedSid` with `DictNovelty`-allocated IDs (above the persisted watermark), but formatters resolved encoded bindings against the on-disk forward packs only — so the issue's `SELECT DISTINCT ?s` shape failed with `InvalidBinding: subject local_id N not found in ns M`.

## Fix

- `GraphDb::binary_graph()` attaches the ledger's `DictNovelty`, so the view handed to formatters supports watermark routing
- `format/materialize.rs`, `format/delimited.rs`, `format/sparql_xml.rs` resolve subjects (and CSV string/ref literals) through the novelty-aware `BinaryGraphView` methods instead of raw store lookups

No transaction or query-execution changes. Formatting adds one Arc clone per query and a per-namespace watermark check before pack lookups; the CSV string fast path stays zero-copy, falling back to novelty decode only when the persisted lookup misses (novelty IDs sit above the watermark, so a miss can't silently alias).

## Tests

`it_values_type_deleted_repro.rs` pins constant vs `VALUES` agreement (counts and listed subjects) across four ledger states: novelty-only, indexed-before-delete, indexed-after-reinsert, and the production-like incremental-index timeline with an RDFS schema. The indexed-before-delete and incremental scenarios fail on v4.0.5 with the exact reported symptom and fail at HEAD with the materialization error before this fix.