### PR TITLE
docs: agent-navigable docs site via llms.txt

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Build
         run: mdbook build docs
 
+      # The [preprocessor.llms] step (docs/scripts/llms_preproc.py) ran during
+      # the build above and staged llms.txt, llms-full.txt, and a raw .md mirror
+      # into docs/.llms-staging. Copy them into the published site root.
+      - name: Stage llms.txt artifacts into the published site
+        run: cp -R docs/.llms-staging/. docs/book/
+
       - name: Configure Pages
         uses: actions/configure-pages@v5
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # mdBook build output
 /docs/book/
 
+# llms.txt artifacts staged by docs/scripts/llms_preproc.py
+/docs/.llms-staging/
+
 # Cargo lock for libraries (keep for binaries)
 # Cargo.lock
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,6 +4,16 @@ authors = ["Fluree"]
 language = "en"
 src = "."
 
+# Emits llms.txt / llms-full.txt and a raw .md mirror into docs/.llms-staging
+# (a pass-through preprocessor -- it never modifies the book). The docs.yml
+# workflow copies that staging dir into the published site. See
+# docs/scripts/llms_preproc.py.
+# Command is relative to the book root (docs/), which is mdBook's cwd when it
+# invokes a preprocessor.
+[preprocessor.llms]
+command = "python3 scripts/llms_preproc.py"
+renderers = ["html"]
+
 [output.html]
 git-repository-url = "https://github.com/fluree/db"
 edit-url-template = "https://github.com/fluree/db/edit/main/docs/{path}"

--- a/docs/scripts/llms_preproc.py
+++ b/docs/scripts/llms_preproc.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""mdBook preprocessor that emits llms.txt artifacts for the docs site.
+
+This is a *pass-through* preprocessor: it never modifies the book. It reuses
+mdBook's own parser (so ordering, hierarchy, and any future ``{{#include}}``
+expansion come straight from mdBook) and, as a side effect, writes three
+artifacts that make the docs site agent-navigable via the llms.txt convention
+(https://llmstxt.org):
+
+  * ``llms.txt``       -- a curated, ordered markdown index of the whole book.
+  * ``llms-full.txt``  -- every page concatenated, in SUMMARY order.
+  * a mirrored ``.md`` tree so agents can fetch clean markdown per page.
+
+Because preprocessors run *before* renderers and the html renderer cleans its
+output directory, the artifacts are written to a gitignored staging dir
+(``docs/.llms-staging``). The docs.yml workflow copies that dir into
+``docs/book`` after the build, so the artifacts ship at the site root.
+
+The script is *fail-safe*: on any error it logs to stderr and still echoes the
+original book JSON to stdout, so a bug here can never break ``mdbook build`` or
+``mdbook serve``.
+
+Protocol (https://rust-lang.github.io/mdBook/for_developers/preprocessors.html):
+  * ``llms_preproc.py supports <renderer>``  -> exit 0 to participate.
+  * otherwise: read ``[context, book]`` JSON from stdin, write ``book`` to stdout.
+
+Pure Python 3 standard library -- no third-party dependencies.
+"""
+
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# Public origin where the Pages build is served. Overridable for the
+# labs.flur.ee mirror (which uses a different /docs/db/ prefix).
+BASE_URL = os.environ.get("LLMS_BASE_URL", "https://fluree.github.io/db").rstrip("/")
+
+# One-line per-link note length budget (truncated on a word boundary).
+NOTE_MAX = 140
+
+# Pages whose source path we skip when mirroring / linking (TOC source, etc.).
+SKIP_SOURCE_PATHS = {"SUMMARY.md"}
+
+
+# --------------------------------------------------------------------------- #
+# Book traversal
+# --------------------------------------------------------------------------- #
+
+def iter_chapters(items, depth=0, section=None):
+    """Yield (chapter_dict, depth, section_title) in SUMMARY order.
+
+    ``items`` is a list of serialized BookItems. A BookItem is one of:
+      * ``{"Chapter": {...}}``  -- a real chapter
+      * ``"Separator"``         -- horizontal rule in the TOC
+      * ``{"PartTitle": "..."}``-- a part heading
+    Separators and part titles are skipped. ``section`` carries the title of the
+    top-level (depth 0) chapter that opens the current ## group.
+    """
+    for item in items:
+        if not isinstance(item, dict) or "Chapter" not in item:
+            continue  # Separator / PartTitle
+        chapter = item["Chapter"]
+        title = chapter.get("name", "")
+        # A depth-0 chapter opens a new section; deeper chapters inherit it.
+        this_section = title if depth == 0 else section
+        yield chapter, depth, this_section
+        sub_items = chapter.get("sub_items") or []
+        yield from iter_chapters(sub_items, depth + 1, this_section)
+
+
+def chapter_source_path(chapter):
+    """Return the chapter's source path (relative to docs/), or None."""
+    src = chapter.get("source_path") or chapter.get("path")
+    if not src:
+        return None
+    # Normalize to forward slashes for URLs / staging paths.
+    return str(src).replace("\\", "/")
+
+
+# --------------------------------------------------------------------------- #
+# Text helpers
+# --------------------------------------------------------------------------- #
+
+_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
+_IMG_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+_EMPH_RE = re.compile(r"[*_`]+")
+_LIST_PREFIX_RE = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+")
+_WS_RE = re.compile(r"\s+")
+
+
+def strip_markdown(text):
+    """Reduce a line of markdown to clean one-line plain text."""
+    text = _IMG_RE.sub("", text)            # drop images entirely
+    text = _LINK_RE.sub(r"\1", text)        # [text](url) -> text
+    text = _LIST_PREFIX_RE.sub("", text)    # leading bullet / number marker
+    text = _EMPH_RE.sub("", text)           # * _ ` emphasis / code markers
+    text = _WS_RE.sub(" ", text).strip()
+    return text.rstrip(":").strip()
+
+
+def truncate(text, limit=NOTE_MAX):
+    """Truncate on a word boundary, appending an ellipsis if cut."""
+    if len(text) <= limit:
+        return text
+    cut = text[:limit].rsplit(" ", 1)[0].rstrip()
+    return (cut or text[:limit].rstrip()) + "…"
+
+
+def first_h1(content):
+    """Return the text of the first level-1 heading, or ''."""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return strip_markdown(stripped[2:])
+    return ""
+
+
+def lede(content):
+    """First non-empty, non-heading line after the H1 -> a one-line note."""
+    seen_h1 = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            seen_h1 = seen_h1 or stripped.startswith("# ")
+            continue
+        if not seen_h1:
+            # Some pages may start without an H1; still take the first prose line.
+            pass
+        note = strip_markdown(stripped)
+        if note:
+            return truncate(note)
+    # Fallback: the H1 text itself.
+    return truncate(first_h1(content))
+
+
+# --------------------------------------------------------------------------- #
+# Artifact rendering
+# --------------------------------------------------------------------------- #
+
+def to_url(source_path):
+    return f"{BASE_URL}/{source_path}"
+
+
+def render_index(chapters, title, summary):
+    """Build llms.txt from the ordered (chapter, depth, section) list."""
+    lines = [f"# {title}", ""]
+    if summary:
+        lines += [f"> {summary}", ""]
+
+    current_section = None
+    for chapter, _depth, section in chapters:
+        src = chapter_source_path(chapter)
+        if src is None or src in SKIP_SOURCE_PATHS:
+            continue
+        if section != current_section:
+            current_section = section
+            lines += ["", f"## {section}", ""]  # blank line before each header
+        name = chapter.get("name", "") or first_h1(chapter.get("content", ""))
+        note = lede(chapter.get("content", ""))
+        link = f"- [{name}]({to_url(src)})"
+        lines.append(f"{link}: {note}" if note else link)
+    lines.append("")  # trailing newline
+    return "\n".join(lines)
+
+
+def render_full(chapters, out_path):
+    """Stream-write llms-full.txt: every page, in order, with path headers."""
+    with out_path.open("w", encoding="utf-8") as fh:
+        for chapter, _depth, _section in chapters:
+            src = chapter_source_path(chapter)
+            if src is None or src in SKIP_SOURCE_PATHS:
+                continue
+            fh.write(f"\n\n---\n\n# {src}\n\n")
+            fh.write(chapter.get("content", ""))
+
+
+def mirror_markdown(chapters, staging):
+    """Write each chapter's resolved markdown to STAGING/<source_path>."""
+    for chapter, _depth, _section in chapters:
+        src = chapter_source_path(chapter)
+        if src is None or src in SKIP_SOURCE_PATHS:
+            continue
+        dest = staging / src
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(chapter.get("content", ""), encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+def resolve_staging(context):
+    root = context.get("root")
+    base = Path(root) if root else Path(__file__).resolve().parent.parent
+    # ``root`` is the book root (where book.toml lives) == docs/.
+    return base / ".llms-staging"
+
+
+def book_title(context):
+    try:
+        return context["config"]["book"]["title"] or "Documentation"
+    except (KeyError, TypeError):
+        return "Documentation"
+
+
+def find_summary(chapters):
+    """Lede of the README/index page -> the blockquote project summary."""
+    for chapter, _depth, _section in chapters:
+        src = chapter_source_path(chapter)
+        if src == "README.md":
+            return lede(chapter.get("content", ""))
+    return ""
+
+
+def generate(context, book):
+    staging = resolve_staging(context)
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True, exist_ok=True)
+
+    # mdBook 0.5.x serializes the book's items under "items"; older versions
+    # used "sections". Accept either.
+    chapters = list(iter_chapters(book.get("items") or book.get("sections") or []))
+    linkable = [c for c in chapters
+                if chapter_source_path(c[0]) not in (None, *SKIP_SOURCE_PATHS)]
+
+    title = book_title(context)
+    summary = find_summary(chapters)
+
+    (staging / "llms.txt").write_text(
+        render_index(chapters, title, summary), encoding="utf-8")
+    render_full(chapters, staging / "llms-full.txt")
+    mirror_markdown(chapters, staging)
+
+    print(f"[llms_preproc] wrote {len(linkable)} pages to {staging}",
+          file=sys.stderr)
+
+
+def main():
+    # Support check: `llms_preproc.py supports <renderer>` -> exit 0 to run.
+    if len(sys.argv) > 1 and sys.argv[1] == "supports":
+        sys.exit(0)
+
+    raw = sys.stdin.read()
+    context, book = json.loads(raw)
+
+    try:
+        generate(context, book)
+    except Exception as exc:  # noqa: BLE001 -- fail-safe: never break the build
+        print(f"[llms_preproc] WARNING: artifact generation failed: {exc}",
+              file=sys.stderr)
+
+    # Always echo the book back unchanged (pass-through preprocessor).
+    json.dump(book, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Makes Fluree's published docs site consumable by LLM/coding agents via the [`llms.txt` convention](https://llmstxt.org), with **zero install** in any language/runtime — for the growing audience of agents working in downstream (often non-Rust) projects that build on Fluree.

> Complementary to the separate in-CLI `fluree docs` / `fluree-docs` MCP effort. This is the **web** surface; the two share only the `docs/` source tree. No dependency on the Rust binary, the CLI, or any crate.

## How

A pass-through **mdBook preprocessor** (`docs/scripts/llms_preproc.py`, Python 3 stdlib) that reuses mdBook's parsed book and emits three artifacts into a gitignored staging dir, which the docs workflow copies into the published site root:

- **`/llms.txt`** — curated markdown index: H1 + one-line summary + one `##` section per top-level `SUMMARY.md` entry, each link annotated with the page's lede. Order/structure come straight from mdBook, so it can't drift from the real TOC.
- **`/llms-full.txt`** — every page concatenated in `SUMMARY.md` order with per-page source-path headers (~1.9 MB).
- **Raw `.md` mirror** — each page fetchable as clean markdown at `<base>/<path>.md` (mdBook otherwise serves only HTML); `.md` and `.html` coexist with no clobber.

### Design notes
- **Preprocessor, not a custom backend** — a second backend would relocate the HTML output to `book/html` and break the existing Pages deploy. The preprocessor keeps `docs/book/` and `site-url` untouched.
- **Reuses mdBook's parser** (via the `[context, book]` stdin protocol) rather than hand-rolling a `SUMMARY.md` parser — so any future `{{#include}}`/templating is already resolved in the emitted content.
- **Fail-safe** — on any error the script logs to stderr and echoes the book unchanged, so it can never break `mdbook build`/`mdbook serve`.
- **Base URL** defaults to `https://fluree.github.io/db` (the Pages target) and is env-overridable (`LLMS_BASE_URL`) for the `labs.flur.ee/docs/db` mirror.
- **No drift / zero maintenance** — regenerated on every docs deploy purely from `docs/`.

## Files
- `docs/scripts/llms_preproc.py` (new) — the preprocessor
- `docs/book.toml` — register `[preprocessor.llms]`
- `.github/workflows/docs.yml` — copy staged artifacts into `docs/book` before upload
- `.gitignore` — ignore `docs/.llms-staging/`

## Verification (local, mdBook v0.5.3)
- ✅ `mdbook build docs` succeeds; **196 pages** emitted (matches `SUMMARY.md` link count and the pages mdBook builds)
- ✅ `llms.txt`: `# Fluree DB` + blockquote + 18 `##` sections in exact `SUMMARY.md` order; clean one-line notes
- ✅ `llms-full.txt`: 196 page delimiters, first `README.md` → last `contributing/releasing.md`
- ✅ Raw `.md` mirror byte-identical to source; deep nests present; `.html`/`.md` coexist
- ✅ Fail-safe: forced error → build still succeeds, book echoed unchanged
- ✅ `supports html` check exits 0

## Notes for reviewers
- The plan's "201" was a miscount: 201 `.md` files exist on disk, but `SUMMARY.md` links 196. The artifacts correctly mirror the navigable book (196).
- **4 orphan pages** exist on disk but aren't in `SUMMARY.md`, so they're absent from the site *and* these artifacts (pre-existing, out of scope): `cli/server-integration.md`, `contributing/benches.md`, `design/spatial-index.md`, `operations/running-fluree.md`. If they should be published, they need adding to `SUMMARY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)