### PR TITLE
fix(turtle): resolve RFC 3986 §5.3 fragment refs against @base

### DIFF
--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -855,17 +855,10 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         Ok(first_node)
     }
 
-    /// Resolve a potentially relative IRI against the base (RFC3986).
+    /// Resolve a potentially relative IRI against the base (RFC 3986 §5).
     fn resolve_iri(&self, reference: &str) -> Result<String> {
-        if reference.is_empty() {
-            return match &self.base {
-                Some(base) => Ok(base.clone()),
-                None => Err(TurtleError::IriResolution(
-                    "empty IRI reference without base".to_string(),
-                )),
-            };
-        }
-
+        // Absolute IRI reference (carries a valid scheme) — returned verbatim,
+        // fragment included; resolution does not apply.
         if let Some(colon_pos) = reference.find(':') {
             let potential_scheme = &reference[..colon_pos];
             if !potential_scheme.is_empty()
@@ -891,9 +884,31 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             }
         };
 
-        let (base_scheme, base_authority, base_path, _base_query) = parse_iri_components(base);
+        // RFC 3986 §5.2.1: split the reference into its fragment and everything
+        // before it. The fragment is the portion after the FIRST `#`. Per
+        // §5.2.2 the resolved fragment is ALWAYS the reference's fragment and is
+        // never inherited from the base, so scheme/authority/path/query are
+        // resolved against the fragment-less portion and the reference fragment
+        // is re-attached during recomposition (§5.3).
+        let (ref_no_fragment, ref_fragment) = match reference.find('#') {
+            Some(pos) => (&reference[..pos], Some(&reference[pos + 1..])),
+            None => (reference, None),
+        };
 
-        let (scheme, authority, path, query) = if let Some(rest) = reference.strip_prefix("//") {
+        let (base_scheme, base_authority, base_path, base_query) = parse_iri_components(base);
+
+        let (scheme, authority, path, query) = if ref_no_fragment.is_empty() {
+            // Same-document reference (`<>` or `<#frag>`): the reference has an
+            // empty path and no query, so the target inherits the base path and
+            // query (RFC 3986 §5.2.2). The base's own fragment is dropped because
+            // `parse_iri_components` never returns it.
+            (
+                base_scheme.to_string(),
+                base_authority.map(std::string::ToString::to_string),
+                base_path.to_string(),
+                base_query.map(std::string::ToString::to_string),
+            )
+        } else if let Some(rest) = ref_no_fragment.strip_prefix("//") {
             let (ref_authority, ref_path, ref_query) = parse_hier_part(rest);
             (
                 base_scheme.to_string(),
@@ -901,30 +916,23 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
                 remove_dot_segments(&ref_path),
                 ref_query,
             )
-        } else if reference.starts_with('/') {
-            let (ref_path, ref_query) = split_path_query(reference);
+        } else if ref_no_fragment.starts_with('/') {
+            let (ref_path, ref_query) = split_path_query(ref_no_fragment);
             (
                 base_scheme.to_string(),
                 base_authority.map(std::string::ToString::to_string),
                 remove_dot_segments(ref_path),
                 ref_query.map(std::string::ToString::to_string),
             )
-        } else if let Some(query_rest) = reference.strip_prefix('?') {
+        } else if let Some(query_rest) = ref_no_fragment.strip_prefix('?') {
             (
                 base_scheme.to_string(),
                 base_authority.map(std::string::ToString::to_string),
                 base_path.to_string(),
                 Some(query_rest.to_string()),
             )
-        } else if reference.starts_with('#') {
-            (
-                base_scheme.to_string(),
-                base_authority.map(std::string::ToString::to_string),
-                base_path.to_string(),
-                None,
-            )
         } else {
-            let (ref_path, ref_query) = split_path_query(reference);
+            let (ref_path, ref_query) = split_path_query(ref_no_fragment);
             let merged = if base_authority.is_some() && base_path.is_empty() {
                 format!("/{ref_path}")
             } else {
@@ -952,6 +960,10 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         if let Some(q) = query {
             result.push('?');
             result.push_str(&q);
+        }
+        if let Some(fragment) = ref_fragment {
+            result.push('#');
+            result.push_str(fragment);
         }
 
         Ok(result)
@@ -1406,5 +1418,119 @@ mod tests {
         assert_eq!(graph.len(), 1);
         let triple = graph.iter().next().unwrap();
         assert!(matches!(&triple.s, Term::Iri(iri) if iri.as_ref() == "http://example.org/doc"));
+    }
+
+    /// Collect every subject IRI in document order.
+    fn subject_iris(input: &str) -> Vec<String> {
+        let graph = parse_to_graph(input).unwrap();
+        graph
+            .iter()
+            .filter_map(|t| match &t.s {
+                Term::Iri(iri) => Some(iri.as_ref().to_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Regression guard for issue #1395: `<#A>` and `<#B>` resolved against the
+    /// same `@base` MUST yield two DISTINCT IRIs. The old `resolve_iri` dropped
+    /// the fragment, collapsing every `<#Name>` to the bare base IRI (which in
+    /// turn collapsed multi-`TriplesMap` R2RML mappings to one table).
+    #[test]
+    fn test_base_fragment_refs_resolve_to_distinct_iris() {
+        let input = r#"
+            @base <http://example.org/edw> .
+            <#A> <p> "a" .
+            <#B> <p> "b" .
+        "#;
+        let subjects = subject_iris(input);
+        assert!(
+            subjects.contains(&"http://example.org/edw#A".to_string()),
+            "expected http://example.org/edw#A, got {subjects:?}"
+        );
+        assert!(
+            subjects.contains(&"http://example.org/edw#B".to_string()),
+            "expected http://example.org/edw#B, got {subjects:?}"
+        );
+        // The two references must NOT collapse to the same IRI.
+        assert_ne!(subjects[0], subjects[1]);
+    }
+
+    /// A relative path reference that also carries a fragment: both the merged
+    /// path and the reference fragment must survive (`<rel#frag>`).
+    #[test]
+    fn test_base_relative_path_with_fragment() {
+        let input = r#"
+            @base <http://example.org/edw> .
+            <DimDate#col> <p> "x" .
+        "#;
+        let subjects = subject_iris(input);
+        assert_eq!(subjects, vec!["http://example.org/DimDate#col".to_string()]);
+    }
+
+    /// When the base itself carries a fragment, a `<#frag>` reference replaces
+    /// it (RFC 3986 §5.2.2: the resolved fragment is always the reference's).
+    #[test]
+    fn test_fragment_ref_against_base_with_fragment() {
+        let input = r#"
+            @base <http://example.org/path#oldfrag> .
+            <#new> <p> "x" .
+            <other#f> <p> "y" .
+        "#;
+        let subjects = subject_iris(input);
+        assert!(
+            subjects.contains(&"http://example.org/path#new".to_string()),
+            "expected http://example.org/path#new, got {subjects:?}"
+        );
+        assert!(
+            subjects.contains(&"http://example.org/other#f".to_string()),
+            "expected http://example.org/other#f, got {subjects:?}"
+        );
+    }
+
+    /// `<>` against a fragmented base resolves to the base MINUS its fragment.
+    #[test]
+    fn test_empty_ref_against_fragmented_base_drops_fragment() {
+        let input = r#"
+            @base <http://example.org/path#oldfrag> .
+            <> <p> "x" .
+        "#;
+        let subjects = subject_iris(input);
+        assert_eq!(subjects, vec!["http://example.org/path".to_string()]);
+    }
+
+    /// A reference with no fragment of its own must NOT inherit the base's
+    /// fragment.
+    #[test]
+    fn test_ref_without_fragment_does_not_inherit_base_fragment() {
+        let input = r#"
+            @base <http://example.org/path#oldfrag> .
+            <other> <p> "x" .
+        "#;
+        let subjects = subject_iris(input);
+        assert_eq!(subjects, vec!["http://example.org/other".to_string()]);
+    }
+
+    /// RFC 3986 §5.4.1 examples covering query + fragment recomposition against
+    /// a base that has both a query and (implicitly) no fragment.
+    #[test]
+    fn test_query_and_fragment_resolution_rfc3986() {
+        // base = http://a/b/c/d;p?q  (path "/b/c/d;p", query "q")
+        let cases = [
+            ("<#s>", "http://a/b/c/d;p?q#s"),
+            ("<?y#s>", "http://a/b/c/d;p?y#s"),
+            ("<g#s>", "http://a/b/c/g#s"),
+            ("<g?y#s>", "http://a/b/c/g?y#s"),
+            ("<>", "http://a/b/c/d;p?q"),
+        ];
+        for (reference, expected) in cases {
+            let input = format!("@base <http://a/b/c/d;p?q> .\n{reference} <p> \"v\" .\n");
+            let subjects = subject_iris(&input);
+            assert_eq!(
+                subjects,
+                vec![expected.to_string()],
+                "reference {reference} should resolve to {expected}"
+            );
+        }
     }
 }


### PR DESCRIPTION
# fix(turtle): resolve RFC 3986 §5.3 fragment refs against `@base`

## Summary

The Turtle parser's `resolve_iri` dropped the **fragment** when resolving a
relative IRI reference such as `<#Name>` against an `@base`. As a result, every
`<#DimDate>`, `<#DimProduct>`, … collapsed to the *same* IRI (the base with its
fragment stripped). This is a direct RFC 3986 §5.2.2 / §5.3 violation and is the
root cause of issue #1395: an idiomatic `@base` + `<#Name>` multi-`TriplesMap`
R2RML mapping silently collapsed into a single TriplesMap / single logical table.

This PR is **Phase 1** — the foundational parser fix at the bottom of the
fluree/db ↔ Snowflake-managed-Iceberg stack. It is fully self-contained in the
`fluree-graph-turtle` crate.

## Root cause

Per RFC 3986 §5.2.2, the *fragment* of a resolved reference is **always** the
reference's own fragment (`T.fragment = R.fragment`); it is never inherited from
the base. The previous `resolve_iri` (a) returned `None` for the fragment on the
`#`-only branch, (b) never appended `#<fragment>` during component recomposition,
and (c) used helpers (`split_path_query`) that strip everything after `#`. So the
reference fragment was discarded on every relative resolution, and the empty `<>`
reference incorrectly returned the base *with* its fragment intact. Existing
R2RML fixtures all used **absolute** TriplesMap IRIs, which short-circuit
resolution entirely, so the bug was never exercised.

## What changed

`fluree-graph-turtle/src/parser.rs` — `resolve_iri` only:

- Split the reference into its fragment (everything after the first `#`) and the
  fragment-less remainder up front (RFC 3986 §5.2.1). Scheme/authority/path/query
  are resolved against the remainder; the reference fragment is re-attached during
  recomposition (§5.3).
- Same-document references (`<>` and `<#frag>`) now inherit the base path **and
  query** but **not** the base fragment (the base fragment is naturally dropped by
  `parse_iri_components`).
- Append `#<fragment>` in the result assembly when (and only when) the reference
  itself carries a fragment.
- Removed the special-case early return for the empty `<>` reference, which had
  returned the full base *including* its fragment; `<>` now correctly resolves to
  base-minus-fragment.

No helper signatures changed and no other call sites were touched. Absolute-IRI
and prefixed-name inputs are completely unaffected.

## Tests added

Six new parser unit tests in `fluree-graph-turtle/src/parser.rs` (all driven
through the real `parse` path via `parse_to_graph`):

- `test_base_fragment_refs_resolve_to_distinct_iris` — **the regression guard for
  #1395**: with `@base <http://example.org/edw>`, `<#A>` and `<#B>` resolve to two
  DISTINCT IRIs (`…/edw#A`, `…/edw#B`).
- `test_base_relative_path_with_fragment` — `<DimDate#col>` → `…/DimDate#col`.
- `test_fragment_ref_against_base_with_fragment` — a base that itself has a
  fragment: `<#new>` replaces it; `<other#f>` carries its own fragment.
- `test_empty_ref_against_fragmented_base_drops_fragment` — `<>` against a
  fragmented base → base minus fragment.
- `test_ref_without_fragment_does_not_inherit_base_fragment` — a ref with no
  fragment does NOT inherit the base's.
- `test_query_and_fragment_resolution_rfc3986` — RFC 3986 §5.4.1 query+fragment
  examples against `@base <http://a/b/c/d;p?q>` (`<#s>`, `<?y#s>`, `<g#s>`,
  `<g?y#s>`, `<>`).

## Results

- `cargo test -p fluree-graph-turtle` — **77 passed, 0 failed** (incl. the 6 new + 1 doctest).
- `cargo clippy -p fluree-graph-turtle --all-targets` — clean, no warnings.
- `cargo fmt -p fluree-graph-turtle` — applied.
- Downstream: `cargo test -p fluree-db-r2rml` — **46 passed, 0 failed**;
  `cargo check -p fluree-db-api` — clean.

## Risk / compatibility

`resolve_iri` is the resolution path for all relative IRIs in Turtle ingestion
(R2RML loader, `fluree-db-memory/turtle_io.rs`). Fragments were *always* dropped
before, so any `@base` + fragment Turtle was already parsed incorrectly — the fix
is strictly more correct. The change is conservative:

- No fixtures or golden snapshots encode the old fragment-dropped behavior. The
  only `.ttl` carrying `@base` is the MCP server's own `.fluree-memory/repo.ttl`
  (not a test fixture). The W3C SPARQL testsuite uses its **own** separate base
  resolver (`testsuite-sparql/src/result_format.rs`), not this `resolve_iri`.
- The one existing empty-ref test (`test_empty_iri_resolves_to_base`) uses a base
  with no fragment and stays green.
- Absolute-IRI and prefixed-name inputs are unchanged.

Phases 2–4 from issue #1395 (R2RML dup-IRI hardening, `Tables: N` UX, O(1) map
selection) are intentionally **out of scope** for this PR and stack on top.

Fixes #1395
