### PR TITLE
Lifecycle bug-candidate triage: one real fix, one regression pin, two false positives

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1513,13 +1513,13 @@ mem:fact-01ktwep3pg2dxz9r44083zdrxy a mem:Fact ;
     mem:rationale "Anchor document for any future refactor work; recall before structural changes to query/ledger/binary-index." .
 
 mem:fact-01ktwepk8ernqdycdrns8e8kyq a mem:Fact ;
-    mem:content "Audit flagged unconfirmed lifecycle/correctness candidates — verify before fixing: (1) apply_loaded_db (~ledger lib.rs:606-622) merges old namespace codes but may not replay graph_registry deltas from remaining novelty; (2) apply_index_v2 (~ledger_manager.rs:351) doesn't call sync_binary_store_from_state before releasing state lock (snapshot/store TOCTOU); (3) reload swap condition new_state.t() >= current.t() (~ledger_manager.rs:1157) races concurrent commits; (4) export translate path WARN-drops non-Unsupported translation errors (binary_scan.rs:2238-2242) — same silent-drop class fixed earlier in graph crawl. Also: DecodedRow.dt u32 vs OverlayOp/RunRecord.dt u16; GraphId is bare u16 alias." ;
+    mem:content "Audit lifecycle bug candidates — TRIAGED 2026-06-12 (PR #1315): (1) apply_loaded_db graph-registry replay: already implemented (old graph IRIs merged via apply_delta alongside ns codes); pinned by it_graph_registry_apply_loaded_db.rs incl. same-g_id property. (2) apply_index_v2 store TOCTOU: FALSE POSITIVE — out-of-band binary_store write is inside the state write-lock scope. (3) reload t() swap race: FALSE POSITIVE — comparison runs after lock_for_write(); skip-swap is novelty-protective by design. (4) export translation WARN-drop: REAL, FIXED — all failed translations now keep raw flakes for the untranslated post-pass. Also: dt-width mismatch (DecodedRow u32 vs OverlayOp/RunRecord u16) and bare GraphId alias remain open Phase 0 newtype items." ;
     mem:tag "audit" ;
     mem:tag "bug-candidates" ;
-    mem:tag "id-space" ;
     mem:tag "lifecycle" ;
     mem:tag "overlay" ;
-    mem:tag "verification-needed" ;
+    mem:tag "resolved" ;
+    mem:tag "triage" ;
     mem:scope mem:repo ;
     mem:artifactRef "fluree-db-api/src/ledger_manager.rs" ;
     mem:artifactRef "fluree-db-binary-index/src/types.rs" ;

--- a/fluree-db-ledger/tests/it_graph_registry_apply_loaded_db.rs
+++ b/fluree-db-ledger/tests/it_graph_registry_apply_loaded_db.rs
@@ -1,0 +1,135 @@
+//! Regression test: advancing an index must not lose named-graph
+//! registrations introduced by commits still in novelty.
+//!
+//! If an index advances while there are still commits in novelty
+//! (t > index_t), `LedgerState::apply_loaded_db` replaces the snapshot with
+//! one built from the new index root — whose graph registry only knows
+//! graphs up to index_t. Graphs allocated by the remaining novelty commits
+//! must be carried forward, and at their ORIGINAL `g_id`s: the remaining
+//! novelty flakes are stored under those numeric ids, so a re-registration
+//! that permuted ids would silently re-route every named-graph fact.
+//!
+//! Companion to `it_dict_novelty_apply_loaded_db.rs`, which pins the same
+//! lifecycle moment for subject/string dictionary state. (Flagged by the
+//! 2026-06 architecture audit as a suspected gap; the preservation logic
+//! exists in `apply_loaded_db` — this test pins it.)
+
+use fluree_db_core::{Flake, FlakeValue, IndexType, LedgerSnapshot, Sid};
+use fluree_db_ledger::LedgerState;
+use fluree_db_novelty::Novelty;
+use std::sync::Arc;
+
+const G2_IRI: &str = "http://example.org/graphs/g2";
+const G3_IRI: &str = "http://example.org/graphs/g3";
+
+#[test]
+fn apply_loaded_db_preserves_novelty_graph_registrations_and_ids() {
+    // Scenario:
+    // - Index at t=1; registry knows only the ledger-default graphs.
+    // - Commit t=2: default-graph flake (will be cleared by the index apply).
+    // - Commit t=3: registers TWO named graphs (mirroring the commit
+    //   envelope's graph_delta application) and writes a flake into each.
+    // - Apply a newer index snapshot at t=2 whose root does NOT know either
+    //   graph. The t=3 commit stays in novelty; both graphs must survive at
+    //   their original g_ids.
+
+    let mut snapshot = LedgerSnapshot::genesis("test:main");
+    snapshot.t = 1;
+    let mut state = LedgerState::new(snapshot, Novelty::new(1));
+
+    let s = Sid::new(0, "ex:s");
+    let p = Sid::new(0, "ex:p");
+    let dt = Sid::new(2, "string");
+
+    // t=2: ordinary default-graph commit.
+    let reverse_graph = state.snapshot.build_reverse_graph().unwrap_or_default();
+    let flakes_t2 = vec![Flake::new(
+        s.clone(),
+        p.clone(),
+        FlakeValue::String("default-graph".to_string()),
+        dt.clone(),
+        2,
+        true,
+        None,
+    )];
+    Arc::make_mut(&mut state.novelty)
+        .apply_commit(flakes_t2, 2, &reverse_graph)
+        .unwrap();
+
+    // t=3: register the named graphs (as apply_single_commit does via the
+    // commit envelope's graph_delta) and commit one flake into each.
+    let assigned = Arc::make_mut(&mut state.snapshot)
+        .graph_registry
+        .apply_delta([G2_IRI, G3_IRI]);
+    assert_eq!(assigned.len(), 2, "both graphs newly registered");
+    let g2_id = state
+        .snapshot
+        .graph_registry
+        .graph_id_for_iri(G2_IRI)
+        .expect("g2 registered");
+    let g3_id = state
+        .snapshot
+        .graph_registry
+        .graph_id_for_iri(G3_IRI)
+        .expect("g3 registered");
+    assert_ne!(g2_id, g3_id);
+
+    let reverse_graph = state.snapshot.build_reverse_graph().expect("reverse graph");
+    let g2_sid = state.snapshot.encode_iri(G2_IRI).expect("encode g2");
+    let g3_sid = state.snapshot.encode_iri(G3_IRI).expect("encode g3");
+
+    let mut f2 = Flake::new(
+        s.clone(),
+        p.clone(),
+        FlakeValue::String("in-g2".to_string()),
+        dt.clone(),
+        3,
+        true,
+        None,
+    );
+    f2.g = Some(g2_sid);
+    let mut f3 = Flake::new(
+        s,
+        p,
+        FlakeValue::String("in-g3".to_string()),
+        dt,
+        3,
+        true,
+        None,
+    );
+    f3.g = Some(g3_sid);
+    Arc::make_mut(&mut state.novelty)
+        .apply_commit(vec![f2, f3], 3, &reverse_graph)
+        .unwrap();
+
+    // Apply a newer index snapshot at t=2. Its root-derived registry knows
+    // only the ledger defaults — exactly what a real FIR6 root built before
+    // the t=3 commit would carry.
+    let mut new_snapshot = LedgerSnapshot::genesis("test:main");
+    new_snapshot.t = 2;
+    state.apply_loaded_db(new_snapshot, None).unwrap();
+
+    // t<=2 novelty cleared; the two t=3 named-graph flakes remain.
+    assert_eq!(
+        state.novelty.iter_index(IndexType::Spot).count(),
+        2,
+        "t=3 named-graph flakes must remain in novelty"
+    );
+
+    // Both graphs survive the snapshot replacement AT THEIR ORIGINAL IDS.
+    assert_eq!(
+        state.snapshot.graph_registry.graph_id_for_iri(G2_IRI),
+        Some(g2_id),
+        "g2 must keep its pre-apply g_id (novelty rows are stored under it)"
+    );
+    assert_eq!(
+        state.snapshot.graph_registry.graph_id_for_iri(G3_IRI),
+        Some(g3_id),
+        "g3 must keep its pre-apply g_id (novelty rows are stored under it)"
+    );
+
+    // And the routing map can still be rebuilt (every registered IRI encodes).
+    let reverse_after = state.snapshot.build_reverse_graph().expect("reverse graph");
+    assert!(reverse_after.values().any(|gid| *gid == g2_id));
+    assert!(reverse_after.values().any(|gid| *gid == g3_id));
+}

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -2236,11 +2236,26 @@ pub fn translate_overlay_flakes_with_untranslated(
         ) {
             Ok(op) => ops.push(op),
             Err(e) => {
-                if e.kind() == std::io::ErrorKind::Unsupported {
-                    untranslated.push(flake.clone());
-                } else {
-                    tracing::warn!(error = %e, "failed to translate overlay flake to V3");
+                // EVERY failed translation keeps the raw flake: the callers'
+                // untranslated post-pass (lifecycle-resolve, filter, stream
+                // after the cursor) makes it visible to results. `Unsupported`
+                // is the expected lane (e.g. @vector values); anything else —
+                // NotFound from a stale/detached DictNovelty, InvalidData —
+                // indicates degraded state and is warned, but the fact must
+                // not silently vanish. Dropping here previously caused
+                // disappearing properties in export under exactly the state
+                // the warning describes (same bug class fixed earlier in
+                // graph crawl). Failures only occur for identities the
+                // persisted dicts can't resolve, so the matching base rows —
+                // which always translate — are unaffected, and assert/retract
+                // pairs fail together and resolve within the raw set.
+                if e.kind() != std::io::ErrorKind::Unsupported {
+                    tracing::warn!(
+                        error = %e,
+                        "overlay flake failed V3 translation; keeping raw flake"
+                    );
                 }
+                untranslated.push(flake.clone());
             }
         },
     );


### PR DESCRIPTION
## Summary

Stacked on #1314. Closes out the four lifecycle bug candidates flagged by the architecture audit (`docs/audit/2026-06-architecture-audit.md` §3.3 / Phase 0.3): each was either fixed, pinned, or affirmatively cleared with the analysis recorded here. Net: **one real data-loss fix, one regression test pinning behavior that already worked, two false positives** whose clearing is itself valuable — it corrects the audit record.

## Candidate 4 — REAL, fixed: silent data loss on failed overlay translation

`translate_overlay_flakes_with_untranslated` (`binary_scan.rs`) routed `Unsupported` failures into the untranslated raw-flake stream but **WARN-dropped every other failure kind** (`NotFound` from a stale/detached DictNovelty, `InvalidData`). A dropped flake lands in neither the overlay ops nor the raw stream — the fact silently vanishes from export and scan output under exactly the degraded state the warning describes. Same bug class as the previously-fixed graph-crawl disappearing-properties issue, surviving in this one path.

Fix: all failures keep the raw flake; both callers already lifecycle-resolve, filter, and stream untranslated flakes after the cursor. Widening is safe — failures only occur for identities the persisted dicts can't resolve, so matching base rows (which always translate) are unaffected, and assert/retract pairs fail together and resolve within the raw set. Not reachable via the public API without corrupted dictionary state, hence no repro test; Phase 1's translation chokepoint gives this a typed home.

## Candidate 1 — already works, now pinned: graph-registry survival through `apply_loaded_db`

The audit flagged `apply_loaded_db` as possibly losing named-graph registrations from commits still in novelty. Current code preserves them (old IRIs merged via `graph_registry.apply_delta` alongside namespace codes) — the audit agent's read was stale. New regression test `it_graph_registry_apply_loaded_db.rs` pins it, including the property that actually matters: surviving graphs keep their **original `g_id`s**, since remaining novelty flakes are stored under those numeric ids.

## Candidates 2 & 3 — false positives, cleared with analysis

- **`apply_index_v2` snapshot/binary-store TOCTOU**: the out-of-band `binary_store` write (`ledger_manager.rs:351`) happens *inside* the block holding the `state` write lock; readers take `state.read()` first (documented lock ordering), so new-state/old-store is unobservable. The audit misread the scoping.
- **Reload `t()` swap race**: the `new_state.t() >= current.t()` comparison executes *after* `lock_for_write()`, so no commit can move the in-memory state mid-comparison; when in-memory is newer the swap is skipped (novelty-protective, explicitly documented at the site). No lost commits.

Related: the audit's Arc-identity concern (`BinaryRangeProvider` capturing `state.dict_novelty`) has no live bug — the provider is rebuilt at every mutation point (commit path `commit.rs:707`, index apply, reload). The *structural* exposure (correctness depends on remembering to rebuild) stands as Phase 2 motivation, unchanged.

## Validation

- New regression test green; all 1,045 `fluree-db-query` unit tests green
- Differential harness (fully enforced) green — the translation fix doesn't perturb healthy-state results
- Export (`it_flpack_round_trip`) and `it_named_graph_isolation` green
- Clippy + fmt clean