### PR TITLE
build(cli): enable aws feature by default (S3/DynamoDB in Docker)

### DIFF
--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -228,10 +228,12 @@ fluree server run
 # error: server support not compiled. Rebuild with `--features server`.
 ```
 
-For S3/DynamoDB support via `--connection-config`, the `aws` feature must be enabled:
+S3/DynamoDB support via `--connection-config` requires the `aws` feature, which
+is **on by default** for the CLI (and the published Docker image). It is dormant
+unless an AWS backend is configured. To build a CLI *without* it:
 
 ```bash
-cargo build -p fluree-db-cli --features aws
+cargo build -p fluree-db-cli --no-default-features --features server,iceberg,shacl
 ```
 
 Without this feature, S3 storage configs in the connection config will produce a clear error at startup.

--- a/fluree-db-cli/Cargo.toml
+++ b/fluree-db-cli/Cargo.toml
@@ -16,7 +16,11 @@ name = "fluree_db_cli"
 path = "src/lib.rs"
 
 [features]
-default = ["server", "iceberg", "shacl"]
+# `aws` is on by default so the shipped CLI (incl. the Docker image, which
+# reuses the dist binary) can use S3 storage + DynamoDB nameservice via
+# connection config. Dormant unless configured; ~+2 MB over the AWS SDK that
+# `iceberg` already pulls in.
+default = ["server", "iceberg", "shacl", "aws"]
 server = ["dep:fluree-db-server"]
 iceberg = ["fluree-db-api/iceberg"]
 aws = ["fluree-db-server/aws"]


### PR DESCRIPTION
## Summary

Enable the `aws` feature by default for the `fluree-db-cli` crate.

The published Docker image runs the dist-built `fluree` CLI binary (the CLI wraps/embeds the server). That binary was compiled with **default features only** (`server, iceberg, shacl`), so the `aws` feature was off — meaning **S3 storage and the DynamoDB nameservice were unavailable in Docker**, despite being needed for cloud-native deployments. cargo-dist builds with default features and the Docker job reuses that artifact, so there was no path to AWS support in the image without flipping a default.

## Change

Add `aws` to the CLI default feature set, so the shipped binary — and therefore the Docker image, which reuses the dist artifact — is AWS-capable out of the box. The feature is dormant unless an AWS backend is configured via connection config.

## Size impact (measured, dist profile: LTO + stripped)

| Build | Size |
|---|---|
| default (`server, iceberg, shacl`) | 41.83 MB |
| default + `aws` | 43.84 MB |
| **delta** | **+2.01 MB (+4.80%)** |

The increment is small because the AWS SDK is already linked in via the default `iceberg` feature (`fluree-db-iceberg/aws`); turning on `aws` mainly adds the S3 storage backend + DynamoDB nameservice. Given the small footprint, we just enable it in the CLI always rather than maintaining a Docker-only build variant.

## Notes

- Docs updated: `docs/cli/server.md` (the old "must build with `--features aws`" instruction is now stale).
- Stacked on top of the GROUP BY grouping fix; base branch is set accordingly so this PR's diff shows only the aws change.
