### PR TITLE
test(api): consolidate integration test binaries into domain groups

### DIFF
--- a/docs/contributing/sparql-compliance.md
+++ b/docs/contributing/sparql-compliance.md
@@ -438,9 +438,11 @@ SPARQL and JSON-LD queries in Fluree compile to the **same intermediate represen
 # SPARQL W3C tests (from testsuite-sparql/)
 make test-eval-cat CAT=<category>
 
-# JSON-LD query tests (from workspace root)
-cargo test -p fluree-db-api --test it_query
-cargo test -p fluree-db-api --test it_query_analytical
+# JSON-LD query tests (from workspace root) — integration tests are grouped
+# into grp_* binaries; run a whole group or filter to one file's module.
+cargo test -p fluree-db-api --test grp_query
+cargo test -p fluree-db-api --test grp_query_sparql
+# e.g. just one file's tests: cargo test -p fluree-db-api --test grp_query it_query_jsonld
 ```
 
 ## Architecture Overview

--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -50,6 +50,47 @@ fn test_query_workflow() {
 }
 ```
 
+#### Grouped integration binaries (`fluree-db-api`)
+
+Every top-level `tests/*.rs` file is a **separate test binary** that links the
+entire crate dependency graph. With ~160 integration files that meant ~160 full
+link steps per `cargo test` — the dominant cost of building the test suite.
+
+`fluree-db-api` therefore **groups** its integration files into a handful of
+binaries by domain (`grp_query`, `grp_policy`, `grp_import`, `grp_index`,
+`grp_transact`, `grp_ledger`, `grp_graphsource`, `grp_reasoning`, `grp_misc`,
+…). The crate sets `autotests = false` and declares each binary explicitly via
+`[[test]]` in `Cargo.toml`. Each case file is included as a module:
+
+```rust
+// tests/grp_query.rs
+#[path = "support/mod.rs"]
+mod support;            // shared harness, compiled once per binary
+
+#[path = "it_query_jsonld.rs"]
+mod it_query_jsonld;
+#[path = "it_query_sparql.rs"]
+mod it_query_sparql;
+// …
+```
+
+Within a case file, refer to the shared harness as `crate::support` (not
+`mod support;`). Each file becomes its own module, so item names never collide
+across files.
+
+To **add a new integration test**: create `tests/it_<name>.rs`, then add a
+`#[path = "it_<name>.rs"] mod it_<name>;` line to the appropriate `grp_*.rs`
+binary. No new `[[test]]` entry is needed unless you are creating a new group.
+
+**Kept standalone** (their own `[[test]]` binary, *not* grouped):
+- Feature-gated suites (`credential`, `iceberg`, `aws-testcontainers`, `vector`)
+  — declared with `required-features`.
+- Tests that mutate **process-global env vars** (e.g. `FLUREE_*` toggles). A
+  grouped binary runs its tests as threads in one process under plain
+  `cargo test`, so env mutation must stay in a dedicated binary to remain
+  isolated. (Under `cargo nextest`, every test already runs in its own process,
+  so this only matters for bare `cargo test`.)
+
 ### Example Tests
 
 Tests in `examples/`:

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "fluree-db-api"
+autotests = false
 description = "High-level API for Fluree DB operations"
 version.workspace = true
 edition.workspace = true
@@ -128,9 +129,72 @@ rand = { workspace = true }
 fluree-db-nameservice-sync = { path = "../fluree-db-nameservice-sync" }
 
 [[test]]
-name = "it_graph_source_r2rml"
-path = "tests/it_graph_source_r2rml.rs"
-required-features = ["iceberg"]
+name = "grp_graphsource"
+path = "tests/grp_graphsource.rs"
+
+[[test]]
+name = "grp_import"
+path = "tests/grp_import.rs"
+
+[[test]]
+name = "grp_index"
+path = "tests/grp_index.rs"
+
+[[test]]
+name = "grp_ledger"
+path = "tests/grp_ledger.rs"
+
+[[test]]
+name = "grp_misc"
+path = "tests/grp_misc.rs"
+
+[[test]]
+name = "grp_policy"
+path = "tests/grp_policy.rs"
+
+[[test]]
+name = "grp_query"
+path = "tests/grp_query.rs"
+
+[[test]]
+name = "grp_query_history"
+path = "tests/grp_query_history.rs"
+
+[[test]]
+name = "grp_query_reason"
+path = "tests/grp_query_reason.rs"
+
+[[test]]
+name = "grp_query_sparql"
+path = "tests/grp_query_sparql.rs"
+
+[[test]]
+name = "grp_reasoning"
+path = "tests/grp_reasoning.rs"
+
+[[test]]
+name = "grp_transact"
+path = "tests/grp_transact.rs"
+
+[[test]]
+name = "it_cyclic_bgp_novelty_pred"
+path = "tests/it_cyclic_bgp_novelty_pred.rs"
+
+[[test]]
+name = "it_cyclic_bgp_probe"
+path = "tests/it_cyclic_bgp_probe.rs"
+
+[[test]]
+name = "it_query_explain"
+path = "tests/it_query_explain.rs"
+
+[[test]]
+name = "it_query_sparql_indexed"
+path = "tests/it_query_sparql_indexed.rs"
+
+[[test]]
+name = "it_rebuild_fetch_counts"
+path = "tests/it_rebuild_fetch_counts.rs"
 
 [[test]]
 name = "it_credential"
@@ -138,14 +202,24 @@ path = "tests/it_credential.rs"
 required-features = ["credential"]
 
 [[test]]
-name = "it_storage_s3_testcontainers"
-path = "tests/it_storage_s3_testcontainers.rs"
-required-features = ["aws-testcontainers"]
+name = "it_graph_source_r2rml"
+path = "tests/it_graph_source_r2rml.rs"
+required-features = ["iceberg"]
 
 [[test]]
 name = "it_iceberg_direct"
 path = "tests/it_iceberg_direct.rs"
 required-features = ["iceberg", "aws-testcontainers"]
+
+[[test]]
+name = "it_storage_s3_testcontainers"
+path = "tests/it_storage_s3_testcontainers.rs"
+required-features = ["aws-testcontainers"]
+
+[[test]]
+name = "it_graph_source_vector"
+path = "tests/it_graph_source_vector.rs"
+required-features = ["vector"]
 
 [[bench]]
 name = "vector_query"

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -221,6 +221,11 @@ name = "it_graph_source_vector"
 path = "tests/it_graph_source_vector.rs"
 required-features = ["vector"]
 
+[[test]]
+name = "it_vector_flatrank"
+path = "tests/it_vector_flatrank.rs"
+required-features = ["vector"]
+
 [[bench]]
 name = "vector_query"
 harness = false

--- a/fluree-db-api/tests/grp_graphsource.rs
+++ b/fluree-db-api/tests/grp_graphsource.rs
@@ -1,0 +1,31 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_config_graph.rs"]
+mod it_config_graph;
+#[path = "it_constraints_cross_ledger.rs"]
+mod it_constraints_cross_ledger;
+#[path = "it_constraints_inline.rs"]
+mod it_constraints_inline;
+#[path = "it_cross_ledger_resolver.rs"]
+mod it_cross_ledger_resolver;
+#[path = "it_default_context.rs"]
+mod it_default_context;
+#[path = "it_graph_commit.rs"]
+mod it_graph_commit;
+#[path = "it_graph_source_bm25.rs"]
+mod it_graph_source_bm25;
+#[path = "it_named_graph_isolation.rs"]
+mod it_named_graph_isolation;
+#[path = "it_named_graphs.rs"]
+mod it_named_graphs;
+#[path = "it_nameservice_graph_source.rs"]
+mod it_nameservice_graph_source;
+#[path = "it_nameservice_query.rs"]
+mod it_nameservice_query;
+#[path = "it_ontology_inline.rs"]
+mod it_ontology_inline;
+#[path = "it_shapes_cross_ledger.rs"]
+mod it_shapes_cross_ledger;
+#[path = "it_shapes_inline.rs"]
+mod it_shapes_inline;

--- a/fluree-db-api/tests/grp_import.rs
+++ b/fluree-db-api/tests/grp_import.rs
@@ -1,0 +1,23 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_flpack_round_trip.rs"]
+mod it_flpack_round_trip;
+#[path = "it_import.rs"]
+mod it_import;
+#[path = "it_import_class_stats.rs"]
+mod it_import_class_stats;
+#[path = "it_import_ndjson.rs"]
+mod it_import_ndjson;
+#[path = "it_import_ns_split_mode.rs"]
+mod it_import_ns_split_mode;
+#[path = "it_import_remote.rs"]
+mod it_import_remote;
+#[path = "it_import_v3.rs"]
+mod it_import_v3;
+#[path = "it_namespace_new_after_index.rs"]
+mod it_namespace_new_after_index;
+#[path = "it_ns_sync_conflict.rs"]
+mod it_ns_sync_conflict;
+#[path = "it_pack_validation.rs"]
+mod it_pack_validation;

--- a/fluree-db-api/tests/grp_index.rs
+++ b/fluree-db-api/tests/grp_index.rs
@@ -1,0 +1,29 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_indexing_fuel.rs"]
+mod it_indexing_fuel;
+#[path = "it_indexing_stats.rs"]
+mod it_indexing_stats;
+#[path = "it_indexing_wait.rs"]
+mod it_indexing_wait;
+#[path = "it_indexing_workflow.rs"]
+mod it_indexing_workflow;
+#[path = "it_ledger_info_reindex_cache.rs"]
+mod it_ledger_info_reindex_cache;
+#[path = "it_ledger_info_reindex_size.rs"]
+mod it_ledger_info_reindex_size;
+#[path = "it_notify_incremental.rs"]
+mod it_notify_incremental;
+#[path = "it_reasoning_reindex.rs"]
+mod it_reasoning_reindex;
+#[path = "it_reindex_class_stats.rs"]
+mod it_reindex_class_stats;
+#[path = "it_reindex_pre_build_perf.rs"]
+mod it_reindex_pre_build_perf;
+#[path = "it_reindex_schema.rs"]
+mod it_reindex_schema;
+#[path = "it_time_travel_indexing.rs"]
+mod it_time_travel_indexing;
+#[path = "it_trigger_index_incremental.rs"]
+mod it_trigger_index_incremental;

--- a/fluree-db-api/tests/grp_ledger.rs
+++ b/fluree-db-api/tests/grp_ledger.rs
@@ -1,0 +1,27 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_branch.rs"]
+mod it_branch;
+#[path = "it_drop_ledger.rs"]
+mod it_drop_ledger;
+#[path = "it_drop_named_graph.rs"]
+mod it_drop_named_graph;
+#[path = "it_ledger_info_named_graphs.rs"]
+mod it_ledger_info_named_graphs;
+#[path = "it_ledger_lifecycle.rs"]
+mod it_ledger_lifecycle;
+#[path = "it_merge.rs"]
+mod it_merge;
+#[path = "it_merge_preview.rs"]
+mod it_merge_preview;
+#[path = "it_rebase.rs"]
+mod it_rebase;
+#[path = "it_refresh.rs"]
+mod it_refresh;
+#[path = "it_revert.rs"]
+mod it_revert;
+#[path = "it_revert_preview.rs"]
+mod it_revert_preview;
+#[path = "it_stable_hashes.rs"]
+mod it_stable_hashes;

--- a/fluree-db-api/tests/grp_misc.rs
+++ b/fluree-db-api/tests/grp_misc.rs
@@ -1,0 +1,67 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_compile_breakdown.rs"]
+mod it_compile_breakdown;
+#[path = "it_count_distinct_objects.rs"]
+mod it_count_distinct_objects;
+#[path = "it_debug_graph_ids.rs"]
+mod it_debug_graph_ids;
+#[path = "it_decimal_exactness.rs"]
+mod it_decimal_exactness;
+#[path = "it_edge_annotations.rs"]
+mod it_edge_annotations;
+#[path = "it_edge_annotations_indexed.rs"]
+mod it_edge_annotations_indexed;
+#[path = "it_edge_annotations_parse.rs"]
+mod it_edge_annotations_parse;
+#[path = "it_fast_group_count.rs"]
+mod it_fast_group_count;
+#[path = "it_file_backed.rs"]
+mod it_file_backed;
+#[path = "it_file_storage_jsonld.rs"]
+mod it_file_storage_jsonld;
+#[path = "it_fuel_floor.rs"]
+mod it_fuel_floor;
+#[path = "it_historical_uses_index.rs"]
+mod it_historical_uses_index;
+#[path = "it_host_plus_n_e2e.rs"]
+mod it_host_plus_n_e2e;
+#[path = "it_hydration_predicate_gating.rs"]
+mod it_hydration_predicate_gating;
+#[path = "it_join_batched_overlay.rs"]
+mod it_join_batched_overlay;
+#[path = "it_minmax_fast_path_fired.rs"]
+mod it_minmax_fast_path_fired;
+#[path = "it_minmax_string_fast_path.rs"]
+mod it_minmax_string_fast_path;
+#[path = "it_mixed_representation.rs"]
+mod it_mixed_representation;
+#[path = "it_multi_ledger_formatting.rs"]
+mod it_multi_ledger_formatting;
+#[path = "it_multi_query.rs"]
+mod it_multi_query;
+#[path = "it_novelty_dictionary_decode.rs"]
+mod it_novelty_dictionary_decode;
+#[path = "it_scaling_bench.rs"]
+mod it_scaling_bench;
+#[path = "it_select_star_novelty.rs"]
+mod it_select_star_novelty;
+#[path = "it_select_star_novelty_retract.rs"]
+mod it_select_star_novelty_retract;
+#[path = "it_storage_encrypted.rs"]
+mod it_storage_encrypted;
+#[path = "it_stream_query.rs"]
+mod it_stream_query;
+#[path = "it_string_fold_fast_path.rs"]
+mod it_string_fold_fast_path;
+#[path = "it_tracing_spans.rs"]
+mod it_tracing_spans;
+#[path = "it_tutorial_end_to_end.rs"]
+mod it_tutorial_end_to_end;
+#[path = "it_values_type_deleted_repro.rs"]
+mod it_values_type_deleted_repro;
+#[path = "it_vector_corruption_repro.rs"]
+mod it_vector_corruption_repro;
+#[path = "it_vector_flatrank.rs"]
+mod it_vector_flatrank;

--- a/fluree-db-api/tests/grp_misc.rs
+++ b/fluree-db-api/tests/grp_misc.rs
@@ -63,5 +63,3 @@ mod it_tutorial_end_to_end;
 mod it_values_type_deleted_repro;
 #[path = "it_vector_corruption_repro.rs"]
 mod it_vector_corruption_repro;
-#[path = "it_vector_flatrank.rs"]
-mod it_vector_flatrank;

--- a/fluree-db-api/tests/grp_policy.rs
+++ b/fluree-db-api/tests/grp_policy.rs
@@ -1,0 +1,29 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_policy_allow.rs"]
+mod it_policy_allow;
+#[path = "it_policy_class.rs"]
+mod it_policy_class;
+#[path = "it_policy_cross_ledger.rs"]
+mod it_policy_cross_ledger;
+#[path = "it_policy_federation.rs"]
+mod it_policy_federation;
+#[path = "it_policy_fquery.rs"]
+mod it_policy_fquery;
+#[path = "it_policy_identity_based.rs"]
+mod it_policy_identity_based;
+#[path = "it_policy_indexed.rs"]
+mod it_policy_indexed;
+#[path = "it_policy_named_graphs.rs"]
+mod it_policy_named_graphs;
+#[path = "it_policy_optional_hashjoin.rs"]
+mod it_policy_optional_hashjoin;
+#[path = "it_policy_query_connection.rs"]
+mod it_policy_query_connection;
+#[path = "it_policy_time_travel.rs"]
+mod it_policy_time_travel;
+#[path = "it_policy_tracking.rs"]
+mod it_policy_tracking;
+#[path = "it_policy_tx.rs"]
+mod it_policy_tx;

--- a/fluree-db-api/tests/grp_query.rs
+++ b/fluree-db-api/tests/grp_query.rs
@@ -1,0 +1,45 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_query_agent_json.rs"]
+mod it_query_agent_json;
+#[path = "it_query_aggregates.rs"]
+mod it_query_aggregates;
+#[path = "it_query_connection.rs"]
+mod it_query_connection;
+#[path = "it_query_dataset.rs"]
+mod it_query_dataset;
+#[path = "it_query_datatype.rs"]
+mod it_query_datatype;
+#[path = "it_query_explain_native.rs"]
+mod it_query_explain_native;
+#[path = "it_query_fuel_bound_object.rs"]
+mod it_query_fuel_bound_object;
+#[path = "it_query_fulltext.rs"]
+mod it_query_fulltext;
+#[path = "it_query_geo.rs"]
+mod it_query_geo;
+#[path = "it_query_geo_search.rs"]
+mod it_query_geo_search;
+#[path = "it_query_jsonld.rs"]
+mod it_query_jsonld;
+#[path = "it_query_jsonld_basic.rs"]
+mod it_query_jsonld_basic;
+#[path = "it_query_jsonld_compound.rs"]
+mod it_query_jsonld_compound;
+#[path = "it_query_list_functions.rs"]
+mod it_query_list_functions;
+#[path = "it_query_misc.rs"]
+mod it_query_misc;
+#[path = "it_query_optional_hashjoin.rs"]
+mod it_query_optional_hashjoin;
+#[path = "it_query_post_order_limit.rs"]
+mod it_query_post_order_limit;
+#[path = "it_query_property.rs"]
+mod it_query_property;
+#[path = "it_query_reverse.rs"]
+mod it_query_reverse;
+#[path = "it_query_typed_json.rs"]
+mod it_query_typed_json;
+#[path = "it_query_vocab_id_compaction.rs"]
+mod it_query_vocab_id_compaction;

--- a/fluree-db-api/tests/grp_query_history.rs
+++ b/fluree-db-api/tests/grp_query_history.rs
@@ -1,0 +1,11 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_query_history_combinations.rs"]
+mod it_query_history_combinations;
+#[path = "it_query_history_range.rs"]
+mod it_query_history_range;
+#[path = "it_query_time_travel.rs"]
+mod it_query_time_travel;
+#[path = "it_query_time_travel_bgp.rs"]
+mod it_query_time_travel_bgp;

--- a/fluree-db-api/tests/grp_query_reason.rs
+++ b/fluree-db-api/tests/grp_query_reason.rs
@@ -1,0 +1,19 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_query_owl2ql.rs"]
+mod it_query_owl2ql;
+#[path = "it_query_owl2rl.rs"]
+mod it_query_owl2rl;
+#[path = "it_query_owl2rl_edge_cases.rs"]
+mod it_query_owl2rl_edge_cases;
+#[path = "it_query_property_path.rs"]
+mod it_query_property_path;
+#[path = "it_query_rdfs_class_repro.rs"]
+mod it_query_rdfs_class_repro;
+#[path = "it_query_seq_path_count_repro.rs"]
+mod it_query_seq_path_count_repro;
+#[path = "it_query_shortest_path.rs"]
+mod it_query_shortest_path;
+#[path = "it_query_subclass.rs"]
+mod it_query_subclass;

--- a/fluree-db-api/tests/grp_query_sparql.rs
+++ b/fluree-db-api/tests/grp_query_sparql.rs
@@ -1,0 +1,21 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_query_ask.rs"]
+mod it_query_ask;
+#[path = "it_query_collect.rs"]
+mod it_query_collect;
+#[path = "it_query_construct.rs"]
+mod it_query_construct;
+#[path = "it_query_negation.rs"]
+mod it_query_negation;
+#[path = "it_query_sparql.rs"]
+mod it_query_sparql;
+#[path = "it_query_sparql_annotations.rs"]
+mod it_query_sparql_annotations;
+#[path = "it_query_subquery.rs"]
+mod it_query_subquery;
+#[path = "it_query_unwind.rs"]
+mod it_query_unwind;
+#[path = "it_query_values.rs"]
+mod it_query_values;

--- a/fluree-db-api/tests/grp_reasoning.rs
+++ b/fluree-db-api/tests/grp_reasoning.rs
@@ -1,0 +1,15 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_datalog_rules.rs"]
+mod it_datalog_rules;
+#[path = "it_reasoning_budget.rs"]
+mod it_reasoning_budget;
+#[path = "it_reasoning_imports.rs"]
+mod it_reasoning_imports;
+#[path = "it_reasoning_join_repro.rs"]
+mod it_reasoning_join_repro;
+#[path = "it_rules_cross_ledger.rs"]
+mod it_rules_cross_ledger;
+#[path = "it_rules_source.rs"]
+mod it_rules_source;

--- a/fluree-db-api/tests/grp_transact.rs
+++ b/fluree-db-api/tests/grp_transact.rs
@@ -1,0 +1,35 @@
+#[path = "support/mod.rs"]
+mod support;
+
+#[path = "it_concurrent_update_reconcile.rs"]
+mod it_concurrent_update_reconcile;
+#[path = "it_enforce_unique_upsert_indexed.rs"]
+mod it_enforce_unique_upsert_indexed;
+#[path = "it_raw_txn_parallel_upload.rs"]
+mod it_raw_txn_parallel_upload;
+#[path = "it_transact.rs"]
+mod it_transact;
+#[path = "it_transact_conditional.rs"]
+mod it_transact_conditional;
+#[path = "it_transact_datatype_cancellation.rs"]
+mod it_transact_datatype_cancellation;
+#[path = "it_transact_growth_slope.rs"]
+mod it_transact_growth_slope;
+#[path = "it_transact_list_container.rs"]
+mod it_transact_list_container;
+#[path = "it_transact_list_retract.rs"]
+mod it_transact_list_retract;
+#[path = "it_transact_object_var.rs"]
+mod it_transact_object_var;
+#[path = "it_transact_pure_delete_dedup.rs"]
+mod it_transact_pure_delete_dedup;
+#[path = "it_transact_update.rs"]
+mod it_transact_update;
+#[path = "it_transact_upsert.rs"]
+mod it_transact_upsert;
+#[path = "it_txn_meta.rs"]
+mod it_txn_meta;
+#[path = "it_update_wildcard_delete_indexed.rs"]
+mod it_update_wildcard_delete_indexed;
+#[path = "it_upsert_duplicate_ids_repro.rs"]
+mod it_upsert_duplicate_ids_repro;

--- a/fluree-db-api/tests/it_branch.rs
+++ b/fluree-db-api/tests/it_branch.rs
@@ -3,8 +3,7 @@
 //! Tests the branch lifecycle: creating branches, transacting on branches
 //! independently, and verifying data isolation between branches.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{CommitRef, FlureeBuilder};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_compile_breakdown.rs
+++ b/fluree-db-api/tests/it_compile_breakdown.rs
@@ -19,14 +19,12 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
 use std::hint::black_box;
 use std::time::Instant;
 
+use crate::support::graphdb_from_ledger;
 use fluree_db_api::{parse_sparql, FlureeBuilder, ReindexOptions};
 use serde_json::json;
-use support::graphdb_from_ledger;
 
 const SEED: usize = 8000;
 const ITERS: usize = 2000;

--- a/fluree-db-api/tests/it_compile_breakdown.rs
+++ b/fluree-db-api/tests/it_compile_breakdown.rs
@@ -14,7 +14,7 @@
 //! Decision inputs: compile% of total (is the cache worth it?) and
 //! compile-vs-raw_parse (does a cheap normalizer stay << the savings?).
 //!
-//!   cargo test -p fluree-db-api --test it_compile_breakdown --features native \
+//!   cargo test -p fluree-db-api --test grp_misc it_compile_breakdown --features native \
 //!       --profile dev-fast -- --ignored --nocapture compile_breakdown
 
 #![cfg(feature = "native")]

--- a/fluree-db-api/tests/it_concurrent_update_reconcile.rs
+++ b/fluree-db-api/tests/it_concurrent_update_reconcile.rs
@@ -20,8 +20,6 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_concurrent_update_reconcile.rs
+++ b/fluree-db-api/tests/it_concurrent_update_reconcile.rs
@@ -16,7 +16,7 @@
 //! advances the shared head, then B writes through its now-stale cached handle.
 //!
 //! Run with:
-//!   cargo test -p fluree-db-api --test it_concurrent_update_reconcile --features native
+//!   cargo test -p fluree-db-api --test grp_transact it_concurrent_update_reconcile --features native
 
 #![cfg(feature = "native")]
 

--- a/fluree-db-api/tests/it_config_graph.rs
+++ b/fluree-db-api/tests/it_config_graph.rs
@@ -5,12 +5,11 @@
 //! overrides work, override control blocks/permits query-time overrides,
 //! and config is time-travel consistent.
 
-mod support;
-
+use crate::support;
+use crate::support::genesis_ledger;
 use fluree_db_api::config_resolver;
 use fluree_db_api::{FlureeBuilder, GovernanceOptions};
 use serde_json::json;
-use support::genesis_ledger;
 
 /// Build the config graph IRI for a canonical ledger id.
 fn config_graph_iri(ledger_id: &str) -> String {

--- a/fluree-db-api/tests/it_constraints_cross_ledger.rs
+++ b/fluree-db-api/tests/it_constraints_cross_ledger.rs
@@ -9,11 +9,9 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::genesis_ledger;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::genesis_ledger;
 
 fn config_graph_iri(ledger_id: &str) -> String {
     format!("urn:fluree:{ledger_id}#config")

--- a/fluree-db-api/tests/it_constraints_inline.rs
+++ b/fluree-db-api/tests/it_constraints_inline.rs
@@ -7,12 +7,10 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::genesis_ledger;
 use fluree_db_api::{CommitOpts, FlureeBuilder, IndexConfig};
 use fluree_db_transact::ir::TxnOpts;
 use serde_json::json;
-use support::genesis_ledger;
 
 fn test_index_cfg() -> IndexConfig {
     IndexConfig {

--- a/fluree-db-api/tests/it_count_distinct_objects.rs
+++ b/fluree-db-api/tests/it_count_distinct_objects.rs
@@ -7,8 +7,7 @@
 //! value ordering, so it works on incrementally built indexes too.
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use std::io::Write;
 use tempfile::TempDir;

--- a/fluree-db-api/tests/it_cross_ledger_resolver.rs
+++ b/fluree-db-api/tests/it_cross_ledger_resolver.rs
@@ -6,8 +6,7 @@
 //! step (slice 5) and enforcement against a real query (slice 9) are
 //! covered separately; this file's job is the wire-artifact contract.
 
-mod support;
-
+use crate::support::genesis_ledger;
 use fluree_db_api::cross_ledger::{
     resolve_graph_ref, ArtifactKind, GovernanceArtifact, ResolveCtx,
 };
@@ -15,7 +14,6 @@ use fluree_db_api::FlureeBuilder;
 use fluree_db_core::ledger_config::GraphSourceRef;
 use fluree_db_policy::TargetMode;
 use serde_json::json;
-use support::genesis_ledger;
 
 /// Build a cross-ledger GraphSourceRef.
 fn cross_ref(ledger: &str, graph: &str) -> GraphSourceRef {

--- a/fluree-db-api/tests/it_datalog_rules.rs
+++ b/fluree-db-api/tests/it_datalog_rules.rs
@@ -8,11 +8,10 @@
 //! - Rule with multiple where patterns
 //! - Fixpoint iteration (rules triggering other rules)
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows};
 
 // =============================================================================
 // Basic Datalog Rule Tests

--- a/fluree-db-api/tests/it_debug_graph_ids.rs
+++ b/fluree-db-api/tests/it_debug_graph_ids.rs
@@ -5,9 +5,8 @@ use fluree_db_core::ContentStore;
 use serde_json::json;
 
 use std::sync::Arc;
-mod support;
 
-use support::{genesis_ledger, start_background_indexer_local, trigger_index_and_wait};
+use crate::support::{genesis_ledger, start_background_indexer_local, trigger_index_and_wait};
 
 #[tokio::test]
 #[ignore]

--- a/fluree-db-api/tests/it_decimal_exactness.rs
+++ b/fluree-db-api/tests/it_decimal_exactness.rs
@@ -4,15 +4,14 @@
 //! ingestion and output: query constants, SPARQL UPDATE templates, and
 //! stored values all carry exact BigDecimal representations.
 
-mod support;
-
-use fluree_db_api::FlureeBuilder;
-use serde_json::Value as JsonValue;
-use std::sync::Arc;
-use support::{
+use crate::support;
+use crate::support::{
     assert_index_defaults, genesis_ledger, start_background_indexer_local, trigger_index_and_wait,
     MemoryFluree,
 };
+use fluree_db_api::FlureeBuilder;
+use serde_json::Value as JsonValue;
+use std::sync::Arc;
 
 async fn run_sparql_update(
     fluree: &fluree_db_api::Fluree,

--- a/fluree-db-api/tests/it_default_context.rs
+++ b/fluree-db-api/tests/it_default_context.rs
@@ -8,8 +8,6 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_drop_ledger.rs
+++ b/fluree-db-api/tests/it_drop_ledger.rs
@@ -8,14 +8,13 @@
 #![cfg(feature = "native")]
 
 use std::sync::Arc;
-mod support;
 
+use crate::support::start_background_indexer_local;
 use fluree_db_api::{DropMode, DropStatus, FlureeBuilder, IndexConfig, LedgerState, Novelty};
 use fluree_db_core::address_path::ledger_id_to_path_prefix;
 use fluree_db_core::LedgerSnapshot;
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::start_background_indexer_local;
 use tokio::time::{timeout, Duration};
 
 /// Test that soft drop only retracts from nameservice and leaves files intact.

--- a/fluree-db-api/tests/it_drop_named_graph.rs
+++ b/fluree-db-api/tests/it_drop_named_graph.rs
@@ -7,11 +7,9 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::genesis_ledger;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::genesis_ledger;
 
 const ALPHA_IRI: &str = "http://example.org/graphs/alpha";
 const BETA_IRI: &str = "http://example.org/graphs/beta";

--- a/fluree-db-api/tests/it_edge_annotations.rs
+++ b/fluree-db-api/tests/it_edge_annotations.rs
@@ -23,13 +23,12 @@
 //! envelope of the IR-level expansion in
 //! `fluree-db-query/src/execute/where_plan.rs::expand_edge_annotation_patterns`.
 
-mod support;
-
+use crate::support;
 use std::sync::Arc;
 
+use crate::support::{genesis_ledger, genesis_ledger_for_fluree, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, genesis_ledger_for_fluree, MemoryFluree, MemoryLedger};
 
 fn ctx() -> JsonValue {
     json!({

--- a/fluree-db-api/tests/it_edge_annotations_indexed.rs
+++ b/fluree-db-api/tests/it_edge_annotations_indexed.rs
@@ -27,14 +27,13 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use std::sync::Arc;
 
+use crate::support::genesis_ledger;
 use fluree_db_api::FlureeBuilder;
 use fluree_db_indexer::IndexerConfig;
 use serde_json::{json, Value as JsonValue};
-use support::genesis_ledger;
 
 fn ctx() -> JsonValue {
     json!({
@@ -832,7 +831,7 @@ async fn explain_tags_annotation_role_and_uses_arena_stats() {
     // is observable, and (c) report stats as available when the
     // annotation arena is sealed even if no other property stats
     // exist yet.
-    use support::graphdb_from_ledger;
+    use crate::support::graphdb_from_ledger;
 
     let fluree = FlureeBuilder::memory()
         .with_ledger_cache_config(fluree_db_api::LedgerManagerConfig::default())

--- a/fluree-db-api/tests/it_edge_annotations_parse.rs
+++ b/fluree-db-api/tests/it_edge_annotations_parse.rs
@@ -17,11 +17,10 @@
 //! See `docs/concepts/edge-annotations.md` for the user-facing
 //! surface contract.
 
-mod support;
-
+use crate::support;
+use crate::support::genesis_ledger;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::genesis_ledger;
 
 fn ctx() -> serde_json::Value {
     json!({

--- a/fluree-db-api/tests/it_enforce_unique_upsert_indexed.rs
+++ b/fluree-db-api/tests/it_enforce_unique_upsert_indexed.rs
@@ -10,15 +10,14 @@
 #![cfg(feature = "native")]
 
 use std::sync::Arc;
-mod support;
 
-use fluree_db_api::{FlureeBuilder, IndexConfig};
-use fluree_db_transact::{CommitOpts, TxnOpts};
-use serde_json::json;
-use support::{
+use crate::support::{
     query_jsonld_formatted, query_sparql, start_background_indexer_local,
     trigger_index_and_wait_outcome,
 };
+use fluree_db_api::{FlureeBuilder, IndexConfig};
+use fluree_db_transact::{CommitOpts, TxnOpts};
+use serde_json::json;
 
 /// Build the config-graph IRI for a ledger.
 fn config_graph_iri(ledger_id: &str) -> String {

--- a/fluree-db-api/tests/it_fast_group_count.rs
+++ b/fluree-db-api/tests/it_fast_group_count.rs
@@ -8,11 +8,12 @@
 //! scan+aggregate pipeline (since there's no binary graph view), which
 //! exercises the fallback path including EmitMask pruning.
 
-mod support;
-
+use crate::support;
+use crate::support::{
+    context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger,
+};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
 // =============================================================================
 // Seed helpers

--- a/fluree-db-api/tests/it_file_backed.rs
+++ b/fluree-db-api/tests/it_file_backed.rs
@@ -25,7 +25,7 @@ fn get_test_db_path() -> Option<PathBuf> {
 /// End-to-end test using the fluree-db-api with a real file-backed database.
 ///
 /// Run with:
-/// `cargo test -p fluree-db-api --test it_file_backed -- --ignored --nocapture`
+/// `cargo test -p fluree-db-api --test grp_misc it_file_backed -- --ignored --nocapture`
 #[tokio::test]
 #[ignore = "Requires external test-database/ directory"]
 async fn file_backed_query_smoke_test() {
@@ -55,7 +55,7 @@ async fn file_backed_query_smoke_test() {
 /// Benchmark-style test.
 ///
 /// Run with:
-/// `cargo test -p fluree-db-api --test it_file_backed -- --ignored --nocapture`
+/// `cargo test -p fluree-db-api --test grp_misc it_file_backed -- --ignored --nocapture`
 #[tokio::test]
 #[ignore = "Benchmark: requires external test-database/ directory"]
 async fn file_backed_query_benchmark() {

--- a/fluree-db-api/tests/it_file_storage_jsonld.rs
+++ b/fluree-db-api/tests/it_file_storage_jsonld.rs
@@ -7,8 +7,7 @@
 //! - query via JSON-LD query syntax
 //! - reload from file-backed nameservice + storage and re-run the query
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, LedgerState, Novelty};
 use fluree_db_core::LedgerSnapshot;
 use serde_json::json;

--- a/fluree-db-api/tests/it_flpack_round_trip.rs
+++ b/fluree-db-api/tests/it_flpack_round_trip.rs
@@ -5,7 +5,7 @@
 //! under a different name. Verifies that query results match.
 //!
 //! Run with:
-//!   cargo test -p fluree-db-api --test it_flpack_round_trip --features native
+//!   cargo test -p fluree-db-api --test grp_import it_flpack_round_trip --features native
 
 #![cfg(feature = "native")]
 

--- a/fluree-db-api/tests/it_flpack_round_trip.rs
+++ b/fluree-db-api/tests/it_flpack_round_trip.rs
@@ -10,7 +10,6 @@
 #![cfg(feature = "native")]
 
 use std::sync::Arc;
-mod support;
 
 use fluree_db_api::pack::{compute_missing_commits, compute_missing_index_artifacts};
 use fluree_db_api::FlureeBuilder;
@@ -343,7 +342,7 @@ async fn flpack_export_import_round_trip() {
 /// Round-trip with binary indexing: transact → index → export (with index artifacts) → import → query.
 #[tokio::test]
 async fn flpack_export_import_round_trip_with_index() {
-    use support::{start_background_indexer_local, trigger_index_and_wait};
+    use crate::support::{start_background_indexer_local, trigger_index_and_wait};
 
     let src_dir = tempfile::TempDir::new().expect("src tempdir");
     let dst_dir = tempfile::TempDir::new().expect("dst tempdir");
@@ -719,7 +718,7 @@ async fn flpack_preserves_default_context() {
 /// every write loops as retryable, leaving the ledger silently read-only.
 #[tokio::test]
 async fn flpack_restore_restamps_index_root_ledger_id() {
-    use support::{start_background_indexer_local, trigger_index_and_wait};
+    use crate::support::{start_background_indexer_local, trigger_index_and_wait};
 
     let src_dir = tempfile::TempDir::new().expect("src tempdir");
     let dst_dir = tempfile::TempDir::new().expect("dst tempdir");

--- a/fluree-db-api/tests/it_fuel_floor.rs
+++ b/fluree-db-api/tests/it_fuel_floor.rs
@@ -6,8 +6,7 @@
 //! reports at least the floor, a parse error still reports it, and a `max-fuel`
 //! below the floor is rejected up front.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_graph_commit.rs
+++ b/fluree-db-api/tests/it_graph_commit.rs
@@ -1,8 +1,10 @@
 #![cfg(feature = "native")]
 
 use std::sync::Arc;
-mod support;
 
+use crate::support::{
+    genesis_ledger, start_background_indexer_local, trigger_index_and_wait, MemoryFluree,
+};
 use fluree_db_api::{ApiError, FlureeBuilder};
 use fluree_db_core::{
     range_with_overlay, ContentId, Flake, FlakeValue, IndexType, RangeMatch, RangeOptions,
@@ -12,9 +14,6 @@ use fluree_db_ledger::LedgerState;
 use fluree_db_novelty::Novelty;
 use fluree_vocab::namespaces::{FLUREE_COMMIT, FLUREE_DB};
 use serde_json::json;
-use support::{
-    genesis_ledger, start_background_indexer_local, trigger_index_and_wait, MemoryFluree,
-};
 
 async fn seed_two_commits(
     fluree: &MemoryFluree,

--- a/fluree-db-api/tests/it_graph_source_bm25.rs
+++ b/fluree-db-api/tests/it_graph_source_bm25.rs
@@ -1,5 +1,4 @@
-mod support;
-
+use crate::support;
 use fluree_db_api::{Bm25CreateConfig, FlureeBuilder, FlureeIndexProvider};
 use fluree_db_nameservice::STORAGE_SEGMENT_GRAPH_SOURCES;
 use fluree_db_query::bm25::{Analyzer, Bm25IndexProvider, Bm25Scorer};

--- a/fluree-db-api/tests/it_historical_uses_index.rs
+++ b/fluree-db-api/tests/it_historical_uses_index.rs
@@ -19,8 +19,6 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
 use fluree_db_api::{FlureeBuilder, FormatterConfig, ReindexOptions};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_host_plus_n_e2e.rs
+++ b/fluree-db-api/tests/it_host_plus_n_e2e.rs
@@ -10,7 +10,7 @@
 //! for high-cardinality namespace datasets.
 //!
 //! Run with:
-//!   cargo test -p fluree-db-api --test it_host_plus_n_e2e --features native
+//!   cargo test -p fluree-db-api --test grp_misc it_host_plus_n_e2e --features native
 
 #![cfg(feature = "native")]
 

--- a/fluree-db-api/tests/it_host_plus_n_e2e.rs
+++ b/fluree-db-api/tests/it_host_plus_n_e2e.rs
@@ -14,14 +14,13 @@
 
 #![cfg(feature = "native")]
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
+use crate::support::{start_background_indexer_local, trigger_index_and_wait_outcome};
 use fluree_db_api::{FlureeBuilder, IndexConfig};
 use fluree_db_core::NsSplitMode;
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::{start_background_indexer_local, trigger_index_and_wait_outcome};
+use std::sync::Arc;
 
 /// Insert data under HostPlusN(1), index, rebuild from disk, and query.
 ///

--- a/fluree-db-api/tests/it_import.rs
+++ b/fluree-db-api/tests/it_import.rs
@@ -5,8 +5,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use fluree_db_core::{LedgerSnapshot, Sid};
 use serde_json::json;

--- a/fluree-db-api/tests/it_import_class_stats.rs
+++ b/fluree-db-api/tests/it_import_class_stats.rs
@@ -15,8 +15,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use fluree_db_core::{
     range_with_overlay, FlakeValue, IndexType, RangeMatch, RangeOptions, RangeTest, Sid,

--- a/fluree-db-api/tests/it_import_ndjson.rs
+++ b/fluree-db-api/tests/it_import_ndjson.rs
@@ -6,8 +6,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 use std::io::Write;

--- a/fluree-db-api/tests/it_import_ns_split_mode.rs
+++ b/fluree-db-api/tests/it_import_ns_split_mode.rs
@@ -9,8 +9,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use std::io::Write;
 
 use fluree_db_api::{Fluree, FlureeBuilder, ReindexOptions};

--- a/fluree-db-api/tests/it_import_remote.rs
+++ b/fluree-db-api/tests/it_import_remote.rs
@@ -7,8 +7,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, RemoteObject, RemoteSource};
 use fluree_db_core::{MemoryStorage, StorageRead, StorageWrite};
 use serde_json::json;

--- a/fluree-db-api/tests/it_import_v3.rs
+++ b/fluree-db-api/tests/it_import_v3.rs
@@ -6,8 +6,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 use std::io::Write;

--- a/fluree-db-api/tests/it_indexing_fuel.rs
+++ b/fluree-db-api/tests/it_indexing_fuel.rs
@@ -8,8 +8,6 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
 use fluree_db_api::{Fluree, FlureeBuilder, LedgerState, Novelty};
 use fluree_db_core::tracking::{Tracker, TrackingOptions};
 use fluree_db_core::LedgerSnapshot;
@@ -156,10 +154,10 @@ async fn build_index_for_record_already_current_reports_zero_fuel() {
 
 #[tokio::test]
 async fn trigger_index_reports_positive_fuel() {
+    use crate::support::start_background_indexer_local;
     use fluree_db_api::tx::IndexingMode;
     use fluree_db_api::TriggerIndexOptions;
     use std::sync::Arc;
-    use support::start_background_indexer_local;
 
     let mut fluree = FlureeBuilder::memory().build_memory();
     let (local, indexer_handle) = start_background_indexer_local(

--- a/fluree-db-api/tests/it_indexing_stats.rs
+++ b/fluree-db-api/tests/it_indexing_stats.rs
@@ -9,8 +9,10 @@
 #![cfg(feature = "native")]
 
 use std::sync::Arc;
-mod support;
 
+use crate::support::{
+    genesis_ledger_for_fluree, start_background_indexer_local, trigger_index_and_wait_outcome,
+};
 use fluree_db_api::{FlureeBuilder, IndexConfig, LedgerState};
 use fluree_db_binary_index::BinaryIndexStore;
 use fluree_db_core::{
@@ -19,9 +21,6 @@ use fluree_db_core::{
 use fluree_db_query::BinaryRangeProvider;
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::{json, Value as JsonValue};
-use support::{
-    genesis_ledger_for_fluree, start_background_indexer_local, trigger_index_and_wait_outcome,
-};
 
 /// Apply a binary index root to a ledger, loading the full BinaryIndexStore
 /// and attaching a BinaryRangeProvider so subsequent queries work correctly.

--- a/fluree-db-api/tests/it_indexing_wait.rs
+++ b/fluree-db-api/tests/it_indexing_wait.rs
@@ -14,13 +14,12 @@
 #![cfg(feature = "native")]
 
 use std::sync::Arc;
-mod support;
 
+use crate::support::start_background_indexer_local;
 use fluree_db_api::{FlureeBuilder, IndexConfig};
 use fluree_db_core::{load_ledger_snapshot, LedgerSnapshot};
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::start_background_indexer_local;
 use tokio::time::{sleep, Duration};
 
 #[tokio::test]

--- a/fluree-db-api/tests/it_indexing_workflow.rs
+++ b/fluree-db-api/tests/it_indexing_workflow.rs
@@ -3,9 +3,8 @@
 
 #![cfg(feature = "native")]
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
+use crate::support::{assert_index_defaults, normalize_rows, start_background_indexer_local};
 use fluree_db_api::{
     Fluree, FlureeBuilder, IndexConfig, IndexingMode, LedgerState, Novelty, ReindexOptions,
     TriggerIndexOptions,
@@ -13,7 +12,7 @@ use fluree_db_api::{
 use fluree_db_core::LedgerSnapshot;
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::{assert_index_defaults, normalize_rows, start_background_indexer_local};
+use std::sync::Arc;
 
 #[tokio::test]
 async fn indexing_disabled_transaction_exposes_indexing_status_hints() {

--- a/fluree-db-api/tests/it_join_batched_overlay.rs
+++ b/fluree-db-api/tests/it_join_batched_overlay.rs
@@ -18,11 +18,9 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::{genesis_ledger_for_fluree, normalize_rows, span_capture};
 use fluree_db_api::{FlureeBuilder, QueryInput, ReindexOptions};
 use serde_json::json;
-use support::{genesis_ledger_for_fluree, normalize_rows, span_capture};
 
 fn ctx() -> serde_json::Value {
     json!({"ex": "http://example.org/ns/"})

--- a/fluree-db-api/tests/it_ledger_info_named_graphs.rs
+++ b/fluree-db-api/tests/it_ledger_info_named_graphs.rs
@@ -15,11 +15,10 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
+use crate::support::genesis_ledger;
 use fluree_db_api::FlureeBuilder;
 use serde_json::Value as JsonValue;
-use support::genesis_ledger;
 
 const ALPHA_IRI: &str = "http://example.org/graphs/alpha";
 const BETA_IRI: &str = "http://example.org/graphs/beta";

--- a/fluree-db-api/tests/it_ledger_info_reindex_cache.rs
+++ b/fluree-db-api/tests/it_ledger_info_reindex_cache.rs
@@ -5,13 +5,11 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::genesis_ledger_for_fluree;
 use fluree_db_api::{FlureeBuilder, ReindexOptions};
 use fluree_db_indexer::IndexerConfig;
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::genesis_ledger_for_fluree;
 
 #[tokio::test]
 async fn ledger_info_cache_busts_on_reindex_allow_equal() {

--- a/fluree-db-api/tests/it_ledger_info_reindex_size.rs
+++ b/fluree-db-api/tests/it_ledger_info_reindex_size.rs
@@ -5,12 +5,10 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::genesis_ledger_for_fluree;
 use fluree_db_api::{FlureeBuilder, ReindexOptions};
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::genesis_ledger_for_fluree;
 
 #[tokio::test]
 async fn ledger_info_size_is_not_reset_to_zero_by_reindex() {

--- a/fluree-db-api/tests/it_ledger_lifecycle.rs
+++ b/fluree-db-api/tests/it_ledger_lifecycle.rs
@@ -5,8 +5,7 @@
 //!
 //! Merged from: it_api_create.rs, it_db.rs
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_merge.rs
+++ b/fluree-db-api/tests/it_merge.rs
@@ -4,8 +4,7 @@
 //! (diverged target, missing source, self-merge), and post-merge
 //! verification of data, nameservice state, and continued branch use.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{ConflictStrategy, FlureeBuilder};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_merge_preview.rs
+++ b/fluree-db-api/tests/it_merge_preview.rs
@@ -1,8 +1,7 @@
 //! Integration tests for `Fluree::merge_preview` — the read-only branch
 //! diff. Mirrors the structure of `it_merge.rs`.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{ConflictStrategy, FlureeBuilder, MergePreviewOpts};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_minmax_fast_path_fired.rs
+++ b/fluree-db-api/tests/it_minmax_fast_path_fired.rs
@@ -7,8 +7,7 @@
 //! push parts of query execution onto threads the subscriber can't see.
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use std::io::Write;
 use tempfile::TempDir;

--- a/fluree-db-api/tests/it_minmax_string_fast_path.rs
+++ b/fluree-db-api/tests/it_minmax_string_fast_path.rs
@@ -11,8 +11,7 @@
 //! value-ordered results.
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use std::io::Write;
 use tempfile::TempDir;

--- a/fluree-db-api/tests/it_mixed_representation.rs
+++ b/fluree-db-api/tests/it_mixed_representation.rs
@@ -8,8 +8,7 @@
 //! (`object_binding::encoded_equivalent`) before keying.
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use std::io::Write;
 use tempfile::TempDir;

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -14,11 +14,9 @@
 //!
 //! See GitHub issue #1259.
 
-mod support;
-
+use crate::support::{genesis_ledger, MemoryFluree};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, MemoryFluree};
 
 /// Seed three federated ledgers with *divergent* entity vocabularies.
 ///

--- a/fluree-db-api/tests/it_multi_query.rs
+++ b/fluree-db-api/tests/it_multi_query.rs
@@ -19,15 +19,13 @@
 //! to confirm the public API is wired together correctly end to end
 //! for non-server consumers.
 
-mod support;
-
 use std::sync::Arc;
 
+use crate::support::{genesis_ledger, MemoryFluree, MemoryLedger};
 use fluree_db_api::query::multi::MultiQueryError;
 use fluree_db_api::query::multi::{MultiQueryBounds, MultiQueryRequest, MultiQueryStatus};
 use fluree_db_api::{FlureeBuilder, FormatterConfig};
 use serde_json::json;
-use support::{genesis_ledger, MemoryFluree, MemoryLedger};
 
 /// Seed two ledgers with a couple of named entities each so we can run
 /// envelopes that hit both.

--- a/fluree-db-api/tests/it_named_graph_isolation.rs
+++ b/fluree-db-api/tests/it_named_graph_isolation.rs
@@ -15,14 +15,13 @@
 #![cfg(feature = "native")]
 
 use std::sync::Arc;
-mod support;
 
+use crate::support::{genesis_ledger, start_background_indexer_local, trigger_index_and_wait};
 use fluree_db_api::{
     ExportCommitsRequest, FlureeBuilder, GovernanceOptions, IndexConfig, LedgerManagerConfig,
     PushCommitsRequest,
 };
 use serde_json::json;
-use support::{genesis_ledger, start_background_indexer_local, trigger_index_and_wait};
 
 /// Regression: rdf:type in graph A is invisible when querying graph B.
 ///

--- a/fluree-db-api/tests/it_named_graphs.rs
+++ b/fluree-db-api/tests/it_named_graphs.rs
@@ -12,11 +12,10 @@
 #![cfg(feature = "native")]
 
 use std::sync::Arc;
-mod support;
 
+use crate::support::{genesis_ledger, start_background_indexer_local, trigger_index_and_wait};
 use fluree_db_api::{FlureeBuilder, LedgerManagerConfig};
 use serde_json::json;
-use support::{genesis_ledger, start_background_indexer_local, trigger_index_and_wait};
 
 // =============================================================================
 // TriG named graph parsing tests

--- a/fluree-db-api/tests/it_nameservice_graph_source.rs
+++ b/fluree-db-api/tests/it_nameservice_graph_source.rs
@@ -1,5 +1,4 @@
-mod support;
-
+use crate::support;
 use fluree_db_api::{Bm25CreateConfig, Bm25DropResult, FlureeBuilder};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_nameservice_query.rs
+++ b/fluree-db-api/tests/it_nameservice_query.rs
@@ -1,12 +1,10 @@
 //! Nameservice query integration tests
 //!
 
-mod support;
-
+use crate::support::assert_index_defaults;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 use std::collections::HashSet;
-use support::assert_index_defaults;
 
 fn extract_first_string(v: &serde_json::Value) -> Option<String> {
     if let Some(s) = v.as_str() {

--- a/fluree-db-api/tests/it_namespace_new_after_index.rs
+++ b/fluree-db-api/tests/it_namespace_new_after_index.rs
@@ -9,7 +9,7 @@
 //! the binary scan path normalizes bound SIDs through the store's namespace table.
 //!
 //! Run with:
-//!   cargo test -p fluree-db-api --test it_namespace_new_after_index --features native
+//!   cargo test -p fluree-db-api --test grp_import it_namespace_new_after_index --features native
 
 #![cfg(feature = "native")]
 

--- a/fluree-db-api/tests/it_namespace_new_after_index.rs
+++ b/fluree-db-api/tests/it_namespace_new_after_index.rs
@@ -13,8 +13,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, ReindexOptions};
 use fluree_db_ledger::TypeErasedStore;
 use serde_json::json;

--- a/fluree-db-api/tests/it_notify_incremental.rs
+++ b/fluree-db-api/tests/it_notify_incremental.rs
@@ -5,16 +5,17 @@
 
 #![cfg(feature = "native")]
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
+use crate::support::{
+    genesis_ledger_for_fluree, start_background_indexer_local, trigger_index_and_wait,
+};
 use fluree_db_api::{
     ledger_manager::{LedgerManagerConfig, NotifyResult, NsNotify},
     FlureeBuilder, IndexConfig,
 };
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::{genesis_ledger_for_fluree, start_background_indexer_local, trigger_index_and_wait};
+use std::sync::Arc;
 
 /// Helper: transact one insert and return the committed ledger state.
 async fn insert_data(

--- a/fluree-db-api/tests/it_novelty_dictionary_decode.rs
+++ b/fluree-db-api/tests/it_novelty_dictionary_decode.rs
@@ -6,9 +6,8 @@
 
 #![cfg(feature = "native")]
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger_for_fluree, query_sparql, start_background_indexer_local};
 use fluree_db_api::{FlureeBuilder, IndexConfig};
 use fluree_db_core::FlakeValue;
 use fluree_db_query::{
@@ -16,7 +15,7 @@ use fluree_db_query::{
 };
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::{genesis_ledger_for_fluree, query_sparql, start_background_indexer_local};
+use std::sync::Arc;
 
 #[tokio::test]
 async fn novelty_only_strings_subjects_predicates_and_json_decode_with_existing_index() {

--- a/fluree-db-api/tests/it_ns_sync_conflict.rs
+++ b/fluree-db-api/tests/it_ns_sync_conflict.rs
@@ -8,7 +8,7 @@
 //!   - Reverse: same prefix, different code
 //!
 //! Run with:
-//!   cargo test -p fluree-db-api --test it_ns_sync_conflict --features native
+//!   cargo test -p fluree-db-api --test grp_import it_ns_sync_conflict --features native
 
 #![cfg(feature = "native")]
 

--- a/fluree-db-api/tests/it_ns_sync_conflict.rs
+++ b/fluree-db-api/tests/it_ns_sync_conflict.rs
@@ -12,13 +12,12 @@
 
 #![cfg(feature = "native")]
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
+use crate::support::start_background_indexer_local;
 use fluree_db_api::{FlureeBuilder, IndexConfig};
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::start_background_indexer_local;
+use std::sync::Arc;
 
 /// Helper: create a ledger, insert data with a custom namespace, and index it.
 /// Returns the Fluree instance, the ledger ID, and the temp dir (kept alive).

--- a/fluree-db-api/tests/it_ontology_inline.rs
+++ b/fluree-db-api/tests/it_ontology_inline.rs
@@ -8,11 +8,9 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::{genesis_ledger, normalize_rows};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows};
 
 #[tokio::test]
 async fn inline_ontology_subclass_drives_rdfs_reasoning() {

--- a/fluree-db-api/tests/it_pack_validation.rs
+++ b/fluree-db-api/tests/it_pack_validation.rs
@@ -1,7 +1,7 @@
 //! Validation tests for `stream_pack` — guard against silent empty packs.
 //!
 //! Run with:
-//!   cargo test -p fluree-db-api --test it_pack_validation --features native
+//!   cargo test -p fluree-db-api --test grp_import it_pack_validation --features native
 
 #![cfg(feature = "native")]
 

--- a/fluree-db-api/tests/it_policy_allow.rs
+++ b/fluree-db-api/tests/it_policy_allow.rs
@@ -2,11 +2,10 @@
 //!
 //! Tests f:allow true/false, precedence over f:query, and targeting modes.
 
-mod support;
-
+use crate::support;
+use crate::support::{assert_index_defaults, genesis_ledger, normalize_rows};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{assert_index_defaults, genesis_ledger, normalize_rows};
 
 /// Helper to seed test data with users having sensitive SSN property.
 async fn seed_user_data(fluree: &support::MemoryFluree, ledger_id: &str) {

--- a/fluree-db-api/tests/it_policy_class.rs
+++ b/fluree-db-api/tests/it_policy_class.rs
@@ -5,13 +5,12 @@
 //! Tests policy class lookup where policies are stored in the database
 //! and loaded via f:policyClass references.
 
-mod support;
-
+use crate::support;
+use crate::support::{assert_index_defaults, genesis_ledger};
 use fluree_db_api::policy_builder;
 use fluree_db_api::{FlureeBuilder, GovernanceOptions};
 use serde_json::json;
 use std::collections::HashMap;
-use support::{assert_index_defaults, genesis_ledger};
 
 /// Test: Policy class restricts SSN visibility to own user
 ///

--- a/fluree-db-api/tests/it_policy_cross_ledger.rs
+++ b/fluree-db-api/tests/it_policy_cross_ledger.rs
@@ -8,11 +8,9 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::genesis_ledger;
 use fluree_db_api::{FlureeBuilder, GovernanceOptions};
 use serde_json::json;
-use support::genesis_ledger;
 
 fn config_graph_iri(ledger_id: &str) -> String {
     format!("urn:fluree:{ledger_id}#config")

--- a/fluree-db-api/tests/it_policy_federation.rs
+++ b/fluree-db-api/tests/it_policy_federation.rs
@@ -6,8 +6,8 @@
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 
-mod support;
-use support::assert_index_defaults;
+use crate::support;
+use crate::support::assert_index_defaults;
 
 #[tokio::test]
 async fn policy_applies_in_multi_ledger_query_connection() {

--- a/fluree-db-api/tests/it_policy_fquery.rs
+++ b/fluree-db-api/tests/it_policy_fquery.rs
@@ -7,11 +7,9 @@
 //! 2. Supports FILTER expressions
 //! 3. Properly injects ?$this and ?$identity
 
-mod support;
-
+use crate::support::{assert_index_defaults, genesis_ledger, normalize_rows, MemoryFluree};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{assert_index_defaults, genesis_ledger, normalize_rows, MemoryFluree};
 
 /// Diagnostic test: verify basic policy mechanism works with f:allow: true
 #[tokio::test]

--- a/fluree-db-api/tests/it_policy_identity_based.rs
+++ b/fluree-db-api/tests/it_policy_identity_based.rs
@@ -2,11 +2,10 @@
 //!
 //! Tests identity-based access control and policy restrictions.
 
-mod support;
-
+use crate::support;
+use crate::support::{assert_index_defaults, genesis_ledger};
 use fluree_db_api::{wrap_identity_policy_view, FlureeBuilder};
 use serde_json::json;
-use support::{assert_index_defaults, genesis_ledger};
 
 /// Test inline policy with ?$identity binding.
 ///

--- a/fluree-db-api/tests/it_policy_indexed.rs
+++ b/fluree-db-api/tests/it_policy_indexed.rs
@@ -9,14 +9,13 @@
 
 #![cfg(feature = "native")]
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
+use crate::support::{start_background_indexer_local, trigger_index_and_wait_outcome};
 use fluree_db_api::policy_builder;
 use fluree_db_api::{FlureeBuilder, GovernanceOptions, IndexConfig};
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::{start_background_indexer_local, trigger_index_and_wait_outcome};
+use std::sync::Arc;
 
 /// Identity-based `f:policyClass` enforcement must survive binary indexing.
 ///

--- a/fluree-db-api/tests/it_policy_named_graphs.rs
+++ b/fluree-db-api/tests/it_policy_named_graphs.rs
@@ -8,9 +8,9 @@
 use fluree_db_api::{FlureeBuilder, LedgerManagerConfig};
 use serde_json::json;
 
+use crate::support;
+use crate::support::{assert_index_defaults, start_background_indexer_local};
 use std::sync::Arc;
-mod support;
-use support::{assert_index_defaults, start_background_indexer_local};
 
 #[tokio::test]
 async fn policy_applies_to_named_graph_queries() {

--- a/fluree-db-api/tests/it_policy_optional_hashjoin.rs
+++ b/fluree-db-api/tests/it_policy_optional_hashjoin.rs
@@ -10,11 +10,9 @@
 //! a forbidden optional-side row must not leak into the count, and a row whose
 //! only matches are all policy-hidden must collapse to the left-join zero.
 
-mod support;
-
+use crate::support::{assert_index_defaults, genesis_ledger, normalize_rows};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{assert_index_defaults, genesis_ledger, normalize_rows};
 
 fn ctx() -> JsonValue {
     json!({ "ex": "http://example.org/ns/" })

--- a/fluree-db-api/tests/it_policy_query_connection.rs
+++ b/fluree-db-api/tests/it_policy_query_connection.rs
@@ -4,11 +4,9 @@
 //! - identity-based policy loading via `f:policyClass` on the identity subject
 //! - view policy enforcement on direct selects and expansion formatting
 
-mod support;
-
+use crate::support::{assert_index_defaults, genesis_ledger, normalize_rows, seed_people_with_ssn};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{assert_index_defaults, genesis_ledger, normalize_rows, seed_people_with_ssn};
 
 #[tokio::test]
 async fn policy_inline_denies_restricted_property_in_direct_select() {

--- a/fluree-db-api/tests/it_policy_time_travel.rs
+++ b/fluree-db-api/tests/it_policy_time_travel.rs
@@ -3,11 +3,9 @@
 //! Ensures view policy enforcement works when `from` includes a `t` time spec
 //! (time-travel path in query-connection).
 
-mod support;
-
+use crate::support::{assert_index_defaults, genesis_ledger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{assert_index_defaults, genesis_ledger};
 
 #[tokio::test]
 async fn policy_applies_to_time_travel_queries() {

--- a/fluree-db-api/tests/it_policy_tracking.rs
+++ b/fluree-db-api/tests/it_policy_tracking.rs
@@ -2,8 +2,7 @@
 //!
 //! These tests focus on the *tracking* surfaces (policy stats + fuel).
 
-mod support;
-
+use crate::support::{assert_index_defaults, genesis_ledger};
 use fluree_db_api::policy_builder;
 use fluree_db_api::{
     CommitOpts, FlureeBuilder, GovernanceOptions, IndexConfig, TrackedTransactionInput, TxnOpts,
@@ -11,7 +10,6 @@ use fluree_db_api::{
 };
 use serde_json::json;
 use std::collections::HashMap;
-use support::{assert_index_defaults, genesis_ledger};
 
 #[tokio::test]
 async fn transact_policy_denied_includes_policy_and_fuel_tracking() {

--- a/fluree-db-api/tests/it_policy_tx.rs
+++ b/fluree-db-api/tests/it_policy_tx.rs
@@ -7,8 +7,8 @@
 //! - View-only policies blocking all modifications
 //! - Custom error messages via f:exMessage
 
-mod support;
-
+use crate::support;
+use crate::support::{assert_index_defaults, genesis_ledger};
 use fluree_db_api::policy_builder;
 use fluree_db_api::{
     CommitOpts, FlureeBuilder, GovernanceOptions, IndexConfig, TrackedTransactionInput, TxnOpts,
@@ -16,7 +16,6 @@ use fluree_db_api::{
 };
 use serde_json::json;
 use std::collections::HashMap;
-use support::{assert_index_defaults, genesis_ledger};
 
 /// Helper to seed test data with users.
 async fn seed_users(fluree: &support::MemoryFluree, ledger_id: &str) -> fluree_db_api::LedgerState {

--- a/fluree-db-api/tests/it_query_agent_json.rs
+++ b/fluree-db-api/tests/it_query_agent_json.rs
@@ -3,11 +3,9 @@
 //! Verifies envelope structure, schema extraction, byte-budget truncation,
 //! and resume query generation against real query results.
 
-mod support;
-
+use crate::support::{genesis_ledger, query_sparql, MemoryFluree, MemoryLedger};
 use fluree_db_api::{AgentJsonContext, FlureeBuilder, FormatterConfig};
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, query_sparql, MemoryFluree, MemoryLedger};
 
 fn ctx() -> JsonValue {
     json!({

--- a/fluree-db-api/tests/it_query_aggregates.rs
+++ b/fluree-db-api/tests/it_query_aggregates.rs
@@ -8,11 +8,12 @@
 //! - `(count *)` - count all rows in group
 //! - `(groupconcat ?x ", ")` - separator as second argument
 
-mod support;
-
+use crate::support;
+use crate::support::{
+    context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger,
+};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
 async fn seed_people(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
     let ledger0 = genesis_ledger(fluree, ledger_id);

--- a/fluree-db-api/tests/it_query_ask.rs
+++ b/fluree-db-api/tests/it_query_ask.rs
@@ -4,11 +4,10 @@
 //! where clause. Returns a bare boolean indicating whether the patterns
 //! have any solution.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, MemoryFluree, MemoryLedger};
 
 fn ctx() -> JsonValue {
     json!({

--- a/fluree-db-api/tests/it_query_collect.rs
+++ b/fluree-db-api/tests/it_query_collect.rs
@@ -10,10 +10,8 @@
 //! below gives Alice two papers on the same subject so the join produces a
 //! duplicate row.
 
-mod support;
-
+use crate::support::{genesis_ledger, graphdb_from_ledger, MemoryFluree};
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, graphdb_from_ledger, MemoryFluree};
 
 fn ctx() -> JsonValue {
     json!({"ex": "http://example.org/", "xsd": "http://www.w3.org/2001/XMLSchema#"})

--- a/fluree-db-api/tests/it_query_connection.rs
+++ b/fluree-db-api/tests/it_query_connection.rs
@@ -4,14 +4,12 @@
 //! - `query_connection` with `"from"` (combined datasets)
 //! - `query_connection` with `"fromNamed"` + `["graph", ...]` patterns (separate named graphs)
 
-mod support;
-
-use fluree_db_api::FlureeBuilder;
-use serde_json::json;
-use support::{
+use crate::support::{
     assert_index_defaults, context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree,
     MemoryLedger,
 };
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
 
 fn ctx_schema() -> serde_json::Value {
     json!({

--- a/fluree-db-api/tests/it_query_construct.rs
+++ b/fluree-db-api/tests/it_query_construct.rs
@@ -1,8 +1,7 @@
 //! CONSTRUCT integration tests
 //!
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, LedgerState, Novelty};
 use fluree_db_core::LedgerSnapshot;
 use serde_json::{json, Map, Value as JsonValue};

--- a/fluree-db-api/tests/it_query_dataset.rs
+++ b/fluree-db-api/tests/it_query_dataset.rs
@@ -7,16 +7,15 @@
 //! - Variable GRAPH iteration over named graphs
 //! - Cross-graph joins
 
-mod support;
-
+use crate::support;
+use crate::support::{
+    assert_index_defaults, genesis_ledger, normalize_flat_results, normalize_rows, MemoryFluree,
+    MemoryLedger,
+};
 use fluree_db_api::TimeSpec;
 use fluree_db_api::{DataSetDb, DatasetSpec, FlureeBuilder, GraphDb, GraphSource, QueryInput};
 use fluree_db_core::load_commit_by_id;
 use serde_json::json;
-use support::{
-    assert_index_defaults, genesis_ledger, normalize_flat_results, normalize_rows, MemoryFluree,
-    MemoryLedger,
-};
 
 // =============================================================================
 // Helper functions

--- a/fluree-db-api/tests/it_query_datatype.rs
+++ b/fluree-db-api/tests/it_query_datatype.rs
@@ -8,11 +8,10 @@
 //! - Transaction @t bindings are supported.
 //! - Numeric datatype normalization (xsd:int family -> xsd:integer) is an intentional divergence.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 use fluree_db_api::{FlureeBuilder, QueryInput};
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
 fn ctx_datatype() -> JsonValue {
     json!({

--- a/fluree-db-api/tests/it_query_explain_native.rs
+++ b/fluree-db-api/tests/it_query_explain_native.rs
@@ -4,15 +4,14 @@
 #![cfg(feature = "native")]
 
 use std::sync::Arc;
-mod support;
 
+use crate::support::{graphdb_from_ledger, start_background_indexer_local};
 use fluree_db_api::{
     tx::IndexingMode, CommitOpts, FlureeBuilder, IndexConfig, LedgerState, Novelty,
 };
 use fluree_db_core::{load_ledger_snapshot, LedgerSnapshot};
 use fluree_db_transact::TxnOpts;
 use serde_json::json;
-use support::{graphdb_from_ledger, start_background_indexer_local};
 
 async fn index_and_load_db(
     fluree: &fluree_db_api::Fluree,

--- a/fluree-db-api/tests/it_query_fuel_bound_object.rs
+++ b/fluree-db-api/tests/it_query_fuel_bound_object.rs
@@ -21,11 +21,9 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::{assert_index_defaults, genesis_ledger, rebuild_and_publish_index};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{assert_index_defaults, genesis_ledger, rebuild_and_publish_index};
 
 const LEDGER_ID: &str = "fuel-bound-object:main";
 

--- a/fluree-db-api/tests/it_query_fulltext.rs
+++ b/fluree-db-api/tests/it_query_fulltext.rs
@@ -15,13 +15,12 @@
 
 #![cfg(feature = "native")]
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
+use crate::support::start_background_indexer_local;
 use fluree_db_api::{FlureeBuilder, LedgerState, Novelty};
 use fluree_db_core::LedgerSnapshot;
 use serde_json::{json, Value as JsonValue};
-use support::start_background_indexer_local;
+use std::sync::Arc;
 
 fn fulltext_context() -> JsonValue {
     json!({

--- a/fluree-db-api/tests/it_query_geo.rs
+++ b/fluree-db-api/tests/it_query_geo.rs
@@ -2,11 +2,10 @@
 //!
 //! Tests geo:wktLiteral POINT storage and geof:distance function.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, MemoryFluree, MemoryLedger};
 
 fn geo_context() -> JsonValue {
     json!({

--- a/fluree-db-api/tests/it_query_geo_search.rs
+++ b/fluree-db-api/tests/it_query_geo_search.rs
@@ -15,16 +15,15 @@
 
 #![cfg(feature = "native")]
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
+use crate::support::{start_background_indexer_local, trigger_index_and_wait_outcome};
 use fluree_db_api::{
     policy_builder, FlureeBuilder, GovernanceOptions, IndexConfig, LedgerState, Novelty,
 };
 use fluree_db_core::LedgerSnapshot;
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::{json, Value as JsonValue};
-use support::{start_background_indexer_local, trigger_index_and_wait_outcome};
+use std::sync::Arc;
 
 fn geo_search_context() -> JsonValue {
     json!({

--- a/fluree-db-api/tests/it_query_history_combinations.rs
+++ b/fluree-db-api/tests/it_query_history_combinations.rs
@@ -27,8 +27,6 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
 use fluree_db_api::{FlureeBuilder, FormatterConfig, ReindexOptions};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_query_history_range.rs
+++ b/fluree-db-api/tests/it_query_history_range.rs
@@ -23,8 +23,6 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
 use fluree_db_api::{FlureeBuilder, FormatterConfig, ReindexOptions};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_query_jsonld.rs
+++ b/fluree-db-api/tests/it_query_jsonld.rs
@@ -2,14 +2,13 @@
 //!
 //! Focus: query semantics (filters / optionals / union) using JSON inputs only.
 
-mod support;
-
-use fluree_db_api::FlureeBuilder;
-use serde_json::json;
-use support::{
+use crate::support;
+use crate::support::{
     context_ex_schema, genesis_ledger, normalize_rows, seed_people_filter_dataset, MemoryFluree,
     MemoryLedger,
 };
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
 
 async fn assert_query_bind_error(
     fluree: &MemoryFluree,

--- a/fluree-db-api/tests/it_query_jsonld_basic.rs
+++ b/fluree-db-api/tests/it_query_jsonld_basic.rs
@@ -1,11 +1,10 @@
 //! JSON-LD basic integration tests
 //!
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, MemoryFluree, MemoryLedger};
 
 fn ctx() -> JsonValue {
     // Keep this explicit and stable:

--- a/fluree-db-api/tests/it_query_jsonld_compound.rs
+++ b/fluree-db-api/tests/it_query_jsonld_compound.rs
@@ -1,11 +1,10 @@
 //! JSON-LD compound query integration tests
 //!
 
-mod support;
-
+use crate::support;
+use crate::support::{normalize_rows, seed_people_compound_dataset};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{normalize_rows, seed_people_compound_dataset};
 
 #[tokio::test]
 async fn compound_two_tuple_select_with_crawl_and_values() {

--- a/fluree-db-api/tests/it_query_list_functions.rs
+++ b/fluree-db-api/tests/it_query_list_functions.rs
@@ -3,10 +3,8 @@
 //! or `collect`. List-returning functions (`tail`, `reverse`) are composed with
 //! scalar accessors here so each assertion is a single value.
 
-mod support;
-
+use crate::support::{genesis_ledger, graphdb_from_ledger, MemoryFluree};
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, graphdb_from_ledger, MemoryFluree};
 
 fn ctx() -> JsonValue {
     json!({"ex": "http://example.org/", "xsd": "http://www.w3.org/2001/XMLSchema#"})

--- a/fluree-db-api/tests/it_query_misc.rs
+++ b/fluree-db-api/tests/it_query_misc.rs
@@ -2,14 +2,15 @@
 //!
 //! We prioritize query semantics; some scenarios are intentionally out of scope here.
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
+use crate::support::{
+    context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger,
+};
+#[cfg(feature = "native")]
+use crate::support::{start_background_indexer_local, trigger_index_and_wait};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
-#[cfg(feature = "native")]
-use support::{start_background_indexer_local, trigger_index_and_wait};
+use std::sync::Arc;
 
 async fn seed_three_people(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
     let ledger0 = genesis_ledger(fluree, ledger_id);

--- a/fluree-db-api/tests/it_query_negation.rs
+++ b/fluree-db-api/tests/it_query_negation.rs
@@ -2,11 +2,10 @@
 //!
 //! All inserts and queries are explicit with `@context`.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
 fn ctx_ex() -> serde_json::Value {
     // Match the minimal {"ex" "http://example.com/"} context and include xsd/schema for safety.

--- a/fluree-db-api/tests/it_query_optional_hashjoin.rs
+++ b/fluree-db-api/tests/it_query_optional_hashjoin.rs
@@ -16,11 +16,9 @@
 //! batched hash-join. The dataset includes a forum (`F3`) whose member has no
 //! qualifying post, validating the left-join no-match (count = 0) path.
 
-mod support;
-
+use crate::support::{genesis_ledger, graphdb_from_ledger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, graphdb_from_ledger};
 
 fn ctx() -> JsonValue {
     json!({

--- a/fluree-db-api/tests/it_query_owl2ql.rs
+++ b/fluree-db-api/tests/it_query_owl2ql.rs
@@ -5,11 +5,10 @@
 //! - `owl:equivalentProperty` expansion
 //! - explicit `"reasoning": "none"` disabling auto-RDFS
 
-mod support;
-
+use crate::support;
+use crate::support::genesis_ledger;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::genesis_ledger;
 
 #[tokio::test]
 async fn owl2ql_equivalent_property_expands_across_properties() {

--- a/fluree-db-api/tests/it_query_owl2rl.rs
+++ b/fluree-db-api/tests/it_query_owl2rl.rs
@@ -23,11 +23,10 @@
 //! - cls-uni: owl:unionOf
 //! - cls-oo: owl:oneOf
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows};
 
 // =============================================================================
 // Equality Tests (eq-sym, eq-trans)

--- a/fluree-db-api/tests/it_query_owl2rl_edge_cases.rs
+++ b/fluree-db-api/tests/it_query_owl2rl_edge_cases.rs
@@ -6,11 +6,10 @@
 //! - Negative tests (partial conditions shouldn't trigger inference)
 //!
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows};
 
 // =============================================================================
 // Restriction Edge Cases

--- a/fluree-db-api/tests/it_query_post_order_limit.rs
+++ b/fluree-db-api/tests/it_query_post_order_limit.rs
@@ -9,11 +9,9 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::{genesis_ledger_for_fluree, rebuild_and_publish_index};
 use fluree_db_api::{FlureeBuilder, LedgerManagerConfig, QueryInput};
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger_for_fluree, rebuild_and_publish_index};
 
 type MemoryFluree = fluree_db_api::Fluree;
 

--- a/fluree-db-api/tests/it_query_property.rs
+++ b/fluree-db-api/tests/it_query_property.rs
@@ -2,11 +2,10 @@
 //!
 //! We keep `@context` explicit and compare results order-insensitively when ordering is not defined.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
 async fn seed_subject_as_predicate(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
     let ledger0 = genesis_ledger(fluree, ledger_id);

--- a/fluree-db-api/tests/it_query_property_path.rs
+++ b/fluree-db-api/tests/it_query_property_path.rs
@@ -4,11 +4,10 @@
 //! and using them in WHERE node-maps. Both string form (SPARQL syntax) and
 //! array form (S-expression) are tested.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
 async fn seed_knows_chain(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
     let ledger0 = genesis_ledger(fluree, ledger_id);

--- a/fluree-db-api/tests/it_query_rdfs_class_repro.rs
+++ b/fluree-db-api/tests/it_query_rdfs_class_repro.rs
@@ -11,8 +11,7 @@
 //! `count_mixed_predicate_leaflet_regression` below.
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 use std::io::Write;

--- a/fluree-db-api/tests/it_query_reverse.rs
+++ b/fluree-db-api/tests/it_query_reverse.rs
@@ -3,11 +3,10 @@
 //! We focus first on reverse predicates **in WHERE** (query semantics).
 //! Graph crawl output using reverse selections and policy wrapping are included but ignored for now.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
 async fn seed_reverse_friends(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
     let ledger0 = genesis_ledger(fluree, ledger_id);

--- a/fluree-db-api/tests/it_query_seq_path_count_repro.rs
+++ b/fluree-db-api/tests/it_query_seq_path_count_repro.rs
@@ -35,18 +35,17 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use std::sync::Arc;
 
+use crate::support::{
+    genesis_ledger, genesis_ledger_for_fluree, start_background_indexer_local,
+    trigger_index_and_wait_outcome, MemoryFluree, MemoryLedger,
+};
 use fluree_db_api::{FlureeBuilder, GraphDb, IndexConfig, LedgerManagerConfig, QueryInput};
 use fluree_db_core::LedgerSnapshot;
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::{
-    genesis_ledger, genesis_ledger_for_fluree, start_background_indexer_local,
-    trigger_index_and_wait_outcome, MemoryFluree, MemoryLedger,
-};
 
 const PREFIX: &str = "PREFIX ex: <http://example.org/>";
 

--- a/fluree-db-api/tests/it_query_shortest_path.rs
+++ b/fluree-db-api/tests/it_query_shortest_path.rs
@@ -4,10 +4,8 @@
 //! Graph (ex:knows): a→b→d, a→c→d (two 2-hop paths), a→e→f→d (a 3-hop path).
 //! So the shortest a→d distance is 2 hops, reachable two ways.
 
-mod support;
-
+use crate::support::{genesis_ledger, graphdb_from_ledger, MemoryFluree};
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, graphdb_from_ledger, MemoryFluree};
 
 fn ctx() -> JsonValue {
     json!({"ex": "http://example.org/", "xsd": "http://www.w3.org/2001/XMLSchema#"})

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -2,15 +2,14 @@
 //!
 //! Covers query + update semantics (DELETE/INSERT/WHERE) using JSON-LD Update transactions.
 
-mod support;
-
-use fluree_db_api::FlureeBuilder;
-use serde_json::{json, Value as JsonValue};
-use std::sync::Arc;
-use support::{
+use crate::support;
+use crate::support::{
     assert_index_defaults, genesis_ledger, normalize_rows, normalize_sparql_bindings, MemoryFluree,
     MemoryLedger,
 };
+use fluree_db_api::FlureeBuilder;
+use serde_json::{json, Value as JsonValue};
+use std::sync::Arc;
 
 fn normalize_object_rows(value: &JsonValue) -> Vec<String> {
     let Some(array) = value.as_array() else {

--- a/fluree-db-api/tests/it_query_sparql_annotations.rs
+++ b/fluree-db-api/tests/it_query_sparql_annotations.rs
@@ -8,11 +8,10 @@
 //! surface" for the user-facing surface contract and the
 //! per-operation blank-node / variable rules.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, MemoryFluree, MemoryLedger};
 
 fn ctx() -> JsonValue {
     json!({

--- a/fluree-db-api/tests/it_query_subclass.rs
+++ b/fluree-db-api/tests/it_query_subclass.rs
@@ -4,11 +4,10 @@
 //! during `@type` matching. Reasoning is opt-in, so each expanding query sets
 //! `"reasoning": "rdfs"` explicitly; one test pins the plain-semantics default.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 use tempfile::TempDir;
 
 async fn seed_schema_creative_work(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {

--- a/fluree-db-api/tests/it_query_subquery.rs
+++ b/fluree-db-api/tests/it_query_subquery.rs
@@ -2,11 +2,12 @@
 //!
 //! All inserts and queries are explicit with `@context`.
 
-mod support;
-
+use crate::support;
+use crate::support::{
+    context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger,
+};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
 async fn seed_people(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
     let ledger0 = genesis_ledger(fluree, ledger_id);

--- a/fluree-db-api/tests/it_query_time_travel.rs
+++ b/fluree-db-api/tests/it_query_time_travel.rs
@@ -5,12 +5,12 @@
 //! - Error cases for invalid formats and missing values
 //! - Branch interaction (`ledger:main@t:<t>`)
 
-mod support;
-
+use crate::support::{
+    assert_index_defaults, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger,
+};
 use chrono::{DateTime, Duration, FixedOffset, SecondsFormat, TimeZone, Utc};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{assert_index_defaults, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 use tokio::time::sleep;
 
 fn ctx_test() -> JsonValue {

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -17,11 +17,10 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
+use crate::support::{assert_index_defaults, genesis_ledger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{assert_index_defaults, genesis_ledger};
 
 const LEDGER_ID: &str = "tt-bgp:main";
 

--- a/fluree-db-api/tests/it_query_typed_json.rs
+++ b/fluree-db-api/tests/it_query_typed_json.rs
@@ -4,13 +4,11 @@
 //! explicit `@type` annotations in expansion results, and that `normalize_arrays`
 //! forces array wrapping for single-valued properties.
 
-mod support;
-
-use fluree_db_api::{FlureeBuilder, FormatterConfig};
-use serde_json::{json, Value as JsonValue};
-use support::{
+use crate::support::{
     genesis_ledger, query_jsonld_format, query_jsonld_formatted, MemoryFluree, MemoryLedger,
 };
+use fluree_db_api::{FlureeBuilder, FormatterConfig};
+use serde_json::{json, Value as JsonValue};
 
 fn ctx() -> JsonValue {
     json!({

--- a/fluree-db-api/tests/it_query_unwind.rs
+++ b/fluree-db-api/tests/it_query_unwind.rs
@@ -6,10 +6,8 @@
 //! patterns (stored data only) cannot do. The canonical case is a dense /
 //! gap-filled series: generate the axis with `range`, LEFT JOIN the data.
 
-mod support;
-
+use crate::support::{genesis_ledger, graphdb_from_ledger, MemoryFluree};
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, graphdb_from_ledger, MemoryFluree};
 
 fn ctx() -> JsonValue {
     json!({"ex": "http://example.org/", "xsd": "http://www.w3.org/2001/XMLSchema#"})

--- a/fluree-db-api/tests/it_query_values.rs
+++ b/fluree-db-api/tests/it_query_values.rs
@@ -6,11 +6,12 @@
 //! - Federated query behavior (`query-connection` + `:from`) is covered.
 //! - VALUES inside multi-pattern OPTIONAL is supported.
 
-mod support;
-
+use crate::support;
+use crate::support::{
+    context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger,
+};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{context_ex_schema, genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
 
 async fn seed_values_dataset(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
     let ledger0 = genesis_ledger(fluree, ledger_id);

--- a/fluree-db-api/tests/it_query_vocab_id_compaction.rs
+++ b/fluree-db-api/tests/it_query_vocab_id_compaction.rs
@@ -9,11 +9,10 @@
 //! (e.g. `"summer"` for `http://example.org/lists/summer`), which a compliant
 //! JSON-LD processor would re-resolve against `@base`, not `@vocab`.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, query_jsonld_formatted, MemoryFluree, MemoryLedger};
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, query_jsonld_formatted, MemoryFluree, MemoryLedger};
 
 /// Seed two subjects in distinct namespaces:
 /// - `http://example.org/lists/summer` (a List, will sit under the query `@vocab`)

--- a/fluree-db-api/tests/it_raw_txn_parallel_upload.rs
+++ b/fluree-db-api/tests/it_raw_txn_parallel_upload.rs
@@ -6,8 +6,6 @@
 //! writing the commit blob. On success, the commit record references the
 //! raw-txn ContentId and the bytes are retrievable from the content store.
 
-mod support;
-
 use fluree_db_api::{CommitOpts, FlureeBuilder, IndexConfig, LedgerState, Novelty};
 use fluree_db_core::{commit::codec::read_commit, ContentKind, LedgerSnapshot};
 use fluree_db_transact::{ir::TxnType, TxnOpts as IrTxnOpts};

--- a/fluree-db-api/tests/it_reasoning_budget.rs
+++ b/fluree-db-api/tests/it_reasoning_budget.rs
@@ -7,11 +7,9 @@
 //! and per query (`"reasoningBudget"`), and (b) loud — visible in the
 //! tracked response's `reasoning` block, not only in server logs.
 
-mod support;
-
+use crate::support::genesis_ledger;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::genesis_ledger;
 
 fn config_graph_iri(ledger_id: &str) -> String {
     format!("urn:fluree:{ledger_id}#config")

--- a/fluree-db-api/tests/it_reasoning_imports.rs
+++ b/fluree-db-api/tests/it_reasoning_imports.rs
@@ -10,11 +10,10 @@
 //! - Cycles in the import graph don't loop forever.
 //! - The schema-projection whitelist keeps instance data from leaking.
 
-mod support;
-
+use crate::support;
+use crate::support::genesis_ledger;
 use fluree_db_api::{ApiError, FlureeBuilder};
 use serde_json::json;
-use support::genesis_ledger;
 
 fn config_graph_iri(ledger_id: &str) -> String {
     format!("urn:fluree:{ledger_id}#config")

--- a/fluree-db-api/tests/it_reasoning_join_repro.rs
+++ b/fluree-db-api/tests/it_reasoning_join_repro.rs
@@ -4,11 +4,10 @@
 //! property pattern on the same subject, while it works with a literal-valued
 //! property and works when the type is asserted (base) rather than derived.
 
-mod support;
-
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, rebuild_and_publish_index};
 use fluree_db_api::{FlureeBuilder, QueryInput};
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows, rebuild_and_publish_index};
 
 /// Insert `data`, build+publish the binary index, then run `q` against the
 /// reloaded indexed view (binary store attached — the path that diverged from

--- a/fluree-db-api/tests/it_reasoning_reindex.rs
+++ b/fluree-db-api/tests/it_reasoning_reindex.rs
@@ -18,8 +18,7 @@
 //! syntax has a separate known flattening bug and would not exercise the
 //! same structure.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, ReindexOptions};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_rebase.rs
+++ b/fluree-db-api/tests/it_rebase.rs
@@ -3,8 +3,7 @@
 //! Tests the branch rebase lifecycle: fast-forward, clean replay,
 //! conflict detection with various resolution strategies, and edge cases.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{ConflictStrategy, FlureeBuilder};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_refresh.rs
+++ b/fluree-db-api/tests/it_refresh.rs
@@ -7,13 +7,12 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
+use crate::support::genesis_ledger_for_fluree;
 use fluree_db_api::ledger_manager::{NotifyResult, RefreshOpts, RefreshResult};
 use fluree_db_api::{ApiError, FlureeBuilder, IndexConfig};
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::genesis_ledger_for_fluree;
 
 /// Helper: transact one insert and return the committed ledger state.
 async fn insert_data(

--- a/fluree-db-api/tests/it_reindex_class_stats.rs
+++ b/fluree-db-api/tests/it_reindex_class_stats.rs
@@ -7,12 +7,10 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::genesis_ledger_for_fluree;
 use fluree_db_api::{FlureeBuilder, ReindexOptions};
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::genesis_ledger_for_fluree;
 
 #[tokio::test]
 async fn reindex_produces_correct_class_counts_and_property_usage() {

--- a/fluree-db-api/tests/it_reindex_pre_build_perf.rs
+++ b/fluree-db-api/tests/it_reindex_pre_build_perf.rs
@@ -43,8 +43,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-mod support;
-
+use crate::support;
 /// Atomic counters tracking every read through a [`CountingContentStore`].
 #[derive(Default)]
 struct FetchCounters {

--- a/fluree-db-api/tests/it_reindex_schema.rs
+++ b/fluree-db-api/tests/it_reindex_schema.rs
@@ -2,12 +2,10 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::genesis_ledger_for_fluree;
 use fluree_db_api::{FlureeBuilder, ReindexOptions};
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::genesis_ledger_for_fluree;
 
 #[tokio::test]
 async fn reindex_populates_index_schema_from_subclass_and_subproperty_ops() {

--- a/fluree-db-api/tests/it_revert.rs
+++ b/fluree-db-api/tests/it_revert.rs
@@ -5,8 +5,7 @@
 //! conflict-resolution strategies (`Abort`/`TakeSource`/`TakeBranch`), and
 //! validation errors (merge commits, unreachable commit IDs, unsupported strategies).
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{CommitRef, ConflictStrategy, FlureeBuilder};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_revert_preview.rs
+++ b/fluree-db-api/tests/it_revert_preview.rs
@@ -4,8 +4,7 @@
 //! detection, the `revertable` verdict for each strategy, the no-mutation
 //! guarantee, and the cap/include flags on `RevertPreviewOpts`.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{CommitRef, ConflictStrategy, FlureeBuilder, RevertPreviewOpts};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_rules_cross_ledger.rs
+++ b/fluree-db-api/tests/it_rules_cross_ledger.rs
@@ -11,11 +11,9 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::{genesis_ledger, normalize_rows};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows};
 
 fn config_iri(ledger_id: &str) -> String {
     format!("urn:fluree:{ledger_id}#config")

--- a/fluree-db-api/tests/it_rules_source.rs
+++ b/fluree-db-api/tests/it_rules_source.rs
@@ -8,11 +8,9 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::{genesis_ledger, normalize_rows};
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, normalize_rows};
 
 fn config_iri(ledger_id: &str) -> String {
     format!("urn:fluree:{ledger_id}#config")

--- a/fluree-db-api/tests/it_scaling_bench.rs
+++ b/fluree-db-api/tests/it_scaling_bench.rs
@@ -8,7 +8,7 @@
 //!
 //! Manual run (release-ish optimization matters for absolute numbers, but the
 //! SCALING ratio is the signal):
-//!   cargo test -p fluree-db-api --test it_scaling_bench --features native --release -- --ignored --nocapture
+//!   cargo test -p fluree-db-api --test grp_misc it_scaling_bench --features native --release -- --ignored --nocapture
 //!
 //! Interpreting output: look at QPS(C)/QPS(1). Linear-ish scaling => reads run
 //! concurrently. Flat after a few cores => a read-path serialization bottleneck.

--- a/fluree-db-api/tests/it_scaling_bench.rs
+++ b/fluree-db-api/tests/it_scaling_bench.rs
@@ -15,8 +15,6 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/fluree-db-api/tests/it_select_star_novelty.rs
+++ b/fluree-db-api/tests/it_select_star_novelty.rs
@@ -7,8 +7,6 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
 use fluree_db_api::{FlureeBuilder, FormatterConfig, ReindexOptions};
 use serde_json::{json, Value};
 

--- a/fluree-db-api/tests/it_select_star_novelty_retract.rs
+++ b/fluree-db-api/tests/it_select_star_novelty_retract.rs
@@ -11,8 +11,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, FormatterConfig, ReindexOptions};
 use serde_json::{json, Value};
 

--- a/fluree-db-api/tests/it_shapes_cross_ledger.rs
+++ b/fluree-db-api/tests/it_shapes_cross_ledger.rs
@@ -12,11 +12,9 @@
 
 #![cfg(all(feature = "native", feature = "shacl"))]
 
-mod support;
-
+use crate::support::genesis_ledger;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::genesis_ledger;
 
 fn config_graph_iri(ledger_id: &str) -> String {
     format!("urn:fluree:{ledger_id}#config")

--- a/fluree-db-api/tests/it_shapes_inline.rs
+++ b/fluree-db-api/tests/it_shapes_inline.rs
@@ -10,8 +10,7 @@ use fluree_db_api::{CommitOpts, FlureeBuilder, IndexConfig};
 use fluree_db_transact::ir::TxnOpts;
 use serde_json::json;
 
-mod support;
-use support::genesis_ledger;
+use crate::support::genesis_ledger;
 
 fn test_index_cfg() -> IndexConfig {
     IndexConfig {

--- a/fluree-db-api/tests/it_stable_hashes.rs
+++ b/fluree-db-api/tests/it_stable_hashes.rs
@@ -6,8 +6,7 @@
 //! commit IDs) is not currently testable because commit timestamps are generated
 //! internally via `Utc::now()`. See TODO in `fluree-db-transact/src/commit.rs`.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_storage_encrypted.rs
+++ b/fluree-db-api/tests/it_storage_encrypted.rs
@@ -3,8 +3,7 @@
 //! Tests that FlureeBuilder::build_memory_encrypted() works correctly
 //! with the full Fluree API.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use fluree_db_core::prelude::*; // For storage traits
 use serde_json::json;

--- a/fluree-db-api/tests/it_stream_query.rs
+++ b/fluree-db-api/tests/it_stream_query.rs
@@ -5,8 +5,7 @@
 //! asserts the NDJSON record protocol: a `head` record, one `row` per result
 //! row, and a single `end` terminator. Also covers eligibility rejection.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{
     FlureeBuilder, OwnedStreamQuery, QueryExecutionOptions, Tracker, TrackingOptions,
 };

--- a/fluree-db-api/tests/it_string_fold_fast_path.rs
+++ b/fluree-db-api/tests/it_string_fold_fast_path.rs
@@ -7,8 +7,7 @@
 //! strings (STRLEN counts codepoints, not bytes).
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use std::io::Write;
 use tempfile::TempDir;

--- a/fluree-db-api/tests/it_time_travel_indexing.rs
+++ b/fluree-db-api/tests/it_time_travel_indexing.rs
@@ -11,16 +11,15 @@
 #![cfg(feature = "native")]
 
 use std::sync::Arc;
-mod support;
 
+use crate::support::{
+    assert_index_defaults, genesis_ledger_for_fluree, start_background_indexer_local,
+    trigger_index_and_wait_outcome,
+};
 use fluree_db_api::{FlureeBuilder, IndexConfig, LedgerManagerConfig, LedgerState, Novelty};
 use fluree_db_core::LedgerSnapshot;
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
-use support::{
-    assert_index_defaults, genesis_ledger_for_fluree, start_background_indexer_local,
-    trigger_index_and_wait_outcome,
-};
 
 type MemoryFluree = fluree_db_api::Fluree;
 type MemoryLedger = LedgerState;

--- a/fluree-db-api/tests/it_tracing_spans.rs
+++ b/fluree-db-api/tests/it_tracing_spans.rs
@@ -9,11 +9,10 @@
 //! All tests use `current_thread` tokio flavor to ensure the thread-local
 //! `set_default()` subscriber captures spans from all async work.
 
-mod support;
-
+use crate::support;
+use crate::support::span_capture;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::span_capture;
 
 /// Seed a small dataset and return the ledger state.
 async fn seed_people(fluree: &support::MemoryFluree, ledger_id: &str) -> support::MemoryLedger {

--- a/fluree-db-api/tests/it_transact.rs
+++ b/fluree-db-api/tests/it_transact.rs
@@ -2,11 +2,10 @@
 //!
 //! Tests core transaction functionality including validation, data types, and API behavior.
 
-mod support;
-
+use crate::support;
+use crate::support::normalize_rows;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::normalize_rows;
 
 // Helper function to create a standard context
 fn default_context() -> serde_json::Value {

--- a/fluree-db-api/tests/it_transact_conditional.rs
+++ b/fluree-db-api/tests/it_transact_conditional.rs
@@ -11,8 +11,7 @@
 //! - Cascading / dependent updates (graph traversal)
 //! - Batch conditional updates (multi-entity)
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, LedgerState, Novelty};
 use fluree_db_core::LedgerSnapshot;
 use serde_json::{json, Value as JsonValue};

--- a/fluree-db-api/tests/it_transact_datatype_cancellation.rs
+++ b/fluree-db-api/tests/it_transact_datatype_cancellation.rs
@@ -37,8 +37,7 @@
 //! Legacy datasets require an audit + manual re-insertion of affected
 //! flakes; see `docs/operations/` for the recovery runbook.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use fluree_db_core::{load_commit_by_id, FlakeValue};
 use serde_json::json;

--- a/fluree-db-api/tests/it_transact_growth_slope.rs
+++ b/fluree-db-api/tests/it_transact_growth_slope.rs
@@ -18,7 +18,7 @@
 //! so this test PRINTS it rather than hard-asserting a hardware-specific bound.
 //!
 //! Manual run (release matters for absolute numbers; the slope is the signal):
-//!   cargo test -p fluree-db-api --test it_transact_growth_slope --features native \
+//!   cargo test -p fluree-db-api --test grp_transact it_transact_growth_slope --features native \
 //!     --release -- --ignored --nocapture
 //!
 //! Knobs: GROWTH_TEST_COMMITS (default 3000), GROWTH_TEST_NPC (default 10),

--- a/fluree-db-api/tests/it_transact_list_container.rs
+++ b/fluree-db-api/tests/it_transact_list_container.rs
@@ -2,8 +2,7 @@
 //!
 //! Tests RDF @list container serialization and persistence.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 use tempfile::TempDir;

--- a/fluree-db-api/tests/it_transact_list_retract.rs
+++ b/fluree-db-api/tests/it_transact_list_retract.rs
@@ -38,8 +38,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
 

--- a/fluree-db-api/tests/it_transact_object_var.rs
+++ b/fluree-db-api/tests/it_transact_object_var.rs
@@ -5,8 +5,7 @@
 //! Note: Internal parsing tests are marked as ignored since they test transaction parser
 //! internals that may not be exposed in the public Rust API.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, TxnOpts};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_transact_pure_delete_dedup.rs
+++ b/fluree-db-api/tests/it_transact_pure_delete_dedup.rs
@@ -20,8 +20,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, ReindexOptions};
 use serde_json::{json, Value as JsonValue};
 

--- a/fluree-db-api/tests/it_transact_update.rs
+++ b/fluree-db-api/tests/it_transact_update.rs
@@ -2,13 +2,12 @@
 //!
 //! Note: The `transaction-functions` section (hash/datetime) is covered with bind support.
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, IndexConfig, LedgerState, Novelty};
 use fluree_db_core::{load_commit_by_id, FlakeValue, LedgerSnapshot};
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::{json, Value as JsonValue};
+use std::sync::Arc;
 
 fn ctx_ex_schema() -> JsonValue {
     json!({
@@ -1899,7 +1898,7 @@ async fn update_values_wildcard_delete_across_two_transactions() {
 #[cfg(feature = "native")]
 #[tokio::test]
 async fn update_values_wildcard_delete_index_plus_novelty() {
-    use support::{start_background_indexer_local, trigger_index_and_wait};
+    use crate::support::{start_background_indexer_local, trigger_index_and_wait};
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/transact-update:wildcard-delete-indexed";
@@ -2030,7 +2029,7 @@ async fn update_values_wildcard_delete_index_plus_novelty() {
 #[cfg(feature = "native")]
 #[tokio::test]
 async fn update_wildcard_delete_duplicate_facts_across_index_and_novelty() {
-    use support::{start_background_indexer_local, trigger_index_and_wait};
+    use crate::support::{start_background_indexer_local, trigger_index_and_wait};
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/transact-update:wildcard-delete-dup-index-novelty";
@@ -2160,7 +2159,7 @@ async fn update_wildcard_delete_duplicate_facts_across_index_and_novelty() {
 #[cfg(feature = "native")]
 #[tokio::test]
 async fn update_values_wildcard_delete_after_updates_and_indexing() {
-    use support::{start_background_indexer_local, trigger_index_and_wait};
+    use crate::support::{start_background_indexer_local, trigger_index_and_wait};
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/transact-update:wildcard-delete-updates-indexed";

--- a/fluree-db-api/tests/it_transact_upsert.rs
+++ b/fluree-db-api/tests/it_transact_upsert.rs
@@ -2,13 +2,12 @@
 //!
 //! Tests upsert functionality where existing data gets replaced rather than merged.
 
-mod support;
-
+use crate::support;
+use crate::support::normalize_rows;
 use fluree_db_api::FlureeBuilder;
 use fluree_db_core::comparator::IndexType;
 use fluree_db_core::{load_commit_by_id, FlakeValue};
 use serde_json::json;
-use support::normalize_rows;
 
 // Helper function to create a standard context
 fn ctx() -> serde_json::Value {

--- a/fluree-db-api/tests/it_trigger_index_incremental.rs
+++ b/fluree-db-api/tests/it_trigger_index_incremental.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use async_trait::async_trait;
 use fluree_db_api::tx::IndexingMode;
 use fluree_db_api::{Fluree, IndexerConfig, NameServiceMode, TriggerIndexOptions};

--- a/fluree-db-api/tests/it_tutorial_end_to_end.rs
+++ b/fluree-db-api/tests/it_tutorial_end_to_end.rs
@@ -6,8 +6,7 @@
 //! Covers: insert (JSON-LD + Turtle), SPARQL queries, JSON-LD queries,
 //! fulltext search, time travel, branching, merge, and update transactions.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{ConflictStrategy, FlureeBuilder};
 use serde_json::{json, Value as JsonValue};
 

--- a/fluree-db-api/tests/it_txn_meta.rs
+++ b/fluree-db-api/tests/it_txn_meta.rs
@@ -7,12 +7,10 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::{genesis_ledger, start_background_indexer_local, trigger_index_and_wait};
 use fluree_db_api::{FlureeBuilder, IndexConfig, LedgerManagerConfig};
 use serde_json::json;
 use std::sync::Arc;
-use support::{genesis_ledger, start_background_indexer_local, trigger_index_and_wait};
 
 /// Extract an i64 from a JSON value, handling both bare numbers and typed literals
 /// like `{"@value": 42, "@type": "xsd:long"}`.

--- a/fluree-db-api/tests/it_update_wildcard_delete_indexed.rs
+++ b/fluree-db-api/tests/it_update_wildcard_delete_indexed.rs
@@ -7,8 +7,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, ReindexOptions};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_upsert_duplicate_ids_repro.rs
+++ b/fluree-db-api/tests/it_upsert_duplicate_ids_repro.rs
@@ -5,8 +5,9 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support::{
+    query_sparql, start_background_indexer_local, trigger_index_and_wait_outcome,
+};
 use fluree_db_api::{FlureeBuilder, IndexConfig};
 use fluree_db_binary_index::BinaryIndexStore;
 use fluree_db_core::Sid;
@@ -14,7 +15,6 @@ use fluree_db_query::binding::Binding;
 use fluree_db_transact::{CommitOpts, TxnOpts};
 use serde_json::json;
 use std::sync::Arc;
-use support::{query_sparql, start_background_indexer_local, trigger_index_and_wait_outcome};
 
 fn sid_to_iri(sid: &Sid, codes: &std::collections::HashMap<u16, String>) -> String {
     if sid.namespace_code == fluree_vocab::namespaces::OVERFLOW {

--- a/fluree-db-api/tests/it_values_type_deleted_repro.rs
+++ b/fluree-db-api/tests/it_values_type_deleted_repro.rs
@@ -7,8 +7,7 @@
 
 #![cfg(feature = "native")]
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, LedgerState, ReindexOptions};
 use serde_json::json;
 

--- a/fluree-db-api/tests/it_vector_corruption_repro.rs
+++ b/fluree-db-api/tests/it_vector_corruption_repro.rs
@@ -31,8 +31,7 @@
 //!   of base-asserted vectors find their handle via the pre-populated
 //!   fact map.
 
-mod support;
-
+use crate::support;
 use fluree_db_api::{FlureeBuilder, LedgerState};
 use fluree_db_transact::{NamespaceRegistry, Txn, TxnOpts};
 use serde_json::json;

--- a/fluree-db-api/tests/it_vector_flatrank.rs
+++ b/fluree-db-api/tests/it_vector_flatrank.rs
@@ -9,11 +9,10 @@
 //! The `vector_search_post_indexing_*` tests exercise the binary index path:
 //! transact → index build → query from arena (not novelty).
 
-use std::sync::Arc;
-mod support;
-
+use crate::support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
+use std::sync::Arc;
 
 /// Integration test for basic vector search with dot product scoring
 #[tokio::test]
@@ -482,10 +481,10 @@ async fn vector_search_mixed_datatypes() {
 #[cfg(feature = "native")]
 #[tokio::test]
 async fn vector_search_post_indexing() {
+    use crate::support::start_background_indexer_local;
     use fluree_db_api::{IndexConfig, LedgerState, Novelty};
     use fluree_db_core::LedgerSnapshot;
     use fluree_db_transact::{CommitOpts, TxnOpts};
-    use support::start_background_indexer_local;
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/vector-post-index:main";
@@ -603,10 +602,10 @@ async fn vector_search_post_indexing() {
 #[cfg(feature = "native")]
 #[tokio::test]
 async fn vector_search_novelty_plus_indexed() {
+    use crate::support::start_background_indexer_local;
     use fluree_db_api::{IndexConfig, LedgerState, Novelty};
     use fluree_db_core::LedgerSnapshot;
     use fluree_db_transact::{CommitOpts, TxnOpts};
-    use support::start_background_indexer_local;
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/vector-novelty-plus-index:main";
@@ -790,10 +789,10 @@ async fn vector_at_type_shorthand() {
 #[cfg(feature = "native")]
 #[tokio::test]
 async fn vector_cosine_normalized_optimization() {
+    use crate::support::start_background_indexer_local;
     use fluree_db_api::{IndexConfig, LedgerState, Novelty};
     use fluree_db_core::LedgerSnapshot;
     use fluree_db_transact::{CommitOpts, TxnOpts};
-    use support::start_background_indexer_local;
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/vector-cosine-norm:main";

--- a/fluree-db-api/tests/it_vector_flatrank.rs
+++ b/fluree-db-api/tests/it_vector_flatrank.rs
@@ -9,7 +9,7 @@
 //! The `vector_search_post_indexing_*` tests exercise the binary index path:
 //! transact → index build → query from arena (not novelty).
 
-use crate::support;
+mod support;
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
 use std::sync::Arc;
@@ -481,10 +481,10 @@ async fn vector_search_mixed_datatypes() {
 #[cfg(feature = "native")]
 #[tokio::test]
 async fn vector_search_post_indexing() {
-    use crate::support::start_background_indexer_local;
     use fluree_db_api::{IndexConfig, LedgerState, Novelty};
     use fluree_db_core::LedgerSnapshot;
     use fluree_db_transact::{CommitOpts, TxnOpts};
+    use support::start_background_indexer_local;
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/vector-post-index:main";
@@ -602,10 +602,10 @@ async fn vector_search_post_indexing() {
 #[cfg(feature = "native")]
 #[tokio::test]
 async fn vector_search_novelty_plus_indexed() {
-    use crate::support::start_background_indexer_local;
     use fluree_db_api::{IndexConfig, LedgerState, Novelty};
     use fluree_db_core::LedgerSnapshot;
     use fluree_db_transact::{CommitOpts, TxnOpts};
+    use support::start_background_indexer_local;
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/vector-novelty-plus-index:main";
@@ -789,10 +789,10 @@ async fn vector_at_type_shorthand() {
 #[cfg(feature = "native")]
 #[tokio::test]
 async fn vector_cosine_normalized_optimization() {
-    use crate::support::start_background_indexer_local;
     use fluree_db_api::{IndexConfig, LedgerState, Novelty};
     use fluree_db_core::LedgerSnapshot;
     use fluree_db_transact::{CommitOpts, TxnOpts};
+    use support::start_background_indexer_local;
 
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/vector-cosine-norm:main";

--- a/fluree-db-api/tests/support/mod.rs
+++ b/fluree-db-api/tests/support/mod.rs
@@ -8,7 +8,7 @@
 //
 // Kept as a shared utility module across many integration tests. Individual
 // test crates intentionally do not use every helper.
-#![expect(dead_code)]
+#![allow(dead_code)]
 
 pub mod span_capture;
 

--- a/fluree-db-api/tests/support/mod.rs
+++ b/fluree-db-api/tests/support/mod.rs
@@ -2,12 +2,15 @@
 //!
 //! Provides type aliases, helpers, and utilities used by integration tests.
 
-// Many helpers are used by *some* integration test crates but not others.
-// Keep them centralized here and silence dead_code warnings in crates that
-// don't reference every helper.
+// Many helpers are used by *some* integration test groups but not others.
+// Keep them centralized here and silence dead_code warnings in group binaries
+// that don't reference every helper.
 //
-// Kept as a shared utility module across many integration tests. Individual
-// test crates intentionally do not use every helper.
+// `allow` (not the repo-preferred `expect`) is deliberate: this module is
+// compiled once into each `grp_*` test binary, and the subset of helpers used
+// differs per group. `#![expect(dead_code)]` would fire an "unfulfilled
+// expectation" warning in any group that happens to use *all* of them, so a
+// plain `allow` is the only annotation correct across every binary.
 #![allow(dead_code)]
 
 pub mod span_capture;


### PR DESCRIPTION
## Why

In `fluree-db-api`, every `tests/*.rs` is its own test **binary** that links the entire crate dependency graph. With ~160 integration files that meant ~160 full link steps per `cargo test`/`nextest` build — the dominant cost of building the suite — plus the shared `support` harness recompiled ~160× and ~27 GB of debug artifacts.

## What

Group the integration files into **12 domain binaries** (`query`, `query_sparql`, `query_reason`, `query_history`, `policy`, `import`, `index`, `transact`, `ledger`, `graphsource`, `reasoning`, `misc`) via `autotests = false` + explicit `[[test]]` targets. Each case file is included as a `#[path]` module and refers to the shared harness as `crate::support` (compiled **once per binary**). Files become modules, so item names never collide across files.

**Kept standalone** (their own `[[test]]` binary):
- Feature-gated suites — `credential`, `iceberg`, `aws-testcontainers`, `vector` (with `required-features`).
- Tests that mutate **process-global `FLUREE_*` env vars** — so they stay process-isolated under bare `cargo test`, exactly as before. (Under `nextest` every test is already its own process.)

**168 → 22 test binaries.**

## Results (local; CI gains more)

| Metric | Before (168) | After (22) |
|---|---|---|
| Clean test build (`--all-features --tests --no-run`, deps cached) | 68 s | **27 s (~2.5×)** |
| Debug build artifacts | ~27 GB | a few GB (~7–10× smaller) |

Local numbers **understate CI**: CI runners are 2-core and use the `bfd` linker, where per-binary *link* cost dominates — eliminating 146 link steps saves proportionally more, and the smaller artifacts shrink the rust-cache.

## Validation

- Full suite under `nextest`: **2368 passed, 0 failed** (12 skipped = Docker/LocalStack not present locally).
- Biggest group `grp_misc` under bare `cargo test` (one process): **233 passed, 0 failed** — no intra-process races.
- `cargo fmt --all --check` clean; **0 compiler warnings**.

## Adding a test

Create `tests/it_<name>.rs`, then add `#[path = "it_<name>.rs"] mod it_<name>;` to the appropriate `grp_*.rs`. No new `[[test]]` entry unless you start a new group. See `docs/contributing/tests.md`.

## Follow-ups (not in this PR)
- Optionally split `grp_misc` (32 files) / `grp_query` (21) further for finer edit-locality vs. link-count tradeoff.
- The same pattern could be applied to `fluree-db-server` (16 binaries).