### PR TITLE
chore: bump version to 4.0.7

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1188,6 +1188,150 @@ mem:decision-01krvht9hdmca3m5j1rz761g46 a mem:Decision ;
     mem:rationale "Named-graph data is interleaved in the same index/leaves/dicts as the rest of the ledger — there is no storage prefix to wipe the way drop_branch/drop_ledger do. A transactional retract is the only approach that composes cleanly with branches, rebases, replication, and Fluree's immutable history model. Alternative: structural drop + reindex (rejected as a needless rewrite of history)." ;
     mem:alternatives "structural drop with graph_registry mark + reindex skip; soft/hard mode like drop_ledger" .
 
+mem:constraint-01kv5g47r2z640tkx6nxd1d8qm a mem:Constraint ;
+    mem:content "To roll back / delete a freshly-created ledger you must call `drop_ledger(name, mode)` with the BARE name (it rejects a `:branch` suffix), NOT `drop_branch` — drop_branch refuses the root branch (source_branch=None). Use `split_ledger_id(id)` to strip the branch. Also: after a commits-only restore, `handle.snapshot.t` is the INDEX t (0, no index built), not the commit-head t — assert restore success via `nameservice().lookup(id).commit_t` or a query, not snapshot.t." ;
+    mem:tag "drop" ;
+    mem:tag "gotcha" ;
+    mem:tag "ledger" ;
+    mem:tag "nameservice" ;
+    mem:tag "rollback" ;
+    mem:tag "snapshot" ;
+    mem:scope mem:repo ;
+    mem:severity "should" ;
+    mem:artifactRef "fluree-db-api/src/admin.rs" ;
+    mem:artifactRef "fluree-db-api/src/commit_transfer.rs" ;
+    mem:artifactRef "fluree-db-core/src/ledger_id.rs" ;
+    mem:branch "feature/flpack-server-import" ;
+    mem:createdAt "2026-06-15T11:19:34.402368+00:00"^^xsd:dateTime .
+
+mem:constraint-01kv5xfff7s53v2zrawppjeg51 a mem:Constraint ;
+    mem:content "When PUTting a file body to an S3 presigned URL via reqwest, you MUST set an explicit `Content-Length` header. `reqwest::Body::wrap_stream` (used to stream a file without buffering) produces an unknown-length body, so reqwest sends `Transfer-Encoding: chunked`, which real S3 presigned PUTs reject with `NotImplemented: ... Header: Transfer-Encoding`. Stat the file and set `header(CONTENT_LENGTH, len)` — the body still streams, just length-delimited. Gotcha: the flpack reference dev backend (axum) tolerates chunked, so integration tests pass while live S3 fails; test the wire shape against a raw socket." ;
+    mem:tag "content-length" ;
+    mem:tag "flpack" ;
+    mem:tag "gotcha" ;
+    mem:tag "presigned" ;
+    mem:tag "reqwest" ;
+    mem:tag "s3" ;
+    mem:tag "upload" ;
+    mem:scope mem:repo ;
+    mem:severity "must" ;
+    mem:artifactRef "fluree-db-cli/src/remote_client.rs" ;
+    mem:branch "feature/flpack-server-import" ;
+    mem:createdAt "2026-06-15T15:12:54.247579+00:00"^^xsd:dateTime .
+
+mem:constraint-01kv6381pw05a3nw3cmmrtkmwm a mem:Constraint ;
+    mem:content ".flpack restore to a NEW ledger name must re-stamp the FIR6 index root's inline `ledger_id` field and re-write the root under a fresh CID before set_index_head. The source name is baked into the root; cold query loads trust it and work, but the write/reload path (apply_loaded_db, fluree-db-ledger lib.rs:554) asserts root.ledger_id == live ledger id — a mismatch loops every write as retryable and leaves the restored ledger silently read-only. Only the head root carries the name (all_cas_ids excludes prev_index); branches/leaves/dicts are name-independent. Fix is at index-head finalization in restore_into_created." ;
+    mem:tag "apply-loaded-db" ;
+    mem:tag "flpack" ;
+    mem:tag "index-root" ;
+    mem:tag "ledger-rename" ;
+    mem:tag "restore" ;
+    mem:scope mem:repo ;
+    mem:severity "must" ;
+    mem:artifactRef "fluree-db-api/src/commit_transfer.rs" ;
+    mem:artifactRef "fluree-db-binary-index/src/format/index_root.rs" ;
+    mem:artifactRef "fluree-db-ledger/src/lib.rs" ;
+    mem:branch "feature/flpack-server-import" ;
+    mem:createdAt "2026-06-15T16:53:42.236148+00:00"^^xsd:dateTime ;
+    mem:rationale "Third independent flpack restore-to-new-name bug (after default-context drop and chunked-PUT). The ledger_id embedding in FIR6 is the one name-dependent index artifact." .
+
+mem:decision-01kv65wecd75ns7ysjftyc5q36 a mem:Decision ;
+    mem:content "Negotiated .flpack upload supports multipart for archives >5 GiB (single S3 PUT cap). The SERVER picks single-PUT vs multipart by declared `size` vs import_multipart_threshold_bytes at mint time; CLI just reacts to the mint response shape (`upload` vs `multipart` key). App owns S3: it does CreateMultipartUpload, presigns one UploadPart URL per part, and CompleteMultipartUpload — the CLI only PUTs part byte-ranges (fixed Content-Length, bounded concurrency) and reports ETags back on `complete`. Part size adapts up to stay ≤10k parts. Reference server stages parts to sibling files + concatenates on complete (no per-part ETag re-verify; restore_ledger hashes every frame anyway)." ;
+    mem:tag "cli" ;
+    mem:tag "flpack" ;
+    mem:tag "import" ;
+    mem:tag "multipart" ;
+    mem:tag "negotiated-upload" ;
+    mem:tag "s3" ;
+    mem:tag "server" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "docs/cli/server-integration.md" ;
+    mem:artifactRef "fluree-db-cli/src/commands/create.rs" ;
+    mem:artifactRef "fluree-db-cli/src/remote_client.rs" ;
+    mem:artifactRef "fluree-db-server/src/import_jobs.rs" ;
+    mem:artifactRef "fluree-db-server/src/routes/import.rs" ;
+    mem:branch "feature/flpack-server-import" ;
+    mem:createdAt "2026-06-15T17:39:47.725400+00:00"^^xsd:dateTime ;
+    mem:rationale "DBLP-scale migration (~21 GB archive) exceeds the 5 GiB single-PUT limit; this is the general fix. 'App owns S3, app completes MPU' keeps all object-store ownership in the upstream app per the established negotiated-upload model." .
+
+mem:fact-01kv5g46054cwjpky834823fkx a mem:Fact ;
+    mem:content ".flpack wholesale restore = `Fluree::restore_ledger` (commit_transfer.rs): streams over `AsyncRead`, ingests+verifies frames, sets heads from the embedded `phase:nameservice` manifest, rolls back on failure. Server `POST /import/*ledger` (routes/import.rs, admin route group) adapts the body via StreamReader and calls it; CLI `create --remote --from x.flpack` (RemoteLedgerClient::import_ledger streams the file) and local `--from x.flpack` both route through it. Distinct from /push (which replays+revalidates+reindexes). Reimplements ingest against fluree-db-core because fluree-db-nameservice-sync is a DEV-dependency of fluree-db-api (keeps reqwest out of the lib)." ;
+    mem:tag "cli" ;
+    mem:tag "flpack" ;
+    mem:tag "import" ;
+    mem:tag "pack" ;
+    mem:tag "restore" ;
+    mem:tag "server" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "docs/operations/pack-archive-restore.md" ;
+    mem:artifactRef "fluree-db-api/src/commit_transfer.rs" ;
+    mem:artifactRef "fluree-db-cli/src/commands/create.rs" ;
+    mem:artifactRef "fluree-db-cli/src/remote_client.rs" ;
+    mem:artifactRef "fluree-db-server/src/routes/import.rs" ;
+    mem:branch "feature/flpack-server-import" ;
+    mem:createdAt "2026-06-15T11:19:32.613138+00:00"^^xsd:dateTime .
+
+mem:fact-01kv5m1266d9qr9h8q83kppfy5 a mem:Fact ;
+    mem:content "Negotiated `.flpack` upload (size-capped clients e.g. Lambda): discovery `/.well-known/fluree.json` carries `import:{modes,direct_max_bytes}`; CLI picks direct-vs-negotiated by size. Handshake: `POST /import-upload` (mint, ledger in BODY) → `PUT /import-upload/:id/blob?token=` (token-in-URL auth, NOT admin) → `POST .../complete` (async restore on a spawned task) → `GET /import-upload/:id` (poll). Uses a SEPARATE `/import-upload` prefix because `/import/*ledger` is a greedy axum tail that would swallow `/uploads`. Reference backend gated by FLUREE_IMPORT_PRESIGN_ENABLED, stages to local disk, in-memory ImportJobs; a prod app mints a real presigned S3 PUT." ;
+    mem:tag "flpack" ;
+    mem:tag "import" ;
+    mem:tag "lambda" ;
+    mem:tag "negotiation" ;
+    mem:tag "presigned" ;
+    mem:tag "upload" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "docs/cli/server-integration.md" ;
+    mem:artifactRef "fluree-db-cli/src/commands/create.rs" ;
+    mem:artifactRef "fluree-db-cli/src/remote_client.rs" ;
+    mem:artifactRef "fluree-db-server/src/import_jobs.rs" ;
+    mem:artifactRef "fluree-db-server/src/routes/import.rs" ;
+    mem:branch "feature/flpack-server-import" ;
+    mem:createdAt "2026-06-15T12:27:44.710230+00:00"^^xsd:dateTime .
+
+mem:fact-01kv5v3j9svb78b9nh0mp1911m a mem:Fact ;
+    mem:content "A ledger's default JSON-LD context is a `LedgerConfig` CAS blob pointed to by `NsRecord.default_context`/`ConfigPayload.default_context` (+`configV`). It is NOT reachable from the commit chain or index root, so any pack/sync/archive that only walks commits+index artifacts silently drops it. The `.flpack` export now ships it: `archive_ledger` adds `default_context_id` to the nameservice manifest and `stream_archive` emits the blob as a data frame; `restore_ledger` re-points via `set_default_context`. The REMOTE `export --remote` path (server /pack) still omits it. set_default_context writes ConfigPayload; the file nameservice mirrors it onto NsRecord.default_context so lookup() exposes it." ;
+    mem:tag "config" ;
+    mem:tag "default-context" ;
+    mem:tag "flpack" ;
+    mem:tag "gotcha" ;
+    mem:tag "pack" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/src/commit_transfer.rs" ;
+    mem:artifactRef "fluree-db-api/src/lib.rs" ;
+    mem:artifactRef "fluree-db-api/src/pack.rs" ;
+    mem:branch "feature/flpack-server-import" ;
+    mem:createdAt "2026-06-15T14:31:26.777370+00:00"^^xsd:dateTime .
+
+mem:fact-01kv6d6e7p8ys5h6gcxaqsjx9h a mem:Fact ;
+    mem:content ".flpack restore frame cap collided with the indexer's dict pack target: each data frame is one whole CAS object, dicts pack to a 256 MiB target (DEFAULT_RUN_BUDGET_BYTES), so a pack lands just over 256 MiB and the producer emits a frame its own reader (DEFAULT_MAX_PAYLOAD = 256 MiB) refuses — fails restore of any large ledger, transport-independent. Fix: restore_into_created now decodes with RESTORE_MAX_FRAME_PAYLOAD = 1 GiB (commit_transfer.rs); frame length is u32 + every frame SHA-256-verified, so the cap is only a sanity ceiling. DEFAULT_MAX_PAYLOAD stays 256 MiB for the pull path. The clone/pull (nameservice-sync ingest) path still has the 256 MiB cap and would hit this on a large clone." ;
+    mem:tag "dict-pack" ;
+    mem:tag "flpack" ;
+    mem:tag "import" ;
+    mem:tag "indexer" ;
+    mem:tag "pack-frame" ;
+    mem:tag "restore" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/src/commit_transfer.rs" ;
+    mem:artifactRef "fluree-db-core/src/pack.rs" ;
+    mem:artifactRef "fluree-db-indexer/src/config.rs" ;
+    mem:branch "feature/flpack-server-import" ;
+    mem:createdAt "2026-06-15T19:47:35.286342+00:00"^^xsd:dateTime ;
+    mem:rationale "DBLP 21 GB archive failed restore on the first oversized dict frame after multipart upload+stitch succeeded. The cap/target both being 256 MiB is the precise bug; a future session touching pull/clone should raise that path's cap too." .
+
+mem:fact-01kv6sahj5se39hv5hkmjytznz a mem:Fact ;
+    mem:content "restore_into_created (commit_transfer.rs) parallelizes CAS writes: decode stays sequential, per-object PUTs dispatch into a bounded FuturesUnordered pool — RESTORE_MAX_WRITES_IN_FLIGHT=32 AND RESTORE_MAX_BYTES_IN_FLIGHT=512 MiB. Byte bound is restore-specific (frames vary 290 KB leaf .. 1 GiB dict; count-only would balloon memory; indexer leaf-upload bounds count only since leaves are uniform ~187 KB). Oversized single frame admitted once pool drains (no deadlock); all writes flushed before head finalization; error aborts+rolls back. Ceiling remains: archive is read as ONE sequential stream, so a huge restore still can't fit a 15-min Lambda — needs a long-lived worker." ;
+    mem:tag "cas-write" ;
+    mem:tag "flpack" ;
+    mem:tag "import" ;
+    mem:tag "lambda" ;
+    mem:tag "performance" ;
+    mem:tag "restore" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/src/commit_transfer.rs" ;
+    mem:branch "feature/flpack-server-import" ;
+    mem:createdAt "2026-06-15T23:19:32.677756+00:00"^^xsd:dateTime ;
+    mem:rationale "Serial writes (summed S3 round-trips) blew the 15-min Lambda cap on a real 21 GB/74k-artifact DBLP restore; user chose the parallelize-writes fix. Sequential-stream-read ceiling is still unaddressed." .
+
 mem:fact-01kjg3zmevnz6mdn53wkqn08p0 a mem:Fact ;
     mem:content "Fluree uses CIDv1 for all content-addressed blobs. Implementation in fluree-db-core/src/content_id.rs wrapping `cid` crate.\n\nFormat: CIDv1 = version(1) + multicodec + multihash(SHA2-256, 32 bytes). Multicodec values in private-use range 0x300000+: Commit(0x300001), Txn(0x300002), IndexRoot(0x300003), IndexBranch/Leaf, DictBlob, Garbage, LedgerConfig, StatsSketch, GraphSourceSnapshot, SpatialIndex.\n\nKey APIs: ContentId::new(kind, bytes) hashes with SHA-256; verify(bytes) re-hashes and compares (NOT valid for commit-v2 which excludes trailing hash+sig); digest_hex() returns 64-char hex; Display uses base32-lower multibase." ;
     mem:tag "CIDv1" ;
@@ -1289,6 +1433,42 @@ mem:fact-01kj8k5nzpe59p5vp7zrehbrr9 a mem:Fact ;
     mem:branch "feature/memory" ;
     mem:createdAt "2026-02-24T19:49:14.358637+00:00"^^xsd:dateTime .
 
+mem:decision-01kv5jegwe2h3fmsrbygh9j644 a mem:Decision ;
+    mem:content "DATATYPE(?v) now returns the datatype IRI as ComparableValue::Sid (SPARQL 1.1 §17.4.2.3), not the old compact string (\"xsd:decimal\"). eval_datatype maps Lit→dtc.datatype() Sid, EncodedLit→reserved_datatype_sid() fast path or store.dt_sids(), IRI bindings→id_type Sid. Removed format_datatype_sid/format_reserved_datatype. Comparison works because filter-side xsd:decimal lowers via IRI()→encode_iri_strict→same Sid. Serialization: SPARQL results = full IRI; JSON-LD compacts via @context (so xsd prefix → \"xsd:decimal\"). JSON-LD s-expr filters can't express IRIs as bare prefixed names — must use (iri \"<full-iri>\"); STR(DATATYPE()) now yields the FULL IRI, breaking old \"xsd:decimal\" string workarounds." ;
+    mem:tag "datatype" ;
+    mem:tag "eval" ;
+    mem:tag "jsonld" ;
+    mem:tag "query" ;
+    mem:tag "rdf-term-functions" ;
+    mem:tag "sparql" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/tests/it_query_datatype.rs" ;
+    mem:artifactRef "fluree-db-query/src/eval/helpers.rs" ;
+    mem:artifactRef "fluree-db-query/src/eval/rdf.rs" ;
+    mem:branch "fix/datatype-returns-iri" ;
+    mem:createdAt "2026-06-15T12:00:08.590823+00:00"^^xsd:dateTime ;
+    mem:rationale "Old behavior silently returned 0 rows for FILTER(DATATYPE(?v)=xsd:decimal) instead of erroring — a correctness bug reported against 4.0.6. Future work touching datatype()/eval must know it's an IRI term now, and that the JSON-LD compact-string convention was intentionally removed (unify-on-IRI decision)." .
+
+mem:fact-01ktyzzbs4ewxqpgvssvj72tt5 a mem:Fact ;
+    mem:content "Branch fix/decimal-exactness (17 commits, June 2026) fixed DECIMAL_AUDIT.md priorities 1-5: exact ingestion everywhere (SPARQL/UPDATE/JSON-number/json-ld adapter/trig GRAPH), >i64 ints promote to BigInt (was 0), SUM/AVG+GROUP_CONCAT NUM_BIG, SHACL numeric_cmp, COUNT fast-path defer, FlakeValue Hash matches Eq for non-integer doubles, NumBig arena keys normalized (legacy NBA1 loads positionally w/ dual reprs), GROUP BY/DISTINCT/MINUS/joins key NUM_BIG by decoded value (EqualityNorm = store+gv), GRAPH-scope NUM_BIG materializes on exit (per-graph arenas), r2rml format_decimal sign fix, datalog BindingValue/ObjectMatch gained exact Decimal/BigInt + numeric_cmp equality. Remaining: priority 6 (B3 AVG fastpath dt, B8-B12 spec semantics, F2 XML datatype, Iceberg G3)." ;
+    mem:tag "aggregate" ;
+    mem:tag "audit" ;
+    mem:tag "bigint" ;
+    mem:tag "branch" ;
+    mem:tag "decimal" ;
+    mem:tag "exactness" ;
+    mem:tag "shacl" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "DECIMAL_AUDIT.md" ;
+    mem:artifactRef "fluree-db-api/tests/it_decimal_exactness.rs" ;
+    mem:artifactRef "fluree-db-core/src/coerce.rs" ;
+    mem:artifactRef "fluree-db-query/src/aggregate.rs" ;
+    mem:artifactRef "fluree-db-query/src/fast_count.rs" ;
+    mem:artifactRef "fluree-db-sparql/src/lower/term.rs" ;
+    mem:branch "fix/decimal-exactness" ;
+    mem:createdAt "2026-06-12T22:41:50.884413+00:00"^^xsd:dateTime ;
+    mem:rationale "Continuation point for the decimal fix series; the remaining priority-4 cluster (canonical identity) is the prerequisite for issues #1324/#1325." .
+
 mem:fact-01kta2t986nsjneban0hgbwzq7 a mem:Fact ;
     mem:content "RDF term/fact identity in Fluree is (s, p, o, dt, m) where m=FlakeMeta{lang, i} — matching Flake::eq/hash. Any dedup/stale-removal key that omits m collapses distinct facts: langString variants sharing a value (\"animal\"@en vs @fr), and @list members repeating a value at different indices. Issue #1273 was range::remove_stale_flakes (overlay-only/genesis read path) keying on (s,p,o,dt) only; the binary-scan stale-removal (binary_scan.rs FactKeyRef) already included m. Including m also correctly scopes retraction cancellation per variant." ;
     mem:tag "dedup" ;
@@ -1350,6 +1530,24 @@ mem:fact-01kqfy6txdrjppaf6756xzdz25 a mem:Fact ;
     mem:branch "fix/reindex-pre-build-perf-regression" ;
     mem:createdAt "2026-04-30T19:35:16.653062+00:00"^^xsd:dateTime ;
     mem:rationale "Captures the design contract and arena-bloat semantics from PR #1211 so future callers of bulk_apply_commits don't accidentally wire it into a hot-path mutation site." .
+
+mem:constraint-01kv3h37ky6wpm8c8jdvpnamjk a mem:Constraint ;
+    mem:content "A present WHERE that yields zero solutions is now a strict no-op for INSERT in the shared staging layer (commit 79e8fd4fe): the old fallback that fired all-literal INSERT templates (constants only, no WHERE-bound vars) against a synthetic empty solution was removed, so SPARQL UPDATE and JSON-LD update both follow SPARQL 1.1 Update §3.1.3. Unaffected paths: (1) NO WHERE at all still fires templates once via the SingleEmpty cursor in stream_where_into_accumulator; (2) INSERT DATA/DELETE DATA; (3) the OPTIONAL-based \"insert-if-not-exists/always-insert\" idiom yields ONE row (probe var unbound), not zero, so it still fires." ;
+    mem:tag "compliance" ;
+    mem:tag "insert" ;
+    mem:tag "jsonld" ;
+    mem:tag "sparql-update" ;
+    mem:tag "stage" ;
+    mem:tag "transact" ;
+    mem:tag "where" ;
+    mem:scope mem:repo ;
+    mem:severity "must" ;
+    mem:artifactRef "docs/transactions/conditional-updates.md" ;
+    mem:artifactRef "fluree-db-api/tests/it_transact_conditional.rs" ;
+    mem:artifactRef "fluree-db-transact/src/stage.rs" ;
+    mem:branch "fix/sparql-update-strict-where-inserts" ;
+    mem:createdAt "2026-06-14T16:58:01.214124+00:00"^^xsd:dateTime ;
+    mem:rationale "Non-obvious behavior change: distinguishing \"WHERE matched nothing\" (no-op) from \"no WHERE clause\" (fire once) and the OPTIONAL=1-row subtlety prevents future regressions or confusion when touching stage.rs." .
 
 mem:constraint-01kjte29y3cp8mae56xy6yfv2n a mem:Constraint ;
     mem:content "SPARQL↔JSON-LD Parity: both compile to the same IR (fluree-db-query/src/ir.rs) and share the entire execution engine. When adding SPARQL features: (1) shared IR changes already affect JSON-LD — verify JSON-LD tests pass, (2) if expressible in JSON-LD, add parallel tests, (3) execution path missing in JSON-LD lower → track follow-up.\n\nSPARQL tests: it_query_sparql.rs | JSON-LD tests: it_query.rs, it_query_analytical.rs, it_query_grouping.rs\nValidate: `cd testsuite-sparql && make test-eval-cat CAT=<cat>` then `cargo test -p fluree-db-api --test it_query`" ;
@@ -1450,7 +1648,7 @@ mem:fact-01kjte1yw4jyrqvnpq27mr2m9v a mem:Fact ;
     mem:createdAt "2026-03-03T18:06:09.284115+00:00"^^xsd:dateTime .
 
 mem:fact-01ks1m2nn2exrjt7tjkmzgqtg2 a mem:Fact ;
-    mem:content "SUM/AVG aggregates use a shared `NumericAcc` in fluree-db-query/src/aggregate.rs that handles xsd:integer/decimal/double + BigInt with W3C type promotion (Integer→Decimal→Double, sticky upward). Inputs flow through `binding_to_numeric` (Lit + inline-encoded NUM_INT/NUM_F64) or `extract_numeric_with_gv` in group_aggregate.rs (also decodes NUM_BIG via BinaryGraphView). AVG of integer/decimal inputs yields xsd:decimal (W3C op:numeric-divide), with division precision capped at AVG_DECIMAL_PRECISION=34 (decimal128) to bound output. Both streaming (group_aggregate.rs AggState::Sum/Avg) and non-streaming (aggregate.rs agg_sum/agg_avg) paths share the accumulator." ;
+    mem:content "SUM/AVG aggregates use a shared `NumericAcc` in fluree-db-query/src/aggregate.rs with W3C type promotion (Integer→Decimal→Double); inputs via `binding_to_numeric` (Lit + inline NUM_INT/NUM_F64) or `extract_numeric_with_gv` in group_aggregate.rs (also decodes NUM_BIG via BinaryGraphView). AVG of integer/decimal yields xsd:decimal, division capped at AVG_DECIMAL_PRECISION=34. KNOWN GAP (decimal audit June 2026, DECIMAL_AUDIT.md B1): the NON-streaming path's decode gate (aggregate.rs:311) excludes Sum/Avg and binding_to_numeric has no NUM_BIG arm — arena-backed (indexed) decimals contribute NOTHING to non-streaming SUM/AVG. Only the streaming group_aggregate path decodes them." ;
     mem:tag "aggregate" ;
     mem:tag "avg" ;
     mem:tag "decimal" ;
@@ -1463,6 +1661,27 @@ mem:fact-01ks1m2nn2exrjt7tjkmzgqtg2 a mem:Fact ;
     mem:branch "main" ;
     mem:createdAt "2026-05-20T02:40:16.034976+00:00"^^xsd:dateTime ;
     mem:rationale "Pre-fix the extractors only handled Long/Double/Boolean and silently dropped FlakeValue::Decimal, causing SUM(decimal)=0 and AVG(decimal)=Unbound. The shared NumericAcc keeps the streaming and non-streaming paths in sync and prevents future drift between them." .
+
+mem:fact-01ktys13s07fm2mphwxqnr339h a mem:Fact ;
+    mem:content "Decimal audit (DECIMAL_AUDIT.md, repo root, June 2026): most ingest paths destroy xsd:decimal via f64 before storage — SPARQL constants (lower/term.rs:138), SPARQL UPDATE (lower_sparql_update.rs:752/892), JSON-number @value (coerce.rs:582/257), bulk-import JSON-LD (adapter.rs:399), TriG GRAPH blocks (trig_meta.rs:873). Only JSON-LD string @value and default-graph Turtle are exact. Also: non-streaming SUM/AVG drop NUM_BIG EncodedLits (aggregate.rs:311), SHACL range facets unconditionally fail all decimals (fluree-db-shacl value.rs:94), both lexers turn >i64 integers into 0, R2RML format_decimal drops sign for -1<x<0, datalog ObjectMatch has no Decimal arm." ;
+    mem:tag "aggregate" ;
+    mem:tag "audit" ;
+    mem:tag "decimal" ;
+    mem:tag "ingestion" ;
+    mem:tag "numbig" ;
+    mem:tag "precision" ;
+    mem:tag "shacl" ;
+    mem:tag "xsd-decimal" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "DECIMAL_AUDIT.md" ;
+    mem:artifactRef "fluree-db-core/src/coerce.rs" ;
+    mem:artifactRef "fluree-db-query/src/aggregate.rs" ;
+    mem:artifactRef "fluree-db-shacl/src/constraints/value.rs" ;
+    mem:artifactRef "fluree-db-sparql/src/lower/term.rs" ;
+    mem:artifactRef "fluree-db-transact/src/lower_sparql_update.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-06-12T20:40:28.192512+00:00"^^xsd:dateTime ;
+    mem:rationale "46 panel-confirmed findings from a 260-agent audit; fixing engine lanes is pointless until ingestion stops corrupting values — any future decimal work should start from DECIMAL_AUDIT.md's priority list." .
 
 mem:constraint-01kp8yczz09ndt54ztchbheeyb a mem:Constraint ;
     mem:content "JSON-LD transaction parsing does NOT auto-promote bare string values to IRI references. User data becomes an IRI only when wrapped in `{\"@id\": \"...\"}` or when the property has `@type: \"@id\"` in `@context`. The former `looks_like_iri` heuristic (three sites in parse/jsonld.rs) was removed — it silently promoted strings starting with `http://`/`https://`/`did:`/`fluree:`/`urn:` to IRIs, which violated the JSON-LD spec (especially for `{\"@value\": \"...\"}`, explicitly a literal)." ;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,7 +2293,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-bench-support"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "chrono",
  "rand 0.8.5",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-api"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cli"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-iceberg"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-memory"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "chrono",
  "fluree-db-api",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice-sync"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2721,7 +2721,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-peer"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-server"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-aws"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-ipfs"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "cid",
@@ -3008,14 +3008,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "fluree-vocab",
  "pretty_assertions",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-httpd"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-service"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3158,14 +3158,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-sse"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-vocab"
-version = "4.0.6"
+version = "4.0.7"
 
 [[package]]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 exclude = ["testsuite-sparql"]
 
 [workspace.package]
-version = "4.0.6"
+version = "4.0.7"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/fluree/db"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -80,6 +80,7 @@
   - [Ontology imports (`f:schemaSource` + `owl:imports`)](design/ontology-imports.md)
   - [Cross-ledger model enforcement](design/cross-ledger-model-enforcement.md)
   - [Storage traits](design/storage-traits.md)
+  - [Reasoning roadmap (OWL2RL maintenance, reasoned index head)](design/reasoning-roadmap.md)
 
 - [HTTP API (fluree-db-server)](api/README.md)
   - [Overview](api/overview.md)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -44,6 +44,10 @@ How a single **model ledger** can hold the ontology, SHACL shapes, policy rules,
 
 Storage trait architecture: `StorageRead`, `StorageWrite`, `ContentAddressedWrite`, `Storage`, and `NameService` trait design with guidance for implementing new backends.
 
+### [Reasoning Roadmap](reasoning-roadmap.md)
+
+Two-axis plan for OWL reasoning: (A) static OWL2RL materialization performance (rule compilation, parallel fixpoint, post-import pass) and incremental maintenance via FBF with derived facts persisted in a branch-plumbing-based "reasoned index head"; (B) practitioner UX/DX (explanations from a provenance sidecar, ROBOT-style workflows, `versionIRI ↔ t` mapping, virtual RDF-star lineage).
+
 ## Related Documentation
 
 - [Crate Map](../reference/crate-map.md) - Workspace architecture

--- a/docs/design/reasoning-a2-reasoned-head.md
+++ b/docs/design/reasoning-a2-reasoned-head.md
@@ -1,0 +1,887 @@
+# A2 Design: Reasoned Index Head + FBF Incremental Maintenance
+
+Status: **draft** (June 2026). Companion to
+[`reasoning-roadmap.md`](reasoning-roadmap.md) (the plan) and
+`REASONING_STATUS.md` (where we are). This document specifies roadmap phase
+**A2** — persisting OWL2-RL derived facts as index artifacts maintained
+incrementally per commit — and the **B1 provenance sidecar** format, which
+must be designed with the storage so derivations carry `(rule, premises)`
+tags from day one. Every structural claim below is grounded in the current
+code; file references are to `refactor/resoning-2`.
+
+## 1. Problem
+
+Derived facts today live only in a transient `DerivedFactsOverlay`
+(`fluree-db-reasoner/src/overlay.rs`) — four sorted in-memory `Vec<Flake>`
+copies, rebuilt by full re-materialization whenever the cache key
+`(ledger_id, db_epoch, to_t, overlay_epoch, ontology_epoch, config_hash)`
+changes, i.e. **on every commit**. Measured consequences at LUBM-25
+(1.58M derived facts):
+
+- **Per-query overlay tax.** Overlay flakes must be translated to V3 ids and
+  merged in every binary cursor walk. Caches (per-execution +
+  4-entry global LRU at `fluree-db-query/src/binary_scan.rs:2292`) mitigate
+  but don't eliminate it. Relatedly, the batched-probe join paths and the
+  cyclic-BGP fast path bail on *any* overlay (novelty included) — which is
+  why q02 times out (>600 s) and q09 takes 69 s. That bail is a general
+  engine gap, not a reasoning-specific one, and is addressed by the **P0
+  precursor workstream** (§7.2, §10) rather than by persistence itself.
+- **Resident memory.** ~2.8 GB RSS per materialization; the 16-entry LRU can
+  hold several. LUBM-100 projects to ~8–10 GB per entry.
+- **Recompute churn.** Every commit and every server restart re-derives the
+  full closure (10.6 s at LUBM-25 after A1.2; minutes at LUBM-100).
+- **No explanations.** Nothing records *why* a fact was derived (B1).
+
+A2 addresses these problems unevenly, and the distinction is load-bearing:
+it removes full re-materialization churn, lowers resident-memory pressure,
+creates a place for provenance, and can eliminate the overlay→V3
+translation floor. It does **not** make the merge disappear, and it does
+**not** by itself fix the q02/q09-class fast-path bails. Those bails are a
+general novelty-awareness gap in the query engine and must be solved by P0;
+if P0 makes today's in-memory reasoning overlay fast enough, A2's remaining
+performance case is mostly operational scale rather than raw hot-query
+speed. The A2 mechanism is persisted, derived-only index artifacts with
+their own head record, maintained per commit by a background worker running
+**FBF** (Backward/Forward) incremental maintenance over the A1.2 compiled
+rule set.
+
+## 2. Goals and non-goals
+
+### 2.0 The three delivery modes — one engine, composable layers
+
+All reasoning delivery reduces to the same engine (compiled rules +
+semi-naive/FBF) parameterized by *which rule profile* runs and *who waits*
+for it. The modes are **not alternatives — they compose**, and a single
+ledger plausibly runs all three at once with different profiles:
+
+| | Mode 1 — query-time (today) | Mode 2 — background (this doc) | Mode 3 — transaction-time (future feature) |
+|---|---|---|---|
+| Rule profile | anything, ad-hoc | heavy profiles (full `owl2rl`, …) | small **transactional entailment profile** (hierarchy/domain-range typing, light datalog x-forms — bounded-cost shapes only) |
+| Who waits | the reader (materialization on cache miss) | nobody — staleness disclosed; readers may opt to wait (`strict`) | the writer (small, budgeted, predictable) |
+| Consistency | always exact at requested `t` | eventual (`exact`/`strict`/`asOf` per query) | transactionally consistent |
+| Why you'd use it | what-ifs, history, ad-hoc rules | analytical/steady-state reasoning at scale | entailments that **gate writes** (commit-time SHACL over inferred state, B4) and must be immediately visible |
+
+**Layering rule: each layer treats the layers below as ground truth.**
+Mode 3's derived facts land in the *index* at the commit's `t` (never the
+commit log — "commit log is sole source of truth; reindex re-derives"
+holds, with reindex re-running the transactional profile), and their
+lifecycle is owned by the transaction engine: premises retract ⇒ its
+conclusions retract, transactionally. Mode 2's worker therefore treats
+txn-derived facts as explicit — it reasons over (asserted ∪ txn-derived)
+and never FBF-maintains Mode 3's outputs; when the head's profile ⊇ the
+transactional profile, re-derivation is an idempotent no-op. Mode 1 is
+the ad-hoc lens over whatever the lower layers produced, and the
+universal fallback (historical `t`, no head, lag).
+
+Scoping Mode 3 to a restricted profile is what makes it viable at all:
+the per-transaction budget question changes from "cap arbitrary OWL
+reasoning" (hopeless in a write path) to "admit only rule shapes with
+predictable cost." Recursive/expansive constructs (transitive closure,
+`sameAs`, restriction classes) are excluded by construction and belong to
+Mode 2. TBox changes never recompute in the write path (degrade to
+async). A side payoff: txn-time entailments are stamped at their commit
+`t`, so for the transactional profile, time-travel-with-reasoning is
+exact at every `t` automatically.
+
+Mode 3 is out of scope for v1; it is Mode 2's maintenance step invoked
+synchronously with a restricted profile, so nothing in this document
+forecloses it.
+
+**Goals**
+
+1. A queryable, persisted derived-facts index per `(ledger:branch,
+   rule-config)` pair, pinned to a base commit `t` — the **reasoned head**.
+2. Insert-only commits (the dominant case) maintain it with semi-naive
+   evaluation over the commit delta; retract-bearing commits run FBF. No
+   full re-materialization for data commits.
+3. Zero persistent auxiliary state beyond the derived index + provenance
+   sidecar: the head remains a pure function of (rules, data-at-t),
+   rebuildable at any time. Reindex re-derives; the commit log stays the
+   sole source of truth.
+4. Staleness is first-class: a `reasonedThroughT` watermark, surfaced in the
+   query response `reasoning` block (shipped on `refactor/resoning-2`) and
+   ledger status, with a per-query escape hatch to the existing overlay path
+   for read-your-writes freshness.
+5. Provenance recorded per derived fact (`rule_id`, premise keys) in a
+   sidecar, enabling B1 proof-tree reconstruction and accelerating FBF's
+   overdeletion step.
+6. Non-reasoning queries never touch any of it — zero cost by artifact
+   separation, no inferred-marker bit in the main indexes.
+
+**Performance claim boundary.** A2 must not be sold as "persistence solves
+reasoning query performance." The hot-query hypothesis is narrower: a head
+can avoid (a) per-query materialization and (b) Flake→V3 translation, then
+pay the same kind of sorted side-channel merge that novelty already pays.
+The q02/q09 timeout shape is not evidence for persistence; it is evidence
+that the optimized probe paths need to become novelty-aware. P0 should be
+benchmarked first against today's in-memory overlay and against a
+novelty-heavy non-reasoning ledger. If that solves the slow queries, A2 is
+still valuable for restart behavior, memory footprint, incremental
+maintenance, provenance, and LUBM-100-scale operability — but not as the
+primary fix for those queries.
+
+**Non-goals (this phase)**
+
+- Stratum-scoped recompute for ontology changes (ZodiacEdge-style) — TBox
+  commits trigger full re-derivation in v1.
+- The IJCAI-2015 incremental `owl:sameAs` deletion algorithm — v1 recomputes
+  the affected equivalence component (or falls back to full re-derive).
+- Parallel fixpoint (A1.3) — orthogonal; FBF consumes the same compiled
+  dispatch and benefits automatically when A1.3 lands.
+- Datalog (user-rule) persistence — the uncached datalog lane is unchanged;
+  only `owl2rl` materializations get heads in v1.
+- **Mode 3 (transaction-time entailment) — see §2.0.** In v1, transactions
+  are never gated on reasoning of any kind. Mode 3 arrives later as a
+  separate, composable per-ledger feature: the same engine invoked
+  synchronously with a *restricted, bounded-cost* transactional profile
+  (its scoping is what makes a write-path budget tractable). Heavy
+  profiles stay in Mode 2 regardless; consistency-needing readers have
+  `freshness: strict` meanwhile.
+
+## 3. Architecture overview
+
+```
+                       ┌─────────────────────────────┐
+ commits ───────────▶  │  ledger  mydb:main          │
+                       │  NsRecord: commit_t, index_t│
+                       └──────────────┬──────────────┘
+                                      │ LedgerCommitPublished events
+                                      ▼
+                       ┌─────────────────────────────┐
+                       │  reasoning worker (new)     │
+                       │  per-head state machine     │
+                       │  insert-only: semi-naive E+ │
+                       │  retracts:    FBF           │
+                       │  TBox commit: re-derive     │
+                       └──────────────┬──────────────┘
+                                      │ publishes
+                                      ▼
+   ReasonedHeadRecord  ──────────  derived-only index artifacts
+   (GraphSourceRecord-shaped)      reasoning/{name}/{branch}/...
+   reasoned_t, base_root,          FDR1 manifest + leaflets (V3 rows,
+   ontology_epoch, config_hash,    base-id-aligned) + FPS1 provenance
+   capped, index_id                sidecar
+                                      ▲
+                                      │ three-way compose at query time
+   query («reasoning: owl2rl») ───────┘
+   base index rows ⋈ derived rows ⋈ novelty ops
+```
+
+A **literal reasoning branch was already rejected** in the roadmap
+(rebase-replay is wrong for derived facts; branch novelty is
+commit-reconstructed; branch `t` diverges). Research for this document adds
+a fourth, decisive reason: **a derived-only artifact cannot be a FIR6 index
+root at all.** `LedgerSnapshot::from_root_bytes`
+(`fluree-db-ledger/src/lib.rs:178`) treats the root as the complete ground
+truth — full namespace registrations, graph IRIs, and dictionary watermarks
+are required to decode and route post-index commits. A root containing only
+derived facts is not a loadable snapshot. This forks the storage design
+(§5.0): either the head is a **new derived-only artifact kind** loaded
+only by the reasoning-aware query path (Strategy A), or it is a
+**complete merged FIR6 index family** — a fully loadable snapshot that
+sidesteps this problem entirely (Strategy B, recommended). Goal 6
+(non-reasoning queries untouched) holds under both: separation is by
+artifact/record either way, never by an inferred-marker bit in the base
+index.
+
+## 4. The reasoned head record
+
+The roadmap sketched an `NsRecord`-shaped record. The closer existing fit is
+**`GraphSourceRecord`** (`fluree-db-nameservice/src/lib.rs`) — the record
+the BM25/vector sidecars already use — because a reasoned head is exactly
+what that record models: a derived artifact with declared dependencies on a
+source ledger, its own index CID + watermark, and a retraction lifecycle:
+
+```rust
+GraphSourceRecord {
+    graph_source_id: "mydb~reasoning-default:main", // head id (see naming below)
+    name:            "mydb~reasoning-default",
+    branch:          "main",                        // tracks the base branch
+    source_type:     GraphSourceType::Reasoning,    // NEW variant
+    config:          { ... JSON, see below ... },
+    dependencies:    ["mydb:main"],
+    index_id:        Some(<FDR1 manifest CID>),
+    index_t:         <reasoned_t>,                  // == reasonedThroughT
+    retracted:       false,
+}
+```
+
+`config` (JSON, hashed into the head identity):
+
+```json
+{
+  "modes": ["owl2rl"],
+  "enabledRules": [],
+  "budget": {"maxFacts": 20000000, "maxSeconds": 300},
+  "schemaSource": "<resolved schema-source descriptor or null>",
+  "profile": "default"
+}
+```
+
+Head identity = `(base ledger:branch, rule_config_hash)`. N rule configs =
+N heads = N small derived indexes (read-through sharing means no base
+copies). `rule_config_hash` reuses `ReasoningOptions::config_hash()`
+(`fluree-db-reasoner/src/lib.rs`) extended with the schema-source
+descriptor. The default `owl2rl` config gets the well-known profile name
+`default`; named profiles (B3) map onto additional heads.
+
+Additional head state (in `config` or alongside `index_t` — decide at
+implementation time whether `GraphSourceRecord` grows fields or the FDR1
+manifest carries them; manifest preferred to keep the record schema stable):
+
+| Field | Meaning |
+|---|---|
+| `reasoned_t` | base commit `t` the closure is exact for (`= index_t`) |
+| `base_root_id` | CID of the base index root the derived rows are id-aligned to |
+| `ontology_epoch` | monotone counter bumped on every TBox-touching commit the worker observed |
+| `capped` / `capped_reason` | the head's closure hit its budget — propagated into every query's `reasoning` block |
+| `derived_count`, `iterations`, `last_maintenance_ms` | diagnostics |
+
+**Lifecycle.** Heads are created on demand: the first `reasoning: owl2rl`
+query against a ledger (or an explicit admin/config opt-in,
+`f:reasoningDefaults` gaining `f:materialize true`) registers the record;
+the worker bootstraps it with a full materialization (the A1.4 post-import
+pass is exactly this bootstrap with `E− = ∅`). Drop = `retracted: true` +
+artifact GC, mirroring graph-source drop. Branch drop cascades to its heads.
+
+**What heads never do:** participate in merge/rebase (`fluree-db-api/src/
+{merge,rebase}.rs` replay *commits* and update `commit_head_id` — a head has
+neither), accept transactions, or serve as a base for branching. On a merge
+into the tracked branch, the head's `reasoned_t` simply falls behind the new
+`commit_t` and the worker catches up through the merged commits like any
+others (the merge produces ordinary replayed commits with op-flagged
+flakes). A reset/rollback below `reasoned_t` invalidates the head →
+re-derive (v1; FBF-rewind is possible later since the closure is a pure
+function of state).
+
+## 5. Storage
+
+### 5.0 Two strategies — merged full index (recommended) vs derived-only
+
+Once P0 owns probe performance, the head's honest job description is a
+**persistent materialization cache**: survive restarts, maintain
+incrementally, carry provenance. That framing (June 11 discussion) exposes
+a choice the first draft under-weighed:
+
+**Strategy B — merged full index (recommended, pending the M0
+measurement).** The reasoned head is a *complete* FIR6 index family
+(base ∪ derived) per rule config, bootstrapped the way `create_branch`
+bootstraps a branch at HEAD — copy the base index *references*, fold the
+derived facts in as one incremental update — and maintained by the
+existing incremental indexer, whose input novelty is simply
+base novelty ∪ FBF derived deltas (the existing `Novelty` shape).
+
+- *Query side*: a reasoning query becomes exactly a normal query —
+  reasoned snapshot + novelty, two lanes, the standard engine path.
+  **Zero cursor changes, no third lane, no id-alignment machinery, no
+  `eager_materialization` gate** (no Sid-space overlay exists), and the
+  "derived-only roots are not loadable snapshots" problem (§3) vanishes:
+  the merged root is a complete snapshot by construction. Steady-state
+  reasoning queries don't even depend on P0 (P0 still serves
+  novelty-heavy ledgers and the fallback lane).
+- *Storage*: the earlier "duplicates the base per config" objection is
+  largely defeated by **content addressing** — leaves untouched by
+  derived facts keep their CIDs and are stored once, shared with the
+  base index. Real amplification = leaves derived facts intrude on
+  (heavy in `rdf:type` POST/PSOT extents, light elsewhere) plus branch
+  structure. Measurable, not assumed.
+- *Maintenance*: ≈ a second background index family per config (~2×
+  background indexing per cycle), not per-commit write amplification.
+- *Unchanged from this doc*: the head record (§4), the worker and FBF
+  (§6 — the derived deltas just land in the reasoned index's novelty
+  instead of a separate artifact), freshness/resolution (§7.1),
+  provenance sidecar (§5.3 — keyed by fact identity, position-
+  independent), head-invisibility, reindex/drop lifecycle (§8). B3
+  asserted-vs-inferred = base index vs reasoned index; "inferred-only"
+  = FPS1 membership.
+
+**Strategy A — derived-only artifacts + third cursor lane** (the rest of
+this §5 and §7.2): smaller artifacts and no second index family, at the
+price of new formats (FDR1), base-id alignment, the three-pointer merge,
+and derived-lane probe work — substantial new query-engine surface whose
+performance then needs to be proven against the same merge costs novelty
+pays.
+
+**Two-tier shape (June 11 discussion): the delta log is the head's
+novelty; the full index is its compaction target.** The persistence
+options — an LSM-like derived-delta log vs. a full index — are not
+competitors but the two tiers of the architecture base reads already use:
+
+- *Hot tier — derived delta log.* Each worker run appends one sorted
+  segment (the FBF output: derived asserts + retract tombstones, stamped
+  with its t-range). Maintenance writes are delta-sized — no index
+  rewrite per run — reusing the novelty LSM machinery (flat write slope,
+  tiered compaction bounding segment count). Cleanest form: the head owns
+  **its own `Novelty` instance**, fed by base commits ∪ derived deltas,
+  so a head query is *structurally identical* to a base query (snapshot +
+  novelty, two lanes, same engine, same P0 treatment, same compaction
+  knobs).
+- *Cold tier — fold.* On the same threshold logic that folds base novelty
+  into the base index, accumulated segments fold into the reasoned index
+  family and the log resets — bounding query-side merge cost exactly the
+  way base reads bound it.
+- *Bonuses:* segments carry closure transitions with t-ranges, so
+  head-window time travel (§7.1's v2 option) becomes "merge segments up
+  to t". One real difference from base novelty: derived deltas are NOT in
+  the commit log, so the head's log is persisted as append-only blobs
+  (zero restart cost; preferred) or re-derived over the gap on restart
+  (bounded by fold cadence; fallback).
+
+Strategy A vs. B is therefore a **cold-tier-only** decision.
+
+**Decision gate (M0):** bootstrap a Strategy-B reasoned index from the
+LUBM-25 base refs and measure (a) the leaf-sharing ratio (shared vs
+diverged CIDs across all four orders), (b) the incremental fold cost per
+index cycle, (c) reasoning-query latency vs the base index (expect
+parity). Adopt B unless storage divergence or fold cost is pathological;
+A remains the fallback and its sections are retained below for that case.
+
+### 5.1 Layout and manifest (Strategy A)
+
+Artifacts live under the graph-sources storage segment, reasoning-scoped:
+
+```
+reasoning/{name}/{branch}/{config-hash}/
+  manifest.fdr1          # derived-index manifest (new kind, magic "FDR1")
+  leaves/{cid}.fdl1      # derived leaflets per sort order (columnar V3 rows)
+  prov/{cid}.fps1        # provenance sidecar segments (B1)
+```
+
+The **FDR1 manifest** is deliberately *not* a FIR6 root. It contains:
+
+- `reasoned_t`, `base_root_id`, `ontology_epoch`, `rule_config_hash`,
+  `capped`/`capped_reason`, counts;
+- per-sort-order (SPOT, PSOT, POST, OPST) branch tables → derived leaflet
+  CIDs with min/max keys — the same columnar leaf encoding the binary index
+  already uses (`RowColumnSlice` layout), reusing the existing leaf
+  writer/reader;
+- **dict-delta tables** (§5.2);
+- per-leaflet provenance segment refs (offset/len), mirroring how
+  `LeafEntry.sidecar_cid` attaches the FHS1 history sidecar today
+  (`fluree-db-binary-index/src/format/history_sidecar.rs`).
+
+Default graph only, matching `DerivedFactsOverlay` semantics (derived facts
+are `g_id = 0`; `fluree-db-reasoner/src/overlay.rs:171`).
+
+### 5.2 Id alignment — Strategy A's load-bearing decision
+
+The translation-side query win depends on derived rows being encoded in the
+**base store's V3 id space** (`s_id: u64`, `p_id: u32`, `o_type: u16`,
+`o_key: u64`, `o_i: u32` — `FactKeyV3`,
+`fluree-db-binary-index/src/read/types.rs:19`). Then the cursor can merge
+them like already-translated overlay ops, with **zero per-query
+translation** — deleting the overlay→V3 translation tax that A1.1 could only
+memoize. This is not the same as eliminating query-time reconciliation:
+derived rows are still a side channel, so fast paths must explicitly merge
+them just as P0 makes them merge novelty.
+
+Alignment facts established from the dictionary code
+(`binary_index_store.rs:2251-2393`):
+
+- **Subjects/strings** are append-only per namespace with watermarks
+  persisted in the root — ids are stable across index builds. Derived facts
+  reference only terms that already exist in the base data (OWL2-RL derives
+  over existing constants; it mints no IRIs), so subject/object ids are
+  always resolvable against the base dicts + dict-novelty at `reasoned_t`.
+- **Predicates** are the wrinkle: `p_id` is an index into the root's
+  `predicate_sids` table, and a derived fact's predicate may never occur in
+  a *predicate position* in base data (e.g. a chain-axiom's derived property
+  or `owl:sameAs` itself). The FDR1 manifest therefore carries an
+  **appended-predicate table**: `p_id`s above the base root's watermark,
+  mapping to SIDs — the same mechanism `DictNovelty` uses for unindexed
+  commits. Same approach for the rare appended datatype/lang ids.
+- The manifest records `base_root_id`. When the base indexer publishes a new
+  root, ids remain valid (append-only growth); the worker refreshes
+  `base_root_id` opportunistically at its next maintenance step. If a future
+  base format change ever renumbers ids, alignment breaks detectably
+  (root id mismatch) and the head re-derives — correctness never depends on
+  silent compatibility.
+
+### 5.3 Provenance sidecar (B1) — FPS1 (both strategies)
+
+Designed now, written from the first persisted head. Per derived fact, one
+or more derivation records, segmented per derived leaflet (FHS1 precedent —
+builder accumulates per-leaflet segments; refs stored in the manifest):
+
+```
+FPS1 segment:
+  entry_count: u32
+  entries: [ProvEntry; entry_count]    # sorted by derived FactKeyV3
+
+ProvEntry (variable length):
+  fact:        FactKeyV3       (26 B)  # the derived fact
+  rule_id:     u16                     # compiled-rule identity (see below)
+  n_premises:  u8                      # 0..=4 in OWL2-RL rule bodies
+  premises:    [FactKeyV3; n_premises] # 26 B each
+  flags:       u8                      # bit0: also-base-asserted, bit1: capped-context
+```
+
+Two-premise derivation ≈ 81 B — in the roadmap's 85–90 B envelope, and
+*only* fetched for explanation queries or FBF retract handling; the hot
+query path never reads it.
+
+`rule_id` is a stable enumeration of the **compiled** rule bindings:
+`(RuleKind, axiom discriminator)` from A1.2's `CompiledRules`
+(`fluree-db-reasoner/src/compile.rs`) — e.g. *cax-sco via
+ex:Professor ⊑ ex:Faculty*. The compile step assigns dense u16 ids and the
+manifest stores the id→(rule name, axiom SIDs) table, so proof trees render
+without recompilation and survive ontology evolution (ids are per-head,
+re-assigned on TBox recompile, never reused within a head generation).
+
+Multi-derivation: multiple `ProvEntry`s per fact are allowed and expected
+(a fact often has several proofs). The maintenance algorithm (§6) keeps *at
+least one* valid entry per live derived fact; it does not guarantee
+exhaustive proof storage (that's justification storage, rejected in the
+roadmap for its blow-up). Exposure as virtual RDF-star
+(`<< ?s ?p ?o >> f:derivedBy ?rule`) follows the `rdf_star.rs`
+BIND-projection precedent and is B1 scope, not A2.
+
+## 6. Maintenance: the reasoning worker
+
+### 6.1 Worker shape
+
+A new `reasoning_worker` in `fluree-db-api` (sibling of `bm25_worker.rs` /
+`vector_worker.rs`), with the indexer orchestrator's hardening
+(`fluree-db-indexer/src/orchestrator.rs`): subscribes to
+`LedgerCommitPublished` nameservice events, maintains a reverse map
+ledger → heads, debounces (~100 ms default), coalesces triggers per head
+(maintain to current `commit_t`, resolve all waiters with `min_t ≤
+reasoned_t`), panic-safe dispatch with exponential-backoff retry, and
+clears retry deadlines on idle/cancel (the orchestrator's
+retry-deadline invariant). One in-flight maintenance per head.
+
+The worker holds per-head in-memory state between commits — this is what
+makes incrementality cheap:
+
+- the loaded derived store handle (mmap'd leaflets);
+- the **`CompiledRules` artifact** and extracted `OntologyRL` /
+  `RestrictionIndex`. This resolves A1.2's deferred per-epoch caching
+  soundly: the worker inspects *every* commit delta, so it recompiles
+  exactly when a TBox-touching commit arrives — no reliance on
+  `schema_epoch` covering all OWL predicates;
+- the `FrozenSameAs` union-find and the identity-rule grouping state
+  (`IdentityRuleState`), both reconstructible from the derived store on
+  restart (sameAs facts are part of the closure).
+
+### 6.2 Commit classification
+
+For each commit in `(reasoned_t, commit_t]`, taken from the commit's
+op-flagged flake delta (the same `CollectedCommitData` shape merge/rebase
+consume):
+
+1. **TBox-touching?** Predicate-set match against the OWL/RDFS vocabulary
+   (`subClassOf`, `subPropertyOf`, `domain`, `range`, `equivalentClass`,
+   `inverseOf`, `propertyChainAxiom`, restriction predicates,
+   `intersectionOf`/`unionOf`/`oneOf`, `hasKey`, the property-type classes
+   in `rdf:type` objects, …) — the closed list lives next to the extractor
+   so it can't drift from what `OntologyRL::from_db_with_overlay` reads.
+   → bump `ontology_epoch`, **full re-derive** (v1; stratum-scoped later).
+   Rule *addition* via config change → semi-naive with only the new rules;
+   rule *removal* → treat that rule's consequences as retracts → FBF.
+2. **Retract-free data commit** (`E− = ∅`, the dominant case) → §6.3.
+3. **Retract-bearing data commit** → §6.4. If any retract touches
+   `owl:sameAs` or a member of a non-singleton equivalence class → §6.5.
+
+Multiple pending commits are folded into one net `(E+, E−)` via the
+`fact_state` latest-op semantics before maintenance runs.
+
+### 6.3 Insert-only fast path (semi-naive over E+)
+
+Exactly the A1.2 fixpoint with a different seed: `delta := E+` (plus their
+canonicalization through the live union-find) instead of the full base scan;
+`derived` is backed by the persisted store (point lookups `contains`,
+`get_by_ps/po` served by the derived leaflets + base index — the same
+delta ⋈ (derived ∪ base) joins the rules already perform, reading the
+persisted artifacts instead of RAM vectors). Each new fact appends a
+provenance entry. Fixpoint output is sorted, merged into the four derived
+orders (leaflet rewrite is localized — same incremental-leaf machinery the
+main indexer uses), sidecar segments appended, manifest + record published
+with the new `reasoned_t`.
+
+Semi-naive over the delta is optimal here in every maintenance-algorithm
+family — no special machinery, per the roadmap's design principle 2.
+
+### 6.4 Retract path: FBF (Backward/Forward)
+
+Per Motik et al. (AAAI 2015 / AIJ 2019), chosen because it needs **zero
+persistent auxiliary state** — the provenance sidecar is an accelerator, not
+a correctness dependency:
+
+1. **Overdelete (forward).** Seed `D := E−`. Repeatedly apply the compiled
+   rules *forward* over `D ⋈ (old materialization ∪ base-at-t−1)` to find
+   derived facts whose recorded derivations could have consumed a deleted
+   fact; the FPS1 reverse direction (premise → derived) makes this a sidecar
+   range scan instead of rule re-application where entries exist. Everything
+   reached goes into the **doubtful set**.
+2. **Back-chain (backward).** For each doubtful fact, search for a surviving
+   proof: backward-chain through the compiled rules against
+   (base-at-t ∪ (materialization \ doubtful)), with memoized proved/disproved
+   sets per run. Fluree's snapshot-at-any-t makes "explicit facts at t"
+   a native lookup — no logging needed, the property that made FBF the
+   roadmap's pick. Facts with a surviving proof are kept (and get a fresh
+   provenance entry for the found proof); the rest are deleted.
+3. **Re-derive (forward).** Semi-naive from the kept frontier ∪ E+ to
+   restore anything the deletions transitively unsupported, as §6.3.
+
+The AIJ 2019 empirical result — backward/forward dominates on small updates
+— is exactly the per-commit case.
+
+### 6.5 `owl:sameAs` retraction (v1)
+
+Never through generic rules (quadratic closure). When a retract removes a
+sameAs edge or a fact about a merged individual: recompute the affected
+**equivalence component** — dissolve the component in the union-find,
+re-run identity rules (prp-fp/ifp/key, cls-maxc/maxqc) and
+recanonicalization restricted to facts touching the component's members,
+then FBF the resulting derived-fact deltas. Equality deletion is
+non-monotonic (it can *restore* previously-rewritten facts), which the
+component recompute handles by construction. If the component exceeds a
+size threshold, fall back to full re-derive — correct and bounded. The
+IJCAI-2015 incremental algorithm is the v2 upgrade.
+
+### 6.6 Budgets and capping
+
+Maintenance runs under the same `ReasoningBudget` resolution shipped on
+`refactor/resoning-2` (ledger config → env → default; per-query budgets
+don't apply to the worker). A capped maintenance run marks the **head**
+capped; every query served from it carries `capped: true` in its
+`reasoning` response block until an uncapped run succeeds. A capped head is
+still monotonically *under* the true closure, so serving it is no worse
+than today's capped overlay — but it is now visible.
+
+### 6.7 Overload: when write volume outpaces reasoning
+
+Eventual consistency trades a transaction guarantee for a lag risk:
+sustained transaction volume × inference cost can exceed the worker's
+throughput, and **which side is the long pole varies per deployment**
+(data shape, rule complexity, hardware) — it cannot be designed away, only
+bounded, observed, and adapted to:
+
+1. **Writes are never throttled by reasoning** (non-goal above). Under
+   either storage strategy the worker is off the transaction path;
+   Strategy B's second index family is resource contention, not pipeline
+   coupling, and its cadence may lag the base indexer's arbitrarily.
+2. **Coalescing is the built-in backpressure absorber.** Each worker run
+   folds *all* pending commits into one net `(E+, E−)` — cost scales with
+   the net delta and its inference consequences, not with commit count.
+   Bursts of overlapping or small commits absorb nearly for free; lag
+   grows without bound only when net inference work itself outpaces the
+   worker.
+3. **The worker is adaptive, not loyal to FBF.** Per run, if the
+   accumulated delta (or the FBF doubt set) exceeds a threshold fraction
+   of the closure, it switches to a full re-derive at latest — often
+   cheaper than incremental catch-up over a huge gap, and bounding
+   worst-case catch-up at one full materialization (the cost A1.3
+   attacks). This is also the hedge for "you don't know which is the long
+   pole": the worker measures and chooses per run rather than the design
+   guessing.
+4. **Degradation floor: never worse than pre-A2.** As lag grows, `exact`
+   reads pay larger top-ups until resolution falls back to the overlay
+   path — i.e. today's behavior, caches included. `asOf` reads stay cheap
+   and merely age, staleness disclosed. `strict` reads wait (bounded by
+   the query timeout, then fall back). No degradation mode touches write
+   latency.
+5. **Lag is observable and alarmable.** `commit_t − reasoned_t` (and its
+   wall-clock age) in worker metrics, ledger status, and every reasoned
+   response (`reasonedThroughT`); a configurable lag threshold raises an
+   operator alarm, and worker cadence/priority are config knobs.
+
+## 7. Query-time composition
+
+### 7.1 Resolution
+
+**Invariant: a head never changes query results, only how fast they
+arrive.** Reasoning is a per-query lens — `reasoning: owl2rl` at `to_t`
+means *the closure over data-as-of-`to_t`*, whether or not a head exists,
+was bootstrapped later, or lags. If head existence affected answers, the
+same query would return different results depending on when an operator
+created the head, breaking the pure-function-of-(rules, data-at-t)
+property. The fallback path guarantees the invariant; heads only
+accelerate.
+
+(`f:reasoningDefaults`-driven reasoning composes with this naturally and
+gives "before reasoning was enabled" semantics for free: the config graph
+is versioned ledger state, so a time-travel view at `t` resolves the
+config *as of `t`* — a default that didn't exist yet simply doesn't apply.
+Explicit per-query reasoning at historical `t` still gets the full
+closure-at-`t` via fallback.)
+
+`reasoning: owl2rl` (query, view, or ledger default — unchanged precedence)
+resolves in order, governed by a per-query
+`"reasoning": {"freshness": "exact" | "strict" | "asOf"}` option
+(default `exact`):
+
+1. **Head exact** (`to_t == reasoned_t`, common steady-state) → attach the
+   derived store; no overlay materialization at all.
+2. **Head behind** (`reasoned_t < to_t ≤ commit_t`), by freshness policy:
+   - `exact` (default) → attach the derived store **plus a top-up
+     overlay**: semi-naive over the gap commits' `E+` — small, in-memory,
+     cached by `(head generation, gap epoch)`. Correct latest answers.
+     Gap retracts force fallback (3) in v1 rather than in-memory FBF.
+   - `strict` → block on the worker's waiter mechanism until
+     `reasoned_t ≥ to_t`, then serve as (1). For pipelines that must not
+     pay query-side reasoning at all.
+   - `asOf` → lower the **whole query's** effective `to_t` to
+     `reasoned_t` — base lanes included, not just the derived lane (base
+     at `commit_t` joined with closure at `reasoned_t` would be exactly
+     the mixed-state inconsistency the time-travel rule forbids) — and
+     serve from the head with **no top-up**. The cheapest read,
+     semantically an exact answer for a slightly older `t`. The effective
+     t is disclosed (below); this is the eventually-consistent read mode
+     and is only acceptable *because* it is disclosed.
+3. **No head / time-travel below head coverage / gap too complex** → today's
+   overlay materialization path, unchanged — including ad-hoc historical
+   reasoning (`to_t` + modes + inline `ontology`/`rules`/budget), which
+   already works today and stays the universal correctness backstop.
+   **No `t` ever regresses.**
+
+Time-travel rule (v1): a closure is only valid *at its pinned t* — for
+`to_t < reasoned_t` the head may contain facts derived from data the query
+must not see, so heads are never filtered downward by `to_t`; path (3)
+serves historical reasoning. (Per-fact `t` filtering is insufficient
+because a derivation's premises may individually predate `to_t` while the
+closure also lost retracted facts — correctness requires the
+pure-function-of-state property, not row filtering.)
+
+*Future option — a replayable head (v2):* FBF maintenance computes, per
+commit, exactly which derived facts gained or lost support. Persisting
+those transitions as op-flagged derived rows (assert/retract with their
+transition `t`s, FHS1-style) would make the head itself time-travelable
+across its maintained window `[bootstrap_t, reasoned_t]` using the same
+replay machinery base leaflets use — turning path (3)'s historical
+fallback into a head read for any maintained `t`. Deliberately not v1
+scope; noted because it falls out of the maintenance algorithm nearly for
+free and constrains nothing if skipped.
+
+The `reasoning` response block gains `reasonedThroughT`, `effectiveT`
+(differs from the requested `to_t` only under `asOf`), and
+`source: "head" | "head+gap" | "overlay"`, riding the `ReasoningTally`
+plumbing already in place; ledger status reports per-head watermarks.
+
+**API surface.** The existing `"reasoning"` string/array shorthand stays
+valid (defaults to `exact`). An **object form** carries freshness and gives
+the accumulating reasoning options a single home (the `reasoningBudget`
+sibling key stays accepted):
+
+```json
+{
+  "from": "mydb:main",
+  "select": ["?x"],
+  "where": {"@id": "?x", "@type": "ex:Chair"},
+  "reasoning": {
+    "modes": ["owl2rl"],
+    "freshness": "asOf",
+    "budget": {"maxFacts": 20000000}
+  }
+}
+```
+
+SPARQL adds one pragma alongside the existing ones:
+
+```sparql
+# PRAGMA reasoning: owl2rl
+# PRAGMA reasoning-freshness: strict
+SELECT ?x WHERE { ?x a ex:Chair }
+```
+
+Response (tracked body and `x-fdb-reasoning` header), e.g. `asOf` served
+from a head lagging at `t=41` while `commit_t=43`:
+
+```json
+"reasoning": {
+  "source": "head",
+  "reasonedThroughT": 41,
+  "effectiveT": 41,
+  "capped": false,
+  "derived_facts": 1584268
+}
+```
+
+When no head exists, every mode degrades to the overlay path rather than
+erroring — `exact`/`strict` are satisfied by it (the closure *is* computed
+at `to_t`, just slower) and `asOf` has no older pinned t to offer, so
+`effectiveT = to_t`. Freshness never changes whether the answer is
+correct, only which `t` it is exact for and what the query pays; `source`
+always discloses what happened. Ledger-config may set a default freshness
+in `f:reasoningDefaults` (`f:reasoningFreshness`), subject to the group's
+override control like every other reasoning setting.
+
+### 7.2 Cursor composition (Strategy A only)
+
+Under Strategy B (§5.0) none of this subsection exists: reasoning queries
+run the standard snapshot+novelty path against the merged index. What
+follows is Strategy A's query plan, retained for the fallback case.
+
+**What persisting derived-only does and doesn't eliminate.** The "overlay
+tax" of §1 is three distinct costs; only the first two are A2's to fix:
+
+1. *Translation* (Flake → V3 ids, dictionary lookups per flake, today
+   memoized in the 4-entry LRU): **eliminated** — derived rows are persisted
+   already V3-encoded in the base id space (§5.2). Nothing to cache.
+2. *Merge*: **remains, and must be measured rather than assumed away** —
+   the target is the same windowed, pre-skippable per-leaflet merge that
+   novelty already pays on any ledger with unindexed commits: O(rows
+   overlapping the scanned range), not O(closure) per query. We add a third
+   pointer to an existing two-pointer walk. If the derived side channel is
+   large and overlaps the hot ranges, persisted-vs-in-memory may behave
+   similarly for hot-cache query latency; the benefit is avoiding
+   materialization/translation and keeping the side channel mmap-windowed
+   instead of fully resident.
+3. *Fast-path bails* (batched-probe joins, cyclic-BGP — the actual q02/q09
+   killer): **not fixed by persistence — fixed by the P0 precursor
+   workstream (§10).** The bail gate is `ctx.overlay_free_single_graph()`
+   (`fluree-db-query/src/context.rs:761`): the probe paths
+   (`join.rs:1150`, `property_join.rs:316/793`, `optional.rs:429/782`)
+   read base leaflets directly and bail on *any* overlay — **including
+   plain novelty on a non-reasoning ledger**. The fix is to make the
+   probes merge a sorted side-channel per probed key (the translated
+   overlay ops are already in identical V3 sort order and windowable —
+   binary-searchable exactly like leaflet s_ids), following the
+   "strategy (b): merge overlay" pattern the count fast paths already
+   adopted. That work is representation-agnostic: done against today's
+   overlay it fixes q02/q09 *before* A2 ships, fixes novelty-heavy
+   non-reasoning workloads, and hands the A2 derived lane the same
+   reconciliation logic for free. What persistence contributes to the
+   probe paths is only scale hygiene: mmap'd leaflet windows instead of a
+   multi-GB resident ops vector at LUBM-100 sizes.
+
+Persisting a *merged* base+derived index was considered and rejected: the
+RL closure rivals base size, so N rule configs would each duplicate the
+full base; every base commit would force merged-index maintenance even
+when it triggers zero inferences (defeating per-commit incrementality);
+and a merged index still composes with novelty at query time, so a merge
+lane exists regardless.
+
+Research confirmed the two-pointer cursor merge
+(`merge_overlay_into_batch`, `binary_cursor.rs:539`) cannot absorb a second
+*index* in the same walk, and wrapping the derived store as an
+`OverlayProvider` would resurrect the Flake→V3 translation tax. The design
+is therefore a **derived-rows lane** in the existing merge:
+
+- `GraphDb` gains `reasoned_store: Option<Arc<DerivedIndexStore>>`
+  (alongside `binary_store`), populated by the view layer only when
+  reasoning resolves to a head.
+- `BinaryCursor` gains a second pre-sorted source: derived leaflet windows,
+  sliced per leaf exactly like overlay windows (`slice_overlay_for_leaf`
+  precedent). The merge becomes three-pointer — base rows ⋈ derived rows ⋈
+  novelty ops — over identical V3 sort keys (id alignment, §5.2). Derived
+  rows are asserts by construction; net add/remove against novelty follows
+  the existing overlay-op lifecycle rules.
+- `has_ov`-style pre-skips extend to the derived lane, so leaves with no
+  derived rows in range pay one comparison. Non-reasoning queries have
+  `reasoned_store = None` and an untouched two-pointer walk.
+
+With P0 in place, the probe paths already know how to reconcile a sorted
+side-channel; the derived lane plugs into the same logic (derived leaflet
+windows instead of ops windows). A reasoning query in steady state then
+runs with no overlay materialization at all and fully live fast paths. The
+expected delta versus today's cached in-memory overlay is specifically
+"no materialize, no translate, less resident memory"; it is not expected to
+turn a side-channel merge into base-index-only access.
+
+## 8. Reindex, GC, and recovery
+
+- **Full reindex / rebuild**: reasoned heads are dropped and re-derived
+  against the new base root (new ids ⇒ alignment reset). Prerequisite from
+  the roadmap stands: root-cause the historical `fluree index` blank-node
+  regression (`benchmark-db/.../FINDINGS.md`, Chair→0) before heads ship
+  over reindex, since re-derivation correctness depends on reindexed TBox
+  blank nodes.
+- **GC**: superseded FDR1 manifests/leaflets/sidecars are CAS-unreferenced
+  once the record points at the new manifest; reuse the indexer's
+  post-publish GC hook (bounded concurrency).
+- **Crash recovery**: publication is atomic at the record update; a crash
+  mid-maintenance leaves the old head valid. The worker restarts from the
+  record, reloads union-find + identity state from the derived store, and
+  re-runs the pending window.
+
+## 9. Coordination and risks
+
+| Item | Plan |
+|---|---|
+| `feature/merge-preview3` custom merging | Heads don't participate in merge; but the *record* shape and the "head lags after merge" UX should be reviewed with that work so branch tooling lists reasoned heads sensibly. Confirm `GraphSourceType::Reasoning` doesn't collide with its record changes. |
+| Blank-node reindex regression | **Resolved as prerequisite** (June 11): does not reproduce on `refactor/resoning-2` — LUBM-1 import → `fluree reindex` → full suite returns identical reasoning-complete results (the FINDINGS.md Chair→0 entry predated the `canonical_split` and #1294-era fixes). Now pinned by `fluree-db-api/tests/it_reasoning_reindex.rs` (minimal blank-node Chair shape, reason → reindex → reason equality, commit f7e5f1216). Residual idea if it ever resurfaces: a dangling-anonymous-`ClassRef` counter in `RestrictionIndex` extraction would turn any blank-node structure corruption into a loud diagnostic instead of silent 0-row answers. |
+| Dict id stability across base roots | Manifest pins `base_root_id`; mismatch ⇒ re-derive. Add an invariant test that subject/predicate watermarks only grow across publishes. |
+| Identity-rule state size | `IdentityRuleState` grouping maps scale with fp/ifp extents; worker memory must be bounded — spill or rebuild-on-demand if a head's maps exceed a threshold (they are reconstructible). |
+| Worker lag under write bursts | Coalescing bounds work to one run per burst; freshness option (§7.1) gives strict readers an out. Lag is visible (`reasonedThroughT`). |
+
+## 10. Milestones
+
+- **P0 — overlay-aware batched probes (precursor, independent of A2).**
+  Convert the batched-probe joins (`join.rs` `scan_matches` lane,
+  `property_join.rs`, `optional.rs`) and the cyclic-BGP fast path from the
+  `overlay_free_single_graph()` bail to "strategy (b)": merge the windowed,
+  V3-sorted overlay ops per probed key, including retract reconciliation
+  against matched base rows — the pattern the count fast paths already
+  use. The mechanism is representation-agnostic (anything implementing
+  `OverlayProvider` flows through the same translate-and-merge), which is
+  what hands the A2 derived lane its reconciliation for free.
+  **Reasoning queries hit a second, independent bail** that novelty-only
+  workloads don't: `!ctx.eager_materialization` (`join.rs:1158`), set by
+  `execute_prepared` whenever a derived overlay exists because derived
+  facts are Sid-space while the batched lanes emit `EncodedSid` (the two
+  never compare equal). Fixing q02/q09 against today's in-memory reasoning
+  overlay therefore also requires revisiting that eager gate (e.g. batched
+  lanes emitting decoded Sids under eager mode, or encoding probe keys on
+  entry) — in scope for P0, not deferrable to A2.
+  *Acceptance:* q02/q09 at LUBM-25 collapse against **today's**
+  reasoning overlay (this requires both gates addressed); batched probes
+  stay live on a novelty-heavy non-reasoning ledger (new benchmark to pin
+  this — the win applies to every ledger with unindexed commits, not just
+  reasoning). This work de-risks the M1 cursor lane: same reconciliation
+  case analysis. After P0, rerun the A2 go/no-go performance argument: if
+  the current in-memory overlay is already fast enough for the target
+  queries, A2's justification should be stated as operational
+  persistence/RSS/provenance/incremental maintenance, not as the primary
+  q02/q09 performance fix.
+- **M0 — spike (1–2 wk).** Decide the §5.0 storage strategy: bootstrap a
+  Strategy-B merged reasoned index from the LUBM-25 base refs (branch-style
+  ref copy + incremental fold of an existing full materialization) and
+  measure leaf-sharing ratio, fold cost, and query parity. Either way:
+  FPS1 format stub + `GraphSourceType::Reasoning` record. Only if B is
+  rejected: FDR1 stubs + id-alignment validation (Strategy A).
+- **M1 — persisted head, full-materialization maintenance (2–4 wk).**
+  Worker bootstraps and republishes the head by full re-derivation per
+  commit (correct, not yet incremental); query-side three-pointer cursor
+  lane + resolution order + `reasonedThroughT` surfacing. *Acceptance:*
+  LUBM-25 q01–q14 correct from the head with zero per-query
+  materialization and zero translation; restart serves reasoning queries
+  without re-deriving; steady-state per-query reasoning overhead is measured
+  against three controls: today's cached in-memory overlay with P0, a
+  novelty-heavy non-reasoning ledger with equivalent side-channel volume,
+  and a base-only indexed run. Success is no hidden full-closure scan and no
+  translation floor; any remaining latency should be attributable to the
+  same range-overlap merge cost novelty pays.
+- **M2 — insert-only FBF (2–3 wk).** §6.3 semi-naive over `E+`; provenance
+  entries written. *Acceptance:* steady-state commit maintenance cost is
+  O(|E+| consequences), validated on a LUBM-25 ledger with incremental
+  inserts; A1.4 post-import pass enabled (bootstrap = E−-empty maintenance).
+- **M3 — retracts + sameAs v1 (3–5 wk).** §6.4 FBF + §6.5 component
+  recompute; TBox-commit detection + full re-derive; reindex drop/rebuild.
+  *Acceptance:* randomized assert/retract soak vs. full re-materialization
+  oracle (property test), including sameAs dissolution cases.
+- **M4 — B1 surface (with M2/M3 sidecar in place).** `f:derivedBy` /
+  proof-tree endpoint reconstructing from FPS1; virtual RDF-star projection.
+- Throughout: the LUBM runner gains a head-mode column; baselines recorded
+  in `REASONING_STATUS.md`.
+
+## 11. Open questions
+
+1. **Record vs. manifest split** for head metadata (§4) — keep
+   `GraphSourceRecord` untouched and put everything in FDR1, or add typed
+   fields? Leaning manifest-only until a second consumer needs the fields.
+2. **Derived-store leaflet sizing** — derived extents are skewed (huge
+   `rdf:type` POST runs); reuse base leaf-split heuristics or tune?
+3. **Top-up overlay caching** (§7.1 path 2) — per-head generation cache vs.
+   reusing the global reasoning LRU with a head-aware key.
+4. **Multiple heads per ledger** — worker scheduling fairness when N
+   profiles exist; likely fine with per-head coalescing, verify under load.
+5. **`owl:sameAs` canonical-representative choice** must stay stable across
+   incremental runs to avoid churning derived rows (today: sorted-first
+   member; persist the choice in the manifest?).
+6. **What remains after P0?** If novelty-aware probes collapse q02/q09
+   against today's overlay, should A2 still be prioritized immediately, or
+   should it be framed as an operational milestone for cold restart, RSS,
+   incremental commit maintenance, and provenance? The answer should come
+   from the P0 benchmark controls above, not from assuming persistence is
+   faster than hot in-memory side-channel data.

--- a/docs/design/reasoning-roadmap.md
+++ b/docs/design/reasoning-roadmap.md
@@ -1,0 +1,243 @@
+# Reasoning Roadmap
+
+Status: **proposed** (June 2026). Synthesized from code analysis of the current
+reasoner, the incremental-materialization literature, and research into how
+ontologists and knowledge-graph practitioners actually work. Two axes: (A)
+reasoning performance — static materialization first, then incremental
+maintenance on a changing ledger; (B) UX/DX for knowledge-graph practitioners.
+
+## 1. Current state
+
+- **OWL2QL** is handled at query time (rewriting); **OWL2RL** by materialization
+  against a snapshot. `reason_owl2rl` (`fluree-db-reasoner/src/lib.rs`) runs a
+  semi-naive fixpoint and caches the result in a 16-entry LRU keyed by
+  `(ledger_id, db_epoch, to_t, overlay_epoch, ontology_epoch, modes, config_hash)`
+  (`cache.rs`). **Any commit changes the key → full re-materialization.** There
+  is no retraction handling; deletes just invalidate the cache.
+- Derived facts live only in a virtual `DerivedFactsOverlay` (default-graph
+  only), rebuilt per state change — never committed, never indexed.
+- Fixpoint hotspots: seeding does full PSOT scans per rule-relevant predicate
+  plus the whole `rdf:type` extent and merges seeded base facts into the
+  derived set; identity rules (prp-fp/ifp/key, max-cardinality) rescan
+  delta∪derived per iteration; single-threaded; heavy `Sid`/`Flake` cloning;
+  `max_memory_bytes` unenforced; the user-datalog lane is uncached and re-runs
+  on every query prepare.
+- Latent bugs: the cache key hardcodes `ReasoningModes::default()`;
+  `enabled_rules` feeds the cache hash but does not filter rules.
+- LUBM passes (derived-overlay join bugs fixed in PR #1294). Ledger-wide
+  `f:reasoningDefaults` is applied via `merge_reasoning`
+  (`fluree-db-api/src/config_resolver.rs`) with override control. Still
+  missing: SPARQL per-query reasoning — lowering hardcodes
+  `ReasoningConfig::default()` (`fluree-db-sparql/src/lower/mod.rs`).
+- Raw material for incrementality exists: commits carry exact (asserts,
+  retracts) deltas as op-flagged flakes; the indexer has a proven async sidecar
+  pattern (stats/spatial/fulltext); novelty `fact_state` computes net
+  add/remove semantics.
+
+## 2. Design principles (from the literature and established practice)
+
+1. **Hybrid, stratified by cost class.** Keep cheap, hierarchy-shaped
+   inference (QL/RDFS) at query time via rewriting; materialize the RL
+   closure, whose recursive rules (transitive closure, property chains,
+   sameAs) are too expensive to expand per query. The open problem is then
+   *maintenance* of the materialization, not the strategy choice.
+2. **Insert-only updates need no special machinery** — semi-naive evaluation
+   over the delta is optimal in every maintenance-algorithm family, and
+   inserts dominate Fluree's workload. Only retracts need a real algorithm.
+3. **Special-case `owl:sameAs`.** Equality through generic rules produces
+   quadratic closure; mature systems use canonical-representative rewriting
+   (union-find) with dedicated retraction handling.
+4. **Firewall ontology changes from data changes.** Ontology edits are rare
+   and may pay a bigger, coarser recompute; data commits must stay cheap.
+5. **Static-performance playbook**: compile the active ontology into
+   ontology-specific ground rules (replacing generic rule-family dispatch —
+   several-fold wins are reported in the literature), index rules by the facts
+   that can fire them (`rulesFor`), and parallelize the fixpoint
+   fact-at-a-time; near-linear multicore scaling is achievable.
+6. **Make staleness first-class.** A materialized-inference store should
+   expose a queryable "reasoned through" watermark rather than pretending the
+   closure is always current.
+
+Key papers: DRed (Gupta/Mumick/Subrahmanian, SIGMOD 1993); the
+Backward/Forward algorithm (Motik/Nenov/Piro/Horrocks, AAAI 2015);
+"Maintenance of Datalog Materialisations Revisited" (AIJ 2019 — including the
+empirical comparison of DRed/counting/FBF); incremental `owl:sameAs`
+maintenance (IJCAI 2015); stratum-scoped maintenance under rule-set changes
+(ZodiacEdge, 2023).
+
+## 3. Axis A — performance
+
+### A1. Static materialization
+
+- **A1.1 — fixpoint engine hygiene (weeks).** Stop merging seeded base facts
+  into the derived overlay; incremental grouping maps for identity rules; cache
+  the overlay post-build (stop re-sorting four index copies per query);
+  path-compress the union-find; intern `Sid`s to dense u64 ids per run.
+  Publish a LUBM timing baseline — none exists; A1.2/A1.3 must be sized
+  against it.
+- **A1.2 — rule compilation + rule indexing (1–2 months, keystone).** Compile
+  the active ontology into ontology-specific ground rules once per
+  `ontology_epoch`, replacing fixed rule-family dispatch, with a
+  `rulesFor(predicate/class)` index. A1.3, A2, and B1 all consume this
+  artifact. Do not start A2 before this.
+- **A1.3 — parallel fixpoint (1–2 months).** Fact-at-a-time parallel
+  semi-naive over compiled rules. Input is an immutable snapshot: keep
+  sorted-index seeding, hash-indexed working sets.
+- **A1.4 — import-time reasoning = post-import pass, not streaming.**
+  Streaming inference inside the import sink is rejected (chunk-local IDs, no
+  global view, RL closure needs the complete ontology). Instead run an
+  automatic post-import materialization pass against the freshly built index,
+  persisting via the A2 path (incremental maintenance with E− = ∅), so a
+  ledger comes up "reasoned" instead of paying closure on first query. Rule
+  compilation can pipeline with data indexing when a schema source is
+  identifiable up front (`f:schemaSource`, else TBox-predicate detection).
+
+### A2. Incremental maintenance (no full re-reasoning required)
+
+**Algorithm: FBF (Backward/Forward).** Insert-only commits (the dominant case)
+run plain semi-naive over the commit delta. Commits containing retracts run
+FBF: mark retract-affected derived facts doubtful, backward-chain against the
+old materialization + explicit facts (provided natively by snapshot-at-t−1)
+for surviving proofs. FBF needs **zero persistent auxiliary state**, keeping
+the materialization a pure function of (rules, data-at-t) — rebuildable at any
+t, consistent with immutability and time travel. The AIJ 2019 empirical study
+shows the backward/forward family dominating on small updates, which is
+exactly the per-commit case.
+
+Rejected alternatives: *counting* (per-fact counters maintained on every
+commit, complex under recursion, poor fit when retracts are rare); *full
+justification storage* (derivation sets are often orders of magnitude larger
+than derived facts — AIJ 2019); *differential dataflow* (RAM-resident
+arrangements with multi-x memory blowup, wrong operational shape for
+CAS-backed time-indexed indexes; revisit only if novelty grows native
+count-merge); *pure DRed* (FBF strictly generalizes it and wins on small
+updates).
+
+**Storage: a "reasoned index head" riding the branching plumbing — not branch
+commits, not inferred-marked entries in the main indexes.**
+
+Derived facts live in **derived-only index artifacts** under a branch-like
+namespace with their own index root, pinned to a main
+`(commit_t, ontology_epoch, rule_config_hash)`. Reused branching machinery:
+
+- `NsRecord` shape (own `index_head_id`/`index_t`, `source_branch` pointer,
+  `create/drop/reset` lifecycle) — `reasonedThroughT` *is* this record's
+  `index_t`;
+- `BranchedContentStore` read-through — the reasoned namespace holds only
+  derived artifacts and reads through to the base namespace (no base-index
+  copy; N rule configs = N small derived indexes);
+- alias routing (`name:reasoned`) plus per-query `"reasoning": "owl2rl"`, both
+  resolving to the same artifact;
+- per-head background worker and the `graph-sources/{name}/{branch}/` sidecar
+  layout (fulltext/vector precedent) — reasoning composes per branch of the
+  base ledger.
+
+Query-time composition is a three-way merge (base index + reasoned index +
+novelty), same shape as the existing overlay merge. Non-reasoning queries
+never open the reasoned root — zero cost, **no inferred-marker bit needed**
+(separation by artifact, not by bit).
+
+A literal reasoning *branch* ("merge main + reason") was evaluated and
+rejected on three code-verified grounds: (1) rebase semantics replay the
+branch's own commits — wrong for derived facts under retracts (FBF must
+recompute, not replay) — and every rebase physically copies main's index
+artifacts into the branch namespace; (2) branch novelty is reconstructed from
+commits, so persistence would force derived-fact commits, and replay/reindex
+would then resurrect stale inferences (breaking "reindex re-derives"); (3)
+branch t diverges from main t at the first derived commit, killing
+time-travel-with-reasoning. (Note: merge/rebase/merge-preview *are* on main —
+`fluree-db-api/src/{merge,rebase,merge_preview}.rs`; the reasoned-head
+NsRecord design should be coordinated with the custom-merging work on
+`feature/merge-preview3`.)
+
+**Consistency model.** The reasoning sidecar lags commits; the reasoned head's
+pinned t makes staleness first-class: surfaced in query-response metadata and
+ledger status, with a per-query option forcing the existing overlay path for
+read-your-writes freshness. Any t lacking persisted derivations falls back to
+today's overlay computation — no t regresses. Full reindex drops reasoned
+heads and re-derives; the commit log remains the sole source of truth.
+
+**Ontology vs data changes.** Detect TBox-touching commits by predicate match
+on the delta (`subClassOf`, `domain`/`range`, `intersectionOf`,
+`someValuesFrom`, `hasKey`, …). Data commits run FBF; ontology commits trigger
+stratum-scoped recompute (dependency-hypergraph approach per ZodiacEdge) with
+full re-reason as fallback. Rule addition = semi-naive with the new rules
+only; rule removal = treat that rule's consequences as retracts → FBF.
+
+**sameAs retraction.** Never through generic rules. v1: recompute the affected
+equivalence class's connected component. v2: the IJCAI 2015 incremental
+algorithm (equality deletion is non-monotonic — it can *restore*
+previously-rewritten facts).
+
+**Lineage/provenance placement** (for explanations):
+
+- **Not in `FlakeMeta`** — meta participates in `Flake` Eq/Hash, all four
+  index comparators, novelty `FactKey`, and v3 sort keys; lineage there makes
+  an asserted+derived (or twice-derived) fact two distinct index rows with
+  broken retraction matching. Variable-length premise refs also cannot fit the
+  fixed 32-byte `RunRecordV2`.
+- **Not as stored RDF-star/edge annotations** — under the
+  `feature/edge-annotations` storage model a 2-premise derivation costs 12
+  flakes × 4 orders ≈ 7–13× index amplification vs the bare fact, and the
+  first annotation flips a sticky ledger-wide `has_annotations` bit (every
+  base-edge retract pays a cascade lookup thereafter). OWL2RL closures rival
+  base data in size; prohibitive.
+- **Yes: provenance sidecar stream** beside the reasoned index leaves
+  (`history_sidecar.rs` precedent): keyed by v3 fact identity → `(rule_id,
+  premise keys)`, ~85–90 B per derived fact, fetched only on explanation
+  queries, supports multi-derivation.
+- **Exposed as *virtual* RDF-star when RDF 1.2 lands**: main already
+  BIND-projects `f:t`/`f:op` virtually (`fluree-db-sparql/src/lower/rdf_star.rs`),
+  and the edge-annotations branch's `expand_edge_annotation_patterns` is a
+  pre-planner rewrite — `<< ?s ?p ?o >> f:derivedBy ?rule` expands into
+  sidecar lookups. Standard queryability, zero physical amplification.
+
+## 4. Axis B — UX/DX for knowledge-graph practitioners
+
+Research headline: **no real "connect Protégé to a triplestore" integration
+exists anywhere** (Protégé's SPARQL tab is local-only; third-party connector
+plugins are folklore). Ontologists live in OWL *files* and ROBOT/ODK CI
+pipelines (merge → reason → validate-profile → diff → release). Supporting
+Protégé users means meeting the file-and-pipeline workflow.
+
+- **B0 — table stakes (with A1.1).** SPARQL per-query reasoning (protocol
+  param and/or `PRAGMA`); make `enabled_rules` actually filter; fix the
+  hardcoded cache-key modes.
+- **B1 — explanations.** Proof trees for any inferred fact — consistently the
+  most-valued reasoning feature among practitioners. Built on the A2
+  provenance sidecar; reconstruct trees on demand from per-fact `(rule,
+  premises)` tags rather than storing whole proofs. Design the sidecar format
+  during A2.
+- **B2 — Protégé-realistic workflow.** OWL file round-trip (clean
+  Turtle/RDF-XML export of a schema graph; fix the Turtle
+  `owl:intersectionOf` collection-flattening bug); **`versionIRI ↔ ledger t`
+  mapping** with structural axiom diff between any two t's (robot-diff
+  semantics over native history — Fluree's differentiator: ontology
+  versioning for free); ROBOT-style CLI verbs (`reason --assert-inferred`,
+  `validate-profile`, consistency check) for ODK pipelines; store-side
+  `owl:imports` resolution (extends existing `f:schemaSource` machinery).
+- **B3 — inspection & toggles.** Asserted-vs-inferred scoping falls out of the
+  reasoned-head artifact separation (query base-only vs composed) — no
+  pseudo-graph filtering needed; inferred-set diff between t1 and t2; named
+  reasoning profiles per query (schemaSource bundles + config hash = one
+  reasoned head each).
+- **B4 — SHACL/OWL division.** SHACL = closed-world validation, OWL =
+  open-world inference; ship "inference feeds validation" (SHACL evaluated
+  over the materialized closure), not semantic unification.
+
+## 5. Sequencing
+
+1. **A1.1 + B0** now; publish the LUBM baseline.
+2. **A1.2 rule compilation** — keystone; A1.3, A2, B1 consume it.
+3. **A2 reasoned head + FBF**, designing the provenance sidecar (B1) at the
+   same time; A1.4's post-import pass is A2 with E− = ∅.
+4. **B2 is independent, can start anytime** — highest differentiation per
+   engineering dollar (ontology versioning on an immutable ledger).
+
+Open items: ~~root-cause the historical `fluree index` blank-node
+regression~~ resolved June 11, 2026 — does not reproduce on
+`refactor/resoning-2` (LUBM-1 import → reindex → identical
+reasoning-complete suite; the FINDINGS.md Chair→0 entry predated the
+`canonical_split`/#1294-era fixes); guarded by
+`fluree-db-api/tests/it_reasoning_reindex.rs`. Remaining: coordinate the
+reasoned-head record with `feature/merge-preview3`'s custom-merging work.

--- a/fluree-db-api/examples/index_throughput.rs
+++ b/fluree-db-api/examples/index_throughput.rs
@@ -1,0 +1,424 @@
+//! Background-indexing throughput harness — the realistic write path.
+//!
+//! Unlike `transact_growth_profile` (which disables indexing and forces a
+//! synchronous `reindex()`), this drives the **real background indexer**: a
+//! file-backed `Fluree` with `with_indexing_thresholds(min, max)` spawns a
+//! `BackgroundIndexerWorker` that indexes concurrently with commits.
+//!
+//! - `reindex_min_bytes` (MIN): novelty size at which a background index STARTS.
+//! - `reindex_max_bytes` (MAX): novelty ceiling that BLOCKS commits
+//!   (`TransactError::NoveltyAtMax`) until the index drains novelty below it.
+//!
+//! Two canonical configs:
+//!   - **keep-up** (MIN tiny, MAX comfortable): index after ~every commit unless
+//!     busy; measures whether the indexer keeps pace and how many index cycles
+//!     run (more cycles = fresher index = more reads hit index, not novelty).
+//!   - **wall** (MIN ≈ MAX): accumulate to the ceiling, block until the index
+//!     drains, continue — effectively synchronous via backpressure.
+//!
+//! Runs on a MULTI-THREAD runtime so the indexer truly overlaps commits.
+//!
+//! ## Config (env)
+//! | Var | Default | Meaning |
+//! |---|---|---|
+//! | `IDX_COMMITS` | `4000` | commits to drive |
+//! | `IDX_NODES_PER_COMMIT` | `10` | nodes/commit (~8 flakes each) |
+//! | `IDX_MIN_BYTES` | `100` | reindex_min_bytes (start trigger) |
+//! | `IDX_MAX_BYTES` | `4000000` | reindex_max_bytes (backpressure wall) |
+//! | `IDX_DB_DIR` | `/dev/shm/idx-throughput` | file storage dir |
+//! | `IDX_CSV` | `target/index-throughput.csv` | per-commit CSV |
+//! | `IDX_DRAIN_WAIT_S` | `120` | max wait for the final index to drain after commits |
+//!
+//! ## Run
+//! ```bash
+//! IDX_MIN_BYTES=100 IDX_MAX_BYTES=4000000 \
+//!   cargo run --release --example index_throughput -p fluree-db-api --features native
+//! ```
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::Value as JsonValue;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
+
+use fluree_bench_support::gen::people::{generate_txn_data, txn_data_to_jsonld};
+
+fn env_str(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+// ---- tracing capture of index START / FINISH (the orchestrator logs these) ----
+
+#[derive(Default)]
+struct MsgVisit {
+    msg: String,
+    index_t: i64,
+}
+impl Visit for MsgVisit {
+    fn record_i64(&mut self, f: &Field, v: i64) {
+        if f.name() == "index_t" {
+            self.index_t = v;
+        }
+    }
+    fn record_u64(&mut self, f: &Field, v: u64) {
+        if f.name() == "index_t" {
+            self.index_t = v as i64;
+        }
+    }
+    fn record_debug(&mut self, f: &Field, v: &dyn std::fmt::Debug) {
+        if f.name() == "message" {
+            self.msg = format!("{v:?}");
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum IdxEvent {
+    Start(u128),
+    Finish(u128, i64),
+}
+
+struct IdxLayer {
+    start: Instant,
+    ev: Arc<Mutex<Vec<IdxEvent>>>,
+}
+impl<S: Subscriber> Layer<S> for IdxLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut v = MsgVisit::default();
+        event.record(&mut v);
+        if v.msg.is_empty() {
+            return;
+        }
+        let at = self.start.elapsed().as_millis();
+        if v.msg.contains("Starting queued indexing work") {
+            self.ev.lock().unwrap().push(IdxEvent::Start(at));
+        } else if v.msg.contains("Successfully indexed ledger") {
+            self.ev
+                .lock()
+                .unwrap()
+                .push(IdxEvent::Finish(at, v.index_t));
+        }
+    }
+}
+
+struct Row {
+    idx: usize,
+    t: i64,
+    index_t: i64,
+    novelty_bytes: usize,
+    commit_us: u128,
+    wall_ms: u128,
+    stalled_ms: u128,
+}
+
+fn is_at_max(e: &impl std::fmt::Debug) -> bool {
+    format!("{e:?}").contains("NoveltyAtMax")
+}
+
+async fn run(ev: Arc<Mutex<Vec<IdxEvent>>>, t0: Instant) {
+    let commits = env_usize("IDX_COMMITS", 4000);
+    let npc = env_usize("IDX_NODES_PER_COMMIT", 10);
+    let min_bytes = env_usize("IDX_MIN_BYTES", 100);
+    let max_bytes = env_usize("IDX_MAX_BYTES", 4_000_000);
+    let dir = env_str("IDX_DB_DIR", "/dev/shm/idx-throughput");
+    let csv = env_str("IDX_CSV", "target/index-throughput.csv");
+    let drain_wait_s = env_usize("IDX_DRAIN_WAIT_S", 120);
+    let ledger_id = env_str("IDX_LEDGER", "idx/bench:main");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    let fluree = FlureeBuilder::file(dir)
+        .with_indexing_thresholds(min_bytes, max_bytes)
+        .build()
+        .expect("build (file + indexing)");
+
+    eprintln!(
+        "index_throughput: {commits} commits x {npc} nodes | MIN={min_bytes}B MAX={max_bytes}B"
+    );
+
+    let mut ledger = fluree
+        .create_ledger(&ledger_id)
+        .await
+        .expect("create_ledger");
+    let mut rows: Vec<Row> = Vec::with_capacity(commits);
+    let mut last_index_t = ledger.index_t();
+    let mut index_advances = 0usize; // index_t transitions seen from the commit loop
+    let mut stalled_commits = 0usize;
+    let mut total_stall = Duration::ZERO;
+    let mut max_stall = Duration::ZERO;
+    let mut commit_only_us: Vec<u128> = Vec::with_capacity(commits);
+    let report_every = (commits / 20).max(1);
+
+    let loop_start = Instant::now();
+    for i in 0..commits {
+        let json: JsonValue = txn_data_to_jsonld(&generate_txn_data(i, npc));
+
+        // Each commit builds on the CURRENT published state (reload), so the
+        // committer reflects background-index publications: novelty clears,
+        // index_t advances, and backpressure (NoveltyAtMax) is evaluated against
+        // the real shared novelty — modelling a server handling successive txns.
+        let mut stall = Duration::ZERO;
+        let next = loop {
+            let base = fluree.ledger(&ledger_id).await.expect("reload base ledger");
+            let c0 = Instant::now();
+            match fluree.insert(base, &json).await {
+                Ok(res) => {
+                    commit_only_us.push(c0.elapsed().as_micros());
+                    break res.ledger;
+                }
+                Err(e) if is_at_max(&e) => {
+                    let s = Duration::from_micros(500);
+                    tokio::time::sleep(s).await;
+                    stall += s;
+                    assert!(
+                        stall <= Duration::from_secs(drain_wait_s as u64),
+                        "commit {i} stalled >{drain_wait_s}s at MAX novelty — indexer not draining"
+                    );
+                }
+                Err(e) => panic!("insert commit {i} failed: {e:?}"),
+            }
+        };
+        ledger = next;
+        if !stall.is_zero() {
+            stalled_commits += 1;
+            total_stall += stall;
+            max_stall = max_stall.max(stall);
+        }
+
+        let it = ledger.index_t();
+        if it > last_index_t {
+            index_advances += 1;
+            last_index_t = it;
+        }
+        rows.push(Row {
+            idx: i,
+            t: ledger.t(),
+            index_t: it,
+            novelty_bytes: ledger.novelty_size(),
+            commit_us: commit_only_us.last().copied().unwrap_or(0),
+            wall_ms: t0.elapsed().as_millis(),
+            stalled_ms: stall.as_millis(),
+        });
+        if i % report_every == 0 {
+            eprintln!(
+                "[idx] commit {i}/{commits}  t={} index_t={} novelty={:.2} MiB  index_cycles={}  stalled={}",
+                ledger.t(),
+                it,
+                ledger.novelty_size() as f64 / (1024.0 * 1024.0),
+                index_advances,
+                stalled_commits,
+            );
+        }
+    }
+    let commit_wall = loop_start.elapsed();
+
+    // Wait for the final index to catch up (index_t -> t), polling a fresh view.
+    let drain0 = Instant::now();
+    let final_t = ledger.t();
+    let mut final_index_t = ledger.index_t();
+    while final_index_t < final_t && drain0.elapsed() < Duration::from_secs(drain_wait_s as u64) {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let l = fluree.ledger(&ledger_id).await.expect("reload");
+        final_index_t = l.index_t();
+    }
+    let drain_wall = drain0.elapsed();
+
+    write_csv(&csv, &rows);
+    summarize(
+        commits,
+        commit_wall,
+        drain_wall,
+        &commit_only_us,
+        stalled_commits,
+        total_stall,
+        max_stall,
+        index_advances,
+        final_t,
+        final_index_t,
+        &rows,
+        &ev.lock().unwrap(),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn summarize(
+    commits: usize,
+    commit_wall: Duration,
+    drain_wall: Duration,
+    commit_only_us: &[u128],
+    stalled_commits: usize,
+    total_stall: Duration,
+    max_stall: Duration,
+    index_advances: usize,
+    final_t: i64,
+    final_index_t: i64,
+    rows: &[Row],
+    events: &[IdxEvent],
+) {
+    let mut sorted: Vec<u128> = commit_only_us.to_vec();
+    sorted.sort_unstable();
+    let pct = |p: f64| -> u128 {
+        if sorted.is_empty() {
+            return 0;
+        }
+        sorted[((sorted.len() as f64 * p) as usize).min(sorted.len() - 1)]
+    };
+    let mean_commit = if sorted.is_empty() {
+        0
+    } else {
+        sorted.iter().sum::<u128>() / sorted.len() as u128
+    };
+
+    // pair Start->Finish for per-index durations (serial per ledger)
+    let mut durs: Vec<u128> = Vec::new();
+    let mut pending_start: Option<u128> = None;
+    let mut last_finish_ms = 0u128;
+    let mut last_indexed_t = -1i64;
+    for e in events {
+        match *e {
+            IdxEvent::Start(at) => pending_start = Some(at),
+            IdxEvent::Finish(at, idx_t) => {
+                if let Some(s) = pending_start.take() {
+                    durs.push(at.saturating_sub(s));
+                }
+                last_finish_ms = at;
+                last_indexed_t = last_indexed_t.max(idx_t);
+            }
+        }
+    }
+    let n_idx = durs.len();
+    let total_idx_ms: u128 = durs.iter().sum();
+    let mean_idx = if n_idx > 0 {
+        total_idx_ms / n_idx as u128
+    } else {
+        0
+    };
+    let max_idx = durs.iter().copied().max().unwrap_or(0);
+    let min_idx = durs.iter().copied().min().unwrap_or(0);
+
+    let nov: Vec<usize> = rows.iter().map(|r| r.novelty_bytes).collect();
+    let nov_max = nov.iter().copied().max().unwrap_or(0);
+    let nov_mean = if nov.is_empty() {
+        0
+    } else {
+        nov.iter().sum::<usize>() / nov.len()
+    };
+    let final_nov = rows.last().map(|r| r.novelty_bytes).unwrap_or(0);
+
+    let total_wall = commit_wall + drain_wall;
+    let cps_commit = commits as f64 / commit_wall.as_secs_f64();
+    let cps_total = commits as f64 / total_wall.as_secs_f64();
+    let mib = |b: usize| b as f64 / (1024.0 * 1024.0);
+
+    println!("\n================ index-throughput summary ================");
+    println!("commits                : {commits}");
+    println!(
+        "commit-loop wall       : {:.2} s",
+        commit_wall.as_secs_f64()
+    );
+    println!(
+        "final-drain wall       : {:.2} s (wait index_t -> t after commits)",
+        drain_wall.as_secs_f64()
+    );
+    println!("THROUGHPUT (commit loop): {cps_commit:.0} commits/s");
+    println!("THROUGHPUT (incl drain) : {cps_total:.0} commits/s");
+    println!(
+        "commit latency us      : mean {mean_commit}  p50 {}  p95 {}  p99 {}",
+        pct(0.50),
+        pct(0.95),
+        pct(0.99)
+    );
+    println!("--- backpressure (MAX wall) ---");
+    println!(
+        "stalled commits        : {stalled_commits}  ({:.1}%)",
+        100.0 * stalled_commits as f64 / commits as f64
+    );
+    println!(
+        "total stall            : {:.2} s   max single stall {:.0} ms",
+        total_stall.as_secs_f64(),
+        max_stall.as_millis()
+    );
+    println!("--- background indexing ---");
+    println!(
+        "index cycles (logs)    : {n_idx}    (index_t advances seen by commits: {index_advances})"
+    );
+    println!("per-index ms           : mean {mean_idx}  min {min_idx}  max {max_idx}");
+    println!(
+        "total index time       : {:.2} s   ({:.0}% of commit-loop wall)",
+        total_idx_ms as f64 / 1000.0,
+        100.0 * total_idx_ms as f64 / commit_wall.as_millis() as f64
+    );
+    println!(
+        "last index finished at : {:.2} s into run  (reached index_t={last_indexed_t})",
+        last_finish_ms as f64 / 1000.0
+    );
+    println!("--- novelty (clearing / lag) ---");
+    println!(
+        "novelty MiB            : mean {:.2}  max {:.2}  final {:.2}",
+        mib(nov_mean),
+        mib(nov_max),
+        mib(final_nov)
+    );
+    println!(
+        "final t / index_t      : {final_t} / {final_index_t}   (lag {} commits)",
+        final_t - final_index_t
+    );
+    let keeping_up = stalled_commits == 0;
+    println!(
+        "verdict                : indexer {} (more cycles + low novelty = fresher index for reads)",
+        if keeping_up {
+            "KEPT UP (no backpressure)"
+        } else {
+            "FELL BEHIND (hit MAX wall)"
+        }
+    );
+    println!("=========================================================");
+    println!("(slope of per-commit cost is flat by design; this measures NET throughput with real background indexing)");
+}
+
+fn write_csv(path: &str, rows: &[Row]) {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(rows.len() * 56 + 64);
+    out.push_str("commit_idx,t,index_t,novelty_bytes,commit_us,wall_ms,stalled_ms\n");
+    for r in rows {
+        let _ = writeln!(
+            out,
+            "{},{},{},{},{},{},{}",
+            r.idx, r.t, r.index_t, r.novelty_bytes, r.commit_us, r.wall_ms, r.stalled_ms
+        );
+    }
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Err(e) = std::fs::write(path, out) {
+        eprintln!("[csv] write {path} failed: {e}");
+    } else {
+        eprintln!("[csv] wrote {} rows -> {path}", rows.len());
+    }
+}
+
+fn main() {
+    let t0 = Instant::now();
+    let ev = Arc::new(Mutex::new(Vec::<IdxEvent>::new()));
+    tracing_subscriber::registry()
+        .with(IdxLayer {
+            start: t0,
+            ev: ev.clone(),
+        })
+        .init();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("multi-thread runtime");
+    rt.block_on(run(ev, t0));
+}

--- a/testsuite-sparql/Cargo.lock
+++ b/testsuite-sparql/Cargo.lock
@@ -641,7 +641,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-db-api"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "base64",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "bigdecimal 0.4.10",
  "chrono",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "base64",
  "bs58",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "fluree-graph-ir",
  "serde",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "fluree-vocab",
  "serde",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.0.6"
+version = "4.0.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-vocab"
-version = "4.0.6"
+version = "4.0.7"
 
 [[package]]
 name = "foldhash"
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "testsuite-sparql"
-version = "4.0.4"
+version = "4.0.7"
 dependencies = [
  "anyhow",
  "fluree-db-api",

--- a/testsuite-sparql/Cargo.toml
+++ b/testsuite-sparql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testsuite-sparql"
-version = "4.0.4"
+version = "4.0.7"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Bumps the workspace version to **4.0.7**.

## Changes
- `Cargo.toml` — workspace `version` 4.0.6 → 4.0.7
- `Cargo.lock` — all workspace crate pins refreshed
- `testsuite-sparql/Cargo.toml` — straggler 4.0.4 → 4.0.7 (excluded from the workspace, so it pins its own version)
- `testsuite-sparql/Cargo.lock` — pin refreshed

No code changes; version metadata only.