### PR TITLE
test(query): add BSBM-BI F2 bowtie bench

### DIFF
--- a/docs/contributing/benches.md
+++ b/docs/contributing/benches.md
@@ -208,7 +208,7 @@ future micro-bench wants to exercise `fluree-db-indexer`,
 | `import` | bulk Turtle / N-Quads / JSON-LD ingest | `fluree-db-api/benches/import_bulk.rs` |
 | `transact` | stage + commit | `fluree-db-api/benches/transact_commit.rs` |
 | `reindex` | full reindex; incremental | `fluree-db-api/benches/reindex_full.rs`, `fluree-db-api/benches/reindex_incremental.rs` |
-| `query_hot` | BSBM-shape SPARQL on warm cache | `fluree-db-api/benches/query_hot_bsbm.rs` |
+| `query_hot` | BSBM-shape SPARQL on warm cache | `fluree-db-api/benches/query_hot_bsbm.rs` (Explore Q3/Q5/Q9), `fluree-db-api/benches/query_hot_bsbm_bi.rs` (BI-F2 bowtie / seed tie-break) |
 | `query_cold` | reload + first-query latency | `fluree-db-api/benches/query_cold_reload.rs` |
 | `novelty` | replay, catch-up, bulk-apply | `fluree-db-api/benches/novelty_replay.rs` |
 | `vector_math` | SIMD vs scalar math micro-benches | `fluree-db-query/benches/vector_math.rs` |

--- a/fluree-bench-support/src/gen/bsbm.rs
+++ b/fluree-bench-support/src/gen/bsbm.rs
@@ -33,7 +33,7 @@
 //! ex:vendor-N    a bsbm:Vendor   ; bsbm:label ; bsbm:country .
 //! ex:product-N   a bsbm:Product  ; bsbm:label ; bsbm:vendor ;
 //!                                  bsbm:productType ; bsbm:price .
-//! ex:person-N    a bsbm:Person   ; bsbm:name .
+//! ex:person-N    a bsbm:Person   ; bsbm:name ; bsbm:country .
 //! ex:review-N    a bsbm:Review   ; bsbm:reviewFor ; bsbm:reviewer ;
 //!                                  bsbm:rating ; bsbm:text .
 //! ```
@@ -69,6 +69,10 @@ pub struct Product {
 pub struct Person {
     pub id: String,
     pub name: String,
+    /// Reviewer's country. Paired with `Vendor::country` this gives the
+    /// BSBM-BI "bowtie" shape: two equally-selective country anchors that
+    /// meet through the large review predicate (see `query_hot_bsbm_bi`).
+    pub country: &'static str,
 }
 
 #[derive(Debug, Clone)]
@@ -94,11 +98,11 @@ impl BsbmData {
     pub fn estimated_triples(&self) -> u64 {
         // Vendor: 3 (a, label, country)
         // Product: 5 (a, label, productType, vendor, price)
-        // Person: 2 (a, name)
+        // Person: 3 (a, name, country)
         // Review: 5 (a, reviewFor, reviewer, rating, text)
         (self.vendors.len() * 3
             + self.products.len() * 5
-            + self.persons.len() * 2
+            + self.persons.len() * 3
             + self.reviews.len() * 5) as u64
     }
 }
@@ -139,6 +143,11 @@ pub fn generate_dataset(n_products: usize) -> BsbmData {
         .map(|i| Person {
             id: format!("ex:person-{i:06}"),
             name: format!("Person {i:06}"),
+            // Stride differs from the vendor assignment (`i % len`) so the
+            // reviewer-country and vendor-country anchors are not trivially
+            // correlated — the BI-F2 bowtie wants two independent, equally
+            // selective (~1/5) filters meeting through the review predicate.
+            country: COUNTRIES[(i * 3 + 1) % COUNTRIES.len()],
         })
         .collect();
 
@@ -202,7 +211,8 @@ pub fn bsbm_data_to_turtle(data: &BsbmData) -> String {
     for p in &data.persons {
         buf.push_str(&p.id);
         buf.push_str(" a bsbm:Person ;\n");
-        buf.push_str(&format!("    bsbm:name \"{}\" .\n\n", p.name));
+        buf.push_str(&format!("    bsbm:name \"{}\" ;\n", p.name));
+        buf.push_str(&format!("    bsbm:country \"{}\" .\n\n", p.country));
     }
 
     for r in &data.reviews {
@@ -287,8 +297,17 @@ mod tests {
     #[test]
     fn estimated_triples_reasonable() {
         let d = generate_dataset(100);
-        // 100 * 5 (products) + 2 (vendors) * 3 + 10 (persons) * 2 + 300 (reviews) * 5
-        // = 500 + 6 + 20 + 1500 = 2026
-        assert_eq!(d.estimated_triples(), 2026);
+        // 100 * 5 (products) + 2 (vendors) * 3 + 10 (persons) * 3 + 300 (reviews) * 5
+        // = 500 + 6 + 30 + 1500 = 2036
+        assert_eq!(d.estimated_triples(), 2036);
+    }
+
+    #[test]
+    fn person_countries_distribute() {
+        let d = generate_dataset(500); // 50 persons
+        let countries: std::collections::HashSet<_> = d.persons.iter().map(|p| p.country).collect();
+        // 50 persons over 5 countries ⇒ every country appears, so the
+        // BI-F2 reviewer-country filter is genuinely ~1/5 selective.
+        assert_eq!(countries.len(), COUNTRIES.len());
     }
 }

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -182,5 +182,9 @@ harness = false
 name = "query_hot_bsbm"
 harness = false
 
+[[bench]]
+name = "query_hot_bsbm_bi"
+harness = false
+
 [lints]
 workspace = true

--- a/fluree-db-api/benches/query_hot_bsbm_bi.rs
+++ b/fluree-db-api/benches/query_hot_bsbm_bi.rs
@@ -1,0 +1,178 @@
+//! Hot-cache SPARQL latency for the BSBM Business-Intelligence "bowtie"
+//! shape (BI-1's F2 fragment).
+//!
+//! Distinct from `query_hot_bsbm.rs` (the Explore-use-case Q3/Q5/Q9
+//! join/filter/aggregate shapes), this bench targets the join-ordering
+//! decision the query-planner change in PR #1356 introduced: when a query
+//! has **two equally-selective anchors** that meet through one large
+//! predicate, the seed tie-break must drive from the side that keeps the
+//! big predicate hash-able rather than forward-joining over a large
+//! intermediate.
+//!
+//! ## The F2 bowtie
+//!
+//! ```text
+//!   ?vendor bsbm:country "US"          ← anchor A (~1/5 selective)
+//!   ?product bsbm:vendor ?vendor
+//!   ?review  bsbm:reviewFor ?product   ← the large predicate (the knot)
+//!   ?review  bsbm:reviewer  ?person
+//!   ?person bsbm:country "DE"          ← anchor B (~1/5 selective)
+//! ```
+//!
+//! Both country filters are equally selective, so cardinality ties at the
+//! seed and the planner's `unlocked_object_hash_scan` tie-break decides
+//! the drive direction. On the original planner this fragment regressed
+//! ~46× when the chain was written producer/vendor-first; the fix keeps
+//! the `bsbm:reviewFor`/`bsbm:reviewer` predicate (the bowtie knot, the
+//! 2.85M-row predicate at full BSBM-BI scale) on the hash-able side. This
+//! bench guards that the chosen drive direction does not silently regress.
+//!
+//! ## Setup discipline
+//!
+//! Mirrors `query_hot_bsbm.rs`: build the dataset once per scale,
+//! populate a file-backed ledger, run an explicit reindex so the measured
+//! query traverses the binary columnar index (warm-cache binary scan),
+//! then reuse the loaded snapshot across all `b.iter` calls.
+//!
+//! ## Matrix
+//!
+//!   inputs:    BenchScale → n_products
+//!              (Tiny=100, Small=1k, Medium=10k, Large=100k)
+//!              reviews = n_products * 3 — the bowtie knot grows with this.
+//!   metric:    ns/query (criterion default)
+//!
+//! ## Running
+//!
+//!   cargo bench -p fluree-db-api --bench query_hot_bsbm_bi
+//!   cargo bench -p fluree-db-api --bench query_hot_bsbm_bi -- --test
+//!   FLUREE_BENCH_SCALE=medium cargo bench -p fluree-db-api --bench query_hot_bsbm_bi
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use fluree_bench_support::gen::bsbm::{bsbm_data_to_turtle, generate_dataset};
+use fluree_bench_support::{
+    bench_runtime, current_profile, current_scale, init_tracing_for_bench, next_ledger_alias,
+    BenchScale,
+};
+use fluree_db_api::admin::ReindexOptions;
+use fluree_db_api::{CommitOpts, Fluree, FlureeBuilder, IndexConfig, TxnOpts};
+
+fn scale_n_products(scale: BenchScale) -> usize {
+    match scale {
+        BenchScale::Tiny => 100,
+        BenchScale::Small => 1_000,
+        BenchScale::Medium => 10_000,
+        BenchScale::Large => 100_000,
+    }
+}
+
+/// BI-F2 bowtie: products whose vendor is in one country and which carry a
+/// review by a person in another country, joined through the review
+/// predicate. The two `bsbm:country` filters are equally selective, so the
+/// planner's seed tie-break — not raw cardinality — picks the drive side.
+const F2: &str = r#"
+PREFIX bsbm: <http://example.org/bsbm/>
+SELECT ?product ?vendor ?person WHERE {
+  ?vendor a bsbm:Vendor ;
+          bsbm:country "US" .
+  ?product bsbm:vendor ?vendor .
+  ?review bsbm:reviewFor ?product ;
+          bsbm:reviewer ?person .
+  ?person a bsbm:Person ;
+          bsbm:country "DE" .
+}
+LIMIT 100
+"#;
+
+/// Build a populated, indexed file-backed Fluree ready for hot-cache
+/// query benchmarking. The caller keeps the returned `(TempDir, Fluree,
+/// alias)` alive for the duration of the bench (the snapshot loaded from
+/// `fluree` borrows from it; the alias is the ledger ID used for
+/// `graph(...)` lookup).
+async fn setup_indexed(n_products: usize) -> (tempfile::TempDir, Fluree, String) {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let alias = next_ledger_alias("query-hot-bsbm-bi");
+    let ledger = fluree.create_ledger(&alias).await.expect("create_ledger");
+
+    let data = generate_dataset(n_products);
+    let turtle = bsbm_data_to_turtle(&data);
+
+    // High thresholds during populate so the foreground commit doesn't
+    // race with background indexing — we run an explicit reindex below.
+    let index_config = IndexConfig {
+        reindex_min_bytes: 5_000_000_000,
+        reindex_max_bytes: 5_000_000_000,
+    };
+    let _ = fluree
+        .insert_turtle_with_opts(
+            ledger,
+            &turtle,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config,
+        )
+        .await
+        .expect("populate insert");
+
+    let _ = fluree
+        .reindex(&alias, ReindexOptions::default())
+        .await
+        .expect("reindex");
+
+    (db_dir, fluree, alias)
+}
+
+fn bench_query_hot_bsbm_bi(c: &mut Criterion) {
+    init_tracing_for_bench();
+    let rt = bench_runtime();
+    let scale = current_scale();
+    let profile = current_profile();
+    let n_products = scale_n_products(scale);
+
+    eprintln!(
+        "  [query_hot_bsbm_bi] scale={} n_products={}",
+        scale.as_str(),
+        n_products
+    );
+
+    // Setup once per scale. `_db_dir` and `fluree` are held in scope so
+    // `snapshot` (which borrows from `fluree`) stays valid for the
+    // duration of the bench group.
+    let (_db_dir, fluree, alias) = rt.block_on(setup_indexed(n_products));
+    let snapshot = rt.block_on(async { fluree.graph(&alias).load().await.expect("graph load") });
+
+    let mut group = c.benchmark_group("query_hot_bsbm_bi");
+    group.sample_size(profile.sample_size());
+    group.sampling_mode(criterion::SamplingMode::Flat);
+
+    // --- F2 bowtie ---
+    group.bench_with_input(
+        BenchmarkId::new("f2", scale.as_str()),
+        &n_products,
+        |b, _| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let result = snapshot
+                        .query()
+                        .sparql(F2)
+                        .execute()
+                        .await
+                        .expect("F2 execute");
+                    black_box(result);
+                });
+            });
+        },
+    );
+
+    group.finish();
+    // snapshot's borrow of fluree ends here; explicit drops below keep
+    // the order well-defined.
+    drop(snapshot);
+    drop(fluree);
+}
+
+criterion_group!(benches, bench_query_hot_bsbm_bi);
+criterion_main!(benches);

--- a/regression-budget.json
+++ b/regression-budget.json
@@ -48,6 +48,11 @@
         "tiny": 10.0,
         "small": 5.0,
         "medium": 3.0
+      },
+      "query_hot_bsbm_bi": {
+        "tiny": 10.0,
+        "small": 5.0,
+        "medium": 3.0
       }
     },
     "fluree-db-query": {


### PR DESCRIPTION
Follow-up to #1356, addressing the review request there to guard the planner's deliberate trade-offs against future drift.

Adds the **BSBM-BI F2 bowtie** bench (`query_hot_bsbm_bi`): two equally-selective `bsbm:country` anchors (vendor side + reviewer side) meeting through the large `reviewFor`/`reviewer` predicate. This exercises the seed tie-break introduced in #1356 — the planner must drive from the side that keeps the big review predicate hash-able rather than forward-joining over a large intermediate (the 46× regression that PR fixed).

## Changes
- New `fluree-db-api/benches/query_hot_bsbm_bi.rs` — reuses the `query_hot_bsbm` setup discipline (build once → reindex → warm-cache binary scan).
- `fluree-bench-support` BSBM generator: `country` added to `Person`, with a stride independent of vendor country so the bowtie has two genuinely ~1/5-selective ends. Serialization, `estimated_triples`, doc, and tests updated.
- `[[bench]]` + `regression-budget.json` entries wired (reconcile gate passes).
- `docs/contributing/benches.md` category table updated.

## Caveat
This builds and smoke-runs in the `bench-gate` job per PR, but the actual nanosecond-vs-budget comparison only kicks in once `bench-nightly` exists (not yet in the repo). So this is ready-to-guard scaffolding, not an active perf gate today.

## Deferred
The IC5-shaped OPTIONAL bench is deferred — it needs a new social-graph generator from scratch, and that path's correctness is already covered by `it_query_optional_hashjoin` / `it_policy_optional_hashjoin`.

## Validation
- `cargo test -p fluree-bench-support` (incl. `workspace_reconcile` gate) ✅
- `cargo bench -p fluree-db-api --bench query_hot_bsbm_bi -- --test` → `Success` ✅
- `cargo fmt --all --check` + clippy clean ✅