### PR TITLE
Fix the three fast-path divergences (FD-1/2/3) + scenario-attributable memory gating

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1307,6 +1307,22 @@ mem:fact-01kj8k5nzpe59p5vp7zrehbrr9 a mem:Fact ;
     mem:branch "feature/memory" ;
     mem:createdAt "2026-02-24T19:49:14.358637+00:00"^^xsd:dateTime .
 
+mem:constraint-01ktwn58n7jgsxdax2rsxv7rg2 a mem:Constraint ;
+    mem:content "Bench memory gating must use scenario_peak_bytes (peak minus live-bytes-at-reset), not absolute peak_bytes: absolute peak measures from process zero and inherits ambient heap shifts that a recompile moves uniformly (~+1.6MiB observed across ALL scenarios including untouched code paths), while same-binary variance is ±0.04%. bench-baseline compare prefers scenario_mem when both sides carry it. Also: StatsView/IndexStats property counts are planner estimates (count dup re-asserts, rdf:type tracked asymmetrically between indexer and novelty accumulation) — never answer user queries from them." ;
+    mem:tag "benchmarking" ;
+    mem:tag "gotcha" ;
+    mem:tag "guardrails" ;
+    mem:tag "memory-metrics" ;
+    mem:tag "stats" ;
+    mem:scope mem:repo ;
+    mem:severity "must" ;
+    mem:artifactRef "fluree-bench-alloc/src/lib.rs" ;
+    mem:artifactRef "fluree-bench-support/src/baseline.rs" ;
+    mem:artifactRef "fluree-db-query/src/stats_query.rs" ;
+    mem:branch "fix/fastpath-divergences" ;
+    mem:createdAt "2026-06-12T00:54:21.095112+00:00"^^xsd:dateTime ;
+    mem:rationale "Both learned by dogfooding the Phase 0.0 gate on PR #1314: the gate fired 9 false-positive peak_mem breaches that classification traced to ambient heap shift; the stats finding is why FD-3 was rewritten to directory counts." .
+
 mem:fact-01kta2t986nsjneban0hgbwzq7 a mem:Fact ;
     mem:content "RDF term/fact identity in Fluree is (s, p, o, dt, m) where m=FlakeMeta{lang, i} — matching Flake::eq/hash. Any dedup/stale-removal key that omits m collapses distinct facts: langString variants sharing a value (\"animal\"@en vs @fr), and @list members repeating a value at different indices. Issue #1273 was range::remove_stale_flakes (overlay-only/genesis read path) keying on (s,p,o,dt) only; the binary-scan stale-removal (binary_scan.rs FactKeyRef) already included m. Including m also correctly scopes retraction cancellation per variant." ;
     mem:tag "dedup" ;
@@ -1890,7 +1906,7 @@ mem:fact-01ktcfdrpyfq8btp10mf75cmp5 a mem:Fact ;
     mem:rationale "Candidate 3 lever is scatter/sort assembly, not join grouping or DISTINCT which are already optimized." .
 
 mem:fact-01ktwjrjrvj60k0v0q7gstwknz a mem:Fact ;
-    mem:content "Differential fast-path harness (Phase 0.7) found 3 reproducible fast≠generic divergences on first run (2026-06-11), pinned as known_divergence markers: FD-1 AVG fast path emits f64 JSON number vs generic's xsd:decimal string; FD-2 MIN/MAX-string fast path returns WRONG answers on reindex-built ledgers (treats string-ID order as lexicographic; lex_sorted_string_ids only holds after bulk import — suspect missing gate in fast_min_max_string); FD-3 StatsCountByPredicateOperator counts duplicate re-asserts, applies novelty deltas inconsistently per predicate, and drops rdf:type in pure novelty. Cross-condition axis (generic: base≡overlay≡novelty) passed all 16 cases. Kill switch: set_fast_paths_disabled / FLUREE_DISABLE_QUERY_FAST_PATHS." ;
+    mem:content "Differential fast-path harness (Phase 0.7) found 3 fast≠generic divergences on first run (2026-06-11); ALL THREE FIXED same-day in PR #1314 and now hard-enforced by the harness: FD-1 AVG fast path now mirrors generic finalize_avg per number kind (exact i64+BigDecimal for integers → xsd:decimal, plain non-Kahan f64 for doubles); FD-2 MIN/MAX-string gated on lex_sorted_string_ids (was returning insertion-order extremes on reindex-built ledgers); FD-3 per-predicate counts rewritten to exact POST leaf-directory row_count sums at epoch-0 (StatsView numbers are estimates — never use as query answers). Cross-condition axis (generic: base≡overlay≡novelty) passed throughout. Kill switch: set_fast_paths_disabled / FLUREE_DISABLE_QUERY_FAST_PATHS." ;
     mem:tag "audit" ;
     mem:tag "bug" ;
     mem:tag "correctness" ;
@@ -1902,6 +1918,7 @@ mem:fact-01ktwjrjrvj60k0v0q7gstwknz a mem:Fact ;
     mem:artifactRef "fluree-db-api/tests/it_differential_fastpath.rs" ;
     mem:artifactRef "fluree-db-query/src/fast_min_max_string.rs" ;
     mem:artifactRef "fluree-db-query/src/fast_predicate_scalar_agg.rs" ;
+    mem:artifactRef "fluree-db-query/src/stats_query.rs" ;
     mem:branch "test/phase0-differential-harness" ;
     mem:createdAt "2026-06-12T00:12:28.315996+00:00"^^xsd:dateTime ;
     mem:rationale "FD-2 and FD-3 are user-visible wrong answers — high-priority fixes. Remove a case's known_divergence marker when its fix lands so the harness enforces it." .

--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1888,3 +1888,20 @@ mem:fact-01ktcfdrpyfq8btp10mf75cmp5 a mem:Fact ;
     mem:branch "refactor/column-caching" ;
     mem:createdAt "2026-06-05T18:06:17.310296+00:00"^^xsd:dateTime ;
     mem:rationale "Candidate 3 lever is scatter/sort assembly, not join grouping or DISTINCT which are already optimized." .
+
+mem:fact-01ktwjrjrvj60k0v0q7gstwknz a mem:Fact ;
+    mem:content "Differential fast-path harness (Phase 0.7) found 3 reproducible fast≠generic divergences on first run (2026-06-11), pinned as known_divergence markers: FD-1 AVG fast path emits f64 JSON number vs generic's xsd:decimal string; FD-2 MIN/MAX-string fast path returns WRONG answers on reindex-built ledgers (treats string-ID order as lexicographic; lex_sorted_string_ids only holds after bulk import — suspect missing gate in fast_min_max_string); FD-3 StatsCountByPredicateOperator counts duplicate re-asserts, applies novelty deltas inconsistently per predicate, and drops rdf:type in pure novelty. Cross-condition axis (generic: base≡overlay≡novelty) passed all 16 cases. Kill switch: set_fast_paths_disabled / FLUREE_DISABLE_QUERY_FAST_PATHS." ;
+    mem:tag "audit" ;
+    mem:tag "bug" ;
+    mem:tag "correctness" ;
+    mem:tag "differential-harness" ;
+    mem:tag "fast-path" ;
+    mem:tag "min-max" ;
+    mem:tag "stats" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/tests/it_differential_fastpath.rs" ;
+    mem:artifactRef "fluree-db-query/src/fast_min_max_string.rs" ;
+    mem:artifactRef "fluree-db-query/src/fast_predicate_scalar_agg.rs" ;
+    mem:branch "test/phase0-differential-harness" ;
+    mem:createdAt "2026-06-12T00:12:28.315996+00:00"^^xsd:dateTime ;
+    mem:rationale "FD-2 and FD-3 are user-visible wrong answers — high-priority fixes. Remove a case's known_divergence marker when its fix lands so the harness enforces it." .

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -189,7 +189,12 @@ fluree_bench_support::mem::record_scenario("my_bench", "my_bench/q1/small",
 
 Metrics land in `target/fluree-bench-mem/<bench>.json` sidecars;
 `bench-baseline capture` merges them into the baseline and `compare`
-gates `peak_mem` with the same per-bench budgets as time.
+gates memory with the same per-bench budgets as time. The gated metric
+is `scenario_mem` (`scenario_peak_bytes`: the high-water mark *minus*
+live bytes at scenario start) — absolute peak includes the ambient
+process baseline, which a recompile can shift by megabytes uniformly
+across every scenario, so it is recorded but only used as a fallback
+when comparing against baselines captured before the field existed.
 `total_allocated_bytes` (churn) is recorded for analysis but not gated —
 it scales with criterion's adaptive iteration counts. The tracker costs
 two relaxed atomics per alloc; that overhead is identical between a

--- a/fluree-bench-alloc/src/lib.rs
+++ b/fluree-bench-alloc/src/lib.rs
@@ -43,6 +43,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 static CURRENT: AtomicUsize = AtomicUsize::new(0);
 static PEAK: AtomicUsize = AtomicUsize::new(0);
 static TOTAL: AtomicUsize = AtomicUsize::new(0);
+/// Live bytes at the last [`reset_peak`] — the ambient baseline a scenario
+/// starts from. `scenario_peak_bytes = peak - this` isolates the memory a
+/// scenario itself is responsible for, making the gated metric robust
+/// against ambient process-heap shifts between binaries (a recompile can
+/// move absolute peak by megabytes uniformly across every scenario).
+static CURRENT_AT_RESET: AtomicUsize = AtomicUsize::new(0);
 
 /// A `GlobalAlloc` wrapper around [`System`] that maintains the module's
 /// current / peak / total counters.
@@ -122,7 +128,12 @@ pub struct AllocSnapshot {
     /// Live bytes at the time of the snapshot.
     pub current_bytes: usize,
     /// High-water mark of live bytes since the last [`reset_peak`].
+    /// Includes the ambient baseline live at reset time.
     pub peak_bytes: usize,
+    /// `peak_bytes` minus live bytes at the last [`reset_peak`] — the
+    /// scenario-attributable high-water mark. Comparable across binaries;
+    /// prefer this for regression gating.
+    pub scenario_peak_bytes: usize,
     /// Cumulative bytes allocated since the last [`reset_peak`] (churn).
     pub total_allocated_bytes: usize,
 }
@@ -132,15 +143,19 @@ pub struct AllocSnapshot {
 pub fn reset_peak() {
     let cur = CURRENT.load(Ordering::Relaxed);
     PEAK.store(cur, Ordering::Relaxed);
+    CURRENT_AT_RESET.store(cur, Ordering::Relaxed);
     TOTAL.store(0, Ordering::Relaxed);
 }
 
 /// Read the counters. Call after the measured region of a scenario.
 #[must_use]
 pub fn snapshot() -> AllocSnapshot {
+    let peak = PEAK.load(Ordering::Relaxed);
+    let at_reset = CURRENT_AT_RESET.load(Ordering::Relaxed);
     AllocSnapshot {
         current_bytes: CURRENT.load(Ordering::Relaxed),
-        peak_bytes: PEAK.load(Ordering::Relaxed),
+        peak_bytes: peak,
+        scenario_peak_bytes: peak.saturating_sub(at_reset),
         total_allocated_bytes: TOTAL.load(Ordering::Relaxed),
     }
 }

--- a/fluree-bench-support/src/baseline.rs
+++ b/fluree-bench-support/src/baseline.rs
@@ -181,7 +181,8 @@ pub enum CompareStatus {
 #[derive(Debug, Clone)]
 pub struct Comparison {
     pub id: String,
-    /// `"time"` or `"peak_mem"`.
+    /// `"time"`, `"scenario_mem"` (preferred), or `"peak_mem"` (legacy
+    /// absolute fallback).
     pub metric: &'static str,
     pub baseline: f64,
     pub observed: f64,
@@ -295,13 +296,26 @@ pub fn compare(
             });
         }
         if let (Some(bm), Some(cm)) = (base.mem, cur.mem) {
-            let (change_pct, status) =
-                classify(bm.peak_bytes as f64, cm.peak_bytes as f64, budget_pct);
+            // Prefer the scenario-attributable peak (robust against ambient
+            // process-heap shifts between binaries); absolute peak is the
+            // legacy fallback for baselines captured before the field
+            // existed (serde default 0).
+            let (metric, b_val, c_val) = if bm.scenario_peak_bytes > 0 && cm.scenario_peak_bytes > 0
+            {
+                (
+                    "scenario_mem",
+                    bm.scenario_peak_bytes as f64,
+                    cm.scenario_peak_bytes as f64,
+                )
+            } else {
+                ("peak_mem", bm.peak_bytes as f64, cm.peak_bytes as f64)
+            };
+            let (change_pct, status) = classify(b_val, c_val, budget_pct);
             report.comparisons.push(Comparison {
                 id: id.clone(),
-                metric: "peak_mem",
-                baseline: bm.peak_bytes as f64,
-                observed: cm.peak_bytes as f64,
+                metric,
+                baseline: b_val,
+                observed: c_val,
                 change_pct,
                 budget_pct,
                 status,
@@ -430,6 +444,7 @@ mod tests {
     fn compare_includes_memory_metric() {
         let mem = |peak: u64| MemMetrics {
             peak_bytes: peak,
+            scenario_peak_bytes: peak / 2,
             total_allocated_bytes: peak * 2,
         };
         let mut base_entry = entry(1000.0);
@@ -445,7 +460,7 @@ mod tests {
         let report = compare(&base, &current, &budget, None);
         assert!(!report.passed());
         let breach = report.breaches().next().unwrap();
-        assert_eq!(breach.metric, "peak_mem");
+        assert_eq!(breach.metric, "scenario_mem");
     }
 
     #[test]

--- a/fluree-bench-support/src/mem.rs
+++ b/fluree-bench-support/src/mem.rs
@@ -25,7 +25,14 @@ use serde::{Deserialize, Serialize};
 /// (churn). Both come from `fluree_bench_alloc::snapshot()` semantics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemMetrics {
+    /// Absolute live-bytes high-water across the scenario (includes the
+    /// ambient process baseline; can shift uniformly between binaries).
     pub peak_bytes: u64,
+    /// Scenario-attributable high-water (peak minus live bytes at reset).
+    /// Preferred for regression gating; 0 in sidecars written before this
+    /// field existed.
+    #[serde(default)]
+    pub scenario_peak_bytes: u64,
     pub total_allocated_bytes: u64,
 }
 
@@ -126,6 +133,7 @@ mod tests {
             "some_bench/q1/small".into(),
             MemMetrics {
                 peak_bytes: 1024,
+                scenario_peak_bytes: 512,
                 total_allocated_bytes: 4096,
             },
         );

--- a/fluree-db-api/benches/query_overlay_matrix.rs
+++ b/fluree-db-api/benches/query_overlay_matrix.rs
@@ -254,6 +254,7 @@ fn bench_query_overlay_matrix(c: &mut Criterion) {
                 &format!("{GROUP}/{}/{}", $fn_id, scale.as_str()),
                 MemMetrics {
                     peak_bytes: m.peak_bytes as u64,
+                    scenario_peak_bytes: m.scenario_peak_bytes as u64,
                     total_allocated_bytes: m.total_allocated_bytes as u64,
                 },
             );

--- a/fluree-db-api/tests/it_differential_fastpath.rs
+++ b/fluree-db-api/tests/it_differential_fastpath.rs
@@ -29,38 +29,34 @@
 //! the audit's bug-class history says the fast/overlay side is usually the
 //! suspect, but the generic path is not presumed correct either.
 //!
-//! ## Known divergences (found by this harness's first run, 2026-06-11)
+//! ## Finding history
 //!
 //! Cases marked `known_divergence` REPORT their mismatch to stderr instead
 //! of failing, so the harness stays green while pinning the contract for
-//! everything else. Each entry is a real, reproducible fast-vs-generic
-//! divergence awaiting a fix; when the fix lands, remove the marker so the
-//! harness starts enforcing the case. The cross-condition axis is enforced
-//! for ALL cases — generic results agreed across base/overlay/novelty on
-//! every case at harness introduction.
+//! everything else; when a fix lands, the marker is removed and the case
+//! becomes enforced. The harness's first run (2026-06-11) found three
+//! divergence classes, all since fixed and now enforced:
 //!
-//! - **FD-1 `avg_numeric`** (base, overlay): values agree to f64
-//!   precision, but the AVG fast path emits an `xsd:double`-style JSON
-//!   number (`7072.886363636364`) while the generic pipeline emits an
-//!   arbitrary-precision `xsd:decimal` string. Observable datatype
-//!   contract difference. Suspect: `fast_predicate_scalar_agg`.
-//! - **FD-2 `max_label` / `min_label`** (base): wrong answers. With
-//!   `bsbm:label` on vendors and products, generic MAX is
-//!   `"Vendor 000003"` (lexicographic), fast returns `"Product 000219"`
-//!   — the last-inserted label, consistent with assuming string-ID order
-//!   is lexicographic order. That invariant (`lex_sorted_string_ids`)
-//!   only holds after bulk import and is cleared by incremental writes;
-//!   this ledger was reindex-built. Suspect: `fast_min_max_string`
-//!   missing the lex-order gate.
-//! - **FD-3 `group_by_predicate_count`** (all three conditions,
-//!   differently): the stats-answered path
-//!   (`StatsCountByPredicateOperator`) (a) counts duplicate re-asserts
-//!   that set-semantics novelty apply dedups (base: `bsbm:name` 42 vs
-//!   22), (b) applies novelty deltas inconsistently per predicate
-//!   (overlay: `rdf:type` stale at the index-time 824 while other
-//!   predicates include novelty), and (c) omits the `rdf:type` row
-//!   entirely in pure novelty. Suspect: IndexStats accounting +
-//!   `detect_stats_count_by_predicate` novelty handling.
+//! - **FD-1 `avg_numeric`** — FIXED. The AVG fast path accumulated
+//!   Kahan-f64 and emitted xsd:double; the generic pipeline emits exact
+//!   xsd:decimal for integer inputs (SPARQL semantics). Fix: the fast
+//!   path mirrors the generic accumulator per number kind — exact i64 +
+//!   BigDecimal division at the shared AVG_DECIMAL_PRECISION for
+//!   integers, plain (non-Kahan, bit-matching) f64 for doubles, fallback
+//!   for other numeric encodings (`fast_predicate_scalar_agg.rs`).
+//! - **FD-2 `max_label` / `min_label`** — FIXED. The MIN/MAX-string fast
+//!   path took per-leaflet first/last directory keys as candidates,
+//!   which are extremes by StringId, not by lexicographic value; sound
+//!   only under the bulk-import `lex_sorted_string_ids` invariant. Fix:
+//!   the same lex-order gate `fast_string_prefix_count_all` already used
+//!   (`fast_min_max_string.rs`, `minmax_string_dict_post`).
+//! - **FD-3 `group_by_predicate_count`** — FIXED. The path answered from
+//!   `StatsView` planner estimates, which count duplicate re-asserts,
+//!   track `rdf:type` asymmetrically between indexer-built and
+//!   novelty-accumulated stats, and apply novelty deltas inconsistently.
+//!   Fix: rewritten to count exactly from POST leaf-directory metadata
+//!   at epoch 0 (`stats_query.rs`), falling back to the generic pipeline
+//!   under overlay/time-travel/policy/multi-ledger.
 
 #![cfg(feature = "native")]
 
@@ -318,7 +314,7 @@ fn catalog() -> Vec<Case> {
         Case {
             name: "avg_numeric",
             ordered: false,
-            known_divergence: Some("FD-1"),
+            known_divergence: None,
             sparql: "SELECT (AVG(?o) AS ?avg) WHERE { ?s bsbm:price ?o }",
         },
         // detect_predicate_minmax_string — churned labels sort after
@@ -327,13 +323,13 @@ fn catalog() -> Vec<Case> {
         Case {
             name: "max_label",
             ordered: false,
-            known_divergence: Some("FD-2"),
+            known_divergence: None,
             sparql: "SELECT (MAX(?o) AS ?m) WHERE { ?s bsbm:label ?o }",
         },
         Case {
             name: "min_label",
             ordered: false,
-            known_divergence: Some("FD-2"),
+            known_divergence: None,
             sparql: "SELECT (MIN(?o) AS ?m) WHERE { ?s bsbm:label ?o }",
         },
         // detect_post_order_desc_limit — reverse-POST tail walk. The seven
@@ -359,7 +355,7 @@ fn catalog() -> Vec<Case> {
         Case {
             name: "group_by_predicate_count",
             ordered: false,
-            known_divergence: Some("FD-3"),
+            known_divergence: None,
             sparql: "SELECT ?p (COUNT(?s) AS ?c) WHERE { ?s ?p ?o } GROUP BY ?p",
         },
         // Property-join star fusion + ORDER BY (generic-path internal fast

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -7176,10 +7176,15 @@ async fn indexed_numeric_avg_min_max_fast_paths_work() {
                 .await
                 .expect("indexed AVG(?o) query");
             let avg_json = avg_result.to_jsonld(&view.snapshot).expect("to_jsonld");
+            // AVG over xsd:integer inputs is xsd:decimal (SPARQL 1.1), which
+            // formats as a string — same output as the generic pipeline. The
+            // fast path previously emitted a float (xsd:double) here; the
+            // differential harness flagged that divergence (FD-1) and the
+            // fast path now matches the generic accumulator.
             assert_eq!(
                 normalize_rows(&avg_json),
-                normalize_rows(&json!([[2.5]])),
-                "indexed AVG(?o) should average numeric values directly"
+                normalize_rows(&json!([["2.5"]])),
+                "indexed AVG(?o) should average numeric values directly (as xsd:decimal)"
             );
 
             let min_query = r"
@@ -7618,7 +7623,9 @@ async fn indexed_overlay_scalar_agg_reflects_assert_and_retract() {
                 .expect("view t=1");
             for (q, expected) in [
                 (sum_q, json!([[60]])),
-                (avg_q, json!([[20.0]])),
+                // AVG over integers is xsd:decimal (string-formatted) — see FD-1
+                // in the differential harness; fast and generic paths now agree.
+                (avg_q, json!([["20"]])),
                 (cd_q, json!([[2]])),
             ] {
                 let result = fluree
@@ -7650,7 +7657,7 @@ async fn indexed_overlay_scalar_agg_reflects_assert_and_retract() {
                 .expect("view t=2");
             for (q, expected) in [
                 (sum_q, json!([[100]])),
-                (avg_q, json!([[25.0]])),
+                (avg_q, json!([["25"]])),
                 (cd_q, json!([[3]])),
             ] {
                 let result = fluree
@@ -7685,7 +7692,7 @@ async fn indexed_overlay_scalar_agg_reflects_assert_and_retract() {
                 .expect("view t=3");
             for (q, expected) in [
                 (sum_q, json!([[90]])),
-                (avg_q, json!([[30.0]])),
+                (avg_q, json!([["30"]])),
                 (cd_q, json!([[2]])),
             ] {
                 let result = fluree

--- a/fluree-db-query/src/aggregate.rs
+++ b/fluree-db-query/src/aggregate.rs
@@ -468,7 +468,9 @@ impl NumericAcc {
 /// inputs. Matches IEEE-754 decimal128 precision (34 digits) — well past
 /// xsd:double's ~17 digits of precision but small enough to keep output
 /// compact for typical financial / scientific aggregates.
-const AVG_DECIMAL_PRECISION: u64 = 34;
+// Shared with the AVG fast path (fast_predicate_scalar_agg), whose integer
+// lane must produce byte-identical decimal output to finalize_avg.
+pub(crate) const AVG_DECIMAL_PRECISION: u64 = 34;
 
 /// Best-effort `BigInt → f64`. Saturates at infinity for out-of-range values.
 fn bigint_to_f64(b: &BigInt) -> f64 {

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -51,7 +51,7 @@ use crate::project::ProjectOperator;
 use crate::sort::SortDirection;
 use crate::sort::SortOperator;
 use crate::sort::SortSpec;
-use crate::stats_query::StatsCountByPredicateOperator;
+use crate::stats_query::stats_count_by_predicate_operator;
 use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
 use fluree_db_core::StatsView;
@@ -1547,6 +1547,14 @@ fn detect_stats_count_by_predicate(query: &Query) -> Option<(VarId, VarId)> {
     if !query.order_binds.is_empty() {
         return None;
     }
+    // OFFSET would be applied twice when the operator defers to its planned
+    // fallback at open() time (the fallback tree already applies the full
+    // modifier stack; the dispatch wraps modifiers around this operator
+    // again, and OFFSET — unlike sort/project/distinct/limit — is not
+    // idempotent). Decline and let the generic pipeline handle it.
+    if query.offset.is_some() {
+        return None;
+    }
     // Must have stats available (checked by caller)
     // Must have exactly one triple pattern with all variables
     if query.patterns.len() != 1 {
@@ -2639,17 +2647,22 @@ fn build_operator_tree_inner(
         }
     }
 
-    // Fast-path: stats-based count-by-predicate query
-    // This avoids scanning all triples when we can answer directly from IndexStats.
-    // Skipped in `History` mode — IndexStats reflects current-state cardinality,
-    // not the asserts + retracts a history-range query needs.
-    if !planning.is_history() && !fast_paths_globally_disabled {
-        if let Some(ref stats_view) = stats {
+    // Fast-path: per-predicate count answered from POST leaf-directory
+    // metadata (exact; see stats_query.rs for why IndexStats numbers are
+    // NOT used as answers). Part of the fused chain: gating on
+    // `enable_fused_fast_paths` (a) skips it in History mode — directory
+    // rows are current-state only — and (b) keeps the fallback recursion
+    // below (which passes `false`) from re-entering this block. The
+    // operator's open()-time gate (`fast_path_store`) defers to the
+    // planned fallback under overlay/time-travel/policy/multi-ledger.
+    if enable_fused_fast_paths {
+        {
             if let Some((pred_var, count_var)) = detect_stats_count_by_predicate(query) {
-                let mut operator: BoxedOperator = Box::new(StatsCountByPredicateOperator::new(
-                    Arc::clone(stats_view),
+                let fallback = build_operator_tree_inner(query, stats.clone(), false, planning)?;
+                let mut operator: BoxedOperator = Box::new(stats_count_by_predicate_operator(
                     pred_var,
                     count_var,
+                    Some(fallback),
                 ));
 
                 // ORDER BY (on predicate or count)

--- a/fluree-db-query/src/fast_min_max_string.rs
+++ b/fluree-db-query/src/fast_min_max_string.rs
@@ -135,6 +135,19 @@ fn minmax_string_dict_post(
     p_id: u32,
     mode: MinMaxMode,
 ) -> Result<Option<Binding>> {
+    // POST orders string objects by StringId, so a leaflet's first/last
+    // directory key is the min/max *by ID*, not by lexicographic value —
+    // the true lex extreme can sit anywhere inside the leaflet. The
+    // candidate set below is therefore only sound when string IDs are
+    // lex-order-preserving (bulk-import invariant, cleared by incremental
+    // dict appends). Without it, bail to the generic pipeline. Same gate
+    // as fast_string_prefix_count_all. (The `compare_string_lex` calls
+    // below order the *candidates* correctly either way; the gate is about
+    // candidate completeness, not candidate comparison.)
+    if !store.lex_sorted_string_ids() {
+        return Ok(None);
+    }
+
     let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Post, p_id);
 
     let mut best: Option<(EncodedStringIdentity, Binding)> = None;

--- a/fluree-db-query/src/fast_predicate_scalar_agg.rs
+++ b/fluree-db-query/src/fast_predicate_scalar_agg.rs
@@ -213,9 +213,16 @@ enum AggState {
     },
     Avg {
         required_otype: Option<u16>,
-        // Kahan compensated summation state.
-        sum: f64,
-        compensation: f64,
+        // Exactly one of these accumulates, selected by required_otype's
+        // decode kind. The integer lane sums exactly in i64 (checked; falls
+        // back on overflow) and finalizes via BigDecimal division so the
+        // output is byte-identical to the generic pipeline's finalize_avg
+        // (SPARQL: AVG over integers is xsd:decimal). The double lane uses
+        // plain summation — NOT Kahan — to bit-match the generic
+        // accumulator; cross-path indistinguishability outranks the extra
+        // float accuracy (differential harness FD-1).
+        int_sum: i64,
+        dbl_sum: f64,
         count: u64,
     },
     CountDistinct {
@@ -230,8 +237,8 @@ impl AggState {
             ScalarAggKind::Sum(scalar) => AggState::Sum { scalar, sum: 0 },
             ScalarAggKind::AvgNumeric => AggState::Avg {
                 required_otype: None,
-                sum: 0.0,
-                compensation: 0.0,
+                int_sum: 0,
+                dbl_sum: 0.0,
                 count: 0,
             },
             ScalarAggKind::CountDistinctObject => AggState::CountDistinct {
@@ -244,14 +251,44 @@ impl AggState {
     fn finalize(self) -> Result<AggOutput> {
         Ok(match self {
             AggState::Sum { sum, .. } => AggOutput::Integer(sum),
-            AggState::Avg { sum, count, .. } => {
+            AggState::Avg {
+                required_otype,
+                int_sum,
+                dbl_sum,
+                count,
+            } => {
                 if count == 0 {
                     AggOutput::Binding(Binding::Unbound)
                 } else {
-                    AggOutput::Binding(Binding::lit(
-                        FlakeValue::Double(sum / count as f64),
-                        Sid::xsd_double(),
-                    ))
+                    let kind = required_otype
+                        .map(|ot| OType::from_u16(ot).decode_kind())
+                        .ok_or_else(|| {
+                            QueryError::execution("AVG fast-path: count > 0 without o_type")
+                        })?;
+                    match kind {
+                        DecodeKind::I64 => {
+                            // Mirror aggregate.rs finalize_avg (NumKind::Integer):
+                            // exact decimal division at the same precision.
+                            let avg = (bigdecimal::BigDecimal::from(int_sum)
+                                / bigdecimal::BigDecimal::from(count as i64))
+                            .with_prec(crate::aggregate::AVG_DECIMAL_PRECISION)
+                            .normalized();
+                            AggOutput::Binding(Binding::lit(
+                                FlakeValue::Decimal(Box::new(avg)),
+                                Sid::xsd_decimal(),
+                            ))
+                        }
+                        DecodeKind::F64 => AggOutput::Binding(Binding::lit(
+                            FlakeValue::Double(dbl_sum / count as f64),
+                            Sid::xsd_double(),
+                        )),
+                        // fold_row only admits I64/F64 kinds.
+                        other => {
+                            return Err(QueryError::execution(format!(
+                                "AVG fast-path: unexpected decode kind {other:?}"
+                            )))
+                        }
+                    }
                 }
             }
             AggState::CountDistinct { distinct, .. } => {
@@ -288,8 +325,8 @@ impl AggState {
             }
             AggState::Avg {
                 required_otype,
-                sum,
-                compensation,
+                int_sum,
+                dbl_sum,
                 count,
             } => {
                 if !OType::from_u16(o_type).is_numeric() {
@@ -300,12 +337,25 @@ impl AggState {
                     Some(existing) if existing != o_type => return Ok(false),
                     Some(_) => {}
                 }
-                let val = decode_numeric_as_f64(o_type, o_key)?;
-                // Kahan summation: compensate for lost low-order bits.
-                let y = val - *compensation;
-                let t = *sum + y;
-                *compensation = (t - *sum) - y;
-                *sum = t;
+                let key = ObjKey::from_u64(o_key);
+                match OType::from_u16(o_type).decode_kind() {
+                    DecodeKind::I64 => {
+                        // Exact integer accumulation; overflow → generic
+                        // pipeline (which sums in BigDecimal).
+                        let Some(next) = int_sum.checked_add(key.decode_i64()) else {
+                            return Ok(false);
+                        };
+                        *int_sum = next;
+                    }
+                    DecodeKind::F64 => {
+                        // Plain summation to match the generic accumulator
+                        // bit-for-bit (see AggState::Avg field docs).
+                        *dbl_sum += key.decode_f64();
+                    }
+                    // Other numeric encodings (e.g. dict-backed decimals)
+                    // need exact decimal arithmetic — generic pipeline.
+                    _ => return Ok(false),
+                }
                 *count = count.saturating_add(1);
             }
             AggState::CountDistinct {
@@ -502,18 +552,6 @@ fn scan_predicate_scalar_agg_overlay(
 // ---------------------------------------------------------------------------
 // Decode helpers
 // ---------------------------------------------------------------------------
-
-fn decode_numeric_as_f64(o_type: u16, o_key: u64) -> Result<f64> {
-    let ot = OType::from_u16(o_type);
-    let key = ObjKey::from_u64(o_key);
-    match ot.decode_kind() {
-        DecodeKind::I64 => Ok(key.decode_i64() as f64),
-        DecodeKind::F64 => Ok(key.decode_f64()),
-        _ => Err(QueryError::execution(format!(
-            "unsupported numeric decode kind for AVG fast-path: {ot:?}"
-        ))),
-    }
-}
 
 fn constant_component_for_otype(o_type: u16, component: DateComponentFn) -> Option<i64> {
     let ot = OType::from_u16(o_type);

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -150,7 +150,7 @@ pub use rewrite::{rewrite_patterns, Diagnostics as RewriteDiagnostics, PlanConte
 pub use rewrite_owl_ql::{rewrite_owl_ql_patterns, Ontology, OwlQlContext};
 pub use seed::{EmptyOperator, SeedOperator};
 pub use sort::{compare_bindings, compare_flake_values, SortDirection, SortOperator, SortSpec};
-pub use stats_query::StatsCountByPredicateOperator;
+pub use stats_query::stats_count_by_predicate_operator;
 pub use subquery::SubqueryOperator;
 pub use temporal_mode::{PlanningContext, TemporalMode};
 

--- a/fluree-db-query/src/stats_query.rs
+++ b/fluree-db-query/src/stats_query.rs
@@ -1,137 +1,130 @@
-//! Fast-path operators for "stats queries".
+//! Fast-path operator for per-predicate count queries.
 //!
-//! These operators answer certain aggregate queries directly from `IndexStats`
-//! / `StatsView` without scanning the triple store.
+//! Answers `SELECT ?p (COUNT(?s) AS ?c) WHERE { ?s ?p ?o } GROUP BY ?p`
+//! with **exact** counts read from POST leaf-directory metadata —
+//! `O(leaflets)` directory reads, decoding only the rare mixed-predicate
+//! leaflet — instead of scanning all triples.
+//!
+//! ## Why not answer from `IndexStats` / `StatsView`?
+//!
+//! A previous version of this operator returned `StatsView` property
+//! counts directly. The differential harness
+//! (`fluree-db-api/tests/it_differential_fastpath.rs`, FD-3) showed those
+//! numbers are planner *estimates*, not current-state fact counts: they
+//! count duplicate re-asserts that set-semantics novelty application
+//! dedups, track `rdf:type` asymmetrically between indexer-built and
+//! novelty-accumulated stats, and apply novelty deltas inconsistently per
+//! predicate. Selectivity estimation tolerates all of that; an exact
+//! `COUNT` answer does not.
+//!
+//! V3 leaflets store current-state rows only (history lives in the
+//! sidecar), so per-predicate row counts from leaf directories are exact —
+//! but only for the persisted index, which is why this path is gated by
+//! [`fast_path_store`] (binary store present, no overlay epoch, query at
+//! the store's `max_t`, root policy, single ledger). Anything else returns
+//! `Ok(None)` and the planned fallback (the generic scan + group + count
+//! pipeline) runs instead.
 
 use crate::binding::{Batch, Binding};
-use crate::context::{ExecutionContext, WellKnownDatatypes};
+use crate::context::WellKnownDatatypes;
 use crate::error::{QueryError, Result};
-use crate::operator::{Operator, OperatorState};
+use crate::fast_path_common::{fast_path_store, FastPathOperator};
+use crate::operator::BoxedOperator;
 use crate::var_registry::VarId;
-use async_trait::async_trait;
-use fluree_db_core::{FlakeValue, StatsView};
+use fluree_db_binary_index::format::column_block::ColumnId;
+use fluree_db_binary_index::format::run_record::RunSortOrder;
+use fluree_db_binary_index::{BinaryIndexStore, ColumnProjection, ColumnSet};
+use fluree_db_core::{FlakeValue, GraphId};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
-/// Emit per-predicate counts using `StatsView` (no triple scan).
-///
-/// Intended to fast-path queries like:
-/// `SELECT ?p (COUNT(?s) AS ?count) WHERE { ?s ?p ?o } GROUP BY ?p ORDER BY DESC(?count)`
-pub struct StatsCountByPredicateOperator {
-    stats: Arc<StatsView>,
-    schema: Arc<[VarId]>,
-    state: OperatorState,
-    rows: Vec<(Binding, Binding)>,
-    pos: usize,
-}
+/// Build the fused per-predicate count operator. Emits `(pred, count)`
+/// rows when the exact directory-count gate holds; defers to `fallback`
+/// otherwise.
+pub fn stats_count_by_predicate_operator(
+    pred_var: VarId,
+    count_var: VarId,
+    fallback: Option<BoxedOperator>,
+) -> FastPathOperator {
+    let schema: Arc<[VarId]> = Arc::from(vec![pred_var, count_var].into_boxed_slice());
+    let batch_schema = schema.clone();
+    FastPathOperator::with_schema(
+        schema,
+        move |ctx| {
+            let Some(store) = fast_path_store(ctx) else {
+                return Ok(None);
+            };
+            let Some(counts) = exact_count_by_predicate_post(store, ctx.binary_g_id)? else {
+                return Ok(None);
+            };
 
-impl StatsCountByPredicateOperator {
-    pub fn new(stats: Arc<StatsView>, pred_var: VarId, count_var: VarId) -> Self {
-        let schema: Arc<[VarId]> = Arc::from(vec![pred_var, count_var].into_boxed_slice());
-        Self {
-            stats,
-            schema,
-            state: OperatorState::Created,
-            rows: Vec::new(),
-            pos: 0,
-        }
-    }
-
-    fn build_rows(&self, ctx: &ExecutionContext<'_>) -> Result<Vec<(Binding, Binding)>> {
-        let dt = WellKnownDatatypes::new().xsd_long;
-        let store = ctx.binary_store.as_deref();
-
-        // Prefer graph-scoped stats if present (and we can resolve p_id → Sid).
-        if let Some(props) = self.stats.get_graph_properties(ctx.binary_g_id) {
-            let mut out = Vec::with_capacity(props.len());
-            for (&p_id, data) in props {
-                let pred_sid = ctx
-                    .runtime_small_dicts
-                    .and_then(|dicts| dicts.predicate_sid(p_id))
-                    .cloned()
-                    .or_else(|| {
-                        // Safe only for persisted-range IDs: runtime-only predicate IDs are
-                        // resolved above through `runtime_small_dicts`, so reaching this
-                        // fallback implies `p_id` can be interpreted in persisted store space.
-                        store
-                            .and_then(|store| store.resolve_predicate_iri(p_id.as_u32()))
-                            .map(|iri| store.expect("store already used above").encode_iri(iri))
-                    });
-                let Some(pred_sid) = pred_sid else {
-                    continue;
+            let dt = WellKnownDatatypes::new().xsd_long;
+            let mut pred_col: Vec<Binding> = Vec::with_capacity(counts.len());
+            let mut count_col: Vec<Binding> = Vec::with_capacity(counts.len());
+            for (p_id, count) in counts {
+                // Directory p_ids are persisted-store IDs by construction;
+                // an unresolvable one means the store and its directories
+                // disagree — fall back rather than emit a partial result.
+                let Some(iri) = store.resolve_predicate_iri(p_id) else {
+                    return Ok(None);
                 };
-                let pred = Binding::sid(pred_sid);
-                let count = Binding::lit(FlakeValue::Long(data.count as i64), dt.clone());
-                out.push((pred, count));
+                pred_col.push(Binding::sid(store.encode_iri(iri)));
+                count_col.push(Binding::lit(FlakeValue::Long(count), dt.clone()));
             }
-            return Ok(out);
-        }
-
-        // Fallback: aggregate SID-keyed stats (across graphs).
-        if !self.stats.properties.is_empty() {
-            let mut out = Vec::with_capacity(self.stats.properties.len());
-            for (sid, data) in &self.stats.properties {
-                let pred = Binding::sid(sid.clone());
-                let count = Binding::lit(FlakeValue::Long(data.count as i64), dt.clone());
-                out.push((pred, count));
-            }
-            return Ok(out);
-        }
-
-        Err(QueryError::InvalidQuery(
-            "stats query fast-path requires IndexStats/StatsView".to_string(),
-        ))
-    }
+            let batch = Batch::new(batch_schema.clone(), vec![pred_col, count_col])
+                .map_err(|e| QueryError::execution(format!("stats count batch: {e}")))?;
+            Ok(Some(batch))
+        },
+        fallback,
+        "COUNT by predicate (directory)",
+    )
 }
 
-#[async_trait]
-impl Operator for StatsCountByPredicateOperator {
-    fn schema(&self) -> &[VarId] {
-        &self.schema
-    }
+/// Exact per-predicate row counts from POST leaf directories.
+///
+/// Homogeneous leaflets (`p_const = Some(p)`) contribute `row_count`
+/// without any payload read; mixed-predicate leaflets decode only the
+/// `PId` column. Returns `Ok(None)` when the graph has no POST branch —
+/// the caller falls back rather than asserting emptiness from absence.
+fn exact_count_by_predicate_post(
+    store: &BinaryIndexStore,
+    g_id: GraphId,
+) -> Result<Option<Vec<(u32, i64)>>> {
+    let Some(branch) = store.branch_for_order(g_id, RunSortOrder::Post) else {
+        return Ok(None);
+    };
 
-    async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {
-        if !self.state.can_open() {
-            return Err(QueryError::OperatorAlreadyOpened);
+    let pid_projection = ColumnProjection {
+        output: ColumnSet::EMPTY,
+        internal: {
+            let mut s = ColumnSet::EMPTY;
+            s.insert(ColumnId::PId);
+            s
+        },
+    };
+
+    let mut counts: BTreeMap<u32, i64> = BTreeMap::new();
+    for leaf_entry in &branch.leaves {
+        let handle = store
+            .open_leaf_handle(&leaf_entry.leaf_cid, leaf_entry.sidecar_cid.as_ref(), false)
+            .map_err(|e| QueryError::Internal(format!("leaf open: {e}")))?;
+        let dir = handle.dir();
+        for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
+            if entry.row_count == 0 {
+                continue;
+            }
+            if let Some(p) = entry.p_const {
+                *counts.entry(p).or_insert(0) += i64::from(entry.row_count);
+            } else {
+                let batch = handle
+                    .load_columns(leaflet_idx, &pid_projection, RunSortOrder::Post)
+                    .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?;
+                for row in 0..batch.row_count {
+                    *counts.entry(batch.p_id.get(row)).or_insert(0) += 1;
+                }
+            }
         }
-        self.rows = self.build_rows(ctx)?;
-        self.pos = 0;
-        self.state = OperatorState::Open;
-        Ok(())
     }
 
-    async fn next_batch(&mut self, ctx: &ExecutionContext<'_>) -> Result<Option<Batch>> {
-        if self.state != OperatorState::Open {
-            return Ok(None);
-        }
-        if self.pos >= self.rows.len() {
-            self.state = OperatorState::Exhausted;
-            return Ok(None);
-        }
-
-        let end = (self.pos + ctx.batch_size).min(self.rows.len());
-        let slice = &self.rows[self.pos..end];
-        self.pos = end;
-
-        let mut pred_col: Vec<Binding> = Vec::with_capacity(slice.len());
-        let mut count_col: Vec<Binding> = Vec::with_capacity(slice.len());
-        for (p, c) in slice {
-            pred_col.push(p.clone());
-            count_col.push(c.clone());
-        }
-
-        Ok(Some(Batch::new(
-            self.schema.clone(),
-            vec![pred_col, count_col],
-        )?))
-    }
-
-    fn close(&mut self) {
-        self.state = OperatorState::Closed;
-        self.rows.clear();
-        self.pos = 0;
-    }
-
-    fn estimated_rows(&self) -> Option<usize> {
-        Some(self.rows.len())
-    }
+    Ok(Some(counts.into_iter().collect()))
 }


### PR DESCRIPTION
## Summary

Stacked on #1313. Fixes all three divergence classes the differential harness found on its first run, removes their `known_divergence` markers so the harness now **hard-enforces** them across the base/overlay/novelty condition matrix, and improves the Phase 0.0 memory gate based on what dogfooding it on this branch revealed.

## The fixes

**FD-2 — MIN/MAX-string wrong answers** (`fast_min_max_string.rs`): the path took per-leaflet first/last POST directory keys as candidates — extremes by StringId, not by lexicographic value. Sound only under the bulk-import `lex_sorted_string_ids` invariant; on reindex-built ledgers it returned the first/last *inserted* label. Fix: the same lex-order gate `fast_string_prefix_count_all` already used; otherwise defer to generic. One missed convention gate — exactly the audit's predicted failure mode.

**FD-3 — stats-answered per-predicate counts wrong three ways** (`stats_query.rs` rewrite): `StatsView` numbers are planner estimates (count duplicate re-asserts, track `rdf:type` asymmetrically, apply novelty deltas inconsistently) — fine for selectivity, wrong as query answers. Rewritten to count **exactly** from POST leaf-directory metadata (`row_count` per homogeneous leaflet; PId-column decode only for mixed leaflets; V3 leaflets are current-state rows so directory counts are exact), gated by `fast_path_store` at epoch-0/at-head with the generic pipeline as planned fallback. The dispatch joins the fused chain (prevents fallback-recursion re-entry) and the detector declines OFFSET (the one non-idempotent modifier under fallback re-wrapping).

**FD-1 — AVG datatype drift** (`fast_predicate_scalar_agg.rs`): fast path emitted Kahan-f64 `xsd:double`; generic emits exact `xsd:decimal` for integer inputs per SPARQL 1.1. The accumulator now mirrors `finalize_avg` per number kind: exact i64 + BigDecimal division at the shared `AVG_DECIMAL_PRECISION` for integers (overflow → fallback), plain non-Kahan f64 for doubles (bit-parity with generic), fallback for other numeric encodings.

## Guardrail dogfooding → metric improvement

Running this branch through the Phase 0.0 bench gate flagged 9 `peak_mem` breaches: a **uniform** ~+1.6 MiB across every scenario, including pure-novelty lanes that execute none of the changed code. Classification: same-binary rerun variance is ±0.04% (metric is stable); the shift is ambient process heap moving with the recompiled binary, which absolute peak inherits since it measures from process zero. **Time was within noise on all 9 scenarios (max +1.7%).**

Fix: `fluree-bench-alloc` now records live-bytes-at-reset and exposes `scenario_peak_bytes` (peak − scenario start); `bench-baseline compare` gates on `scenario_mem` when both sides carry it (legacy absolute fallback otherwise). Verified ±0.03% across same-code runs.

## Validation

- Differential harness fully enforced (zero markers): 16 cases × 3 conditions × 2 modes, green
- All 1,045 `fluree-db-query` unit tests green
- Bench gate: time within noise on all scenarios; `scenario_mem` stable ±0.03%
- Clippy + fmt clean on all touched crates

## Remaining from the audit's near-term queue

- Underlying `StatsView` accounting inaccuracies (dup re-asserts, rdf:type asymmetry) still exist — now harmless for query answers, but worth fixing for planner estimate quality (filed in audit Phase 1 context)
- The four lifecycle bug candidates (`apply_loaded_db` graph-registry replay, `apply_index_v2` store sync, reload race, export translation drops) — next up