### PR TITLE
chore: release v4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,7 +2336,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-bench-support"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "chrono",
  "rand 0.8.5",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-api"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cli"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-consensus"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-iceberg"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-memory"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "chrono",
  "fluree-db-api",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice-sync"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-peer"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-server"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-aws"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-ipfs"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "cid",
@@ -3075,14 +3075,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "fluree-vocab",
  "pretty_assertions",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-httpd"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-service"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3225,14 +3225,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-sse"
-version = "4.0.7"
+version = "4.1.0"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-vocab"
-version = "4.0.7"
+version = "4.1.0"
 
 [[package]]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 exclude = ["testsuite-sparql"]
 
 [workspace.package]
-version = "4.0.7"
+version = "4.1.0"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/fluree/db"

--- a/testsuite-sparql/Cargo.toml
+++ b/testsuite-sparql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testsuite-sparql"
-version = "4.0.7"
+version = "4.1.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Release v4.1.0

Bumps the workspace version from `4.0.7` to `4.1.0` in preparation for the v4.1.0 release.

### Changes
- `Cargo.toml`: workspace `version` → `4.1.0`
- `Cargo.lock`: regenerated to match

Minor version bump (SemVer) covering the backwards-compatible feature work on this release line, including RDF 1.2 edge annotations.
