### PR TITLE
fix(transact): zero WHERE solutions no longer fire all-literal INSERTs

### DIFF
--- a/docs/transactions/conditional-updates.md
+++ b/docs/transactions/conditional-updates.md
@@ -21,10 +21,15 @@ This guide covers common patterns for state-dependent updates with both **JSON-L
 
 The WHERE clause runs against the **current** database state. If it matches, the bound variables flow into DELETE (to retract old values) and INSERT (to assert new ones). If WHERE returns zero rows — because a FILTER eliminated them or a pattern didn't match — DELETE is skipped entirely (nothing to retract) and INSERT templates with unbound variables produce zero flakes.
 
-### Two INSERT behaviors
+### How INSERT interacts with WHERE solutions
 
-- **INSERT with variables from WHERE** (e.g., `"@id": "?s"`) — conditional. When WHERE returns zero rows, the variable is unbound and the INSERT produces nothing. Use this for CAS, state machines, and guards.
-- **All-literal INSERT** (e.g., `"@id": "ex:alice"`) — unconditional. Fires even when WHERE returns zero rows. Use this for "delete-if-exists, always insert" patterns.
+INSERT templates are instantiated **once per WHERE solution row**, following SPARQL 1.1 Update §3.1.3:
+
+- **WHERE returns one or more rows** — each INSERT template fires once per row. A template term bound to a WHERE variable takes that row's value; a term whose variable is unbound for that row (e.g., from an unmatched OPTIONAL) is skipped, while all-literal terms still assert.
+- **WHERE returns zero rows** — nothing is inserted, *even for all-literal INSERT templates*. A guard (required pattern or `FILTER`) that matches nothing is a true no-op. This applies identically to JSON-LD and SPARQL UPDATE.
+- **No WHERE clause at all** — the INSERT fires once (the plain insert path).
+
+This means an "always insert, delete-if-exists" idiom must be written so WHERE still yields a row when the entity is absent — use `OPTIONAL`, which produces one row with the probe variable unbound, alongside the literal INSERT (see [Insert-If-Not-Exists](#6-insert-if-not-exists-conditional-create)). A bare *required* pattern that fails to match yields zero rows and therefore inserts nothing.
 
 ---
 

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -840,6 +840,41 @@ async fn sparql_subquery_expression_order_by_with_limit() {
     assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([[99]])));
 }
 
+/// Regression: a variable-free subquery (`{ SELECT * WHERE { <ground> } }`)
+/// produces an empty schema. When the ground pattern matches it is one
+/// empty-binding solution and must NOT collapse to zero rows — otherwise it
+/// would wrongly wipe out the joined outer pattern. Guards
+/// `SubqueryOperator::drain_buffer`'s empty-schema handling.
+#[tokio::test]
+async fn sparql_ground_subquery_does_not_wipe_outer_pattern() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    // Outer pattern matches exactly one row (jdoe's full name). The inner
+    // subquery is fully ground (jdoe's handle is "jdoe"), projects no variables,
+    // and exists — so the join must preserve the single outer row.
+    let query = r#"
+        PREFIX ex: <http://example.org/ns/>
+        PREFIX person: <http://example.org/Person#>
+        SELECT ?fullName
+        WHERE {
+          ex:jdoe person:fullName ?fullName .
+          { SELECT * WHERE { ex:jdoe person:handle "jdoe" } }
+        }
+    "#;
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .unwrap();
+    let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["Jane Doe"]])),
+        "ground matching subquery must yield one empty solution, not zero"
+    );
+}
+
 #[tokio::test]
 async fn sparql_subquery_aggregate_order_by_with_limit() {
     // Pattern 2: aggregate ORDER BY `DESC(COUNT(?favNum))` inside a subquery.

--- a/fluree-db-api/tests/it_transact.rs
+++ b/fluree-db-api/tests/it_transact.rs
@@ -571,8 +571,11 @@ async fn no_where_solutions() {
 
     let ledger1 = fluree.update(ledger0, &insert_txn).await.unwrap().ledger;
 
-    // Update with WHERE that matches nothing (no existing description)
-    // Should still insert the new description
+    // A required WHERE pattern that matches nothing yields zero solutions, so
+    // the INSERT does NOT fire — even though its template is all-literal. This
+    // is the compliant behavior (SPARQL 1.1 Update §3.1.3): zero solutions =
+    // no-op. To insert-if-absent, use OPTIONAL so WHERE still yields a row
+    // (see the insert-if-not-exists patterns in it_transact_conditional.rs).
     let update_txn = json!({
         "@context": {"ex": "http://example.org/ns/", "schema": "http://schema.org/"},
         "where": {"@id": "ex:andrew", "schema:description": "?o"},
@@ -598,7 +601,10 @@ async fn no_where_solutions() {
     let andrew = jsonld.as_object().unwrap();
     assert_eq!(andrew["@id"], "ex:andrew");
     assert_eq!(andrew["schema:name"], "Andrew");
-    assert_eq!(andrew["schema:description"], "He's great!");
+    assert!(
+        andrew.get("schema:description").is_none(),
+        "all-literal INSERT must not fire when the required WHERE matched nothing"
+    );
 }
 
 #[tokio::test]

--- a/fluree-db-api/tests/it_transact_conditional.rs
+++ b/fluree-db-api/tests/it_transact_conditional.rs
@@ -65,6 +65,35 @@ async fn query_entity(
         .expect("to_jsonld_async")
 }
 
+/// Helper: run a raw SPARQL UPDATE string through the parse → lower → stage
+/// pipeline (the same path the server's update endpoint uses).
+async fn run_sparql_update(
+    fluree: &fluree_db_api::Fluree,
+    ledger: LedgerState,
+    sparql: &str,
+) -> fluree_db_api::TransactResult {
+    let parsed = fluree_db_sparql::parse_sparql(sparql);
+    assert!(
+        !parsed.has_errors(),
+        "SPARQL parse errors: {:?}",
+        parsed.diagnostics
+    );
+    let ast = parsed.ast.expect("SPARQL AST");
+    let mut ns = fluree_db_transact::NamespaceRegistry::from_db(&ledger.snapshot);
+    let txn = fluree_db_transact::lower_sparql_update_ast(
+        &ast,
+        &mut ns,
+        fluree_db_transact::TxnOpts::default(),
+    )
+    .expect("lower SPARQL UPDATE to Txn IR");
+    fluree
+        .stage_owned(ledger)
+        .txn(txn)
+        .execute()
+        .await
+        .expect("stage SPARQL UPDATE")
+}
+
 // ============================================================================
 // 1. Atomic Increment / Decrement
 // ============================================================================
@@ -236,10 +265,10 @@ async fn compare_and_swap_stale_version_is_noop() {
 
     // Client has stale version=1, but current is 3. WHERE won't match → no-op.
     //
-    // Pattern: use a WHERE variable in the INSERT subject so that when WHERE
-    // returns 0 rows, the variable is unbound and the INSERT produces 0 flakes.
-    // All-literal INSERTs fire unconditionally (the "delete-if-exists, always
-    // insert" pattern), so CAS must use a variable to be conditional.
+    // INSERT templates fire once per WHERE solution; zero solutions = no-op
+    // (SPARQL 1.1 Update §3.1.3), so this is a no-op regardless of whether the
+    // INSERT uses variables. A WHERE variable in the subject is still good
+    // practice here so the asserted subject is the matched one.
     let result = fluree
         .update(
             ledger,
@@ -592,9 +621,9 @@ async fn insert_if_not_exists_noop_when_exists() {
     let t_before = ledger.t();
 
     // Try to insert ex:alice again — should be a no-op because she exists.
-    // Use BIND to create variables for the insert values so the INSERT is
-    // conditional on WHERE (FILTER) passing. All-literal INSERTs fire
-    // unconditionally, so conditional creates must use WHERE variables.
+    // OPTIONAL + FILTER yields one row when alice is absent (probe unbound) and
+    // zero rows when she exists; INSERT fires once per WHERE solution, so the
+    // existing-alice case produces zero solutions and inserts nothing.
     let result = fluree
         .update(
             ledger,
@@ -617,6 +646,136 @@ async fn insert_if_not_exists_noop_when_exists() {
         alice.get("schema:name"),
         Some(&json!("Alice")),
         "name unchanged"
+    );
+}
+
+/// Regression: an all-literal INSERT guarded by a *required* WHERE pattern that
+/// matches nothing must NOT fire. Per SPARQL 1.1 Update §3.1.3, zero WHERE
+/// solutions means zero template instantiations — there is no fallback that
+/// fires constant templates against a synthetic empty solution.
+#[tokio::test]
+async fn all_literal_insert_noop_when_required_where_matches_nothing() {
+    let (fluree, ledger) = seed(
+        "it/conditional:literal-required-where-empty",
+        json!([{ "id": "ex:alice", "schema:name": "Alice" }]),
+    )
+    .await;
+    let t_before = ledger.t();
+
+    // ex:alice has no schema:status, so the required pattern matches nothing.
+    // The INSERT is all-literal — it must still be skipped (zero solutions).
+    let result = fluree
+        .update(
+            ledger,
+            &json!({
+                "@context": ctx(),
+                "where": { "id": "ex:alice", "schema:status": "?status" },
+                "insert": { "id": "ex:config", "ex:lastChecked": "2026-06-14" }
+            }),
+        )
+        .await
+        .expect("update");
+
+    assert_eq!(result.ledger.t(), t_before, "t should not bump on no-op");
+    let config = query_entity(&fluree, &result.ledger, "ex:config").await;
+    assert!(
+        config.get("ex:lastChecked").is_none(),
+        "all-literal insert must not fire when the required WHERE matched nothing"
+    );
+}
+
+/// Regression: an all-literal INSERT guarded by a FILTER that eliminates every
+/// row must NOT fire — the FILTER collapses WHERE to zero solutions.
+#[tokio::test]
+async fn all_literal_insert_noop_when_filter_excludes_all() {
+    let (fluree, ledger) = seed(
+        "it/conditional:literal-filter-false",
+        json!([{ "id": "ex:alice", "schema:age": 30 }]),
+    )
+    .await;
+    let t_before = ledger.t();
+
+    let result = fluree
+        .update(
+            ledger,
+            &json!({
+                "@context": ctx(),
+                "where": [
+                    { "id": "ex:alice", "schema:age": "?age" },
+                    ["filter", "(> ?age 100)"]
+                ],
+                "insert": { "id": "ex:config", "ex:flag": true }
+            }),
+        )
+        .await
+        .expect("update");
+
+    assert_eq!(result.ledger.t(), t_before, "t should not bump on no-op");
+    let config = query_entity(&fluree, &result.ledger, "ex:config").await;
+    assert!(
+        config.get("ex:flag").is_none(),
+        "all-literal insert must not fire when FILTER eliminated every WHERE row"
+    );
+}
+
+/// Contrast: with NO WHERE clause at all, an all-literal INSERT still fires once
+/// (the plain insert path — the single implicit empty solution). This guards
+/// against over-broadening the §3.1.3 no-op into the no-WHERE case.
+#[tokio::test]
+async fn all_literal_insert_fires_when_no_where_clause() {
+    let (fluree, ledger) = seed(
+        "it/conditional:literal-no-where",
+        json!([{ "id": "ex:alice", "schema:name": "Alice" }]),
+    )
+    .await;
+
+    let result = fluree
+        .update(
+            ledger,
+            &json!({
+                "@context": ctx(),
+                "insert": { "id": "ex:config", "ex:flag": true }
+            }),
+        )
+        .await
+        .expect("update");
+
+    let config = query_entity(&fluree, &result.ledger, "ex:config").await;
+    assert_eq!(
+        config.get("ex:flag"),
+        Some(&json!(true)),
+        "all-literal insert with no WHERE must fire once"
+    );
+}
+
+/// Regression (SPARQL parity): `INSERT { <s> <p> <o> } WHERE { FILTER(false) }`
+/// must insert nothing. The fix lives in the shared staging layer, so SPARQL
+/// UPDATE and JSON-LD update behave identically (W3C SPARQL 1.1 Update §3.1.3).
+#[tokio::test]
+async fn sparql_all_literal_insert_noop_when_filter_false() {
+    let (fluree, ledger) = seed(
+        "it/conditional:sparql-filter-false",
+        json!([{ "id": "ex:alice", "schema:name": "Alice" }]),
+    )
+    .await;
+    let t_before = ledger.t();
+
+    let sparql = r#"
+        PREFIX ex: <http://example.org/ns/>
+        INSERT { ex:config ex:flag true }
+        WHERE { FILTER(false) }
+    "#;
+    let result = run_sparql_update(&fluree, ledger, sparql).await;
+
+    assert_eq!(
+        result.ledger.t(),
+        t_before,
+        "FILTER(false) yields zero solutions → no insert → t must not bump"
+    );
+    let config = query_entity(&fluree, &result.ledger, "ex:config").await;
+    assert!(
+        config.get("ex:flag").is_none(),
+        "SPARQL all-literal insert must not fire under FILTER(false)"
     );
 }
 

--- a/fluree-db-api/tests/it_transact_conditional.rs
+++ b/fluree-db-api/tests/it_transact_conditional.rs
@@ -760,11 +760,11 @@ async fn sparql_all_literal_insert_noop_when_filter_false() {
     .await;
     let t_before = ledger.t();
 
-    let sparql = r#"
+    let sparql = r"
         PREFIX ex: <http://example.org/ns/>
         INSERT { ex:config ex:flag true }
         WHERE { FILTER(false) }
-    "#;
+    ";
     let result = run_sparql_update(&fluree, ledger, sparql).await;
 
     assert_eq!(

--- a/fluree-db-query/src/graph.rs
+++ b/fluree-db-query/src/graph.rs
@@ -299,6 +299,10 @@ impl GraphOperator {
             return Ok(None);
         }
 
+        // Number of rows about to be drained — needed to size an empty-schema
+        // batch, where there are no columns to infer the row count from.
+        let drained = self.result_buffer.len() - self.buffer_pos;
+
         // Build batch from buffer
         let num_cols = self.schema.len();
         let mut columns: Vec<Vec<Binding>> = (0..num_cols).map(|_| Vec::new()).collect();
@@ -313,7 +317,16 @@ impl GraphOperator {
 
         self.buffer_pos = self.result_buffer.len();
 
-        if columns.is_empty() || columns[0].is_empty() {
+        // A ground GRAPH body (e.g. `GRAPH <g> { :a :p "1" }`) produces no
+        // variables, so the schema is empty. Each matched row is still one
+        // empty-binding solution and must be preserved — emit an empty-schema
+        // batch carrying the row count rather than collapsing to zero rows
+        // (which would wrongly turn a satisfied existence check into a no-match).
+        if num_cols == 0 {
+            return Ok(Some(Batch::empty_schema_with_len(drained)));
+        }
+
+        if columns[0].is_empty() {
             Ok(None)
         } else {
             Ok(Some(Batch::new(self.schema.clone(), columns)?))

--- a/fluree-db-query/src/service.rs
+++ b/fluree-db-query/src/service.rs
@@ -352,6 +352,10 @@ impl ServiceOperator {
             return Ok(None);
         }
 
+        // Number of rows about to be drained — needed to size an empty-schema
+        // batch, where there are no columns to infer the row count from.
+        let drained = self.result_buffer.len() - self.buffer_pos;
+
         let num_cols = self.schema.len();
         let mut columns: Vec<Vec<Binding>> = (0..num_cols).map(|_| Vec::new()).collect();
 
@@ -365,7 +369,14 @@ impl ServiceOperator {
 
         self.buffer_pos = self.result_buffer.len();
 
-        if columns.is_empty() || columns[0].is_empty() {
+        // A variable-free SERVICE body produces an empty schema; a match is
+        // still one empty-binding solution per row. Emit an empty-schema batch
+        // with the row count rather than collapsing to zero rows.
+        if num_cols == 0 {
+            return Ok(Some(Batch::empty_schema_with_len(drained)));
+        }
+
+        if columns[0].is_empty() {
             Ok(None)
         } else {
             Ok(Some(Batch::new(self.schema.clone(), columns)?))

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -407,6 +407,10 @@ impl SubqueryOperator {
             return Ok(None);
         }
 
+        // Number of rows about to be drained — needed to size an empty-schema
+        // batch, where there are no columns to infer the row count from.
+        let drained = self.result_buffer.len() - self.buffer_pos;
+
         // Build batch from buffer
         let num_cols = self.in_schema.len();
         let mut columns: Vec<Vec<Binding>> = (0..num_cols).map(|_| Vec::new()).collect();
@@ -421,7 +425,16 @@ impl SubqueryOperator {
 
         self.buffer_pos = self.result_buffer.len();
 
-        if columns.is_empty() || columns[0].is_empty() {
+        // A variable-free subquery (e.g. `{ SELECT * WHERE { :a :p "1" } }`)
+        // produces an empty schema; a match is still one empty-binding solution
+        // per row. Emit an empty-schema batch with the row count rather than
+        // collapsing to zero rows (out_schema is also empty here, so there is
+        // nothing to trim).
+        if num_cols == 0 {
+            return Ok(Some(Batch::empty_schema_with_len(drained)));
+        }
+
+        if columns[0].is_empty() {
             Ok(None)
         } else {
             let batch = Batch::new(self.in_schema.clone(), columns)?;

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -205,12 +205,6 @@ pub async fn stage(
         let new_t = ledger.t() + 1;
         tracing::debug!(new_t = new_t, "computed new transaction t");
 
-        // Track whether this transaction has an explicit WHERE clause, before
-        // execute_where consumes the patterns. Needed to distinguish "WHERE that
-        // matched nothing" (→ no-op) from "no WHERE at all" (→ fire templates once).
-        let has_where_clause =
-            !txn.where_patterns.is_empty() || txn.values.is_some() || txn.sparql_where.is_some();
-
         // Pure-DELETE fast path: no INSERT templates and not an Upsert. Skips
         // assertion generation and the assertion/retraction cancellation hashmap;
         // a sort-and-dedup pass over retractions is sufficient since all
@@ -294,31 +288,14 @@ pub async fn stage(
         .instrument(where_span)
         .await?;
 
-        // Per SPARQL 1.1 Update spec (§3.1.3): INSERT/DELETE templates are
-        // instantiated once per solution row from WHERE. Zero solutions = zero
-        // instantiations *except* for all-literal INSERT templates, which
-        // must still fire once against a single empty solution (supports the
-        // common "delete-if-exists, always insert" pattern).
-        //
-        // The signal must be "total emitted rows == 0", not "cursor yielded
-        // any batch". Operators like VALUES, geo/vector search, and some
-        // join/optional shapes legitimately emit `Some(empty_batch)` to
-        // represent a zero-row result while still signalling completion —
-        // the old eager path detected this via `bindings.is_empty()` on the
-        // merged batch. Using `saw_any_batch` would flip that semantic and
-        // suppress the post-loop fallback for valid zero-row cases.
-        //
-        // has_where_clause gates the fallback so the no-WHERE case (where
-        // the SingleEmpty cursor emits an empty-schema-empty batch that
-        // already fires all-literal templates once via the in-loop path)
-        // doesn't double-fire.
-        let where_returned_no_rows = has_where_clause && stream_stats.total_binding_rows == 0;
-        if where_returned_no_rows && !pure_delete {
-            let empty_solution = Batch::single_empty();
-            let assertions =
-                generator.generate_assertions(&txn.insert_templates, &empty_solution)?;
-            acc.push_assertions(assertions);
-        }
+        // Per SPARQL 1.1 Update §3.1.3: INSERT/DELETE templates are instantiated
+        // once per WHERE solution, so a WHERE that matches zero solutions is a
+        // no-op. The no-WHERE case (no patterns, no VALUES) is handled inside
+        // `stream_where_into_accumulator`: the cursor's SingleEmpty variant emits
+        // one empty-schema-empty batch, which generators interpret as a single
+        // empty solution, firing all-literal templates exactly once. A present
+        // WHERE that yields no rows therefore correctly inserts nothing — we do
+        // NOT fall back to a synthetic empty solution here.
 
         // Upsert second wave: retractions derived from direct ledger lookups
         // (not WHERE). These flakes already carry correct `m` from the
@@ -673,14 +650,8 @@ fn collect_template_vars(template_groups: &[&[TripleTemplate]]) -> Vec<VarId> {
 
 /// Stats collected while streaming the WHERE result into the accumulator.
 ///
-/// - `total_binding_rows` is the sum of row counts across all batches. The
-///   caller uses this (combined with `has_where_clause`) to decide whether
-///   all-literal INSERT templates should fire once post-loop against
-///   `Batch::single_empty()`. Using the emitted-row total rather than
-///   "any batch arrived" is important: operators like VALUES, geo/vector
-///   search, and some join/optional shapes legitimately emit an empty
-///   batch to signal a zero-row result, and those cases must be treated
-///   as "WHERE matched nothing" for fallback purposes.
+/// - `total_binding_rows` is the sum of row counts across all batches, recorded
+///   on the `where_exec` span for tracing.
 /// - `retraction_count` / `assertion_count` are the pre-dedup totals pushed
 ///   into the accumulator (for tracing).
 struct WhereStreamStats {


### PR DESCRIPTION
## Summary

INSERT/DELETE templates must instantiate **once per WHERE solution** (SPARQL 1.1 Update §3.1.3), so a *present* WHERE that matches zero rows is a no-op. The shared staging layer previously had a fallback that fired **all-literal** INSERT templates (constants only, no WHERE-bound vars) against a synthetic empty solution when WHERE returned zero rows — so e.g. `INSERT { <s> <p> <o> } WHERE { FILTER(false) }` wrongly inserted.

This removes the fallback in the shared staging path, so **SPARQL UPDATE and JSON-LD update now behave identically and per-spec**. A required pattern (or `FILTER`) that collapses to zero solutions inserts nothing.

## Why remove it for both surfaces (no opt-in flag)

The fallback lives in the single shared `stage.rs` path consumed by both SPARQL and JSON-LD. The one idiom that looked like it depended on it — "delete-if-exists, always insert" — actually rides on `OPTIONAL` producing **one** row (probe var unbound), not zero, so it is unaffected. No scenario was found where firing on an empty guard is the desirable outcome, and keeping behavior consistent between the two surfaces is the goal.

## Unaffected paths

- **No WHERE clause at all** — the `SingleEmpty` cursor still emits one empty solution, firing all-literal templates exactly once (plain insert).
- **INSERT DATA / DELETE DATA** — separate path.
- **OPTIONAL-based insert-if-not-exists / always-insert** — yields one row, still fires correctly.

## Changes

- `fluree-db-transact/src/stage.rs` — remove the zero-row all-literal fallback and the now-unused `has_where_clause`; update surrounding comments.
- `docs/transactions/conditional-updates.md` — rewrite the "Two INSERT behaviors" section that documented the old behavior.
- `fluree-db-api/tests/it_transact_conditional.rs` — fix two stale comments; add regression tests for required-pattern no-op, FILTER-excludes-all no-op, no-WHERE-still-fires, and SPARQL `FILTER(false)` parity.

## Testing

- `fluree-db-transact`: 197/197 pass.
- API transact + sparql + named-graph sweep: 265/265 pass.
- Clippy clean on the changed crate; `cargo fmt --all` applied.

> Base is `fix/docker-cli-aws-support` (the AWS CLI/server branch, PR #1334) since this stacks on it.