### PR TITLE
feat(server): query freshness for disconnected query servers (TTL refresh + read-after-write min-t)

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -901,13 +901,17 @@ The `GET` form is provided for W3C SPARQL Protocol compliance. It accepts SPARQL
 ```http
 Content-Type: application/json
 Accept: application/json
+Fluree-Min-T: 42  # optional read-after-write guarantee
 ```
 
 Or for SPARQL:
 ```http
 Content-Type: application/sparql-query
 Accept: application/sparql-results+json
+Fluree-Min-T: 42  # optional read-after-write guarantee
 ```
+
+`Fluree-Min-T` makes the server refresh the referenced ledger(s) until they have reached at least that transaction time before executing the query. JSON-LD bodies can also send `opts.min-t`, `opts.min_t`, or `opts.minT`; body opts take precedence over the header.
 
 **Request Body (JSON-LD Query):**
 

--- a/docs/api/headers.md
+++ b/docs/api/headers.md
@@ -193,6 +193,8 @@ Before executing the request, the server refreshes the referenced ledger(s) unti
 
 Numeric time-travel snapshots such as `from: "ledger:main@t:42"` also wait until that `t` is visible, then query that pinned snapshot. `Fluree-Min-T` is useful when the query itself reads current HEAD but must not run until a known transaction has arrived.
 
+The header must resolve to at least one target ledger. On a ledger-scoped endpoint the endpoint's ledger is used; on the connection-scoped query endpoint the target comes from the query's `FROM` clause. Sending `Fluree-Min-T` to the connection-scoped endpoint with no `FROM` (and no other resolvable ledger) is rejected with `400 Bad Request` rather than silently ignored.
+
 ## Response Headers
 
 ### Content-Type

--- a/docs/api/headers.md
+++ b/docs/api/headers.md
@@ -181,6 +181,18 @@ X-Request-ID: abc-123-def-456
 
 The server will include this in logs and response headers for correlation. When a request queues background indexing work, the copied `X-Request-ID` also appears on the background indexer worker logs so you can connect the foreground request and later indexing activity in plain log search.
 
+### Fluree-Min-T
+
+Request a hard read-after-write guarantee for query and explain endpoints:
+
+```http
+Fluree-Min-T: 42
+```
+
+Before executing the request, the server refreshes the referenced ledger(s) until each has reached at least the requested transaction time. If the target `t` is not visible before `query_min_t_timeout_ms`, the server returns a read-after-write timeout error. JSON-LD query bodies may also specify the same requirement as `opts.min-t`, `opts.min_t`, or `opts.minT`; body opts take precedence over the header for that query body.
+
+Numeric time-travel snapshots such as `from: "ledger:main@t:42"` also wait until that `t` is visible, then query that pinned snapshot. `Fluree-Min-T` is useful when the query itself reads current HEAD but must not run until a known transaction has arrived.
+
 ## Response Headers
 
 ### Content-Type

--- a/docs/api/multi-query.md
+++ b/docs/api/multi-query.md
@@ -118,7 +118,8 @@ Opts come from three layers, merged shallowly with **the most specific layer win
 
 This precedence is security-relevant. The HTTP server's bearer/identity gate runs against the **pre-merged** opts and writes its decision into the body layer (layer 3), where the dispatcher's merge then makes it the final word. Inverting the order would let an envelope-level or sub-query-level `opts.identity` clobber the gate's decision.
 
-- Per-sub-query overrides recognised at any layer: `meta`, `policy`, `policy-class`, `policy-values`, `identity`, `default-allow`, `timeoutMs`, `max-fuel`.
+- Per-sub-query overrides recognised at any layer: `meta`, `policy`, `policy-class`, `policy-values`, `identity`, `default-allow`, `timeoutMs`, `max-fuel`, `min-t` / `minT`.
+- `opts.min-t` / `opts.minT` requests read-after-write freshness before the envelope snapshot is resolved. Envelope-level values apply to every referenced ledger; sub-query values apply to that sub-query's ledger(s). The `Fluree-Min-T` header provides the same guarantee as an envelope default.
 - `opts.t` is **rejected at every layer** inside a multi-query envelope (envelope opts, sub-query opts, AND body opts). Pin time via `from` (per sub-query) or envelope `asOf`.
 - Envelope-level `opts.max-fuel` is rejected up-front (see [Limitations](#limitations)); per-sub-query `opts.max-fuel` (in either layer 2 or layer 3) is honoured.
 

--- a/docs/concepts/time-travel.md
+++ b/docs/concepts/time-travel.md
@@ -220,7 +220,9 @@ Reader Lambda:
 
 **HTTP API:**
 
-The HTTP query endpoint does not yet expose `min_t` directly. For HTTP clients, use the SSE events endpoint (`GET /v1/fluree/events`) to receive real-time commit notifications, or poll the ledger info endpoint until the desired `t` is reached.
+The HTTP query endpoint does not yet expose `min_t` directly. For HTTP clients that need a hard read-after-write guarantee for a specific transaction, use the SSE events endpoint (`GET /v1/fluree/events`) to receive real-time commit notifications, or poll the ledger info endpoint until the desired `t` is reached.
+
+Long-running HTTP query servers can also enable TTL-gated query-time refresh with `--query-refresh-enabled` and `--query-refresh-ttl-ms`. This makes the server call `refresh()` on demand before current-head queries, after that ledger's TTL window expires, so warm caches observe nameservice advances without checking DynamoDB on every request. The first query in a new TTL window pays the nameservice round-trip; idle ledgers are not refreshed. The TTL bounds ordinary staleness, but it is not a substitute for `min_t` when a client must prove it has observed a specific transaction.
 
 ### Rust API
 

--- a/docs/concepts/time-travel.md
+++ b/docs/concepts/time-travel.md
@@ -220,9 +220,17 @@ Reader Lambda:
 
 **HTTP API:**
 
-The HTTP query endpoint does not yet expose `min_t` directly. For HTTP clients that need a hard read-after-write guarantee for a specific transaction, use the SSE events endpoint (`GET /v1/fluree/events`) to receive real-time commit notifications, or poll the ledger info endpoint until the desired `t` is reached.
+HTTP query clients can request the same read-after-write guarantee by sending the transaction time in the `fluree-min-t` header. The server refreshes the target ledger(s) until each reaches at least that `t`, or until the min-t wait timeout expires:
 
-Long-running HTTP query servers can also enable TTL-gated query-time refresh with `--query-refresh-enabled` and `--query-refresh-ttl-ms`. This makes the server call `refresh()` on demand before current-head queries, after that ledger's TTL window expires, so warm caches observe nameservice advances without checking DynamoDB on every request. The first query in a new TTL window pays the nameservice round-trip; idle ledgers are not refreshed. The TTL bounds ordinary staleness, but it is not a substitute for `min_t` when a client must prove it has observed a specific transaction.
+```http
+fluree-min-t: 42
+```
+
+JSON-LD query bodies may also use `opts.min-t` (or `opts.minT`) for the same request-level guarantee. Numeric query snapshot pins like `from: "ledger:main@t:42"` or `from: {"@id": "ledger:main", "t": 42}` also force the server to observe at least that `t` before executing, then read that pinned snapshot. ISO and commit pins still resolve through normal snapshot resolution.
+
+The wait is capped by `query_min_t_timeout_ms` (default 5 seconds), even if the general query execution timeout is disabled.
+
+Long-running HTTP query servers can also enable TTL-gated query-time refresh with `--query-refresh-enabled` and `--query-refresh-ttl-ms`. This makes the server call `refresh()` on demand before current-head queries, after that ledger's TTL window expires, so warm caches observe nameservice advances without checking DynamoDB on every request. The first query in a new TTL window pays the nameservice round-trip; idle ledgers are not refreshed. The TTL bounds ordinary staleness, but callers that must prove they observed a specific transaction should use `fluree-min-t` or `opts.min-t`.
 
 ### Rust API
 

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -38,6 +38,7 @@ listen_addr = "0.0.0.0:8090"
 storage_path = "/var/lib/fluree"
 log_level = "info"
 query_timeout_ms = 900000  # 15 minutes; set to 0 to disable
+query_min_t_timeout_ms = 5000
 # cache_max_mb = 4096  # global cache budget (MB); default: tiered by RAM (<4GB: 30%, 4-8GB: 40%, >=8GB: 35%)
 
 [server.query_refresh]
@@ -315,6 +316,9 @@ operators can stop at the next checkpoint.
 | Flag                 | Env Var                    | Default                  |
 | -------------------- | -------------------------- | ------------------------ |
 | `--query-timeout-ms` | `FLUREE_QUERY_TIMEOUT_MS`  | `900000` (15 minutes)    |
+| `--query-min-t-timeout-ms` | `FLUREE_QUERY_MIN_T_TIMEOUT_MS` | `5000` (5 seconds) |
+
+`query_min_t_timeout_ms` caps HTTP read-after-write waits from `Fluree-Min-T`, `opts.min-t`, and numeric `@t` snapshot pins. It remains enforced even when `query_timeout_ms = 0`.
 
 ### Query-Time Refresh
 
@@ -323,6 +327,8 @@ Long-running query servers can opt in to a bounded nameservice freshness check b
 This is demand-driven, not a background poller: the first current-head query for a ledger after its TTL window expires pays the nameservice round-trip, and idle ledgers are not refreshed.
 
 This is useful for split deployments where writers update a shared DynamoDB nameservice but query servers do not subscribe to a transaction server's SSE event stream.
+
+For a hard read-after-write guarantee when the client knows the transaction `t`, send `Fluree-Min-T` (or JSON-LD `opts.min-t`) on the query request. TTL refresh bounds ordinary staleness; `min-t` waits for a specific transaction time.
 
 | Flag | Env Var | Default | Description |
 | ---- | ------- | ------- | ----------- |
@@ -815,6 +821,7 @@ fluree server run \
 | `FLUREE_CACHE_MAX_MB`                   | Global cache budget (MB)                        | Tiered by RAM: `<4GB: 30%, 4-8GB: 40%, >=8GB: 35%`                                                     |
 | `FLUREE_BODY_LIMIT`                     | Max request body bytes                          | `52428800`                                                              |
 | `FLUREE_QUERY_TIMEOUT_MS`               | Max query execution time in milliseconds (`0` disables) | `900000`                                                     |
+| `FLUREE_QUERY_MIN_T_TIMEOUT_MS`         | Max read-after-write min-t wait in milliseconds | `5000`                                                                  |
 | `FLUREE_QUERY_REFRESH_ENABLED`          | Enable TTL-gated nameservice refresh before current-head queries | `false`                                                       |
 | `FLUREE_QUERY_REFRESH_TTL_MS`           | Query-time refresh interval per ledger per process (`0` checks every request) | `1000`                                           |
 | `FLUREE_LOG_LEVEL`                      | Log level                                       | `info`                                                                  |

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -40,6 +40,10 @@ log_level = "info"
 query_timeout_ms = 900000  # 15 minutes; set to 0 to disable
 # cache_max_mb = 4096  # global cache budget (MB); default: tiered by RAM (<4GB: 30%, 4-8GB: 40%, >=8GB: 35%)
 
+[server.query_refresh]
+enabled = false
+ttl_ms = 1000
+
 [server.indexing]
 enabled = true
 reindex_min_bytes = 100000
@@ -311,6 +315,27 @@ operators can stop at the next checkpoint.
 | Flag                 | Env Var                    | Default                  |
 | -------------------- | -------------------------- | ------------------------ |
 | `--query-timeout-ms` | `FLUREE_QUERY_TIMEOUT_MS`  | `900000` (15 minutes)    |
+
+### Query-Time Refresh
+
+Long-running query servers can opt in to a bounded nameservice freshness check before current-head queries. When enabled, the server calls the same `Fluree::refresh()` API used by serverless query handlers, but gates the call by a per-process, per-ledger TTL so high-QPS traffic does not check DynamoDB on every request.
+
+This is demand-driven, not a background poller: the first current-head query for a ledger after its TTL window expires pays the nameservice round-trip, and idle ledgers are not refreshed.
+
+This is useful for split deployments where writers update a shared DynamoDB nameservice but query servers do not subscribe to a transaction server's SSE event stream.
+
+| Flag | Env Var | Default | Description |
+| ---- | ------- | ------- | ----------- |
+| `--query-refresh-enabled` | `FLUREE_QUERY_REFRESH_ENABLED` | `false` | Enable TTL-gated nameservice refresh before current-head query execution |
+| `--query-refresh-ttl-ms` | `FLUREE_QUERY_REFRESH_TTL_MS` | `1000` | Minimum interval between refresh checks for the same ledger in one server process; set `0` to check every request |
+
+Config file equivalent:
+
+```toml
+[server.query_refresh]
+enabled = true
+ttl_ms = 200
+```
 
 ### Log Level
 
@@ -790,6 +815,8 @@ fluree server run \
 | `FLUREE_CACHE_MAX_MB`                   | Global cache budget (MB)                        | Tiered by RAM: `<4GB: 30%, 4-8GB: 40%, >=8GB: 35%`                                                     |
 | `FLUREE_BODY_LIMIT`                     | Max request body bytes                          | `52428800`                                                              |
 | `FLUREE_QUERY_TIMEOUT_MS`               | Max query execution time in milliseconds (`0` disables) | `900000`                                                     |
+| `FLUREE_QUERY_REFRESH_ENABLED`          | Enable TTL-gated nameservice refresh before current-head queries | `false`                                                       |
+| `FLUREE_QUERY_REFRESH_TTL_MS`           | Query-time refresh interval per ledger per process (`0` checks every request) | `1000`                                           |
 | `FLUREE_LOG_LEVEL`                      | Log level                                       | `info`                                                                  |
 | `FLUREE_SERVER_ROLE`                    | Server role                                     | `transaction`                                                           |
 | `FLUREE_TX_SERVER_URL`                  | Transaction server URL                          | None                                                                    |

--- a/fluree-db-api/src/server_defaults.rs
+++ b/fluree-db-api/src/server_defaults.rs
@@ -15,6 +15,8 @@ pub const DEFAULT_LOG_LEVEL: &str = "info";
 pub const DEFAULT_CORS_ENABLED: bool = true;
 pub const DEFAULT_BODY_LIMIT: usize = 52_428_800; // 50 MB
 pub const DEFAULT_QUERY_TIMEOUT_MS: u64 = 15 * 60 * 1000; // 15 minutes
+pub const DEFAULT_QUERY_REFRESH_ENABLED: bool = false;
+pub const DEFAULT_QUERY_REFRESH_TTL_MS: u64 = 1000;
 
 // ── Indexing ────────────────────────────────────────────────────────
 
@@ -361,6 +363,10 @@ pub fn generate_config_template(storage_path_override: Option<&str>) -> String {
 # query_timeout_ms = {query_timeout_ms}  # 15 minutes; set 0 to disable
 # cache_max_mb = 4096                    # global cache budget (MB); default: tiered by RAM (<4GB: 30%, 4-8GB: 40%, >=8GB: 35%)
 
+# [server.query_refresh]
+# enabled = {query_refresh_enabled}            # opt-in nameservice refresh before current-head queries
+# ttl_ms = {query_refresh_ttl_ms}              # minimum interval between refresh checks per ledger per process
+
 # [server.indexing]
 # enabled = {indexing_enabled}                    # disable only when a separate peer/indexer owns indexing for this storage
 # reindex_min_bytes = {reindex_min_bytes}         # {reindex_min_kb} KB — triggers background reindexing
@@ -438,6 +444,8 @@ pub fn generate_config_template(storage_path_override: Option<&str>) -> String {
         cors_enabled = DEFAULT_CORS_ENABLED,
         body_limit = DEFAULT_BODY_LIMIT,
         query_timeout_ms = DEFAULT_QUERY_TIMEOUT_MS,
+        query_refresh_enabled = DEFAULT_QUERY_REFRESH_ENABLED,
+        query_refresh_ttl_ms = DEFAULT_QUERY_REFRESH_TTL_MS,
         indexing_enabled = DEFAULT_INDEXING_ENABLED,
         reindex_min_bytes = DEFAULT_REINDEX_MIN_BYTES,
         reindex_min_kb = DEFAULT_REINDEX_MIN_BYTES / 1000,
@@ -476,6 +484,10 @@ pub fn generate_jsonld_config_template(storage_path_override: Option<&str>) -> S
             "cors_enabled": DEFAULT_CORS_ENABLED,
             "body_limit": DEFAULT_BODY_LIMIT,
             "query_timeout_ms": DEFAULT_QUERY_TIMEOUT_MS,
+            "query_refresh": {
+                "enabled": DEFAULT_QUERY_REFRESH_ENABLED,
+                "ttl_ms": DEFAULT_QUERY_REFRESH_TTL_MS
+            },
             "indexing": {
                 "enabled": DEFAULT_INDEXING_ENABLED,
                 "reindex_min_bytes": DEFAULT_REINDEX_MIN_BYTES,

--- a/fluree-db-api/src/server_defaults.rs
+++ b/fluree-db-api/src/server_defaults.rs
@@ -15,6 +15,7 @@ pub const DEFAULT_LOG_LEVEL: &str = "info";
 pub const DEFAULT_CORS_ENABLED: bool = true;
 pub const DEFAULT_BODY_LIMIT: usize = 52_428_800; // 50 MB
 pub const DEFAULT_QUERY_TIMEOUT_MS: u64 = 15 * 60 * 1000; // 15 minutes
+pub const DEFAULT_QUERY_MIN_T_TIMEOUT_MS: u64 = 5_000; // 5 seconds
 pub const DEFAULT_QUERY_REFRESH_ENABLED: bool = false;
 pub const DEFAULT_QUERY_REFRESH_TTL_MS: u64 = 1000;
 
@@ -361,6 +362,7 @@ pub fn generate_config_template(storage_path_override: Option<&str>) -> String {
 # cors_enabled = {cors_enabled}
 # body_limit = {body_limit}              # 50 MB
 # query_timeout_ms = {query_timeout_ms}  # 15 minutes; set 0 to disable
+# query_min_t_timeout_ms = {query_min_t_timeout_ms}  # read-after-write min-t wait cap
 # cache_max_mb = 4096                    # global cache budget (MB); default: tiered by RAM (<4GB: 30%, 4-8GB: 40%, >=8GB: 35%)
 
 # [server.query_refresh]
@@ -444,6 +446,7 @@ pub fn generate_config_template(storage_path_override: Option<&str>) -> String {
         cors_enabled = DEFAULT_CORS_ENABLED,
         body_limit = DEFAULT_BODY_LIMIT,
         query_timeout_ms = DEFAULT_QUERY_TIMEOUT_MS,
+        query_min_t_timeout_ms = DEFAULT_QUERY_MIN_T_TIMEOUT_MS,
         query_refresh_enabled = DEFAULT_QUERY_REFRESH_ENABLED,
         query_refresh_ttl_ms = DEFAULT_QUERY_REFRESH_TTL_MS,
         indexing_enabled = DEFAULT_INDEXING_ENABLED,
@@ -484,6 +487,7 @@ pub fn generate_jsonld_config_template(storage_path_override: Option<&str>) -> S
             "cors_enabled": DEFAULT_CORS_ENABLED,
             "body_limit": DEFAULT_BODY_LIMIT,
             "query_timeout_ms": DEFAULT_QUERY_TIMEOUT_MS,
+            "query_min_t_timeout_ms": DEFAULT_QUERY_MIN_T_TIMEOUT_MS,
             "query_refresh": {
                 "enabled": DEFAULT_QUERY_REFRESH_ENABLED,
                 "ttl_ms": DEFAULT_QUERY_REFRESH_TTL_MS

--- a/fluree-db-server/src/config.rs
+++ b/fluree-db-server/src/config.rs
@@ -434,6 +434,14 @@ pub struct ServerConfig {
     #[arg(long, env = "FLUREE_QUERY_TIMEOUT_MS", default_value_t = server_defaults::DEFAULT_QUERY_TIMEOUT_MS)]
     pub query_timeout_ms: u64,
 
+    /// Enable query-time nameservice refresh checks before current-head reads.
+    #[arg(long, env = "FLUREE_QUERY_REFRESH_ENABLED", default_value_t = server_defaults::DEFAULT_QUERY_REFRESH_ENABLED)]
+    pub query_refresh_enabled: bool,
+
+    /// Minimum milliseconds between query-time refresh checks per ledger per server process.
+    #[arg(long, env = "FLUREE_QUERY_REFRESH_TTL_MS", default_value_t = server_defaults::DEFAULT_QUERY_REFRESH_TTL_MS)]
+    pub query_refresh_ttl_ms: u64,
+
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, env = "FLUREE_LOG_LEVEL", default_value = server_defaults::DEFAULT_LOG_LEVEL)]
     pub log_level: String,
@@ -679,6 +687,8 @@ impl Default for ServerConfig {
             cache_max_mb: None,
             body_limit: server_defaults::DEFAULT_BODY_LIMIT,
             query_timeout_ms: server_defaults::DEFAULT_QUERY_TIMEOUT_MS,
+            query_refresh_enabled: server_defaults::DEFAULT_QUERY_REFRESH_ENABLED,
+            query_refresh_ttl_ms: server_defaults::DEFAULT_QUERY_REFRESH_TTL_MS,
             log_level: server_defaults::DEFAULT_LOG_LEVEL.to_string(),
             events_auth_mode: EventsAuthMode::None,
             events_auth_audience: None,

--- a/fluree-db-server/src/config.rs
+++ b/fluree-db-server/src/config.rs
@@ -434,6 +434,10 @@ pub struct ServerConfig {
     #[arg(long, env = "FLUREE_QUERY_TIMEOUT_MS", default_value_t = server_defaults::DEFAULT_QUERY_TIMEOUT_MS)]
     pub query_timeout_ms: u64,
 
+    /// Maximum time to wait for HTTP read-after-write min-t freshness checks.
+    #[arg(long, env = "FLUREE_QUERY_MIN_T_TIMEOUT_MS", default_value_t = server_defaults::DEFAULT_QUERY_MIN_T_TIMEOUT_MS)]
+    pub query_min_t_timeout_ms: u64,
+
     /// Enable query-time nameservice refresh checks before current-head reads.
     #[arg(long, env = "FLUREE_QUERY_REFRESH_ENABLED", default_value_t = server_defaults::DEFAULT_QUERY_REFRESH_ENABLED)]
     pub query_refresh_enabled: bool,
@@ -687,6 +691,7 @@ impl Default for ServerConfig {
             cache_max_mb: None,
             body_limit: server_defaults::DEFAULT_BODY_LIMIT,
             query_timeout_ms: server_defaults::DEFAULT_QUERY_TIMEOUT_MS,
+            query_min_t_timeout_ms: server_defaults::DEFAULT_QUERY_MIN_T_TIMEOUT_MS,
             query_refresh_enabled: server_defaults::DEFAULT_QUERY_REFRESH_ENABLED,
             query_refresh_ttl_ms: server_defaults::DEFAULT_QUERY_REFRESH_TTL_MS,
             log_level: server_defaults::DEFAULT_LOG_LEVEL.to_string(),

--- a/fluree-db-server/src/config_file.rs
+++ b/fluree-db-server/src/config_file.rs
@@ -62,6 +62,7 @@ pub struct ServerFileConfig {
     pub cors_enabled: Option<bool>,
     pub body_limit: Option<usize>,
     pub query_timeout_ms: Option<u64>,
+    pub query_min_t_timeout_ms: Option<u64>,
     pub cache_max_mb: Option<usize>,
 
     /// `[server.query_refresh]`
@@ -387,6 +388,7 @@ pub const CONFIG_FILE_ARG_IDS: &[&str] = &[
     "cors_enabled",
     "body_limit",
     "query_timeout_ms",
+    "query_min_t_timeout_ms",
     "query_refresh_enabled",
     "query_refresh_ttl_ms",
     "cache_max_mb",
@@ -496,6 +498,11 @@ pub fn apply_to_server_config(
     if is_default("query_timeout_ms") {
         if let Some(v) = file.query_timeout_ms {
             config.query_timeout_ms = v;
+        }
+    }
+    if is_default("query_min_t_timeout_ms") {
+        if let Some(v) = file.query_min_t_timeout_ms {
+            config.query_min_t_timeout_ms = v;
         }
     }
     if is_default("cache_max_mb") {
@@ -916,6 +923,7 @@ listen_addr = "127.0.0.1:9090"
 storage_path = "/var/lib/fluree"
 log_level = "debug"
 cors_enabled = false
+query_min_t_timeout_ms = 5000
 cache_max_mb = 5000
 
 [server.query_refresh]
@@ -942,6 +950,7 @@ default_policy_class = "ex:DefaultPolicy"
         assert_eq!(server.storage_path.as_deref(), Some("/var/lib/fluree"));
         assert_eq!(server.log_level.as_deref(), Some("debug"));
         assert_eq!(server.cors_enabled, Some(false));
+        assert_eq!(server.query_min_t_timeout_ms, Some(5000));
         assert_eq!(server.cache_max_mb, Some(5000));
 
         let refresh = server.query_refresh.unwrap();

--- a/fluree-db-server/src/config_file.rs
+++ b/fluree-db-server/src/config_file.rs
@@ -64,6 +64,10 @@ pub struct ServerFileConfig {
     pub query_timeout_ms: Option<u64>,
     pub cache_max_mb: Option<usize>,
 
+    /// `[server.query_refresh]`
+    #[serde(default)]
+    pub query_refresh: Option<QueryRefreshFileConfig>,
+
     /// `[server.indexing]`
     #[serde(default)]
     pub indexing: Option<IndexingFileConfig>,
@@ -90,6 +94,12 @@ pub struct IndexingFileConfig {
     pub enabled: Option<bool>,
     pub reindex_min_bytes: Option<usize>,
     pub reindex_max_bytes: Option<usize>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct QueryRefreshFileConfig {
+    pub enabled: Option<bool>,
+    pub ttl_ms: Option<u64>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
@@ -377,6 +387,8 @@ pub const CONFIG_FILE_ARG_IDS: &[&str] = &[
     "cors_enabled",
     "body_limit",
     "query_timeout_ms",
+    "query_refresh_enabled",
+    "query_refresh_ttl_ms",
     "cache_max_mb",
     "indexing_enabled",
     "reindex_min_bytes",
@@ -489,6 +501,20 @@ pub fn apply_to_server_config(
     if is_default("cache_max_mb") {
         if let Some(v) = file.cache_max_mb {
             config.cache_max_mb = Some(v);
+        }
+    }
+
+    // --- Query-time refresh ---
+    if let Some(ref refresh) = file.query_refresh {
+        if is_default("query_refresh_enabled") {
+            if let Some(v) = refresh.enabled {
+                config.query_refresh_enabled = v;
+            }
+        }
+        if is_default("query_refresh_ttl_ms") {
+            if let Some(v) = refresh.ttl_ms {
+                config.query_refresh_ttl_ms = v;
+            }
         }
     }
 
@@ -892,6 +918,10 @@ log_level = "debug"
 cors_enabled = false
 cache_max_mb = 5000
 
+[server.query_refresh]
+enabled = true
+ttl_ms = 200
+
 [server.indexing]
 enabled = true
 reindex_min_bytes = 200000
@@ -913,6 +943,10 @@ default_policy_class = "ex:DefaultPolicy"
         assert_eq!(server.log_level.as_deref(), Some("debug"));
         assert_eq!(server.cors_enabled, Some(false));
         assert_eq!(server.cache_max_mb, Some(5000));
+
+        let refresh = server.query_refresh.unwrap();
+        assert_eq!(refresh.enabled, Some(true));
+        assert_eq!(refresh.ttl_ms, Some(200));
 
         let idx = server.indexing.unwrap();
         assert_eq!(idx.enabled, Some(true));

--- a/fluree-db-server/src/error.rs
+++ b/fluree-db-server/src/error.rs
@@ -96,6 +96,7 @@ impl ServerError {
             ServerError::Json(_) => errors::JSON_PARSE,
 
             // Query/Transaction errors
+            ServerError::Api(ApiError::AwaitTNotReached { .. }) => errors::READ_AFTER_WRITE_TIMEOUT,
             ServerError::Api(ApiError::Query(fluree_db_query::QueryError::Cancelled {
                 ..
             })) => errors::QUERY_CANCELLED,
@@ -186,6 +187,7 @@ impl ServerError {
             ServerError::Api(ApiError::SparqlLower(_)) => StatusCode::BAD_REQUEST,
             ServerError::Api(ApiError::Config(_)) => StatusCode::BAD_REQUEST,
             ServerError::Api(ApiError::Format(_)) => StatusCode::BAD_REQUEST,
+            ServerError::Api(ApiError::AwaitTNotReached { .. }) => StatusCode::REQUEST_TIMEOUT,
             ServerError::MissingLedger => StatusCode::BAD_REQUEST,
             ServerError::Json(_) => StatusCode::BAD_REQUEST,
             ServerError::BadRequest(_) => StatusCode::BAD_REQUEST,

--- a/fluree-db-server/src/extract/headers.rs
+++ b/fluree-db-server/src/extract/headers.rs
@@ -48,6 +48,9 @@ pub struct FlureeHeaders {
     /// Maximum fuel limit (decimal). Internally converted to micro-fuel.
     pub max_fuel: Option<f64>,
 
+    /// Minimum ledger `t` the request must observe before executing.
+    pub min_t: Option<i64>,
+
     /// Content-Type header value
     pub content_type: Option<String>,
 
@@ -69,6 +72,7 @@ impl Default for FlureeHeaders {
             track_fuel: false,
             track_time: false,
             max_fuel: None,
+            min_t: None,
             content_type: None,
             accept: None,
         }
@@ -87,6 +91,7 @@ impl FlureeHeaders {
     pub const TRACK_FUEL: &'static str = "fluree-track-fuel";
     pub const TRACK_TIME: &'static str = "fluree-track-time";
     pub const MAX_FUEL: &'static str = "fluree-max-fuel";
+    pub const MIN_T: &'static str = "fluree-min-t";
 
     /// Parse headers from a HeaderMap
     pub fn from_headers(headers: &HeaderMap) -> Result<Self> {
@@ -147,6 +152,19 @@ impl FlureeHeaders {
             fluree_headers.max_fuel = Some(val.parse().map_err(|_| {
                 ServerError::invalid_header(format!("{} must be a number", Self::MAX_FUEL))
             })?);
+        }
+
+        if let Some(val) = get_header_str(headers, Self::MIN_T) {
+            let min_t: i64 = val.parse().map_err(|_| {
+                ServerError::invalid_header(format!("{} must be an integer", Self::MIN_T))
+            })?;
+            if min_t < 0 {
+                return Err(ServerError::invalid_header(format!(
+                    "{} must be non-negative",
+                    Self::MIN_T
+                )));
+            }
+            fluree_headers.min_t = Some(min_t);
         }
 
         // Content-Type
@@ -416,5 +434,31 @@ where
         _state: &S,
     ) -> std::result::Result<Self, Self::Rejection> {
         FlureeHeaders::from_headers(&parts.headers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FlureeHeaders;
+    use axum::http::HeaderMap;
+
+    #[test]
+    fn parses_min_t_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(FlureeHeaders::MIN_T, "42".parse().unwrap());
+
+        let parsed = FlureeHeaders::from_headers(&headers).unwrap();
+
+        assert_eq!(parsed.min_t, Some(42));
+    }
+
+    #[test]
+    fn rejects_negative_min_t_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(FlureeHeaders::MIN_T, "-1".parse().unwrap());
+
+        let err = FlureeHeaders::from_headers(&headers).unwrap_err();
+
+        assert!(err.to_string().contains("fluree-min-t"));
     }
 }

--- a/fluree-db-server/src/main.rs
+++ b/fluree-db-server/src/main.rs
@@ -4,9 +4,9 @@
 
 use clap::{CommandFactory, FromArgMatches};
 use fluree_db_server::{
-    FlureeServer, ServerConfig,
     config_file::{config_error_is_fatal, load_and_merge_config},
-    telemetry::{TelemetryConfig, init_logging, shutdown_tracer},
+    telemetry::{init_logging, shutdown_tracer, TelemetryConfig},
+    FlureeServer, ServerConfig,
 };
 
 #[tokio::main]

--- a/fluree-db-server/src/main.rs
+++ b/fluree-db-server/src/main.rs
@@ -4,9 +4,9 @@
 
 use clap::{CommandFactory, FromArgMatches};
 use fluree_db_server::{
-    config_file::{config_error_is_fatal, load_and_merge_config},
-    telemetry::{init_logging, shutdown_tracer, TelemetryConfig},
     FlureeServer, ServerConfig,
+    config_file::{config_error_is_fatal, load_and_merge_config},
+    telemetry::{TelemetryConfig, init_logging, shutdown_tracer},
 };
 
 #[tokio::main]
@@ -40,6 +40,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         log_level = %config.log_level,
         cors = config.cors_enabled,
         indexing = config.indexing_enabled,
+        query_refresh_enabled = config.query_refresh_enabled,
+        query_refresh_ttl_ms = config.query_refresh_ttl_ms,
         reindex_min_bytes = config.reindex_min_bytes,
         reindex_max_bytes = config.reindex_max_bytes,
         events_auth_mode = ?config.events_auth_mode,

--- a/fluree-db-server/src/main.rs
+++ b/fluree-db-server/src/main.rs
@@ -40,6 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         log_level = %config.log_level,
         cors = config.cors_enabled,
         indexing = config.indexing_enabled,
+        query_min_t_timeout_ms = config.query_min_t_timeout_ms,
         query_refresh_enabled = config.query_refresh_enabled,
         query_refresh_ttl_ms = config.query_refresh_ttl_ms,
         reindex_min_bytes = config.reindex_min_bytes,

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -115,9 +115,14 @@ async fn await_query_min_t_requirements(
                 .map_err(ServerError::Api)?;
             let current = ledger.t();
             if current < min_t {
-                return Err(ServerError::not_implemented(format!(
-                    "fluree-min-t requires t={min_t}, but proxy storage mode can only observe current t={current} and cannot perform local read-after-write refresh"
-                )));
+                // A proxy peer tracks head passively via its SSE subscription and
+                // cannot refresh on demand, so report a behind head as a
+                // read-after-write timeout (HTTP 408) — consistent with the
+                // non-proxy wait path — rather than a misleading "not implemented".
+                return Err(ServerError::Api(ApiError::AwaitTNotReached {
+                    requested: min_t,
+                    current,
+                }));
             }
         }
         return Ok(());

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -21,14 +21,16 @@ use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 use fluree_db_api::dataset::GraphSelector;
 use fluree_db_api::{
-    DatasetSpec, FreshnessCheck, FreshnessSource, GraphDb, GraphSource, LedgerState,
+    ApiError, DatasetSpec, FreshnessCheck, FreshnessSource, GraphDb, GraphSource, LedgerState,
     QueryExecutionOptions, RefreshOpts, TimeSpec, TrackingTally,
 };
+use rand::Rng;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
 use tracing::Instrument;
 
 fn query_execution_options(state: &AppState) -> QueryExecutionOptions {
@@ -82,6 +84,119 @@ where
     for ledger_id in ledgers {
         maybe_refresh_ledger_for_query(state, &ledger_id).await;
     }
+}
+
+fn merge_min_t_requirement(requirements: &mut BTreeMap<String, i64>, ledger_id: &str, min_t: i64) {
+    if min_t < 0 {
+        return;
+    }
+    if let Some(base) = refreshable_ledger_id(ledger_id) {
+        requirements
+            .entry(base)
+            .and_modify(|existing| *existing = (*existing).max(min_t))
+            .or_insert(min_t);
+    }
+}
+
+async fn await_query_min_t_requirements(
+    state: &AppState,
+    requirements: BTreeMap<String, i64>,
+) -> Result<()> {
+    if requirements.is_empty() {
+        return Ok(());
+    }
+
+    if state.config.is_proxy_storage_mode() {
+        for (ledger_id, min_t) in requirements {
+            let ledger = state
+                .fluree
+                .ledger(&ledger_id)
+                .await
+                .map_err(ServerError::Api)?;
+            let current = ledger.t();
+            if current < min_t {
+                return Err(ServerError::not_implemented(format!(
+                    "fluree-min-t requires t={min_t}, but proxy storage mode can only observe current t={current} and cannot perform local read-after-write refresh"
+                )));
+            }
+        }
+        return Ok(());
+    }
+
+    let configured_timeout = Duration::from_millis(state.config.query_min_t_timeout_ms);
+    let timeout = if state.config.query_timeout_ms == 0 {
+        configured_timeout
+    } else {
+        configured_timeout.min(Duration::from_millis(state.config.query_timeout_ms))
+    };
+    let started = Instant::now();
+
+    for (ledger_id, min_t) in requirements {
+        // `refresh()` does not cold-load. Ensure a cache entry exists before
+        // enforcing min_t so first request on a warm process can still wait.
+        state
+            .fluree
+            .ledger_cached(&ledger_id)
+            .await
+            .map_err(ServerError::Api)?;
+
+        let mut delay = Duration::from_millis(25);
+        loop {
+            let current_after_attempt = match state
+                .fluree
+                .refresh(&ledger_id, RefreshOpts { min_t: Some(min_t) })
+                .await
+            {
+                Ok(Some(result)) if result.t >= min_t => {
+                    state.mark_query_refresh_checked(&ledger_id);
+                    break;
+                }
+                Ok(Some(result)) => result.t,
+                Ok(None) => {
+                    return Err(ServerError::not_found(format!(
+                        "Ledger not found: {ledger_id}"
+                    )));
+                }
+                Err(ApiError::AwaitTNotReached { current, .. }) => current,
+                Err(err) => return Err(ServerError::Api(err)),
+            };
+
+            let elapsed = started.elapsed();
+            if elapsed >= timeout {
+                return Err(ServerError::Api(ApiError::AwaitTNotReached {
+                    requested: min_t,
+                    current: current_after_attempt,
+                }));
+            }
+
+            let remaining = timeout.saturating_sub(elapsed);
+            let jitter_ms = {
+                let upper = (delay.as_millis() / 4).min(u128::from(u64::MAX)) as u64;
+                rand::thread_rng().gen_range(0..=upper)
+            };
+            let sleep_for = (delay + Duration::from_millis(jitter_ms)).min(remaining);
+            tokio::time::sleep(sleep_for).await;
+            delay = (delay * 2).min(Duration::from_millis(500));
+        }
+    }
+
+    Ok(())
+}
+
+async fn refresh_ledgers_without_min_t<I>(
+    state: &AppState,
+    ledger_ids: I,
+    requirements: &BTreeMap<String, i64>,
+) where
+    I: IntoIterator<Item = String>,
+{
+    let ledgers = ledger_ids
+        .into_iter()
+        .filter_map(|id| refreshable_ledger_id(&id))
+        .filter(|id| !requirements.contains_key(id))
+        .collect::<BTreeSet<_>>();
+
+    maybe_refresh_query_ledgers(state, ledgers).await;
 }
 
 // ============================================================================
@@ -524,8 +639,20 @@ pub async fn query(
             }
         }
 
-        if let Ok(ledger_ids) = fluree_db_api::sparql_dataset_ledger_ids(&sparql) {
-            maybe_refresh_query_ledgers(state.as_ref(), ledger_ids).await;
+        let min_t_requirements = collect_sparql_min_t_requirements(&headers, &sparql, None);
+        if min_t_requirements.is_empty() {
+            if let Ok(ledger_ids) = fluree_db_api::sparql_dataset_ledger_ids(&sparql) {
+                maybe_refresh_query_ledgers(state.as_ref(), ledger_ids).await;
+            }
+        } else {
+            let ledger_ids = fluree_db_api::sparql_dataset_ledger_ids(&sparql).unwrap_or_default();
+            await_query_min_t_requirements(state.as_ref(), min_t_requirements.clone()).await?;
+            refresh_ledgers_without_min_t(
+                state.as_ref(),
+                ledger_ids,
+                &min_t_requirements,
+            )
+            .await;
         }
 
         // AgentJson: connection-scoped SPARQL with agent-optimized envelope
@@ -740,6 +867,10 @@ pub async fn query(
         // representative id). Parity with the multi-query envelope path.
         enforce_bearer_dataset_scope(&query_json, &bearer, credential.is_signed(), &span)?;
 
+        let min_t_requirements =
+            collect_jsonld_min_t_requirements(&headers, &query_json, Some(&ledger_id))?;
+        await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
+
         // Apply bearer identity + server-default policy-class to opts, honoring
         // the root-identity impersonation semantic (see routes::policy_auth).
         let identity = effective_identity(&credential, &bearer);
@@ -859,6 +990,8 @@ pub async fn query_ledger(
             headers.identity.as_deref(),
         )
         .await;
+        let min_t_requirements = collect_sparql_min_t_requirements(&headers, &sparql, Some(&ledger));
+        await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
         return execute_sparql_ledger(
             &state,
             &ledger,
@@ -912,6 +1045,10 @@ pub async fn query_ledger(
     // references — a scoped token must not reach an out-of-scope ledger via a
     // named graph even on the ledger-scoped endpoint.
     enforce_bearer_dataset_scope(&query_json, &bearer, credential.is_signed(), &span)?;
+
+    let min_t_requirements =
+        collect_jsonld_min_t_requirements(&headers, &query_json, Some(&ledger_id))?;
+    await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
     // Apply bearer identity + server-default policy-class to opts, honoring
     // the root-identity impersonation semantic (see routes::policy_auth).
@@ -1064,6 +1201,10 @@ pub async fn explain_ledger(
                     }
                 }
 
+                let min_t_requirements =
+                    collect_sparql_min_t_requirements(&headers, &sparql, Some(&ledger));
+                await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
+
                 // Route through the connection-explain path so the time-travel
                 // suffix on FROM <ledger@t:N> drives snapshot selection.
                 let result = state
@@ -1078,6 +1219,10 @@ pub async fn explain_ledger(
                 );
                 return Ok(Json(result));
             }
+
+            let min_t_requirements =
+                collect_sparql_min_t_requirements(&headers, &sparql, Some(&ledger));
+            await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
             let ledger_id = ledger.clone();
             let loaded = if state.config.is_proxy_storage_mode() {
@@ -1130,6 +1275,10 @@ pub async fn explain_ledger(
                 return Err(ServerError::not_found("Ledger not found"));
             }
         }
+
+        let min_t_requirements =
+            collect_jsonld_min_t_requirements(&headers, &query_json, Some(&ledger_id))?;
+        await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
         // Apply bearer identity + server-default policy-class to opts, honoring
         // the root-identity impersonation semantic (see routes::policy_auth).
@@ -1340,6 +1489,23 @@ fn refreshable_ledger_id(s: &str) -> Option<String> {
         .filter(|base| !base.is_empty())
 }
 
+fn refreshable_ledger_id_and_t(s: &str) -> Option<(String, Option<i64>)> {
+    if matches!(s, "default" | "txn-meta") || s.contains("://") || s.starts_with("urn:") {
+        return None;
+    }
+    let (no_frag, _frag) = split_graph_fragment(s);
+    let (base, time) = fluree_db_core::ledger_id::split_time_travel_suffix(no_frag).ok()?;
+    let min_t = match time {
+        Some(fluree_db_core::ledger_id::LedgerIdTimeSpec::AtT(t)) => Some(t),
+        _ => None,
+    };
+    if base.is_empty() {
+        None
+    } else {
+        Some((base, min_t))
+    }
+}
+
 fn collect_refreshable_jsonld_ledgers(query: &JsonValue) -> Vec<String> {
     let mut raw_ids = Vec::new();
     if let Some(from) = query.get("from") {
@@ -1352,6 +1518,157 @@ fn collect_refreshable_jsonld_ledgers(query: &JsonValue) -> Vec<String> {
         .into_iter()
         .filter_map(|id| refreshable_ledger_id(&id))
         .collect()
+}
+
+fn parse_non_negative_i64(value: &JsonValue, field: &str) -> Result<i64> {
+    let parsed = if let Some(n) = value.as_i64() {
+        n
+    } else if let Some(s) = value.as_str() {
+        s.parse::<i64>().map_err(|_| {
+            ServerError::bad_request(format!("{field} must be a non-negative integer"))
+        })?
+    } else {
+        return Err(ServerError::bad_request(format!(
+            "{field} must be a non-negative integer"
+        )));
+    };
+    if parsed < 0 {
+        return Err(ServerError::bad_request(format!(
+            "{field} must be non-negative"
+        )));
+    }
+    Ok(parsed)
+}
+
+fn min_t_from_opts(opts: Option<&JsonValue>) -> Result<Option<i64>> {
+    let Some(obj) = opts.and_then(JsonValue::as_object) else {
+        return Ok(None);
+    };
+    for key in ["min-t", "min_t", "minT"] {
+        if let Some(value) = obj.get(key) {
+            return parse_non_negative_i64(value, &format!("opts.{key}")).map(Some);
+        }
+    }
+    Ok(None)
+}
+
+fn collect_jsonld_time_min_t(value: &JsonValue, requirements: &mut BTreeMap<String, i64>) {
+    match value {
+        JsonValue::String(raw) => {
+            if let Some((ledger_id, Some(t))) = refreshable_ledger_id_and_t(raw) {
+                merge_min_t_requirement(requirements, &ledger_id, t);
+            }
+        }
+        JsonValue::Array(items) => {
+            for item in items {
+                collect_jsonld_time_min_t(item, requirements);
+            }
+        }
+        JsonValue::Object(obj) => {
+            if let Some(raw) = obj
+                .get("@id")
+                .or_else(|| obj.get("id"))
+                .and_then(JsonValue::as_str)
+            {
+                if let Some((ledger_id, suffix_t)) = refreshable_ledger_id_and_t(raw) {
+                    if let Some(t) = obj.get("t").and_then(JsonValue::as_i64).or(suffix_t) {
+                        merge_min_t_requirement(requirements, &ledger_id, t);
+                    }
+                }
+            } else {
+                for entry in obj.values() {
+                    collect_jsonld_time_min_t(entry, requirements);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_jsonld_min_t_requirements(
+    headers: &FlureeHeaders,
+    query: &JsonValue,
+    default_ledger: Option<&str>,
+) -> Result<BTreeMap<String, i64>> {
+    let mut requirements = BTreeMap::new();
+
+    if let Some(from) = query.get("from") {
+        collect_jsonld_time_min_t(from, &mut requirements);
+    }
+    if let Some(named) = query.get("fromNamed").or_else(|| query.get("from-named")) {
+        collect_jsonld_time_min_t(named, &mut requirements);
+    }
+    if let Some(to) = query.get("to") {
+        collect_jsonld_time_min_t(to, &mut requirements);
+    }
+
+    let explicit_min_t = min_t_from_opts(query.get("opts"))?.or(headers.min_t);
+    if let Some(min_t) = explicit_min_t {
+        let mut ledgers = collect_refreshable_jsonld_ledgers(query);
+        if ledgers.is_empty() {
+            if let Some(ledger_id) = default_ledger {
+                ledgers.push(ledger_id.to_string());
+            }
+        }
+        for ledger_id in ledgers {
+            merge_min_t_requirement(&mut requirements, &ledger_id, min_t);
+        }
+    }
+
+    Ok(requirements)
+}
+
+fn collect_sparql_min_t_requirements(
+    headers: &FlureeHeaders,
+    sparql: &str,
+    default_ledger: Option<&str>,
+) -> BTreeMap<String, i64> {
+    let mut requirements = BTreeMap::new();
+    let ledger_ids = fluree_db_api::sparql_dataset_ledger_ids(sparql).unwrap_or_default();
+
+    let parsed = fluree_db_sparql::parse_sparql(sparql);
+    if let Some(ast) = parsed.ast.as_ref() {
+        let dataset = match &ast.body {
+            fluree_db_sparql::ast::QueryBody::Select(q) => q.dataset.as_ref(),
+            fluree_db_sparql::ast::QueryBody::Construct(q) => q.dataset.as_ref(),
+            fluree_db_sparql::ast::QueryBody::Ask(q) => q.dataset.as_ref(),
+            fluree_db_sparql::ast::QueryBody::Describe(q) => q.dataset.as_ref(),
+            fluree_db_sparql::ast::QueryBody::Update(_) => None,
+        };
+        if let Some(dataset) = dataset {
+            for iri in dataset
+                .default_graphs
+                .iter()
+                .chain(dataset.named_graphs.iter())
+                .chain(dataset.to_graph.iter())
+            {
+                let raw = iri_to_string(iri);
+                if let Some((ledger_id, Some(t))) = refreshable_ledger_id_and_t(&raw) {
+                    merge_min_t_requirement(&mut requirements, &ledger_id, t);
+                }
+            }
+        }
+    }
+
+    for raw in &ledger_ids {
+        if let Some((ledger_id, Some(t))) = refreshable_ledger_id_and_t(raw) {
+            merge_min_t_requirement(&mut requirements, &ledger_id, t);
+        }
+    }
+
+    if let Some(min_t) = headers.min_t {
+        if ledger_ids.is_empty() {
+            if let Some(ledger_id) = default_ledger {
+                merge_min_t_requirement(&mut requirements, ledger_id, min_t);
+            }
+        } else {
+            for ledger_id in ledger_ids {
+                merge_min_t_requirement(&mut requirements, &ledger_id, min_t);
+            }
+        }
+    }
+
+    requirements
 }
 
 fn looks_like_graph_selector_only(s: &str) -> bool {
@@ -1417,7 +1734,11 @@ fn normalize_ledger_scoped_from(ledger_id: &str, query: &mut JsonValue) -> Resul
 
 #[cfg(test)]
 mod ledger_scoped_from_tests {
-    use super::{normalize_ledger_scoped_from, refreshable_ledger_id, requires_dataset_features};
+    use super::{
+        collect_jsonld_min_t_requirements, collect_sparql_min_t_requirements,
+        normalize_ledger_scoped_from, refreshable_ledger_id, requires_dataset_features,
+    };
+    use crate::extract::FlureeHeaders;
     use serde_json::json;
 
     #[test]
@@ -1429,6 +1750,55 @@ mod ledger_scoped_from_tests {
         assert_eq!(refreshable_ledger_id("books").as_deref(), Some("books"));
         assert!(refreshable_ledger_id("txn-meta").is_none());
         assert!(refreshable_ledger_id("https://example.org/graph").is_none());
+    }
+
+    #[test]
+    fn jsonld_min_t_requirements_include_header_opts_and_time_pins() {
+        let headers = FlureeHeaders {
+            min_t: Some(7),
+            ..Default::default()
+        };
+        let q = json!({
+            "from": [
+                "books:main@t:42",
+                {"@id": "users:main", "t": 9}
+            ],
+            "opts": { "min-t": 11 }
+        });
+
+        let requirements =
+            collect_jsonld_min_t_requirements(&headers, &q, Some("fallback:main")).unwrap();
+
+        assert_eq!(requirements.get("books:main"), Some(&42));
+        assert_eq!(requirements.get("users:main"), Some(&11));
+        assert!(!requirements.contains_key("fallback:main"));
+    }
+
+    #[test]
+    fn jsonld_min_t_header_applies_to_default_ledger() {
+        let headers = FlureeHeaders {
+            min_t: Some(12),
+            ..Default::default()
+        };
+        let q = json!({ "select": ["*"] });
+
+        let requirements =
+            collect_jsonld_min_t_requirements(&headers, &q, Some("books:main")).unwrap();
+
+        assert_eq!(requirements.get("books:main"), Some(&12));
+    }
+
+    #[test]
+    fn sparql_min_t_requirements_include_header_and_from_t() {
+        let headers = FlureeHeaders {
+            min_t: Some(15),
+            ..Default::default()
+        };
+        let sparql = "SELECT * FROM <books:main@t:42> WHERE { ?s ?p ?o }";
+
+        let requirements = collect_sparql_min_t_requirements(&headers, sparql, None);
+
+        assert_eq!(requirements.get("books:main"), Some(&42));
     }
 
     #[test]
@@ -2571,6 +2941,10 @@ pub async fn explain(
                 }
             }
 
+            let min_t_requirements =
+                collect_sparql_min_t_requirements(&headers, &sparql, Some(&ledger_id));
+            await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
+
             // If FROM carries a time-travel suffix, route through the
             // dataset-aware connection-explain path so snapshot selection
             // honors `@t:N` / ISO / commit-prefix. Otherwise keep the
@@ -2651,6 +3025,10 @@ pub async fn explain(
                 return Err(ServerError::not_found("Ledger not found"));
             }
         }
+
+        let min_t_requirements =
+            collect_jsonld_min_t_requirements(&headers, &query_json, Some(&ledger_id))?;
+        await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
         // Apply bearer identity + server-default policy-class to opts, honoring
         // the root-identity impersonation semantic (see routes::policy_auth).
@@ -2975,9 +3353,67 @@ async fn execute_dataset_query(
 
 use fluree_db_api::query::multi::MultiQueryError;
 use fluree_db_api::query::multi::{
-    MultiQueryBounds, MultiQueryRequest, MultiQuerySubquery, MultiQueryValidationError,
+    AsOf, MultiQueryBounds, MultiQueryRequest, MultiQuerySubquery, MultiQueryValidationError,
     SubqueryLanguage,
 };
+
+fn collect_multi_query_min_t_requirements(
+    headers: &FlureeHeaders,
+    envelope: &MultiQueryRequest,
+    distinct_ledgers: &BTreeSet<String>,
+) -> Result<BTreeMap<String, i64>> {
+    let mut requirements = BTreeMap::new();
+
+    let envelope_min_t = min_t_from_opts(envelope.opts.as_ref())?.or(headers.min_t);
+    if let Some(min_t) = envelope_min_t {
+        for ledger_id in distinct_ledgers {
+            merge_min_t_requirement(&mut requirements, ledger_id, min_t);
+        }
+    }
+
+    if let Some(AsOf::T(t)) = envelope.as_of.as_ref() {
+        for ledger_id in distinct_ledgers {
+            merge_min_t_requirement(&mut requirements, ledger_id, *t);
+        }
+    }
+
+    for sub in envelope.queries.values() {
+        let sub_min_t = min_t_from_opts(sub.opts.as_ref())?;
+        match sub.language {
+            SubqueryLanguage::JsonLd => {
+                let mut sub_requirements =
+                    collect_jsonld_min_t_requirements(headers, &sub.query, None)?;
+                if let Some(min_t) = sub_min_t {
+                    let ledgers = collect_refreshable_jsonld_ledgers(&sub.query);
+                    for ledger_id in ledgers {
+                        merge_min_t_requirement(&mut sub_requirements, &ledger_id, min_t);
+                    }
+                }
+                for (ledger_id, min_t) in sub_requirements {
+                    merge_min_t_requirement(&mut requirements, &ledger_id, min_t);
+                }
+            }
+            SubqueryLanguage::Sparql => {
+                if let Some(sparql) = sub.query.as_str() {
+                    let mut sub_requirements =
+                        collect_sparql_min_t_requirements(headers, sparql, None);
+                    if let Some(min_t) = sub_min_t {
+                        if let Ok(ledgers) = fluree_db_api::sparql_dataset_ledger_ids(sparql) {
+                            for ledger_id in ledgers {
+                                merge_min_t_requirement(&mut sub_requirements, &ledger_id, min_t);
+                            }
+                        }
+                    }
+                    for (ledger_id, min_t) in sub_requirements {
+                        merge_min_t_requirement(&mut requirements, &ledger_id, min_t);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(requirements)
+}
 
 /// `POST /v1/fluree/multi-query`
 ///
@@ -3100,7 +3536,19 @@ pub async fn multi_query(
                 }
             }
 
-            maybe_refresh_query_ledgers(state.as_ref(), distinct_ledgers.iter().cloned()).await;
+            let min_t_requirements =
+                collect_multi_query_min_t_requirements(&headers, &envelope, &distinct_ledgers)?;
+            if min_t_requirements.is_empty() {
+                maybe_refresh_query_ledgers(state.as_ref(), distinct_ledgers.iter().cloned()).await;
+            } else {
+                await_query_min_t_requirements(state.as_ref(), min_t_requirements.clone()).await?;
+                refresh_ledgers_without_min_t(
+                    state.as_ref(),
+                    distinct_ledgers.iter().cloned(),
+                    &min_t_requirements,
+                )
+                .await;
+            }
 
             // Per-sub-query identity / default-policy-class injection runs
             // here, not inside the api crate. apply_auth_identity_to_opts

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -8,17 +8,17 @@
 
 use crate::config::ServerRole;
 use crate::error::{Result, ServerError};
-use crate::extract::{FlureeHeaders, MaybeCredential, MaybeDataBearer, tracking_headers};
+use crate::extract::{tracking_headers, FlureeHeaders, MaybeCredential, MaybeDataBearer};
 // Note: NeedsRefresh is no longer used - replaced by FreshnessSource trait
 use crate::state::AppState;
 use crate::telemetry::{
     create_request_span, extract_request_id, extract_trace_id, log_query_text, set_span_error_code,
     should_log_query_text,
 };
-use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
+use axum::Json;
 use fluree_db_api::dataset::GraphSelector;
 use fluree_db_api::{
     ApiError, DatasetSpec, FreshnessCheck, FreshnessSource, GraphDb, GraphSource, LedgerState,
@@ -28,8 +28,8 @@ use rand::Rng;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::Instrument;
 

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -8,30 +8,80 @@
 
 use crate::config::ServerRole;
 use crate::error::{Result, ServerError};
-use crate::extract::{tracking_headers, FlureeHeaders, MaybeCredential, MaybeDataBearer};
+use crate::extract::{FlureeHeaders, MaybeCredential, MaybeDataBearer, tracking_headers};
 // Note: NeedsRefresh is no longer used - replaced by FreshnessSource trait
 use crate::state::AppState;
 use crate::telemetry::{
     create_request_span, extract_request_id, extract_trace_id, log_query_text, set_span_error_code,
     should_log_query_text,
 };
+use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use fluree_db_api::dataset::GraphSelector;
 use fluree_db_api::{
     DatasetSpec, FreshnessCheck, FreshnessSource, GraphDb, GraphSource, LedgerState,
-    QueryExecutionOptions, TimeSpec, TrackingTally,
+    QueryExecutionOptions, RefreshOpts, TimeSpec, TrackingTally,
 };
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
-use std::sync::atomic::Ordering;
+use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use tracing::Instrument;
 
 fn query_execution_options(state: &AppState) -> QueryExecutionOptions {
     crate::query_control::current_query_execution_options(state.config.query_timeout_ms)
+}
+
+async fn maybe_refresh_ledger_for_query(state: &AppState, ledger_id: &str) {
+    let Some(refresh_ledger_id) = refreshable_ledger_id(ledger_id) else {
+        return;
+    };
+    if !state.mark_query_refresh_due(&refresh_ledger_id) {
+        return;
+    }
+
+    match state
+        .fluree
+        .refresh(&refresh_ledger_id, RefreshOpts::default())
+        .await
+    {
+        Ok(Some(result)) => {
+            tracing::debug!(
+                ledger_id = refresh_ledger_id,
+                t = result.t,
+                action = ?result.action,
+                "query-time ledger refresh completed"
+            );
+        }
+        Ok(None) => {
+            tracing::debug!(
+                ledger_id = refresh_ledger_id,
+                "query-time refresh found no nameservice record"
+            );
+        }
+        Err(error) => {
+            // Query-time refresh is a freshness hint. Preserve availability and
+            // let the normal query path surface any load/parse errors.
+            tracing::warn!(
+                ledger_id = refresh_ledger_id,
+                error = %error,
+                "query-time ledger refresh failed; continuing with cached state"
+            );
+        }
+    }
+}
+
+async fn maybe_refresh_query_ledgers<I>(state: &AppState, ledger_ids: I)
+where
+    I: IntoIterator<Item = String>,
+{
+    let ledgers: BTreeSet<String> = ledger_ids.into_iter().filter(|id| !id.is_empty()).collect();
+    for ledger_id in ledgers {
+        maybe_refresh_ledger_for_query(state, &ledger_id).await;
+    }
 }
 
 // ============================================================================
@@ -472,6 +522,10 @@ pub async fn query(
                     }
                 }
             }
+        }
+
+        if let Ok(ledger_ids) = fluree_db_api::sparql_dataset_ledger_ids(&sparql) {
+            maybe_refresh_query_ledgers(state.as_ref(), ledger_ids).await;
         }
 
         // AgentJson: connection-scoped SPARQL with agent-optimized envelope
@@ -1275,6 +1329,31 @@ fn base_ledger_id(s: &str) -> Result<String> {
     Ok(base)
 }
 
+fn refreshable_ledger_id(s: &str) -> Option<String> {
+    if matches!(s, "default" | "txn-meta") || s.contains("://") || s.starts_with("urn:") {
+        return None;
+    }
+    let (no_frag, _frag) = split_graph_fragment(s);
+    fluree_db_core::ledger_id::split_time_travel_suffix(no_frag)
+        .ok()
+        .map(|(base, _time)| base)
+        .filter(|base| !base.is_empty())
+}
+
+fn collect_refreshable_jsonld_ledgers(query: &JsonValue) -> Vec<String> {
+    let mut raw_ids = Vec::new();
+    if let Some(from) = query.get("from") {
+        collect_ledger_identifiers(from, &mut raw_ids);
+    }
+    if let Some(named) = query.get("fromNamed").or_else(|| query.get("from-named")) {
+        collect_ledger_identifiers(named, &mut raw_ids);
+    }
+    raw_ids
+        .into_iter()
+        .filter_map(|id| refreshable_ledger_id(&id))
+        .collect()
+}
+
 fn looks_like_graph_selector_only(s: &str) -> bool {
     // Ledger IDs typically look like `name:branch` and do NOT include `://`.
     // Graph IRIs commonly include `://` or `urn:` and should be treated as selectors.
@@ -1338,8 +1417,19 @@ fn normalize_ledger_scoped_from(ledger_id: &str, query: &mut JsonValue) -> Resul
 
 #[cfg(test)]
 mod ledger_scoped_from_tests {
-    use super::{normalize_ledger_scoped_from, requires_dataset_features};
+    use super::{normalize_ledger_scoped_from, refreshable_ledger_id, requires_dataset_features};
     use serde_json::json;
+
+    #[test]
+    fn refreshable_ledger_id_strips_time_and_graph_selectors() {
+        assert_eq!(
+            refreshable_ledger_id("books:main@t:42#txn-meta").as_deref(),
+            Some("books:main")
+        );
+        assert_eq!(refreshable_ledger_id("books").as_deref(), Some("books"));
+        assert!(refreshable_ledger_id("txn-meta").is_none());
+        assert!(refreshable_ledger_id("https://example.org/graph").is_none());
+    }
 
     #[test]
     fn normalize_from_txn_meta_string_rewrites_to_object() {
@@ -1821,6 +1911,7 @@ async fn execute_sparql_ledger(
                     fmt.name().to_uppercase()
                 )));
             }
+            maybe_refresh_ledger_for_query(state, ledger_id).await;
             let view = state.fluree.db_with_policy(ledger_id, &qc_opts).await
                 .inspect_err(|_| { set_span_error_code(&span, "error:QueryFailed"); })?;
             let view = attach_default_context_to_graph(state, ledger_id, view, use_default_context)
@@ -2639,6 +2730,8 @@ pub(crate) async fn load_ledger_for_query(
 ) -> Result<LedgerState> {
     let fluree = &state.fluree;
 
+    maybe_refresh_ledger_for_query(state, ledger_id).await;
+
     // Get cached handle (loads if not cached)
     let handle = fluree.ledger_cached(ledger_id).await.map_err(|e| {
         set_span_error_code(span, "error:NotFound");
@@ -2823,6 +2916,8 @@ async fn execute_dataset_query(
         }
     }
 
+    maybe_refresh_query_ledgers(state, collect_refreshable_jsonld_ledgers(&query)).await;
+
     // Delegate the actual execution to the connection-scoped sub-query helper —
     // the same path the multi-query dispatcher uses for each sub-query alias.
     let tracked = has_tracking_opts(&query);
@@ -3004,6 +3099,8 @@ pub async fn multi_query(
                     }
                 }
             }
+
+            maybe_refresh_query_ledgers(state.as_ref(), distinct_ledgers.iter().cloned()).await;
 
             // Per-sub-query identity / default-policy-class injection runs
             // here, not inside the api crate. apply_auth_identity_to_opts

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -639,7 +639,7 @@ pub async fn query(
             }
         }
 
-        let min_t_requirements = collect_sparql_min_t_requirements(&headers, &sparql, None);
+        let min_t_requirements = collect_sparql_min_t_requirements(headers.min_t, &sparql, None)?;
         if min_t_requirements.is_empty() {
             if let Ok(ledger_ids) = fluree_db_api::sparql_dataset_ledger_ids(&sparql) {
                 maybe_refresh_query_ledgers(state.as_ref(), ledger_ids).await;
@@ -990,7 +990,8 @@ pub async fn query_ledger(
             headers.identity.as_deref(),
         )
         .await;
-        let min_t_requirements = collect_sparql_min_t_requirements(&headers, &sparql, Some(&ledger));
+        let min_t_requirements =
+            collect_sparql_min_t_requirements(headers.min_t, &sparql, Some(&ledger))?;
         await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
         return execute_sparql_ledger(
             &state,
@@ -1202,7 +1203,7 @@ pub async fn explain_ledger(
                 }
 
                 let min_t_requirements =
-                    collect_sparql_min_t_requirements(&headers, &sparql, Some(&ledger));
+                    collect_sparql_min_t_requirements(headers.min_t, &sparql, Some(&ledger))?;
                 await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
                 // Route through the connection-explain path so the time-travel
@@ -1221,7 +1222,7 @@ pub async fn explain_ledger(
             }
 
             let min_t_requirements =
-                collect_sparql_min_t_requirements(&headers, &sparql, Some(&ledger));
+                collect_sparql_min_t_requirements(headers.min_t, &sparql, Some(&ledger))?;
             await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
             let ledger_id = ledger.clone();
@@ -1619,10 +1620,18 @@ fn collect_jsonld_min_t_requirements(
 }
 
 fn collect_sparql_min_t_requirements(
-    headers: &FlureeHeaders,
+    header_min_t: Option<i64>,
     sparql: &str,
     default_ledger: Option<&str>,
-) -> BTreeMap<String, i64> {
+) -> Result<BTreeMap<String, i64>> {
+    // A min-t requirement can only come from a `Fluree-Min-T` header or an
+    // `@t:` snapshot pin in the query. When neither is present there is nothing
+    // to collect, so skip the SPARQL parses below — ordinary current-head
+    // traffic must not pay the freshness feature's parse cost on every request.
+    if header_min_t.is_none() && !sparql.contains("@t:") {
+        return Ok(BTreeMap::new());
+    }
+
     let mut requirements = BTreeMap::new();
     let ledger_ids = fluree_db_api::sparql_dataset_ledger_ids(sparql).unwrap_or_default();
 
@@ -1656,10 +1665,18 @@ fn collect_sparql_min_t_requirements(
         }
     }
 
-    if let Some(min_t) = headers.min_t {
+    if let Some(min_t) = header_min_t {
         if ledger_ids.is_empty() {
-            if let Some(ledger_id) = default_ledger {
-                merge_min_t_requirement(&mut requirements, ledger_id, min_t);
+            match default_ledger {
+                Some(ledger_id) => merge_min_t_requirement(&mut requirements, ledger_id, min_t),
+                // A read-after-write header with no resolvable ledger would be
+                // silently dropped; fail fast instead so the guarantee is never
+                // quietly ignored.
+                None => {
+                    return Err(ServerError::bad_request(
+                        "Fluree-Min-T requires a target ledger; add a FROM clause or use a ledger-scoped endpoint",
+                    ));
+                }
             }
         } else {
             for ledger_id in ledger_ids {
@@ -1668,7 +1685,7 @@ fn collect_sparql_min_t_requirements(
         }
     }
 
-    requirements
+    Ok(requirements)
 }
 
 fn looks_like_graph_selector_only(s: &str) -> bool {
@@ -1796,9 +1813,27 @@ mod ledger_scoped_from_tests {
         };
         let sparql = "SELECT * FROM <books:main@t:42> WHERE { ?s ?p ?o }";
 
-        let requirements = collect_sparql_min_t_requirements(&headers, sparql, None);
+        let requirements = collect_sparql_min_t_requirements(headers.min_t, sparql, None).unwrap();
 
         assert_eq!(requirements.get("books:main"), Some(&42));
+    }
+
+    #[test]
+    fn sparql_min_t_header_without_target_ledger_errors() {
+        let sparql = "SELECT * WHERE { ?s ?p ?o }";
+
+        let result = collect_sparql_min_t_requirements(Some(15), sparql, None);
+
+        assert!(result.is_err(), "min-t header with no ledger must error");
+    }
+
+    #[test]
+    fn sparql_min_t_without_header_or_pin_skips_collection() {
+        let sparql = "SELECT * WHERE { ?s ?p ?o }";
+
+        let requirements = collect_sparql_min_t_requirements(None, sparql, None).unwrap();
+
+        assert!(requirements.is_empty());
     }
 
     #[test]
@@ -2942,7 +2977,7 @@ pub async fn explain(
             }
 
             let min_t_requirements =
-                collect_sparql_min_t_requirements(&headers, &sparql, Some(&ledger_id));
+                collect_sparql_min_t_requirements(headers.min_t, &sparql, Some(&ledger_id))?;
             await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
             // If FROM carries a time-travel suffix, route through the
@@ -3395,8 +3430,11 @@ fn collect_multi_query_min_t_requirements(
             }
             SubqueryLanguage::Sparql => {
                 if let Some(sparql) = sub.query.as_str() {
+                    // The envelope already applied any `Fluree-Min-T` header to
+                    // every distinct ledger; the sub-collector only needs to pick
+                    // up per-query `@t:` pins, so pass no header here.
                     let mut sub_requirements =
-                        collect_sparql_min_t_requirements(headers, sparql, None);
+                        collect_sparql_min_t_requirements(None, sparql, None)?;
                     if let Some(min_t) = sub_min_t {
                         if let Ok(ledgers) = fluree_db_api::sparql_dataset_ledger_ids(sparql) {
                             for ledger_id in ledgers {

--- a/fluree-db-server/src/state.rs
+++ b/fluree-db-server/src/state.rs
@@ -226,6 +226,17 @@ impl AppState {
         }
     }
 
+    /// Record that a query path has already performed a nameservice refresh.
+    pub fn mark_query_refresh_checked(&self, ledger_id: &str) {
+        if !self.config.query_refresh_enabled || self.config.is_proxy_storage_mode() {
+            return;
+        }
+
+        let canonical = normalize_ledger_id(ledger_id).unwrap_or_else(|_| ledger_id.to_string());
+        self.query_refresh_last_checked
+            .insert(canonical, Instant::now());
+    }
+
     /// Create a direct-storage Fluree instance (file, S3, DynamoDB, etc.)
     ///
     /// Uses `FlureeBuilder::build_client()` which returns a type-erased `FlureeClient`

--- a/fluree-db-server/src/state.rs
+++ b/fluree-db-server/src/state.rs
@@ -23,8 +23,8 @@ use dashmap::DashMap;
 use fluree_db_api::{Fluree, FlureeBuilder, IndexConfig, NameServiceMode};
 use fluree_db_core::ledger_id::normalize_ledger_id;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// Application state shared across all request handlers

--- a/fluree-db-server/src/state.rs
+++ b/fluree-db-server/src/state.rs
@@ -19,10 +19,12 @@ use crate::config::{ServerConfig, ServerRole};
 use crate::peer::{ForwardingClient, PeerState, ProxyNameService, ProxyStorage};
 use crate::registry::LedgerRegistry;
 use crate::telemetry::TelemetryConfig;
+use dashmap::DashMap;
 use fluree_db_api::{Fluree, FlureeBuilder, IndexConfig, NameServiceMode};
+use fluree_db_core::ledger_id::normalize_ledger_id;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
 
 /// Application state shared across all request handlers
@@ -62,6 +64,13 @@ pub struct AppState {
     /// Counter for ledger refreshes (for testing/metrics)
     /// Incremented when a ledger is actually reloaded (not for coalesced requests)
     pub refresh_counter: AtomicU64,
+
+    /// Last query-time nameservice refresh attempt per canonical ledger id.
+    ///
+    /// This gates optional DynamoDB nameservice checks on long-running query
+    /// servers. It stores attempts, not successes, to prevent bursty failures
+    /// from stampeding the nameservice.
+    query_refresh_last_checked: DashMap<String, Instant>,
 
     /// Handle for the background leaflet cache stats logger task.
     /// Aborted on drop so the `Arc<LeafletCache>` doesn't outlive the server.
@@ -182,8 +191,39 @@ impl AppState {
             peer_state,
             forwarding_client,
             refresh_counter: AtomicU64::new(0),
+            query_refresh_last_checked: DashMap::new(),
             cache_stats_handle: Some(cache_stats_handle),
         })
+    }
+
+    /// Return true when this query should perform a nameservice refresh check.
+    ///
+    /// The gate is per process and per canonical ledger id. A TTL of 0 means
+    /// "check on every request"; otherwise a request updates the timestamp
+    /// before doing I/O so concurrent requests within the same window coalesce.
+    pub fn mark_query_refresh_due(&self, ledger_id: &str) -> bool {
+        if !self.config.query_refresh_enabled || self.config.is_proxy_storage_mode() {
+            return false;
+        }
+
+        let canonical = normalize_ledger_id(ledger_id).unwrap_or_else(|_| ledger_id.to_string());
+        let now = Instant::now();
+        let ttl = Duration::from_millis(self.config.query_refresh_ttl_ms);
+
+        match self.query_refresh_last_checked.entry(canonical) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                if !ttl.is_zero() && entry.get().elapsed() < ttl {
+                    false
+                } else {
+                    entry.insert(now);
+                    true
+                }
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                entry.insert(now);
+                true
+            }
+        }
     }
 
     /// Create a direct-storage Fluree instance (file, S3, DynamoDB, etc.)

--- a/fluree-vocab/src/errors.rs
+++ b/fluree-vocab/src/errors.rs
@@ -46,6 +46,9 @@ pub const QUERY_EXECUTION: &str = "err:db/QueryExecution";
 /// Query was cancelled by a timeout monitor, caller, or disconnected client.
 pub const QUERY_CANCELLED: &str = "err:db/QueryCancelled";
 
+/// Query read-after-write freshness wait timed out before requested t was visible.
+pub const READ_AFTER_WRITE_TIMEOUT: &str = "err:db/ReadAfterWriteTimeout";
+
 /// Transaction execution error
 pub const TRANSACTION_EXECUTION: &str = "err:db/TransactionExecution";
 


### PR DESCRIPTION
## Summary

Adds two complementary freshness mechanisms for query servers that run **disconnected** from any transaction server — no direct link to the writer and no subscription to the writer's SSE commit stream — yet read from a shared nameservice (e.g. a DynamoDB table) the writer keeps current. Without a refresh signal such a server serves whatever its caches were warmed with and never observes commits made elsewhere.

### 1. TTL-gated query-time nameservice refresh (opt-in, default off)
Before a current-head read, the server calls `Fluree::refresh()` to pull the latest nameservice record and apply it to the shared cache. The check is gated by a per-process, per-canonical-ledger TTL so high-QPS traffic does not hit the nameservice on every request; the gate records *attempts* (not successes) so bursty failures cannot stampede it. `ttl_ms = 0` checks every request. Demand-driven, not a background poller.

- Config: `--query-refresh-enabled` / `--query-refresh-ttl-ms`, `FLUREE_QUERY_REFRESH_*`, or `[server.query_refresh]`.
- Proxy-storage peers (which track head via their SSE subscription) skip the check.

### 2. Read-after-write `min-t` (hard, per-request guarantee)
A client that just wrote and knows the resulting `t` can require that the server observe at least that `t` before executing. Requested via:
- `Fluree-Min-T` header
- JSON-LD `opts.min-t` / `min_t` / `minT`
- a numeric snapshot pin (`from: "ledger:main@t:N"` or `{"@id":"ledger:main","t":N}`)
- multi-query envelope `opts` / `asOf`

The server refreshes each referenced ledger until it reaches the requested `t`, then runs the query (a numeric pin reads that snapshot; a plain header waits on current HEAD). Per-ledger requirements are merged by maximum across header, opts, and pins.

- Bounded by a dedicated `query_min_t_timeout_ms` (default 5s) so the wait never inherits a disabled or 15-minute query timeout; capped exponential backoff with jitter avoids stampeding the nameservice.
- Absent ledger fails fast as not-found; exhausting the budget returns `ReadAfterWriteTimeout` (HTTP 408).
- On success the refresh gate is stamped so the downstream current-head path does not re-check; other referenced ledgers without a `min-t` still get the ordinary TTL refresh.
- Proxy-storage peers satisfy the requirement from their observed head and reject only when that head is behind.

The TTL bounds ordinary staleness; `min-t` proves a specific transaction is visible. The two work together.

## Docs
`docs/operations/configuration.md`, `docs/concepts/time-travel.md`, `docs/api/headers.md`, `docs/api/endpoints.md`, `docs/api/multi-query.md`.

## Testing
Config round-trip, header parsing/validation, and `min-t` requirement-collection unit tests added. `cargo check -p fluree-db-server` clean. Full test suite not run locally.