### PR TITLE
perf(query): query-planner improvements (hash-joins, source seeding, EXISTS)

### DIFF
--- a/fluree-db-api/tests/it_policy_optional_hashjoin.rs
+++ b/fluree-db-api/tests/it_policy_optional_hashjoin.rs
@@ -1,0 +1,144 @@
+//! View-policy enforcement on the batched correlated-OPTIONAL hash-join.
+//!
+//! `PlanTreeOptionalBuilder::build_batch` seeds and executes the OPTIONAL inner
+//! subplan once per required batch via `build_where_operators_seeded`, reusing
+//! the normal WHERE operators and the SAME `ExecutionContext`. So the inner's
+//! `BinaryScanOperator`s must see the active policy enforcer and filter the
+//! seeded scan exactly as the per-row path would.
+//!
+//! This guards against the batched fast path becoming a view-policy blind spot:
+//! a forbidden optional-side row must not leak into the count, and a row whose
+//! only matches are all policy-hidden must collapse to the left-join zero.
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::{json, Value as JsonValue};
+use support::{assert_index_defaults, genesis_ledger, normalize_rows};
+
+fn ctx() -> JsonValue {
+    json!({ "ex": "http://example.org/ns/" })
+}
+
+/// IC5-shaped correlated OPTIONAL (3 inner triples, correlated on both `?friend`
+/// and `?forum`, introducing `?post`) so it routes through the general
+/// multi-pattern path and the batched hash-left-join — the same shape exercised
+/// by `it_query_optional_hashjoin`.
+fn count_query(from: &str, opts: Option<JsonValue>) -> JsonValue {
+    let mut q = json!({
+        "@context": ctx(),
+        "from": from,
+        "select": ["?forumName", "(as (count ?post) ?postCount)"],
+        "where": [
+            {"@id": "?forum", "@type": "ex:Forum", "ex:name": "?forumName", "ex:HAS_MEMBER": "?friend"},
+            {"@id": "?friend", "@type": "ex:Person"},
+            ["optional",
+                {"@id": "?post", "@type": "ex:Post", "ex:HAS_CREATOR": "?friend"},
+                {"@id": "?forum", "ex:CONTAINER_OF": "?post"}
+            ]
+        ],
+        "groupBy": ["?forum", "?forumName"],
+        "orderBy": ["?forumName"]
+    });
+    if let Some(opts) = opts {
+        q.as_object_mut().unwrap().insert("opts".into(), opts);
+    }
+    q
+}
+
+#[tokio::test]
+async fn batched_optional_inner_enforces_view_policy() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "policy/optional-hashjoin:main";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    // Posts carry ex:level; level < 5 is "secret". p3 and p4 are secret.
+    //   F1 -> members {bob, carol}, contains p1(bob,10), p2(carol,10), p3(bob,1)
+    //   F2 -> members {bob},        contains p4(bob,1)
+    let txn = json!({
+        "@context": ctx(),
+        "@graph": [
+            {"@id": "ex:bob",   "@type": "ex:Person"},
+            {"@id": "ex:carol", "@type": "ex:Person"},
+            {
+                "@id": "ex:f1", "@type": "ex:Forum", "ex:name": "F1",
+                "ex:HAS_MEMBER": [{"@id": "ex:bob"}, {"@id": "ex:carol"}],
+                "ex:CONTAINER_OF": [{"@id": "ex:p1"}, {"@id": "ex:p2"}, {"@id": "ex:p3"}]
+            },
+            {
+                "@id": "ex:f2", "@type": "ex:Forum", "ex:name": "F2",
+                "ex:HAS_MEMBER": [{"@id": "ex:bob"}],
+                "ex:CONTAINER_OF": [{"@id": "ex:p4"}]
+            },
+            {"@id": "ex:p1", "@type": "ex:Post", "ex:HAS_CREATOR": {"@id": "ex:bob"},   "ex:level": 10},
+            {"@id": "ex:p2", "@type": "ex:Post", "ex:HAS_CREATOR": {"@id": "ex:carol"}, "ex:level": 10},
+            {"@id": "ex:p3", "@type": "ex:Post", "ex:HAS_CREATOR": {"@id": "ex:bob"},   "ex:level": 1},
+            {"@id": "ex:p4", "@type": "ex:Post", "ex:HAS_CREATOR": {"@id": "ex:bob"},   "ex:level": 1}
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &txn).await.expect("seed").ledger;
+
+    // --- Root baseline: every post is visible. ---------------------------------
+    let root = fluree
+        .query_connection(&count_query(ledger_id, None))
+        .await
+        .expect("root query");
+    let root_rows = root.to_jsonld(&ledger.snapshot).expect("root rows");
+    assert_eq!(
+        normalize_rows(&root_rows),
+        normalize_rows(&json!([["F1", 3], ["F2", 1]])),
+        "root sees all posts: F1={{p1,p2,p3}}=3, F2={{p4}}=1"
+    );
+
+    // --- Policy: a REQUIRED f:view policy scoped to ex:Post that only allows
+    // posts with ex:level >= 5. Combined with an allow-all and default-allow
+    // true, every flake stays visible EXCEPT Post-subject flakes of secret
+    // posts — so p3 and p4 vanish from the OPTIONAL inner scan.
+    let policy = json!([
+        {
+            "@id": "ex:postLevelPolicy",
+            "@type": "f:AccessPolicy",
+            "f:action": "f:view",
+            "f:required": true,
+            "f:onClass": [{"@id": "http://example.org/ns/Post"}],
+            "f:query": {
+                "@type": "@json",
+                "@value": {
+                    "@context": {"ex": "http://example.org/ns/"},
+                    "where": [
+                        {"@id": "?$this", "ex:level": "?l"},
+                        ["filter", "(>= ?l 5)"]
+                    ]
+                }
+            }
+        },
+        {
+            "@id": "ex:allowAll",
+            "@type": "f:AccessPolicy",
+            "f:action": "f:view",
+            "f:allow": true
+        }
+    ]);
+
+    let restricted = fluree
+        .query_connection(&count_query(
+            ledger_id,
+            Some(json!({ "policy": policy, "default-allow": true })),
+        ))
+        .await
+        .expect("policy query");
+    let restricted_rows = restricted.to_jsonld(&ledger.snapshot).expect("policy rows");
+
+    // p3 (secret, F1) and p4 (secret, F2) are hidden. The batched inner must
+    // filter them out of the seeded scan:
+    //   F1: only p1, p2 visible             -> 2
+    //   F2: bob's only post p4 is hidden    -> 0  (left-join no-match under policy)
+    // If the seeded inner skipped policy, this would wrongly read 3 and 1.
+    assert_eq!(
+        normalize_rows(&restricted_rows),
+        normalize_rows(&json!([["F1", 2], ["F2", 0]])),
+        "batched OPTIONAL inner must enforce view policy: secret posts excluded, \
+         F2 collapses to the left-join zero"
+    );
+}

--- a/fluree-db-api/tests/it_query_optional_hashjoin.rs
+++ b/fluree-db-api/tests/it_query_optional_hashjoin.rs
@@ -1,0 +1,127 @@
+//! Batched correlated-OPTIONAL hash-join end-to-end test.
+//!
+//! Exercises `PlanTreeOptionalBuilder::build_batch` (the batched hash
+//! left-join that replaces the per-driving-row OPTIONAL subplan rebuild —
+//! the LDBC IC5 cliff). The query mirrors IC5's exact shape:
+//!
+//! ```text
+//! MATCH (forum:Forum)-[:HAS_MEMBER]->(friend:Person)
+//! OPTIONAL MATCH (friend)<-[:HAS_CREATOR]-(post:Post)<-[:CONTAINER_OF]-(forum)
+//! WITH forum, count(post) AS postCount
+//! RETURN forum.name AS forumName, postCount ORDER BY postCount DESC, forumName ASC
+//! ```
+//!
+//! The OPTIONAL is correlated on BOTH `friend` and `forum` and introduces the
+//! new var `post`, so it routes through the general multi-pattern path and the
+//! batched hash-join. The dataset includes a forum (`F3`) whose member has no
+//! qualifying post, validating the left-join no-match (count = 0) path.
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::{json, Value as JsonValue};
+use support::{genesis_ledger, graphdb_from_ledger};
+
+fn ctx() -> JsonValue {
+    json!({
+        "ex": "http://example.org/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    })
+}
+
+#[tokio::test]
+async fn correlated_multi_pattern_optional_counts_per_group_with_left_join() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/optional:hashjoin";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    // People, forums (with member edges), and posts (creator + container edges).
+    //
+    // Members:   F1 -> {bob, carol}, F2 -> {bob}, F3 -> {bob}
+    // Posts:     p1 (creator bob,   in F1)
+    //            p2 (creator carol, in F1)
+    //            p3 (creator bob,   in F2)
+    //            (F3 has a member, bob, but no post by bob in F3)
+    //
+    // Per (friend, forum) membership the OPTIONAL finds posts the friend
+    // created that are contained in that forum, then count(post) groups by
+    // forum:
+    //   F1: (bob,F1)->p1  + (carol,F1)->p2  = 2
+    //   F2: (bob,F2)->p3                     = 1
+    //   F3: (bob,F3)->(none)                 = 0   <- left-join no-match
+    let txn = json!({
+        "@context": ctx(),
+        "@graph": [
+            {"@id": "ex:bob",   "@type": "ex:Person"},
+            {"@id": "ex:carol", "@type": "ex:Person"},
+            {
+                "@id": "ex:f1", "@type": "ex:Forum", "ex:name": "F1",
+                "ex:HAS_MEMBER": [{"@id": "ex:bob"}, {"@id": "ex:carol"}],
+                "ex:CONTAINER_OF": [{"@id": "ex:p1"}, {"@id": "ex:p2"}]
+            },
+            {
+                "@id": "ex:f2", "@type": "ex:Forum", "ex:name": "F2",
+                "ex:HAS_MEMBER": [{"@id": "ex:bob"}],
+                "ex:CONTAINER_OF": [{"@id": "ex:p3"}]
+            },
+            {
+                "@id": "ex:f3", "@type": "ex:Forum", "ex:name": "F3",
+                "ex:HAS_MEMBER": [{"@id": "ex:bob"}]
+            },
+            {"@id": "ex:p1", "@type": "ex:Post", "ex:HAS_CREATOR": {"@id": "ex:bob"}},
+            {"@id": "ex:p2", "@type": "ex:Post", "ex:HAS_CREATOR": {"@id": "ex:carol"}},
+            {"@id": "ex:p3", "@type": "ex:Post", "ex:HAS_CREATOR": {"@id": "ex:bob"}}
+        ]
+    });
+    let committed = fluree.insert(ledger0, &txn).await.expect("seed");
+    let db = graphdb_from_ledger(&committed.ledger);
+
+    // JSON-LD form of the IC5 shape: the OPTIONAL is correlated on BOTH
+    // `?friend` and `?forum` and introduces `?post`, so it routes through the
+    // general multi-pattern path and the batched hash-left-join.
+    let q = json!({
+        "@context": ctx(),
+        "select": ["?forumName", "(as (count ?post) ?postCount)"],
+        "where": [
+            {"@id": "?forum", "@type": "ex:Forum", "ex:name": "?forumName", "ex:HAS_MEMBER": "?friend"},
+            {"@id": "?friend", "@type": "ex:Person"},
+            ["optional",
+                {"@id": "?post", "@type": "ex:Post", "ex:HAS_CREATOR": "?friend"},
+                {"@id": "?forum", "ex:CONTAINER_OF": "?post"}
+            ]
+        ],
+        "groupBy": ["?forum", "?forumName"],
+        "orderBy": ["(desc ?postCount)", "?forumName"]
+    });
+
+    let result = fluree
+        .query(&db, &q)
+        .await
+        .expect("optional hash-join query");
+
+    let rows = result
+        .to_jsonld_async(db.as_graph_db_ref())
+        .await
+        .expect("format rows");
+
+    let arr = rows.as_array().expect("tabular array result");
+    let pairs: Vec<(String, i64)> = arr
+        .iter()
+        .map(|row| {
+            let r = row.as_array().expect("row is array");
+            let name = r[0].as_str().expect("forumName string").to_string();
+            let count = r[1].as_i64().expect("postCount int");
+            (name, count)
+        })
+        .collect();
+
+    assert_eq!(
+        pairs,
+        vec![
+            ("F1".to_string(), 2),
+            ("F2".to_string(), 1),
+            ("F3".to_string(), 0),
+        ],
+        "per-forum post counts (incl. the left-join zero for F3) must match"
+    );
+}

--- a/fluree-db-api/tests/it_query_optional_hashjoin.rs
+++ b/fluree-db-api/tests/it_query_optional_hashjoin.rs
@@ -125,3 +125,108 @@ async fn correlated_multi_pattern_optional_counts_per_group_with_left_join() {
         "per-forum post counts (incl. the left-join zero for F3) must match"
     );
 }
+
+/// Regression: the batched OPTIONAL hash-join enforces correlation purely by
+/// `binding_to_group_key_normalized` partitioning (the per-row `unify_check`
+/// is a no-op because the optional batches carry no shared vars). That is only
+/// correct because `encoded_equivalent` normalizes a decoded `Iri`/`Sid` on the
+/// REQUIRED side to the same `EncodedSid` the INNER scan produces.
+///
+/// This test deliberately drives the correlation var `?person` from a top-level
+/// `VALUES` clause — so on the required side it is a *materialized* IRI binding,
+/// never touched by a scan — while inside the OPTIONAL `?person` is the object
+/// of `ex:HAS_CREATOR` and is therefore left UNBOUND and *scan-produced*
+/// (`EncodedSid`). If the two representations failed to normalize to the same
+/// group key, every `(person, forum)` bucket would miss and the counts would
+/// collapse to zero. `?forum` is `VALUES`-materialized too and seeded
+/// subject-first, so it is the cross-representation `?person` that is under test.
+#[tokio::test]
+async fn batched_optional_matches_materialized_values_against_scan_produced_corr() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/optional:hashjoin-values";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    // Same shape as the IC5 test: members per forum, posts with creator+container.
+    //   F1 -> {bob, carol}, posts p1(bob), p2(carol)
+    //   F2 -> {bob},        post  p3(bob)
+    //   F3 -> {bob},        no posts
+    let txn = json!({
+        "@context": ctx(),
+        "@graph": [
+            {"@id": "ex:bob",   "@type": "ex:Person"},
+            {"@id": "ex:carol", "@type": "ex:Person"},
+            {
+                "@id": "ex:f1", "@type": "ex:Forum", "ex:name": "F1",
+                "ex:CONTAINER_OF": [{"@id": "ex:p1"}, {"@id": "ex:p2"}]
+            },
+            {
+                "@id": "ex:f2", "@type": "ex:Forum", "ex:name": "F2",
+                "ex:CONTAINER_OF": [{"@id": "ex:p3"}]
+            },
+            {"@id": "ex:f3", "@type": "ex:Forum", "ex:name": "F3"},
+            {"@id": "ex:p1", "@type": "ex:Post", "ex:HAS_CREATOR": {"@id": "ex:bob"}},
+            {"@id": "ex:p2", "@type": "ex:Post", "ex:HAS_CREATOR": {"@id": "ex:carol"}},
+            {"@id": "ex:p3", "@type": "ex:Post", "ex:HAS_CREATOR": {"@id": "ex:bob"}}
+        ]
+    });
+    let committed = fluree.insert(ledger0, &txn).await.expect("seed");
+    let db = graphdb_from_ledger(&committed.ledger);
+
+    // The (person, forum) membership pairs come straight from VALUES — the
+    // required side never scans them, so `?person`/`?forum` arrive materialized.
+    let id = |iri: &str| json!({"@value": iri, "@type": "@id"});
+    let q = json!({
+        "@context": ctx(),
+        "values": [
+            ["?person", "?forum"],
+            [
+                [id("ex:bob"),   id("ex:f1")],
+                [id("ex:carol"), id("ex:f1")],
+                [id("ex:bob"),   id("ex:f2")],
+                [id("ex:bob"),   id("ex:f3")]
+            ]
+        ],
+        "select": ["?forumName", "(as (count ?post) ?postCount)"],
+        "where": [
+            {"@id": "?forum", "ex:name": "?forumName"},
+            ["optional",
+                {"@id": "?post", "@type": "ex:Post", "ex:HAS_CREATOR": "?person"},
+                {"@id": "?forum", "ex:CONTAINER_OF": "?post"}
+            ]
+        ],
+        "groupBy": ["?forum", "?forumName"],
+        "orderBy": ["(desc ?postCount)", "?forumName"]
+    });
+
+    let result = fluree
+        .query(&db, &q)
+        .await
+        .expect("optional hash-join query");
+
+    let rows = result
+        .to_jsonld_async(db.as_graph_db_ref())
+        .await
+        .expect("format rows");
+
+    let arr = rows.as_array().expect("tabular array result");
+    let pairs: Vec<(String, i64)> = arr
+        .iter()
+        .map(|row| {
+            let r = row.as_array().expect("row is array");
+            let name = r[0].as_str().expect("forumName string").to_string();
+            let count = r[1].as_i64().expect("postCount int");
+            (name, count)
+        })
+        .collect();
+
+    assert_eq!(
+        pairs,
+        vec![
+            ("F1".to_string(), 2),
+            ("F2".to_string(), 1),
+            ("F3".to_string(), 0),
+        ],
+        "materialized (VALUES) vs scan-produced correlation must normalize to \
+         the same group key — counts must not collapse to zero"
+    );
+}

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -4866,3 +4866,56 @@ async fn sparql_group_by_expression_via_bind_workaround() {
         normalize_rows(&json!([["usd", 5], ["cad", 3], ["eur", 2]]))
     );
 }
+
+/// `ORDER BY (EXISTS { ... })` routes the EXISTS through an order-expression
+/// BIND built in `apply_solution_modifiers` (the `order_binds` site). That
+/// `BindOperator` resolves EXISTS per row, so this exercises the projected/
+/// ORDER-BY EXISTS path — distinct from a WHERE-clause `FILTER EXISTS`. It also
+/// pins the `with_planning` wiring through `apply_solution_modifiers`: the BIND
+/// must carry the query's temporal context, not default to current-state.
+#[tokio::test]
+async fn sparql_order_by_exists_expression_sorts_by_correlated_existence() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "exists:order-by");
+
+    // alice and dave know someone; bob and carol know no one.
+    let insert = json!({
+        "@context": { "ex": "http://example.org/ns/" },
+        "@graph": [
+            {"@id": "ex:alice", "@type": "ex:Person", "ex:knows": {"@id": "ex:bob"}},
+            {"@id": "ex:bob",   "@type": "ex:Person"},
+            {"@id": "ex:carol", "@type": "ex:Person"},
+            {"@id": "ex:dave",  "@type": "ex:Person", "ex:knows": {"@id": "ex:carol"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &insert).await.expect("insert people");
+
+    // ORDER BY the EXISTS boolean (false sorts before true), then by ?s.
+    // Expect the two friendless people first, then the two who know someone.
+    let query = r"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT ?s WHERE {
+            ?s a ex:Person .
+        }
+        ORDER BY (EXISTS { ?s ex:knows ?o }) ?s
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger.ledger, query)
+        .await
+        .expect("ORDER BY EXISTS query should succeed");
+    let jsonld = result
+        .to_jsonld(&ledger.ledger.snapshot)
+        .expect("to_jsonld");
+
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
+            ["ex:bob"],
+            ["ex:carol"],
+            ["ex:alice"],
+            ["ex:dave"]
+        ])),
+        "friendless subjects (EXISTS=false) must sort before those who know someone"
+    );
+}

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -4889,7 +4889,10 @@ async fn sparql_order_by_exists_expression_sorts_by_correlated_existence() {
             {"@id": "ex:dave",  "@type": "ex:Person", "ex:knows": {"@id": "ex:carol"}}
         ]
     });
-    let ledger = fluree.insert(ledger0, &insert).await.expect("insert people");
+    let ledger = fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert people");
 
     // ORDER BY the EXISTS boolean (false sorts before true), then by ?s.
     // Expect the two friendless people first, then the two who know someone.

--- a/fluree-db-query/src/bind.rs
+++ b/fluree-db-query/src/bind.rs
@@ -51,6 +51,14 @@ pub struct BindOperator {
     state: OperatorState,
     /// Variables required by downstream operators; if set, output is trimmed.
     out_schema: Option<Arc<[VarId]>>,
+    /// True when `expr` contains an `EXISTS { ... }` subexpression, which must
+    /// be resolved per-row (seeded with the row's bindings) before the value
+    /// is computed — projection/BIND counterpart to the FilterOperator path.
+    /// The common case (no EXISTS) keeps the fast synchronous eval.
+    has_exists: bool,
+    /// Temporal context for any per-row EXISTS resolution. Defaults to
+    /// current-state; EXISTS inside a BIND of a history query is out of scope.
+    planning: crate::temporal_mode::PlanningContext,
 }
 
 impl BindOperator {
@@ -92,6 +100,8 @@ impl BindOperator {
             }
         };
 
+        let has_exists = crate::filter::contains_exists(&expr);
+
         Self {
             child,
             var,
@@ -105,7 +115,16 @@ impl BindOperator {
             is_new_var,
             state: OperatorState::Created,
             out_schema: None,
+            has_exists,
+            planning: crate::temporal_mode::PlanningContext::current(),
         }
+    }
+
+    /// Set the temporal context used when resolving a per-row `EXISTS` inside
+    /// the bound expression. Only meaningful when `expr` contains EXISTS.
+    pub fn with_planning(mut self, planning: crate::temporal_mode::PlanningContext) -> Self {
+        self.planning = planning;
+        self
     }
 
     /// Trim output to only the specified downstream variables.
@@ -167,15 +186,33 @@ impl Operator for BindOperator {
 
             // Process each row
             for row_idx in 0..input_batch.len() {
+                // Resolve any EXISTS subexpression against this row first (it
+                // needs the row's bindings to correlate); otherwise evaluate
+                // the expression directly. `Cow` keeps the no-EXISTS path
+                // allocation-free.
+                let expr: std::borrow::Cow<'_, Expression> = if self.has_exists {
+                    std::borrow::Cow::Owned(
+                        crate::filter::resolve_row_exists(
+                            &self.expr,
+                            &input_batch,
+                            row_idx,
+                            ctx,
+                            &self.planning,
+                        )
+                        .await?,
+                    )
+                } else {
+                    std::borrow::Cow::Borrowed(&self.expr)
+                };
+
                 let row_view = input_batch.row_view(row_idx).unwrap();
 
                 // Evaluate expression. Non-strict mode still propagates fatal
                 // execution issues such as dictionary lookup failures.
                 let computed = if ctx.strict_bind_errors {
-                    self.expr.try_eval_to_binding(&row_view, Some(ctx))?
+                    expr.try_eval_to_binding(&row_view, Some(ctx))?
                 } else {
-                    self.expr
-                        .try_eval_to_binding_non_strict(&row_view, Some(ctx))?
+                    expr.try_eval_to_binding_non_strict(&row_view, Some(ctx))?
                 };
 
                 // Check clobber prevention if variable already exists

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2868,6 +2868,7 @@ fn build_operator_tree_inner(
         query.limit,
         detect_partitioned_group_by(query),
         variable_deps.as_ref(),
+        planning,
     )
 }
 
@@ -2897,6 +2898,7 @@ pub(crate) fn apply_solution_modifiers(
     limit: Option<usize>,
     partitioned: bool,
     variable_deps: Option<&VariableDeps>,
+    planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
     // Flatten the grouping phase's data for consumption below. The variant
     // distinction has already done its structural work at the IR boundary; the
@@ -3090,6 +3092,7 @@ pub(crate) fn apply_solution_modifiers(
         for (i, (var, expr)) in post_binds_vec.iter().enumerate() {
             operator = Box::new(
                 crate::bind::BindOperator::new(operator, *var, expr.clone(), vec![])
+                    .with_planning(*planning)
                     .with_out_schema(
                         variable_deps
                             .as_ref()
@@ -3135,12 +3138,10 @@ pub(crate) fn apply_solution_modifiers(
             }
         }
         for (var, expr) in order_binds {
-            operator = Box::new(crate::bind::BindOperator::new(
-                operator,
-                *var,
-                expr.clone(),
-                vec![],
-            ));
+            operator = Box::new(
+                crate::bind::BindOperator::new(operator, *var, expr.clone(), vec![])
+                    .with_planning(*planning),
+            );
         }
     }
 

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -738,6 +738,7 @@ fn apply_eligible_binds(
     pending_binds: Vec<BindPattern>,
     mut pending_filters: Vec<FilterPattern>,
     filter_idxs_consumed: &[usize],
+    planning: &PlanningContext,
 ) -> (BoxedOperator, Vec<BindPattern>, Vec<FilterPattern>) {
     let mut remaining_binds = Vec::new();
 
@@ -749,12 +750,10 @@ fn apply_eligible_binds(
                 partition_eligible_filters(pending_filters, bound, filter_idxs_consumed);
             pending_filters = still_pending;
 
-            child = Box::new(BindOperator::new(
-                child,
-                pending.var,
-                pending.expr,
-                bind_filters,
-            ));
+            child = Box::new(
+                BindOperator::new(child, pending.var, pending.expr, bind_filters)
+                    .with_planning(*planning),
+            );
         } else {
             remaining_binds.push(pending);
         }
@@ -781,6 +780,7 @@ fn apply_deferred_patterns(
         pending_binds,
         pending_filters,
         filter_idxs_consumed,
+        planning,
     );
 
     let (ready, remaining_filters) =
@@ -812,6 +812,7 @@ fn apply_all_remaining(
         pending_binds,
         pending_filters,
         filter_idxs_consumed,
+        planning,
     );
     for pending in remaining_filters {
         if !filter_idxs_consumed.contains(&pending.original_idx) {
@@ -840,12 +841,9 @@ fn build_single_pattern(
     match pattern {
         Pattern::Bind { var, expr } => {
             let child = get_or_empty_seed(operator);
-            Some(Box::new(BindOperator::new(
-                child,
-                *var,
-                expr.clone(),
-                vec![],
-            )))
+            Some(Box::new(
+                BindOperator::new(child, *var, expr.clone(), vec![]).with_planning(*planning),
+            ))
         }
         Pattern::Values { vars, rows } => {
             let child = get_or_empty_seed(operator);
@@ -1091,7 +1089,11 @@ fn build_sequential_join_block(
 
     // Tracks the running driving-chain cardinality across steps for the hash-join
     // cost model; `before_step` snapshots it against the live `bound` set per pattern.
-    let mut hash_planner = HashJoinPlanner::new(ctx.stats);
+    // Seed it from the incoming LEFT operator's estimate (e.g. a subquery producing
+    // `WITH DISTINCT friend`) so the first probe is costed against the producer size,
+    // not 1 — otherwise a large object predicate falsely trips scan-ratio-too-high.
+    let mut hash_planner = HashJoinPlanner::new(ctx.stats)
+        .with_left_estimate(operator.as_ref().and_then(|o| o.estimated_rows()));
     for (k, tp) in triples.iter().enumerate() {
         hash_planner.before_step(tp, &bound);
         let mut vars_after: HashSet<VarId> = bound.clone();
@@ -2151,8 +2153,14 @@ fn build_sequential_triple_chain(
 
     // Drives the hash-join cost model; snapshots cardinality against `seen_vars`
     // (the chain bound so far) before each pattern — see build_sequential_join_block.
-    let mut seen_vars: HashSet<VarId> = HashSet::new();
-    let mut hash_planner = HashJoinPlanner::new(ctx.stats);
+    // Both seed from the incoming LEFT operator: `seen_vars` from its bound schema
+    // (so the first probe is correctly costed as object-bound, not a full scan)
+    // and the driving estimate from its row estimate (e.g. a `WITH DISTINCT
+    // friend` subquery's ~producer size) — otherwise the first probe is weighed
+    // against 1 and a large object predicate falsely trips scan-ratio-too-high.
+    let mut seen_vars: HashSet<VarId> = bound_vars_from_operator(&operator);
+    let mut hash_planner = HashJoinPlanner::new(ctx.stats)
+        .with_left_estimate(operator.as_ref().and_then(|o| o.estimated_rows()));
     for (k, pattern) in triples.iter().enumerate() {
         hash_planner.before_step(pattern, &seen_vars);
         seen_vars.extend(pattern.produced_vars());

--- a/fluree-db-query/src/filter.rs
+++ b/fluree-db-query/src/filter.rs
@@ -405,6 +405,27 @@ fn resolve_exists_for_row<'a>(
     })
 }
 
+/// Resolve every `Expression::Exists` in `expr` for one row, seeding the
+/// row's bindings, and return the expression with each EXISTS replaced by
+/// its `Const(Bool)` result.
+///
+/// This is the projection/BIND counterpart to the per-row resolution the
+/// `FilterOperator` does: it lets EXISTS appear as a *value* (e.g.
+/// `RETURN NOT EXISTS { ... } AS isNew`), not only as a row filter.
+/// Correlation is via `batch[row_idx]`, so any outer variable the inner
+/// pattern references is bound. No semijoin cache — each call resolves
+/// independently (correct; the common no-EXISTS case is gated out by the
+/// caller via [`contains_exists`]).
+pub(crate) async fn resolve_row_exists(
+    expr: &Expression,
+    batch: &Batch,
+    row_idx: usize,
+    ctx: &ExecutionContext<'_>,
+    planning: &crate::temporal_mode::PlanningContext,
+) -> Result<Expression> {
+    resolve_exists_for_row(expr, batch, row_idx, ctx, None, planning).await
+}
+
 /// Filter a batch using an expression that contains EXISTS subexpressions.
 ///
 /// Two-phase evaluation:

--- a/fluree-db-query/src/hash_join.rs
+++ b/fluree-db-query/src/hash_join.rs
@@ -334,6 +334,19 @@ impl<'a> HashJoinPlanner<'a> {
         }
     }
 
+    /// Seed the running driving estimate from the block's incoming LEFT operator
+    /// (e.g. a `SubqueryOperator` producing `WITH DISTINCT friend`). Without this
+    /// the first probe in the block is costed against `driving_est = 1` — so a
+    /// large object predicate trips `scan-ratio-too-high` and the hash join is
+    /// wrongly rejected, even though the left side produces hundreds of rows.
+    /// `None` (left side has no estimate) leaves the default 1.0.
+    pub(crate) fn with_left_estimate(mut self, left_est: Option<usize>) -> Self {
+        if let Some(n) = left_est {
+            self.driving_est = (n as f64).max(1.0);
+        }
+        self
+    }
+
     /// Advance the running driving cardinality past one pattern. Call once per
     /// pattern, in chain order, BEFORE building its operator. Snapshots the product
     /// of the patterns to the LEFT of `tp` (this becomes `step_est`, the size the

--- a/fluree-db-query/src/hash_join.rs
+++ b/fluree-db-query/src/hash_join.rs
@@ -1116,6 +1116,33 @@ mod tests {
     }
 
     #[test]
+    fn producer_seed_clears_scan_ratio_cap() {
+        // Coupling guard: `planner::DISTINCT_SUBQUERY_PRODUCER_SELECTIVITY` (the
+        // estimate handed to a downstream object→subject hash join when an
+        // anchored `WITH DISTINCT` producer drives it) is load-bearing precisely
+        // because it must clear this module's scan-ratio cap. Concretely the seed
+        // must keep a probe of `seed × HASH_JOIN_MAX_SCAN_RATIO` rows within
+        // budget — otherwise the hash join the producer ordering exists to unlock
+        // is re-rejected as scan-ratio-too-high.
+        let seed = crate::planner::DISTINCT_SUBQUERY_PRODUCER_SELECTIVITY;
+        // A probe sized between a too-small seed's budget (100 × cap = 102,400)
+        // and the tuned seed's budget (500 × cap = 512,000): accepted at the
+        // tuned seed, rejected if the seed shrinks to 100.
+        let probe = 300_000_u64;
+        assert!(
+            hash_join_cost_wins(Some(probe), Some(seed)),
+            "seed {seed} must keep a {probe}-row probe within the scan-ratio budget \
+             (seed × {HASH_JOIN_MAX_SCAN_RATIO}); lower either constant and this fails"
+        );
+        // Demonstrate the coupling is real: a seed of 100 (the value the planner
+        // doc warns against) re-rejects the same probe.
+        assert!(
+            !hash_join_cost_wins(Some(probe), Some(100.0)),
+            "a 100-row seed must re-reject the probe — proving the tuned seed is load-bearing"
+        );
+    }
+
+    #[test]
     fn cost_gate_fires_for_small_build_star_anchors() {
         // First object-star joins from slow deep-star plans (build -> probe rows):
         // 5,092 -> 7,100; 2,196 -> 35,246; 1,068 -> 7,684.

--- a/fluree-db-query/src/optional.rs
+++ b/fluree-db-query/src/optional.rs
@@ -1162,6 +1162,22 @@ impl OptionalBuilder for PlanTreeOptionalBuilder {
     /// per-seed evaluation is a pure restriction by the correlation tuple
     /// (no internal LIMIT / independent correlation / row-multiplying subquery).
     /// Any unmet gate returns `Ok(None)`, deferring to the per-row `build` path.
+    ///
+    /// Trade-offs (deliberate, and why `FLUREE_OPTIONAL_HASH_JOIN=0` exists):
+    /// - The whole inner result is MATERIALIZED into `buckets`/`key_batches`
+    ///   before any row is emitted — peak memory is the inner output size, not
+    ///   the streaming O(1) of the per-row path. Bounded in practice by the gates
+    ///   plus single-ledger correlation, but unbounded inner outputs are why this
+    ///   is a kill-switchable fast path, not the default for every shape.
+    /// - The inner is rebuilt and re-executed once PER required BATCH (not once
+    ///   globally): there is no cross-batch seed dedup, so a correlation tuple
+    ///   spanning N required batches drives the inner N times. The win is still
+    ///   decisive vs. per-ROW rebuild; a global hash join would need a different
+    ///   operator boundary.
+    /// - Leaving an object-only correlation var unbound (see
+    ///   [`corr_var_only_triple_object`]) can make the seeded inner read MORE
+    ///   than the per-row path when that var is the selective one — the bet is
+    ///   that the scattered object-probe it replaces is the dominant cost.
     async fn build_batch(
         &self,
         required_batch: &Batch,

--- a/fluree-db-query/src/optional.rs
+++ b/fluree-db-query/src/optional.rs
@@ -1276,7 +1276,7 @@ impl OptionalBuilder for PlanTreeOptionalBuilder {
         // tuples; object-only correlation vars stay unbound so the inner
         // produces them subject-first.
         let seed_schema: Arc<[VarId]> = Arc::from(seed_vars.clone().into_boxed_slice());
-        let seed = MaterializedSeedOperator::new(seed_schema, seed_rows, ctx.batch_size);
+        let seed = MaterializedSeedOperator::new(seed_schema, seed_rows, ctx.batch_size)?;
         let mut inner = crate::execute::build_where_operators_seeded(
             Some(Box::new(seed)),
             &self.inner_patterns,
@@ -1447,7 +1447,12 @@ struct MaterializedSeedOperator {
 }
 
 impl MaterializedSeedOperator {
-    fn new(schema: Arc<[VarId]>, rows: Vec<Vec<Binding>>, chunk: usize) -> Self {
+    /// Build the seed from the distinct correlation tuples. Fallible: a
+    /// `Batch::new` failure here would otherwise silently drop a seed chunk,
+    /// running the inner with fewer correlations and undercounting the OPTIONAL
+    /// — a silent wrong answer. Propagate instead so `build_batch` falls back to
+    /// the per-row path rather than returning short results.
+    fn new(schema: Arc<[VarId]>, rows: Vec<Vec<Binding>>, chunk: usize) -> Result<Self> {
         let chunk = chunk.max(1);
         let ncols = schema.len();
         let mut batches = VecDeque::new();
@@ -1460,15 +1465,13 @@ impl MaterializedSeedOperator {
                     columns[c].push(b.clone());
                 }
             }
-            if let Ok(batch) = Batch::new(schema.clone(), columns) {
-                batches.push_back(batch);
-            }
+            batches.push_back(Batch::new(schema.clone(), columns)?);
         }
-        Self {
+        Ok(Self {
             schema,
             batches,
             state: OperatorState::Created,
-        }
+        })
     }
 }
 

--- a/fluree-db-query/src/optional.rs
+++ b/fluree-db-query/src/optional.rs
@@ -28,12 +28,14 @@ use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::fast_path_common::try_normalize_pred_sid;
 use crate::fast_path_common::{subject_probe_lane_plan, ProbeLanePlan, ProbeOps};
+use crate::group_aggregate::{binding_to_group_key_normalized, GroupKeyOwned};
 use crate::ir::triple::{Ref, Term, TriplePattern};
 use crate::ir::Pattern;
 use crate::join::{
     batched_subject_probe_binary, BindInstruction, PatternPosition, SubjectProbeParams,
     UnifyInstruction,
 };
+use crate::object_binding::{equality_norm, EqualityNorm};
 use crate::operator::{
     compute_trimmed_vars, effective_schema, trim_batch, BoxedOperator, Operator, OperatorState,
 };
@@ -74,6 +76,7 @@ pub type OptionalBatchRow = (usize, Vec<Batch>);
 /// - Substituting bound vars into scan patterns
 /// - Creating a seed `Values` operator with the left row
 /// - Building a join chain that starts from the left bindings
+#[async_trait]
 pub trait OptionalBuilder: Send + Sync {
     /// Build an optional operator for the given required row
     ///
@@ -95,11 +98,16 @@ pub trait OptionalBuilder: Send + Sync {
         ctx: &ExecutionContext<'_>,
     ) -> Result<Option<BoxedOperator>>;
 
-    /// Optionally build all remaining required rows in the current batch in one pass.
+    /// Optionally build *and execute* all remaining required rows in the current
+    /// batch in one pass, returning each row's optional-side result batches.
     ///
-    /// Builders can override this to implement batched probe paths for hot
-    /// correlated OPTIONAL shapes. Default: no batched execution.
-    fn build_batch(
+    /// Builders override this to implement batched paths for hot correlated
+    /// OPTIONAL shapes — either synchronous index probes (see
+    /// `GroupedPatternOptionalBuilder`) or a single seeded subplan execution
+    /// hash-partitioned across rows (see `PlanTreeOptionalBuilder`). The method
+    /// is `async` so the latter can drive a real operator subtree.
+    /// Default: no batched execution (operator falls back to per-row `build`).
+    async fn build_batch(
         &self,
         _required_batch: &Batch,
         _start_row: usize,
@@ -400,6 +408,7 @@ impl PatternOptionalBuilder {
     }
 }
 
+#[async_trait]
 impl OptionalBuilder for PatternOptionalBuilder {
     fn build(
         &self,
@@ -427,7 +436,7 @@ impl OptionalBuilder for PatternOptionalBuilder {
         )))
     }
 
-    fn build_batch(
+    async fn build_batch(
         &self,
         required_batch: &Batch,
         start_row: usize,
@@ -772,6 +781,7 @@ impl GroupedPatternOptionalBuilder {
     }
 }
 
+#[async_trait]
 impl OptionalBuilder for GroupedPatternOptionalBuilder {
     fn build(
         &self,
@@ -782,7 +792,7 @@ impl OptionalBuilder for GroupedPatternOptionalBuilder {
         self.build_fallback_chain(required_batch, row, ctx)
     }
 
-    fn build_batch(
+    async fn build_batch(
         &self,
         required_batch: &Batch,
         start_row: usize,
@@ -1100,6 +1110,7 @@ impl PlanTreeOptionalBuilder {
     }
 }
 
+#[async_trait]
 impl OptionalBuilder for PlanTreeOptionalBuilder {
     fn build(
         &self,
@@ -1136,6 +1147,229 @@ impl OptionalBuilder for PlanTreeOptionalBuilder {
         Ok(Some(op))
     }
 
+    /// Batched correlated OPTIONAL as a hash left-join.
+    ///
+    /// Instead of rebuilding and re-executing the inner subplan once per
+    /// required row, seed it ONCE with the distinct correlation tuples of the
+    /// whole batch, execute it once, then hash-partition the results back to
+    /// each row by correlation key. This collapses the per-driving-row subplan
+    /// rebuild (the LDBC IC5 cliff) into a single inner scan.
+    ///
+    /// Soundness: the inner solutions for a required row depend on the row only
+    /// through its shared (correlation) variables — the sole overlap with the
+    /// inner patterns — so partitioning the single execution by those variables
+    /// reproduces the per-row results exactly. Gated to inner shapes whose
+    /// per-seed evaluation is a pure restriction by the correlation tuple
+    /// (no internal LIMIT / independent correlation / row-multiplying subquery).
+    /// Any unmet gate returns `Ok(None)`, deferring to the per-row `build` path.
+    async fn build_batch(
+        &self,
+        required_batch: &Batch,
+        start_row: usize,
+        ctx: &ExecutionContext<'_>,
+    ) -> Result<Option<Vec<OptionalBatchRow>>> {
+        if start_row >= required_batch.len()
+            || optional_hash_join_disabled()
+            || ctx.is_multi_ledger()
+            || !self
+                .inner_patterns
+                .iter()
+                .all(inner_pattern_is_hash_join_safe)
+        {
+            return Ok(None);
+        }
+
+        // Correlation columns = required columns whose var is referenced anywhere
+        // inside the inner patterns (join keys, filter operands, path endpoints).
+        let req_schema = required_batch.schema();
+        let referenced: HashSet<VarId> = self
+            .inner_patterns
+            .iter()
+            .flat_map(Pattern::referenced_vars)
+            .collect();
+        let corr_cols: Vec<usize> = req_schema
+            .iter()
+            .enumerate()
+            .filter(|(_, v)| referenced.contains(v))
+            .map(|(c, _)| c)
+            .collect();
+        if corr_cols.is_empty() {
+            // Uncorrelated OPTIONAL: leave to the per-row path (rare).
+            return Ok(None);
+        }
+        let corr_vars: Vec<VarId> = corr_cols.iter().map(|&c| req_schema[c]).collect();
+
+        // Seed only the correlation vars that drive the inner subject-first.
+        // A correlation var that appears in the inner SOLELY as a Triple object
+        // is left UNBOUND: the inner then binds it from the subject side (a fast
+        // PSOT scan) instead of object-probing the seeded value through the
+        // scattered global object index — the hash-join drive that fixes the
+        // LDBC IC5 timeout. Correctness is preserved by partitioning on the full
+        // correlation key, so the inner-produced binding is matched back to the
+        // required row's value. Vars used anywhere else (subject/predicate/
+        // filter/path) must be seeded to keep the inner correct.
+        let unbound_corr: HashSet<VarId> = corr_vars
+            .iter()
+            .copied()
+            .filter(|v| corr_var_only_triple_object(*v, &self.inner_patterns))
+            .collect();
+        let seed_cols: Vec<usize> = corr_cols
+            .iter()
+            .copied()
+            .filter(|&c| !unbound_corr.contains(&req_schema[c]))
+            .collect();
+        if seed_cols.is_empty() {
+            // No subject-drivable correlation: seeding nothing would run the
+            // inner uncorrelated (possible explosion). Defer to the per-row path.
+            return Ok(None);
+        }
+        let seed_vars: Vec<VarId> = seed_cols.iter().map(|&c| req_schema[c]).collect();
+
+        let norm = equality_norm(ctx);
+        let (store, gv) = EqualityNorm::parts(&norm);
+
+        // Per row: full correlation key (for matching) + distinct seed tuple
+        // over the seeded subset. A poisoned/unbound correlation var can never
+        // match -> no-match row.
+        let n = required_batch.len();
+        let mut row_keys: Vec<Option<Vec<GroupKeyOwned>>> = Vec::with_capacity(n - start_row);
+        let mut seed_rows: Vec<Vec<Binding>> = Vec::new();
+        let mut seen_seed: HashSet<Vec<GroupKeyOwned>> = HashSet::new();
+        for row in start_row..n {
+            let unmatchable = corr_cols.iter().any(|&c| {
+                let b = required_batch.get_by_col(row, c);
+                b.is_poisoned() || matches!(b, Binding::Unbound)
+            });
+            if unmatchable {
+                row_keys.push(None);
+                continue;
+            }
+            let key: Vec<GroupKeyOwned> = corr_cols
+                .iter()
+                .map(|&c| {
+                    binding_to_group_key_normalized(required_batch.get_by_col(row, c), store, gv)
+                })
+                .collect();
+            let seed_key: Vec<GroupKeyOwned> = seed_cols
+                .iter()
+                .map(|&c| {
+                    binding_to_group_key_normalized(required_batch.get_by_col(row, c), store, gv)
+                })
+                .collect();
+            if seen_seed.insert(seed_key) {
+                seed_rows.push(
+                    seed_cols
+                        .iter()
+                        .map(|&c| required_batch.get_by_col(row, c).clone())
+                        .collect(),
+                );
+            }
+            row_keys.push(Some(key));
+        }
+
+        if seed_rows.is_empty() {
+            // Every row had an unmatchable correlation var.
+            return Ok(Some((start_row..n).map(|row| (row, Vec::new())).collect()));
+        }
+
+        // Build the inner subplan ONCE seeded by the distinct subject-driving
+        // tuples; object-only correlation vars stay unbound so the inner
+        // produces them subject-first.
+        let seed_schema: Arc<[VarId]> = Arc::from(seed_vars.clone().into_boxed_slice());
+        let seed = MaterializedSeedOperator::new(seed_schema, seed_rows, ctx.batch_size);
+        let mut inner = crate::execute::build_where_operators_seeded(
+            Some(Box::new(seed)),
+            &self.inner_patterns,
+            self.stats.clone(),
+            None,
+            &self.planning,
+        )?;
+
+        // The inner output must expose every correlation var (for partitioning)
+        // and every optional-only var (for combine). If emission pruning dropped
+        // one, fall back to the per-row path rather than mis-partition.
+        let inner_schema = inner.schema().to_vec();
+        let mut out_corr_cols: Vec<usize> = Vec::with_capacity(corr_vars.len());
+        for v in &corr_vars {
+            match inner_schema.iter().position(|x| x == v) {
+                Some(c) => out_corr_cols.push(c),
+                None => return Ok(None),
+            }
+        }
+        let mut out_opt_cols: Vec<usize> = Vec::with_capacity(self.optional_only_vars.len());
+        for v in &self.optional_only_vars {
+            match inner_schema.iter().position(|x| x == v) {
+                Some(c) => out_opt_cols.push(c),
+                None => return Ok(None),
+            }
+        }
+        // Optional-side batches carry ONLY the optional-only vars: correlation
+        // equality is already enforced by the partition, so the operator's
+        // per-row unify check is intentionally a no-op here (shared vars absent).
+        let opt_schema: Arc<[VarId]> =
+            Arc::from(self.optional_only_vars.clone().into_boxed_slice());
+
+        // Execute once; hash-partition output rows by the full correlation key.
+        inner.open(ctx).await?;
+        let mut buckets: HashMap<Vec<GroupKeyOwned>, Vec<Vec<Binding>>> = HashMap::new();
+        while let Some(batch) = inner.next_batch(ctx).await? {
+            ctx.check_cancelled()?;
+            for r in 0..batch.len() {
+                let key: Vec<GroupKeyOwned> = out_corr_cols
+                    .iter()
+                    .map(|&c| binding_to_group_key_normalized(batch.get_by_col(r, c), store, gv))
+                    .collect();
+                let projected: Vec<Binding> = out_opt_cols
+                    .iter()
+                    .map(|&c| batch.get_by_col(r, c).clone())
+                    .collect();
+                buckets.entry(key).or_default().push(projected);
+            }
+        }
+        inner.close();
+
+        // One result Batch per correlation key (optional-only columns only),
+        // then assigned to each required row that shares the key.
+        let mut key_batches: HashMap<Vec<GroupKeyOwned>, Batch> = HashMap::new();
+        for (key, rows) in buckets {
+            let batch = if opt_schema.is_empty() {
+                Batch::empty_schema_with_len(rows.len())
+            } else {
+                let mut columns: Vec<Vec<Binding>> = (0..opt_schema.len())
+                    .map(|_| Vec::with_capacity(rows.len()))
+                    .collect();
+                for projected in rows {
+                    for (c, b) in projected.into_iter().enumerate() {
+                        columns[c].push(b);
+                    }
+                }
+                Batch::new(opt_schema.clone(), columns)?
+            };
+            key_batches.insert(key, batch);
+        }
+
+        let mut pending: Vec<OptionalBatchRow> = Vec::with_capacity(n - start_row);
+        for (offset, row) in (start_row..n).enumerate() {
+            let batches = match &row_keys[offset] {
+                Some(key) => key_batches
+                    .get(key)
+                    .map(|b| vec![b.clone()])
+                    .unwrap_or_default(),
+                None => Vec::new(),
+            };
+            pending.push((row, batches));
+        }
+        tracing::debug!(
+            seed_tuples = seen_seed.len(),
+            seed_vars = seed_vars.len(),
+            unbound_corr = unbound_corr.len(),
+            inner_keys = key_batches.len(),
+            rows = pending.len(),
+            "optional batched hash-join complete"
+        );
+        Ok(Some(pending))
+    }
+
     fn schema(&self) -> &[VarId] {
         &self.optional_schema
     }
@@ -1146,6 +1380,128 @@ impl OptionalBuilder for PlanTreeOptionalBuilder {
 
     fn unify_instructions(&self) -> &[UnifyInstruction] {
         &self.unify_instructions
+    }
+}
+
+/// Inner-pattern shapes whose per-row OPTIONAL evaluation is exactly a
+/// restriction by the correlation tuple — safe to evaluate once over all
+/// distinct tuples and hash-partition. Triples, row-local filters, and
+/// property paths from a (possibly seeded) endpoint qualify; subqueries,
+/// nested OPTIONAL/UNION/MINUS, BIND/UNWIND/VALUES, and search patterns do
+/// not (they can carry internal limits or independent correlation).
+fn inner_pattern_is_hash_join_safe(p: &Pattern) -> bool {
+    matches!(
+        p,
+        Pattern::Triple(_) | Pattern::Filter(_) | Pattern::PropertyPath(_)
+    )
+}
+
+/// True iff `v` occurs in the inner patterns ONLY as the object of one or more
+/// Triples (never a subject/predicate, never inside a filter/path/other
+/// pattern). Such a correlation var can be left unbound in the seeded inner so
+/// it is produced subject-first — turning a scattered global object-probe into
+/// a fast subject scan — while the full-key partition still matches the
+/// produced binding back to the required row's value.
+fn corr_var_only_triple_object(v: VarId, patterns: &[Pattern]) -> bool {
+    let mut seen_as_object = false;
+    for p in patterns {
+        match p {
+            Pattern::Triple(t) => {
+                if matches!(&t.s, Ref::Var(x) if *x == v) || matches!(&t.p, Ref::Var(x) if *x == v)
+                {
+                    return false;
+                }
+                if matches!(&t.o, Term::Var(x) if *x == v) {
+                    seen_as_object = true;
+                }
+            }
+            other => {
+                if other.referenced_vars().contains(&v) {
+                    return false;
+                }
+            }
+        }
+    }
+    seen_as_object
+}
+
+/// Kill-switch for the batched OPTIONAL hash-join (`FLUREE_OPTIONAL_HASH_JOIN=0`).
+/// Read once; defaults to enabled.
+fn optional_hash_join_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("FLUREE_OPTIONAL_HASH_JOIN")
+            .map(|v| v == "0" || v.eq_ignore_ascii_case("false") || v.eq_ignore_ascii_case("off"))
+            .unwrap_or(false)
+    })
+}
+
+/// Single-shot operator that emits a precomputed set of rows (the distinct
+/// correlation tuples) as the seed of a batched OPTIONAL hash-join, chunked to
+/// the execution batch size.
+struct MaterializedSeedOperator {
+    schema: Arc<[VarId]>,
+    batches: VecDeque<Batch>,
+    state: OperatorState,
+}
+
+impl MaterializedSeedOperator {
+    fn new(schema: Arc<[VarId]>, rows: Vec<Vec<Binding>>, chunk: usize) -> Self {
+        let chunk = chunk.max(1);
+        let ncols = schema.len();
+        let mut batches = VecDeque::new();
+        for chunk_rows in rows.chunks(chunk) {
+            let mut columns: Vec<Vec<Binding>> = (0..ncols)
+                .map(|_| Vec::with_capacity(chunk_rows.len()))
+                .collect();
+            for row in chunk_rows {
+                for (c, b) in row.iter().enumerate() {
+                    columns[c].push(b.clone());
+                }
+            }
+            if let Ok(batch) = Batch::new(schema.clone(), columns) {
+                batches.push_back(batch);
+            }
+        }
+        Self {
+            schema,
+            batches,
+            state: OperatorState::Created,
+        }
+    }
+}
+
+#[async_trait]
+impl Operator for MaterializedSeedOperator {
+    fn schema(&self) -> &[VarId] {
+        &self.schema
+    }
+
+    async fn open(&mut self, _ctx: &ExecutionContext<'_>) -> Result<()> {
+        self.state = OperatorState::Open;
+        Ok(())
+    }
+
+    async fn next_batch(&mut self, _ctx: &ExecutionContext<'_>) -> Result<Option<Batch>> {
+        if self.state != OperatorState::Open {
+            return Ok(None);
+        }
+        match self.batches.pop_front() {
+            Some(batch) => Ok(Some(batch)),
+            None => {
+                self.state = OperatorState::Exhausted;
+                Ok(None)
+            }
+        }
+    }
+
+    fn close(&mut self) {
+        self.state = OperatorState::Closed;
+    }
+
+    fn estimated_rows(&self) -> Option<usize> {
+        Some(self.batches.iter().map(Batch::len).sum())
     }
 }
 
@@ -1547,11 +1903,11 @@ impl Operator for OptionalOperator {
             // Process current required row
             if self.current_required_row < required_batch.len() {
                 if self.pending_output.is_empty() {
-                    if let Some(batched_pending) = self.optional_builder.build_batch(
-                        required_batch,
-                        self.current_required_row,
-                        ctx,
-                    )? {
+                    if let Some(batched_pending) = self
+                        .optional_builder
+                        .build_batch(required_batch, self.current_required_row, ctx)
+                        .await?
+                    {
                         batched_builds += 1;
                         batched_rows += batched_pending.len();
                         required_rows_seen += batched_pending.len();

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -829,9 +829,11 @@ fn subquery_body_has_constant_anchor(patterns: &[Pattern]) -> bool {
 ///   estimated at [`DISTINCT_SUBQUERY_PRODUCER_SELECTIVITY`].
 /// - Everything else keeps the body cardinality as an upper bound.
 ///
-/// Shared by [`estimate_pattern`] (join ordering) and
-/// `SubqueryOperator::estimated_rows` (seeding the downstream hash join), so the
-/// producer's estimate is consistent in both places.
+/// Used by [`estimate_pattern`] for join *ordering*, where a loose upper bound
+/// is acceptable. The operator cost model takes the narrower
+/// [`subquery_output_estimate_is_bounded`] gate before trusting this value (see
+/// `SubqueryOperator::estimated_rows`), so an arbitrary subquery's body-cardinality
+/// guess does not perturb downstream hash-join decisions.
 pub(crate) fn estimate_subquery_output(sq: &SubqueryPattern, stats: Option<&StatsView>) -> f64 {
     let rows = match &sq.grouping {
         Some(Grouping::Implicit { .. }) => HIGHLY_SELECTIVE,
@@ -847,6 +849,27 @@ pub(crate) fn estimate_subquery_output(sq: &SubqueryPattern, stats: Option<&Stat
     // A LIMIT caps the output regardless of grouping.
     let rows = sq.limit.map_or(rows, |l| rows.min(l as f64));
     rows.max(HIGHLY_SELECTIVE)
+}
+
+/// Is [`estimate_subquery_output`] reliable enough to feed the operator cost
+/// model (`SubqueryOperator::estimated_rows`, which seeds the downstream
+/// hash-join driving estimate)?
+///
+/// True only for shapes whose output is bounded INDEPENDENT of body
+/// cardinality:
+/// - a scalar aggregate (implicit `GROUP BY`) — exactly one row;
+/// - an anchored `DISTINCT` single-var producer — the intended hash-join seed;
+/// - any subquery with an explicit `LIMIT` — a hard cap.
+///
+/// For everything else (a plain row-per-solution subquery, or an explicit
+/// `GROUP BY` whose distinct-key count we cannot estimate) the value is just the
+/// body cardinality — a fine upper bound for join *ordering* but too unreliable
+/// to perturb hash-join cost decisions, so the operator keeps the conservative
+/// `None`.
+pub(crate) fn subquery_output_estimate_is_bounded(sq: &SubqueryPattern) -> bool {
+    matches!(&sq.grouping, Some(Grouping::Implicit { .. }))
+        || sq.limit.is_some()
+        || (sq.distinct && sq.select.len() == 1 && subquery_body_has_constant_anchor(&sq.patterns))
 }
 
 /// Estimate cardinality for any pattern type.
@@ -3440,5 +3463,87 @@ mod tests {
                 if matches!(&tp.p, Ref::Sid(s) if s.name.as_ref() == "HAS_CREATOR")),
             "consumer drains right after the producer: {ordered:?}"
         );
+    }
+
+    // --- which subquery shapes feed the operator cost model -------------------
+    //
+    // `subquery_output_estimate_is_bounded` gates `SubqueryOperator::estimated_rows`
+    // (which seeds the downstream hash-join driving estimate). Only reliably
+    // bounded shapes may return `Some`; an arbitrary subquery keeps the
+    // conservative `None` so its body-cardinality guess cannot perturb hash-join
+    // decisions for unrelated queries.
+
+    use crate::ir::{AggregateFn, AggregateSpec};
+
+    /// A `?s <p> <const>` triple — a constant-object anchor (not `rdf:type`).
+    fn value_anchor(subject: VarId) -> Pattern {
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(subject),
+            Ref::Sid(Sid::new(100, "id")),
+            Term::Sid(Sid::new(100, "x")),
+        ))
+    }
+
+    fn count_all_grouping(group_by: Vec<VarId>, out: VarId) -> Grouping {
+        Grouping::assemble(
+            group_by,
+            vec![AggregateSpec {
+                function: AggregateFn::CountAll,
+                output_var: out,
+            }],
+            vec![],
+            None,
+        )
+        .expect("aggregate present")
+    }
+
+    #[test]
+    fn scalar_aggregate_subquery_is_bounded() {
+        // Implicit GROUP BY → exactly one row.
+        let sq = SubqueryPattern::new(vec![VarId(0)], vec![value_anchor(VarId(1))])
+            .with_grouping(count_all_grouping(vec![], VarId(0)));
+        assert!(subquery_output_estimate_is_bounded(&sq));
+    }
+
+    #[test]
+    fn anchored_distinct_producer_is_bounded() {
+        // `WITH DISTINCT ?x` over an anchored body — the intended hash-join seed.
+        let sq = SubqueryPattern::new(vec![VarId(0)], vec![value_anchor(VarId(0))]).with_distinct();
+        assert!(subquery_output_estimate_is_bounded(&sq));
+    }
+
+    /// A plain `?x knows ?y` body — no anchor, multiplies rows.
+    fn unanchored_body() -> Vec<Pattern> {
+        vec![Pattern::Triple(make_pattern(VarId(0), "knows", VarId(1)))]
+    }
+
+    #[test]
+    fn limited_subquery_is_bounded() {
+        // An explicit LIMIT is a hard cap regardless of shape.
+        let sq = SubqueryPattern::new(vec![VarId(0)], unanchored_body()).with_limit(5);
+        assert!(subquery_output_estimate_is_bounded(&sq));
+    }
+
+    #[test]
+    fn plain_row_per_solution_subquery_is_unbounded() {
+        // Non-DISTINCT, no grouping, no limit: body cardinality only → keep None.
+        let sq = SubqueryPattern::new(vec![VarId(0)], unanchored_body());
+        assert!(!subquery_output_estimate_is_bounded(&sq));
+    }
+
+    #[test]
+    fn explicit_group_by_subquery_is_unbounded() {
+        // Distinct-key count is unknown → not safe to feed the cost model.
+        let sq = SubqueryPattern::new(vec![VarId(0)], unanchored_body())
+            .with_grouping(count_all_grouping(vec![VarId(0)], VarId(2)));
+        assert!(!subquery_output_estimate_is_bounded(&sq));
+    }
+
+    #[test]
+    fn distinct_without_anchor_is_unbounded() {
+        // DISTINCT single-var but no constant anchor in the body: the 500-row
+        // producer estimate does not apply, so it is not a trustworthy seed.
+        let sq = SubqueryPattern::new(vec![VarId(0)], unanchored_body()).with_distinct();
+        assert!(!subquery_output_estimate_is_bounded(&sq));
     }
 }

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -57,6 +57,20 @@ const DEFAULT_PROPERTY_SCAN_SELECTIVITY: f64 = 1_000_000.0;
 /// probes the joined predicate by the produced var) instead of letting a
 /// high-cardinality predicate scan run first. See issue #1287.
 const ANCHORED_PROPERTY_PATH_SELECTIVITY: f64 = 100.0;
+/// A `WITH DISTINCT <one var>` subquery anchored by a constant in its body
+/// (e.g. `MATCH (p {id: $x})-[:KNOWS*1..2]-(friend) WITH DISTINCT friend`) emits
+/// the projected distinct rows reachable from that anchor — NOT the body's join
+/// product. The product wildly overestimates (a 2-hop KNOWS reads ~792M) and
+/// pushes the producer behind unrelated sources in join ordering. Estimate such
+/// an anchored producer at this small bounded value so it is placed first and
+/// binds its output before consumers are ranked.
+///
+/// Tuned above the pure-ordering minimum: it ALSO seeds the object→subject
+/// hash-join driving estimate for a downstream consumer (a `(message
+/// HAS_CREATOR friend)` probe), so it must stay realistic enough that
+/// `probe_count / driving_est` clears [`hash_join`'s scan-ratio cap](crate::hash_join)
+/// — too small (e.g. 100) re-rejects the very hash join this ordering unlocks.
+const DISTINCT_SUBQUERY_PRODUCER_SELECTIVITY: f64 = 500.0;
 /// Full scan - all variables unbound
 const FULL_SCAN: f64 = 1e12;
 
@@ -778,6 +792,63 @@ impl PatternEstimate {
     }
 }
 
+/// Does this subquery body contain a constant anchor — a specific starting node
+/// (`<const> p ?x`) or a property-value lookup that pins a subject
+/// (`?x p <const>`, e.g. `?root id $personId`) — that bounds the traversal to a
+/// small reachable set? Used to recognize an anchored `DISTINCT` producer (see
+/// [`DISTINCT_SUBQUERY_PRODUCER_SELECTIVITY`]). A broad `?x rdf:type Class` is
+/// NOT an anchor: it constrains membership, not a starting point.
+fn subquery_body_has_constant_anchor(patterns: &[Pattern]) -> bool {
+    patterns.iter().any(|p| match p {
+        Pattern::Triple(tp) => {
+            let const_subject = !matches!(tp.s, Ref::Var(_));
+            let pins_subject = tp.o.as_var().is_none() && !tp.p.is_rdf_type();
+            const_subject || pins_subject
+        }
+        Pattern::PropertyPath(pp) => {
+            !matches!(pp.subject, Ref::Var(_)) || !matches!(pp.object, Ref::Var(_))
+        }
+        Pattern::Union(branches) => branches
+            .iter()
+            .any(|b| subquery_body_has_constant_anchor(b)),
+        Pattern::Optional(ps) | Pattern::Graph { patterns: ps, .. } => {
+            subquery_body_has_constant_anchor(ps)
+        }
+        Pattern::Subquery(inner) => subquery_body_has_constant_anchor(&inner.patterns),
+        _ => false,
+    })
+}
+
+/// Estimate a subquery's OUTPUT cardinality (what join ordering and the
+/// hash-join driving estimate care about) — NOT the size of its internal scan.
+///
+/// - A scalar aggregate (implicit `GROUP BY`) emits exactly one row.
+/// - A `DISTINCT` producer of a single var anchored by a constant in its body
+///   (`WITH DISTINCT friend` over an `{id: $x}`-anchored traversal) emits the
+///   projected distinct rows reachable from the anchor, not the body product —
+///   estimated at [`DISTINCT_SUBQUERY_PRODUCER_SELECTIVITY`].
+/// - Everything else keeps the body cardinality as an upper bound.
+///
+/// Shared by [`estimate_pattern`] (join ordering) and
+/// `SubqueryOperator::estimated_rows` (seeding the downstream hash join), so the
+/// producer's estimate is consistent in both places.
+pub(crate) fn estimate_subquery_output(sq: &SubqueryPattern, stats: Option<&StatsView>) -> f64 {
+    let rows = match &sq.grouping {
+        Some(Grouping::Implicit { .. }) => HIGHLY_SELECTIVE,
+        _ if sq.distinct
+            && sq.select.len() == 1
+            && sq.limit.is_none()
+            && subquery_body_has_constant_anchor(&sq.patterns) =>
+        {
+            DISTINCT_SUBQUERY_PRODUCER_SELECTIVITY
+        }
+        _ => estimate_branch_cardinality(&sq.patterns, stats),
+    };
+    // A LIMIT caps the output regardless of grouping.
+    let rows = sq.limit.map_or(rows, |l| rows.min(l as f64));
+    rows.max(HIGHLY_SELECTIVE)
+}
+
 /// Estimate cardinality for any pattern type.
 ///
 /// The `bound_vars` parameter indicates which variables are already bound from
@@ -808,28 +879,9 @@ pub fn estimate_pattern(
             }
         }
 
-        Pattern::Subquery(sq) => {
-            // Join ordering cares about a subquery's OUTPUT cardinality, not the
-            // size of its internal scan. A scalar aggregate (no `GROUP BY`) emits
-            // exactly one row. Estimating it by the (large) body cardinality
-            // wrongly ranks the subquery as a huge source and pushes it to the
-            // END of the join order — precisely where, if it is uncorrelated, it
-            // gets re-executed once per parent row (see `SubqueryOperator`'s
-            // uncorrelated fast-path). Treat a scalar-aggregate subquery as a
-            // single row so the planner places it early.
-            let rows = match &sq.grouping {
-                Some(Grouping::Implicit { .. }) => HIGHLY_SELECTIVE,
-                // `Explicit` GROUP BY emits one row per distinct key combination
-                // and `None` emits one row per solution; absent per-key NDV we
-                // keep the body estimate (an upper bound) for these.
-                _ => estimate_branch_cardinality(&sq.patterns, stats),
-            };
-            // A LIMIT caps the output regardless of grouping.
-            let rows = sq.limit.map_or(rows, |l| rows.min(l as f64));
-            PatternEstimate::Source {
-                row_count: rows.max(HIGHLY_SELECTIVE),
-            }
-        }
+        Pattern::Subquery(sq) => PatternEstimate::Source {
+            row_count: estimate_subquery_output(sq, stats),
+        },
 
         Pattern::Optional(_) => PatternEstimate::Expander { multiplier: 1.0 },
 
@@ -1070,6 +1122,26 @@ pub fn reorder_patterns(
 
     let mut bound_vars = initial_bound_vars.clone();
 
+    // Outputs of UNCORRELATED sibling subqueries (Cypher WITH-pipeline
+    // producers). A pattern consuming one of these must be placed AFTER the
+    // producing subquery — otherwise the greedy source race can place the
+    // consumer first (e.g. a cheap `?post a :Post` scan ahead of a var-length
+    // WITH whose cost estimate is high), which turns the uncorrelated producer
+    // into a per-row correlated subquery over its own consumer and silently
+    // collapses the consumer's bindings. Correlated subqueries are excluded:
+    // their own outputs are handled by the correlation deferral below.
+    let subquery_output_vars: HashSet<VarId> = patterns
+        .iter()
+        .enumerate()
+        .filter_map(|(i, p)| match p {
+            Pattern::Subquery(sq) if subquery_correlation_vars(sq, patterns, i).is_empty() => {
+                Some(subquery_produced_select_vars(sq))
+            }
+            _ => None,
+        })
+        .flatten()
+        .collect();
+
     // Classify each pattern by its cardinality category.
     let mut sources: Vec<RankedPattern> = Vec::new();
     let mut reducers: Vec<RankedPattern> = Vec::new();
@@ -1124,6 +1196,22 @@ pub fn reorder_patterns(
                 });
                 continue;
             }
+        } else {
+            // Consumer of an uncorrelated WITH-subquery's output: defer it on
+            // those vars so the producing subquery is placed first.
+            let needs: HashSet<VarId> = pattern
+                .referenced_vars()
+                .into_iter()
+                .filter(|v| subquery_output_vars.contains(v))
+                .collect();
+            if !needs.is_empty() {
+                deferred.push(DeferredPattern {
+                    orig_index: i,
+                    required_vars: needs,
+                    pattern: pattern.clone(),
+                });
+                continue;
+            }
         }
 
         match estimate_pattern(pattern, &bound_vars, stats) {
@@ -1156,7 +1244,13 @@ pub fn reorder_patterns(
     // Greedy loop: place patterns by priority
     while !sources.is_empty() || !reducers.is_empty() || !expanders.is_empty() {
         let placed = try_place_reducer(&mut reducers, &mut bound_vars, stats, &mut result)
-            || try_place_source(&mut sources, &mut bound_vars, stats, &mut result)
+            || try_place_source(
+                &mut sources,
+                &mut bound_vars,
+                stats,
+                &mut result,
+                &subquery_output_vars,
+            )
             || try_place_expander(&mut expanders, &mut bound_vars, stats, &mut result);
 
         if !placed {
@@ -1268,12 +1362,50 @@ fn unlocked_object_hash_scan(
         .unwrap_or(0)
 }
 
+/// A disconnected `?x rdf:type <const>` class anchor: a `rdf:type` triple whose
+/// object is a constant class and whose subject variable is part of neither the
+/// bound set nor the producer component. Seeding/placing from such a triple
+/// drives the join backward off the (often broad) class extension — e.g. `home
+/// rdf:type Country` reverse-scanning `IS_PART_OF`/`IS_LOCATED_IN` for every
+/// city. Only class anchors are matched: a selective property-value anchor such
+/// as `?c name "X"` (cardinality 1) is a *good* disconnected seed and is left
+/// alone. See [`try_place_source`].
+fn is_disconnected_class_anchor(
+    pattern: &Pattern,
+    bound_vars: &HashSet<VarId>,
+    anchor_vars: &HashSet<VarId>,
+) -> bool {
+    let Pattern::Triple(tp) = pattern else {
+        return false;
+    };
+    if !tp.p.is_rdf_type() || !matches!(tp.o, Term::Iri(_) | Term::Sid(_)) {
+        return false;
+    }
+    match &tp.s {
+        Ref::Var(v) => !bound_vars.contains(v) && !anchor_vars.contains(v),
+        _ => false,
+    }
+}
+
 /// Try to place the best source. Returns true if one was placed.
+///
+/// `anchor_vars` are the outputs of uncorrelated WITH-subquery producers (see
+/// `reorder_patterns`) — a pseudo-bound pipeline component. At every placement,
+/// when a pipeline exists (bound vars or a producer) and some other candidate is
+/// connected to it, a disconnected `rdf:type <const>` class anchor is dropped
+/// from the pool so it cannot flip the chain into a scattered reverse
+/// object-drive (the IC3 `home:Country` case). This is deliberately narrow:
+/// only class anchors are demoted, only when a connected alternative exists, and
+/// selective property-value anchors (`?c name "X"`) are never touched — so
+/// IC6/IC11-style queries that legitimately seed from a constant entity, and
+/// genuine class-anchored queries (no producer, no bound pipeline), are
+/// unaffected.
 fn try_place_source(
     remaining: &mut Vec<RankedPattern>,
     bound_vars: &mut HashSet<VarId>,
     stats: Option<&StatsView>,
     result: &mut Vec<Pattern>,
+    anchor_vars: &HashSet<VarId>,
 ) -> bool {
     if remaining.is_empty() {
         return false;
@@ -1281,19 +1413,51 @@ fn try_place_source(
 
     let has_bound = !bound_vars.is_empty();
 
-    // Prefer joinable sources (share variables with bound set)
-    let candidates: Vec<usize> = remaining
+    // Base pool: prefer sources joinable with the bound set; if none are (e.g.
+    // the only forward continuation is a not-yet-placed producer), fall back to
+    // all sources.
+    let connected: Vec<usize> = remaining
         .iter()
         .enumerate()
         .filter(|(_, rp)| !has_bound || pattern_shares_variables(&rp.pattern, bound_vars))
         .map(|(idx, _)| idx)
         .collect();
-
-    // Fall back to all sources if none are joinable
-    let pool = if candidates.is_empty() {
+    let base_pool = if connected.is_empty() {
         (0..remaining.len()).collect::<Vec<_>>()
     } else {
-        candidates
+        connected
+    };
+
+    // Demote "broad index" sources from whichever pool we use — including the
+    // fall-back-to-all pool — so they cannot win the seed when a concrete
+    // connected alternative exists: disconnected `rdf:type <const>` class
+    // anchors (the IC3 chain-A `home:Country` reverse-drive).
+    // Only applies when a pipeline exists with a connected alternative, so
+    // selective property-value anchors, the base edge, and genuine
+    // class-anchored queries are untouched. If demotion would empty the pool,
+    // keep the base pool.
+    let pipeline_active = has_bound || !anchor_vars.is_empty();
+    let has_connected_alt = pipeline_active
+        && remaining.iter().any(|rp| {
+            pattern_shares_variables(&rp.pattern, bound_vars)
+                || pattern_shares_variables(&rp.pattern, anchor_vars)
+        });
+    let pool: Vec<usize> = if has_connected_alt {
+        let demoted: Vec<usize> = base_pool
+            .iter()
+            .copied()
+            .filter(|&i| {
+                let p = &remaining[i].pattern;
+                !is_disconnected_class_anchor(p, bound_vars, anchor_vars)
+            })
+            .collect();
+        if demoted.is_empty() {
+            base_pool
+        } else {
+            demoted
+        }
+    } else {
+        base_pool
     };
 
     let best_idx = pool.into_iter().min_by(|&i, &j| {
@@ -1495,6 +1659,18 @@ fn subquery_correlation_vars(
         }
     }
     corr
+}
+
+/// Variables a subquery binds itself and exposes in its SELECT — its
+/// WITH-pipeline outputs. A sibling that consumes one of these must run after
+/// the subquery (see the call site in `reorder_patterns`).
+fn subquery_produced_select_vars(sq: &SubqueryPattern) -> HashSet<VarId> {
+    let select: HashSet<VarId> = sq.select.iter().copied().collect();
+    sq.patterns
+        .iter()
+        .flat_map(Pattern::produced_vars)
+        .filter(|v| select.contains(v))
+        .collect()
 }
 
 fn deferred_required_vars(pattern: &Pattern) -> Vec<VarId> {
@@ -3115,5 +3291,154 @@ mod tests {
         // Age filter is pushed into UNION branches.
         assert_eq!(count_patterns(&reordered, is_filter), 1);
         assert_union_branches_contain(&reordered, is_filter, "should contain pushed-in age filter");
+    }
+
+    // --- seed-time WITH-producer vs disconnected class anchor ------------------
+
+    fn type_anchor(subject: VarId, class: &str) -> Pattern {
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(subject),
+            Ref::Sid(Sid::new(
+                fluree_vocab::namespaces::RDF,
+                fluree_vocab::predicates::RDF_TYPE,
+            )),
+            Term::Sid(Sid::new(100, class)),
+        ))
+    }
+
+    fn with_producer(out: VarId) -> Pattern {
+        use crate::ir::SubqueryPattern;
+        Pattern::Subquery(SubqueryPattern::new(
+            vec![out],
+            vec![Pattern::Triple(make_pattern(out, "knows", VarId(99)))],
+        ))
+    }
+
+    #[test]
+    fn with_producer_seeds_before_disconnected_class_anchor() {
+        // IC3 Stage 2 shape: WITH-subquery produces `friend`; `home rdf:type
+        // Country` is a tiny (111) but disconnected class anchor. Without the
+        // guard, Country seeds #0 and drives the chain backward (50s plan).
+        let (friend, city, home) = (VarId(0), VarId(1), VarId(2));
+        let mut stats = StatsView::default();
+        stats.classes.insert(Sid::new(100, "Country"), 111);
+        // Realistic shape: the location predicates are broad scans, the producer
+        // body (`knows`) is comparatively small — so once the disconnected Country
+        // anchor is dropped from the seed pool, the producer wins the seed.
+        for (p, c) in [
+            ("IS_PART_OF", 10_000),
+            ("IS_LOCATED_IN", 10_000),
+            ("knows", 50),
+        ] {
+            stats.properties.insert(
+                Sid::new(100, p),
+                PropertyStatData {
+                    count: c,
+                    ndv_values: c,
+                    ndv_subjects: c,
+                },
+            );
+        }
+
+        let patterns = vec![
+            type_anchor(home, "Country"),
+            Pattern::Triple(make_pattern(city, "IS_PART_OF", home)),
+            Pattern::Triple(make_pattern(friend, "IS_LOCATED_IN", city)), // consumes friend
+            with_producer(friend),
+        ];
+        let ordered = reorder_patterns(&patterns, Some(&stats), &HashSet::new());
+
+        let sub_pos = ordered
+            .iter()
+            .position(|p| matches!(p, Pattern::Subquery(_)))
+            .expect("subquery present");
+        let anchor_pos = ordered
+            .iter()
+            .position(|p| matches!(p, Pattern::Triple(tp) if tp.p.is_rdf_type()))
+            .expect("rdf:type anchor present");
+        assert!(
+            sub_pos < anchor_pos,
+            "WITH producer must seed before the disconnected class anchor: {ordered:?}"
+        );
+        assert!(
+            !matches!(&ordered[0], Pattern::Triple(tp) if tp.p.is_rdf_type()),
+            "class anchor must not seed the block: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn pure_class_anchor_seeds_without_producer() {
+        // No WITH producer: `home rdf:type Country` is the genuine anchor and must
+        // still seed (the guard must not penalize class anchors in general).
+        let (home, city, p) = (VarId(0), VarId(1), VarId(2));
+        let mut stats = StatsView::default();
+        stats.classes.insert(Sid::new(100, "Country"), 111);
+
+        let patterns = vec![
+            type_anchor(home, "Country"),
+            Pattern::Triple(make_pattern(city, "IS_PART_OF", home)),
+            Pattern::Triple(make_pattern(p, "IS_LOCATED_IN", city)),
+        ];
+        let ordered = reorder_patterns(&patterns, Some(&stats), &HashSet::new());
+        assert!(
+            matches!(&ordered[0], Pattern::Triple(tp) if tp.p.is_rdf_type()),
+            "with no producer the class anchor still seeds first: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn class_anchor_demoted_in_fallback_when_producer_continues() {
+        // IC3 mid-block shape: a selective chain has already bound `cx`, so no
+        // remaining source shares the bound set — the only forward continuation
+        // is the WITH producer (connected via `friend`, an anchor var). A cheap
+        // disconnected `home rdf:type Country` is also available. The producer
+        // must win: the class anchor must not seed a reverse drive out of the
+        // fall-back-to-all pool. (The seed-only demotion failed this.)
+        let (friend, cx, mx, home) = (VarId(0), VarId(1), VarId(2), VarId(4));
+        let mut stats = StatsView::default();
+        stats.classes.insert(Sid::new(100, "Country"), 111);
+
+        let patterns = vec![
+            type_anchor(home, "Country"),
+            with_producer(friend),
+            Pattern::Triple(make_pattern(mx, "HAS_CREATOR", friend)), // consumer of friend
+        ];
+        let mut bound = HashSet::new();
+        bound.insert(cx); // pretend the selective chain already bound `cx`
+        let ordered = reorder_patterns(&patterns, Some(&stats), &bound);
+
+        let sub_pos = ordered
+            .iter()
+            .position(|p| matches!(p, Pattern::Subquery(_)))
+            .expect("subquery present");
+        let anchor_pos = ordered
+            .iter()
+            .position(|p| matches!(p, Pattern::Triple(tp) if tp.p.is_rdf_type()))
+            .expect("rdf:type anchor present");
+        assert!(
+            sub_pos < anchor_pos,
+            "producer must beat the class anchor in the fall-back pool: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn producer_then_consumer_order_not_regressed() {
+        // IC9 shape: the WITH producer seeds, then its consumer (`HAS_CREATOR`,
+        // which references `friend`) drains immediately after.
+        let (friend, message) = (VarId(0), VarId(1));
+        let patterns = vec![
+            Pattern::Triple(make_pattern(message, "HAS_CREATOR", friend)),
+            with_producer(friend),
+        ];
+        let ordered = reorder_patterns(&patterns, None, &HashSet::new());
+        assert!(
+            matches!(&ordered[0], Pattern::Subquery(_)),
+            "producer seeds first: {ordered:?}"
+        );
+        assert!(
+            matches!(&ordered[1], Pattern::Triple(tp)
+                if matches!(&tp.p, Ref::Sid(s) if s.name.as_ref() == "HAS_CREATOR")),
+            "consumer drains right after the producer: {ordered:?}"
+        );
     }
 }

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -70,7 +70,10 @@ const ANCHORED_PROPERTY_PATH_SELECTIVITY: f64 = 100.0;
 /// HAS_CREATOR friend)` probe), so it must stay realistic enough that
 /// `probe_count / driving_est` clears [`hash_join`'s scan-ratio cap](crate::hash_join)
 /// — too small (e.g. 100) re-rejects the very hash join this ordering unlocks.
-const DISTINCT_SUBQUERY_PRODUCER_SELECTIVITY: f64 = 500.0;
+/// That coupling is asserted by `hash_join::tests::producer_seed_clears_scan_ratio_cap`,
+/// which fails if either this value or `HASH_JOIN_MAX_SCAN_RATIO` drifts below
+/// the targeted probe size.
+pub(crate) const DISTINCT_SUBQUERY_PRODUCER_SELECTIVITY: f64 = 500.0;
 /// Full scan - all variables unbound
 const FULL_SCAN: f64 = 1e12;
 

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -1413,19 +1413,125 @@ fn is_disconnected_class_anchor(
     }
 }
 
+/// Seed-candidate pool, phase 1: sources joinable with the bound set, or — when
+/// none are (e.g. the only forward continuation is a not-yet-placed producer) —
+/// every source as a fallback. Returns indices into `remaining`.
+fn connected_or_fallback_pool(
+    remaining: &[RankedPattern],
+    bound_vars: &HashSet<VarId>,
+) -> Vec<usize> {
+    let has_bound = !bound_vars.is_empty();
+    let connected: Vec<usize> = remaining
+        .iter()
+        .enumerate()
+        .filter(|(_, rp)| !has_bound || pattern_shares_variables(&rp.pattern, bound_vars))
+        .map(|(idx, _)| idx)
+        .collect();
+    if connected.is_empty() {
+        (0..remaining.len()).collect()
+    } else {
+        connected
+    }
+}
+
+/// Seed-candidate pool, phase 2: drop disconnected `rdf:type <const>` class
+/// anchors so a broad class extension cannot win the seed and flip the chain
+/// into a scattered reverse object-drive (the IC3 `home:Country` case).
+///
+/// Applies ONLY when a pipeline is active (bound vars or a producer) AND a
+/// connected alternative exists — otherwise the class anchor IS the legitimate
+/// seed and is kept. Deliberately narrow: only class anchors are demoted (a
+/// selective property-value anchor such as `?c name "X"` is never an
+/// [`is_disconnected_class_anchor`] and stays), and demotion never empties the
+/// pool. Returns `base_pool` unchanged when nothing is demoted.
+fn demote_disconnected_class_anchors(
+    base_pool: Vec<usize>,
+    remaining: &[RankedPattern],
+    bound_vars: &HashSet<VarId>,
+    anchor_vars: &HashSet<VarId>,
+) -> Vec<usize> {
+    let pipeline_active = !bound_vars.is_empty() || !anchor_vars.is_empty();
+    let has_connected_alt = pipeline_active
+        && remaining.iter().any(|rp| {
+            pattern_shares_variables(&rp.pattern, bound_vars)
+                || pattern_shares_variables(&rp.pattern, anchor_vars)
+        });
+    if !has_connected_alt {
+        return base_pool;
+    }
+    let demoted: Vec<usize> = base_pool
+        .iter()
+        .copied()
+        .filter(|&i| !is_disconnected_class_anchor(&remaining[i].pattern, bound_vars, anchor_vars))
+        .collect();
+    if demoted.is_empty() {
+        base_pool
+    } else {
+        demoted
+    }
+}
+
+/// Rank two seed candidates `i`/`j` (lower = better). The whole tie-break chain
+/// lives here, one level per `then_with`, in strict priority order:
+///   1. **search-source priority** — only at seed time (no bound vars), so a
+///      search source emits its result IDs/IriMatch bindings before plain
+///      triples consume them;
+///   2. **estimated cardinality** — the primary signal;
+///   3. **unlocked object→subject hash scan** — among EQUAL-cardinality starts
+///      only, prefer the one that keeps the LARGER predicate hash-able rather
+///      than forward-joining over a big intermediate (the BSBM-BI bowtie: 46× on
+///      BI-1's F2);
+///   4. **original position** — stable final tie-break.
+fn rank_seed_candidates(
+    i: usize,
+    j: usize,
+    remaining: &[RankedPattern],
+    bound_vars: &HashSet<VarId>,
+    stats: Option<&StatsView>,
+    has_bound: bool,
+) -> std::cmp::Ordering {
+    let search_priority = |pattern: &Pattern| match pattern {
+        Pattern::IndexSearch(_)
+        | Pattern::VectorSearch(_)
+        | Pattern::GeoSearch(_)
+        | Pattern::S2Search(_) => 0_u8,
+        _ => 1_u8,
+    };
+    let ci = estimate_pattern(&remaining[i].pattern, bound_vars, stats);
+    let cj = estimate_pattern(&remaining[j].pattern, bound_vars, stats);
+
+    // 1. Search sources seed first — but only before anything is bound.
+    let by_search = if has_bound {
+        std::cmp::Ordering::Equal
+    } else {
+        search_priority(&remaining[i].pattern).cmp(&search_priority(&remaining[j].pattern))
+    };
+    by_search
+        // 2. Primary: estimated cardinality.
+        .then_with(|| {
+            ci.row_count()
+                .partial_cmp(&cj.row_count())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        // 3. Equal-cardinality only: keep the larger predicate hash-able.
+        .then_with(|| {
+            let bi = unlocked_object_hash_scan(i, remaining, bound_vars, stats);
+            let bj = unlocked_object_hash_scan(j, remaining, bound_vars, stats);
+            bj.cmp(&bi)
+        })
+        // 4. Stable: original position.
+        .then_with(|| remaining[i].orig_index.cmp(&remaining[j].orig_index))
+}
+
 /// Try to place the best source. Returns true if one was placed.
 ///
-/// `anchor_vars` are the outputs of uncorrelated WITH-subquery producers (see
-/// `reorder_patterns`) — a pseudo-bound pipeline component. At every placement,
-/// when a pipeline exists (bound vars or a producer) and some other candidate is
-/// connected to it, a disconnected `rdf:type <const>` class anchor is dropped
-/// from the pool so it cannot flip the chain into a scattered reverse
-/// object-drive (the IC3 `home:Country` case). This is deliberately narrow:
-/// only class anchors are demoted, only when a connected alternative exists, and
-/// selective property-value anchors (`?c name "X"`) are never touched — so
-/// IC6/IC11-style queries that legitimately seed from a constant entity, and
-/// genuine class-anchored queries (no producer, no bound pipeline), are
-/// unaffected.
+/// Three phases (each a named helper): build the connected/fallback candidate
+/// pool, demote disconnected `rdf:type <const>` class anchors when a connected
+/// alternative exists (the IC3 guard — see [`demote_disconnected_class_anchors`]),
+/// then pick the best by [`rank_seed_candidates`]. `anchor_vars` are the outputs
+/// of uncorrelated WITH-subquery producers (see `reorder_patterns`) — a
+/// pseudo-bound pipeline component for both the connectivity test and the
+/// demotion guard.
 fn try_place_source(
     remaining: &mut Vec<RankedPattern>,
     bound_vars: &mut HashSet<VarId>,
@@ -1438,89 +1544,12 @@ fn try_place_source(
     }
 
     let has_bound = !bound_vars.is_empty();
+    let base_pool = connected_or_fallback_pool(remaining, bound_vars);
+    let pool = demote_disconnected_class_anchors(base_pool, remaining, bound_vars, anchor_vars);
 
-    // Base pool: prefer sources joinable with the bound set; if none are (e.g.
-    // the only forward continuation is a not-yet-placed producer), fall back to
-    // all sources.
-    let connected: Vec<usize> = remaining
-        .iter()
-        .enumerate()
-        .filter(|(_, rp)| !has_bound || pattern_shares_variables(&rp.pattern, bound_vars))
-        .map(|(idx, _)| idx)
-        .collect();
-    let base_pool = if connected.is_empty() {
-        (0..remaining.len()).collect::<Vec<_>>()
-    } else {
-        connected
-    };
-
-    // Demote "broad index" sources from whichever pool we use — including the
-    // fall-back-to-all pool — so they cannot win the seed when a concrete
-    // connected alternative exists: disconnected `rdf:type <const>` class
-    // anchors (the IC3 chain-A `home:Country` reverse-drive).
-    // Only applies when a pipeline exists with a connected alternative, so
-    // selective property-value anchors, the base edge, and genuine
-    // class-anchored queries are untouched. If demotion would empty the pool,
-    // keep the base pool.
-    let pipeline_active = has_bound || !anchor_vars.is_empty();
-    let has_connected_alt = pipeline_active
-        && remaining.iter().any(|rp| {
-            pattern_shares_variables(&rp.pattern, bound_vars)
-                || pattern_shares_variables(&rp.pattern, anchor_vars)
-        });
-    let pool: Vec<usize> = if has_connected_alt {
-        let demoted: Vec<usize> = base_pool
-            .iter()
-            .copied()
-            .filter(|&i| {
-                let p = &remaining[i].pattern;
-                !is_disconnected_class_anchor(p, bound_vars, anchor_vars)
-            })
-            .collect();
-        if demoted.is_empty() {
-            base_pool
-        } else {
-            demoted
-        }
-    } else {
-        base_pool
-    };
-
-    let best_idx = pool.into_iter().min_by(|&i, &j| {
-        let seed_priority = |pattern: &Pattern| match pattern {
-            // Search sources should seed the pipeline before plain triples so
-            // they can emit result IDs/IriMatch bindings that later joins consume.
-            Pattern::IndexSearch(_)
-            | Pattern::VectorSearch(_)
-            | Pattern::GeoSearch(_)
-            | Pattern::S2Search(_) => 0_u8,
-            _ => 1_u8,
-        };
-        let ci = estimate_pattern(&remaining[i].pattern, bound_vars, stats);
-        let cj = estimate_pattern(&remaining[j].pattern, bound_vars, stats);
-        if !has_bound {
-            seed_priority(&remaining[i].pattern).cmp(&seed_priority(&remaining[j].pattern))
-        } else {
-            std::cmp::Ordering::Equal
-        }
-        .then_with(|| {
-            ci.row_count()
-                .partial_cmp(&cj.row_count())
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
-        // Before falling back to original index: among equally-selective starts,
-        // prefer the one that turns the LARGER predicate into an object→subject
-        // hash join rather than a forward join over a big intermediate. This flips
-        // a BSBM-BI bowtie (two equally-selective country filters, written
-        // producer/DE-first) onto the side whose chain keeps the 2.85M-row
-        // predicate hash-able — 46x on BI-1's F2.
-        .then_with(|| {
-            let bi = unlocked_object_hash_scan(i, &remaining[..], bound_vars, stats);
-            let bj = unlocked_object_hash_scan(j, &remaining[..], bound_vars, stats);
-            bj.cmp(&bi)
-        })
-        .then_with(|| remaining[i].orig_index.cmp(&remaining[j].orig_index))
-    });
+    let best_idx = pool
+        .into_iter()
+        .min_by(|&i, &j| rank_seed_candidates(i, j, remaining, bound_vars, stats, has_bound));
 
     if let Some(idx) = best_idx {
         let rp = remaining.remove(idx);
@@ -3465,6 +3494,98 @@ mod tests {
             matches!(&ordered[1], Pattern::Triple(tp)
                 if matches!(&tp.p, Ref::Sid(s) if s.name.as_ref() == "HAS_CREATOR")),
             "consumer drains right after the producer: {ordered:?}"
+        );
+    }
+
+    /// Position of the first triple whose predicate name is `name`.
+    fn triple_pos(ordered: &[Pattern], name: &str) -> usize {
+        ordered
+            .iter()
+            .position(|p| {
+                matches!(p, Pattern::Triple(tp)
+                    if matches!(&tp.p, Ref::Sid(s) if s.name.as_ref() == name))
+            })
+            .unwrap_or_else(|| panic!("predicate {name} present in {ordered:?}"))
+    }
+
+    #[test]
+    fn demotion_is_class_anchor_specific_property_anchor_survives() {
+        // Companion to `class_anchor_demoted_in_fallback_when_producer_continues`:
+        // the SAME pipeline shape, but the disconnected anchor is a SELECTIVE
+        // property-value anchor (`?home id <x>`), not an rdf:type class anchor.
+        // Demotion targets only class anchors, so the property anchor stays in
+        // the pool and — being more selective than the producer — seeds first.
+        // (If demotion over-reached to property anchors, the producer would win,
+        // exactly as it does for a class anchor.)
+        let (friend, home, mx) = (VarId(0), VarId(2), VarId(3));
+        let patterns = vec![
+            value_anchor(home),
+            with_producer(friend),
+            Pattern::Triple(make_pattern(mx, "HAS_CREATOR", friend)), // consumer of friend
+        ];
+        let ordered = reorder_patterns(&patterns, None, &HashSet::new());
+        assert!(
+            matches!(&ordered[0], Pattern::Triple(tp) if !tp.p.is_rdf_type()),
+            "selective property-value anchor is not demoted and seeds first: {ordered:?}"
+        );
+        assert!(
+            ordered
+                .iter()
+                .position(|p| matches!(p, Pattern::Subquery(_)))
+                .expect("producer present")
+                > 0,
+            "producer does not seed ahead of the surviving property anchor: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn hash_scan_tiebreak_only_breaks_equal_cardinality_seeds() {
+        // Two seed candidates A (`?x pa ?y`) and B (`?z pb ?w`) plus a large
+        // downstream predicate `?m big ?y` whose object A binds. The hash-scan
+        // tie-break is subordinate to cardinality, so it must decide ONLY when A
+        // and B tie.
+        let (x, y, z, w, m) = (VarId(0), VarId(1), VarId(2), VarId(3), VarId(4));
+        let stat = |c: u64| PropertyStatData {
+            count: c,
+            ndv_values: c,
+            ndv_subjects: c,
+        };
+
+        // Equal cardinality (100 vs 100): the unlocked-object-hash-scan tie-break
+        // prefers A, which keeps the 1M-row `big` predicate hash-able.
+        let mut tied = StatsView::default();
+        tied.properties.insert(Sid::new(100, "pa"), stat(100));
+        tied.properties.insert(Sid::new(100, "pb"), stat(100));
+        tied.properties
+            .insert(Sid::new(100, "big"), stat(1_000_000));
+        let patterns = vec![
+            Pattern::Triple(make_pattern(x, "pa", y)),
+            Pattern::Triple(make_pattern(z, "pb", w)),
+            Pattern::Triple(make_pattern(m, "big", y)),
+        ];
+        let ordered = reorder_patterns(&patterns, Some(&tied), &HashSet::new());
+        assert!(
+            triple_pos(&ordered, "pa") < triple_pos(&ordered, "pb"),
+            "equal cardinality: A unlocks the big hash scan and seeds before B: {ordered:?}"
+        );
+
+        // Break the tie on cardinality (B = 50 < A = 100): cardinality is primary,
+        // so B wins and the hash-scan tie-break is never consulted.
+        let mut skewed = StatsView::default();
+        skewed.properties.insert(Sid::new(100, "pa"), stat(100));
+        skewed.properties.insert(Sid::new(100, "pb"), stat(50));
+        skewed
+            .properties
+            .insert(Sid::new(100, "big"), stat(1_000_000));
+        let patterns = vec![
+            Pattern::Triple(make_pattern(x, "pa", y)),
+            Pattern::Triple(make_pattern(z, "pb", w)),
+            Pattern::Triple(make_pattern(m, "big", y)),
+        ];
+        let ordered = reorder_patterns(&patterns, Some(&skewed), &HashSet::new());
+        assert!(
+            triple_pos(&ordered, "pb") < triple_pos(&ordered, "pa"),
+            "strictly-more-selective B wins; the unlock tie-break does not override cardinality: {ordered:?}"
         );
     }
 

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -398,11 +398,17 @@ impl Operator for SubqueryOperator {
     }
 
     fn estimated_rows(&self) -> Option<usize> {
-        // The subquery's OWN output estimate (uncorrelated producers — the common
-        // `WITH DISTINCT friend` case — emit this many rows). Seeds the downstream
-        // object→subject hash join's driving estimate so a `(message HAS_CREATOR
-        // friend)` probe is costed against the ~producer size, not 1. Shared with
-        // the planner's join-ordering estimate for consistency.
+        // The subquery's OWN output estimate seeds the downstream object→subject
+        // hash join's driving estimate so a `(message HAS_CREATOR friend)` probe
+        // is costed against the ~producer size, not 1 — but ONLY for shapes whose
+        // output is reliably bounded (scalar aggregate, anchored `WITH DISTINCT`
+        // producer, or explicit LIMIT). For an arbitrary subquery the estimate is
+        // just body cardinality, which is fine for join ordering but too
+        // unreliable to perturb the hash-join cost model, so we keep the
+        // conservative `None` the operator returned before.
+        if !crate::planner::subquery_output_estimate_is_bounded(&self.subquery) {
+            return None;
+        }
         Some(
             crate::planner::estimate_subquery_output(&self.subquery, self.stats.as_deref()).round()
                 as usize,

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -398,8 +398,15 @@ impl Operator for SubqueryOperator {
     }
 
     fn estimated_rows(&self) -> Option<usize> {
-        // Subqueries can multiply rows; hard to estimate
-        None
+        // The subquery's OWN output estimate (uncorrelated producers — the common
+        // `WITH DISTINCT friend` case — emit this many rows). Seeds the downstream
+        // object→subject hash join's driving estimate so a `(message HAS_CREATOR
+        // friend)` probe is costed against the ~producer size, not 1. Shared with
+        // the planner's join-ordering estimate for consistency.
+        Some(
+            crate::planner::estimate_subquery_output(&self.subquery, self.stats.as_deref()).round()
+                as usize,
+        )
     }
 }
 

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -558,6 +558,7 @@ impl SubqueryOperator {
             self.subquery.limit,
             false,
             None,
+            &self.planning,
         )
     }
 
@@ -600,6 +601,7 @@ impl SubqueryOperator {
             self.subquery.limit,
             false,
             None,
+            &self.planning,
         )?;
 
         // Execute and collect results


### PR DESCRIPTION
These query-planner and execution improvements were identified while building out RDF 1.2 edge-annotation support, but they are entirely independent of RDF 1.2: they apply to ordinary SPARQL and JSON-LD queries and carry no annotation- or edge-specific code. Pulling them out so they can land and be reviewed on their own, ahead of the larger RDF 1.2 work.

## What's included

- **object→subject hash join after a DISTINCT producer** — the object→subject hash join now fires when its left input is an uncorrelated DISTINCT sub-SELECT producer, instead of falling back to a scattered object-driven scan.
- **connectedness-aware source seeding** — when a pipeline already has a connected alternative, a disconnected `rdf:type <const>` class anchor is demoted from the seed pool so it can't flip the join order into a scattered reverse object-drive.
- **subquery producer placement** — an uncorrelated sub-SELECT producer is placed before the triples that consume its output, so a cheap consumer scan can't be hoisted ahead of the producer and silently collapse its bindings.
- **subject-driving batched hash-left-join for correlated OPTIONAL** — a correlated multi-pattern OPTIONAL is evaluated as a single batched hash left-join keyed on the correlation vars, replacing the per-driving-row OPTIONAL subplan rebuild.
- **evaluate EXISTS as a projected/BIND expression** — `EXISTS { ... }` can be evaluated in projection / `BIND` position, not only as a pattern-level filter.

## Testing

- New `it_query_optional_hashjoin.rs` (JSON-LD) covers the correlated multi-pattern OPTIONAL left-join, including the no-match `count = 0` group.
- Existing planner-exercising suites pass: `it_query_negation`, `it_query_aggregates`, `it_query_jsonld`.
