### PR TITLE
fix(memory): make developer-memory store safe across processes

### DIFF
--- a/docs/memory/reference/ttl-format.md
+++ b/docs/memory/reference/ttl-format.md
@@ -52,6 +52,13 @@ When you `memory add`, the CLI / MCP server:
 
 If the ledger write fails, the hash is left stale and the next `ensure_synced` call rebuilds the ledger from the files. When git pulls in a new version of `repo.ttl`, the hash mismatch triggers the same rebuild. In practice this is invisible.
 
+## Concurrent access
+
+It's normal for several processes to touch one project's memory at once — Cursor and Claude Code together, or several Claude sessions, each running its own `fluree mcp serve`. Two guarantees keep that safe:
+
+- **The TTL file is the only shared mutable state, and writes are serialized.** Every mutation takes a cross-process file lock (`.fluree-memory/.local/rebuild.lock`) before rewriting the file, and re-reads the file under that lock, so two writers can't lose each other's memories.
+- **Each process keeps its ledger cache private.** The `mcp serve` ledger is held **in-memory** and rebuilt from the TTL files on startup, so one process refreshing its cache can never disturb another's. Each process also tracks, in memory, the file content its own ledger reflects — the shared on-disk `build-hash` alone can't tell a long-running process that *another* process changed the files, so the per-process watermark is what triggers its rebuild. (Short-lived `fluree memory` CLI commands keep a file-backed ledger for `import` and legacy migration; they're not long-lived enough to drift.)
+
 ## Editing by hand
 
 You *can* edit `repo.ttl` or `user.ttl` directly if you need to — fix a typo, reorder, batch-retag. After editing:

--- a/fluree-db-api/src/server_defaults.rs
+++ b/fluree-db-api/src/server_defaults.rs
@@ -129,6 +129,17 @@ pub const DEFAULT_MCP_AGENT_JSON_MAX_BYTES: usize = 32_768;
 /// Default timeout for MCP `sparql_query` execution (5 minutes).
 pub const DEFAULT_MCP_QUERY_TIMEOUT_MS: u64 = 5 * 60 * 1000;
 
+/// Leaflet-cache budget (MB) for the `fluree mcp serve` / `fluree memory`
+/// helper processes.
+///
+/// Unlike `fluree server`, these are lightweight, per-IDE stdio helpers backing
+/// a small developer-memory store, and several can run at once (one per editor
+/// window / agent session). Letting each inherit the server's RAM-tiered cache
+/// (~35% of system memory) means N helpers could collectively reserve a huge
+/// ceiling for a workload that never needs it. A small fixed cap keeps every
+/// helper cheap and composable; the memory store is tiny, so this is ample.
+pub const DEFAULT_MEMORY_HELPER_CACHE_MAX_MB: usize = 256;
+
 // ── Peer ────────────────────────────────────────────────────────────
 
 pub const DEFAULT_PEER_ROLE: &str = "transaction";

--- a/fluree-db-cli/src/commands/mcp_serve.rs
+++ b/fluree-db-cli/src/commands/mcp_serve.rs
@@ -60,7 +60,10 @@ fn init_mcp_tracing(memory_dir: Option<&Path>) {
 /// `fluree mcp serve --transport stdio` and communicates via JSON-RPC
 /// over stdin/stdout.
 async fn run_stdio(dirs: &FlureeDir) -> CliResult<()> {
-    let fluree = context::build_fluree(dirs)?;
+    // Process-private in-memory ledger: many MCP helpers can run at once
+    // (one per IDE/agent session) over the same `.fluree-memory` files, so the
+    // ledger cache must not be shared on disk. See `context::build_memory_fluree`.
+    let fluree = context::build_memory_fluree();
 
     // Determine memory_dir: .fluree-memory/ at the project root (same logic as CLI).
     // Always enable in unified mode — MemoryStore creates the directory structure on init.
@@ -76,7 +79,10 @@ async fn run_stdio(dirs: &FlureeDir) -> CliResult<()> {
 
     tracing::info!("MCP server starting");
 
-    let store = MemoryStore::new(fluree, memory_dir);
+    // Ephemeral (in-memory) ledger: rebuilt from the `.ttl` files on startup,
+    // never seeded from the shared on-disk hash, so concurrent MCP processes
+    // never corrupt each other's cache.
+    let store = MemoryStore::new_ephemeral_ledger(fluree, memory_dir);
     let service = MemoryToolService::new(store);
 
     let transport = rmcp::transport::io::stdio();

--- a/fluree-db-cli/src/commands/memory.rs
+++ b/fluree-db-cli/src/commands/memory.rs
@@ -62,6 +62,11 @@ pub async fn run(action: MemoryAction, dirs: &FlureeDir) -> CliResult<()> {
 }
 
 fn build_store(dirs: &FlureeDir) -> CliResult<MemoryStore> {
+    // Short-lived CLI commands keep a persistent (file-backed) ledger so that
+    // `import` and the `init` legacy-ledger migration work and repeated
+    // invocations don't rebuild from scratch. The long-lived `mcp serve` path
+    // uses an ephemeral in-memory ledger instead (see `mcp_serve`), which is
+    // what makes many concurrent MCP processes safe.
     let fluree = context::build_fluree(dirs)?;
 
     // Determine memory_dir: use .fluree-memory/ at the project root.

--- a/fluree-db-cli/src/context.rs
+++ b/fluree-db-cli/src/context.rs
@@ -331,6 +331,24 @@ pub fn build_fluree(dirs: &FlureeDir) -> CliResult<Fluree> {
         .map_err(|e| CliError::Config(format!("failed to initialize Fluree: {e}")))
 }
 
+/// Build the Fluree instance that backs the developer-memory store
+/// (`mcp serve`, `fluree memory`).
+///
+/// Unlike [`build_fluree`], this uses a **process-private, in-memory** ledger
+/// rather than the shared on-disk `.fluree/storage`. The git-tracked
+/// `.fluree-memory/*.ttl` files remain the durable source of truth; the ledger
+/// is a disposable query cache rebuilt from them on startup. Keeping it private
+/// is what makes concurrent access safe: several memory helpers can run at once
+/// (one per IDE/agent session, plus overlapping CLI invocations) without one
+/// process's cache rebuild deleting commits another process is reading. It also
+/// right-sizes memory — an in-memory ledger never holds the server's RAM-tiered
+/// leaflet cache — and the cap below keeps that explicit.
+pub fn build_memory_fluree() -> Fluree {
+    FlureeBuilder::memory()
+        .cache_max_mb(fluree_db_api::server_defaults::DEFAULT_MEMORY_HELPER_CACHE_MAX_MB)
+        .build_memory()
+}
+
 /// Normalize a ledger identifier to include a branch suffix if missing.
 ///
 /// The nameservice uses canonical ledger IDs like `mydb:main`.

--- a/fluree-db-cli/src/main.rs
+++ b/fluree-db-cli/src/main.rs
@@ -187,8 +187,26 @@ async fn shutdown_tracer() {
     }
 }
 
-#[tokio::main]
-async fn main() {
+/// Worker-thread stack size for the CLI runtime.
+///
+/// The default Tokio worker stack is 2 MB. The `fluree memory` / `mcp serve`
+/// subsystem composes a deep async chain when it rebuilds its ledger cache from
+/// the `.ttl` files inside a mutation's locked critical section
+/// (`add` → file-sync → `transact` → `commit`), which can exceed 2 MB and abort
+/// the worker. A larger stack covers that bounded depth; stacks are committed
+/// lazily, so the unused headroom costs no resident memory.
+const WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(WORKER_STACK_SIZE)
+        .build()
+        .expect("failed to build Tokio runtime")
+        .block_on(async_main());
+}
+
+async fn async_main() {
     let cli = Cli::parse();
 
     // Disable color when --no-color flag or NO_COLOR env var is set.

--- a/fluree-db-memory/examples/concurrent_add_repro.rs
+++ b/fluree-db-memory/examples/concurrent_add_repro.rs
@@ -46,8 +46,22 @@ fn mk(kind: MemoryKind, content: &str, tags: &[&str]) -> MemoryInput {
     }
 }
 
-#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
-async fn main() {
+fn main() {
+    // Default matches the CLI runtime's worker stack (main::WORKER_STACK_SIZE).
+    let stack_mb: usize = std::env::var("REPRO_STACK_MB")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8);
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_stack_size(stack_mb * 1024 * 1024)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async_main());
+}
+
+async fn async_main() {
     let mut args = std::env::args().skip(1);
     let concurrency: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(4);
     let seed: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(30);
@@ -104,11 +118,57 @@ async fn main() {
     if mode == "recall" {
         run_recall_stress(stores[0].clone(), concurrency).await;
     } else {
-        run_add_stress(stores, concurrency, rounds).await;
+        run_add_stress(stores.clone(), concurrency, rounds).await;
+        verify_no_lost_updates(&stores, seed, concurrency, rounds).await;
     }
 }
 
+/// After the add storm, every seeded and concurrently-added memory must be
+/// present in the authoritative `.ttl` file. With multiple stores sharing one
+/// directory (the cross-process model), a stale-ledger rewrite would silently
+/// drop another store's writes — this catches exactly that.
+async fn verify_no_lost_updates(
+    stores: &[Arc<MemoryStore>],
+    seed: usize,
+    concurrency: usize,
+    rounds: usize,
+) {
+    let expected = seed + concurrency * rounds;
+
+    // Force a fresh rebuild from the file so we count what is actually
+    // persisted (file is truth), not any one store's in-memory ledger.
+    let store = &stores[0];
+    store.ensure_synced().await.expect("final ensure_synced");
+    let all = store
+        .current_memories(&MemoryFilter::default())
+        .await
+        .expect("final current_memories");
+
+    eprintln!(
+        "VERIFY: expected={expected} persisted={} (seed={seed} + adds={})",
+        all.len(),
+        concurrency * rounds
+    );
+    assert_eq!(
+        all.len(),
+        expected,
+        "lost updates: {} memories persisted, expected {expected}",
+        all.len()
+    );
+    eprintln!("VERIFY OK: no lost updates");
+}
+
 fn build_store(storage: &Path, mem_dir: &Path, index: bool) -> MemoryStore {
+    // Production model (context::build_memory_fluree): a process-private,
+    // in-memory ledger over shared `.fluree-memory` files. Multiple stores
+    // sharing one `mem_dir` simulate multiple processes (Cursor + Claude Code,
+    // or several Claude sessions) in the same project.
+    if std::env::var("REPRO_FILE_LEDGER").as_deref() != Ok("1") {
+        let fluree = FlureeBuilder::memory().build_memory();
+        return MemoryStore::new_ephemeral_ledger(fluree, Some(mem_dir.to_path_buf()));
+    }
+    // REPRO_FILE_LEDGER=1 reproduces the old shared-on-disk ledger for
+    // comparison (exhibits cross-process commit "Not found" corruption).
     let mut b = FlureeBuilder::file(storage.to_string_lossy().to_string()).without_ledger_caching();
     b = if index {
         b.with_indexing_thresholds(8 * 1024, 256 * 1024)

--- a/fluree-db-memory/src/file_sync.rs
+++ b/fluree-db-memory/src/file_sync.rs
@@ -64,20 +64,38 @@ pub fn write_stored_hash(memory_dir: &Path, hash: &str) -> Result<()> {
 // Sync check
 // ---------------------------------------------------------------------------
 
-/// Recompute and write the build hash.
+/// Recompute and write the build hash, returning it.
 ///
-/// Called after any mutation to `.ttl` files (add, update, forget).
-pub fn update_hash(memory_dir: &Path) -> Result<()> {
+/// Called after any mutation to `.ttl` files (add, update, forget). The
+/// returned hash lets the caller advance its per-process sync watermark to
+/// match the file it just wrote, without re-hashing.
+pub fn update_hash(memory_dir: &Path) -> Result<String> {
     let hash = compute_build_hash(memory_dir)?;
-    write_stored_hash(memory_dir, &hash)
+    write_stored_hash(memory_dir, &hash)?;
+    Ok(hash)
 }
 
-/// Check if the ledger needs rebuilding from files.
+/// Check if **this process's** ledger needs rebuilding from files.
 ///
 /// Returns true if:
-/// - Stored hash is missing (fresh clone or first init)
-/// - Hash mismatch (files changed externally — e.g., `git pull`)
-/// - Ledger doesn't exist (deleted or corrupted)
+/// - Ledger doesn't exist (deleted, corrupted, or fresh init)
+/// - This process has not yet synced (no watermark — e.g. a fresh in-memory
+///   ledger that has not ingested the files)
+/// - The live file hash differs from the hash our ledger last ingested
+///   (another process wrote the files, or `git pull` changed them)
+///
+/// The decision is made against the store's **per-process** watermark, not the
+/// shared on-disk `build-hash`: that on-disk hash records whoever wrote the
+/// files last, so a long-lived process whose own ledger never ingested those
+/// writes would otherwise be fooled into thinking it is in sync. The watermark
+/// is advanced only by our own rebuilds and mutations, so once set it rebuilds
+/// whenever the files diverge from what our ledger holds.
+///
+/// On the first check the watermark is unset. For a persistent (file-backed)
+/// ledger it is seeded from the on-disk hash — the just-loaded ledger is
+/// consistent with it, avoiding a needless rebuild — but for an ephemeral
+/// (in-memory) ledger seeding is unsafe (the fresh ledger is empty), so a
+/// rebuild is forced. See [`MemoryStore::seed_watermark_from_disk`].
 pub async fn needs_rebuild(store: &MemoryStore, memory_dir: &Path) -> Result<bool> {
     // Check if ledger exists
     if !store.is_initialized().await? {
@@ -85,23 +103,34 @@ pub async fn needs_rebuild(store: &MemoryStore, memory_dir: &Path) -> Result<boo
         return Ok(true);
     }
 
-    let current_hash = compute_build_hash(memory_dir)?;
-    let stored_hash = read_stored_hash(memory_dir);
+    let synced = match store.synced_hash() {
+        Some(h) => Some(h),
+        None if store.seed_watermark_from_disk() => {
+            let seed = read_stored_hash(memory_dir);
+            store.set_synced_hash(seed.clone());
+            seed
+        }
+        None => None,
+    };
 
-    match stored_hash {
+    match synced {
         None => {
-            debug!("No stored build hash — rebuild needed");
+            debug!("No watermark for this process — rebuild needed");
             Ok(true)
         }
-        Some(stored) if stored != current_hash => {
-            debug!(
-                stored = %stored,
-                current = %current_hash,
-                "Build hash mismatch — rebuild needed"
-            );
-            Ok(true)
+        Some(synced) => {
+            let current_hash = compute_build_hash(memory_dir)?;
+            if synced != current_hash {
+                debug!(
+                    synced = %synced,
+                    current = %current_hash,
+                    "Files diverged from this process's ledger — rebuild needed"
+                );
+                Ok(true)
+            } else {
+                Ok(false)
+            }
         }
-        _ => Ok(false),
     }
 }
 
@@ -182,6 +211,28 @@ async fn acquire_lock_file(lock_path: PathBuf) -> Result<fs::File> {
     .map_err(|e| MemoryError::FileSync(format!("failed to join rebuild lock task: {e}")))?
 }
 
+/// Rebuild the ledger from files if this process's ledger is stale, assuming
+/// the caller **already holds** the cross-process file lock (and the store
+/// mutation lock).
+///
+/// Unlike [`ensure_synced`], this acquires neither lock itself, so it is safe
+/// to call from inside a mutation's locked critical section. `needs_rebuild`
+/// and `rebuild_from_files` (via `drop_and_reinit_unlocked`) take no locks of
+/// their own.
+pub(crate) async fn rebuild_if_stale_unlocked(
+    store: &MemoryStore,
+    memory_dir: &Path,
+) -> Result<()> {
+    if !memory_dir.exists() {
+        return Ok(());
+    }
+    if needs_rebuild(store, memory_dir).await? {
+        debug!("In-lock rebuild: files diverged from this process's ledger");
+        rebuild_from_files(store, memory_dir).await?;
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Atomic rebuild
 // ---------------------------------------------------------------------------
@@ -235,9 +286,11 @@ async fn rebuild_from_files(store: &MemoryStore, memory_dir: &Path) -> Result<()
         transact_batch(store, user_data).await?;
     }
 
-    // Phase 4: Write hash
+    // Phase 4: Write hash and record it as this process's sync watermark —
+    // our ledger now reflects exactly this file content.
     let hash = compute_build_hash(memory_dir)?;
     write_stored_hash(memory_dir, &hash)?;
+    store.set_synced_hash(Some(hash.clone()));
 
     debug!(hash = %hash, "Memory ledger rebuilt from files");
     Ok(())

--- a/fluree-db-memory/src/store.rs
+++ b/fluree-db-memory/src/store.rs
@@ -101,24 +101,79 @@ pub struct MemoryStore {
     /// read-modify-write sequence concurrently can leave the file watermark and
     /// cache diverged, causing rebuild storms.
     mutation_lock: Mutex<()>,
+    /// Hash of the `.ttl` file content that **this process's** ledger cache
+    /// currently reflects (`None` until the first sync).
+    ///
+    /// The on-disk `.local/build-hash` is shared by every process, so it only
+    /// records who wrote the files *last* — it cannot tell a long-lived process
+    /// that another process changed the files out from under its in-memory
+    /// ledger. This per-process watermark closes that gap: it is advanced only
+    /// by our own rebuilds and mutations, so when the live file hash diverges
+    /// from it we know our ledger is stale and must rebuild before reading.
+    synced_hash: std::sync::Mutex<Option<String>>,
+    /// Whether the first sync may seed [`Self::synced_hash`] from the on-disk
+    /// `build-hash` instead of forcing a rebuild.
+    ///
+    /// True for a **persistent** (file-backed) ledger: at startup the loaded
+    /// ledger is consistent with the on-disk hash, so seeding avoids a needless
+    /// rebuild on every short-lived CLI invocation. False for an **ephemeral**
+    /// (in-memory) ledger: a fresh process starts empty and must rebuild from
+    /// the files before it can answer queries, so it must not trust the shared
+    /// on-disk hash.
+    seed_watermark_from_disk: bool,
 }
 
 impl MemoryStore {
-    /// Create a new memory store wrapping a Fluree instance.
+    /// Create a memory store backed by a **persistent** (file-backed) ledger.
     ///
     /// Pass `memory_dir` to enable file-based sync (e.g., `.fluree-memory/`).
     /// Pass `None` for legacy behavior (ledger-only, no file sharing).
     pub fn new(fluree: Fluree, memory_dir: Option<PathBuf>) -> Self {
+        Self::build(fluree, memory_dir, true)
+    }
+
+    /// Create a memory store backed by an **ephemeral** (in-memory) ledger.
+    ///
+    /// Use this when the ledger is a process-private cache that does not persist
+    /// across restarts (e.g. `mcp serve`, where many processes share one
+    /// `.fluree-memory` directory). The ledger is rebuilt from the `.ttl` files
+    /// on first use, so the watermark must not be seeded from the shared
+    /// on-disk hash.
+    pub fn new_ephemeral_ledger(fluree: Fluree, memory_dir: Option<PathBuf>) -> Self {
+        Self::build(fluree, memory_dir, false)
+    }
+
+    fn build(fluree: Fluree, memory_dir: Option<PathBuf>, seed_watermark_from_disk: bool) -> Self {
         Self {
             fluree,
             memory_dir,
             mutation_lock: Mutex::new(()),
+            synced_hash: std::sync::Mutex::new(None),
+            seed_watermark_from_disk,
         }
+    }
+
+    /// Whether the first sync may seed the watermark from the on-disk hash.
+    pub(crate) fn seed_watermark_from_disk(&self) -> bool {
+        self.seed_watermark_from_disk
     }
 
     /// The memory directory path, if file-based sync is enabled.
     pub fn memory_dir(&self) -> Option<&Path> {
         self.memory_dir.as_deref()
+    }
+
+    /// The file-content hash this process's ledger currently reflects.
+    pub(crate) fn synced_hash(&self) -> Option<String> {
+        self.synced_hash
+            .lock()
+            .expect("synced_hash poisoned")
+            .clone()
+    }
+
+    /// Record the file-content hash this process's ledger now reflects.
+    pub(crate) fn set_synced_hash(&self, hash: Option<String>) {
+        *self.synced_hash.lock().expect("synced_hash poisoned") = hash;
     }
 
     /// Check if the memory ledger has been initialized.
@@ -221,6 +276,10 @@ impl MemoryStore {
     /// Drop and reinitialize the `__memory` ledger while the caller already
     /// holds the store mutation lock.
     pub(crate) async fn drop_and_reinit_unlocked(&self) -> Result<()> {
+        // The ledger is about to be emptied, so it no longer reflects any file
+        // content. Clear the watermark so the next sync rebuilds from the files.
+        self.set_synced_hash(None);
+
         // Delete the ledger if it exists
         if self.is_initialized().await? {
             debug!("Dropping __memory ledger for rebuild");
@@ -256,6 +315,22 @@ impl MemoryStore {
         Ok(())
     }
 
+    /// Rebuild the ledger from files if this process's ledger is stale,
+    /// assuming the caller **already holds** the mutation lock and the
+    /// cross-process file lock.
+    ///
+    /// Mutations call this after taking both locks and before reading the
+    /// current memory set, so the sync-from-file and the subsequent file
+    /// rewrite happen in one uninterrupted critical section. That closes the
+    /// window where another process could write the files in between, which
+    /// would otherwise be silently overwritten by the stale-ledger rewrite.
+    async fn sync_under_lock(&self) -> Result<()> {
+        if let Some(dir) = &self.memory_dir {
+            crate::file_sync::rebuild_if_stale_unlocked(self, dir).await?;
+        }
+        Ok(())
+    }
+
     /// Insert a JSON-LD document into the memory ledger (used by rebuild).
     pub async fn transact_insert(&self, doc: &Value) -> Result<()> {
         self.fluree
@@ -279,6 +354,7 @@ impl MemoryStore {
         let _guard = self.mutation_lock.lock().await;
         let file_lock = self.acquire_file_lock().await?;
         self.initialize().await?;
+        self.sync_under_lock().await?;
 
         let id = crate::id::generate_memory_id(input.kind);
         let created_at = Utc::now().to_rfc3339();
@@ -328,7 +404,8 @@ impl MemoryStore {
 
         // Update the file watermark only after cache commit succeeds.
         if let Some(dir) = &self.memory_dir {
-            crate::file_sync::update_hash(dir)?;
+            let hash = crate::file_sync::update_hash(dir)?;
+            self.set_synced_hash(Some(hash));
         }
 
         debug!(id = %id, kind = %mem.kind, "Memory added");
@@ -377,6 +454,7 @@ WHERE {{\n\
         let _guard = self.mutation_lock.lock().await;
         let file_lock = self.acquire_file_lock().await?;
         self.initialize().await?;
+        self.sync_under_lock().await?;
 
         let expanded = expand_id(id);
         let compact = compact_id(&expanded);
@@ -449,7 +527,8 @@ WHERE {{\n\
 
         // Update the file watermark only after cache commits succeed.
         if let Some(dir) = &self.memory_dir {
-            crate::file_sync::update_hash(dir)?;
+            let hash = crate::file_sync::update_hash(dir)?;
+            self.set_synced_hash(Some(hash));
         }
 
         debug!(id = %compact, "Memory updated in place");
@@ -465,6 +544,7 @@ WHERE {{\n\
         let _guard = self.mutation_lock.lock().await;
         let file_lock = self.acquire_file_lock().await?;
         self.initialize().await?;
+        self.sync_under_lock().await?;
 
         let expanded = expand_id(id);
         let compact = compact_id(&expanded);
@@ -518,7 +598,8 @@ WHERE {{\n\
 
         // Update the file watermark only after cache commit succeeds.
         if let Some(dir) = &self.memory_dir {
-            crate::file_sync::update_hash(dir)?;
+            let hash = crate::file_sync::update_hash(dir)?;
+            self.set_synced_hash(Some(hash));
         }
 
         debug!(id = %id, "Memory forgotten");

--- a/fluree-db-memory/tests/it_concurrent_cross_process.rs
+++ b/fluree-db-memory/tests/it_concurrent_cross_process.rs
@@ -1,0 +1,94 @@
+//! Concurrent cross-process memory writes must not lose updates.
+//!
+//! Models several processes (MCP servers and/or CLI invocations — e.g. Cursor
+//! and Claude Code, or multiple Claude sessions) operating on the same
+//! `.fluree-memory` directory in one project. Each process gets a
+//! **process-private in-memory ledger** (matching `context::build_memory_fluree`);
+//! the git-tracked `.ttl` file is the shared source of truth, guarded by a
+//! cross-process file lock. Before the fix, a writer rewrote the file from its
+//! own stale ledger and silently dropped a concurrent writer's memory.
+
+use fluree_db_api::FlureeBuilder;
+use fluree_db_memory::{MemoryFilter, MemoryInput, MemoryKind, MemoryStore, Scope};
+use std::sync::Arc;
+
+fn mk(store_idx: usize, i: usize) -> MemoryInput {
+    MemoryInput {
+        kind: MemoryKind::Fact,
+        content: format!("cross-process memory from store {store_idx} item {i}"),
+        tags: vec!["concurrency".to_string(), "cross-process".to_string()],
+        scope: Scope::Repo,
+        severity: None,
+        artifact_refs: Vec::new(),
+        branch: None,
+        rationale: None,
+        alternatives: None,
+    }
+}
+
+fn build_store(mem_dir: &std::path::Path) -> MemoryStore {
+    // Process-private in-memory ledger over the shared `.fluree-memory` files,
+    // matching the production `mcp serve` configuration.
+    let fluree = FlureeBuilder::memory().build_memory();
+    MemoryStore::new_ephemeral_ledger(fluree, Some(mem_dir.to_path_buf()))
+}
+
+#[test]
+fn concurrent_cross_process_adds_do_not_lose_updates() {
+    // An 8 MB worker stack mirrors the CLI runtime (main::WORKER_STACK_SIZE):
+    // the in-lock rebuild-from-file path is deep and overflows the default 2 MB
+    // tokio worker stack under contention.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_stack_size(8 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let tmp = tempfile::tempdir().unwrap();
+        let mem_dir = tmp.path().join(".fluree-memory");
+        std::fs::create_dir_all(&mem_dir).unwrap();
+
+        const STORES: usize = 3;
+        const PER_STORE: usize = 8;
+        let expected = STORES * PER_STORE;
+
+        let stores: Vec<Arc<MemoryStore>> = (0..STORES)
+            .map(|_| Arc::new(build_store(&mem_dir)))
+            .collect();
+
+        // Create the shared directory structure / `.ttl` files once before the
+        // storm so first-add file creation isn't itself a race.
+        stores[0].initialize().await.expect("initialize");
+
+        let mut handles = Vec::new();
+        for (s, store) in stores.iter().enumerate() {
+            for i in 0..PER_STORE {
+                let store = Arc::clone(store);
+                handles.push(tokio::spawn(async move { store.add(mk(s, i)).await }));
+            }
+        }
+        for h in handles {
+            h.await
+                .expect("task join")
+                .expect("add must succeed (no commit corruption)");
+        }
+
+        // File is truth: a fresh store rebuilds from the `.ttl` files, so its
+        // ledger reflects exactly what persisted across all writers.
+        let verifier = build_store(&mem_dir);
+        verifier.ensure_synced().await.expect("final ensure_synced");
+        let all = verifier
+            .current_memories(&MemoryFilter::default())
+            .await
+            .expect("current_memories");
+
+        assert_eq!(
+            all.len(),
+            expected,
+            "lost updates: {} memories persisted, expected {expected}",
+            all.len()
+        );
+    });
+}


### PR DESCRIPTION
## Problem

Several processes can share one project's `.fluree-memory` at once — two editors, or multiple coding-agent sessions, each spawning its own `fluree mcp serve`. Concurrent writes **silently lost memories**.

Root cause: `needs_rebuild` compared the live `.ttl` hash against the shared on-disk `build-hash`, which only records who wrote *last*. A process whose own ledger never ingested another process's write believed it was in sync, then `add`/`update`/`forget` rewrote the whole `.ttl` file from its stale ledger (`all_memories_for_scope` reads the ledger, not the file) — dropping the other process's memories.

Investigation also surfaced two pre-existing hazards that any real fix exposes: concurrent rebuilds on a *shared* on-disk `__memory` ledger delete commits another process is reading (`Failed to read commit … Not found`), and the in-lock rebuild composes a deep transact/commit chain that overflows the default 2 MB tokio worker stack.

## Fix

- **Per-process watermark** — each store tracks the file content its own ledger reflects and decides rebuilds against that, not the shared on-disk hash.
- **In-lock sync** — `add`/`update`/`forget` rebuild-from-file inside the mutation's own cross-process file lock, before reading the set, so sync and the file rewrite are one critical section.
- **Process-private in-memory ledger for `mcp serve`** — rebuilt from the `.ttl` files on startup, so one process's cache refresh can't corrupt another's. CLI `fluree memory` keeps a file-backed ledger (for `import` and legacy migration); watermark seeding is gated per backend.
- **8 MB CLI worker stack** — covers the bounded depth of the in-lock rebuild chain.

The `.ttl` file stays the single source of truth, guarded by the existing file lock. This also right-sizes memory: the in-memory ledger never holds the server's RAM-tiered leaflet cache.

## Validation

- New `it_concurrent_cross_process` regression test: **8/24 memories survive on the old logic, 24/24 with the fix**.
- Stress harness (`concurrent_add_repro`, 3 stores / high concurrency): no lost updates, zero errors; the old shared-on-disk ledger still throws `commit … Not found` under the same load.
- Manual end-to-end: CLI memory roundtrip and `mcp serve` (rebuilds from file, recall returns seeded memories).

## Docs

Adds a "Concurrent access" section to `docs/memory/reference/ttl-format.md`.