### PR TITLE
Fix flaky raft muliti-node test

### DIFF
--- a/fluree-db-consensus/src/raft/liveness_monitor.rs
+++ b/fluree-db-consensus/src/raft/liveness_monitor.rs
@@ -201,24 +201,13 @@ impl LivenessMonitor {
     /// them on abort.
     pub async fn run(self) {
         let mut trackers: HashMap<NodeId, PeerTracker> = HashMap::new();
-        // Cache the log id of the most recently observed membership
-        // change. When it doesn't advance between ticks, the voter
-        // set is unchanged and the tracker-pruning collect+retain
-        // pair can be skipped.
-        let mut last_membership_log_id: Option<LogId<NodeId>> = None;
         loop {
             tokio::time::sleep(self.config.sample_interval).await;
-            self.tick(&mut trackers, &mut last_membership_log_id, Instant::now())
-                .await;
+            self.tick(&mut trackers, Instant::now()).await;
         }
     }
 
-    async fn tick(
-        &self,
-        trackers: &mut HashMap<NodeId, PeerTracker>,
-        last_membership_log_id: &mut Option<LogId<NodeId>>,
-        now: Instant,
-    ) {
+    async fn tick(&self, trackers: &mut HashMap<NodeId, PeerTracker>, now: Instant) {
         // Read what we need from the metrics ref and drop it
         // before any await. Cloning the whole `RaftMetrics` (the
         // earlier shape) deep-copied the per-peer replication
@@ -226,7 +215,7 @@ impl LivenessMonitor {
         // need, leaving the watch ref free for openraft's writer.
         // Holding the ref across `propose_*` awaits would also
         // block metrics updates for the entire tick.
-        let (leader_last_log, peers, configured_voters) = {
+        let (leader_last_log, peers) = {
             let metrics_rx = self.raft.metrics();
             let metrics = metrics_rx.borrow();
             // No replication metrics = not the leader. The leader
@@ -242,38 +231,39 @@ impl LivenessMonitor {
                 .filter(|(id, _)| **id != leader_id)
                 .map(|(id, log)| (*id, *log))
                 .collect();
-            // Skip the voter-set collect when membership hasn't
-            // changed since the previous tick — `log_id` advances
-            // only on a membership-apply, so equality means the
-            // voter set is identical and the retain below would
-            // be a no-op.
-            let current_log_id = *metrics.membership_config.log_id();
-            let configured_voters = if current_log_id != *last_membership_log_id {
-                *last_membership_log_id = current_log_id;
-                Some(
-                    metrics
-                        .membership_config
-                        .membership()
-                        .voter_ids()
-                        .collect::<std::collections::HashSet<NodeId>>(),
-                )
-            } else {
-                None
-            };
-            (leader_last_log, peers, configured_voters)
+            (leader_last_log, peers)
         };
 
-        // Snapshot the replicated eligible set so every per-peer
-        // tracker created in this tick reads a consistent view, and
-        // so the per-peer awaits below don't hold the state lock
-        // against writers. Cloning a `BTreeSet<NodeId>` is cheap at
-        // realistic cluster sizes.
-        let eligible_voters = {
+        // Snapshot the replicated voter + eligibility sets together
+        // so every per-peer tracker created in this tick reads a
+        // consistent view, and so the per-peer awaits below don't
+        // hold the state lock against writers. Membership-apply
+        // updates both sets atomically (see `EntryPayload::Membership`
+        // in the state-machine adapter), so the snapshot can't see a
+        // voter in one set but not the other.
+        let (configured_voters, eligible_voters) = {
             let state = self.shared_state.read().await;
-            state.worker_eligible_voters.clone()
+            (
+                state.configured_voters.clone(),
+                state.worker_eligible_voters.clone(),
+            )
         };
 
         for (peer_id, peer_log) in peers {
+            // Learners appear in openraft's replication map from the
+            // moment `add-learner` starts shipping them log entries,
+            // but they aren't workers — `apply_set_worker_eligibility`
+            // refuses proposes for any voter outside `configured_voters`.
+            // Building a tracker for a learner seeds it as `for_ineligible_peer`
+            // (it's not yet in `worker_eligible_voters`), and once
+            // `change-membership` promotes the learner to a voter the
+            // stale `last_proposed = Some(Demote)` blocks every future
+            // Demote on this peer — including the one a subsequent
+            // kill ought to fire. Skipping non-voters at the top is
+            // what avoids that pre-promotion seeding.
+            if !configured_voters.contains(&peer_id) {
+                continue;
+            }
             let tracker = trackers.entry(peer_id).or_insert_with(|| {
                 if eligible_voters.contains(&peer_id) {
                     PeerTracker::for_eligible_peer()
@@ -311,13 +301,9 @@ impl LivenessMonitor {
             }
         }
         // Drop trackers for peers that left the voter set on a
-        // membership change. Only run when membership actually
-        // changed — the cached `last_membership_log_id` lets us
-        // skip the retain (and the prior collect) on steady-state
-        // ticks where the voter set is unchanged.
-        if let Some(configured) = configured_voters {
-            trackers.retain(|id, _| configured.contains(id));
-        }
+        // membership change. Cheap at realistic cluster sizes — a
+        // BTreeSet lookup per tracked voter.
+        trackers.retain(|id, _| configured_voters.contains(id));
     }
 
     /// Propose `eligible: true` for `voter`. Returns `true` when the

--- a/fluree-db-server/tests/raft_multi_node.rs
+++ b/fluree-db-server/tests/raft_multi_node.rs
@@ -1137,9 +1137,48 @@ async fn wait_for_voter_demoted(
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
+    // Dump leader-side raft metrics so a future flake says *why* the
+    // demote never landed: leader/log advance and the per-peer match
+    // indices the monitor reads. The pre-fix flake left
+    // `peer_match_indices=[..., (target, Some(<old idx>)), ...]` with
+    // the leader several entries ahead — visibly stuck without a
+    // demote propose ever firing.
+    let metrics_dump = leader_metrics_snapshot(cluster, via_node);
     panic!(
-        "timed out waiting for voter {voter} to drop out of worker_eligible_voters; last={last:?}"
+        "timed out waiting for voter {voter} to drop out of worker_eligible_voters; \
+         last={last:?}; leader_metrics={metrics_dump}"
     );
+}
+
+/// Format the leader-side openraft metrics relevant to liveness
+/// demotion decisions: current leader, last log index, and each
+/// peer's last matched log index. Read directly from the in-process
+/// raft handle on `via_node`.
+fn leader_metrics_snapshot(cluster: &TestCluster, via_node: NodeId) -> String {
+    let node = cluster
+        .nodes
+        .iter()
+        .find(|n| n.node_id == via_node)
+        .expect("node exists");
+    let integration = node
+        ._state
+        .raft
+        .as_ref()
+        .expect("test node always has raft integration");
+    let m = integration.raft.metrics().borrow().clone();
+    let peer_states: Vec<(NodeId, Option<u64>)> = m
+        .replication
+        .as_ref()
+        .map(|r| {
+            r.iter()
+                .map(|(id, log)| (*id, log.as_ref().map(|l| l.index)))
+                .collect()
+        })
+        .unwrap_or_default();
+    format!(
+        "current_leader={:?}, last_log_index={:?}, peer_match_indices={peer_states:?}",
+        m.current_leader, m.last_log_index,
+    )
 }
 
 /// Drive log advancement on the leader. Submits a new insert every


### PR DESCRIPTION
Fixes the `liveness_monitor_demotes_killed_follower` test in `fluree-db-server/tests/raft_multi_node.rs`, which flaked at ~25–37% under `cargo nextest` parallelism on CI. The underlying bug is in `LivenessMonitor::tick`, not the test: under the bootstrap sequence (`initialize` → `add-learner` → `change-membership`), the monitor was seeding peer trackers for learners before they were promoted to voters, leaving each seeded tracker in a state where the hysteresis check permanently blocked any future Demote propose for that peer.

## Root cause

`LivenessMonitor::tick` iterated openraft's `metrics.replication` map to build per-peer trackers. That map includes **learners** as well as voters — a node added via `add-learner` shows up there from the first append-entries it receives. At that moment the learner is not in `worker_eligible_voters` (only voters are), so `or_insert_with` seeded the tracker via `PeerTracker::for_ineligible_peer()`, which sets `last_proposed = Some(Demote)` to support the cross-leader-transition promote path.

When `change-membership` later promoted the learner to a voter, the state-machine apply atomically added it to both `configured_voters` and `worker_eligible_voters` — but the monitor's existing tracker was untouched. The stale `last_proposed = Some(Demote)` then short-circuited the Demote arm of `next_eligibility_proposal` forever: when the voter was later killed, the monitor correctly observed lag (`unreachable_since` set, `unreachable_after` elapsed) but the `tracker.last_proposed != Some(Demote)` guard returned `None`, and `worker_eligible_voters` never lost the dead voter.

Local repro under parallel load showed the leader stable at `last_log_index = 12`, peer 2 stuck at match index 7 — five entries of unambiguous "leader ahead of peer" lag — with the monitor proposing nothing. Sequential runs passed reliably because the bootstrap window closed before the test killed the follower, and the monitor's first tick caught a steady-state membership; only the contention-induced delay between `add-learner` and `change-membership` made the bug observable.

## Fix

`fluree-db-consensus/src/raft/liveness_monitor.rs`:

- Snapshot `configured_voters` from the replicated state machine alongside `worker_eligible_voters` in the same `shared_state.read().await`. Both sets are updated atomically by the membership-apply in `state_machine_adapter.rs`, so the snapshot can never see a voter present in one but not the other.
- Skip any peer not in `configured_voters` before creating its tracker. Learners are not workers (`apply_set_worker_eligibility` refuses any voter outside `configured_voters` anyway), so there's no reason to track them — and skipping them is what prevents the pre-promotion `for_ineligible_peer` seeding.
- Drop the `last_membership_log_id` caching that previously gated the tracker-pruning `retain`. The optimization predates pulling `configured_voters` from state every tick; with the state read already happening for `eligible_voters`, the additional `BTreeSet<NodeId>` clone is free at realistic cluster sizes. The `retain` now runs every tick directly against the per-tick voter snapshot.

`fluree-db-server/tests/raft_multi_node.rs`:

- Add `leader_metrics_snapshot` and include its output (`current_leader`, `last_log_index`, per-peer match indices) in `wait_for_voter_demoted`'s timeout panic. The pre-fix flake message was `last={1, 2, 3, 4, 5}` — which says the demote didn't land but doesn't say why. The new message attaches the openraft metrics the monitor reads, so a future regression points straight at whether the leader was advancing, which peers were stuck, and at what index.

## Verification

- `raft_multi_node` test binary, 20 consecutive parallel runs under `cargo test` default parallelism: **20/20 pass**. Pre-fix baseline on the same machine flaked 25–37% on the same workload.
- 5 consecutive sequential runs (`--test-threads=1`): 5/5 pass.
- `fluree-db-consensus` lib tests: 345 passed, 0 failed.
- `liveness_monitor` unit tests (the tracker-level logic): 12/12 pass — no behavior change at that layer.
- `raft_integration` tests: 5/5 pass.
- `cargo fmt --check` and `cargo clippy --all-targets` clean on both touched crates.

