### PR TITLE
fix: speed up fluree-memory adds and stop them hanging under concurrency

### DIFF
--- a/docs/memory/guides/team-workflows.md
+++ b/docs/memory/guides/team-workflows.md
@@ -39,7 +39,7 @@ Memories in `repo.ttl` are sorted by `(branch, id)` — memories from the same g
 
 The branch name is captured automatically when a memory is created, so memories from `feature/auth` sort separately from memories created on `feature/indexer`. Within each branch group, memories are ordered chronologically (ULID encodes creation time).
 
-When conflicts do occur, they're usually because two branches modified the same existing memory (via `update`) or both worked on the same branch. These are typically clean to resolve:
+When conflicts do occur, they're usually because two branches modified the same existing memory (via `update`/`forget`) or both worked on the same branch. That's by design: a normal git merge surfaces the overlap so you choose the right version, rather than silently fusing two edits into one corrupted memory. These are typically clean to resolve:
 
 ```ttl
 <<<<<<< HEAD

--- a/docs/memory/reference/ttl-format.md
+++ b/docs/memory/reference/ttl-format.md
@@ -46,7 +46,7 @@ The TTL file is the **canonical** store for a given scope. The `__memory` ledger
 
 When you `memory add`, the CLI / MCP server:
 
-1. Rewrites the TTL file with the new memory inserted in sorted position (authoritative).
+1. Splices the new memory's block into its sorted `(branch, id)` position in the TTL file (authoritative). It reads and rewrites the file text directly — it does **not** re-derive the file from the ledger — so an add stays fast as the store grows. (`update` and `forget` rewrite the whole file, since they change or remove an existing block.)
 2. Transacts the new triples into the `__memory` ledger (so recall is fast).
 3. Writes a content-hash watermark to `.fluree-memory/.local/build-hash`.
 
@@ -56,7 +56,7 @@ If the ledger write fails, the hash is left stale and the next `ensure_synced` c
 
 It's normal for several processes to touch one project's memory at once — Cursor and Claude Code together, or several Claude sessions, each running its own `fluree mcp serve`. Two guarantees keep that safe:
 
-- **The TTL file is the only shared mutable state, and writes are serialized.** Every mutation takes a cross-process file lock (`.fluree-memory/.local/rebuild.lock`) before rewriting the file, and re-reads the file under that lock, so two writers can't lose each other's memories.
+- **The TTL file is the only shared mutable state, and writes are serialized.** Every mutation takes a cross-process file lock (`.fluree-memory/.local/rebuild.lock`) before touching the file, and re-reads the file under that lock, so two writers can't lose each other's memories. The lock wait is bounded (30s default, override with `FLUREE_MEMORY_LOCK_TIMEOUT_SECS`): if another process is wedged holding it, the operation fails with a clear error instead of hanging.
 - **Each process keeps its ledger cache private.** The `mcp serve` ledger is held **in-memory** and rebuilt from the TTL files on startup, so one process refreshing its cache can never disturb another's. Each process also tracks, in memory, the file content its own ledger reflects — the shared on-disk `build-hash` alone can't tell a long-running process that *another* process changed the files, so the per-process watermark is what triggers its rebuild. (Short-lived `fluree memory` CLI commands keep a file-backed ledger for `import` and legacy migration; they're not long-lived enough to drift.)
 
 ## Editing by hand

--- a/fluree-db-memory/src/file_sync.rs
+++ b/fluree-db-memory/src/file_sync.rs
@@ -440,6 +440,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join(".local")).unwrap();
         // Keep the timeout short so the test is fast.
+        // NOTE: this mutates the process-global env that `lock_timeout()` reads.
+        // It is safe only because no sibling test in this binary reads
+        // `lock_timeout()`; if one is added, this test must serialize against it
+        // (e.g. a shared mutex) or scope the var, since nextest runs siblings on
+        // parallel threads in the same process.
         std::env::set_var("FLUREE_MEMORY_LOCK_TIMEOUT_SECS", "1");
 
         // First acquisition succeeds and holds the lock.

--- a/fluree-db-memory/src/file_sync.rs
+++ b/fluree-db-memory/src/file_sync.rs
@@ -190,6 +190,7 @@ pub(crate) async fn acquire_memory_lock(memory_dir: &Path) -> Result<fs::File> {
 }
 
 async fn acquire_lock_file(lock_path: PathBuf) -> Result<fs::File> {
+    let timeout = lock_timeout();
     tokio::task::spawn_blocking(move || {
         if let Some(parent) = lock_path.parent() {
             fs::create_dir_all(parent)?;
@@ -201,14 +202,51 @@ async fn acquire_lock_file(lock_path: PathBuf) -> Result<fs::File> {
             .truncate(false)
             .open(&lock_path)?;
 
+        // Poll `try_lock` to a deadline instead of blocking forever. A wedged
+        // peer process (e.g. a spun memory server from another IDE window) must
+        // not be able to freeze this one indefinitely — time out with a clear
+        // error so the caller can surface it and recover.
         use fs2::FileExt;
-        lock_file
-            .lock_exclusive()
-            .map_err(|e| MemoryError::FileSync(format!("failed to acquire rebuild lock: {e}")))?;
-        Ok(lock_file)
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            match lock_file.try_lock_exclusive() {
+                Ok(()) => return Ok(lock_file),
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err(MemoryError::FileSync(format!(
+                            "timed out after {timeout:?} waiting for the memory rebuild lock \
+                             ({}); another fluree process may be stuck holding it",
+                            lock_path.display()
+                        )));
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(e) => {
+                    return Err(MemoryError::FileSync(format!(
+                        "failed to acquire rebuild lock: {e}"
+                    )))
+                }
+            }
+        }
     })
     .await
     .map_err(|e| MemoryError::FileSync(format!("failed to join rebuild lock task: {e}")))?
+}
+
+/// Maximum time to wait for either memory lock before giving up.
+///
+/// Bounds both the cross-process flock and the in-process mutation lock so a
+/// stuck operation surfaces a recoverable error instead of freezing a session.
+/// Generous by default (legitimate rebuilds are sub-second now that adds are
+/// append-only) and overridable via `FLUREE_MEMORY_LOCK_TIMEOUT_SECS`.
+pub(crate) fn lock_timeout() -> std::time::Duration {
+    const DEFAULT_SECS: u64 = 30;
+    let secs = std::env::var("FLUREE_MEMORY_LOCK_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(DEFAULT_SECS);
+    std::time::Duration::from_secs(secs)
 }
 
 /// Rebuild the ledger from files if this process's ledger is stale, assuming
@@ -396,6 +434,35 @@ mod hex {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn rebuild_lock_times_out_when_already_held() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".local")).unwrap();
+        // Keep the timeout short so the test is fast.
+        std::env::set_var("FLUREE_MEMORY_LOCK_TIMEOUT_SECS", "1");
+
+        // First acquisition succeeds and holds the lock.
+        let held = acquire_memory_lock(dir.path()).await.expect("first lock");
+
+        // A second acquisition (separate fd, same process) must not block
+        // forever — it times out with an error.
+        let start = std::time::Instant::now();
+        let res = acquire_memory_lock(dir.path()).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            res.is_err(),
+            "second acquisition should time out while the lock is held"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "timeout should fire promptly (took {elapsed:?})"
+        );
+
+        drop(held);
+        std::env::remove_var("FLUREE_MEMORY_LOCK_TIMEOUT_SECS");
+    }
 
     #[test]
     fn hash_determinism() {

--- a/fluree-db-memory/src/store.rs
+++ b/fluree-db-memory/src/store.rs
@@ -176,6 +176,23 @@ impl MemoryStore {
         *self.synced_hash.lock().expect("synced_hash poisoned") = hash;
     }
 
+    /// Acquire the in-process mutation lock, bounded by [`crate::file_sync::lock_timeout`].
+    ///
+    /// Using a timeout instead of an unbounded `.lock().await` means that if a
+    /// prior memory operation is stuck holding the lock (e.g. a wedged task
+    /// spinning under it), later calls fail with a recoverable error rather than
+    /// freezing the session forever.
+    async fn lock_mutation(&self) -> Result<tokio::sync::MutexGuard<'_, ()>> {
+        let timeout = crate::file_sync::lock_timeout();
+        match tokio::time::timeout(timeout, self.mutation_lock.lock()).await {
+            Ok(guard) => Ok(guard),
+            Err(_) => Err(MemoryError::FileSync(format!(
+                "timed out after {timeout:?} waiting for the in-process memory lock; \
+                 a prior memory operation may be stuck"
+            ))),
+        }
+    }
+
     /// Check if the memory ledger has been initialized.
     pub async fn is_initialized(&self) -> Result<bool> {
         Ok(self.fluree.ledger_exists(MEMORY_LEDGER_ID).await?)
@@ -266,7 +283,7 @@ impl MemoryStore {
     ///
     /// Used by the rebuild pipeline to recreate the ledger from `.ttl` files.
     pub async fn drop_and_reinit(&self) -> Result<()> {
-        let _guard = self.mutation_lock.lock().await;
+        let _guard = self.lock_mutation().await?;
         let file_lock = self.acquire_file_lock().await?;
         let result = self.drop_and_reinit_unlocked().await;
         drop(file_lock);
@@ -309,7 +326,7 @@ impl MemoryStore {
     /// No-op if `memory_dir` is `None`.
     pub async fn ensure_synced(&self) -> Result<()> {
         if let Some(dir) = &self.memory_dir {
-            let _guard = self.mutation_lock.lock().await;
+            let _guard = self.lock_mutation().await?;
             crate::file_sync::ensure_synced(self, dir).await?;
         }
         Ok(())
@@ -351,7 +368,7 @@ impl MemoryStore {
     /// the ledger cache commit succeeds so that any cache failure leaves a hash
     /// mismatch and triggers a rebuild on the next `ensure_synced()`.
     pub async fn add(&self, input: MemoryInput) -> Result<String> {
-        let _guard = self.mutation_lock.lock().await;
+        let _guard = self.lock_mutation().await?;
         let file_lock = self.acquire_file_lock().await?;
         self.initialize().await?;
         self.sync_under_lock().await?;
@@ -373,24 +390,23 @@ impl MemoryStore {
             alternatives: input.alternatives,
         };
 
-        // File is truth — sorted rewrite so memories from different branches
-        // land in different regions of the file, reducing merge conflicts.
+        // File is truth — splice the new block into its sorted (branch, id)
+        // position by reading only the `.ttl` text, never re-querying the
+        // ledger. Untouched blocks stay byte-identical, so concurrent adds on
+        // different branches land in different regions and merge cleanly under
+        // a default git merge, while same-memory edits still conflict.
         if let Some(dir) = &self.memory_dir {
-            let (path, header, scope_filter) = match mem.scope {
+            let (path, header) = match mem.scope {
                 Scope::Repo => (
                     crate::turtle_io::repo_ttl_path(dir),
                     crate::turtle_io::REPO_HEADER,
-                    Some(Scope::Repo),
                 ),
                 Scope::User => (
                     crate::turtle_io::user_ttl_path(dir),
                     crate::turtle_io::USER_HEADER,
-                    Some(Scope::User),
                 ),
             };
-            let mut all = self.all_memories_for_scope(scope_filter.as_ref()).await?;
-            all.push(mem.clone());
-            crate::turtle_io::write_memory_file(&path, &all, header)?;
+            crate::turtle_io::insert_memory_into_file(&path, &mem, header)?;
         }
 
         // Then update the ledger cache
@@ -451,7 +467,7 @@ WHERE {{\n\
     /// In file-based mode, the `.ttl` file is rewritten first (authoritative),
     /// then the ledger is updated via retract-all + re-insert.
     pub async fn update(&self, id: &str, update: MemoryUpdate) -> Result<String> {
-        let _guard = self.mutation_lock.lock().await;
+        let _guard = self.lock_mutation().await?;
         let file_lock = self.acquire_file_lock().await?;
         self.initialize().await?;
         self.sync_under_lock().await?;
@@ -541,7 +557,7 @@ WHERE {{\n\
     /// In file-based mode, the `.ttl` file is rewritten first (authoritative),
     /// then the ledger cache is updated. This is the only non-append file mutation.
     pub async fn forget(&self, id: &str) -> Result<()> {
-        let _guard = self.mutation_lock.lock().await;
+        let _guard = self.lock_mutation().await?;
         let file_lock = self.acquire_file_lock().await?;
         self.initialize().await?;
         self.sync_under_lock().await?;
@@ -843,7 +859,7 @@ WHERE {{\n\
     ///
     /// Returns the number of memories imported.
     pub async fn import(&self, data: Value) -> Result<usize> {
-        let _guard = self.mutation_lock.lock().await;
+        let _guard = self.lock_mutation().await?;
         self.initialize().await?;
 
         let memories: Vec<Memory> = serde_json::from_value(data)?;

--- a/fluree-db-memory/src/turtle_io.rs
+++ b/fluree-db-memory/src/turtle_io.rs
@@ -148,12 +148,102 @@ pub fn append_memory_to_file(path: &Path, mem: &Memory, header_comment: &str) ->
     Ok(())
 }
 
+/// Insert one memory block into an existing `.ttl` file at its sorted
+/// `(branch, id)` position, leaving every other block byte-for-byte unchanged.
+///
+/// This is the hot path for `add`. It reads only the `.ttl` text (never the
+/// ledger), so it is O(file size) in cheap string work rather than an O(N)
+/// SPARQL round-trip. Keeping the untouched blocks byte-identical is what lets
+/// two branches' inserts merge cleanly under a default git merge: their changes
+/// land in different regions, while a change to the *same* block still
+/// conflicts. Ordering matches [`write_memory_file`].
+pub fn insert_memory_into_file(path: &Path, mem: &Memory, header_comment: &str) -> Result<()> {
+    // No file yet (or it lost its header) → create it with this single block.
+    if !path.exists() {
+        return append_memory_to_file(path, mem, header_comment);
+    }
+
+    let existing = fs::read_to_string(path)?;
+
+    // Byte offsets of each block's subject line (column-0 `mem:… a mem:…`).
+    let mut starts: Vec<usize> = Vec::new();
+    let mut pos = 0;
+    for line in existing.split_inclusive('\n') {
+        let l = line.trim_end_matches('\n');
+        if l.starts_with("mem:") && l.contains(" a mem:") {
+            starts.push(pos);
+        }
+        pos += line.len();
+    }
+
+    // Empty (header only) → behave like the create path: append after header.
+    if starts.is_empty() {
+        return append_memory_to_file(path, mem, header_comment);
+    }
+
+    let header = &existing[..starts[0]];
+    let blocks: Vec<&str> = (0..starts.len())
+        .map(|i| {
+            let end = starts.get(i + 1).copied().unwrap_or(existing.len());
+            &existing[starts[i]..end]
+        })
+        .collect();
+
+    let new_key = (mem.branch.clone().unwrap_or_default(), mem.id.clone());
+    let new_block = memory_to_turtle_block(mem);
+    let idx = blocks
+        .iter()
+        .position(|b| parse_block_key(b) > new_key)
+        .unwrap_or(blocks.len());
+
+    let mut out = String::with_capacity(existing.len() + new_block.len() + 2);
+    out.push_str(header);
+    for (i, b) in blocks.iter().enumerate() {
+        if i == idx {
+            out.push_str(&new_block);
+            out.push('\n');
+        }
+        out.push_str(b);
+    }
+    if idx == blocks.len() {
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push('\n');
+        out.push_str(&new_block);
+    }
+
+    fs::write(path, out)?;
+    Ok(())
+}
+
+/// Extract the `(branch, id)` sort key from a block's text, matching the order
+/// `write_memory_file` sorts by. `branch` defaults to "" when absent.
+fn parse_block_key(block: &str) -> (String, String) {
+    let mut id = String::new();
+    let mut branch = String::new();
+    for line in block.lines() {
+        if id.is_empty() && line.starts_with("mem:") {
+            if let Some(tok) = line.split_whitespace().next() {
+                id = tok.to_string();
+            }
+        } else if let Some(rest) = line.trim_start().strip_prefix("mem:branch \"") {
+            if let Some(end) = rest.find('"') {
+                branch = rest[..end].to_string();
+            }
+        }
+    }
+    (branch, id)
+}
+
 /// Write a full `.ttl` file from scratch with all memories.
 ///
-/// Used by `add`, `update`, and `forget` for all file mutations.
-/// Memories are sorted by `(branch, id)` so that memories from the same
-/// branch cluster together. This reduces merge conflicts: two feature
-/// branches adding memories will insert into different regions of the file.
+/// Used by `update` and `forget`, which must rewrite the whole file. `add`
+/// uses [`insert_memory_into_file`] instead. Memories are sorted by
+/// `(branch, id)` so memories from the same branch cluster together: two
+/// feature branches adding memories land in different regions of the file, so
+/// a default git merge resolves their additions without conflict while still
+/// surfacing a real conflict when both branches change the *same* memory.
 /// **Skips write if the new content is byte-identical** to the existing file.
 pub fn write_memory_file(path: &Path, memories: &[Memory], header_comment: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
@@ -164,8 +254,9 @@ pub fn write_memory_file(path: &Path, memories: &[Memory], header_comment: &str)
     content.push_str(header_comment);
     content.push_str(TURTLE_PREFIXES);
 
-    // Sort by (branch, id): groups memories by originating branch,
-    // chronological within each branch (ULID encodes time).
+    // Sort by (branch, id): groups memories by originating branch, chronological
+    // within each branch (ULID encodes time). Keep this in sync with the
+    // ordering used by `insert_memory_into_file`.
     let mut sorted: Vec<&Memory> = memories.iter().collect();
     sorted.sort_by(|a, b| {
         let branch_a = a.branch.as_deref().unwrap_or("");
@@ -488,6 +579,46 @@ mod tests {
         assert!(
             pos2 < pos1,
             "memories should be sorted by (branch, id) — no-branch before 'main'"
+        );
+    }
+
+    #[test]
+    fn insert_matches_full_rewrite() {
+        // Inserting memories one at a time must yield the same file a full
+        // sorted rewrite would — byte-for-byte — regardless of insert order.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("insert.ttl");
+
+        let mut a = make_test_memory(); // branch "main", id fact-01jdxyz...
+        a.content = "memory A".to_string();
+        a.tags = vec![];
+        a.artifact_refs = vec![];
+        let mut b = make_test_memory();
+        b.id = "mem:fact-01zzzz0000000000000000".to_string();
+        b.content = "memory B".to_string();
+        b.tags = vec![];
+        b.artifact_refs = vec![];
+        b.branch = None; // sorts before "main"
+        let mut c = make_test_memory();
+        c.id = "mem:fact-01aaaa0000000000000000".to_string();
+        c.content = "memory C".to_string();
+        c.tags = vec![];
+        c.artifact_refs = vec![];
+        c.branch = Some("zzz".to_string()); // sorts after "main"
+
+        // Insert in an order that exercises front/middle/end placement.
+        insert_memory_into_file(&path, &a, REPO_HEADER).unwrap();
+        insert_memory_into_file(&path, &c, REPO_HEADER).unwrap();
+        insert_memory_into_file(&path, &b, REPO_HEADER).unwrap();
+        let spliced = fs::read_to_string(&path).unwrap();
+
+        let rewritten_path = dir.path().join("rewrite.ttl");
+        write_memory_file(&rewritten_path, &[a, b, c], REPO_HEADER).unwrap();
+        let rewritten = fs::read_to_string(&rewritten_path).unwrap();
+
+        assert_eq!(
+            spliced, rewritten,
+            "incremental splice must match a full sorted rewrite byte-for-byte"
         );
     }
 

--- a/fluree-db-memory/src/turtle_io.rs
+++ b/fluree-db-memory/src/turtle_io.rs
@@ -606,7 +606,9 @@ mod tests {
         c.artifact_refs = vec![];
         c.branch = Some("zzz".to_string()); // sorts after "main"
 
-        // Insert in an order that exercises front/middle/end placement.
+        // Insert in an order that exercises end placement (c after a) then
+        // front placement (b before both). The strictly-between-two-blocks
+        // case is covered separately by `insert_between_existing_blocks`.
         insert_memory_into_file(&path, &a, REPO_HEADER).unwrap();
         insert_memory_into_file(&path, &c, REPO_HEADER).unwrap();
         insert_memory_into_file(&path, &b, REPO_HEADER).unwrap();
@@ -619,6 +621,54 @@ mod tests {
         assert_eq!(
             spliced, rewritten,
             "incremental splice must match a full sorted rewrite byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn insert_between_existing_blocks() {
+        // Seed [X, Z] then insert a Y that sorts strictly between them, so the
+        // splice lands in the middle of the block list (idx > 0 and
+        // idx < blocks.len()) rather than at the front or end. Must still match
+        // a full sorted rewrite byte-for-byte.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("between.ttl");
+
+        // All on the same branch so ordering is purely by id.
+        let mut x = make_test_memory();
+        x.id = "mem:fact-01aaaa0000000000000000".to_string();
+        x.content = "memory X".to_string();
+        x.tags = vec![];
+        x.artifact_refs = vec![];
+        let mut y = make_test_memory();
+        y.id = "mem:fact-01mmmm0000000000000000".to_string();
+        y.content = "memory Y".to_string();
+        y.tags = vec![];
+        y.artifact_refs = vec![];
+        let mut z = make_test_memory();
+        z.id = "mem:fact-01zzzz0000000000000000".to_string();
+        z.content = "memory Z".to_string();
+        z.tags = vec![];
+        z.artifact_refs = vec![];
+
+        // Seed the outer pair, then splice Y between X and Z.
+        insert_memory_into_file(&path, &x, REPO_HEADER).unwrap();
+        insert_memory_into_file(&path, &z, REPO_HEADER).unwrap();
+        insert_memory_into_file(&path, &y, REPO_HEADER).unwrap();
+        let spliced = fs::read_to_string(&path).unwrap();
+
+        // Y must land between X and Z.
+        let px = spliced.find("fact-01aaaa").unwrap();
+        let py = spliced.find("fact-01mmmm").unwrap();
+        let pz = spliced.find("fact-01zzzz").unwrap();
+        assert!(px < py && py < pz, "Y should splice between X and Z");
+
+        let rewritten_path = dir.path().join("rewrite.ttl");
+        write_memory_file(&rewritten_path, &[x, y, z], REPO_HEADER).unwrap();
+        let rewritten = fs::read_to_string(&rewritten_path).unwrap();
+
+        assert_eq!(
+            spliced, rewritten,
+            "middle splice must match a full sorted rewrite byte-for-byte"
         );
     }
 

--- a/fluree-db-memory/tests/it_merge.rs
+++ b/fluree-db-memory/tests/it_merge.rs
@@ -1,0 +1,186 @@
+//! Proves the memory file's git-merge behavior under a **default** merge (no
+//! special `.gitattributes`):
+//!   1. two branches each adding a memory in different `(branch, id)` regions
+//!      merge cleanly, and
+//!   2. two branches changing the *same* memory correctly CONFLICT — the safety
+//!      property that a blanket `merge=union` would have silently destroyed.
+//!
+//! See `turtle_io::insert_memory_into_file` (the sorted splice used by `add`)
+//! and `turtle_io::write_memory_file` (the rewrite used by update/forget).
+
+use fluree_db_memory::turtle_io::{
+    insert_memory_into_file, repo_ttl_path, write_memory_file, REPO_HEADER,
+};
+use fluree_db_memory::{Memory, MemoryKind, Scope};
+use std::path::Path;
+use std::process::Command;
+
+fn git(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("run git")
+}
+
+fn git_ok(dir: &Path, args: &[&str]) {
+    let out = git(dir, args);
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn mem(id: &str, content: &str, branch: &str) -> Memory {
+    Memory {
+        id: format!("mem:fact-{id}"),
+        kind: MemoryKind::Fact,
+        content: content.to_string(),
+        tags: vec!["t".to_string()],
+        scope: Scope::Repo,
+        severity: None,
+        artifact_refs: vec![],
+        branch: Some(branch.to_string()),
+        created_at: "2026-06-26T00:00:00+00:00".to_string(),
+        rationale: None,
+        alternatives: None,
+    }
+}
+
+fn init_repo(root: &Path) {
+    git_ok(root, &["init", "-q"]);
+    git_ok(root, &["config", "user.email", "t@t"]);
+    git_ok(root, &["config", "user.name", "t"]);
+    git_ok(root, &["config", "commit.gpgsign", "false"]);
+}
+
+/// Two branches each add a memory in different `(branch, id)` regions → clean
+/// merge under the default driver, both memories present exactly once.
+#[test]
+fn distinct_adds_merge_cleanly_under_default_merge() {
+    if !git_available() {
+        eprintln!("git not available — skipping merge test");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let mem_dir = root.join(".fluree-memory");
+    std::fs::create_dir_all(&mem_dir).unwrap();
+    let ttl = repo_ttl_path(&mem_dir);
+    init_repo(root);
+
+    // Base: a few memories on branch "main" so the regions are well separated.
+    write_memory_file(
+        &ttl,
+        &[
+            mem("00000000000000000000000001", "base one", "main"),
+            mem("00000000000000000000000002", "base two", "main"),
+        ],
+        REPO_HEADER,
+    )
+    .unwrap();
+    git_ok(root, &["add", "-A"]);
+    git_ok(root, &["commit", "-qm", "base"]);
+    let base = String::from_utf8(git(root, &["branch", "--show-current"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // feat adds a memory on branch "aaa" → sorts to the very front.
+    git_ok(root, &["checkout", "-q", "-b", "feat"]);
+    insert_memory_into_file(
+        &ttl,
+        &mem("aaaaaaaaaaaaaaaaaaaaaaaaaa", "from feat", "aaa"),
+        REPO_HEADER,
+    )
+    .unwrap();
+    git_ok(root, &["commit", "-qam", "add on feat"]);
+
+    // base adds a memory on branch "zzz" → sorts to the very end.
+    git_ok(root, &["checkout", "-q", &base]);
+    insert_memory_into_file(
+        &ttl,
+        &mem("zzzzzzzzzzzzzzzzzzzzzzzzzz", "from main", "zzz"),
+        REPO_HEADER,
+    )
+    .unwrap();
+    git_ok(root, &["commit", "-qam", "add on main"]);
+
+    let merge = git(root, &["merge", "--no-edit", "feat"]);
+    let merged = std::fs::read_to_string(&ttl).unwrap();
+    assert!(
+        merge.status.success(),
+        "distinct-region adds should auto-merge; stderr={} file=\n{merged}",
+        String::from_utf8_lossy(&merge.stderr)
+    );
+    assert!(!merged.contains("<<<<<<<") && !merged.contains(">>>>>>>"));
+    assert_eq!(
+        merged.matches("fact-aaaa").count(),
+        1,
+        "feat memory present once"
+    );
+    assert_eq!(
+        merged.matches("fact-zzzz").count(),
+        1,
+        "main memory present once"
+    );
+    assert_eq!(merged.matches("@prefix mem:").count(), 1, "prefixes once");
+}
+
+/// Two branches change the SAME memory → the default merge MUST conflict, so the
+/// change is never silently merged/corrupted (the union-merge failure mode).
+#[test]
+fn concurrent_same_memory_edit_conflicts() {
+    if !git_available() {
+        eprintln!("git not available — skipping merge test");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let mem_dir = root.join(".fluree-memory");
+    std::fs::create_dir_all(&mem_dir).unwrap();
+    let ttl = repo_ttl_path(&mem_dir);
+    init_repo(root);
+
+    let base_mems = |content: &str| {
+        vec![
+            mem("00000000000000000000000001", "keeper", "main"),
+            mem("mmmmmmmmmmmmmmmmmmmmmmmmmm", content, "main"),
+        ]
+    };
+    write_memory_file(&ttl, &base_mems("original M"), REPO_HEADER).unwrap();
+    git_ok(root, &["add", "-A"]);
+    git_ok(root, &["commit", "-qm", "base"]);
+    let base = String::from_utf8(git(root, &["branch", "--show-current"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+
+    git_ok(root, &["checkout", "-q", "-b", "feat"]);
+    write_memory_file(&ttl, &base_mems("edited on feat"), REPO_HEADER).unwrap();
+    git_ok(root, &["commit", "-qam", "edit M on feat"]);
+
+    git_ok(root, &["checkout", "-q", &base]);
+    write_memory_file(&ttl, &base_mems("edited on main"), REPO_HEADER).unwrap();
+    git_ok(root, &["commit", "-qam", "edit M on main"]);
+
+    let merge = git(root, &["merge", "--no-edit", "feat"]);
+    assert!(
+        !merge.status.success(),
+        "concurrent edits of the same memory must conflict, not silently merge"
+    );
+    let conflicted = std::fs::read_to_string(&ttl).unwrap();
+    assert!(
+        conflicted.contains("<<<<<<<"),
+        "the conflict should be surfaced with markers for manual resolution"
+    );
+}


### PR DESCRIPTION
## Problem

`memory_add` (CLI and MCP) re-read every memory from the `__memory` ledger via a SPARQL query (`all_memories_for_scope`) and rewrote the whole `repo.ttl` on each call. Under concurrent MCP requests — e.g. an agent saving 2–3 memories at once, which the client dispatches in parallel — that O(N) work serialized behind the per-process mutation lock and made adds take seconds (~13.5s at 100 memories), which users experienced as hangs. A separately-observed failure mode: a wedged operation could hold a lock forever (a CPU-spun MCP server froze every later call in that process).

## Changes

- **Fast add via sorted file splice.** `add` now inserts the new block at its sorted `(branch, id)` position by reading only the `.ttl` text (`turtle_io::insert_memory_into_file`), never the ledger. Untouched blocks stay byte-identical (asserted equal to a full rewrite), so the on-disk result and merge behavior are unchanged. The add itself drops to ~2ms; the per-add ledger round-trip is gone.
- **Merge behavior preserved and safe.** The file keeps its `(branch, id)` sort under a default git merge: distinct-branch adds auto-merge, while two branches changing the *same* memory correctly conflict — no silent corruption.
- **Bounded locks.** The cross-process flock now polls `try_lock` to a deadline, and the in-process mutation lock uses a timeout, so a wedged operation surfaces a recoverable error instead of freezing the session. Shared `file_sync::lock_timeout` (30s default, override with `FLUREE_MEMORY_LOCK_TIMEOUT_SECS`).
- Memory docs updated to match.

## Tests

- `it_merge`: distinct-region adds merge cleanly; same-memory edits conflict.
- `turtle_io`: incremental splice equals a full sorted rewrite byte-for-byte.
- `file_sync`: the rebuild lock times out when already held.
