### PR TITLE
fix: consistent xsd:decimal/xsd:integer datatype across index and novelty (#1329)

### DIFF
--- a/fluree-db-api/src/block_fetch.rs
+++ b/fluree-db-api/src/block_fetch.rs
@@ -299,7 +299,7 @@ pub fn decode_leaf_block(
                 );
             }
 
-            let dt = match store.resolve_datatype_sid(o_type) {
+            let dt = match store.resolve_datatype_sid_for_value(o_type, &o) {
                 None => fluree_db_core::Sid::new(0, ""),
                 Some(sid) => {
                     let iri = store.sid_to_iri(&sid).ok_or_else(|| {

--- a/fluree-db-api/src/format/materialize.rs
+++ b/fluree-db-api/src/format/materialize.rs
@@ -78,11 +78,16 @@ fn materialize_encoded_lit(binding: &Binding, gv: &BinaryGraphView) -> std::io::
     match val {
         FlakeValue::Ref(sid) => Ok(Binding::sid(sid)),
         other => {
-            let dt_sid = store
-                .dt_sids()
-                .get(*dt_id as usize)
-                .cloned()
-                .unwrap_or_else(|| Sid::new(0, ""));
+            // NUM_BIG arena values share one EncodedLit whose dt_id is hardcoded
+            // to decimal — recover xsd:integer vs xsd:decimal from the decoded
+            // value, not dt_id (issue #1329).
+            let dt_sid = other.overflow_numeric_datatype_sid().unwrap_or_else(|| {
+                store
+                    .dt_sids()
+                    .get(*dt_id as usize)
+                    .cloned()
+                    .unwrap_or_else(|| Sid::new(0, ""))
+            });
             let meta = store.decode_meta(*lang_id, *i_val);
             let dtc = match meta.and_then(|m| m.lang.map(std::sync::Arc::from)) {
                 Some(lang) => DatatypeConstraint::LangTag(lang),

--- a/fluree-db-api/tests/it_decimal_exactness.rs
+++ b/fluree-db-api/tests/it_decimal_exactness.rs
@@ -461,6 +461,66 @@ async fn integer_beyond_i64_round_trips_exactly() {
 }
 
 #[tokio::test]
+async fn indexed_overflow_integer_reports_xsd_integer_not_decimal() {
+    // BigInt (overflow xsd:integer) and BigDecimal share the NUM_BIG arena and
+    // the same late-materialized EncodedLit, whose dt_id is hardcoded to
+    // decimal. Materialization must recover the datatype from the decoded value,
+    // else an indexed > i64 integer is mislabeled xsd:decimal (#1329 sibling).
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(fluree_db_api::LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "decimal/bigint-indexed:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let ledger = genesis_ledger(&fluree, ledger_id);
+            let big = "123456789012345678901234567890";
+            let result = run_sparql_update(
+                &fluree,
+                ledger,
+                &format!(
+                    r#"
+                    PREFIX ex: <http://example.org/>
+                    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+                    INSERT DATA {{ ex:item ex:serial "{big}"^^xsd:integer . }}
+                    "#
+                ),
+            )
+            .await;
+            trigger_index_and_wait(&handle, ledger_id, result.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.expect("load ledger");
+
+            let result = support::query_sparql(
+                &fluree,
+                &ledger,
+                "PREFIX ex: <http://example.org/>
+                 SELECT ?serial WHERE { ex:item ex:serial ?serial . }",
+            )
+            .await
+            .expect("query indexed bigint");
+            let sparql_json = result
+                .to_sparql_json(&ledger.snapshot)
+                .expect("to_sparql_json");
+            assert_eq!(binding_values(&sparql_json, "serial"), vec![big]);
+            assert_eq!(
+                binding_datatypes(&sparql_json, "serial"),
+                vec!["http://www.w3.org/2001/XMLSchema#integer".to_string()],
+                "indexed overflow integer must report xsd:integer, not xsd:decimal"
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
 async fn sum_avg_over_indexed_decimals_is_exact() {
     // Indexed decimals are arena-backed (NUM_BIG encoded). SUM/AVG must
     // decode and accumulate them exactly — they previously contributed

--- a/fluree-db-api/tests/it_decimal_exactness.rs
+++ b/fluree-db-api/tests/it_decimal_exactness.rs
@@ -1022,3 +1022,165 @@ async fn integer_valued_double_over_indexed_predicate_is_not_corrupted() {
         })
         .await;
 }
+
+/// Issue #1329: JSON-LD decimal rendering must be consistent regardless of
+/// whether the value is served from the binary index (arena-decoded) or from
+/// novelty (raw flake merge). The reported bug rendered index-served decimals
+/// as `{"@value": "19.99", "@type": ""}` (empty type) and novelty-served ones
+/// as a bare string with no `@type`.
+#[tokio::test]
+async fn jsonld_decimal_renders_consistently_across_index_and_novelty() {
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(fluree_db_api::LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "decimal/jsonld-render:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let ledger = genesis_ledger(&fluree, ledger_id);
+
+            // Indexed base: ex:a is arena-backed after the index build.
+            let result = run_sparql_update(
+                &fluree,
+                ledger,
+                r"
+                PREFIX ex: <http://example.org/>
+                INSERT DATA { ex:a ex:price 19.99 . }
+                ",
+            )
+            .await;
+            trigger_index_and_wait(&handle, ledger_id, result.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.expect("load ledger");
+
+            // Novelty overlay: ex:c served from the raw-merge path.
+            let result = run_sparql_update(
+                &fluree,
+                ledger,
+                r"
+                PREFIX ex: <http://example.org/>
+                INSERT DATA { ex:c ex:price 24.50 . }
+                ",
+            )
+            .await;
+            let ledger = result.ledger;
+
+            // Graph crawl over both subjects: each ex:price must render as a
+            // value object with @type == xsd:decimal.
+            let query = serde_json::json!({
+                "@context": {
+                    "ex": "http://example.org/",
+                    "xsd": "http://www.w3.org/2001/XMLSchema#"
+                },
+                "select": {"?s": ["*"]},
+                "where": [{"@id": "?s", "ex:price": "?price"}]
+            });
+            let nodes = support::query_jsonld_formatted(&fluree, &ledger, &query)
+                .await
+                .expect("jsonld crawl query");
+            let rows = nodes.as_array().expect("array of nodes");
+            assert_eq!(rows.len(), 2, "two priced subjects: {rows:?}");
+
+            // Both the arena-served (indexed) and novelty-served decimals must
+            // render in the SAME shape. Before the fix the indexed copy lost its
+            // datatype and rendered as `{"@value":"19.99","@type":""}` while the
+            // novelty copy rendered as the bare string `"24.50"` (issue #1329).
+            let mut by_id = std::collections::HashMap::new();
+            for node in rows {
+                let id = node["@id"].as_str().expect("@id").to_string();
+                by_id.insert(id, node["ex:price"].clone());
+            }
+            let indexed = &by_id["ex:a"];
+            let novel = &by_id["ex:c"];
+
+            // No empty @type may leak through any serving path.
+            for (label, price) in [("indexed ex:a", indexed), ("novelty ex:c", novel)] {
+                if let Some(obj) = price.as_object() {
+                    assert_ne!(
+                        obj.get("@type").and_then(JsonValue::as_str),
+                        Some(""),
+                        "{label}: decimal rendered with an empty @type: {price}"
+                    );
+                }
+            }
+
+            // Consistency: identical JSON shape across the two paths (xsd:decimal
+            // is an inferable datatype, so both render as the exact bare string).
+            assert_eq!(
+                indexed.is_object(),
+                novel.is_object(),
+                "decimal must render in one consistent shape across index/novelty: \
+                 indexed={indexed}, novelty={novel}"
+            );
+            assert_eq!(indexed, &JsonValue::String("19.99".to_string()), "indexed decimal");
+            assert_eq!(novel, &JsonValue::String("24.50".to_string()), "novelty decimal");
+
+            // Tabular SPARQL lane (object_binding): both the arena- and
+            // novelty-served decimals must report xsd:decimal, not an empty
+            // datatype, in the SPARQL JSON results.
+            let result = support::query_sparql(
+                &fluree,
+                &ledger,
+                "PREFIX ex: <http://example.org/>
+                 SELECT ?price WHERE { ?s ex:price ?price . }",
+            )
+            .await
+            .expect("tabular decimal query");
+            let sparql_json = result
+                .to_sparql_json(&ledger.snapshot)
+                .expect("to_sparql_json");
+            let dts = binding_datatypes(&sparql_json, "price");
+            assert_eq!(
+                dts,
+                vec![
+                    "http://www.w3.org/2001/XMLSchema#decimal".to_string(),
+                    "http://www.w3.org/2001/XMLSchema#decimal".to_string(),
+                ],
+                "both index- and novelty-served decimals must appear and report \
+                 xsd:decimal (two rows): {sparql_json}"
+            );
+
+            // Datatype-constrained pattern (`{"@value":"?price","@type":"xsd:decimal"}`)
+            // sets the binary-scan datatype filter, which runs BEFORE object decode.
+            // NUM_BIG_OVERFLOW names no datatype from o_type alone, so the indexed
+            // decimal was dropped pre-decode while the novelty copy passed via the
+            // raw-flake path (issue #1329).
+            let constrained = serde_json::json!({
+                "@context": {
+                    "ex": "http://example.org/",
+                    "xsd": "http://www.w3.org/2001/XMLSchema#"
+                },
+                "select": "?s",
+                "where": [{
+                    "@id": "?s",
+                    "ex:price": {"@value": "?price", "@type": "xsd:decimal"}
+                }]
+            });
+            let result = support::query_jsonld(&fluree, &ledger, &constrained)
+                .await
+                .expect("datatype-constrained query");
+            let rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+            let mut subjects: Vec<String> = rows
+                .as_array()
+                .expect("array")
+                .iter()
+                .map(|v| v.as_str().expect("subject iri").to_string())
+                .collect();
+            subjects.sort();
+            assert_eq!(
+                subjects,
+                vec!["ex:a".to_string(), "ex:c".to_string()],
+                "xsd:decimal-constrained pattern must match BOTH the indexed (ex:a) \
+                 and novelty (ex:c) decimals"
+            );
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_decimal_exactness.rs
+++ b/fluree-db-api/tests/it_decimal_exactness.rs
@@ -1180,8 +1180,16 @@ async fn jsonld_decimal_renders_consistently_across_index_and_novelty() {
                 "decimal must render in one consistent shape across index/novelty: \
                  indexed={indexed}, novelty={novel}"
             );
-            assert_eq!(indexed, &JsonValue::String("19.99".to_string()), "indexed decimal");
-            assert_eq!(novel, &JsonValue::String("24.50".to_string()), "novelty decimal");
+            assert_eq!(
+                indexed,
+                &JsonValue::String("19.99".to_string()),
+                "indexed decimal"
+            );
+            assert_eq!(
+                novel,
+                &JsonValue::String("24.50".to_string()),
+                "novelty decimal"
+            );
 
             // Tabular SPARQL lane (object_binding): both the arena- and
             // novelty-served decimals must report xsd:decimal, not an empty

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -1396,6 +1396,25 @@ impl BinaryIndexStore {
         }
     }
 
+    /// Resolve the datatype Sid for a decoded value, disambiguating o_types
+    /// that name no single datatype.
+    ///
+    /// The `NUM_BIG_OVERFLOW` arena holds both overflow `xsd:integer` (BigInt)
+    /// and `xsd:decimal` (BigDecimal) values, so [`resolve_datatype_sid`] can't
+    /// name its type from `o_type` alone and returns `None`. Fall back to the
+    /// decoded value's variant so the datatype isn't lost — otherwise arena-
+    /// served big numerics render with an empty `@type` while their novelty
+    /// counterparts (still o_type-tagged) render correctly (issue #1329).
+    ///
+    /// [`resolve_datatype_sid`]: Self::resolve_datatype_sid
+    pub fn resolve_datatype_sid_for_value(&self, o_type: u16, val: &FlakeValue) -> Option<Sid> {
+        self.resolve_datatype_sid(o_type).or_else(|| match val {
+            FlakeValue::Decimal(_) => Some(Sid::new(namespaces::XSD, xsd_names::DECIMAL)),
+            FlakeValue::BigInt(_) => Some(Sid::new(namespaces::XSD, xsd_names::INTEGER)),
+            _ => None,
+        })
+    }
+
     /// Look up an o_type table entry by o_type value. O(1).
     pub fn lookup_o_type(&self, o_type: u16) -> Option<&OTypeTableEntry> {
         self.o_type_index

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -1408,11 +1408,8 @@ impl BinaryIndexStore {
     ///
     /// [`resolve_datatype_sid`]: Self::resolve_datatype_sid
     pub fn resolve_datatype_sid_for_value(&self, o_type: u16, val: &FlakeValue) -> Option<Sid> {
-        self.resolve_datatype_sid(o_type).or_else(|| match val {
-            FlakeValue::Decimal(_) => Some(Sid::new(namespaces::XSD, xsd_names::DECIMAL)),
-            FlakeValue::BigInt(_) => Some(Sid::new(namespaces::XSD, xsd_names::INTEGER)),
-            _ => None,
-        })
+        self.resolve_datatype_sid(o_type)
+            .or_else(|| val.overflow_numeric_datatype_sid())
     }
 
     /// Look up an o_type table entry by o_type value. O(1).

--- a/fluree-db-core/src/value.rs
+++ b/fluree-db-core/src/value.rs
@@ -243,6 +243,21 @@ impl FlakeValue {
         )
     }
 
+    /// Canonical XSD datatype `Sid` for arbitrary-precision numerics.
+    ///
+    /// `BigInt` and `BigDecimal` share the NUM_BIG_OVERFLOW arena and the same
+    /// late-materialization `EncodedLit` (whose `dt_id` is hardcoded), so their
+    /// datatype can only be recovered from the value variant — not from the
+    /// `o_type` or `dt_id`. Returns `None` for every other variant (whose
+    /// datatype is already named by its `o_type`).
+    pub fn overflow_numeric_datatype_sid(&self) -> Option<Sid> {
+        match self {
+            FlakeValue::BigInt(_) => Some(Sid::xsd_integer()),
+            FlakeValue::Decimal(_) => Some(Sid::xsd_decimal()),
+            _ => None,
+        }
+    }
+
     /// Check if this is any temporal type (DateTime, Date, Time, g-types)
     pub fn is_temporal(&self) -> bool {
         matches!(

--- a/fluree-db-query/src/binary_history.rs
+++ b/fluree-db-query/src/binary_history.rs
@@ -559,7 +559,7 @@ fn decode_event_to_flake(
         .decode_value(o_type, o_key, p_id)
         .map_err(|e| QueryError::from_io("history decode decode_value", e))?;
     let dt = store
-        .resolve_datatype_sid(o_type)
+        .resolve_datatype_sid_for_value(o_type, &o_val)
         .unwrap_or_else(|| Sid::new(0, ""));
     let lang = store
         .resolve_lang_tag(o_type)

--- a/fluree-db-query/src/binary_range.rs
+++ b/fluree-db-query/src/binary_range.rs
@@ -557,9 +557,9 @@ fn binary_range_eq_v3(
             };
             // Decode object.
             let o_val = view.decode_value(o_type, o_key, p_id)?;
-            // Resolve datatype.
+            // Resolve datatype (value-aware: NUM_BIG_OVERFLOW names no o_type).
             let dt = store
-                .resolve_datatype_sid(o_type)
+                .resolve_datatype_sid_for_value(o_type, &o_val)
                 .unwrap_or_else(|| Sid::new(0, ""));
             // Language tag.
             let lang = store
@@ -1201,7 +1201,7 @@ fn binary_range_bounded_v3(
             };
             let o_val = view.decode_value(o_type, o_key, p_id)?;
             let dt = store
-                .resolve_datatype_sid(o_type)
+                .resolve_datatype_sid_for_value(o_type, &o_val)
                 .unwrap_or_else(|| Sid::new(0, ""));
             let lang = store
                 .resolve_lang_tag(o_type)

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1168,14 +1168,35 @@ impl BinaryScanOperator {
     }
 
     /// Check whether this row matches the triple pattern's datatype constraint (if any).
+    ///
+    /// Runs *before* object decode, so the datatype is resolved from `o_type`
+    /// alone on the common path (zero decode cost). `NUM_BIG_OVERFLOW` names no
+    /// single datatype — its arena holds both `xsd:integer` (BigInt) and
+    /// `xsd:decimal` (BigDecimal) — so in that one ambiguous case decode the
+    /// value to disambiguate. Without this, a value-object query like
+    /// `{"@value":"?p","@type":"xsd:decimal"}` silently dropped indexed big
+    /// numerics while novelty copies passed (issue #1329).
     #[inline]
-    fn matches_datatype_constraint(&self, o_type: u16) -> bool {
+    fn matches_datatype_constraint(
+        &self,
+        view: &BinaryGraphView,
+        o_type: u16,
+        o_key: u64,
+        p_id: u32,
+    ) -> bool {
         let Some(dtc) = &self.pattern.dtc else {
             return true;
         };
 
-        let Some(dt_sid) = self.store().resolve_datatype_sid(o_type) else {
-            return false;
+        let dt_sid = match self.store().resolve_datatype_sid(o_type) {
+            Some(sid) => sid,
+            None => match view.decode_value(o_type, o_key, p_id) {
+                Ok(val) => match self.store().resolve_datatype_sid_for_value(o_type, &val) {
+                    Some(sid) => sid,
+                    None => return false,
+                },
+                Err(_) => return false,
+            },
         };
         if !dt_compatible(dtc.datatype(), &dt_sid) {
             return false;
@@ -1297,7 +1318,7 @@ impl BinaryScanOperator {
             }
 
             // Enforce datatype constraints before decoding into bindings.
-            if !self.matches_datatype_constraint(o_type) {
+            if !self.matches_datatype_constraint(&view, o_type, o_key, p_id) {
                 continue;
             }
 

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -273,7 +273,7 @@ impl Operator for PredicateGroupCountFirstsOperator {
                     .decode_value(o_type, o_key, p_id)
                     .map_err(|e| QueryError::Internal(format!("V6 decode_value: {e}")))?;
                 let dt = binary_index_store
-                    .resolve_datatype_sid(o_type)
+                    .resolve_datatype_sid_for_value(o_type, &val)
                     .unwrap_or_else(|| fluree_db_core::Sid::new(0, ""));
                 let lang: Option<Arc<str>> =
                     binary_index_store.resolve_lang_tag(o_type).map(Arc::from);
@@ -1570,7 +1570,7 @@ fn compute_group_by_object_star_topk(
                 .decode_value(k.o_type, k.o_key, p_id)
                 .map_err(|e| QueryError::Internal(format!("decode_value: {e}")))?;
             let dt = store
-                .resolve_datatype_sid(k.o_type)
+                .resolve_datatype_sid_for_value(k.o_type, &val)
                 .unwrap_or_else(|| Sid::new(0, ""));
             let lang = store.resolve_lang_tag(k.o_type).map(Arc::from);
             col_o1.push(Binding::Lit {

--- a/fluree-db-query/src/materializer.rs
+++ b/fluree-db-query/src/materializer.rs
@@ -578,13 +578,17 @@ impl Materializer {
             {
                 Ok(FlakeValue::Ref(sid)) => Binding::sid(sid),
                 Ok(val) => {
-                    let dt_sid = self
-                        .graph_view
-                        .store()
-                        .dt_sids()
-                        .get(*dt_id as usize)
-                        .cloned()
-                        .unwrap_or_else(|| Sid::new(0, ""));
+                    // NUM_BIG arena values share one EncodedLit whose dt_id is
+                    // hardcoded to decimal — recover xsd:integer vs xsd:decimal
+                    // from the decoded value, not dt_id (issue #1329).
+                    let dt_sid = val.overflow_numeric_datatype_sid().unwrap_or_else(|| {
+                        self.graph_view
+                            .store()
+                            .dt_sids()
+                            .get(*dt_id as usize)
+                            .cloned()
+                            .unwrap_or_else(|| Sid::new(0, ""))
+                    });
                     let meta = self.graph_view.store().decode_meta(*lang_id, *i_val);
                     let dtc = match meta.and_then(|m| m.lang.map(Arc::from)) {
                         Some(lang) => DatatypeConstraint::LangTag(lang),

--- a/fluree-db-query/src/object_binding.rs
+++ b/fluree-db-query/src/object_binding.rs
@@ -395,7 +395,7 @@ pub(crate) fn materialized_object_binding(
                 Some(lang) => DatatypeConstraint::LangTag(lang),
                 None => DatatypeConstraint::Explicit(
                     store
-                        .resolve_datatype_sid(o_type)
+                        .resolve_datatype_sid_for_value(o_type, &other)
                         .unwrap_or_else(|| Sid::new(0, "")),
                 ),
             };


### PR DESCRIPTION
## Summary

Fixes #1329: an `xsd:decimal` served from the binary index rendered with an empty `@type` (`{"@value":"19.99","@type":""}`) while the same value in novelty rendered as a bare string. Also fixes a sibling mislabel where indexed `> i64` integers came back as `xsd:decimal`.

## Root cause

`OType::NUM_BIG_OVERFLOW` names no single datatype from `o_type` alone — its arena holds **both** overflow `xsd:integer` (BigInt) **and** `xsd:decimal` (BigDecimal). So `resolve_datatype_sid(o_type)` returns `None`, and every flake/binding builder fell back to `Sid::new(0, "")` → empty `@type`. Novelty copies still carry `o_type = XSD_DECIMAL`, so they resolved correctly — hence the index-vs-novelty asymmetry.

A second, related issue: the late-materialized `EncodedLit` for the NumBig arena hardcodes `dt_id = DECIMAL` (it has no decoded value at creation time), so an indexed overflow integer materialized as `xsd:decimal`.

## Fix

- New `BinaryIndexStore::resolve_datatype_sid_for_value(o_type, &val)` derives the datatype from the decoded `FlakeValue` (`Decimal`→`xsd:decimal`, `BigInt`→`xsd:integer`) when `o_type` can't name it. Wired into every flake/binding builder that has the decoded value in scope: `binary_range` (x2), `binary_history`, `object_binding`, `fast_group_count_firsts` (x2), `block_fetch`.
- `binary_scan::matches_datatype_constraint` is a **pre-decode** filter — it dropped indexed big numerics from datatype-constrained patterns (e.g. `{"@value":"?p","@type":"xsd:decimal"}`) while novelty copies passed. It now decodes to disambiguate **only** in the rare ambiguous case, keeping the common path decode-free.
- New `FlakeValue::overflow_numeric_datatype_sid()` recovers the datatype at materialization time (the EncodedLit can't be fixed at creation). Consulted before the `dt_id` lookup in both the query materializer and the API formatter; `resolve_datatype_sid_for_value` delegates to it too.

Because `xsd:decimal` is an inferable datatype, the consistent output is the bare-string form across crawl and tabular lanes (matching the existing convention). `export.rs` already had per-variant fallbacks, so it needed no change.

## Tests

- `jsonld_decimal_renders_consistently_across_index_and_novelty` — crawl + tabular SPARQL + datatype-constrained pattern, asserting the indexed and novelty decimals render identically and both match a `xsd:decimal`-constrained query.
- `indexed_overflow_integer_reports_xsd_integer_not_decimal` — pins the late-materialization datatype recovery.

Both confirmed to fail before the fix and pass after. Full `fluree-db-api` suite, `fluree-db-query`/`fluree-db-core` unit tests, and clippy (all-features) are green.