### PR TITLE
(Iceberg) Apply Vended-Credential `client.region` to the S3 Client

### DIFF
--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -663,12 +663,24 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                 );
 
                 let storage = if let Some(ref credentials) = load_response.credentials {
-                    info!("Using vended credentials from catalog");
-                    S3IcebergStorage::from_vended_credentials(credentials)
-                        .await
-                        .map_err(|e| {
-                            QueryError::Internal(format!("Failed to create S3 storage: {e}"))
-                        })?
+                    info!(
+                        region = ?iceberg_config.io.s3_region,
+                        endpoint = ?iceberg_config.io.s3_endpoint,
+                        "Using vended credentials from catalog"
+                    );
+                    // Thread the io overrides so a catalog that omits the region (or where
+                    // we want an operator-configured endpoint/path-style) still resolves
+                    // correctly. Precedence inside the call: vended > these overrides > SDK.
+                    S3IcebergStorage::from_vended_credentials(
+                        credentials,
+                        iceberg_config.io.s3_region.as_deref(),
+                        iceberg_config.io.s3_endpoint.as_deref(),
+                        iceberg_config.io.s3_path_style,
+                    )
+                    .await
+                    .map_err(|e| {
+                        QueryError::Internal(format!("Failed to create S3 storage: {e}"))
+                    })?
                 } else {
                     info!(
                         region = ?iceberg_config.io.s3_region,

--- a/fluree-db-iceberg/src/credential/vended.rs
+++ b/fluree-db-iceberg/src/credential/vended.rs
@@ -33,7 +33,8 @@ impl VendedCredentials {
     /// - `s3.secret-access-key`
     /// - `s3.session-token`
     /// - `s3.endpoint`
-    /// - `s3.region`
+    /// - `client.region` (Iceberg-REST spec key, e.g. sent by Snowflake Horizon),
+    ///   with `s3.region` accepted as a defensive fallback
     /// - `s3.path-style-access`
     /// - `expiration-time` or `s3.session-token-expires-at-ms`
     pub fn from_config_map(config: &HashMap<String, serde_json::Value>) -> Result<Option<Self>> {
@@ -63,8 +64,11 @@ impl VendedCredentials {
             .and_then(|v| v.as_str())
             .map(std::string::ToString::to_string);
 
+        // The Iceberg-REST spec carries the region as `client.region` (this is what
+        // Snowflake Horizon / Polaris send). Prefer it, falling back to `s3.region`.
         let region = config
-            .get("s3.region")
+            .get("client.region")
+            .or_else(|| config.get("s3.region"))
             .and_then(|v| v.as_str())
             .map(std::string::ToString::to_string);
 
@@ -276,6 +280,68 @@ mod tests {
         let config = HashMap::new();
         let creds = VendedCredentials::from_config_map(&config).unwrap();
         assert!(creds.is_none());
+    }
+
+    #[test]
+    fn test_parse_client_region_preferred() {
+        // The Iceberg-REST spec key `client.region` (what Snowflake Horizon sends)
+        // must be honored even when no `s3.region` is present.
+        let mut config = HashMap::new();
+        config.insert(
+            "s3.access-key-id".to_string(),
+            serde_json::json!("AKIATEST"),
+        );
+        config.insert(
+            "s3.secret-access-key".to_string(),
+            serde_json::json!("secret123"),
+        );
+        config.insert("client.region".to_string(), serde_json::json!("us-east-2"));
+
+        let creds = VendedCredentials::from_config_map(&config)
+            .unwrap()
+            .unwrap();
+        assert_eq!(creds.region, Some("us-east-2".to_string()));
+    }
+
+    #[test]
+    fn test_parse_client_region_beats_s3_region() {
+        // When both are present, `client.region` wins.
+        let mut config = HashMap::new();
+        config.insert(
+            "s3.access-key-id".to_string(),
+            serde_json::json!("AKIATEST"),
+        );
+        config.insert(
+            "s3.secret-access-key".to_string(),
+            serde_json::json!("secret123"),
+        );
+        config.insert("client.region".to_string(), serde_json::json!("us-east-2"));
+        config.insert("s3.region".to_string(), serde_json::json!("us-east-1"));
+
+        let creds = VendedCredentials::from_config_map(&config)
+            .unwrap()
+            .unwrap();
+        assert_eq!(creds.region, Some("us-east-2".to_string()));
+    }
+
+    #[test]
+    fn test_parse_s3_region_fallback() {
+        // With only the legacy `s3.region` key present, it is still parsed.
+        let mut config = HashMap::new();
+        config.insert(
+            "s3.access-key-id".to_string(),
+            serde_json::json!("AKIATEST"),
+        );
+        config.insert(
+            "s3.secret-access-key".to_string(),
+            serde_json::json!("secret123"),
+        );
+        config.insert("s3.region".to_string(), serde_json::json!("us-east-1"));
+
+        let creds = VendedCredentials::from_config_map(&config)
+            .unwrap()
+            .unwrap();
+        assert_eq!(creds.region, Some("us-east-1".to_string()));
     }
 
     #[test]

--- a/fluree-db-iceberg/src/io/storage.rs
+++ b/fluree-db-iceberg/src/io/storage.rs
@@ -83,9 +83,50 @@ impl Debug for S3IcebergStorage {
 
 #[cfg(feature = "aws")]
 impl S3IcebergStorage {
+    /// Resolve effective region/endpoint/path-style from vended credentials plus
+    /// caller-supplied overrides.
+    ///
+    /// Precedence: the value vended by the catalog wins, then the override, then
+    /// none. Region/endpoint stay `None` when neither source supplies one (so the
+    /// AWS SDK default chain applies); path-style is enabled if either the vended
+    /// creds or the override request it.
+    ///
+    /// Returned as plain owned values so the precedence logic is unit-testable
+    /// without touching SDK internals (the built `aws_sdk_s3::Config` exposes only
+    /// `region()`, not endpoint/path-style).
+    fn resolve_io(
+        creds: &crate::credential::VendedCredentials,
+        region_override: Option<&str>,
+        endpoint_override: Option<&str>,
+        path_style_override: bool,
+    ) -> (Option<String>, Option<String>, bool) {
+        let region = creds
+            .region
+            .clone()
+            .or_else(|| region_override.map(std::string::ToString::to_string));
+        let endpoint = creds
+            .endpoint
+            .clone()
+            .or_else(|| endpoint_override.map(std::string::ToString::to_string));
+        let path_style = creds.path_style || path_style_override;
+        (region, endpoint, path_style)
+    }
+
     /// Create a new S3 storage from vended credentials.
+    ///
+    /// Region/endpoint/path-style precedence (mirrors [`from_default_chain`] for the
+    /// override sources): the value vended by the catalog wins, then the caller-supplied
+    /// override (typically `io.s3_region` / `io.s3_endpoint` / `io.s3_path_style`), then
+    /// the AWS SDK default chain. Leaving region `None` (vended absent *and* no override)
+    /// preserves the SDK-default behavior (e.g. `us-east-1` / `AWS_REGION`) so the
+    /// previously-working us-east-1 path does not regress.
+    ///
+    /// [`from_default_chain`]: Self::from_default_chain
     pub async fn from_vended_credentials(
         creds: &crate::credential::VendedCredentials,
+        region_override: Option<&str>,
+        endpoint_override: Option<&str>,
+        path_style_override: bool,
     ) -> Result<Self> {
         use aws_credential_types::Credentials;
 
@@ -101,12 +142,20 @@ impl S3IcebergStorage {
             "vended-credentials",
         );
 
+        // Resolve region/endpoint/path-style precedence (vended > override > none).
+        let (region, endpoint, path_style) = Self::resolve_io(
+            creds,
+            region_override,
+            endpoint_override,
+            path_style_override,
+        );
+
         // Build config with vended credentials
         let mut config_loader = aws_config::defaults(aws_config::BehaviorVersion::latest())
             .credentials_provider(aws_creds);
 
-        // Set region if provided
-        if let Some(region) = &creds.region {
+        // Set region only when resolved; leaving it None preserves SDK default resolution.
+        if let Some(region) = &region {
             config_loader = config_loader.region(aws_config::Region::new(region.clone()));
         }
 
@@ -115,11 +164,11 @@ impl S3IcebergStorage {
         // Build S3 client, optionally with endpoint override
         let mut s3_config = aws_sdk_s3::config::Builder::from(&sdk_config);
 
-        if let Some(endpoint) = &creds.endpoint {
+        if let Some(endpoint) = &endpoint {
             s3_config = s3_config.endpoint_url(endpoint);
         }
 
-        if creds.path_style {
+        if path_style {
             s3_config = s3_config.force_path_style(true);
         }
 
@@ -499,6 +548,108 @@ mod tests {
         assert!(S3IcebergStorage::parse_s3_uri("http://bucket/key").is_err());
         assert!(S3IcebergStorage::parse_s3_uri("s3://bucket").is_err());
         assert!(S3IcebergStorage::parse_s3_uri("s3:///key").is_err());
+    }
+
+    #[cfg(feature = "aws")]
+    fn vended_creds(region: Option<&str>) -> crate::credential::VendedCredentials {
+        crate::credential::VendedCredentials {
+            access_key_id: "AKIATEST".to_string(),
+            secret_access_key: "secret123".to_string(),
+            session_token: Some("session456".to_string()),
+            expires_at: None,
+            endpoint: None,
+            region: region.map(std::string::ToString::to_string),
+            path_style: false,
+        }
+    }
+
+    #[cfg(feature = "aws")]
+    fn client_region(storage: &S3IcebergStorage) -> Option<String> {
+        storage
+            .client
+            .config()
+            .region()
+            .map(|r| r.as_ref().to_string())
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "aws")]
+    async fn test_vended_region_applied_to_client() {
+        // The region vended by the catalog must reach the S3 client (so it signs
+        // for the bucket's actual region rather than the SDK us-east-1 default).
+        let creds = vended_creds(Some("us-east-2"));
+        let storage = S3IcebergStorage::from_vended_credentials(&creds, None, None, false)
+            .await
+            .unwrap();
+        assert_eq!(client_region(&storage), Some("us-east-2".to_string()));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "aws")]
+    async fn test_vended_region_beats_override() {
+        // Precedence: the vended region wins over the io.s3_region override.
+        let creds = vended_creds(Some("us-east-2"));
+        let storage =
+            S3IcebergStorage::from_vended_credentials(&creds, Some("eu-west-1"), None, false)
+                .await
+                .unwrap();
+        assert_eq!(client_region(&storage), Some("us-east-2".to_string()));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "aws")]
+    async fn test_override_region_used_when_vended_absent() {
+        // When the catalog vends no region, the io.s3_region override is applied.
+        let creds = vended_creds(None);
+        let storage =
+            S3IcebergStorage::from_vended_credentials(&creds, Some("eu-west-1"), None, false)
+                .await
+                .unwrap();
+        assert_eq!(client_region(&storage), Some("eu-west-1".to_string()));
+    }
+
+    // Endpoint and path-style cannot be read back off the built aws-sdk-s3 `Config`
+    // in this SDK version (only `region()` is exposed; endpoint/path-style live in a
+    // crate-private config bag with no public getter). We therefore assert the
+    // override precedence at the `resolve_io` layer, which is exactly the value
+    // `from_vended_credentials` feeds into the S3 config builder. Region precedence is
+    // additionally proven end-to-end at the client level by the tests above.
+
+    #[test]
+    #[cfg(feature = "aws")]
+    fn test_resolve_io_endpoint_override_used_when_vended_absent() {
+        // When the catalog vends no endpoint, the io.s3_endpoint override is used
+        // (e.g. MinIO-via-vended setups).
+        let creds = vended_creds(Some("us-east-1")); // endpoint absent, path_style false
+        let (region, endpoint, path_style) =
+            S3IcebergStorage::resolve_io(&creds, None, Some("http://minio.test:9000"), false);
+        assert_eq!(region.as_deref(), Some("us-east-1"));
+        assert_eq!(endpoint.as_deref(), Some("http://minio.test:9000"));
+        assert!(!path_style);
+    }
+
+    #[test]
+    #[cfg(feature = "aws")]
+    fn test_resolve_io_path_style_override_forces_true() {
+        // path_style_override = true forces path-style even when the vended creds
+        // default it to false.
+        let creds = vended_creds(Some("us-east-1")); // path_style false
+        let (_, _, path_style) = S3IcebergStorage::resolve_io(&creds, None, None, true);
+        assert!(path_style);
+    }
+
+    #[test]
+    #[cfg(feature = "aws")]
+    fn test_resolve_io_vended_endpoint_and_path_style_beat_override() {
+        // Precedence: a vended endpoint wins over the override, and a vended
+        // path-style of true holds even when the override requests false.
+        let mut creds = vended_creds(None);
+        creds.endpoint = Some("http://vended.minio:9000".to_string());
+        creds.path_style = true;
+        let (_, endpoint, path_style) =
+            S3IcebergStorage::resolve_io(&creds, None, Some("http://override.minio:9000"), false);
+        assert_eq!(endpoint.as_deref(), Some("http://vended.minio:9000"));
+        assert!(path_style);
     }
 
     #[tokio::test]

--- a/fluree-db-iceberg/src/io/storage.rs
+++ b/fluree-db-iceberg/src/io/storage.rs
@@ -86,10 +86,13 @@ impl S3IcebergStorage {
     /// Resolve effective region/endpoint/path-style from vended credentials plus
     /// caller-supplied overrides.
     ///
-    /// Precedence: the value vended by the catalog wins, then the override, then
-    /// none. Region/endpoint stay `None` when neither source supplies one (so the
-    /// AWS SDK default chain applies); path-style is enabled if either the vended
-    /// creds or the override request it.
+    /// Precedence differs by field. Region/endpoint follow "vended wins, then
+    /// override, then none": they stay `None` when neither source supplies one (so
+    /// the AWS SDK default chain applies). Path-style is the logical OR of the
+    /// vended and override flags — *not* "vended wins" — so an override can only
+    /// force it on, never back to `false`. (That asymmetry is intentional: once
+    /// either source requires path-style addressing it must stay enabled, which is
+    /// the only sensible resolution for a bool.)
     ///
     /// Returned as plain owned values so the precedence logic is unit-testable
     /// without touching SDK internals (the built `aws_sdk_s3::Config` exposes only
@@ -114,12 +117,16 @@ impl S3IcebergStorage {
 
     /// Create a new S3 storage from vended credentials.
     ///
-    /// Region/endpoint/path-style precedence (mirrors [`from_default_chain`] for the
-    /// override sources): the value vended by the catalog wins, then the caller-supplied
-    /// override (typically `io.s3_region` / `io.s3_endpoint` / `io.s3_path_style`), then
-    /// the AWS SDK default chain. Leaving region `None` (vended absent *and* no override)
+    /// Region/endpoint precedence (mirrors [`from_default_chain`] for the override
+    /// sources): the value vended by the catalog wins, then the caller-supplied
+    /// override (typically `io.s3_region` / `io.s3_endpoint`), then the AWS SDK
+    /// default chain. Leaving region `None` (vended absent *and* no override)
     /// preserves the SDK-default behavior (e.g. `us-east-1` / `AWS_REGION`) so the
     /// previously-working us-east-1 path does not regress.
+    ///
+    /// Path-style (`io.s3_path_style`) is the exception: it is the logical OR of the
+    /// vended and override flags, so an override can only force it on, never back to
+    /// `false`. See [`resolve_io`](Self::resolve_io).
     ///
     /// [`from_default_chain`]: Self::from_default_chain
     pub async fn from_vended_credentials(


### PR DESCRIPTION
## Summary

Reading a Snowflake-managed Iceberg table through the Horizon (Apache Polaris)
REST catalog with **vended credentials** failed for any bucket outside
`us-east-1` (e.g. `us-east-2`) with:

```
Failed to read table metadata: Storage error: S3 GetObject failed: service error
```

The catalog vends the bucket's region as the Iceberg-REST spec key
`client.region`, but fluree's vended-credentials S3 client never read it, so the
AWS SDK fell back to its global `us-east-1` default and signed requests for the
wrong region. The only workaround was setting `AWS_REGION=us-east-2` on the
server. This PR threads the region (and endpoint / path-style) through to the
vended client so the catalog's region is honored.

## Root cause — region dropped at three points

1. **Parser ignored it.** `fluree-db-iceberg/src/credential/vended.rs`
   (`from_config_map`) parsed only `s3.region`; the actual `client.region` value
   present in the `loadTable` response was never read, so `creds.region == None`.
2. **Override not threaded to the vended client.**
   `fluree-db-api/src/graph_source/r2rml.rs` passed `io.s3_region` /
   `io.s3_endpoint` / `io.s3_path_style` only on the ambient
   (`from_default_chain`) branch; the vended branch received only the creds, so a
   configured `--s3-region` never reached the vended client.
3. **Client fell to the SDK default.** `fluree-db-iceberg/src/io/storage.rs`
   (`from_vended_credentials`) only applied a region when `creds.region` was
   `Some`; with `None` and no `AWS_REGION`, aws-sdk-s3 defaulted to `us-east-1`.

## What changed

- **`fluree-db-iceberg/src/credential/vended.rs`** — `from_config_map` now parses
  `client.region` first (the Iceberg-REST spec key Snowflake Horizon / Polaris
  send), keeping `s3.region` as a defensive fallback. Doc comment updated to list
  the expected keys.
- **`fluree-db-iceberg/src/io/storage.rs`** — `from_vended_credentials` now takes
  `region_override` / `endpoint_override` / `path_style_override` params,
  mirroring its sibling `from_default_chain`. It resolves
  `creds.region.or(region_override)` (same for endpoint; path-style is enabled if
  either source requests it). Leaving region `None` (vended absent *and* no
  override) preserves today's SDK-default behavior, so the working `us-east-1`
  path does not regress. The single in-repo caller made changing the `pub`
  signature directly cleaner than adding a `_with_overrides` shim. The precedence
  itself is factored into a small pure `resolve_io` helper so it is unit-testable
  without touching SDK internals.
- **`fluree-db-api/src/graph_source/r2rml.rs`** — the vended branch now threads
  `io.s3_region` / `io.s3_endpoint` / `io.s3_path_style` into the
  `from_vended_credentials` call, matching the ambient branch.

**Target precedence:** vended `client.region` > vended `s3.region` >
`io.s3_region` override > SDK default chain (same fallback for endpoint and
path-style).

## Tests (all offline — no live bucket / no network)

Parser (`credential/vended.rs`):
- `test_parse_client_region_preferred` — `client.region` present (no
  `s3.region`) → parsed.
- `test_parse_client_region_beats_s3_region` — both present → `client.region`
  wins.
- `test_parse_s3_region_fallback` — only `s3.region` → still parsed.

Client region (`io/storage.rs`, build via `from_vended_credentials`, assert
`client.config().region()`):
- `test_vended_region_applied_to_client` — vended region reaches the client.
- `test_vended_region_beats_override` — precedence: vended beats the override.
- `test_override_region_used_when_vended_absent` — override applied when vended
  absent.

Endpoint + path-style precedence (`io/storage.rs`): this aws-sdk-s3 version
exposes only `region()` on the built `Config` (endpoint/path-style live in a
crate-private config bag with no public getter), so the override precedence is
factored into a small pure `resolve_io(creds, overrides) -> (region, endpoint,
path_style)` helper — exactly the values `from_vended_credentials` feeds the S3
config builder — and asserted directly:
- `test_resolve_io_endpoint_override_used_when_vended_absent` — `io.s3_endpoint`
  override used when the catalog vends no endpoint.
- `test_resolve_io_path_style_override_forces_true` — `path_style_override=true`
  forces path-style.
- `test_resolve_io_vended_endpoint_and_path_style_beat_override` — vended endpoint
  wins over the override, and a vended `path_style=true` holds even when the
  override is false.

### Results

- `cargo test -p fluree-db-iceberg --features aws` — pass (all 9 new tests green:
  3 parser + 3 client-region + 3 `resolve_io`; full crate suite green).
- `cargo clippy -p fluree-db-iceberg --all-targets --features aws` — clean (no
  warnings).
- `cargo fmt` — clean.
- `cargo check -p fluree-db-api` and `cargo check -p fluree-db-api --features iceberg`
  — both pass (the latter type-checks the changed vended call site, which is
  gated behind the `iceberg` feature).

## Risk / compatibility

- Intended behavior change: when the catalog vends `client.region`, it now
  overrides any ambient `AWS_REGION` — correct, since the catalog is
  authoritative — and **removes the `AWS_REGION=us-east-2` workaround**.
- **No regression for `us-east-1`:** with no vended region and no override, region
  stays `None` → SDK default resolution, exactly as before.
- Newly honoring `io.s3_endpoint` / `io.s3_path_style` on the vended path also
  improves MinIO-via-vended setups.
- All changes are behind the `aws` feature; `r2rml.rs` is the sole
  storage-construction site, so this covers the whole Iceberg read path.

Fixes #1396
