### PR TITLE
fix: stabilize raft leader failover (election livelock, follower cache staleness, test race)

### DIFF
--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -1222,28 +1222,7 @@ pub fn spawn_local_cache_event_listener(
                         ..
                     },
                 ) => {
-                    match ledger_manager
-                        .notify(NsNotify {
-                            ledger_id: ledger_id.clone(),
-                            record: None,
-                        })
-                        .await
-                    {
-                        Ok(result) => {
-                            tracing::debug!(
-                                alias = %ledger_id,
-                                ?result,
-                                "local cache event listener reconciled ledger"
-                            );
-                        }
-                        Err(error) => {
-                            tracing::warn!(
-                                alias = %ledger_id,
-                                error = %error,
-                                "local cache event listener failed to reconcile ledger"
-                            );
-                        }
-                    }
+                    reconcile_cached_ledger(&ledger_manager, &ledger_id).await;
                 }
                 Ok(fluree_db_nameservice::NameServiceEvent::LedgerRetracted { ledger_id }) => {
                     ledger_manager.disconnect(&ledger_id).await;
@@ -1254,10 +1233,22 @@ pub fn spawn_local_cache_event_listener(
                 }
                 Ok(_) => {}
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    // The channel overflowed and dropped events. With
+                    // commit publishes on the bus this is the only
+                    // notice some ledger gets, so a bare log would leave
+                    // its cache stale until the next event happens to
+                    // land. Fall back to a catch-up sweep: re-reconcile
+                    // every currently-loaded ledger against the
+                    // nameservice head (a no-op for any already current).
+                    let aliases = ledger_manager.cached_aliases().await;
                     tracing::warn!(
                         skipped,
-                        "local cache event listener lagged behind nameservice events"
+                        ledgers = aliases.len(),
+                        "local cache event listener lagged; sweeping loaded ledgers"
                     );
+                    for alias in aliases {
+                        reconcile_cached_ledger(&ledger_manager, &alias).await;
+                    }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                     tracing::debug!("local cache event listener stopped");
@@ -1266,6 +1257,34 @@ pub fn spawn_local_cache_event_listener(
             }
         }
     });
+}
+
+/// Reconcile one cached ledger against the current nameservice head.
+/// A no-op when the cache is already current or the ledger isn't
+/// loaded. Shared by the per-event path and the lag catch-up sweep.
+async fn reconcile_cached_ledger(ledger_manager: &LedgerManager, ledger_id: &str) {
+    match ledger_manager
+        .notify(NsNotify {
+            ledger_id: ledger_id.to_string(),
+            record: None,
+        })
+        .await
+    {
+        Ok(result) => {
+            tracing::debug!(
+                alias = %ledger_id,
+                ?result,
+                "local cache event listener reconciled ledger"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                alias = %ledger_id,
+                error = %error,
+                "local cache event listener failed to reconcile ledger"
+            );
+        }
+    }
 }
 
 impl FlureeBuilder {

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -1204,10 +1204,24 @@ pub fn spawn_local_cache_event_listener(
 
         loop {
             match subscription.receiver.recv().await {
-                Ok(fluree_db_nameservice::NameServiceEvent::LedgerIndexPublished {
-                    ledger_id,
-                    ..
-                }) => {
+                // A new commit OR a new index head both move the ledger
+                // forward relative to a cached follower view. Reconcile
+                // on either: without the commit arm, a follower's cache
+                // only advances when an index publish happens to follow,
+                // leaving committed-but-unindexed writes invisible to
+                // reads served by that node (the exact failure exercised
+                // by raft failover — a write lands, replicates, applies
+                // on every node, yet only the staging node's cache shows
+                // it).
+                Ok(
+                    fluree_db_nameservice::NameServiceEvent::LedgerIndexPublished {
+                        ledger_id, ..
+                    }
+                    | fluree_db_nameservice::NameServiceEvent::LedgerCommitPublished {
+                        ledger_id,
+                        ..
+                    },
+                ) => {
                     match ledger_manager
                         .notify(NsNotify {
                             ledger_id: ledger_id.clone(),

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -1240,6 +1240,14 @@ pub fn spawn_local_cache_event_listener(
                     // land. Fall back to a catch-up sweep: re-reconcile
                     // every currently-loaded ledger against the
                     // nameservice head (a no-op for any already current).
+                    //
+                    // The sweep runs inline in this receive loop, so it
+                    // does not drain the channel while it executes. If a
+                    // future workload makes reconciles slow enough that
+                    // the sweep itself keeps the receiver from draining,
+                    // this could re-trigger Lagged. Not observed in
+                    // practice; revisit with a bound or a provably-behind
+                    // scope only if it proves to arise.
                     let aliases = ledger_manager.cached_aliases().await;
                     tracing::warn!(
                         skipped,

--- a/fluree-db-server/src/raft.rs
+++ b/fluree-db-server/src/raft.rs
@@ -198,6 +198,26 @@ impl RaftIntegration {
 
         let raft_cfg = Arc::new(config.raft_config.validate()?);
 
+        // Liveness invariant: a candidate must outlast its own vote
+        // RPCs before re-electing, or votes land on stale terms and a
+        // failover livelocks (every survivor climbs to the same term
+        // with no leader). openraft's own `validate()` can't see this —
+        // it doesn't know the transport timeout — so check it here, the
+        // one place that holds both configs. Warn rather than reject so
+        // an operator who has deliberately tuned for a fast link isn't
+        // hard-blocked; `default_raft_config` keeps the shipped default
+        // safe.
+        let rpc_timeout_ms = config.network_config.rpc_timeout.as_millis() as u64;
+        if raft_cfg.election_timeout_min <= rpc_timeout_ms {
+            tracing::warn!(
+                election_timeout_min = raft_cfg.election_timeout_min,
+                rpc_timeout_ms,
+                "election_timeout_min <= rpc_timeout: candidates may re-elect before their vote \
+                 RPCs resolve, risking election livelock on leader failover; set \
+                 election_timeout_min comfortably above rpc_timeout"
+            );
+        }
+
         let http_client = HttpRaftNetworkFactory::build_client(&config.network_config)?;
         let network_config = config.network_config.clone();
         let factory =
@@ -286,18 +306,19 @@ impl RaftBootstrapConfig {
     /// tune `raft_config` / `network_config` as workload patterns
     /// demand.
     pub fn new(node_id: NodeId, storage_path: impl Into<PathBuf>) -> Self {
+        let network_config = NetworkConfig::default();
         Self {
             node_id,
             storage_path: storage_path.into(),
-            raft_config: default_raft_config(),
-            network_config: NetworkConfig::default(),
+            raft_config: default_raft_config(&network_config),
+            network_config,
             event_bus_capacity: 1024,
         }
     }
 }
 
-/// Election timeouts tuned to compose with [`NetworkConfig`]'s RPC
-/// timeouts, rather than openraft's stock 150–300 ms.
+/// Election timeouts derived from [`NetworkConfig`]'s RPC timeouts,
+/// rather than openraft's stock 150–300 ms.
 ///
 /// openraft's defaults assume sub-millisecond, always-reachable peers.
 /// Ours don't hold: `rpc_timeout` is 500 ms and a *dead but not yet
@@ -308,18 +329,22 @@ impl RaftBootstrapConfig {
 /// forms. On a leader failover the survivors then livelock: all climb
 /// to the same term with no leader and never converge.
 ///
-/// Raising `election_timeout_min` safely above `rpc_timeout` (and
-/// keeping a wide min→max spread so timers desynchronize) lets a
-/// candidate collect votes from the live quorum — which answer in
-/// well under a millisecond on a LAN — before it gives up on the term.
-/// Cost is a slightly slower failover (~0.75–1.5 s vs the unreachable
-/// sub-second the stock window only nominally delivered); correctness
-/// of failover is worth it. Operators on faster or slower links can
-/// still override `raft_config` wholesale.
-fn default_raft_config() -> RaftConfig {
+/// The fix is the invariant `election_timeout_min > rpc_timeout`: a
+/// candidate must give the live quorum (which answers in well under a
+/// millisecond on a LAN) time to vote before it abandons the term.
+/// Deriving the window from `rpc_timeout` keeps that invariant intact
+/// if the network defaults are ever retuned. We use 2× `rpc_timeout`
+/// with a 750 ms floor for `min`, and a 2× spread to `max` so timers
+/// desynchronize. Cost is a slightly slower failover (~1–2 s at the
+/// defaults). [`RaftIntegration::bootstrap`] re-checks the invariant
+/// at runtime so an override of *either* config that breaks it is
+/// caught even when this constructor isn't used.
+fn default_raft_config(network: &NetworkConfig) -> RaftConfig {
+    let rpc_ms = network.rpc_timeout.as_millis() as u64;
+    let election_timeout_min = rpc_ms.saturating_mul(2).max(750);
     RaftConfig {
-        election_timeout_min: 750,
-        election_timeout_max: 1500,
+        election_timeout_min,
+        election_timeout_max: election_timeout_min.saturating_mul(2),
         ..RaftConfig::default()
     }
 }

--- a/fluree-db-server/src/raft.rs
+++ b/fluree-db-server/src/raft.rs
@@ -289,10 +289,38 @@ impl RaftBootstrapConfig {
         Self {
             node_id,
             storage_path: storage_path.into(),
-            raft_config: RaftConfig::default(),
+            raft_config: default_raft_config(),
             network_config: NetworkConfig::default(),
             event_bus_capacity: 1024,
         }
+    }
+}
+
+/// Election timeouts tuned to compose with [`NetworkConfig`]'s RPC
+/// timeouts, rather than openraft's stock 150–300 ms.
+///
+/// openraft's defaults assume sub-millisecond, always-reachable peers.
+/// Ours don't hold: `rpc_timeout` is 500 ms and a *dead but not yet
+/// evicted* voter costs `connect_timeout` (250 ms) on every vote round.
+/// With the stock 150–300 ms election window, a candidate re-elects —
+/// bumping its term — before its own vote RPCs from the previous round
+/// resolve, so every vote lands on a now-stale term and no quorum ever
+/// forms. On a leader failover the survivors then livelock: all climb
+/// to the same term with no leader and never converge.
+///
+/// Raising `election_timeout_min` safely above `rpc_timeout` (and
+/// keeping a wide min→max spread so timers desynchronize) lets a
+/// candidate collect votes from the live quorum — which answer in
+/// well under a millisecond on a LAN — before it gives up on the term.
+/// Cost is a slightly slower failover (~0.75–1.5 s vs the unreachable
+/// sub-second the stock window only nominally delivered); correctness
+/// of failover is worth it. Operators on faster or slower links can
+/// still override `raft_config` wholesale.
+fn default_raft_config() -> RaftConfig {
+    RaftConfig {
+        election_timeout_min: 750,
+        election_timeout_max: 1500,
+        ..RaftConfig::default()
     }
 }
 

--- a/fluree-db-server/tests/raft_multi_node.rs
+++ b/fluree-db-server/tests/raft_multi_node.rs
@@ -307,6 +307,43 @@ impl TestCluster {
         }
     }
 
+    /// Poll until *every* live node agrees on a single leader that is
+    /// not `excluding`, then return it. Used after a failover: a write
+    /// forwarded through a surviving follower only reaches the new
+    /// leader once that follower's own raft metrics have caught up, so
+    /// requiring cluster-wide agreement (not just the first node's
+    /// possibly-stale view) is what makes a follower-forwarded write
+    /// race-free. Panics on timeout.
+    async fn wait_for_new_leader(&self, excluding: NodeId, timeout: Duration) -> NodeId {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let mut leaders = BTreeSet::new();
+            let mut all_reported = true;
+            for node in self.nodes.iter().filter(|n| n.is_alive()) {
+                match self.cluster_status(node).await {
+                    Ok(status) => match status.current_leader {
+                        Some(id) => {
+                            leaders.insert(id);
+                        }
+                        None => all_reported = false,
+                    },
+                    Err(_) => all_reported = false,
+                }
+            }
+            if all_reported && leaders.len() == 1 {
+                let leader = *leaders.iter().next().expect("one leader");
+                if leader != excluding {
+                    return leader;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "no agreed new leader (excluding {excluding}) within {timeout:?}; saw {leaders:?}"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
     async fn cluster_status(&self, node: &TestNode) -> reqwest::Result<ClusterStatus> {
         self.client
             .get(format!("{}/cluster/status", node.raft_url))
@@ -715,28 +752,13 @@ async fn leader_failover_resumes_writes() {
     cluster.shutdown_node(old_leader).await;
 
     // Quorum survives losing one of five nodes; a new leader should
-    // emerge within a few election timeouts. The bound here is
-    // generous so a slow CI tick doesn't flake the test — the
-    // raft default election timeout is on the order of hundreds of
-    // milliseconds.
-    let new_leader = {
-        let deadline = Instant::now() + DEFAULT_TIMEOUT;
-        let mut current = old_leader;
-        while Instant::now() < deadline {
-            if let Some(id) = cluster.current_leader().await {
-                if id != old_leader {
-                    current = id;
-                    break;
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        assert_ne!(
-            current, old_leader,
-            "no new leader elected within {DEFAULT_TIMEOUT:?}"
-        );
-        current
-    };
+    // emerge within a few election timeouts. Wait until every survivor
+    // *agrees* on the new leader — not just until one node reports one —
+    // so the follower we resume writes through can actually forward to
+    // it. The bound is generous so a slow CI tick doesn't flake.
+    let new_leader = cluster
+        .wait_for_new_leader(old_leader, DEFAULT_TIMEOUT)
+        .await;
     assert_ne!(new_leader, old_leader);
 
     // Resume writes through a surviving non-leader to also exercise


### PR DESCRIPTION
## Background

CI/CD was intermittently failing on `fluree-db-server::raft_multi_node leader_failover_resumes_writes` — a transient red that didn't reproduce on a re-run and didn't obviously point at any one change. Reproducing it locally showed a ~60% failure rate with *three distinct* panics, which turned out to be three independent issues. Two are real product bugs in the consensus layer; the third is a race in the test itself. The flakiness was self-masking: the test usually failed at an earlier stage before it could exercise the most important bug.

## Root causes & fixes

### 1. Election livelock — no new leader after failover (product)
The default election timeout (openraft's stock 150–300 ms) sat *below* `NetworkConfig::rpc_timeout` (500 ms) and near `connect_timeout` (250 ms to a dead-but-not-yet-evicted voter). A candidate re-elected — bumping its term — before its own vote RPCs from the previous round resolved, so every vote landed on a now-stale term and no quorum ever formed. Survivors livelocked: all four climbed to the same term with `leader = None` and never converged.

Fix: derive the election window from the transport timeouts so the invariant `election_timeout_min > rpc_timeout` holds by construction (`2× rpc_timeout`, 750 ms floor, 2× spread → 1000–2000 ms at the defaults). `RaftIntegration::bootstrap` also warns at startup if `election_timeout_min <= rpc_timeout`, so an embedder who tunes either config independently and reintroduces the risk is told about it.

### 2. Committed write invisible on followers (product — the actual CI failure)
After a write replicated and applied on **every** node (all at the same raft applied index), only the staging node's query reflected it; followers kept serving the prior head. The local cache event listener reconciled the ledger view only on `LedgerIndexPublished`, never `LedgerCommitPublished` — so a committed-but-unindexed write left follower caches stale until some later index publish happened to land. The leader stayed correct because its own commit path updates its cache directly.

Fix: reconcile on commit publishes as well as index publishes (matching the listener's own documented contract). While here, the listener now also recovers from broadcast `Lagged`: rather than only logging, it sweeps the loaded ledgers and reconciles each against the nameservice head, so a dropped event can't strand a ledger's cache.

### 3. Test race on a transient leadership 503 (test)
The test read the new leader from one node, then immediately wrote through a *different* surviving follower that hadn't yet learned the new leader — getting a retryable `503 "no leader currently elected"`. It now waits until every surviving node agrees on the new leader before resuming writes.

## Verification

`leader_failover_resumes_writes` was run in a tight loop (90+ iterations across the iterations of this change) and is now consistently green; the full `raft_multi_node` and `raft_integration` suites pass, as do the `fluree-db-api` unit tests. fmt + clippy clean.
