### PR TITLE
fix: harden CLI auth token storage and robustness

### DIFF
--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -67,6 +67,8 @@ Auth Status:
 
 Store a bearer token for a remote. The token is saved in `.fluree/config.toml` and will be sent as a `Authorization: Bearer` header on subsequent remote operations (`fetch`, `pull`, `push`, `query --remote`, etc.).
 
+> **Which path do I use?** If the remote is backed by an identity provider (`auth.type = "oidc_device"`, auto-discovered), `fluree auth login` runs an interactive browser/device login for you — see [OIDC login flow](#oidc-login-flow) below; you do **not** pass `--token`. The `--token` options documented here are for manually supplying a token you already have, such as a locally-created Ed25519 JWS (`fluree token create`) or a service-account token for automation.
+
 ### Usage
 
 ```bash
@@ -183,7 +185,7 @@ When `--remote` is omitted:
 
 ## Security Notes
 
-- Tokens are stored in plaintext in `.fluree/config.toml`. Protect this file with appropriate filesystem permissions.
+- Tokens are stored in plaintext in `.fluree/config.toml`. On Unix, the CLI restricts the config file to `0600` and the `.fluree` directory to `0700` (owner-only) whenever it writes token material, so the file is not group/world-readable. On other platforms, protect the file with appropriate filesystem permissions yourself.
 - The `status` command never displays the raw token value.
 - On 401 errors from remote operations, the CLI checks token expiry and suggests `fluree auth login` if the token appears expired.
 
@@ -197,6 +199,39 @@ When a remote is configured with `auth.type = "oidc_device"` (auto-discovered fr
    - Otherwise, if it includes `authorization_endpoint`: use OAuth authorization-code + PKCE (opens a browser and receives a localhost callback).
 3. Exchanges the IdP token for a Fluree-scoped Bearer token via the server's `exchange_url`
 4. Stores the token (and optional refresh token) in the remote config
+
+If the IdP grants fewer scopes than were requested, the CLI prints a warning at login (the downgraded token still works, but a missing scope would otherwise surface later as an unrelated authorization failure). If the exchange returns no refresh token, the CLI notes that you will need to re-run `fluree auth login` when the token expires.
+
+### End-to-end walkthrough
+
+```bash
+# 1. Add the remote (auth type is auto-discovered from /.well-known/fluree.json)
+fluree remote add origin https://db.example.com
+
+# 2. Log in — opens a browser (PKCE) or prints a device code, then exchanges for a Fluree token
+fluree auth login --remote origin
+#   Discovering OIDC endpoints...
+#   >> Open this URL and enter the code below:  (device flow)
+#   ...or a browser window opens automatically  (PKCE flow)
+#   IdP authentication successful
+#   Exchanging for Fluree token...
+#   Token stored for remote 'origin'
+
+# 3. Use the remote
+fluree pull --remote origin
+```
+
+When the stored token later expires, data-plane commands (`query`, `insert`, …) auto-refresh silently if a refresh token is present; otherwise, or for replication commands, re-run `fluree auth login --remote origin`.
+
+### Automation / headless environments
+
+The browser (PKCE) flow needs a loopback callback port and, for most IdPs, an interactive browser — neither is available in CI or containers. For automation, **do not use the browser flow**; instead provision a service-account token and supply it directly:
+
+```bash
+fluree token create --private-key @~/.fluree/key --all | fluree auth login --remote origin --token @-
+```
+
+If you must use PKCE non-interactively, note that the callback listener only binds ports `8400`–`8405` (override with `redirect_port` in `/.well-known/fluree.json` or the `FLUREE_AUTH_PORT` env var). The port cannot be OS-assigned because the callback URL must be pre-allowlisted at the IdP (see the Cognito note below).
 
 ### Cognito note (Authorization Code + PKCE)
 

--- a/docs/design/auth-contract.md
+++ b/docs/design/auth-contract.md
@@ -240,11 +240,18 @@ When a data-plane command receives a 401 from the remote:
 
 ### Replication commands (`fetch`, `pull`, `push`)
 
-Replication commands use `HttpRemoteClient` (from `fluree-db-nameservice-sync`) which does **not** perform auto-refresh. This is intentional:
+A replication command uses **two** clients, and only one of them auto-refreshes:
+
+- **Metadata calls** (nameservice lookups, commit pagination) go through `RemoteLedgerClient`, which **does** auto-refresh on 401 exactly as described above. After a successful command the CLI persists any rotated token back to `.fluree/config.toml` (`context::persist_refreshed_tokens`).
+- **The bulk pack transfer** goes through `HttpRemoteClient` (from `fluree-db-nameservice-sync`), which holds a static token and does **not** auto-refresh.
+
+This split is intentional:
 
 - Replication requires `fluree.storage.*` scopes, which are reserved for operators and service accounts.
 - Operator tokens are typically long-lived or non-expiring. If an operator token expires, the user should run `fluree auth login` to obtain a new one.
 - Regular users who only have query-scoped tokens should use `fluree track` + `--remote` mode instead of `fetch`/`pull`/`push`.
+
+If the token expires **during** a pack transfer, the CLI does not resume it. It detects the resulting auth failure and fails fast with the `fluree auth login` guidance rather than silently retrying a doomed paginated fallback. Re-authenticate and re-run the transfer.
 
 ## Scope rules
 

--- a/fluree-db-cli/src/commands/auth.rs
+++ b/fluree-db-cli/src/commands/auth.rs
@@ -383,6 +383,7 @@ async fn run_oidc_login(config: &mut fluree_db_nameservice_sync::RemoteConfig) -
     };
 
     eprintln!("  IdP authentication successful");
+    warn_on_scope_downgrade(&scopes, idp_tokens.granted_scope.as_deref());
 
     // Step 3: Exchange IdP token for Fluree token
     //
@@ -408,7 +409,37 @@ async fn run_oidc_login(config: &mut fluree_db_nameservice_sync::RemoteConfig) -
     config.auth.token = Some(fluree_tokens.access_token);
     config.auth.refresh_token = fluree_tokens.refresh_token;
 
+    if config.auth.refresh_token.is_none() {
+        eprintln!(
+            "  {} no refresh token issued; you will need to run `fluree auth login` again when the token expires",
+            "note:".cyan().bold()
+        );
+    }
+
     Ok(())
+}
+
+/// Warn if the IdP granted fewer scopes than were requested.
+///
+/// OAuth providers may silently downgrade scopes (RFC 6749 §3.3); the token
+/// is still valid, so this is a warning, not an error — but a missing scope
+/// surfaces later as an unrelated authorization failure, which is hard to
+/// diagnose. Surfacing it at login makes the cause obvious. Skipped when the
+/// IdP does not echo a `scope` field (granted set is then unknown).
+fn warn_on_scope_downgrade(requested: &str, granted: Option<&str>) {
+    let Some(granted) = granted else { return };
+    let granted: std::collections::HashSet<&str> = granted.split_whitespace().collect();
+    let missing: Vec<&str> = requested
+        .split_whitespace()
+        .filter(|s| !granted.contains(s))
+        .collect();
+    if !missing.is_empty() {
+        eprintln!(
+            "  {} IdP granted fewer scopes than requested; missing: {}",
+            "warning:".yellow().bold(),
+            missing.join(", ")
+        );
+    }
 }
 
 /// Fetch OIDC discovery document and determine which flow to use.
@@ -591,6 +622,9 @@ struct IdpTokenResponse {
     /// Present when the IdP returns an id_token (e.g., Cognito auth code flow).
     /// Preferred for exchange because its `aud` claim matches the client_id.
     id_token: Option<String>,
+    /// The `scope` the IdP actually granted, when echoed in the token response.
+    /// Compared against the requested scopes to warn on a silent downgrade.
+    granted_scope: Option<String>,
 }
 
 /// Poll the token endpoint until the user completes authorization.
@@ -633,10 +667,12 @@ async fn poll_for_token(
                 .get("id_token")
                 .and_then(|v| v.as_str())
                 .map(String::from);
+            let granted_scope = body.get("scope").and_then(|v| v.as_str()).map(String::from);
 
             return Ok(IdpTokenResponse {
                 access_token,
                 id_token,
+                granted_scope,
             });
         }
 
@@ -793,10 +829,12 @@ async fn run_auth_code_flow(
         .get("id_token")
         .and_then(|v| v.as_str())
         .map(String::from);
+    let granted_scope = body.get("scope").and_then(|v| v.as_str()).map(String::from);
 
     Ok(IdpTokenResponse {
         access_token,
         id_token,
+        granted_scope,
     })
 }
 

--- a/fluree-db-cli/src/commands/sync.rs
+++ b/fluree-db-cli/src/commands/sync.rs
@@ -92,9 +92,15 @@ fn confirm_large_transfer(estimated_bytes: u64) -> bool {
 /// Whether a remote error string indicates an auth/permission failure
 /// (expired or insufficient token). `fluree-db-nameservice-sync` reports
 /// remote failures as strings, so we match on the common server messages.
+///
+/// The HTTP status checks match the canonical reason phrase (e.g.
+/// `401 Unauthorized`) rather than the bare code: the sync client always
+/// renders statuses via reqwest's `StatusCode` Display, and the error
+/// strings interpolate the request URL and response body, so a bare `401`
+/// could false-match a port or ledger name that merely contains those digits.
 fn is_replication_auth_error(err: &str) -> bool {
-    err.contains("401")
-        || err.contains("403")
+    err.contains("401 Unauthorized")
+        || err.contains("403 Forbidden")
         || err.contains("Bearer token required")
         || err.contains("Untrusted issuer")
         || err.contains("Token lacks storage proxy permissions")

--- a/fluree-db-cli/src/commands/sync.rs
+++ b/fluree-db-cli/src/commands/sync.rs
@@ -89,16 +89,20 @@ fn confirm_large_transfer(estimated_bytes: u64) -> bool {
     trimmed.is_empty() || trimmed == "y" || trimmed == "yes"
 }
 
-fn map_sync_auth_error(remote: &str, err: &str) -> Option<CliError> {
-    // `fluree-db-nameservice-sync` reports remote failures as strings; match the common
-    // permission-related server errors and provide a clearer CLI message.
-    if err.contains("401")
+/// Whether a remote error string indicates an auth/permission failure
+/// (expired or insufficient token). `fluree-db-nameservice-sync` reports
+/// remote failures as strings, so we match on the common server messages.
+fn is_replication_auth_error(err: &str) -> bool {
+    err.contains("401")
         || err.contains("403")
         || err.contains("Bearer token required")
         || err.contains("Untrusted issuer")
         || err.contains("Token lacks storage proxy permissions")
         || err.contains("Storage proxy not enabled")
-    {
+}
+
+fn map_sync_auth_error(remote: &str, err: &str) -> Option<CliError> {
+    if is_replication_auth_error(err) {
         Some(replication_permission_error(remote))
     } else {
         None
@@ -472,6 +476,15 @@ pub async fn run_pull(ledger: Option<&str>, no_indexes: bool, dirs: &FlureeDir) 
                                         return Ok(());
                                     }
                                     Err(e) => {
+                                        let msg = e.to_string();
+                                        if is_replication_auth_error(&msg) {
+                                            // Token expired mid-transfer: falling back to a
+                                            // paginated export would just 401 again. Fail fast
+                                            // with the re-login guidance.
+                                            return Err(replication_permission_error(
+                                                upstream.remote.as_str(),
+                                            ));
+                                        }
                                         eprintln!(
                                             "  {} pack import failed: {e}, falling back to paginated export",
                                             "warning:".yellow().bold()
@@ -1176,6 +1189,13 @@ pub async fn run_clone(
                                         eprint!("  fetched {objects} object(s) via pack\r");
                                     }
                                     Err(e) => {
+                                        let msg = e.to_string();
+                                        if is_replication_auth_error(&msg) {
+                                            // Token expired mid-transfer: falling back to a
+                                            // paginated export would just 401 again. Fail fast
+                                            // with the re-login guidance.
+                                            return Err(replication_permission_error(remote_name));
+                                        }
                                         eprintln!(
                                             "  {} pack import failed: {e}, falling back to paginated export",
                                             "warning:".yellow().bold()

--- a/fluree-db-cli/src/config.rs
+++ b/fluree-db-cli/src/config.rs
@@ -11,6 +11,52 @@ const PREFIXES_FILE: &str = "prefixes.json";
 /// within the CLI codebase.
 pub type ConfigFileFormat = ConfigFormat;
 
+/// Restrict a file to owner read/write only (`0o600`) on Unix.
+///
+/// The config file can hold OIDC bearer and refresh tokens, so it must not
+/// be group/world-readable. `fs::write` honors the process umask (typically
+/// `0o644`), so we tighten permissions explicitly after writing. No-op on
+/// non-Unix platforms, where filesystem ACLs are managed differently.
+fn restrict_file_to_owner(path: &Path) -> CliResult<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).map_err(|e| {
+            CliError::Config(format!(
+                "failed to restrict permissions on {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+/// Restrict a directory to owner access only (`0o700`) on Unix.
+///
+/// Protects token-bearing config files even during the brief window between
+/// creation and [`restrict_file_to_owner`]. No-op on non-Unix platforms.
+fn restrict_dir_to_owner(path: &Path) -> CliResult<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700)).map_err(|e| {
+            CliError::Config(format!(
+                "failed to restrict permissions on {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
 /// Detect which config file exists in a `.fluree/` directory.
 ///
 /// Checks for `config.toml` first, then `config.jsonld`. If both exist,
@@ -171,6 +217,8 @@ pub fn init_fluree_dir(
             dirs.config_dir().display()
         ))
     })?;
+    // The config file may later hold auth tokens; keep the directory owner-only.
+    restrict_dir_to_owner(dirs.config_dir())?;
 
     // Write config template if config file doesn't already exist
     let config_path = dirs.config_dir().join(config_filename);
@@ -178,6 +226,7 @@ pub fn init_fluree_dir(
         fs::write(&config_path, config_template).map_err(|e| {
             CliError::Config(format!("failed to create {}: {e}", config_path.display()))
         })?;
+        restrict_file_to_owner(&config_path)?;
     }
 
     Ok(())
@@ -536,7 +585,9 @@ impl TomlSyncConfigStore {
         let pretty =
             serde_json::to_string_pretty(&doc).map_err(|e| CliError::Config(e.to_string()))?;
         fs::write(path, pretty)
-            .map_err(|e| CliError::Config(format!("failed to write config: {e}")))
+            .map_err(|e| CliError::Config(format!("failed to write config: {e}")))?;
+        // May contain auth tokens; restrict to owner read/write.
+        restrict_file_to_owner(path)
     }
 
     /// Write sync config to a TOML file using toml_edit to preserve other keys.
@@ -681,7 +732,9 @@ impl TomlSyncConfigStore {
         }
 
         fs::write(path, doc.to_string())
-            .map_err(|e| CliError::Config(format!("failed to write config: {e}")))
+            .map_err(|e| CliError::Config(format!("failed to write config: {e}")))?;
+        // May contain auth tokens; restrict to owner read/write.
+        restrict_file_to_owner(path)
     }
 }
 
@@ -951,5 +1004,29 @@ mod tests {
         let dirs = FlureeDir::unified(fluree_dir.clone());
         let result = resolve_storage_path(&dirs);
         assert_eq!(result, fluree_dir.join("storage"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn init_fluree_dir_restricts_token_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = FlureeDir::unified(tmp.path().join(".fluree"));
+        init_fluree_dir(&dirs, "# config\n", CONFIG_FILE_TOML).unwrap();
+
+        let dir_mode = fs::metadata(dirs.config_dir())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dir_mode, 0o700, "config dir should be owner-only");
+
+        let config_path = dirs.config_dir().join(CONFIG_FILE_TOML);
+        let file_mode = fs::metadata(&config_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            file_mode, 0o600,
+            "config file should be owner read/write only"
+        );
     }
 }

--- a/fluree-db-cli/src/context.rs
+++ b/fluree-db-cli/src/context.rs
@@ -285,6 +285,13 @@ pub fn build_client_from_auth(base_url: &str, auth: &RemoteAuth) -> RemoteLedger
                 refresh_token: refresh_token.clone(),
             });
         }
+    } else if auth.refresh_token.is_some() {
+        // Auto-refresh only engages for `oidc_device`; a refresh_token under any
+        // other auth type is dead config that will never be used. Warn rather
+        // than silently ignore it.
+        eprintln!(
+            "warning: 'refresh_token' is set but auth type is not 'oidc_device'; it will be ignored"
+        );
     }
 
     client


### PR DESCRIPTION
Addresses a set of auth findings in `fluree-db-cli` reported against the CLI auth/replication paths.

## Changes

### Token file permissions (security)
The `.fluree` config dir and token-bearing config files were written with the default umask (typically `0644` → group/world-readable). Now, on Unix, the CLI restricts the config dir to `0700` and the config file to `0600` whenever it writes token material (and at init). No-op on non-Unix platforms, where ACLs are managed differently. Matches the convention used by `gh`, `aws`, `gcloud`, etc. Token storage remains plaintext (consistent with peer CLIs) — this closes the actual exposure (backups, synced dotfiles, multi-user boxes).

### Replication fail-fast on mid-transfer token expiry
The bulk pack transfer uses `HttpRemoteClient`, which holds a static token and does not auto-refresh (intentional: replication is for long-lived operator/service tokens). Previously a token expiry partway through a transfer printed a misleading "falling back to paginated export" and then 401'd again. The CLI now detects the auth failure mid-transfer and fails fast with the `fluree auth login` guidance the docs promise. Applied to both bearer-token flows (`run_pull`, `run_clone`).

### Login robustness
- Warn when the IdP grants fewer scopes than requested, so a silent downgrade doesn't surface later as an unrelated authorization failure.
- Note at login when no refresh token is issued (manual re-login will be needed) — no network probe.
- Warn when a `refresh_token` is configured under a non-`oidc_device` auth type, where it is silently ignored as dead config.

### Docs
- Clarify the two-client refresh layering in the auth contract (`RemoteLedgerClient` auto-refreshes and persists rotated tokens; `HttpRemoteClient` transfer does not).
- Add an end-to-end OIDC login walkthrough and a headless/automation section (steers CI/containers to a service-account JWS token; explains the `FLUREE_AUTH_PORT` / `redirect_port` overrides and why the callback port cannot be OS-assigned).
- Document the new file-permission behavior.

## Notes
- The reported `:0` (OS-assigned) callback-port fallback for PKCE is **not** implemented: it's architecturally infeasible because OIDC requires the redirect URI to be pre-allowlisted at the IdP. Handled via the new automation docs instead.

## Validation
`cargo check`, `cargo clippy -p fluree-db-cli --all-features --all-targets -D warnings`, config unit tests (incl. a new permission-mode test), and `cargo fmt --all` all pass.