### PR TITLE
fix(query): stop corrupting integer-valued doubles read through the overlay

### DIFF
--- a/fluree-db-api/tests/it_decimal_exactness.rs
+++ b/fluree-db-api/tests/it_decimal_exactness.rs
@@ -56,6 +56,20 @@ fn binding_values(sparql_json: &JsonValue, var: &str) -> Vec<String> {
         .collect()
 }
 
+fn binding_datatypes(sparql_json: &JsonValue, var: &str) -> Vec<String> {
+    sparql_json["results"]["bindings"]
+        .as_array()
+        .expect("bindings array")
+        .iter()
+        .map(|b| {
+            b[var]["datatype"]
+                .as_str()
+                .expect("binding datatype string")
+                .to_string()
+        })
+        .collect()
+}
+
 fn memory_fluree() -> MemoryFluree {
     assert_index_defaults();
     FlureeBuilder::memory().build_memory()
@@ -928,38 +942,67 @@ async fn integer_valued_double_over_indexed_predicate_is_not_corrupted() {
             trigger_index_and_wait(&handle, ledger_id, result.receipt.t).await;
             let ledger = fluree.ledger(ledger_id).await.expect("load ledger");
 
-            // Insert a NEW integer-valued double into the now-indexed predicate;
-            // it lands in novelty and is read back through the overlay merge.
+            // Insert NEW integer-valued doubles into the now-indexed predicate;
+            // they land in novelty and are read back through the overlay merge.
+            // Boundary companions exercise the encode_f64/decode_f64 sign-flip
+            // branch (-55000.0) and the i64-range edge (2^53, the largest
+            // exactly-representable integral double).
             let result = run_sparql_update(
                 &fluree,
                 ledger,
                 r#"
                 PREFIX ex: <http://example.org/>
                 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                INSERT DATA { ex:a ex:amount "55000.0"^^xsd:double . }
+                INSERT DATA {
+                    ex:a ex:amount "55000.0"^^xsd:double .
+                    ex:b ex:amount "-55000.0"^^xsd:double .
+                    ex:c ex:amount "9.007199254740992e15"^^xsd:double .
+                }
                 "#,
             )
             .await;
             let ledger = result.ledger;
 
-            let query = r"
-                PREFIX ex: <http://example.org/>
-                SELECT ?amount WHERE { ex:a ex:amount ?amount . }
-            ";
-            let result = support::query_sparql(&fluree, &ledger, query)
-                .await
-                .expect("query");
-            let sparql_json = result
-                .to_sparql_json(&ledger.snapshot)
-                .expect("to_sparql_json");
-            let values = binding_values(&sparql_json, "amount");
-            assert_eq!(values.len(), 1, "expected exactly one row, got {values:?}");
-            let got: f64 = values[0].parse().expect("double result");
-            assert_eq!(
-                got, 55000.0,
-                "integer-valued double over an indexed predicate must round-trip \
-                 exactly (was corrupted to a subnormal), got {got:e}"
-            );
+            // (subject, expected exact f64) for each inserted integral double.
+            let cases = [
+                ("ex:a", 55000.0),
+                ("ex:b", -55000.0),
+                ("ex:c", 9.007_199_254_740_992e15),
+            ];
+            for (subject, expected) in cases {
+                let query = format!(
+                    "PREFIX ex: <http://example.org/>
+                     SELECT ?amount WHERE {{ {subject} ex:amount ?amount . }}"
+                );
+                let result = support::query_sparql(&fluree, &ledger, &query)
+                    .await
+                    .expect("query");
+                let sparql_json = result
+                    .to_sparql_json(&ledger.snapshot)
+                    .expect("to_sparql_json");
+
+                let values = binding_values(&sparql_json, "amount");
+                assert_eq!(
+                    values.len(),
+                    1,
+                    "{subject}: expected exactly one row, got {values:?}"
+                );
+                let got: f64 = values[0].parse().expect("double result");
+                assert_eq!(
+                    got, expected,
+                    "{subject}: integer-valued double over an indexed predicate must \
+                     round-trip exactly (was corrupted to a subnormal), got {got:e}"
+                );
+
+                // Lock in that the uniform-f64 encoding does not silently downgrade
+                // the reported datatype to xsd:integer/xsd:long.
+                let datatypes = binding_datatypes(&sparql_json, "amount");
+                assert_eq!(
+                    datatypes,
+                    vec!["http://www.w3.org/2001/XMLSchema#double".to_string()],
+                    "{subject}: datatype must stay xsd:double"
+                );
+            }
         })
         .await;
 }

--- a/fluree-db-api/tests/it_decimal_exactness.rs
+++ b/fluree-db-api/tests/it_decimal_exactness.rs
@@ -889,3 +889,77 @@ async fn sparql_delete_data_decimal_retracts_exactly() {
         "deleted decimal fact must not survive"
     );
 }
+
+#[tokio::test]
+async fn integer_valued_double_over_indexed_predicate_is_not_corrupted() {
+    // Regression (fluree/db-r#142): an integer-valued double inserted into a
+    // predicate that already has INDEXED double/float data was silently
+    // corrupted to a tiny subnormal. The novelty overlay encoder paired the
+    // datatype-derived OType (F64 decode) with an i64-encoded key, so the
+    // reader ran decode_f64 over integer bits (55000.0 -> 2.71736e-319).
+    // The trigger needs a persisted index for the predicate; novelty-only
+    // ledgers encode the value correctly.
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(fluree_db_api::LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "double/indexed-overlay:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        Arc::new(fluree.nameservice_mode().clone()),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let ledger = genesis_ledger(&fluree, ledger_id);
+
+            // Seed + index an integer-valued double for ex:amount.
+            let result = run_sparql_update(
+                &fluree,
+                ledger,
+                r#"
+                PREFIX ex: <http://example.org/>
+                PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                INSERT DATA { ex:seed ex:amount "28575.0"^^xsd:double . }
+                "#,
+            )
+            .await;
+            trigger_index_and_wait(&handle, ledger_id, result.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.expect("load ledger");
+
+            // Insert a NEW integer-valued double into the now-indexed predicate;
+            // it lands in novelty and is read back through the overlay merge.
+            let result = run_sparql_update(
+                &fluree,
+                ledger,
+                r#"
+                PREFIX ex: <http://example.org/>
+                PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                INSERT DATA { ex:a ex:amount "55000.0"^^xsd:double . }
+                "#,
+            )
+            .await;
+            let ledger = result.ledger;
+
+            let query = r"
+                PREFIX ex: <http://example.org/>
+                SELECT ?amount WHERE { ex:a ex:amount ?amount . }
+            ";
+            let result = support::query_sparql(&fluree, &ledger, query)
+                .await
+                .expect("query");
+            let sparql_json = result
+                .to_sparql_json(&ledger.snapshot)
+                .expect("to_sparql_json");
+            let values = binding_values(&sparql_json, "amount");
+            assert_eq!(values.len(), 1, "expected exactly one row, got {values:?}");
+            let got: f64 = values[0].parse().expect("double result");
+            assert_eq!(
+                got, 55000.0,
+                "integer-valued double over an indexed predicate must round-trip \
+                 exactly (was corrupted to a subnormal), got {got:e}"
+            );
+        })
+        .await;
+}

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -2592,13 +2592,10 @@ fn value_to_otype_okey(
             // over integer bits, corrupting the value to a tiny subnormal
             // (55000.0 -> 2.71736e-319). Mirrors the encode-side guards in
             // resolver.rs / import_sink.rs. (fluree/db-r#142)
-            if d.is_finite() {
-                match ObjKey::encode_f64(*d) {
-                    Ok(key) => Ok((ot, key.as_u64())),
-                    Err(_) => Ok((OType::NULL, 0)),
-                }
-            } else {
-                Ok((OType::NULL, 0))
+            match ObjKey::encode_f64(*d) {
+                Ok(key) => Ok((ot, key.as_u64())),
+                // NaN/Inf can't be order-encoded → NULL sentinel.
+                Err(_) => Ok((OType::NULL, 0)),
             }
         }
         FlakeValue::Ref(sid) => {

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -2586,12 +2586,12 @@ fn value_to_otype_okey(
                     "datatype not resolvable to OType for Double value",
                 )
             })?;
-            if d.is_finite() && d.fract() == 0.0 {
-                let as_i64 = *d as i64;
-                if (as_i64 as f64) == *d {
-                    return Ok((ot, ObjKey::encode_i64(as_i64).as_u64()));
-                }
-            }
+            // Do NOT optimize integral doubles to encode_i64: `ot` is the
+            // datatype-derived OType (e.g. XSD_DOUBLE), whose decode kind is F64.
+            // Pairing it with an i64-encoded key makes the reader run decode_f64
+            // over integer bits, corrupting the value to a tiny subnormal
+            // (55000.0 -> 2.71736e-319). Mirrors the encode-side guards in
+            // resolver.rs / import_sink.rs. (fluree/db-r#142)
             if d.is_finite() {
                 match ObjKey::encode_f64(*d) {
                     Ok(key) => Ok((ot, key.as_u64())),

--- a/fluree-db-query/src/dict_overlay.rs
+++ b/fluree-db-query/src/dict_overlay.rs
@@ -483,13 +483,11 @@ impl DictOverlay {
             FlakeValue::Long(n) => Ok((ObjKind::NUM_INT, ObjKey::encode_i64(*n))),
 
             FlakeValue::Double(d) => {
-                // Integer-valued doubles that fit i64 → NUM_INT
-                if d.is_finite() && d.fract() == 0.0 {
-                    let as_i64 = *d as i64;
-                    if (as_i64 as f64) == *d {
-                        return Ok((ObjKind::NUM_INT, ObjKey::encode_i64(as_i64)));
-                    }
-                }
+                // Do NOT optimize integral doubles to NUM_INT: when paired with a
+                // float/double datatype the decode resolves an F64 OType and runs
+                // decode_f64 over the i64-encoded bits, corrupting the value to a
+                // tiny subnormal. Mirrors value_to_otype_okey and the encode-side
+                // guards in resolver.rs / import_sink.rs. (fluree/db-r#142)
                 if d.is_finite() {
                     match ObjKey::encode_f64(*d) {
                         Ok(key) => Ok((ObjKind::NUM_F64, key)),

--- a/fluree-db-query/src/dict_overlay.rs
+++ b/fluree-db-query/src/dict_overlay.rs
@@ -476,7 +476,14 @@ impl DictOverlay {
     ///
     /// Unlike `BinaryIndexStore::value_to_obj_pair()`, this never returns `None`
     /// for representable values.
-    pub fn value_to_obj_pair(&mut self, val: &FlakeValue) -> io::Result<(ObjKind, ObjKey)> {
+    ///
+    /// Kept for: parity with the live `value_to_otype_okey` encoder in
+    /// `binary_scan.rs` — both must apply the same integral-double guard so a
+    /// future overlay write path can reuse this twin without reintroducing the
+    /// subnormal corruption (fluree/db-r#142).
+    /// Use when: a `DictOverlay`-based write path needs (ObjKind, ObjKey) pairs.
+    #[expect(dead_code)]
+    pub(crate) fn value_to_obj_pair(&mut self, val: &FlakeValue) -> io::Result<(ObjKind, ObjKey)> {
         match val {
             FlakeValue::Null => Ok((ObjKind::NULL, ObjKey::from_u64(0))),
             FlakeValue::Boolean(b) => Ok((ObjKind::BOOL, ObjKey::encode_bool(*b))),
@@ -488,14 +495,10 @@ impl DictOverlay {
                 // decode_f64 over the i64-encoded bits, corrupting the value to a
                 // tiny subnormal. Mirrors value_to_otype_okey and the encode-side
                 // guards in resolver.rs / import_sink.rs. (fluree/db-r#142)
-                if d.is_finite() {
-                    match ObjKey::encode_f64(*d) {
-                        Ok(key) => Ok((ObjKind::NUM_F64, key)),
-                        Err(_) => Ok((ObjKind::NULL, ObjKey::from_u64(0))),
-                    }
-                } else {
-                    // NaN/Inf → NULL sentinel (can't represent in index)
-                    Ok((ObjKind::NULL, ObjKey::from_u64(0)))
+                match ObjKey::encode_f64(*d) {
+                    Ok(key) => Ok((ObjKind::NUM_F64, key)),
+                    // NaN/Inf can't be order-encoded → NULL sentinel.
+                    Err(_) => Ok((ObjKind::NULL, ObjKey::from_u64(0))),
                 }
             }
 


### PR DESCRIPTION
## Summary

An integer-valued double (e.g. `55000.0`) inserted into a `xsd:double`/`xsd:float` predicate that **already has indexed data** was silently read back as a tiny subnormal (`2.71736e-319`). No error, deterministic, and it surfaces in queries and aggregates (`SUM` over the column reads ≈ 0).

## Root cause

The novelty→overlay encoder `value_to_otype_okey` (used when reading novelty over an indexed predicate) optimized integer-valued doubles to `encode_i64`, but paired the key with the **datatype-derived** `OType` (`XSD_DOUBLE`/`XSD_FLOAT`), whose decode kind is `F64`. The reader then ran `decode_f64` over the `encode_i64` bits:

```
decode_f64(encode_i64(55000)) == f64::from_bits(55000) == 2.71736e-319   (ratio 2^-1074)
```

This is the same anti-pattern already guarded at three **encode-side** sites (`resolver.rs`, `import_sink.rs`); the read-side overlay was the one path that still had it.

## Scope / impact

- Triggers only when the predicate has a **persisted index**; novelty-only ledgers encode correctly.
- The persisted commits were always correct — corruption was purely on the read path. **Affected data is recoverable with the fixed reader; no re-ingestion required.**
- Non-integer doubles (`55000.5`) and integer types were never affected.

## Changes

- `binary_scan.rs` — `value_to_otype_okey` always encodes finite doubles with `encode_f64`.
- `dict_overlay.rs` — same guard applied to the unused twin `value_to_obj_pair` (defensive).
- `it_decimal_exactness.rs` — regression test: index a double, insert an integer-valued double, assert exact round-trip. Verified it fails without the fix with the exact `2.71736e-319` signature.

## Testing

- New regression test passes; fails when the fix is reverted.
- `fluree-db-query` unit (1078) + decimal exactness (14), batched-overlay (4), aggregates (16), SPARQL (136) all green. `fmt` + `clippy` clean.