### PR TITLE
`docs`: fix landing page links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Fluree DB is a single binary that stores your data as an RDF knowledge graph, qu
 
 ## Start here
 
-- **New to Fluree?** → [Getting started](getting-started/README.md)
+- **New to Fluree?** → [Getting started](getting-started/)
 - **Run the server** → [Quickstart: run the server](getting-started/quickstart-server.md)
 - **Create a ledger and write data** → [Quickstart: create a ledger](getting-started/quickstart-ledger.md) → [Quickstart: write data](getting-started/quickstart-write.md)
 - **Query data** → [Quickstart: query (JSON-LD + SPARQL)](getting-started/quickstart-query.md)
@@ -29,27 +29,27 @@ Fluree DB is a single binary that stores your data as an RDF knowledge graph, qu
 
 ## Explore the docs
 
-- [Concepts](concepts/README.md) — ledgers, graph sources, IRIs, datatypes, edge annotations, time travel, policy, verifiable data, reasoning
-- [Guides (cookbooks)](guides/README.md) — query patterns, search, time travel, branching, policies, SHACL, edge annotations — task-oriented recipes
-- [CLI reference](cli/README.md) — every `fluree` command, flag by flag
-- [HTTP API](api/README.md) — endpoints, headers, signed requests, error model
-- [Query](query/README.md) — JSON-LD Query, SPARQL, output formats, CONSTRUCT, explain plans, reasoning
-- [Transactions](transactions/README.md) — insert, upsert, update, conditional updates, signed transactions
-- [Security and policy](security/README.md) — authentication, encryption, commit signing, policy model
-- [Indexing and search](indexing-and-search/README.md) — background indexing, BM25, vector search, geospatial
-- [Graph sources and integrations](graph-sources/README.md) — Iceberg/Parquet, R2RML, BM25 graph source
-- [Operations](operations/README.md) — configuration, Docker, storage modes, telemetry, archive/restore
-- [Design](design/README.md) — internals: query execution, storage traits, index format, nameservice
-- [Reference](reference/README.md) — glossary, vocabulary, OWL/RDFS support, crate map
-- [Troubleshooting](troubleshooting/README.md) — common errors, debugging queries, performance tracing
-- [Contributing](contributing/README.md) — dev setup, tests, SPARQL compliance, releasing
+- [Concepts](concepts/) — ledgers, graph sources, IRIs, datatypes, edge annotations, time travel, policy, verifiable data, reasoning
+- [Guides (cookbooks)](guides/) — query patterns, search, time travel, branching, policies, SHACL, edge annotations — task-oriented recipes
+- [CLI reference](cli/) — every `fluree` command, flag by flag
+- [HTTP API](api/) — endpoints, headers, signed requests, error model
+- [Query](query/) — JSON-LD Query, SPARQL, output formats, CONSTRUCT, explain plans, reasoning
+- [Transactions](transactions/) — insert, upsert, update, conditional updates, signed transactions
+- [Security and policy](security/) — authentication, encryption, commit signing, policy model
+- [Indexing and search](indexing-and-search/) — background indexing, BM25, vector search, geospatial
+- [Graph sources and integrations](graph-sources/) — Iceberg/Parquet, R2RML, BM25 graph source
+- [Operations](operations/) — configuration, Docker, storage modes, telemetry, archive/restore
+- [Design](design/) — internals: query execution, storage traits, index format, nameservice
+- [Reference](reference/) — glossary, vocabulary, OWL/RDFS support, crate map
+- [Troubleshooting](troubleshooting/) — common errors, debugging queries, performance tracing
+- [Contributing](contributing/) — dev setup, tests, SPARQL compliance, releasing
 
-The full table of contents is in [`SUMMARY.md`](SUMMARY.md).
+The full table of contents is in the sidebar.
 
 ## Building with AI and agents
 
-[Fluree for AI and agents](ai/README.md) features for the AI use case — it ties together Agent JSON (token-efficient query output), the MCP server (Fluree as an agent tool), Fluree Memory, vector and full-text search as a RAG substrate, and reasoning.
+[Fluree for AI and agents](ai/) features for the AI use case — it ties together Agent JSON (token-efficient query output), the MCP server (Fluree as an agent tool), Fluree Memory, vector and full-text search as a RAG substrate, and reasoning.
 
 ## Fluree Memory
 
-[Fluree Memory](memory/README.md) is persistent, searchable memory for AI coding assistants — built on Fluree DB and shipped in the same `fluree` binary. If you're here for the memory tooling, jump straight to the [Memory docs](memory/README.md).
+[Fluree Memory](memory/) is persistent, searchable memory for AI coding assistants — built on Fluree DB and shipped in the same `fluree` binary. If you're here for the memory tooling, jump straight to the [Memory docs](memory/).


### PR DESCRIPTION
I first noticed the [AI docs link](https://fluree.github.io/db/ai/README.html) was sending readers to a 404. After building the `mdBook` locally and running [`lychee`](https://github.com/lycheeverse/lychee), similar issues showed up on the rest of the landing page links, so this keeps that intro page from sending readers to incorrect paths.

This might be worth turning into a lightweight docs check with [`lychee-action`](https://github.com/lycheeverse/lychee-action) (the workflow could start by checking `.md` files first, since that maps failures directly back to the files authors edit. Once that is clean, checking the generated `mdBook` outputs would catch publishing-specific issues like `README.md` links becoming `README.html`.).

The repo does have enough links for it to help: the local pass checked 1,406 links and the remaining failures might be useful for future _follow-up_ docs cleanup PRs.