### PR TITLE
Fix complex aggregates in SELECT

### DIFF
--- a/fluree-db-api/tests/it_query_aggregates.rs
+++ b/fluree-db-api/tests/it_query_aggregates.rs
@@ -590,3 +590,97 @@ async fn select_expr_if_branches_on_age() {
         ]))
     );
 }
+
+async fn seed_receipt_line_items_jsonld(
+    fluree: &MemoryFluree,
+    ledger_id: &str,
+) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+
+    let insert = json!({
+        "@context": {
+            "sup": "http://Magna/SupplyChain#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@graph": [
+            {
+                "@id": "sup:r1",
+                "@type": "sup:ReceiptLineItem",
+                "sup:forEngcPart": {"@id": "sup:partA"},
+                "sup:receiptUnitPrice": 10
+            },
+            {
+                "@id": "sup:r2",
+                "@type": "sup:ReceiptLineItem",
+                "sup:forEngcPart": {"@id": "sup:partA"},
+                "sup:receiptUnitPrice": 14
+            },
+            {
+                "@id": "sup:r3",
+                "@type": "sup:ReceiptLineItem",
+                "sup:forEngcPart": {"@id": "sup:partA"},
+                "sup:receiptUnitPrice": 12
+            },
+            {
+                "@id": "sup:r4",
+                "@type": "sup:ReceiptLineItem",
+                "sup:forEngcPart": {"@id": "sup:partB"},
+                "sup:receiptUnitPrice": 5
+            },
+            {
+                "@id": "sup:r5",
+                "@type": "sup:ReceiptLineItem",
+                "sup:forEngcPart": {"@id": "sup:partB"},
+                "sup:receiptUnitPrice": 9
+            }
+        ]
+    });
+
+    fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("seed receipt line items")
+        .ledger
+}
+
+#[tokio::test]
+async fn aggregates_arithmetic_over_min_max_jsonld() {
+    // JSON-LD equivalent of the SPARQL
+    //   SELECT ?part ((MAX(?u) - MIN(?u)) AS ?spread) GROUP BY ?part
+    // which currently fails on the SPARQL side.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger =
+        seed_receipt_line_items_jsonld(&fluree, "query/agg-spread-jsonld:main").await;
+    let ctx = json!({
+        "sup": "http://Magna/SupplyChain#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    });
+
+    let query = json!({
+        "@context": ctx,
+        "select": [
+            "?part",
+            "(as (- (max ?u) (min ?u)) ?spread)"
+        ],
+        "where": {
+            "@id": "?r",
+            "@type": "sup:ReceiptLineItem",
+            "sup:forEngcPart": "?part",
+            "sup:receiptUnitPrice": "?u"
+        },
+        "groupBy": ["?part"]
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+
+    assert_eq!(
+        normalize_rows(&json_rows),
+        normalize_rows(&json!([
+            ["sup:partA", 4],
+            ["sup:partB", 4]
+        ]))
+    );
+}

--- a/fluree-db-api/tests/it_query_aggregates.rs
+++ b/fluree-db-api/tests/it_query_aggregates.rs
@@ -591,10 +591,7 @@ async fn select_expr_if_branches_on_age() {
     );
 }
 
-async fn seed_receipt_line_items_jsonld(
-    fluree: &MemoryFluree,
-    ledger_id: &str,
-) -> MemoryLedger {
+async fn seed_receipt_line_items_jsonld(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
     let ledger0 = genesis_ledger(fluree, ledger_id);
 
     let insert = json!({
@@ -649,8 +646,7 @@ async fn aggregates_arithmetic_over_min_max_jsonld() {
     //   SELECT ?part ((MAX(?u) - MIN(?u)) AS ?spread) GROUP BY ?part
     // which currently fails on the SPARQL side.
     let fluree = FlureeBuilder::memory().build_memory();
-    let ledger =
-        seed_receipt_line_items_jsonld(&fluree, "query/agg-spread-jsonld:main").await;
+    let ledger = seed_receipt_line_items_jsonld(&fluree, "query/agg-spread-jsonld:main").await;
     let ctx = json!({
         "sup": "http://Magna/SupplyChain#",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
@@ -678,9 +674,6 @@ async fn aggregates_arithmetic_over_min_max_jsonld() {
 
     assert_eq!(
         normalize_rows(&json_rows),
-        normalize_rows(&json!([
-            ["sup:partA", 4],
-            ["sup:partB", 4]
-        ]))
+        normalize_rows(&json!([["sup:partA", 4], ["sup:partB", 4]]))
     );
 }

--- a/fluree-db-api/tests/it_query_aggregates.rs
+++ b/fluree-db-api/tests/it_query_aggregates.rs
@@ -644,7 +644,8 @@ async fn seed_receipt_line_items_jsonld(fluree: &MemoryFluree, ledger_id: &str) 
 async fn aggregates_arithmetic_over_min_max_jsonld() {
     // JSON-LD equivalent of the SPARQL
     //   SELECT ?part ((MAX(?u) - MIN(?u)) AS ?spread) GROUP BY ?part
-    // which currently fails on the SPARQL side.
+    // The compound aggregate is computed directly: inner MAX/MIN are hoisted
+    // and the surrounding arithmetic runs as a post-aggregation bind.
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger = seed_receipt_line_items_jsonld(&fluree, "query/agg-spread-jsonld:main").await;
     let ctx = json!({

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -3831,6 +3831,113 @@ async fn sparql_sum_avg_over_xsd_decimal_repro() {
     );
 }
 
+async fn seed_receipt_line_items(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+
+    let insert = json!({
+        "@context": {
+            "sup": "http://Magna/SupplyChain#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@graph": [
+            {
+                "@id": "sup:r1",
+                "@type": "sup:ReceiptLineItem",
+                "sup:forEngcPart": {"@id": "sup:partA"},
+                "sup:receiptUnitPrice": 10
+            },
+            {
+                "@id": "sup:r2",
+                "@type": "sup:ReceiptLineItem",
+                "sup:forEngcPart": {"@id": "sup:partA"},
+                "sup:receiptUnitPrice": 14
+            },
+            {
+                "@id": "sup:r3",
+                "@type": "sup:ReceiptLineItem",
+                "sup:forEngcPart": {"@id": "sup:partA"},
+                "sup:receiptUnitPrice": 12
+            },
+            {
+                "@id": "sup:r4",
+                "@type": "sup:ReceiptLineItem",
+                "sup:forEngcPart": {"@id": "sup:partB"},
+                "sup:receiptUnitPrice": 5
+            },
+            {
+                "@id": "sup:r5",
+                "@type": "sup:ReceiptLineItem",
+                "sup:forEngcPart": {"@id": "sup:partB"},
+                "sup:receiptUnitPrice": 9
+            }
+        ]
+    });
+
+    fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("seed receipt line items")
+        .ledger
+}
+
+#[tokio::test]
+async fn sparql_arithmetic_over_min_max_in_select_repro() {
+    // Repro for reported bug: SELECT with arithmetic over MAX(?u) - MIN(?u)
+    // grouped by ?part fails or returns wrong rows.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_receipt_line_items(&fluree, "agg:spread").await;
+
+    let query = r"
+        PREFIX sup: <http://Magna/SupplyChain#>
+        SELECT ?part ((MAX(?u) - MIN(?u)) AS ?spread)
+        WHERE { ?r a sup:ReceiptLineItem ; sup:forEngcPart ?part ; sup:receiptUnitPrice ?u }
+        GROUP BY ?part
+        LIMIT 5
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("MAX - MIN over grouped values");
+    let sparql_json = result
+        .to_sparql_json(&ledger.snapshot)
+        .expect("to_sparql_json");
+    let bindings = normalize_sparql_bindings(&sparql_json);
+    assert_eq!(bindings.len(), 2, "expected one row per part");
+
+    // partA: values 10, 14, 12 → spread 4
+    // partB: values 5, 9       → spread 4
+    let mut spreads: Vec<&str> = bindings
+        .iter()
+        .map(|b| b["spread"]["value"].as_str().expect("spread bound"))
+        .collect();
+    spreads.sort();
+    assert_eq!(spreads, vec!["4", "4"]);
+}
+
+#[tokio::test]
+async fn sparql_bare_min_max_in_select_works() {
+    // Control for the arithmetic-over-aggregates repro: bare MAX/MIN columns
+    // should succeed.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_receipt_line_items(&fluree, "agg:bare-minmax").await;
+
+    let query = r"
+        PREFIX sup: <http://Magna/SupplyChain#>
+        SELECT ?part (MAX(?u) AS ?hi) (MIN(?u) AS ?lo)
+        WHERE { ?r a sup:ReceiptLineItem ; sup:forEngcPart ?part ; sup:receiptUnitPrice ?u }
+        GROUP BY ?part
+    ";
+
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("bare MAX/MIN per group");
+    let sparql_json = result
+        .to_sparql_json(&ledger.snapshot)
+        .expect("to_sparql_json");
+    let bindings = normalize_sparql_bindings(&sparql_json);
+    assert_eq!(bindings.len(), 2);
+}
+
 #[tokio::test]
 async fn sparql_ucase_preserves_language_tag() {
     // W3C: UCASE must preserve language tags from the input.

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -712,7 +712,15 @@ fn parse_select_string(
         }
 
         // Scalar expression with explicit alias — desugars to a BIND.
-        let expr = filter_sexpr::expr_from_sexpr_token(&list[1])?;
+        //
+        // Compound expressions can contain aggregate calls (e.g.
+        // `(as (- (max ?u) (min ?u)) ?spread)`). Each one is hoisted into
+        // `aggregates` with a synthetic output var and the call is rewritten
+        // to reference that var; the surrounding expression then lowers as a
+        // post-aggregation bind via `lower_select_expr_bind`.
+        let mut inner_tok = list[1].clone();
+        hoist_inline_aggregates(&mut inner_tok, aggregates)?;
+        let expr = filter_sexpr::expr_from_sexpr_token(&inner_tok)?;
         return Ok(UnresolvedColumn::Computation {
             expr,
             alias: Arc::from(alias),
@@ -834,6 +842,68 @@ fn parse_aggregate_fn_and_input(
     }
 
     Ok((function, input.to_string()))
+}
+
+/// Walk a SELECT-clause S-expression token tree, hoisting any nested
+/// aggregate call out into `aggregates` and rewriting the call to an atom
+/// that references the synthetic output variable.
+///
+/// Used by `parse_select_string` so a compound expression like
+/// `(- (max ?u) (min ?u))` becomes `(- ?__inline_agg_0 ?__inline_agg_1)`
+/// with two `UnresolvedAggregateSpec`s pushed onto `aggregates`. Lowering
+/// then routes the surrounding expression to `post_binds` because the
+/// synthetic vars appear in the aggregate-output set.
+///
+/// Identical aggregates (same function + same input) dedupe to one output
+/// var via the `seen` map keyed by `"fn|input"`.
+fn hoist_inline_aggregates(
+    tok: &mut sexpr_tokenize::SexprToken,
+    aggregates: &mut Vec<ast::UnresolvedAggregateSpec>,
+) -> Result<()> {
+    let mut seen: std::collections::HashMap<String, Arc<str>> =
+        std::collections::HashMap::new();
+    hoist_inline_aggregates_inner(tok, aggregates, &mut seen)
+}
+
+fn hoist_inline_aggregates_inner(
+    tok: &mut sexpr_tokenize::SexprToken,
+    aggregates: &mut Vec<ast::UnresolvedAggregateSpec>,
+    seen: &mut std::collections::HashMap<String, Arc<str>>,
+) -> Result<()> {
+    let sexpr_tokenize::SexprToken::List(items) = tok else {
+        return Ok(());
+    };
+
+    // If this list is itself an aggregate call, hoist it whole.
+    if let Some(sexpr_tokenize::SexprToken::Atom(name)) = items.first() {
+        let head = name.to_lowercase();
+        if is_aggregate_name(&head) {
+            let (function, input_var) = parse_aggregate_fn_and_input(&head, &items[1..])?;
+            let dedup_key = format!("{head}|{input_var}");
+            let output_var = if let Some(existing) = seen.get(&dedup_key) {
+                existing.clone()
+            } else {
+                let next_idx = aggregates.len();
+                let name: Arc<str> = Arc::from(format!("?__inline_agg_{next_idx}"));
+                aggregates.push(ast::UnresolvedAggregateSpec {
+                    function,
+                    input_var: Arc::from(input_var),
+                    output_var: name.clone(),
+                });
+                seen.insert(dedup_key, name.clone());
+                name
+            };
+            *tok = sexpr_tokenize::SexprToken::Atom(output_var.to_string());
+            return Ok(());
+        }
+    }
+
+    // Otherwise recurse into children. A nested aggregate inside an arithmetic
+    // or function call gets rewritten in place.
+    for child in items.iter_mut() {
+        hoist_inline_aggregates_inner(child, aggregates, seen)?;
+    }
+    Ok(())
 }
 
 /// Parse a hydration object like `{"?person": ["*", {"ex:friend": ["*"]}]}`.

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -879,21 +879,19 @@ fn hoist_inline_aggregates_inner(
         let head = name.to_lowercase();
         if is_aggregate_name(&head) {
             let (function, input_var) = parse_aggregate_fn_and_input(&head, &items[1..])?;
-            let dedup_key = format!("{head}|{input_var}");
-            let output_var = if let Some(existing) = seen.get(&dedup_key) {
-                existing.clone()
-            } else {
-                let next_idx = aggregates.len();
-                let name: Arc<str> = Arc::from(format!("?__inline_agg_{next_idx}"));
-                aggregates.push(ast::UnresolvedAggregateSpec {
-                    function,
-                    input_var: Arc::from(input_var),
-                    output_var: name.clone(),
-                });
-                seen.insert(dedup_key, name.clone());
-                name
-            };
-            *tok = sexpr_tokenize::SexprToken::Atom(output_var.to_string());
+            let output_var = seen
+                .entry(format!("{head}|{input_var}"))
+                .or_insert_with(|| {
+                    let name: Arc<str> = Arc::from(format!("?__inline_agg_{}", aggregates.len()));
+                    aggregates.push(ast::UnresolvedAggregateSpec {
+                        function,
+                        input_var: Arc::from(input_var),
+                        output_var: name.clone(),
+                    });
+                    name
+                })
+                .clone();
+            *tok = SexprToken::Atom(output_var.to_string());
             return Ok(());
         }
     }

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -860,22 +860,22 @@ fn hoist_inline_aggregates(
     tok: &mut sexpr_tokenize::SexprToken,
     aggregates: &mut Vec<ast::UnresolvedAggregateSpec>,
 ) -> Result<()> {
-    let mut seen: std::collections::HashMap<String, Arc<str>> =
-        std::collections::HashMap::new();
-    hoist_inline_aggregates_inner(tok, aggregates, &mut seen)
+    hoist_inline_aggregates_inner(tok, aggregates, &mut HashMap::new())
 }
 
 fn hoist_inline_aggregates_inner(
     tok: &mut sexpr_tokenize::SexprToken,
     aggregates: &mut Vec<ast::UnresolvedAggregateSpec>,
-    seen: &mut std::collections::HashMap<String, Arc<str>>,
+    seen: &mut HashMap<String, Arc<str>>,
 ) -> Result<()> {
-    let sexpr_tokenize::SexprToken::List(items) = tok else {
+    use sexpr_tokenize::SexprToken;
+
+    let SexprToken::List(items) = tok else {
         return Ok(());
     };
 
     // If this list is itself an aggregate call, hoist it whole.
-    if let Some(sexpr_tokenize::SexprToken::Atom(name)) = items.first() {
+    if let Some(SexprToken::Atom(name)) = items.first() {
         let head = name.to_lowercase();
         if is_aggregate_name(&head) {
             let (function, input_var) = parse_aggregate_fn_and_input(&head, &items[1..])?;
@@ -900,7 +900,7 @@ fn hoist_inline_aggregates_inner(
 
     // Otherwise recurse into children. A nested aggregate inside an arithmetic
     // or function call gets rewritten in place.
-    for child in items.iter_mut() {
+    for child in items {
         hoist_inline_aggregates_inner(child, aggregates, seen)?;
     }
     Ok(())

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -311,16 +311,19 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
                 let distinct = lowered_modifiers.distinct;
 
                 // Assemble the grouping phase from the lowered components.
-                // SELECT post-binds (`select_binds.post`) ride inside the
-                // aggregation stage. Expression-based ORDER BY binds ride on
-                // `Query.order_binds` (a dedicated post-grouping stage in the
-                // operator tree) so they evaluate uniformly with or without
-                // grouping — including dedup-only GROUP BY, which has no
-                // aggregation stage to carry binds.
+                // SELECT post-binds (`select_binds.post`, plus any compound-
+                // aggregate post-binds produced by `lower_solution_modifiers`)
+                // ride inside the aggregation stage. Expression-based ORDER BY
+                // binds ride on `Query.order_binds` (a dedicated post-grouping
+                // stage in the operator tree) so they evaluate uniformly with
+                // or without grouping — including dedup-only GROUP BY, which
+                // has no aggregation stage to carry binds.
+                let mut post_binds = select_binds.post;
+                post_binds.extend(lowered_modifiers.select_post_binds);
                 let grouping = Grouping::assemble(
                     lowered_modifiers.group_by,
                     lowered_modifiers.aggregates,
-                    select_binds.post,
+                    post_binds,
                     lowered_modifiers.having,
                 );
 

--- a/fluree-db-sparql/src/lower/select.rs
+++ b/fluree-db-sparql/src/lower/select.rs
@@ -26,7 +26,14 @@ use super::{LoweringContext, Result};
 pub(super) struct SelectBinds {
     /// BIND patterns to apply before grouping/aggregation
     pub pre: Vec<Pattern>,
-    /// Post-aggregation binds (var, expr) to apply after GROUP BY
+    /// Post-aggregation binds (var, expr) to apply after GROUP BY.
+    ///
+    /// Includes binds whose expression references an aggregate **alias**
+    /// (e.g. `(?count + 1 AS ?bumped)`); compound-aggregate SELECT items —
+    /// expressions like `((MAX(?u) - MIN(?u)) AS ?spread)` whose aggregates
+    /// must first be hoisted into the alias map — are produced later by
+    /// [`Self::lower_solution_modifiers`] and appended onto this list by the
+    /// caller.
     pub post: Vec<(VarId, Expression)>,
 }
 
@@ -71,6 +78,11 @@ pub(super) struct LoweredModifiers {
     /// Pre-GROUP-BY BIND patterns for expression-based GROUP BY conditions.
     /// These must be injected into the WHERE pattern list before query building.
     pub pre_group_binds: Vec<Pattern>,
+    /// Post-aggregation binds produced by compound-aggregate SELECT items
+    /// (e.g. `((MAX(?u) - MIN(?u)) AS ?spread)`). Each inner aggregate has
+    /// been hoisted into `aggregates`; the bind references those synthetic
+    /// output vars. The caller appends these onto `SelectBinds::post`.
+    pub select_post_binds: Vec<(VarId, Expression)>,
 }
 
 impl<E: IriEncoder> LoweringContext<'_, E> {
@@ -106,7 +118,12 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         if let SelectVariables::Explicit(vars) = &clause.variables {
             for var in vars {
                 if let SelectVariable::Expr { expr, alias, .. } = var {
-                    if matches!(expr, AstExpression::Aggregate { .. }) {
+                    // Both bare aggregates (`MAX(?u) AS ?hi`) and compound
+                    // expressions that contain aggregates (`MAX(?u) - MIN(?u)
+                    // AS ?spread`) bind their alias only after the aggregation
+                    // stage. Anything depending on that alias must therefore
+                    // ride as a post-aggregation bind.
+                    if self.expr_contains_aggregate(expr) {
                         names.insert(alias.name.clone());
                     }
                 }
@@ -127,7 +144,16 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         if let SelectVariables::Explicit(vars) = &clause.variables {
             for var in vars {
                 if let SelectVariable::Expr { expr, alias, .. } = var {
-                    if matches!(expr, AstExpression::Aggregate { .. }) {
+                    // Bare aggregates (`MAX(?u) AS ?hi`) become AggregateSpecs
+                    // in `extract_aggregates`. Compound expressions that contain
+                    // aggregates (`MAX(?u) - MIN(?u) AS ?spread`) need their
+                    // inner aggregates hoisted before they can be lowered, so
+                    // `lower_solution_modifiers` produces their post-bind once
+                    // the alias map exists. Both are skipped here.
+                    if self.expr_contains_aggregate(expr) {
+                        // Register the alias so projection / GROUP BY checks
+                        // can resolve it before the post-bind lands.
+                        self.register_var(alias);
                         continue;
                     }
                     let filter_expr = self.lower_expression(expr)?;
@@ -188,18 +214,51 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             group_by = group_vars;
         }
 
-        // Aggregate-alias map shared by HAVING and aggregate-bearing ORDER BY
-        // hoisting. Seeded with SELECT aggregate aliases so both reuse them, and
-        // so the synthetic `?__inline_agg_N` names stay unique across both (the
-        // names are keyed off the shared map's length).
-        let needs_alias_map = modifiers.having.is_some() || !base.deferred_order_exprs.is_empty();
+        // Compound-aggregate SELECT items (`(MAX(?u) - MIN(?u) AS ?spread)`):
+        // these need the alias map too, so their inner aggregates can be
+        // hoisted and the outer expression lowered as a post-aggregation bind.
+        let compound_aggregate_select_items: Vec<(VarId, AstExpression)> =
+            self.collect_compound_aggregate_select_items(select);
+
+        // Aggregate-alias map shared by HAVING, aggregate-bearing ORDER BY, and
+        // compound-aggregate SELECT items. Seeded with bare-Aggregate SELECT
+        // aliases so all three reuse them, and so the synthetic
+        // `?__inline_agg_N` names stay unique across them (keyed off the shared
+        // map's length).
+        let needs_alias_map = modifiers.having.is_some()
+            || !base.deferred_order_exprs.is_empty()
+            || !compound_aggregate_select_items.is_empty();
         let mut aggregate_aliases: HashMap<String, VarId> = if needs_alias_map {
             self.build_aggregate_aliases(select)?
         } else {
             HashMap::new()
         };
-        // Aggregates hoisted out of HAVING and/or ORDER BY expressions.
+        // Aggregates hoisted out of compound SELECT items, HAVING, and/or
+        // ORDER BY expressions.
         let mut hoisted_aggregates: Vec<AggregateSpec> = Vec::new();
+
+        // Compound-aggregate SELECT items: hoist their inner aggregates, then
+        // lower each outer expression to a post-aggregation bind referencing
+        // the synthetic alias vars.
+        let mut select_post_binds: Vec<(VarId, Expression)> = Vec::new();
+        if !compound_aggregate_select_items.is_empty() {
+            let mut select_pre_binds: Vec<Pattern> = Vec::new();
+            for (_, ast_expr) in &compound_aggregate_select_items {
+                self.collect_inline_aggregates(
+                    ast_expr,
+                    &mut aggregate_aliases,
+                    &mut hoisted_aggregates,
+                    &mut select_pre_binds,
+                )?;
+            }
+            self.aggregate_aliases = Some(aggregate_aliases.clone());
+            for (var_id, ast_expr) in &compound_aggregate_select_items {
+                let lowered = self.lower_expression(ast_expr)?;
+                select_post_binds.push((*var_id, lowered));
+            }
+            self.aggregate_aliases = None;
+            pre_group_binds.extend(select_pre_binds);
+        }
 
         // HAVING (may reference aggregate expressions)
         if let Some(ref having_clause) = modifiers.having {
@@ -264,7 +323,34 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             aggregates,
             having,
             pre_group_binds,
+            select_post_binds,
         })
+    }
+
+    /// Walk the SELECT clause for compound expressions that *contain*
+    /// aggregates (e.g. `(MAX(?u) - MIN(?u) AS ?spread)`) — bare aggregates
+    /// (`MAX(?u) AS ?hi`) are handled separately by `extract_aggregates`.
+    /// Returns each as `(alias VarId, AST expression)` for hoisting + post-bind
+    /// lowering in `lower_solution_modifiers`.
+    fn collect_compound_aggregate_select_items(
+        &mut self,
+        select: &SelectClause,
+    ) -> Vec<(VarId, AstExpression)> {
+        let mut items = Vec::new();
+        if let SelectVariables::Explicit(vars) = &select.variables {
+            for var in vars {
+                if let SelectVariable::Expr { expr, alias, .. } = var {
+                    if matches!(expr, AstExpression::Aggregate { .. }) {
+                        continue;
+                    }
+                    if self.expr_contains_aggregate(expr) {
+                        let var_id = self.register_var(alias);
+                        items.push((var_id, expr.clone()));
+                    }
+                }
+            }
+        }
+        items
     }
 
     /// Lower LIMIT, OFFSET, and ORDER BY modifiers (shared by SELECT and
@@ -572,11 +658,16 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         // the grouping's aggregation stage; expression/aggregate ORDER BY binds
         // ride on `order_binds` (a dedicated post-grouping stage in the shared
         // modifier tail) so they evaluate uniformly with or without grouping.
+        // Compound-aggregate SELECT post-binds — produced by
+        // `lower_solution_modifiers` after aggregate hoisting — also ride in
+        // the aggregation stage.
+        let mut post_binds = select_binds.post;
+        post_binds.extend(lowered.select_post_binds);
         let mut sq = SubqueryPattern::new(select, patterns);
         if let Some(grouping) = Grouping::assemble(
             lowered.group_by,
             lowered.aggregates,
-            select_binds.post,
+            post_binds,
             lowered.having,
         ) {
             sq = sq.with_grouping(grouping);

--- a/fluree-db-sparql/src/lower/select.rs
+++ b/fluree-db-sparql/src/lower/select.rs
@@ -149,11 +149,9 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                     // aggregates (`MAX(?u) - MIN(?u) AS ?spread`) need their
                     // inner aggregates hoisted before they can be lowered, so
                     // `lower_solution_modifiers` produces their post-bind once
-                    // the alias map exists. Both are skipped here.
+                    // the alias map exists. Both are skipped here; the alias
+                    // VarId itself was already registered by `lower_select_clause`.
                     if self.expr_contains_aggregate(expr) {
-                        // Register the alias so projection / GROUP BY checks
-                        // can resolve it before the post-bind lands.
-                        self.register_var(alias);
                         continue;
                     }
                     let filter_expr = self.lower_expression(expr)?;
@@ -331,7 +329,8 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
     /// aggregates (e.g. `(MAX(?u) - MIN(?u) AS ?spread)`) — bare aggregates
     /// (`MAX(?u) AS ?hi`) are handled separately by `extract_aggregates`.
     /// Returns each as `(alias VarId, AST expression)` for hoisting + post-bind
-    /// lowering in `lower_solution_modifiers`.
+    /// lowering in `lower_solution_modifiers`. Alias VarIds were registered
+    /// upstream by `lower_select_clause`.
     fn collect_compound_aggregate_select_items(
         &mut self,
         select: &SelectClause,

--- a/fluree-db-sparql/src/lower/select.rs
+++ b/fluree-db-sparql/src/lower/select.rs
@@ -335,17 +335,17 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         &mut self,
         select: &SelectClause,
     ) -> Vec<(VarId, AstExpression)> {
+        let SelectVariables::Explicit(vars) = &select.variables else {
+            return Vec::new();
+        };
         let mut items = Vec::new();
-        if let SelectVariables::Explicit(vars) = &select.variables {
-            for var in vars {
-                if let SelectVariable::Expr { expr, alias, .. } = var {
-                    if matches!(expr, AstExpression::Aggregate { .. }) {
-                        continue;
-                    }
-                    if self.expr_contains_aggregate(expr) {
-                        let var_id = self.register_var(alias);
-                        items.push((var_id, expr.clone()));
-                    }
+        for var in vars {
+            if let SelectVariable::Expr { expr, alias, .. } = var {
+                if matches!(expr, AstExpression::Aggregate { .. }) {
+                    continue;
+                }
+                if self.expr_contains_aggregate(expr) {
+                    items.push((self.register_var(alias), expr.clone()));
                 }
             }
         }


### PR DESCRIPTION
A SPARQL query that wraps multiple aggregates inside an arithmetic expression — for example, `SELECT ?part ((MAX(?u) - MIN(?u)) AS ?spread) ... GROUP BY ?part LIMIT 5` — failed with `SparqlLower(NotImplemented { feature: "Aggregate function Max", ... })`. The equivalent JSON-LD form `(as (- (max ?u) (min ?u)) ?spread)` failed with `Parse(InvalidFilter("Unknown function: max"))`. Both languages already supported bare `(MAX(?u) AS ?hi)` columns; only the *compound-aggregate* shape was broken. This branch fixes both, end to end.

## Reported query

```sparql
PREFIX sup: <http://Magna/SupplyChain#>
SELECT ?part ((MAX(?u) - MIN(?u)) AS ?spread)
WHERE { ?r a sup:ReceiptLineItem ; sup:forEngcPart ?part ; sup:receiptUnitPrice ?u }
GROUP BY ?part
LIMIT 5
```

## Root cause — SPARQL side

`fluree-db-sparql/src/lower/` had three SELECT helpers that only recognised `SelectVariable::Expr { expr: Expression::Aggregate, .. }` — i.e. *bare* aggregates. A compound `(MAX(?u) - MIN(?u)) AS ?spread` fell into `lower_select_expression_binds`, which called `lower_expression` without an `aggregate_aliases` map in scope; the recursive lowerer then rejected the nested `MAX` with `NotImplemented`. HAVING and ORDER BY already had the correct pattern (`collect_inline_aggregates` + a temporarily-set `self.aggregate_aliases`); SELECT did not.

## Fix — SPARQL side

Extend SELECT lowering to mirror the HAVING / ORDER BY path that already worked:

- `collect_aggregate_alias_names` now uses `expr_contains_aggregate` instead of `matches!(_, Aggregate)` so compound-aggregate SELECT aliases also count as post-aggregation aliases.
- `lower_select_expression_binds` skips any SELECT expression that contains an aggregate (compound or bare) — `lower_solution_modifiers` handles them later.
- `lower_solution_modifiers` gains a new pass `collect_compound_aggregate_select_items` that hoists each compound expression's inner aggregates via `collect_inline_aggregates`, then lowers the outer expression to a `(VarId, Expression)` post-aggregation bind. The hoist shares the same `aggregate_aliases` map as HAVING and ORDER BY, so duplicate aggregates dedupe across all three.
- `LoweredModifiers` gains a `select_post_binds: Vec<(VarId, Expression)>` field; the two callers (`lower::lower` and `lower_subselect`) append it onto `select_binds.post` before `Grouping::assemble`.

## Root cause — JSON-LD side

`fluree-db-query/src/parse/mod.rs::parse_select_string` only recognised an S-expression as an aggregate when the aggregate name was the *immediate* head. For `(as (- (max ?u) (min ?u)) ?spread)` the head is `-`, so the call fell into the scalar-expression branch (`filter_sexpr::expr_from_sexpr_token`). That path lowered `max` and `min` as generic `UnresolvedExpression::Call`s, and the function-call lowerer subsequently rejected them with "Unknown function: max".

## Fix — JSON-LD side

A new `hoist_inline_aggregates` helper walks the SELECT-clause S-expression token tree *before* it is converted to an `UnresolvedExpression`. Each nested aggregate call (`(max ?u)`, `(min ?u)`, …) is replaced in place with a synthetic atom `?__inline_agg_N`, and a corresponding `UnresolvedAggregateSpec` is pushed onto the running `aggregates` vector. Identical `(fn, input)` pairs within a single column dedupe to one output var via a small `seen: HashMap<String, Arc<str>>`. The existing `lower_select_expr_bind` then sees the synthetic vars in `aggregate_output_vars` and routes the column as a post-aggregation bind — the same channel `subquery_post_aggregation_bind_jsonld` already exercises.

## Tests

- `it_query_sparql::sparql_arithmetic_over_min_max_in_select_repro` — the user's exact query verbatim; was the failing repro, now passes.
- `it_query_sparql::sparql_bare_min_max_in_select_works` — control test for the bare-aggregate shape, guards against the SPARQL-side fix accidentally breaking the simpler path.
- `it_query_aggregates::aggregates_arithmetic_over_min_max_jsonld` — the JSON-LD equivalent `(as (- (max ?u) (min ?u)) ?spread)`, computing the compound aggregate directly (no `?hi` / `?lo` helper aliases).
