### PR TITLE
fix(sparql): CONSTRUCT WHERE and STRBEFORE/STRAFTER edge cases

### DIFF
--- a/docs/query/construct.md
+++ b/docs/query/construct.md
@@ -27,6 +27,22 @@ WHERE {
 
 This generates a new graph with `ex:displayName` properties from `ex:name` values.
 
+### Shorthand Form (`CONSTRUCT WHERE`)
+
+When the template is identical to the WHERE pattern, omit the template:
+
+```sparql
+PREFIX ex: <http://example.org/ns/>
+
+CONSTRUCT WHERE { ?s ex:name ?o }
+```
+
+Per the SPARQL 1.1 grammar, the shorthand WHERE block is a **basic graph
+pattern of triple patterns only**. `FILTER`, `GRAPH`, `OPTIONAL`, `BIND`,
+`UNION`, and sub-`SELECT` are rejected as syntax errors in this position — use
+the explicit-template form (`CONSTRUCT { ... } WHERE { ... }`) when you need
+them.
+
 ### Multiple Triples
 
 Construct multiple triples per solution:
@@ -158,6 +174,13 @@ WHERE {
 2. **Filter Early**: Apply filters in WHERE clause, not CONSTRUCT
 3. **Avoid Duplicates**: Use DISTINCT if needed
 4. **Performance**: CONSTRUCT can be expensive for large result sets
+
+## Current Limitations
+
+- **RDF collection syntax** (`( ?a ?b )`) is not yet supported in CONSTRUCT
+  templates — list the `rdf:first`/`rdf:rest`/`rdf:nil` triples explicitly.
+- **No annotations in CONSTRUCT templates** (the template output form is
+  deferred); a `CONSTRUCT` whose `WHERE` uses annotations to filter still works.
 
 ## Related Documentation
 

--- a/fluree-db-query/src/eval/string.rs
+++ b/fluree-db-query/src/eval/string.rs
@@ -325,22 +325,71 @@ pub fn eval_concat<R: RowAccess>(
     Ok(Some(string_with_lang(&result, lang)))
 }
 
+/// Extract the `(string content, language tag)` of a STRBEFORE/STRAFTER argument.
+///
+/// Returns `None` when the argument is unbound or not a string-typed literal
+/// (e.g. a number or IRI) — both cases make the function raise a type error,
+/// which demotes to an unbound result. The language tag comes from a
+/// language-tagged `TypedLiteral` value (constants) or, for variable bindings
+/// that materialize as a plain string, from [`extract_lang_tag`].
+fn str_arg_and_lang<R: RowAccess>(
+    expr: &Expression,
+    value: Option<ComparableValue>,
+    row: &R,
+    ctx: Option<&ExecutionContext<'_>>,
+) -> Option<(String, Option<Arc<str>>)> {
+    match value? {
+        ComparableValue::String(s) => Some((s.to_string(), extract_lang_tag(expr, row, ctx))),
+        ComparableValue::TypedLiteral {
+            val: FlakeValue::String(s),
+            dtc,
+        } => {
+            let lang = match dtc {
+                Some(UnresolvedDatatypeConstraint::LangTag(tag)) => Some(tag),
+                // xsd:string (or any non-lang datatype) carries no language tag.
+                _ => extract_lang_tag(expr, row, ctx),
+            };
+            Some((s, lang))
+        }
+        _ => None,
+    }
+}
+
+/// SPARQL 1.1 §17.4.3.5 argument compatibility for STRBEFORE/STRAFTER.
+///
+/// The search string (`arg2`) is compatible when it is a simple literal /
+/// `xsd:string` (no language tag), or when it shares `arg1`'s language tag.
+/// An incompatible pair raises a type error (→ unbound).
+fn args_compatible(lang1: &Option<Arc<str>>, lang2: &Option<Arc<str>>) -> bool {
+    match lang2 {
+        None => true,
+        Some(l2) => lang1.as_deref() == Some(l2.as_ref()),
+    }
+}
+
 pub fn eval_str_before<R: RowAccess>(
     args: &[Expression],
     row: &R,
     ctx: Option<&ExecutionContext<'_>>,
 ) -> Result<Option<ComparableValue>> {
     check_arity(args, 2, "STRBEFORE")?;
-    let lang = extract_lang_tag(&args[0], row, ctx);
     let arg1 = args[0].eval_to_comparable(row, ctx)?;
     let arg2 = args[1].eval_to_comparable(row, ctx)?;
-    match (arg1, arg2) {
-        (Some(ComparableValue::String(s)), Some(ComparableValue::String(d))) => {
-            let result = s.find(d.as_ref()).map(|pos| &s[..pos]).unwrap_or("");
-            Ok(Some(string_with_lang(result, lang)))
-        }
-        (None, _) | (_, None) => Ok(None),
-        _ => Ok(None),
+    let (Some((s, lang1)), Some((sub, lang2))) = (
+        str_arg_and_lang(&args[0], arg1, row, ctx),
+        str_arg_and_lang(&args[1], arg2, row, ctx),
+    ) else {
+        return Ok(None);
+    };
+    if !args_compatible(&lang1, &lang2) {
+        return Ok(None);
+    }
+    match s.find(&sub) {
+        // Found (including the empty search string, found at position 0):
+        // the result carries arg1's language tag.
+        Some(pos) => Ok(Some(string_with_lang(&s[..pos], lang1))),
+        // Not found: a plain empty simple literal (no language tag).
+        None => Ok(Some(ComparableValue::String(Arc::from("")))),
     }
 }
 
@@ -350,19 +399,23 @@ pub fn eval_str_after<R: RowAccess>(
     ctx: Option<&ExecutionContext<'_>>,
 ) -> Result<Option<ComparableValue>> {
     check_arity(args, 2, "STRAFTER")?;
-    let lang = extract_lang_tag(&args[0], row, ctx);
     let arg1 = args[0].eval_to_comparable(row, ctx)?;
     let arg2 = args[1].eval_to_comparable(row, ctx)?;
-    match (arg1, arg2) {
-        (Some(ComparableValue::String(s)), Some(ComparableValue::String(d))) => {
-            let result = s
-                .find(d.as_ref())
-                .map(|pos| &s[pos + d.len()..])
-                .unwrap_or("");
-            Ok(Some(string_with_lang(result, lang)))
-        }
-        (None, _) | (_, None) => Ok(None),
-        _ => Ok(None),
+    let (Some((s, lang1)), Some((sub, lang2))) = (
+        str_arg_and_lang(&args[0], arg1, row, ctx),
+        str_arg_and_lang(&args[1], arg2, row, ctx),
+    ) else {
+        return Ok(None);
+    };
+    if !args_compatible(&lang1, &lang2) {
+        return Ok(None);
+    }
+    match s.find(&sub) {
+        // Found (the empty search string matches at 0 → the whole string):
+        // the result carries arg1's language tag.
+        Some(pos) => Ok(Some(string_with_lang(&s[pos + sub.len()..], lang1))),
+        // Not found: a plain empty simple literal (no language tag).
+        None => Ok(Some(ComparableValue::String(Arc::from("")))),
     }
 }
 
@@ -587,6 +640,7 @@ pub fn eval_str_lang<R: RowAccess>(
 mod tests {
     use super::*;
     use crate::binding::Batch;
+    use crate::ir::Function;
     use crate::var_registry::VarId;
     use fluree_db_core::value::FlakeValue;
     use fluree_db_core::Sid;
@@ -656,5 +710,104 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result, Some(ComparableValue::Bool(true)));
+    }
+
+    // STRBEFORE / STRAFTER — SPARQL 1.1 §17.4.3.7/8 datatyping rules.
+
+    fn lang_batch(value: &str, lang: &str) -> Batch {
+        let schema: Arc<[VarId]> = Arc::from(vec![VarId(0)].into_boxed_slice());
+        let col = vec![Binding::lit_lang(
+            FlakeValue::String(value.to_string()),
+            lang,
+        )];
+        Batch::new(schema, vec![col]).unwrap()
+    }
+
+    fn lang_const(value: &str, lang: &str) -> Expression {
+        // `"value"@lang` in expression position lowers to STRLANG(value, lang).
+        Expression::Call {
+            func: Function::StrLang,
+            args: vec![
+                Expression::Const(FlakeValue::String(value.to_string())),
+                Expression::Const(FlakeValue::String(lang.to_string())),
+            ],
+        }
+    }
+
+    fn s_const(value: &str) -> Expression {
+        Expression::Const(FlakeValue::String(value.to_string()))
+    }
+
+    #[test]
+    fn test_strbefore_found_preserves_lang() {
+        let batch = lang_batch("english", "en");
+        let row = batch.row_view(0).unwrap();
+        let r =
+            eval_str_before::<_>(&[Expression::Var(VarId(0)), s_const("s")], &row, None).unwrap();
+        assert_eq!(r, Some(string_with_lang("engli", Some(Arc::from("en")))));
+    }
+
+    #[test]
+    fn test_strbefore_no_match_is_plain_empty() {
+        // No match must drop arg1's language tag → plain "".
+        let batch = lang_batch("日本語", "ja");
+        let row = batch.row_view(0).unwrap();
+        let r =
+            eval_str_before::<_>(&[Expression::Var(VarId(0)), s_const("s")], &row, None).unwrap();
+        assert_eq!(r, Some(ComparableValue::String(Arc::from(""))));
+    }
+
+    #[test]
+    fn test_strafter_empty_substring_returns_whole_with_lang() {
+        let batch = lang_batch("abc", "en");
+        let row = batch.row_view(0).unwrap();
+        let r = eval_str_after::<_>(&[Expression::Var(VarId(0)), s_const("")], &row, None).unwrap();
+        assert_eq!(r, Some(string_with_lang("abc", Some(Arc::from("en")))));
+    }
+
+    #[test]
+    fn test_strbefore_empty_substring_returns_empty_with_lang() {
+        let batch = lang_batch("abc", "en");
+        let row = batch.row_view(0).unwrap();
+        let r =
+            eval_str_before::<_>(&[Expression::Var(VarId(0)), s_const("")], &row, None).unwrap();
+        assert_eq!(r, Some(string_with_lang("", Some(Arc::from("en")))));
+    }
+
+    #[test]
+    fn test_strbefore_incompatible_lang_is_unbound() {
+        // arg1 @en, arg2 @cy → incompatible → type error → unbound.
+        let batch = lang_batch("abc", "en");
+        let row = batch.row_view(0).unwrap();
+        let r = eval_str_before::<_>(
+            &[Expression::Var(VarId(0)), lang_const("b", "cy")],
+            &row,
+            None,
+        )
+        .unwrap();
+        assert_eq!(r, None);
+
+        // Same lang → compatible.
+        let r2 = eval_str_before::<_>(
+            &[Expression::Var(VarId(0)), lang_const("b", "en")],
+            &row,
+            None,
+        )
+        .unwrap();
+        assert_eq!(r2, Some(string_with_lang("a", Some(Arc::from("en")))));
+    }
+
+    #[test]
+    fn test_strbefore_simple_arg1_with_lang_arg2_is_unbound() {
+        // arg1 simple (no lang), arg2 @en → incompatible.
+        let batch = make_string_batch(); // "Hello World", no lang
+        let row = batch.row_view(0).unwrap();
+        let r = eval_str_before::<_>(
+            &[Expression::Var(VarId(0)), lang_const("World", "en")],
+            &row,
+            None,
+        )
+        .unwrap();
+        assert_eq!(r, None);
     }
 }

--- a/fluree-db-query/src/eval/string.rs
+++ b/fluree-db-query/src/eval/string.rs
@@ -337,20 +337,27 @@ fn str_arg_and_lang<R: RowAccess>(
     value: Option<ComparableValue>,
     row: &R,
     ctx: Option<&ExecutionContext<'_>>,
-) -> Option<(String, Option<Arc<str>>)> {
+) -> Option<(Arc<str>, Option<Arc<str>>)> {
     match value? {
-        ComparableValue::String(s) => Some((s.to_string(), extract_lang_tag(expr, row, ctx))),
+        // Common case: a variable-bound string already holds an `Arc<str>`,
+        // so this is a zero-copy move.
+        ComparableValue::String(s) => Some((s, extract_lang_tag(expr, row, ctx))),
         ComparableValue::TypedLiteral {
             val: FlakeValue::String(s),
             dtc,
-        } => {
-            let lang = match dtc {
-                Some(UnresolvedDatatypeConstraint::LangTag(tag)) => Some(tag),
-                // xsd:string (or any non-lang datatype) carries no language tag.
-                _ => extract_lang_tag(expr, row, ctx),
-            };
-            Some((s, lang))
-        }
+        } => match dtc {
+            Some(UnresolvedDatatypeConstraint::LangTag(tag)) => Some((Arc::from(s), Some(tag))),
+            // A non-string custom datatype (e.g. `STRDT("x","ex:dt")`) is not a
+            // valid STRBEFORE/STRAFTER argument per SPARQL 1.1 — raise a type
+            // error (→ unbound) rather than treating it as a plain string.
+            Some(UnresolvedDatatypeConstraint::Explicit(iri))
+                if iri.as_ref() != fluree_vocab::xsd::STRING =>
+            {
+                None
+            }
+            // Simple literal (no dtc) or explicit `xsd:string`: no language tag.
+            _ => Some((Arc::from(s), extract_lang_tag(expr, row, ctx))),
+        },
         _ => None,
     }
 }
@@ -363,7 +370,10 @@ fn str_arg_and_lang<R: RowAccess>(
 fn args_compatible(lang1: &Option<Arc<str>>, lang2: &Option<Arc<str>>) -> bool {
     match lang2 {
         None => true,
-        Some(l2) => lang1.as_deref() == Some(l2.as_ref()),
+        // RDF 1.1 language tags compare case-insensitively (`@en` == `@EN`).
+        Some(l2) => lang1
+            .as_deref()
+            .is_some_and(|l1| l1.eq_ignore_ascii_case(l2)),
     }
 }
 
@@ -384,7 +394,7 @@ pub fn eval_str_before<R: RowAccess>(
     if !args_compatible(&lang1, &lang2) {
         return Ok(None);
     }
-    match s.find(&sub) {
+    match s.find(sub.as_ref()) {
         // Found (including the empty search string, found at position 0):
         // the result carries arg1's language tag.
         Some(pos) => Ok(Some(string_with_lang(&s[..pos], lang1))),
@@ -410,7 +420,7 @@ pub fn eval_str_after<R: RowAccess>(
     if !args_compatible(&lang1, &lang2) {
         return Ok(None);
     }
-    match s.find(&sub) {
+    match s.find(sub.as_ref()) {
         // Found (the empty search string matches at 0 → the whole string):
         // the result carries arg1's language tag.
         Some(pos) => Ok(Some(string_with_lang(&s[pos + sub.len()..], lang1))),
@@ -809,5 +819,57 @@ mod tests {
         )
         .unwrap();
         assert_eq!(r, None);
+    }
+
+    fn strdt_const(value: &str, dt_iri: &str) -> Expression {
+        Expression::Call {
+            func: Function::StrDt,
+            args: vec![
+                Expression::Const(FlakeValue::String(value.to_string())),
+                Expression::Const(FlakeValue::String(dt_iri.to_string())),
+            ],
+        }
+    }
+
+    #[test]
+    fn test_strbefore_custom_datatype_arg_is_unbound() {
+        // A string with a custom (non-xsd:string) datatype is not a valid
+        // STRBEFORE argument per SPARQL 1.1 → type error → unbound.
+        let batch = make_string_batch();
+        let row = batch.row_view(0).unwrap();
+        let r = eval_str_before::<_>(
+            &[strdt_const("hello", "http://example.org/dt"), s_const("l")],
+            &row,
+            None,
+        )
+        .unwrap();
+        assert_eq!(r, None);
+
+        // An explicit `xsd:string` datatype IS valid (behaves like a simple literal).
+        let r2 = eval_str_before::<_>(
+            &[
+                strdt_const("hello", "http://www.w3.org/2001/XMLSchema#string"),
+                s_const("l"),
+            ],
+            &row,
+            None,
+        )
+        .unwrap();
+        assert_eq!(r2, Some(ComparableValue::String(Arc::from("he"))));
+    }
+
+    #[test]
+    fn test_strbefore_lang_tags_compare_case_insensitively() {
+        // RDF 1.1 language tags are case-insensitive: arg1 @EN, arg2 @en are
+        // compatible, and the result preserves arg1's tag verbatim.
+        let batch = make_string_batch();
+        let row = batch.row_view(0).unwrap();
+        let r = eval_str_before::<_>(
+            &[lang_const("english", "EN"), lang_const("s", "en")],
+            &row,
+            None,
+        )
+        .unwrap();
+        assert_eq!(r, Some(string_with_lang("engli", Some(Arc::from("EN")))));
     }
 }

--- a/fluree-db-sparql/src/lower/expression.rs
+++ b/fluree-db-sparql/src/lower/expression.rs
@@ -21,6 +21,20 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             }
 
             AstExpression::Literal(lit) => {
+                // A language-tagged literal must keep its tag in expression
+                // position (`"x"@lang` ≡ `STRLANG("x", "lang")`). Lowering it to
+                // a bare string constant would lose the tag and break language
+                // semantics (e.g. STRBEFORE/STRAFTER argument compatibility,
+                // language-aware equality).
+                if let LiteralValue::LangTagged { value, lang } = &lit.value {
+                    return Ok(Expression::Call {
+                        func: Function::StrLang,
+                        args: vec![
+                            Expression::Const(FlakeValue::String(value.to_string())),
+                            Expression::Const(FlakeValue::String(lang.to_string())),
+                        ],
+                    });
+                }
                 let value = self.lower_filter_value(lit)?;
                 Ok(Expression::Const(value))
             }

--- a/fluree-db-sparql/src/parse/query/construct.rs
+++ b/fluree-db-sparql/src/parse/query/construct.rs
@@ -1,6 +1,6 @@
 //! CONSTRUCT query parsing.
 
-use crate::ast::{ConstructQuery, ConstructTemplate, TriplePattern};
+use crate::ast::{ConstructQuery, ConstructTemplate, GraphPattern, TriplePattern, WhereClause};
 use crate::lex::TokenKind;
 
 impl super::Parser<'_> {
@@ -45,12 +45,20 @@ impl super::Parser<'_> {
                 span,
             })
         } else {
-            // Shorthand form: CONSTRUCT DatasetClause* WHERE { ... }
-            // Parse optional dataset clause
+            // Shorthand form: CONSTRUCT DatasetClause* WHERE '{' TriplesTemplate? '}'
+            // The WHERE block is a *triples template* only — FILTER, GRAPH,
+            // OPTIONAL, BIND, UNION, sub-SELECT, etc. are NOT permitted here
+            // (negative tests constructwhere05/06). The template is derived
+            // from these triples at lowering time.
             let dataset = self.parse_dataset_clause();
 
-            // Parse WHERE clause (required for shorthand)
-            let where_clause = self.parse_where_clause()?;
+            if !self.stream.match_keyword(TokenKind::KwWhere) {
+                self.stream
+                    .error_at_current("expected WHERE for CONSTRUCT shorthand form");
+                return None;
+            }
+
+            let where_clause = self.parse_construct_where_shorthand()?;
 
             // Parse solution modifiers
             let modifiers = self.parse_solution_modifiers();
@@ -65,6 +73,52 @@ impl super::Parser<'_> {
                 span,
             })
         }
+    }
+
+    /// Parse the restricted WHERE block of the `CONSTRUCT WHERE { ... }` shorthand.
+    ///
+    /// Per the SPARQL 1.1 grammar (`ConstructQuery`), the shorthand WHERE block is
+    /// `'{' TriplesTemplate? '}'` — a basic graph pattern of triple patterns only.
+    /// Anything else (FILTER, GRAPH, OPTIONAL, BIND, UNION, nested groups) is a
+    /// syntax error in this position.
+    fn parse_construct_where_shorthand(&mut self) -> Option<WhereClause> {
+        let start = self.stream.current_span();
+
+        if !self.stream.match_token(&TokenKind::LBrace) {
+            self.stream.error_at_current("expected '{' after WHERE");
+            return None;
+        }
+
+        let mut triples: Vec<TriplePattern> = Vec::new();
+
+        while !self.stream.check(&TokenKind::RBrace) && !self.stream.is_eof() {
+            let subject = match self.parse_subject() {
+                Some(s) => s,
+                None => {
+                    self.stream
+                        .error_at_current("CONSTRUCT WHERE shorthand permits only triple patterns");
+                    return None;
+                }
+            };
+
+            self.parse_construct_predicate_object_list(&subject, &mut triples)?;
+
+            // Optional triple separator
+            self.stream.match_token(&TokenKind::Dot);
+        }
+
+        if !self.stream.match_token(&TokenKind::RBrace) {
+            self.stream
+                .error_at_current("expected '}' after CONSTRUCT WHERE pattern");
+            return None;
+        }
+
+        let span = start.union(self.stream.previous_span());
+        let bgp = GraphPattern::Bgp {
+            patterns: triples,
+            span,
+        };
+        Some(WhereClause::new(bgp, true, span))
     }
 
     /// Parse a CONSTRUCT template (the triples to build).

--- a/testsuite-sparql/src/result_format.rs
+++ b/testsuite-sparql/src/result_format.rs
@@ -650,11 +650,97 @@ fn ir_term_to_rdf_term(term: &IrTerm) -> RdfTerm {
 // Convert Fluree CONSTRUCT JSON-LD output → SparqlResults::Graph
 // ---------------------------------------------------------------------------
 
+/// A minimal JSON-LD `@context` used to expand compact IRIs in CONSTRUCT output.
+///
+/// Fluree emits CONSTRUCT graphs as *compact* JSON-LD (e.g. `@id: ":s1"` with a
+/// context `{"": "http://example.org/"}`). To compare against the W3C expected
+/// graphs we must expand those compact IRIs back to absolute form. This handles
+/// the subset of context features Fluree actually produces: prefix terms
+/// (including the empty prefix), `@vocab`, and `@base`.
+#[derive(Default)]
+struct JsonLdContext {
+    /// Prefix/term → namespace IRI (keyed by the part before `:`; `""` = empty prefix).
+    prefixes: HashMap<String, String>,
+    vocab: Option<String>,
+    base: Option<String>,
+}
+
+impl JsonLdContext {
+    fn parse(json: &serde_json::Value) -> Self {
+        let mut ctx = JsonLdContext::default();
+        let Some(obj) = json.get("@context").and_then(|c| c.as_object()) else {
+            return ctx;
+        };
+        for (key, val) in obj {
+            // A term may be defined directly as an IRI string, or as an
+            // expanded term object `{"@id": "..."}`.
+            let iri = match val {
+                serde_json::Value::String(s) => Some(s.clone()),
+                serde_json::Value::Object(o) => {
+                    o.get("@id").and_then(|v| v.as_str()).map(String::from)
+                }
+                _ => None,
+            };
+            let Some(iri) = iri else { continue };
+            match key.as_str() {
+                "@vocab" => ctx.vocab = Some(iri),
+                "@base" => ctx.base = Some(iri),
+                _ => {
+                    ctx.prefixes.insert(key.clone(), iri);
+                }
+            }
+        }
+        ctx
+    }
+
+    /// Expand a node identifier or `@id` reference (NOT vocab-mapped).
+    fn expand_id(&self, value: &str) -> String {
+        if let Some((prefix, suffix)) = value.split_once(':') {
+            // `scheme://…` absolute IRIs must pass through untouched.
+            if suffix.starts_with("//") {
+                return value.to_string();
+            }
+            if let Some(ns) = self.prefixes.get(prefix) {
+                return format!("{ns}{suffix}");
+            }
+            return value.to_string();
+        }
+        // Relative reference: resolve against @base when present.
+        match &self.base {
+            Some(base) => format!("{base}{value}"),
+            None => value.to_string(),
+        }
+    }
+
+    /// Expand a predicate key or `@type` value (vocab-mapped).
+    fn expand_vocab(&self, value: &str) -> String {
+        if let Some((prefix, suffix)) = value.split_once(':') {
+            if suffix.starts_with("//") {
+                return value.to_string();
+            }
+            if let Some(ns) = self.prefixes.get(prefix) {
+                return format!("{ns}{suffix}");
+            }
+            return value.to_string();
+        }
+        // Bare term: an explicit term definition wins, else fall back to @vocab.
+        if let Some(ns) = self.prefixes.get(value) {
+            return ns.clone();
+        }
+        match &self.vocab {
+            Some(vocab) => format!("{vocab}{value}"),
+            None => value.to_string(),
+        }
+    }
+}
+
 /// Convert Fluree's CONSTRUCT JSON-LD output into a [`SparqlResults::Graph`].
 ///
 /// Expects a JSON-LD `@graph` array (or a single node object). Each node has
 /// `@id` as the subject; every other key is a predicate whose values are objects.
+/// Compact IRIs are expanded against the result's `@context`.
 pub fn fluree_construct_to_sparql_results(json: &serde_json::Value) -> Result<SparqlResults> {
+    let ctx = JsonLdContext::parse(json);
     let nodes = if let Some(graph) = json.get("@graph").and_then(|g| g.as_array()) {
         graph.clone()
     } else if json.is_array() {
@@ -675,7 +761,7 @@ pub fn fluree_construct_to_sparql_results(json: &serde_json::Value) -> Result<Sp
         let subject = match obj.get("@id").and_then(|v| v.as_str()) {
             Some(id) => match id.strip_prefix("_:") {
                 Some(label) => RdfTerm::BlankNode(label.to_string()),
-                None => RdfTerm::Iri(id.to_string()),
+                None => RdfTerm::Iri(ctx.expand_id(id)),
             },
             None => continue, // skip nodes without @id
         };
@@ -697,21 +783,21 @@ pub fn fluree_construct_to_sparql_results(json: &serde_json::Value) -> Result<Sp
                         triples.push(Triple {
                             subject: subject.clone(),
                             predicate: rdf_type.clone(),
-                            object: RdfTerm::Iri(t.to_string()),
+                            object: RdfTerm::Iri(ctx.expand_vocab(t)),
                         });
                     }
                 }
                 continue;
             }
 
-            let predicate = RdfTerm::Iri(key.clone());
+            let predicate = RdfTerm::Iri(ctx.expand_vocab(key));
             let values = match value {
                 serde_json::Value::Array(arr) => arr.clone(),
                 other => vec![other.clone()],
             };
 
             for val in &values {
-                if let Some(term) = json_ld_value_to_rdf_term(val) {
+                if let Some(term) = json_ld_value_to_rdf_term(val, &ctx) {
                     triples.push(Triple {
                         subject: subject.clone(),
                         predicate: predicate.clone(),
@@ -729,13 +815,13 @@ pub fn fluree_construct_to_sparql_results(json: &serde_json::Value) -> Result<Sp
 ///
 /// Handles `{"@id": "..."}`, `{"@value": "...", "@type": "...", "@language": "..."}`,
 /// and plain string/number values.
-fn json_ld_value_to_rdf_term(val: &serde_json::Value) -> Option<RdfTerm> {
+fn json_ld_value_to_rdf_term(val: &serde_json::Value, ctx: &JsonLdContext) -> Option<RdfTerm> {
     if let Some(obj) = val.as_object() {
         // Node reference: {"@id": "http://..."}
         if let Some(id) = obj.get("@id").and_then(|v| v.as_str()) {
             return Some(match id.strip_prefix("_:") {
                 Some(label) => RdfTerm::BlankNode(label.to_string()),
-                None => RdfTerm::Iri(id.to_string()),
+                None => RdfTerm::Iri(ctx.expand_id(id)),
             });
         }
 
@@ -747,7 +833,10 @@ fn json_ld_value_to_rdf_term(val: &serde_json::Value) -> Option<RdfTerm> {
                 serde_json::Value::Bool(b) => b.to_string(),
                 _ => return None,
             };
-            let datatype = obj.get("@type").and_then(|v| v.as_str()).map(String::from);
+            let datatype = obj
+                .get("@type")
+                .and_then(|v| v.as_str())
+                .map(|t| ctx.expand_vocab(t));
             let language = obj
                 .get("@language")
                 .and_then(|v| v.as_str())
@@ -1022,6 +1111,68 @@ ex:bob ex:name "Bob" .
             }
             _ => panic!("Expected Graph, got {result:?}"),
         }
+    }
+
+    #[test]
+    fn test_construct_jsonld_expands_compact_iris() {
+        // Fluree emits CONSTRUCT graphs as compact JSON-LD. The converter must
+        // expand `@id`, predicate keys, and node references against `@context`
+        // (here using the empty prefix `""`), matching the W3C expected graph.
+        let json = serde_json::json!({
+            "@context": { "": "http://example.org/" },
+            "@graph": [
+                { "@id": ":s1", ":p": [ { "@id": ":o1" } ] },
+                { "@id": ":s2", ":p": [ { "@id": ":o1" }, { "@id": ":o2" } ] },
+            ]
+        });
+        let result = fluree_construct_to_sparql_results(&json).unwrap();
+        let SparqlResults::Graph(triples) = result else {
+            panic!("expected Graph");
+        };
+        assert_eq!(triples.len(), 3);
+        assert!(triples.contains(&Triple {
+            subject: RdfTerm::Iri("http://example.org/s1".into()),
+            predicate: RdfTerm::Iri("http://example.org/p".into()),
+            object: RdfTerm::Iri("http://example.org/o1".into()),
+        }));
+        assert!(triples.contains(&Triple {
+            subject: RdfTerm::Iri("http://example.org/s2".into()),
+            predicate: RdfTerm::Iri("http://example.org/p".into()),
+            object: RdfTerm::Iri("http://example.org/o2".into()),
+        }));
+    }
+
+    #[test]
+    fn test_construct_jsonld_vocab_and_absolute_passthrough() {
+        // @vocab maps bare predicate terms; already-absolute IRIs pass through.
+        let json = serde_json::json!({
+            "@context": { "@vocab": "http://example.org/" },
+            "@graph": [
+                {
+                    "@id": "http://example.org/s1",
+                    "name": [ { "@value": "Alice" } ],
+                    "@type": "Person"
+                }
+            ]
+        });
+        let result = fluree_construct_to_sparql_results(&json).unwrap();
+        let SparqlResults::Graph(triples) = result else {
+            panic!("expected Graph");
+        };
+        assert!(triples.contains(&Triple {
+            subject: RdfTerm::Iri("http://example.org/s1".into()),
+            predicate: RdfTerm::Iri("http://example.org/name".into()),
+            object: RdfTerm::Literal {
+                value: "Alice".into(),
+                datatype: None,
+                language: None,
+            },
+        }));
+        assert!(triples.contains(&Triple {
+            subject: RdfTerm::Iri("http://example.org/s1".into()),
+            predicate: RdfTerm::Iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".into()),
+            object: RdfTerm::Iri("http://example.org/Person".into()),
+        }));
     }
 
     #[test]


### PR DESCRIPTION
A couple of narrow SPARQL correctness fixes surfaced by the W3C 1.1 query test suite. These are edge-case bugs in already-supported features — not gaps in functionality.

## CONSTRUCT

- **Compact-IRI comparison in the test harness.** Our engine already emits valid *compact* JSON-LD for CONSTRUCT (e.g. `@id: ":s1"` with `@context: {"": "http://example.org/"}`). The W3C harness's graph comparator was reading `@id`/predicate keys literally and ignoring `@context`, so equivalent graphs compared unequal. Added a minimal context expander (prefix terms incl. the empty prefix, `@vocab`, `@base`). Engine output unchanged.
- **`CONSTRUCT WHERE` shorthand was too permissive.** Per the SPARQL 1.1 grammar the shorthand block is triples-only; we were routing it through the full group-graph-pattern parser and accepting `FILTER`/`GRAPH`/etc. Now rejected as a syntax error, matching the spec's negative tests.

## STRBEFORE / STRAFTER

- **Datatyping edge cases** (SPARQL 1.1 §17.4.3.7/8): a not-found search now returns a plain empty literal (previously it inherited arg1's language tag), a found match — including the empty search string — preserves arg1's tag, and an arg2 with an incompatible language tag now raises a type error per the argument-compatibility rules.
- **Language tags on literal constants in expression position** were dropped at lowering (`"x"@lang` became a bare `"x"`). They now lower to `STRLANG("x", "lang")` so the tag survives — needed for the compatibility checks above, and correct for language-aware expressions generally.

## Validation

- W3C SPARQL 1.1 eval suite: **+9 tests, zero regressions**.
- Full `fluree-db-sparql`, `fluree-db-query`, and `fluree-db-api` test suites pass; added unit tests covering the STRBEFORE/STRAFTER cases and the CONSTRUCT context expansion.
- `cargo fmt` + `clippy` clean on the touched crates.