### PR TITLE
fix(cli): accept -l/--ledger on query/insert/upsert/update

### DIFF
--- a/docs/cli/branch.md
+++ b/docs/cli/branch.md
@@ -24,7 +24,7 @@ fluree branch create <NAME> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--ledger <LEDGER>` | Ledger name (defaults to active ledger) |
+| `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger) |
 | `--from <BRANCH>` | Source branch to create from (defaults to "main") |
 | `--at <COMMIT-REF>` | Commit to branch at (defaults to source branch HEAD). Accepts `t:N` for a transaction number or a hex digest / full CID. |
 | `--remote <REMOTE>` | Execute against a remote server |
@@ -130,7 +130,7 @@ fluree branch drop <NAME> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--ledger <LEDGER>` | Ledger name (defaults to active ledger) |
+| `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger) |
 | `--remote <REMOTE>` | Execute against a remote server |
 
 **Description:**
@@ -194,7 +194,7 @@ fluree branch rebase <NAME> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--ledger <LEDGER>` | Ledger name (defaults to active ledger) |
+| `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger) |
 | `--strategy <STRATEGY>` | Conflict resolution strategy (default: "take-both"). Options: `take-both`, `abort`, `take-source`, `take-branch`, `skip` |
 | `--remote <REMOTE>` | Execute against a remote server |
 
@@ -262,7 +262,7 @@ fluree branch diff <SOURCE> [OPTIONS]
 | `--conflict-details` | Include source/target flake values for returned conflict keys |
 | `--strategy <STRATEGY>` | Strategy used for conflict detail labels (default: `take-both`). Options: `take-both`, `abort`, `take-source`, `take-branch` |
 | `--json` | Emit the raw JSON preview |
-| `--ledger <LEDGER>` | Ledger name (defaults to active ledger) |
+| `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger) |
 | `--remote <REMOTE>` | Execute against a remote server |
 
 **Description:**
@@ -305,7 +305,7 @@ fluree branch merge <SOURCE> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--ledger <LEDGER>` | Ledger name (defaults to active ledger) |
+| `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger) |
 | `--target <BRANCH>` | Target branch to merge into (defaults to source's parent branch) |
 | `--strategy <STRATEGY>` | Conflict resolution strategy (default: `take-both`). Options: `take-both`, `abort`, `take-source`, `take-branch`. |
 | `--remote <REMOTE>` | Execute against a remote server |

--- a/docs/cli/graph.md
+++ b/docs/cli/graph.md
@@ -20,7 +20,7 @@ fluree graph list [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--ledger <LEDGER>` | Ledger identifier (e.g. `mydb` or `mydb:feature-x`). Defaults to the active ledger. |
+| `-l, --ledger <LEDGER>` | Ledger identifier (e.g. `mydb` or `mydb:feature-x`). Defaults to the active ledger. |
 | `--remote <REMOTE>` | List graphs on a remote server by remote name (e.g. `origin`). |
 | `--json` | Emit the filtered `named-graphs` JSON array instead of a table. |
 | `--include-system` | Include the default graph and the system `txn-meta` / `config` graphs. Off by default. |
@@ -69,7 +69,7 @@ fluree graph drop <IRI> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--ledger <LEDGER>` | Ledger identifier. Defaults to the active ledger. |
+| `-l, --ledger <LEDGER>` | Ledger identifier. Defaults to the active ledger. |
 | `--remote <REMOTE>` | Execute against a remote server by remote name. |
 
 **Description:**

--- a/docs/cli/history.md
+++ b/docs/cli/history.md
@@ -18,7 +18,7 @@ fluree history <ENTITY> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--ledger <LEDGER>` | Ledger name (defaults to active ledger) |
+| `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger) |
 | `--from <TIME>` | Start of time range (default: `1`) |
 | `--to <TIME>` | End of time range (default: `latest`) |
 | `-p, --predicate <PRED>` | Filter to specific predicate |

--- a/docs/cli/insert.md
+++ b/docs/cli/insert.md
@@ -20,6 +20,7 @@ fluree insert [LEDGER] [DATA] [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
+| `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger); explicit alternative to the positional ledger argument |
 | `-e, --expr <EXPR>` | Inline data expression (alternative to positional) |
 | `-f, --file <FILE>` | Read data from a file |
 | `-m, --message <MSG>` | Commit message |

--- a/docs/cli/query.md
+++ b/docs/cli/query.md
@@ -16,10 +16,14 @@ fluree query [LEDGER] [QUERY] [OPTIONS]
 | `<arg>` | Auto-detected: if it looks like a query, uses it inline with the active ledger; if it's an existing file, reads from it; otherwise treats it as a ledger name |
 | `<ledger> <query>` | Specified ledger + inline query |
 
+The ledger may also be given explicitly with `-l`/`--ledger`, which bypasses
+the positional auto-detection (e.g. `fluree query --ledger mydb:main 'SELECT …'`).
+
 ## Options
 
 | Option | Description |
 |--------|-------------|
+| `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger); explicit alternative to the positional ledger argument |
 | `-e, --expr <EXPR>` | Inline query expression (alternative to positional) |
 | `-f, --file <FILE>` | Read query from a file |
 | `--format <FORMAT>` | Output format: `json`, `typed-json`, `table`, `csv`, `tsv`, or `ndjson` (default: `table`) |

--- a/docs/cli/show.md
+++ b/docs/cli/show.md
@@ -18,7 +18,7 @@ fluree show <COMMIT> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--ledger <NAME>` | Ledger name (defaults to active ledger) |
+| `-l, --ledger <NAME>` | Ledger name (defaults to active ledger) |
 | `--remote <NAME>` | Execute against a remote server (by remote name, e.g., "origin") |
 
 ## Description

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -20,6 +20,7 @@ fluree update [LEDGER] [DATA] [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
+| `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger); explicit alternative to the positional ledger argument |
 | `-e, --expr <EXPR>` | Inline data expression (alternative to positional) |
 | `-f, --file <FILE>` | Read data from a file |
 | `-m, --message <MSG>` | Commit message |

--- a/docs/cli/upsert.md
+++ b/docs/cli/upsert.md
@@ -20,6 +20,7 @@ fluree upsert [LEDGER] [DATA] [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
+| `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger); explicit alternative to the positional ledger argument |
 | `-e, --expr <EXPR>` | Inline data expression (alternative to positional) |
 | `-f, --file <FILE>` | Read data from a file |
 | `-m, --message <MSG>` | Commit message |

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -356,6 +356,12 @@ pub enum Commands {
         #[arg(num_args = 0..=2)]
         args: Vec<String>,
 
+        /// Ledger name (defaults to active ledger). Explicit alternative to
+        /// the positional ledger argument; when given, positional args carry
+        /// only the inline data or a file path.
+        #[arg(short = 'l', long)]
+        ledger: Option<String>,
+
         /// Inline data expression (Turtle or JSON-LD).
         #[arg(short = 'e', long = "expr")]
         expr: Option<String>,
@@ -394,6 +400,12 @@ pub enum Commands {
         #[arg(num_args = 0..=2)]
         args: Vec<String>,
 
+        /// Ledger name (defaults to active ledger). Explicit alternative to
+        /// the positional ledger argument; when given, positional args carry
+        /// only the inline data or a file path.
+        #[arg(short = 'l', long)]
+        ledger: Option<String>,
+
         /// Inline data expression (JSON-LD or SPARQL UPDATE).
         #[arg(short = 'e', long = "expr")]
         expr: Option<String>,
@@ -430,6 +442,12 @@ pub enum Commands {
         /// With 2 args: first is ledger name, second is inline data.
         #[arg(num_args = 0..=2)]
         args: Vec<String>,
+
+        /// Ledger name (defaults to active ledger). Explicit alternative to
+        /// the positional ledger argument; when given, positional args carry
+        /// only the inline data or a file path.
+        #[arg(short = 'l', long)]
+        ledger: Option<String>,
 
         /// Inline data expression (Turtle or JSON-LD).
         #[arg(short = 'e', long = "expr")]
@@ -468,6 +486,12 @@ pub enum Commands {
         /// With 2 args: first is ledger name, second is inline query.
         #[arg(num_args = 0..=2)]
         args: Vec<String>,
+
+        /// Ledger name (defaults to active ledger). Explicit alternative to
+        /// the positional ledger argument; when given, positional args carry
+        /// only the inline query or a file path.
+        #[arg(short = 'l', long)]
+        ledger: Option<String>,
 
         /// Inline query expression (SPARQL or JSON-LD query).
         #[arg(short = 'e', long = "expr")]

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -630,7 +630,7 @@ pub enum Commands {
         entity: String,
 
         /// Ledger name (defaults to active ledger)
-        #[arg(long)]
+        #[arg(short = 'l', long)]
         ledger: Option<String>,
 
         /// Start of time range (transaction number, default: 1)
@@ -739,7 +739,7 @@ pub enum Commands {
         commit: String,
 
         /// Ledger name (defaults to active ledger)
-        #[arg(long)]
+        #[arg(short = 'l', long)]
         ledger: Option<String>,
 
         /// Execute against a remote server (by remote name, e.g., "origin")
@@ -942,7 +942,7 @@ pub enum GraphAction {
     List {
         /// Ledger identifier (e.g. "mydb" or "mydb:feature-x").
         /// Defaults to the active ledger.
-        #[arg(long)]
+        #[arg(short = 'l', long)]
         ledger: Option<String>,
 
         /// List graphs on a remote server (by remote name, e.g. "origin")
@@ -981,7 +981,7 @@ pub enum GraphAction {
 
         /// Ledger identifier (e.g. "mydb" or "mydb:feature-x").
         /// Defaults to the active ledger.
-        #[arg(long)]
+        #[arg(short = 'l', long)]
         ledger: Option<String>,
 
         /// Execute against a remote server (by remote name, e.g. "origin")
@@ -999,7 +999,7 @@ pub enum BranchAction {
         name: String,
 
         /// Ledger name (defaults to active ledger)
-        #[arg(long)]
+        #[arg(short = 'l', long)]
         ledger: Option<String>,
 
         /// Source branch to create from (defaults to "main")
@@ -1025,7 +1025,7 @@ pub enum BranchAction {
         name: String,
 
         /// Ledger name (defaults to active ledger)
-        #[arg(long)]
+        #[arg(short = 'l', long)]
         ledger: Option<String>,
 
         /// Execute against a remote server (by remote name, e.g., "origin")
@@ -1049,7 +1049,7 @@ pub enum BranchAction {
         name: String,
 
         /// Ledger name (defaults to active ledger)
-        #[arg(long)]
+        #[arg(short = 'l', long)]
         ledger: Option<String>,
 
         /// Conflict resolution strategy (default: "take-both")
@@ -1077,7 +1077,7 @@ pub enum BranchAction {
         strategy: String,
 
         /// Ledger name (defaults to active ledger)
-        #[arg(long)]
+        #[arg(short = 'l', long)]
         ledger: Option<String>,
 
         /// Execute against a remote server (by remote name, e.g., "origin")
@@ -1125,7 +1125,7 @@ pub enum BranchAction {
         json: bool,
 
         /// Ledger name (defaults to active ledger)
-        #[arg(long)]
+        #[arg(short = 'l', long)]
         ledger: Option<String>,
 
         /// Execute against a remote server (by remote name, e.g., "origin")
@@ -1176,7 +1176,7 @@ pub enum BranchAction {
         json: bool,
 
         /// Ledger name (defaults to active ledger)
-        #[arg(long)]
+        #[arg(short = 'l', long)]
         ledger: Option<String>,
 
         /// Execute against a remote server (by remote name, e.g., "origin")

--- a/fluree-db-cli/src/commands/insert.rs
+++ b/fluree-db-cli/src/commands/insert.rs
@@ -65,6 +65,15 @@ pub fn resolve_inputs<'a>(
             let p = Path::new(&args[0]);
             if !looks_like_query(&args[0]) && p.is_file() {
                 Ok((Some(ledger), None, Some(p.to_path_buf())))
+            } else if !looks_like_query(&args[0]) && looks_like_path(&args[0]) {
+                // Path-shaped but no such file: almost always a typo'd file
+                // path rather than inline data. Feeding it to the input reader
+                // would surface a confusing parse error, so reject clearly.
+                Err(CliError::Usage(format!(
+                    "no such file: '{}' — with --ledger, the positional argument \
+                     must be inline data/query or an existing file path",
+                    args[0]
+                )))
             } else {
                 // Inline data/query (or a path the input reader will reject).
                 Ok((Some(ledger), Some(&args[0]), None))
@@ -76,6 +85,26 @@ pub fn resolve_inputs<'a>(
                 .into(),
         )),
     }
+}
+
+/// Heuristic: does this string look like an intended file path (so a missing
+/// file is a typo worth flagging) rather than inline data? Single-token, no
+/// whitespace, and either contains a path separator or ends in a known
+/// data-file extension.
+fn looks_like_path(s: &str) -> bool {
+    let t = s.trim();
+    if t.is_empty() || t.contains(char::is_whitespace) {
+        return false;
+    }
+    if t.contains('/') || t.contains('\\') {
+        return true;
+    }
+    let lower = t.to_ascii_lowercase();
+    [
+        ".json", ".jsonld", ".ttl", ".nt", ".nq", ".trig", ".rq", ".sparql",
+    ]
+    .iter()
+    .any(|ext| lower.ends_with(ext))
 }
 
 /// Heuristic: does this string look like a query or data literal rather than a

--- a/fluree-db-cli/src/commands/insert.rs
+++ b/fluree-db-cli/src/commands/insert.rs
@@ -41,6 +41,43 @@ pub fn resolve_positional_args(
     }
 }
 
+/// Resolve the ledger plus input source for insert/query/upsert/update,
+/// honoring an explicit `--ledger`/`-l` flag.
+///
+/// When `--ledger` is given it takes precedence and removes all ambiguity:
+/// the positional args carry only inline data/query or a file path — never a
+/// ledger name — so the `looks_like_query` heuristic is bypassed for ledger
+/// disambiguation. When `--ledger` is absent, falls back to the positional
+/// heuristic in [`resolve_positional_args`].
+///
+/// Returns `(ledger_name, inline_input, file_path)`.
+pub fn resolve_inputs<'a>(
+    ledger_flag: Option<&'a str>,
+    args: &'a [String],
+) -> CliResult<(Option<&'a str>, Option<&'a str>, Option<PathBuf>)> {
+    let Some(ledger) = ledger_flag else {
+        return resolve_positional_args(args);
+    };
+
+    match args.len() {
+        0 => Ok((Some(ledger), None, None)),
+        1 => {
+            let p = Path::new(&args[0]);
+            if !looks_like_query(&args[0]) && p.is_file() {
+                Ok((Some(ledger), None, Some(p.to_path_buf())))
+            } else {
+                // Inline data/query (or a path the input reader will reject).
+                Ok((Some(ledger), Some(&args[0]), None))
+            }
+        }
+        _ => Err(CliError::Usage(
+            "--ledger was given, so provide at most one positional argument \
+             (the inline query/data); the ledger comes from --ledger"
+                .into(),
+        )),
+    }
+}
+
 /// Heuristic: does this string look like a query or data literal rather than a
 /// ledger name or file path?
 fn looks_like_query(s: &str) -> bool {
@@ -68,6 +105,7 @@ fn looks_like_query(s: &str) -> bool {
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     args: &[String],
+    ledger_flag: Option<&str>,
     expr: Option<&str>,
     file_flag: Option<&Path>,
     format_flag: Option<&str>,
@@ -76,7 +114,7 @@ pub async fn run(
     direct: bool,
     policy: &PolicyArgs,
 ) -> CliResult<()> {
-    let (explicit_ledger, positional_inline, positional_file) = resolve_positional_args(args)?;
+    let (explicit_ledger, positional_inline, positional_file) = resolve_inputs(ledger_flag, args)?;
 
     // Resolve input: -e > positional inline > -f > positional file > stdin
     let source = input::resolve_input(

--- a/fluree-db-cli/src/commands/query.rs
+++ b/fluree-db-cli/src/commands/query.rs
@@ -1,5 +1,5 @@
 use crate::cli::PolicyArgs;
-use crate::commands::insert::resolve_positional_args;
+use crate::commands::insert::resolve_inputs;
 use crate::commands::query_stream::{self, NdjsonConsumer};
 use crate::context::{self, LedgerMode};
 use crate::detect;
@@ -213,6 +213,7 @@ fn inject_sparql_from_before_where(sparql: &str, from_iri: &str) -> Option<Strin
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     args: &[String],
+    ledger_flag: Option<&str>,
     expr: Option<&str>,
     file_flag: Option<&Path>,
     format_str: &str,
@@ -232,7 +233,7 @@ pub async fn run(
     const BENCH_ROWS: usize = 5;
     const DEFAULT_TABLE_PREVIEW_ROWS: usize = 200;
     let limit = if bench { Some(BENCH_ROWS) } else { None };
-    let (explicit_ledger, positional_inline, positional_file) = resolve_positional_args(args)?;
+    let (explicit_ledger, positional_inline, positional_file) = resolve_inputs(ledger_flag, args)?;
 
     // Resolve input: -e > positional inline > -f > positional file > stdin
     let source = input::resolve_input(

--- a/fluree-db-cli/src/commands/update.rs
+++ b/fluree-db-cli/src/commands/update.rs
@@ -1,6 +1,6 @@
 use crate::cli::PolicyArgs;
 use crate::commands::insert::{
-    build_policy_ctx, print_txn_result, resolve_positional_args, warn_novelty_if_needed,
+    build_policy_ctx, print_txn_result, resolve_inputs, warn_novelty_if_needed,
 };
 use crate::context::{self, LedgerMode};
 use crate::error::{CliError, CliResult};
@@ -78,6 +78,7 @@ fn sniff_update_format(content: &str) -> CliResult<UpdateFormat> {
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     args: &[String],
+    ledger_flag: Option<&str>,
     expr: Option<&str>,
     file_flag: Option<&Path>,
     format_flag: Option<&str>,
@@ -86,7 +87,7 @@ pub async fn run(
     direct: bool,
     policy: &PolicyArgs,
 ) -> CliResult<()> {
-    let (explicit_ledger, positional_inline, positional_file) = resolve_positional_args(args)?;
+    let (explicit_ledger, positional_inline, positional_file) = resolve_inputs(ledger_flag, args)?;
 
     // Resolve input: -e > positional inline > -f > positional file > stdin
     let source = input::resolve_input(

--- a/fluree-db-cli/src/commands/upsert.rs
+++ b/fluree-db-cli/src/commands/upsert.rs
@@ -1,6 +1,6 @@
 use crate::cli::PolicyArgs;
 use crate::commands::insert::{
-    build_policy_ctx, print_txn_result, resolve_positional_args, warn_novelty_if_needed,
+    build_policy_ctx, print_txn_result, resolve_inputs, warn_novelty_if_needed,
 };
 use crate::context::{self, LedgerMode};
 use crate::detect;
@@ -13,6 +13,7 @@ use std::path::Path;
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     args: &[String],
+    ledger_flag: Option<&str>,
     expr: Option<&str>,
     file_flag: Option<&Path>,
     format_flag: Option<&str>,
@@ -21,7 +22,7 @@ pub async fn run(
     direct: bool,
     policy: &PolicyArgs,
 ) -> CliResult<()> {
-    let (explicit_ledger, positional_inline, positional_file) = resolve_positional_args(args)?;
+    let (explicit_ledger, positional_inline, positional_file) = resolve_inputs(ledger_flag, args)?;
 
     // Resolve input: -e > positional inline > -f > positional file > stdin
     let source = input::resolve_input(

--- a/fluree-db-cli/src/lib.rs
+++ b/fluree-db-cli/src/lib.rs
@@ -193,6 +193,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
 
         Commands::Insert {
             args,
+            ledger,
             expr,
             file,
             format,
@@ -202,6 +203,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             let fluree_dir = config::require_fluree_dir(config_path)?;
             commands::insert::run(
                 &args,
+                ledger.as_deref(),
                 expr.as_deref(),
                 file.as_deref(),
                 format.as_deref(),
@@ -215,6 +217,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
 
         Commands::Update {
             args,
+            ledger,
             expr,
             file,
             format,
@@ -224,6 +227,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             let fluree_dir = config::require_fluree_dir(config_path)?;
             commands::update::run(
                 &args,
+                ledger.as_deref(),
                 expr.as_deref(),
                 file.as_deref(),
                 format.as_deref(),
@@ -237,6 +241,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
 
         Commands::Upsert {
             args,
+            ledger,
             expr,
             file,
             format,
@@ -246,6 +251,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             let fluree_dir = config::require_fluree_dir(config_path)?;
             commands::upsert::run(
                 &args,
+                ledger.as_deref(),
                 expr.as_deref(),
                 file.as_deref(),
                 format.as_deref(),
@@ -259,6 +265,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
 
         Commands::Query {
             args,
+            ledger,
             expr,
             file,
             format,
@@ -280,6 +287,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             let fluree_dir = config::require_fluree_dir_or_global(config_path)?;
             commands::query::run(
                 &args,
+                ledger.as_deref(),
                 expr.as_deref(),
                 file.as_deref(),
                 &format,

--- a/fluree-db-cli/tests/integration.rs
+++ b/fluree-db-cli/tests/integration.rs
@@ -282,6 +282,21 @@ fn query_ledger_flag_rejects_extra_positional() {
 }
 
 #[test]
+fn insert_ledger_flag_rejects_missing_file_positional() {
+    let tmp = TempDir::new().unwrap();
+    seed_named_people(&tmp, "streamdb");
+
+    // With --ledger, a lone path-shaped positional that doesn't exist (a typo'd
+    // file path) is reported as a missing file rather than fed to the input
+    // reader as inline data, which would fail with a confusing parse error.
+    fluree_cmd(&tmp)
+        .args(["insert", "--ledger", "streamdb", "typo-data.jsonld"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no such file"));
+}
+
+#[test]
 fn query_ndjson_bare_streams_row_objects() {
     let tmp = TempDir::new().unwrap();
     seed_named_people(&tmp, "streamdb");

--- a/fluree-db-cli/tests/integration.rs
+++ b/fluree-db-cli/tests/integration.rs
@@ -200,6 +200,88 @@ fn seed_named_people(tmp: &TempDir, ledger: &str) {
 }
 
 #[test]
+fn query_and_insert_accept_ledger_flag() {
+    let tmp = TempDir::new().unwrap();
+    // Seed `streamdb`, then create `otherdb` so it becomes the active ledger.
+    seed_named_people(&tmp, "streamdb");
+    fluree_cmd(&tmp)
+        .args(["create", "otherdb"])
+        .assert()
+        .success();
+
+    // `query --ledger` targets a non-active ledger; the positional arg is the
+    // inline query (heuristic bypassed because the ledger is explicit).
+    fluree_cmd(&tmp)
+        .args([
+            "query",
+            "--ledger",
+            "streamdb",
+            "--sparql",
+            "SELECT ?name WHERE { ?s <http://example.org/name> ?name }",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+
+    // Short form `-l` plus `-e` behaves identically.
+    fluree_cmd(&tmp)
+        .args([
+            "query",
+            "-l",
+            "streamdb",
+            "--sparql",
+            "-e",
+            "SELECT ?name WHERE { ?s <http://example.org/name> ?name }",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"));
+
+    // `insert --ledger` writes to the named ledger regardless of the active one.
+    fluree_cmd(&tmp)
+        .args([
+            "insert",
+            "--ledger",
+            "streamdb",
+            "-e",
+            r#"{"@context": {"ex": "http://example.org/"}, "@id": "ex:carol", "ex:name": "Carol"}"#,
+        ])
+        .assert()
+        .success();
+    fluree_cmd(&tmp)
+        .args([
+            "query",
+            "--ledger",
+            "streamdb",
+            "--sparql",
+            "SELECT ?name WHERE { ?s <http://example.org/name> ?name }",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Carol"));
+}
+
+#[test]
+fn query_ledger_flag_rejects_extra_positional() {
+    let tmp = TempDir::new().unwrap();
+    seed_named_people(&tmp, "streamdb");
+
+    // With --ledger, a second positional (a stray ledger name) is ambiguous.
+    fluree_cmd(&tmp)
+        .args([
+            "query",
+            "--ledger",
+            "streamdb",
+            "streamdb",
+            "SELECT ?name WHERE { ?s <http://example.org/name> ?name }",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--ledger"));
+}
+
+#[test]
 fn query_ndjson_bare_streams_row_objects() {
     let tmp = TempDir::new().unwrap();
     seed_named_people(&tmp, "streamdb");


### PR DESCRIPTION
## Summary

The data commands (`query`, `insert`, `upsert`, `update`) only accepted the ledger as a **positional** argument, so the documented form

```bash
fluree query --ledger knowledge-base:main '<SPARQL>'
```

errored with `unexpected argument '--ledger' found`. Meanwhile the metadata commands (`history`, `branch`, `graph`, `show`, `drop`) already used a `--ledger` flag — an inconsistency reported in #1368.

## Changes

- Add `-l`/`--ledger` to `query`, `insert`, `upsert`, and `update` as an explicit alternative to the positional ledger argument.
- New shared `resolve_inputs(ledger_flag, args)` wraps the existing `resolve_positional_args`: when `--ledger` is given it takes precedence and **bypasses the `looks_like_query` heuristic** (positionals carry only inline data/query or a file path; a stray second positional is rejected with a clear usage error). When the flag is absent, positional behavior is unchanged.
- Both forms now work:
  ```bash
  fluree query knowledge-base:main 'SELECT …'            # positional (still works)
  fluree query --ledger knowledge-base:main 'SELECT …'   # flag (now works)
  ```
- Document the flag in the `docs/cli/{query,insert,upsert,update}.md` option tables.

## Tests

- `query_and_insert_accept_ledger_flag` and `query_ledger_flag_rejects_extra_positional` in `fluree-db-cli/tests/integration.rs`.
- Full CLI integration suite passes (95); `cargo fmt` + `clippy --all-features --all-targets -D warnings` clean.

Closes #1368
