### PR TITLE
fix: Reuse shared runtime for sync CAS fetches

### DIFF
--- a/fluree-db-binary-index/src/arena/vector.rs
+++ b/fluree-db-binary-index/src/arena/vector.rs
@@ -63,14 +63,13 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
         Some(dir) => dir.join(format!(".{file_name}.tmp.{pid}.{seq}")),
         None => PathBuf::from(format!(".{file_name}.tmp.{pid}.{seq}")),
     };
-    std::fs::write(&tmp, bytes)?;
-    match std::fs::rename(&tmp, path) {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            let _ = std::fs::remove_file(&tmp);
-            Err(e)
-        }
+    // Clean up the staging file on any failure (write or rename) so a mid-write
+    // error doesn't leave an orphaned temp file behind.
+    let staged = std::fs::write(&tmp, bytes).and_then(|()| std::fs::rename(&tmp, path));
+    if staged.is_err() {
+        let _ = std::fs::remove_file(&tmp);
     }
+    staged
 }
 
 /// Maximum vectors per shard. At 768-dim f32 each shard ≈ 9 MB.

--- a/fluree-db-binary-index/src/arena/vector.rs
+++ b/fluree-db-binary-index/src/arena/vector.rs
@@ -752,10 +752,26 @@ impl LazyVectorArena {
         let cs = Arc::clone(cas);
         let cid = cid.clone();
         let path = source.path.clone();
+        // Bound the fetch with the same `cas_sync_timeout()` the index-leaf and
+        // dict-pack bridges use, so a stalled remote (S3) GET fails fast instead
+        // of blocking the waiting thread indefinitely.
+        let timeout = crate::read::binary_index_store::cas_sync_timeout();
         let bytes = crate::read::binary_index_store::run_sync_on_runtime(async move {
-            cs.get(&cid)
-                .await
-                .map_err(|e| io::Error::other(e.to_string()))
+            let fut = cs.get(&cid);
+            if let Some(dur) = timeout {
+                tokio::time::timeout(dur, fut)
+                    .await
+                    .map_err(|_| {
+                        io::Error::other(format!(
+                            "vector shard CAS fetch timed out after {}ms (cid={})",
+                            dur.as_millis(),
+                            cid
+                        ))
+                    })?
+                    .map_err(|e| io::Error::other(e.to_string()))
+            } else {
+                fut.await.map_err(|e| io::Error::other(e.to_string()))
+            }
         })?;
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;

--- a/fluree-db-binary-index/src/arena/vector.rs
+++ b/fluree-db-binary-index/src/arena/vector.rs
@@ -720,7 +720,7 @@ impl LazyVectorArena {
         // Sync→async bridge via the shared `run_sync_on_runtime` helper, which
         // uses `block_in_place(handle.block_on)` on a multi-thread runtime (a
         // replacement worker keeps driving the reactor while this thread
-        // blocks) and a self-contained helper runtime on current-thread. The
+        // blocks) and a process-wide helper runtime when needed. The
         // previous `std::thread::spawn` + outer-`Handle::block_on` + `rx.recv()`
         // had no `block_in_place`, so on a small runtime every worker could park
         // in `recv()` with no thread left to drive the reactor — the same wedge

--- a/fluree-db-binary-index/src/arena/vector.rs
+++ b/fluree-db-binary-index/src/arena/vector.rs
@@ -46,8 +46,32 @@ use serde::{Deserialize, Serialize};
 use std::io;
 use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+
+/// Write `bytes` to `path` atomically: stage in a uniquely-named temp file in
+/// the same directory, then `rename` it onto `path`. A POSIX rename is atomic,
+/// so concurrent readers never observe a partially-written file. The temp name
+/// is unique per (pid, monotonic counter) so concurrent writers of the same
+/// shard never collide on the staging file.
+fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("shard");
+    let tmp = match path.parent() {
+        Some(dir) => dir.join(format!(".{file_name}.tmp.{pid}.{seq}")),
+        None => PathBuf::from(format!(".{file_name}.tmp.{pid}.{seq}")),
+    };
+    std::fs::write(&tmp, bytes)?;
+    match std::fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
 
 /// Maximum vectors per shard. At 768-dim f32 each shard ≈ 9 MB.
 pub const SHARD_CAPACITY: u32 = 3072;
@@ -737,7 +761,14 @@ impl LazyVectorArena {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(&path, &bytes)?;
+        // Publish atomically: write to a unique temp file in the same directory,
+        // then rename onto the final path. Without this, two concurrent
+        // `ensure_on_disk` calls for the same shard (e.g. a cached `lookup_vector`
+        // racing a transient streaming scan) both `fs::write` the same path, and a
+        // reader can observe a half-written file — surfacing as
+        // "vector shard too small for header". A POSIX rename is atomic, so a
+        // reader always sees a complete shard once this returns.
+        write_atomic(&path, &bytes)?;
         source.on_disk.store(true, Ordering::Release);
         Ok(())
     }

--- a/fluree-db-binary-index/src/dict/pack_reader.rs
+++ b/fluree-db-binary-index/src/dict/pack_reader.rs
@@ -418,8 +418,8 @@ fn fetch_and_load(
     // Remote fetch: bridge the sync lookup to the async CAS get via the shared
     // `run_sync_on_runtime` helper. It uses `block_in_place(handle.block_on)`
     // on a multi-thread runtime (a replacement worker keeps driving the
-    // reactor while this thread blocks) and a self-contained helper runtime on
-    // current-thread. The previous `thread::spawn` + outer-`Handle::block_on`
+    // reactor while this thread blocks) and a process-wide helper runtime when
+    // needed. The previous `thread::spawn` + outer-`Handle::block_on`
     // + `.join()` re-injected the fetch onto the OUTER runtime with no
     // `block_in_place`, which can wedge a small (e.g. 2-worker) runtime under
     // query fan-out (every worker parked with no thread driving the reactor).

--- a/fluree-db-binary-index/src/dict/reader.rs
+++ b/fluree-db-binary-index/src/dict/reader.rs
@@ -446,7 +446,7 @@ impl DictTreeReader {
             // the shared `run_sync_on_runtime` helper, which uses
             // `block_in_place(handle.block_on)` on a multi-thread runtime (so a
             // replacement worker keeps driving the reactor while this thread
-            // blocks) and a self-contained helper runtime on current-thread.
+            // blocks) and a process-wide helper runtime when needed.
             //
             // The previous hand-rolled `thread::spawn` + outer-`Handle::block_on`
             // + `rx.recv()` re-injected the fetch onto the OUTER runtime with no

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -8,7 +8,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use fluree_db_core::ids::DatatypeDictId;
@@ -36,6 +36,7 @@ use super::artifact_cache::{fetch_cached_bytes, fetch_cached_bytes_cid};
 use super::leaflet_cache::LeafletCache;
 
 const HOT_REMOTE_LEAF_PROMOTION_TOUCHES: usize = 2;
+const CAS_HELPER_RUNTIME_THREADS: usize = 2;
 
 // ============================================================================
 // Shared dictionary / CAS utilities
@@ -79,6 +80,38 @@ pub(crate) fn cas_sync_timeout() -> Option<Duration> {
         .map(Duration::from_millis)
 }
 
+fn shared_cas_helper_runtime() -> io::Result<&'static tokio::runtime::Runtime> {
+    static RT: OnceLock<Result<tokio::runtime::Runtime, String>> = OnceLock::new();
+
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(CAS_HELPER_RUNTIME_THREADS)
+            .thread_name("fluree-cas-helper")
+            .enable_all()
+            .build()
+            .map_err(|e| format!("failed to build shared CAS helper runtime: {e}"))
+    })
+    .as_ref()
+    .map_err(|e| io::Error::other(e.clone()))
+}
+
+fn run_on_shared_cas_helper_thread<T, Fut>(fut: Fut) -> io::Result<T>
+where
+    T: Send + 'static,
+    Fut: std::future::Future<Output = io::Result<T>> + Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::sync_channel::<io::Result<T>>(1);
+    std::thread::Builder::new()
+        .name("fluree-cas-helper-bridge".into())
+        .spawn(move || {
+            let result = shared_cas_helper_runtime().and_then(|rt| rt.block_on(fut));
+            let _ = tx.send(result);
+        })
+        .map_err(|e| io::Error::other(format!("failed to spawn CAS helper bridge: {e}")))?;
+    rx.recv()
+        .map_err(|_| io::Error::other("CAS helper bridge thread panicked"))?
+}
+
 /// Drive an async future to completion from synchronous code, safely on any
 /// Tokio runtime flavor.
 ///
@@ -86,8 +119,10 @@ pub(crate) fn cas_sync_timeout() -> Option<Duration> {
 /// the calling worker is converted to a blocking thread and Tokio promotes a
 /// replacement that keeps driving the IO reactor / timer, so the awaited
 /// future (e.g. an S3 `get`) makes progress even while this thread blocks.
-/// On a **current-thread** (or unknown / absent) runtime it runs the future on
-/// a self-contained helper runtime so it never deadlocks the single thread.
+/// On a **current-thread** (or unknown) runtime it moves the blocking wait to a
+/// helper thread backed by the process-wide CAS helper runtime, so it never
+/// deadlocks the single thread. With no ambient runtime (e.g. Rayon workers),
+/// it drives the future directly on that same long-lived helper runtime.
 ///
 /// This is the canonical sync→async bridge for the index read path. All
 /// CAS-backed reads (leaf bytes, dict-tree leaves, forward packs) must go
@@ -111,47 +146,22 @@ where
             tokio::runtime::RuntimeFlavor::CurrentThread => {
                 // Avoid deadlock:
                 // - We're on the single runtime thread.
-                // - If we block here waiting for another thread that calls
-                //   `handle.block_on(...)`, the runtime can't make progress.
-                // Instead, run the future on a self-contained runtime in a helper thread.
-                let (tx, rx) = std::sync::mpsc::sync_channel::<io::Result<T>>(1);
-                std::thread::spawn(move || {
-                    let result = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                        .map_err(|e| {
-                            io::Error::other(format!("failed to build helper runtime: {e}"))
-                        })
-                        .and_then(|rt| rt.block_on(fut));
-                    let _ = tx.send(result);
-                });
-                rx.recv()
-                    .map_err(|_| io::Error::other("helper runtime thread panicked"))?
+                // - Calling `Runtime::block_on` directly here can panic or stall.
+                // Move the wait to a plain thread, but keep the async work on the
+                // long-lived CAS helper runtime so SDK dispatch tasks outlive each
+                // individual fetch.
+                run_on_shared_cas_helper_thread(fut)
             }
             _ => {
                 // Future-proofing: treat unknown flavors conservatively.
-                let (tx, rx) = std::sync::mpsc::sync_channel::<io::Result<T>>(1);
-                std::thread::spawn(move || {
-                    let result = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                        .map_err(|e| {
-                            io::Error::other(format!("failed to build helper runtime: {e}"))
-                        })
-                        .and_then(|rt| rt.block_on(fut));
-                    let _ = tx.send(result);
-                });
-                rx.recv()
-                    .map_err(|_| io::Error::other("helper runtime thread panicked"))?
+                run_on_shared_cas_helper_thread(fut)
             }
         },
         Err(_) => {
-            // No runtime context available. Create a local runtime to run the future.
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| io::Error::other(format!("failed to build helper runtime: {e}")))?
-                .block_on(fut)
+            // No runtime context available (for example a Rayon worker). Use the
+            // process-wide runtime so pooled async-client connections keep their
+            // dispatch tasks on a runtime that is not dropped after each fetch.
+            shared_cas_helper_runtime()?.block_on(fut)
         }
     }
 }
@@ -3294,6 +3304,50 @@ mod tests {
             ),
             Err(_) => {
                 panic!("run_sync_on_runtime wedged a 2-worker runtime under fan-out (regression)")
+            }
+        }
+    }
+
+    /// Regression guard for the Lambda/Solo remote leaf-fetch failure mode.
+    ///
+    /// Fast-path leaf scans can run on Rayon workers with no ambient Tokio
+    /// runtime. The bridge must use the long-lived process-wide helper runtime
+    /// in that case, not create and drop a fresh runtime per fetch.
+    #[test]
+    fn run_sync_on_runtime_no_runtime_fanout_uses_shared_runtime() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        assert!(tokio::runtime::Handle::try_current().is_err());
+
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut workers = Vec::new();
+            for _ in 0..32 {
+                workers.push(std::thread::spawn(|| {
+                    run_sync_on_runtime(async {
+                        tokio::time::sleep(Duration::from_millis(25)).await;
+                        Ok::<(), std::io::Error>(())
+                    })
+                }));
+            }
+
+            let mut ok = 0usize;
+            for worker in workers {
+                if matches!(worker.join(), Ok(Ok(()))) {
+                    ok += 1;
+                }
+            }
+            let _ = tx.send(ok);
+        });
+
+        match rx.recv_timeout(Duration::from_secs(8)) {
+            Ok(done) => assert_eq!(
+                done, 32,
+                "all no-runtime bridged fetches must complete on the shared helper runtime"
+            ),
+            Err(_) => {
+                panic!("run_sync_on_runtime wedged no-runtime fan-out on shared helper runtime")
             }
         }
     }

--- a/fluree-db-storage-aws/src/s3/mod.rs
+++ b/fluree-db-storage-aws/src/s3/mod.rs
@@ -439,7 +439,9 @@ impl StorageRead for S3Storage {
                     key = key.as_str(),
                     address,
                     range = range_header.as_str(),
+                    send_elapsed_ms,
                     body_elapsed_ms,
+                    total_elapsed_ms = total_started.elapsed().as_millis() as u64,
                     timeout_ms = send_timeout.as_millis() as u64,
                     is_express = Self::is_express_bucket(&self.bucket),
                     "s3 read_byte_range: body collect timed out"
@@ -459,6 +461,7 @@ impl StorageRead for S3Storage {
                 address,
                 range = range_header.as_str(),
                 body_bytes = bytes.len(),
+                send_elapsed_ms,
                 body_elapsed_ms,
                 total_elapsed_ms = total_started.elapsed().as_millis() as u64,
                 is_express = Self::is_express_bucket(&self.bucket),


### PR DESCRIPTION
## Summary

Fixes a bug where remote CAS leaf fetches could stall when querying an S3-backed ledger. Discovered while running a query against a ~0.6B-flake database — a query whose result set had to span many index leaves, fanning out enough remote leaf range scans to surface the failure.

The sync→async CAS bridge (`run_sync_on_runtime`) used to build and **drop a fresh `current_thread` Tokio runtime on every fetch** in the no-ambient-runtime and current-thread paths. Pooled S3/hyper connections bind their dispatch tasks to the runtime that created them, so dropping that runtime after each fetch killed the dispatch task. The next fetch that reused a pooled connection had nothing driving it and stalled.

## Fix

Replace the per-fetch runtime with a **process-wide, long-lived multi-thread helper runtime** (`OnceLock`), so pooled connections keep their dispatch tasks alive across fetches. This also makes cross-path connection reuse safe (a connection first dispatched on the helper runtime, later reused from the ambient runtime, still has a live task).

Dispatch by runtime context:
- **No ambient runtime** (Rayon fast-path leaf scans — the failure mode here): drive the future directly on the shared runtime.
- **Current-thread / unknown flavor**: move the blocking wait to a plain thread (can't call `block_on` from inside a runtime), but run the async work on the same shared runtime.
- **Multi-thread** (server hot path): unchanged — `block_in_place(handle.block_on)` on the ambient runtime.

## Testing

- Adds a no-runtime fan-out regression guard (`run_sync_on_runtime_no_runtime_fanout_uses_shared_runtime`) that drives 32 concurrent bridged fetches with no ambient runtime and asserts all complete.
- `cargo check` / `cargo test` pass for `fluree-db-binary-index` and `fluree-db-storage-aws`.