### PR TITLE
Phase 0.7 differential fast-path harness (+ kill switch) — finds 3 divergence classes

### DIFF
--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -228,6 +228,9 @@ pub use fluree_db_query::{
     execute, execute_pattern, Batch, ContextConfig, ExecutableQuery, NoOpR2rmlProvider, Pattern,
     ReasoningConfig, VarRegistry,
 };
+// Planner fast-path kill switch — differential correctness harness
+// (tests/it_differential_fastpath.rs) and operational triage.
+pub use fluree_db_query::{fast_paths_disabled, set_fast_paths_disabled};
 // Re-export for lower-level pattern-based queries (internal/advanced use)
 pub use fluree_db_query::{Term, TriplePattern};
 // Re-export parse types for query results

--- a/fluree-db-api/tests/it_differential_fastpath.rs
+++ b/fluree-db-api/tests/it_differential_fastpath.rs
@@ -1,0 +1,506 @@
+//! Differential fast-path correctness harness (audit roadmap Phase 0.7,
+//! `docs/audit/2026-06-architecture-audit.md`).
+//!
+//! The planner has 30+ `detect_*` fast paths whose results must be
+//! indistinguishable from the generic operator pipeline, and the engine has
+//! three physical representations of the same logical data (binary index,
+//! index + novelty overlay, pure novelty) whose query results must be
+//! indistinguishable from each other. Both contracts are exactly where the
+//! historical correctness bugs lived. This harness pins them:
+//!
+//! **Axis 1 — fast vs generic.** Every catalog query runs twice per
+//! condition: once normally and once with the planner kill switch
+//! (`fluree_db_api::set_fast_paths_disabled`) forcing the generic pipeline.
+//! Results must match exactly (ordered queries) or as sets (unordered).
+//!
+//! **Axis 2 — representation equivalence.** The same logical dataset is
+//! materialized three ways — `base` (everything reindexed; epoch 0),
+//! `overlay` (base indexed, churn + new entities trailing in novelty),
+//! `novelty` (never indexed) — and the *generic* results must agree across
+//! all three conditions.
+//!
+//! The dataset deliberately includes overlay churn that exercises the
+//! brittle lanes: upserts that retract-and-replace indexed values (price /
+//! label changes whose new values dominate `ORDER BY DESC` top-k), plus
+//! novelty-only subjects and strings (tail products + reviews).
+//!
+//! **A mismatch here is a finding, not a flaky test.** Investigate which
+//! side is wrong against first principles before touching the harness —
+//! the audit's bug-class history says the fast/overlay side is usually the
+//! suspect, but the generic path is not presumed correct either.
+//!
+//! ## Known divergences (found by this harness's first run, 2026-06-11)
+//!
+//! Cases marked `known_divergence` REPORT their mismatch to stderr instead
+//! of failing, so the harness stays green while pinning the contract for
+//! everything else. Each entry is a real, reproducible fast-vs-generic
+//! divergence awaiting a fix; when the fix lands, remove the marker so the
+//! harness starts enforcing the case. The cross-condition axis is enforced
+//! for ALL cases — generic results agreed across base/overlay/novelty on
+//! every case at harness introduction.
+//!
+//! - **FD-1 `avg_numeric`** (base, overlay): values agree to f64
+//!   precision, but the AVG fast path emits an `xsd:double`-style JSON
+//!   number (`7072.886363636364`) while the generic pipeline emits an
+//!   arbitrary-precision `xsd:decimal` string. Observable datatype
+//!   contract difference. Suspect: `fast_predicate_scalar_agg`.
+//! - **FD-2 `max_label` / `min_label`** (base): wrong answers. With
+//!   `bsbm:label` on vendors and products, generic MAX is
+//!   `"Vendor 000003"` (lexicographic), fast returns `"Product 000219"`
+//!   — the last-inserted label, consistent with assuming string-ID order
+//!   is lexicographic order. That invariant (`lex_sorted_string_ids`)
+//!   only holds after bulk import and is cleared by incremental writes;
+//!   this ledger was reindex-built. Suspect: `fast_min_max_string`
+//!   missing the lex-order gate.
+//! - **FD-3 `group_by_predicate_count`** (all three conditions,
+//!   differently): the stats-answered path
+//!   (`StatsCountByPredicateOperator`) (a) counts duplicate re-asserts
+//!   that set-semantics novelty apply dedups (base: `bsbm:name` 42 vs
+//!   22), (b) applies novelty deltas inconsistently per predicate
+//!   (overlay: `rdf:type` stale at the index-time 824 while other
+//!   predicates include novelty), and (c) omits the `rdf:type` row
+//!   entirely in pure novelty. Suspect: IndexStats accounting +
+//!   `detect_stats_count_by_predicate` novelty handling.
+
+#![cfg(feature = "native")]
+
+use fluree_bench_support::gen::bsbm::{bsbm_data_to_turtle, generate_dataset, BsbmData};
+use fluree_db_api::admin::ReindexOptions;
+use fluree_db_api::{
+    set_fast_paths_disabled, CommitOpts, Fluree, FlureeBuilder, FormatterConfig, IndexConfig,
+    TxnOpts,
+};
+use serde_json::Value;
+
+const N_PRODUCTS: usize = 200;
+const N_TAIL: usize = 20;
+const N_CHURNED: usize = 5;
+
+// -----------------------------------------------------------------------------
+// Dataset: base + churn (upsert retract/replace) + tail (novelty-only subjects)
+// -----------------------------------------------------------------------------
+
+fn base_turtle() -> String {
+    bsbm_data_to_turtle(&generate_dataset(N_PRODUCTS))
+}
+
+/// Upsert that retracts and replaces price + label on the first
+/// `N_CHURNED` products. New prices are unique and far above the
+/// generator's 1000–50999 range, so `ORDER BY DESC(?price)` top-k MUST
+/// surface these churned values — in the overlay condition that means the
+/// winner rows come from novelty retract/assert pairs over indexed rows.
+fn churn_turtle() -> String {
+    let mut buf = String::from(
+        "@prefix ex: <http://example.org/ns/> .\n\
+         @prefix bsbm: <http://example.org/bsbm/> .\n\
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n",
+    );
+    for i in 0..N_CHURNED {
+        buf.push_str(&format!(
+            "ex:product-{i:06} bsbm:price \"{}\"^^xsd:integer ;\n    bsbm:label \"Churned Product {i:06}\" .\n\n",
+            90_001 + i * 7,
+        ));
+    }
+    buf
+}
+
+/// New products `[N_PRODUCTS, N_PRODUCTS + N_TAIL)` with their reviews —
+/// novelty-only subjects and strings in the overlay condition. Vendors and
+/// persons from the larger generation are included wholesale; re-asserting
+/// already-present facts is itself a realistic overlay shape (set-semantics
+/// dedup) and keeps the slice robust to generator-internal count rules.
+fn tail_entities_turtle() -> String {
+    let full = generate_dataset(N_PRODUCTS + N_TAIL);
+    bsbm_data_to_turtle(&BsbmData {
+        vendors: full.vendors.clone(),
+        persons: full.persons.clone(),
+        products: full.products[N_PRODUCTS..].to_vec(),
+        reviews: Vec::new(),
+    })
+}
+
+fn tail_reviews_turtle() -> String {
+    let full = generate_dataset(N_PRODUCTS + N_TAIL);
+    bsbm_data_to_turtle(&BsbmData {
+        vendors: Vec::new(),
+        persons: Vec::new(),
+        products: Vec::new(),
+        reviews: full.reviews[N_PRODUCTS * 3..].to_vec(),
+    })
+}
+
+// -----------------------------------------------------------------------------
+// Conditions
+// -----------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Condition {
+    /// All commits applied, then reindexed: everything behind the binary
+    /// index at epoch 0 (including the churn's retraction history).
+    Base,
+    /// Base data reindexed; churn + tail commits trail in novelty.
+    Overlay,
+    /// Indexing disabled; the whole dataset lives in novelty.
+    Novelty,
+}
+
+impl Condition {
+    fn name(self) -> &'static str {
+        match self {
+            Condition::Base => "base",
+            Condition::Overlay => "overlay",
+            Condition::Novelty => "novelty",
+        }
+    }
+}
+
+/// Build a file-backed ledger in the given condition. All three conditions
+/// hold the same logical data (base + churn + tail), differing only in how
+/// much of it sits behind the binary index.
+async fn setup(cond: Condition) -> (tempfile::TempDir, Fluree, String) {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let path = dir.path().to_string_lossy().to_string();
+    let mut builder = FlureeBuilder::file(path);
+    if cond == Condition::Novelty {
+        builder = builder.without_indexing();
+    }
+    let fluree = builder.build().expect("build Fluree");
+
+    let alias = format!("diff:{}", cond.name());
+    let mut ledger = fluree.create_ledger(&alias).await.expect("create_ledger");
+
+    // Thresholds high enough that no commit triggers foreground/background
+    // indexing on its own — the only index points are the explicit
+    // `reindex` calls below, which is what defines each condition.
+    let index_config = IndexConfig {
+        reindex_min_bytes: 5_000_000_000,
+        reindex_max_bytes: 5_000_000_000,
+    };
+
+    let r = fluree
+        .insert_turtle_with_opts(
+            ledger,
+            &base_turtle(),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config,
+        )
+        .await
+        .expect("insert base");
+    ledger = r.ledger;
+
+    if cond == Condition::Overlay {
+        // Index the base only; everything after this trails in novelty.
+        fluree
+            .reindex(&alias, ReindexOptions::default())
+            .await
+            .expect("reindex base");
+    }
+
+    let r = fluree
+        .upsert_turtle_with_opts(
+            ledger,
+            &churn_turtle(),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config,
+        )
+        .await
+        .expect("upsert churn");
+    ledger = r.ledger;
+    for (label, turtle) in [
+        ("insert tail entities", tail_entities_turtle()),
+        ("insert tail reviews", tail_reviews_turtle()),
+    ] {
+        let r = fluree
+            .insert_turtle_with_opts(
+                ledger,
+                &turtle,
+                TxnOpts::default(),
+                CommitOpts::default(),
+                &index_config,
+            )
+            .await
+            .expect(label);
+        ledger = r.ledger;
+    }
+    let _ = ledger;
+
+    if cond == Condition::Base {
+        // Index everything: epoch 0 with the churn in index history.
+        fluree
+            .reindex(&alias, ReindexOptions::default())
+            .await
+            .expect("reindex all");
+    }
+
+    (dir, fluree, alias)
+}
+
+// -----------------------------------------------------------------------------
+// Query catalog
+// -----------------------------------------------------------------------------
+
+struct Case {
+    name: &'static str,
+    /// Compare rows exactly (ORDER BY with unique sort keys) vs as a
+    /// sorted multiset.
+    ordered: bool,
+    /// `Some(finding_id)` — a documented, reproducible fast-vs-generic
+    /// divergence (see module docs). Mismatches are reported to stderr
+    /// instead of failing until the fix lands and the marker is removed.
+    known_divergence: Option<&'static str>,
+    sparql: &'static str,
+}
+
+const PREFIX: &str = "PREFIX bsbm: <http://example.org/bsbm/>\n";
+
+/// Shapes chosen to trigger specific `detect_*` fast paths (see
+/// `fluree-db-query/src/execute/operator_tree.rs`); each comment names the
+/// intended target. Detection is shape-based, so a case that stops matching
+/// after planner changes silently degrades to generic-vs-generic — keep
+/// shapes in sync with the detectors when they evolve.
+fn catalog() -> Vec<Case> {
+    vec![
+        // detect_predicate_object_count (bound-object count via POST FIRSTs)
+        Case {
+            name: "count_class",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT (COUNT(?s) AS ?c) WHERE { ?s a bsbm:Product }",
+        },
+        // detect_predicate_count_rows
+        Case {
+            name: "count_predicate_rows",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT (COUNT(?s) AS ?c) WHERE { ?s bsbm:price ?o }",
+        },
+        // detect_count_triples
+        Case {
+            name: "count_all_triples",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }",
+        },
+        // detect_count_distinct_position
+        Case {
+            name: "count_distinct_subjects",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT (COUNT(DISTINCT ?s) AS ?c) WHERE { ?s ?p ?o }",
+        },
+        // detect_predicate_count_distinct_object
+        Case {
+            name: "count_distinct_objects",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT (COUNT(DISTINCT ?o) AS ?c) WHERE { ?s bsbm:productType ?o }",
+        },
+        // detect_predicate_count_rows_numeric_compare — the FILTER bound
+        // (25000) sits inside the base price range and below the churned
+        // 90k+ prices, so overlay retract/assert churn shifts the count.
+        Case {
+            name: "count_numeric_filter",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT (COUNT(?s) AS ?c) WHERE { ?s bsbm:price ?o . FILTER(?o > 25000) }",
+        },
+        // detect_fused_scan_sum / scalar agg — SUM shifts when churn
+        // replaces five prices.
+        Case {
+            name: "sum_numeric",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT (SUM(?o) AS ?total) WHERE { ?s bsbm:price ?o }",
+        },
+        // detect_predicate_avg_numeric
+        Case {
+            name: "avg_numeric",
+            ordered: false,
+            known_divergence: Some("FD-1"),
+            sparql: "SELECT (AVG(?o) AS ?avg) WHERE { ?s bsbm:price ?o }",
+        },
+        // detect_predicate_minmax_string — churned labels sort after
+        // "Product ..." ("Churned ..." sorts before), and MAX over labels
+        // includes tail products' novelty-only strings.
+        Case {
+            name: "max_label",
+            ordered: false,
+            known_divergence: Some("FD-2"),
+            sparql: "SELECT (MAX(?o) AS ?m) WHERE { ?s bsbm:label ?o }",
+        },
+        Case {
+            name: "min_label",
+            ordered: false,
+            known_divergence: Some("FD-2"),
+            sparql: "SELECT (MIN(?o) AS ?m) WHERE { ?s bsbm:label ?o }",
+        },
+        // detect_post_order_desc_limit — reverse-POST tail walk. The seven
+        // winners include all five churned prices (90k+), which in the
+        // overlay condition exist only as novelty retract/assert pairs over
+        // indexed rows. Prices are unique by construction → fully ordered.
+        Case {
+            name: "order_desc_limit",
+            ordered: true,
+            known_divergence: None,
+            sparql: "SELECT ?s ?o WHERE { ?s bsbm:price ?o } ORDER BY DESC(?o) LIMIT 7",
+        },
+        // detect_predicate_group_by_object_count_topk — LIMIT exceeds the
+        // five product types so the full group set returns and ties in the
+        // count order don't make the row *set* ambiguous (compared unordered).
+        Case {
+            name: "group_by_object_count",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT ?o (COUNT(?s) AS ?c) WHERE { ?s bsbm:productType ?o } GROUP BY ?o ORDER BY DESC(?c) LIMIT 10",
+        },
+        // detect_stats_count_by_predicate (StatsView-answered when indexed)
+        Case {
+            name: "group_by_predicate_count",
+            ordered: false,
+            known_divergence: Some("FD-3"),
+            sparql: "SELECT ?p (COUNT(?s) AS ?c) WHERE { ?s ?p ?o } GROUP BY ?p",
+        },
+        // Property-join star fusion + ORDER BY (generic-path internal fast
+        // lanes; also a Q5-shape sanity anchor). Unique prices → ordered.
+        Case {
+            name: "star_join_ordered",
+            ordered: true,
+            known_divergence: None,
+            sparql: "SELECT ?product ?label ?vendorLabel ?price WHERE {\n\
+                     ?product a bsbm:Product ; bsbm:label ?label ; bsbm:vendor ?vendor ; bsbm:price ?price .\n\
+                     ?vendor bsbm:label ?vendorLabel .\n\
+                     FILTER(?price >= 5000 && ?price <= 25000)\n\
+                     } ORDER BY ?price LIMIT 10",
+        },
+        // detect_label_regex_type / string-prefix lanes. Churn renames
+        // products 0–4 ("Churned ..."), so the overlay's retractions must
+        // suppress their old "Product 0000xx" labels for the count to agree.
+        Case {
+            name: "strstarts_label",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT ?s WHERE { ?s a bsbm:Product ; bsbm:label ?l . FILTER(STRSTARTS(?l, \"Product 0000\")) }",
+        },
+        // detect_string_prefix_count_all
+        Case {
+            name: "count_strstarts",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT (COUNT(?s) AS ?c) WHERE { ?s bsbm:label ?l . FILTER(STRSTARTS(?l, \"Churned\")) }",
+        },
+    ]
+}
+
+// -----------------------------------------------------------------------------
+// Execution + comparison
+// -----------------------------------------------------------------------------
+
+fn normalize(rows: &Value, ordered: bool) -> Vec<String> {
+    let arr = rows
+        .as_array()
+        .unwrap_or_else(|| panic!("expected JSON array of rows, got: {rows}"));
+    let mut out: Vec<String> = arr
+        .iter()
+        .map(|r| serde_json::to_string(r).expect("serialize row"))
+        .collect();
+    if !ordered {
+        out.sort();
+    }
+    out
+}
+
+async fn run_query(fluree: &Fluree, alias: &str, sparql: &str) -> Value {
+    let full = format!("{PREFIX}{sparql}");
+    let snapshot = fluree
+        .graph(alias)
+        .load()
+        .await
+        .unwrap_or_else(|e| panic!("load {alias}: {e}"));
+    snapshot
+        .query()
+        .sparql(&full)
+        .format(FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .unwrap_or_else(|e| panic!("query [{alias}] {sparql}: {e}"))
+}
+
+/// RAII guard: the kill switch is process-global; restore on every exit
+/// path (including panics) so a failure here can't poison other tests.
+struct FastPathGuard;
+impl Drop for FastPathGuard {
+    fn drop(&mut self) {
+        set_fast_paths_disabled(false);
+    }
+}
+
+#[tokio::test]
+async fn differential_fastpath_and_condition_matrix() {
+    let _guard = FastPathGuard;
+    let conditions = [Condition::Base, Condition::Overlay, Condition::Novelty];
+    let cases = catalog();
+    let mut failures: Vec<String> = Vec::new();
+
+    // generic results per (case, condition) for the cross-condition axis.
+    let mut generic_results: Vec<Vec<Vec<String>>> = vec![Vec::new(); cases.len()];
+
+    for cond in conditions {
+        let (_dir, fluree, alias) = setup(cond).await;
+
+        for (ci, case) in cases.iter().enumerate() {
+            set_fast_paths_disabled(false);
+            let fast = run_query(&fluree, &alias, case.sparql).await;
+            set_fast_paths_disabled(true);
+            let generic = run_query(&fluree, &alias, case.sparql).await;
+            set_fast_paths_disabled(false);
+
+            let fast_n = normalize(&fast, case.ordered);
+            let generic_n = normalize(&generic, case.ordered);
+            if fast_n != generic_n {
+                let detail = format!(
+                    "[fast≠generic] case={} condition={}\n  fast:    {:?}\n  generic: {:?}",
+                    case.name,
+                    cond.name(),
+                    fast_n,
+                    generic_n,
+                );
+                match case.known_divergence {
+                    Some(finding) => {
+                        eprintln!("KNOWN DIVERGENCE {finding} (not enforced): {detail}\n");
+                    }
+                    None => failures.push(detail),
+                }
+            }
+            generic_results[ci].push(generic_n);
+        }
+    }
+
+    // Axis 2: the generic pipeline must see identical logical data in all
+    // three physical representations.
+    for (ci, case) in cases.iter().enumerate() {
+        let per_cond = &generic_results[ci];
+        for (i, cond) in conditions.iter().enumerate().skip(1) {
+            if per_cond[i] != per_cond[0] {
+                failures.push(format!(
+                    "[condition≠condition] case={} {}≠{}\n  {}: {:?}\n  {}: {:?}",
+                    case.name,
+                    cond.name(),
+                    conditions[0].name(),
+                    conditions[0].name(),
+                    per_cond[0],
+                    cond.name(),
+                    per_cond[i],
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "differential harness found {} mismatch(es):\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+}

--- a/fluree-db-query/src/execute.rs
+++ b/fluree-db-query/src/execute.rs
@@ -49,7 +49,7 @@ pub use where_plan::build_where_operators_seeded;
 pub(crate) use where_plan::{analyze_property_join_plan, collect_inner_join_block};
 
 // Re-export operator tree builder and runner for custom execution pipelines
-pub use operator_tree::build_operator_tree;
+pub use operator_tree::{build_operator_tree, fast_paths_disabled, set_fast_paths_disabled};
 pub use runner::run_operator;
 
 // Re-export pushdown utilities for tests

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2041,6 +2041,35 @@ fn detect_union_star_count_all(
     Some((union_preds, extra_preds, mode, out_var))
 }
 
+/// Global fast-path kill switch.
+///
+/// When set (programmatically via [`set_fast_paths_disabled`] or via the
+/// `FLUREE_DISABLE_QUERY_FAST_PATHS` env var), the planner skips every
+/// `detect_*` shape recognizer — the fused chain *and* the history-gated
+/// non-fused paths — and always builds the generic operator pipeline.
+///
+/// This exists for the differential correctness harness
+/// (`fluree-db-api/tests/it_differential_fastpath.rs`), which runs the same
+/// query with fast paths on and off and asserts identical results, and as
+/// an operational escape hatch when triaging a suspected fast-path bug.
+/// It is NOT a tuning knob: runtime operator-internal optimizations
+/// (cursor selection, batched joins) are unaffected.
+static FAST_PATHS_DISABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Disable (or re-enable) planner fast paths process-wide. Test/triage use.
+pub fn set_fast_paths_disabled(disabled: bool) {
+    FAST_PATHS_DISABLED.store(disabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// True when planner fast paths are disabled, either programmatically or
+/// via `FLUREE_DISABLE_QUERY_FAST_PATHS` (read once per process).
+pub fn fast_paths_disabled() -> bool {
+    static ENV: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    FAST_PATHS_DISABLED.load(std::sync::atomic::Ordering::Relaxed)
+        || *ENV.get_or_init(|| std::env::var_os("FLUREE_DISABLE_QUERY_FAST_PATHS").is_some())
+}
+
 /// Build the complete operator tree for a query
 ///
 /// Constructs operators in the order:
@@ -2076,6 +2105,12 @@ fn build_operator_tree_inner(
     enable_fused_fast_paths: bool,
     planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
+    // Global kill switch (differential harness / triage): force the generic
+    // pipeline for the fused chain and the non-fused history-gated paths
+    // below alike.
+    let fast_paths_globally_disabled = fast_paths_disabled();
+    let enable_fused_fast_paths = enable_fused_fast_paths && !fast_paths_globally_disabled;
+
     // Phase 5 of the planner-mode refactor: fast paths emit current-state
     // bindings (no `op` channel, no retract events) and don't consult the
     // history sidecar. In `History` mode they're semantically wrong, so the
@@ -2531,7 +2566,7 @@ fn build_operator_tree_inner(
     // This avoids decoding leaflets for long (p,o) runs that span leaflet boundaries.
     // Skipped in `History` mode for the same reason as the fused fast paths above:
     // the path emits current-state counts and ignores retracts.
-    if !planning.is_history() {
+    if !planning.is_history() && !fast_paths_globally_disabled {
         if let Some((pred, s_var, o_var, count_var, limit)) =
             detect_predicate_group_by_object_count_topk(query)
         {
@@ -2561,7 +2596,7 @@ fn build_operator_tree_inner(
 
     // Fast-path: `SELECT (COUNT(?s) AS ?c) WHERE { ?s <p> <o> }` using leaflet FIRST headers.
     // Skipped in `History` mode (current-state count semantics).
-    if !planning.is_history() {
+    if !planning.is_history() && !fast_paths_globally_disabled {
         if let Some((pred, s_var, obj, count_var)) = detect_predicate_object_count(query) {
             let mut operator: BoxedOperator = Box::new(PredicateObjectCountFirstsOperator::new(
                 pred,
@@ -2608,7 +2643,7 @@ fn build_operator_tree_inner(
     // This avoids scanning all triples when we can answer directly from IndexStats.
     // Skipped in `History` mode — IndexStats reflects current-state cardinality,
     // not the asserts + retracts a history-range query needs.
-    if !planning.is_history() {
+    if !planning.is_history() && !fast_paths_globally_disabled {
         if let Some(ref stats_view) = stats {
             if let Some((pred_var, count_var)) = detect_stats_count_by_predicate(query) {
                 let mut operator: BoxedOperator = Box::new(StatsCountByPredicateOperator::new(

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -107,7 +107,10 @@ pub use dataset::{ActiveGraph, ActiveGraphs, DataSet, GraphRef};
 pub use dataset_operator::{DatasetBuilder, DatasetOperator, ScanDatasetBuilder};
 pub use distinct::DistinctOperator;
 pub use error::{QueryError, Result};
-pub use execute::{build_operator_tree, execute, run_operator, ContextConfig, ExecutableQuery};
+pub use execute::{
+    build_operator_tree, execute, fast_paths_disabled, run_operator, set_fast_paths_disabled,
+    ContextConfig, ExecutableQuery,
+};
 pub use exists::ExistsOperator;
 pub use explain::{
     explain_execution_hints, explain_patterns, ExecutionStrategyHint, ExplainPlan, FallbackReason,


### PR DESCRIPTION
## Summary

Stacked on #1311. Implements **Phase 0.7** of the audit roadmap: the differential correctness harness that gates every later refactor phase — and it earned its keep immediately by finding **three reproducible fast-vs-generic divergence classes on its first run**, two of which are user-visible wrong answers.

## What's included

1. **Planner fast-path kill switch** (`fluree-db-query`): `set_fast_paths_disabled(bool)` / `FLUREE_DISABLE_QUERY_FAST_PATHS` skips every `detect_*` shape recognizer (the fused chain *and* the three non-fused history-gated paths), forcing the generic pipeline. Re-exported through `fluree-db-api`. Runtime operator-internal optimizations are unaffected — this isolates exactly the planner fast-path layer.
2. **Differential harness** (`fluree-db-api/tests/it_differential_fastpath.rs`), two axes over a dataset with deliberate overlay churn (upserts that retract/replace indexed values and dominate `ORDER BY DESC` top-k; novelty-only subjects/strings; duplicate re-asserts):
   - **Axis 1 — fast ≡ generic**: 16 catalog queries (each annotated with the `detect_*` path it targets) run with fast paths on/off per condition; results must match.
   - **Axis 2 — representation equivalence**: generic results must agree across `base` (epoch 0), `overlay` (trailing novelty), and `novelty` (no index) conditions.

## Findings (first run, all reproducible)

**Axis 2 passed on all 16 cases** — the historical overlay/dict-novelty bug classes stay fixed across all three physical representations. Axis 1 found:

| ID | Case | What diverges | Severity |
|---|---|---|---|
| FD-1 | `avg_numeric` | fast emits f64 JSON number; generic emits arbitrary-precision `xsd:decimal` string | datatype contract drift |
| FD-2 | `max_label` / `min_label` | **wrong answers** on reindex-built ledgers: fast returns the last-inserted label instead of the lexicographic max — consistent with treating string-ID order as lex order (`lex_sorted_string_ids` only holds after bulk import) | **high — wrong results** |
| FD-3 | `group_by_predicate_count` | stats-answered path counts duplicate re-asserts (base), applies novelty deltas inconsistently per predicate (overlay), and drops the `rdf:type` row entirely (pure novelty) | **high — wrong results** |

Each is pinned via a `known_divergence` marker: the mismatch is reported to stderr but not enforced, so the harness is green while pinning the contract for everything else. Full analysis in the test's module docs. **When a fix lands, remove the marker so the case becomes enforced.**

These land squarely on the audit's thesis: FD-2 is a convention-gate miss (an invariant that only sometimes holds, checked nowhere), FD-3 is stats/novelty accounting divergence — both in the catalog of risks the roadmap's Phases 1–3 are designed to make structurally impossible.

## Validation

- Harness passes: 16 cases × 3 conditions × 2 modes (96 executions) + cross-condition assertions, ~16s
- All 1,045 `fluree-db-query` unit tests pass with the kill switch in place
- Clippy + fmt clean on touched crates

## Suggested follow-ups (not in this PR)

1. Fix FD-2 (`fast_min_max_string` lex-order gate) — wrong results, likely small fix
2. Fix FD-3 (`StatsCountByPredicateOperator` accounting) — wrong results
3. Fix FD-1 (AVG datatype fidelity)
4. Confirm the four lifecycle bug candidates flagged in the audit (`apply_loaded_db` graph-registry replay, `apply_index_v2` store sync, reload race, export translation drops)