### PR TITLE
fix(query): GROUP BY (expr) collapses to one row per group and honors LIMIT

### DIFF
--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -4723,3 +4723,111 @@ async fn sparql_service_remote_no_executor_errors() {
         "Error should mention missing executor, got: {err}"
     );
 }
+
+// =========================================================================
+// Field report repro: GROUP BY over an expression must collapse + honor LIMIT
+// =========================================================================
+
+/// Seed line items across three currencies (mixed case) so that
+/// `GROUP BY (LCASE(?cur))` collapses to exactly three groups.
+async fn seed_currency_line_items(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+
+    // 5 USD, 3 CAD, 2 EUR (mixed case to exercise LCASE collapsing).
+    let currencies = [("USD", 5usize), ("Cad", 3usize), ("eur", 2usize)];
+    let mut graph = Vec::new();
+    let mut idx = 0usize;
+    for (cur, n) in currencies {
+        for _ in 0..n {
+            graph.push(json!({
+                "@id": format!("ex:item{idx}"),
+                "@type": "ex:LineItem",
+                "ex:currency": cur,
+            }));
+            idx += 1;
+        }
+    }
+
+    let insert = json!({
+        "@context": { "ex": "http://example.org/ns/" },
+        "@graph": graph,
+    });
+
+    fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert currency line items")
+        .ledger
+}
+
+#[tokio::test]
+async fn sparql_group_by_expression_collapses_and_honors_limit() {
+    // Field P0 repro: `GROUP BY (LCASE(?cur))` with the same expression aliased
+    // in the SELECT must collapse to one row per distinct expression value, and
+    // LIMIT must bound the result. The buggy behavior returned one row per input
+    // binding (10 rows) with LIMIT ignored.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_currency_line_items(&fluree, "currency:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT (LCASE(?cur) AS ?k) (COUNT(?s) AS ?n)
+        WHERE { ?s a ex:LineItem ; ex:currency ?cur }
+        GROUP BY (LCASE(?cur))
+        ORDER BY DESC(?n)
+        LIMIT 15
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+
+    // SPARQL-results JSON: exactly 3 binding rows (one per distinct group), not
+    // one per input line item. This is the format the field observed exploding.
+    let sparql_json = result
+        .to_sparql_json(&ledger.snapshot)
+        .expect("to_sparql_json");
+    let bindings = support::normalize_sparql_bindings(&sparql_json);
+    assert_eq!(
+        bindings.len(),
+        3,
+        "GROUP BY (expr) must collapse to one row per group, got {} rows: {bindings:#?}",
+        bindings.len()
+    );
+
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    // Expected per SPARQL 1.1: three groups — usd 5, cad 3, eur 2.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["usd", 5], ["cad", 3], ["eur", 2]]))
+    );
+}
+
+#[tokio::test]
+async fn sparql_group_by_expression_via_bind_workaround() {
+    // Control: the BIND-then-GROUP-BY-?k workaround the field is using. This is
+    // expected to already pass; it isolates the bug to the GROUP-BY-expression
+    // desugar path.
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_currency_line_items(&fluree, "currency:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT ?k (COUNT(?s) AS ?n)
+        WHERE { ?s a ex:LineItem ; ex:currency ?cur . BIND(LCASE(?cur) AS ?k) }
+        GROUP BY ?k
+        ORDER BY DESC(?n)
+        LIMIT 15
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["usd", 5], ["cad", 3], ["eur", 2]]))
+    );
+}

--- a/fluree-db-sparql/src/lower/aggregate.rs
+++ b/fluree-db-sparql/src/lower/aggregate.rs
@@ -30,7 +30,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
     ///
     /// This is used to de-duplicate aggregate-input BINDs and to build stable
     /// aggregate alias keys (HAVING → SELECT aggregate lookup).
-    fn expr_key_no_span(expr: &Expression) -> String {
+    pub(super) fn expr_key_no_span(expr: &Expression) -> String {
         use crate::ast::term::LiteralValue;
 
         match expr.unwrap_bracketed() {

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -1651,6 +1651,43 @@ mod tests {
     }
 
     #[test]
+    fn test_group_by_expression_reuses_matching_select_alias() {
+        // Field P0: `SELECT (LCASE(?cur) AS ?k) ... GROUP BY (LCASE(?cur))` must
+        // group on ?k (the SELECT alias), NOT on a fresh synthetic var. Grouping
+        // on a synthetic var left ?k as an ungrouped per-row variable, which the
+        // formatter then exploded into one row per input binding (LIMIT ignored).
+        let (query, vars) = lower_query_with_vars(
+            "PREFIX ex: <http://example.org/>
+             SELECT (LCASE(?cur) AS ?k) (COUNT(?s) AS ?n)
+             WHERE { ?s ex:currency ?cur } GROUP BY (LCASE(?cur))",
+        )
+        .unwrap();
+
+        assert_eq!(group_by_of(&query).len(), 1);
+        let group_var = group_by_of(&query)[0];
+
+        // The group key is the SELECT alias ?k, not a synthetic ?__group_expr_N.
+        assert_eq!(vars.name(group_var), "?k");
+
+        // Exactly one BIND targets ?k (the SELECT pre-bind); GROUP BY adds none.
+        let binds_to_k = query
+            .patterns
+            .iter()
+            .filter(|p| matches!(p, Pattern::Bind { var, .. } if *var == group_var))
+            .count();
+        assert_eq!(
+            binds_to_k, 1,
+            "expected exactly one BIND to the shared group/alias var"
+        );
+
+        // No synthetic group-expression var should have been created.
+        let has_synthetic = query.patterns.iter().any(
+            |p| matches!(p, Pattern::Bind { var, .. } if vars.name(*var).starts_with("?__group_expr_")),
+        );
+        assert!(!has_synthetic, "no synthetic group var should be generated");
+    }
+
+    #[test]
     fn test_group_by_bracketed_var_produces_no_bind() {
         // GROUP BY (?var) should NOT produce a BIND pattern — just unwrap the parens
         let query = lower_query(

--- a/fluree-db-sparql/src/lower/select.rs
+++ b/fluree-db-sparql/src/lower/select.rs
@@ -170,9 +170,16 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         // Expression GROUP BY like `GROUP BY (expr AS ?alias)` desugars to
         // a pre-group BIND pattern + GROUP BY on the alias variable.
         if let Some(ref group_by_clause) = modifiers.group_by {
+            // Map of structural key → alias var for non-aggregate SELECT
+            // expressions, so an unaliased `GROUP BY (expr)` whose expression is
+            // also projected as `(expr AS ?k)` can group on ?k directly rather
+            // than on a fresh synthetic var (SPARQL 1.1 §11.2 — a projected
+            // grouping expression yields the group value).
+            let select_expr_aliases = self.select_expr_alias_map(select);
             let mut group_vars = Vec::with_capacity(group_by_clause.conditions.len());
             for cond in &group_by_clause.conditions {
-                let (var_id, bind_pattern) = self.lower_group_condition(cond)?;
+                let (var_id, bind_pattern) =
+                    self.lower_group_condition(cond, &select_expr_aliases)?;
                 group_vars.push(var_id);
                 if let Some(pattern) = bind_pattern {
                     pre_group_binds.push(pattern);
@@ -357,14 +364,44 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         }
     }
 
+    /// Build a map from structural expression key → alias `VarId` for every
+    /// non-aggregate `(expr AS ?alias)` in the SELECT clause.
+    ///
+    /// Used to recognize when an unaliased `GROUP BY (expr)` groups on an
+    /// expression that the SELECT also projects, so both can share one variable.
+    /// The alias vars are already registered by `lower_select_expression_binds`;
+    /// `register_var` returns the existing id.
+    fn select_expr_alias_map(&mut self, select: &SelectClause) -> HashMap<String, VarId> {
+        let mut map = HashMap::new();
+        if let SelectVariables::Explicit(vars) = &select.variables {
+            for var in vars {
+                if let SelectVariable::Expr { expr, alias, .. } = var {
+                    if matches!(expr, AstExpression::Aggregate { .. }) {
+                        continue;
+                    }
+                    let key = Self::expr_key_no_span(expr);
+                    let var_id = self.register_var(alias);
+                    map.entry(key).or_insert(var_id);
+                }
+            }
+        }
+        map
+    }
+
     /// Lower a GROUP BY condition to a variable ID and optional pre-GROUP-BY BIND.
     ///
     /// Returns `(var_id, Option<Pattern::Bind>)`:
     /// - `GROUP BY ?x`              → variable reference, no BIND needed
     /// - `GROUP BY (?x)`            → parenthesized variable, unwrapped to plain variable
     /// - `GROUP BY (expr AS ?alias)` → desugared to BIND(expr AS ?alias) + GROUP BY ?alias
-    /// - `GROUP BY (expr)`          → same, but with a synthetic `?__group_expr_N` alias
-    fn lower_group_condition(&mut self, cond: &GroupCondition) -> Result<(VarId, Option<Pattern>)> {
+    /// - `GROUP BY (expr)` projected as `(expr AS ?k)` → group on ?k (already
+    ///   bound by the SELECT pre-bind), no new BIND
+    /// - `GROUP BY (expr)`          → otherwise, a synthetic `?__group_expr_N` alias
+    fn lower_group_condition(
+        &mut self,
+        cond: &GroupCondition,
+        select_expr_aliases: &HashMap<String, VarId>,
+    ) -> Result<(VarId, Option<Pattern>)> {
         match cond {
             GroupCondition::Var(var) => Ok((self.register_var(var), None)),
             GroupCondition::Expr { expr, alias, .. } => {
@@ -372,15 +409,34 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                 match expr.unwrap_bracketed() {
                     AstExpression::Var(var) => Ok((self.register_var(var), None)),
                     _ => {
-                        // Expression-based GROUP BY: desugar to BIND + GROUP BY alias
+                        // Explicit `GROUP BY (expr AS ?alias)`: desugar to
+                        // BIND(expr AS ?alias) + GROUP BY ?alias.
+                        if let Some(alias_var) = alias {
+                            let lowered = self.lower_expression(expr)?;
+                            let var_id = self.register_var(alias_var);
+                            return Ok((
+                                var_id,
+                                Some(Pattern::Bind {
+                                    var: var_id,
+                                    expr: lowered,
+                                }),
+                            ));
+                        }
+
+                        // Unaliased `GROUP BY (expr)`: if the SELECT projects the
+                        // same expression as `(expr AS ?k)`, group on ?k. The
+                        // SELECT pre-bind already computes `?k = expr` in the
+                        // WHERE patterns, so no new BIND is needed and the
+                        // projected variable equals the group value. Otherwise
+                        // synthesize a fresh group var + BIND.
+                        let key = Self::expr_key_no_span(expr);
+                        if let Some(&alias_var) = select_expr_aliases.get(&key) {
+                            return Ok((alias_var, None));
+                        }
+
                         let lowered = self.lower_expression(expr)?;
-                        let var_id = if let Some(alias_var) = alias {
-                            self.register_var(alias_var)
-                        } else {
-                            // No alias — generate a synthetic variable
-                            let name = format!("?__group_expr_{}", self.vars.len());
-                            self.vars.get_or_insert(&name)
-                        };
+                        let name = format!("?__group_expr_{}", self.vars.len());
+                        let var_id = self.vars.get_or_insert(&name);
                         Ok((
                             var_id,
                             Some(Pattern::Bind {


### PR DESCRIPTION
## Summary

`GROUP BY` over an expression that is *also* projected in the SELECT (e.g. `SELECT (LCASE(?cur) AS ?k) ... GROUP BY (LCASE(?cur))`) row-exploded and appeared to ignore `LIMIT`. Reported from the field against 4.0.5 and 4.0.6.

## Root cause

The SPARQL lowering produced **two disconnected variables for the same expression**:

- `SELECT (LCASE(?cur) AS ?k)` → an independent per-row bind `?k = LCASE(?cur)` in the WHERE patterns
- `GROUP BY (LCASE(?cur))` → a *separate* synthetic group key (`?__group_expr_N`)

The group key was the synthetic var, so the projected `?k` was neither a group key nor an aggregate. Grouping and `COUNT` were computed correctly, but `?k` survived grouping as a **multi-valued list** which the results formatter then **exploded into one row per input binding**. `LIMIT` had already been applied to the collapsed grouped rows upstream of the explosion, so it had no visible effect.

## Fix

When an unaliased `GROUP BY (expr)` matches a SELECT expression projected as `(expr AS ?k)` (matched on the structural expression key), group on `?k` directly. The SELECT pre-bind already computes `?k = expr`, so grouping happens on the projected variable and each row equals the group value, per SPARQL 1.1 §11.2. This is the BIND-then-`GROUP BY ?k` form that already worked, applied automatically.

Explicit `GROUP BY (expr AS ?alias)` and the synthetic-var fallback (when the expression is not projected) are unchanged.

## Behavior

For the reporter's query, the SPARQL-results JSON now returns one row per distinct group (collapsed, `LIMIT` honored) instead of one row per input line item.

## Tests

- `fluree-db-api/tests/it_query_sparql.rs`: collapse + `LIMIT` integration test, plus a BIND-workaround control.
- `fluree-db-sparql/src/lower/mod.rs`: lowering unit test asserting the group key reuses the SELECT alias var (no synthetic var, single bind).
- Verified no regression against the W3C SPARQL aggregates category (identical failure set before/after).
