### PR TITLE
(R2RML) Error on Colliding TriplesMap IRIs & Report Table Count

### DIFF
--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -185,10 +185,13 @@ impl crate::Fluree {
         config.validate()?;
 
         // Resolve mapping: validate and store to CAS if inline content
-        let (mapping_address, triples_map_count, mapping_validated) = match &config.mapping {
+        let (mapping_address, triples_map_count, table_names, mapping_validated) = match &config
+            .mapping
+        {
             R2rmlMappingInput::Content(content) => {
                 let compiled = Self::compile_r2rml_content(content, &config)?;
                 let count = compiled.len();
+                let tables = Self::sorted_table_names(&compiled);
                 let gs_id = config.graph_source_id();
                 let cs = self.content_store(&gs_id);
                 let cid = cs
@@ -202,20 +205,21 @@ impl crate::Fluree {
                     })?;
                 let addr = cid.to_string();
                 info!(graph_source_id = %graph_source_id, mapping_cid = %addr, "R2RML mapping stored to CAS");
-                (addr, count, true)
+                (addr, count, tables, true)
             }
             R2rmlMappingInput::Address(address) => {
-                let (count, validated) = self
-                    .validate_r2rml_mapping_from_address(address, &config)
-                    .await
-                    .map(|c| (c, true))
-                    .unwrap_or_else(|e| {
-                        warn!(graph_source_id = %graph_source_id, error = %e, "Could not validate R2RML mapping from address");
-                        (0, false)
-                    });
-                (address.clone(), count, validated)
+                let (count, tables, validated) = self
+                        .validate_r2rml_mapping_from_address(address, &config)
+                        .await
+                        .map(|(c, t)| (c, t, true))
+                        .unwrap_or_else(|e| {
+                            warn!(graph_source_id = %graph_source_id, error = %e, "Could not validate R2RML mapping from address");
+                            (0, Vec::new(), false)
+                        });
+                (address.clone(), count, tables, validated)
             }
         };
+        let table_count = table_names.len();
 
         // Test catalog connection (REST mode only)
         let connection_tested = if config.iceberg.is_rest() {
@@ -248,6 +252,8 @@ impl crate::Fluree {
             catalog_uri: config.iceberg.catalog_uri_or_location().to_string(),
             mapping_source: mapping_address,
             triples_map_count,
+            table_count,
+            table_names,
             connection_tested,
             mapping_validated,
         })
@@ -324,11 +330,14 @@ impl crate::Fluree {
     }
 
     /// Validate an R2RML mapping from a pre-existing storage address.
+    ///
+    /// Returns the number of TriplesMap definitions and the sorted list of
+    /// distinct logical table names referenced by the mapping.
     async fn validate_r2rml_mapping_from_address(
         &self,
         address: &str,
         config: &R2rmlCreateConfig,
-    ) -> Result<usize> {
+    ) -> Result<(usize, Vec<String>)> {
         let storage = self.admin_storage().ok_or_else(|| {
             crate::ApiError::Config(format!(
                 "Cannot load R2RML mapping from address '{address}': address-based reads are not supported on this backend"
@@ -342,7 +351,20 @@ impl crate::Fluree {
         let content = String::from_utf8(bytes).map_err(|e| {
             crate::ApiError::Config(format!("R2RML mapping is not valid UTF-8: {e}"))
         })?;
-        Ok(Self::compile_r2rml_content(&content, config)?.len())
+        let compiled = Self::compile_r2rml_content(&content, config)?;
+        Ok((compiled.len(), Self::sorted_table_names(&compiled)))
+    }
+
+    /// Collect the distinct logical table names referenced by a compiled
+    /// mapping, sorted for deterministic reporting.
+    fn sorted_table_names(compiled: &CompiledR2rmlMapping) -> Vec<String> {
+        let mut names: Vec<String> = compiled
+            .table_names()
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        names.sort();
+        names
     }
 }
 

--- a/fluree-db-api/src/graph_source/result.rs
+++ b/fluree-db-api/src/graph_source/result.rs
@@ -230,6 +230,12 @@ pub struct R2rmlCreateResult {
     /// Number of TriplesMap definitions in the mapping
     pub triples_map_count: usize,
 
+    /// Number of distinct logical tables referenced by the mapping
+    pub table_count: usize,
+
+    /// Names of the distinct logical tables referenced by the mapping (sorted)
+    pub table_names: Vec<String>,
+
     /// Whether the catalog connection was tested successfully
     pub connection_tested: bool,
 

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -16,7 +16,8 @@ use fluree_db_query::error::{QueryError, Result as QueryResult};
 use fluree_db_query::r2rml::{ColumnBatchStream, R2rmlProvider, R2rmlTableProvider, ScanFilter};
 use fluree_db_r2rml::loader::R2rmlLoader;
 use fluree_db_r2rml::mapping::CompiledR2rmlMapping;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 // Additional imports for engine-level E2E tests
 use fluree_db_api::{
@@ -1975,6 +1976,268 @@ async fn engine_e2e_ref_object_map_join_execution() {
             }
         }
     }
+}
+
+// =============================================================================
+// Multi-table mapping in the idiomatic `@base` + `<#Name>` style (issue #1395)
+// =============================================================================
+
+/// A star-schema-style mapping written the way the W3C R2RML spec writes its
+/// own examples: a document `@base` plus relative `<#Name>` TriplesMap subjects.
+///
+/// Before the parser fix every `<#Name>` resolved to the same fragment-stripped
+/// IRI, collapsing all three TriplesMaps into one (single table, union of every
+/// column). With RFC 3986 §5.3 fragment resolution, `<#DimDate>`,
+/// `<#DimProduct>` and `<#FactSales>` resolve to three distinct IRIs and map
+/// three distinct tables.
+const BASE_FRAGMENT_MULTI_TABLE_TTL: &str = r#"
+@base <http://ex/edw> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix ex: <http://example.org/> .
+
+<#DimDate> a rr:TriplesMap ;
+    rr:logicalTable [ rr:tableName "DW.DIM_DATE" ] ;
+    rr:subjectMap [ rr:template "http://example.org/date/{DATE_KEY}" ; rr:class ex:Date ] ;
+    rr:predicateObjectMap [
+        rr:predicate ex:year ;
+        rr:objectMap [ rr:column "YEAR" ]
+    ] .
+
+<#DimProduct> a rr:TriplesMap ;
+    rr:logicalTable [ rr:tableName "DW.DIM_PRODUCT" ] ;
+    rr:subjectMap [ rr:template "http://example.org/product/{PRODUCT_KEY}" ; rr:class ex:Product ] ;
+    rr:predicateObjectMap [
+        rr:predicate ex:productName ;
+        rr:objectMap [ rr:column "NAME" ]
+    ] .
+
+<#FactSales> a rr:TriplesMap ;
+    rr:logicalTable [ rr:tableName "DW.FACT_SALES" ] ;
+    rr:subjectMap [ rr:template "http://example.org/sale/{SALE_ID}" ; rr:class ex:Sale ] ;
+    rr:predicateObjectMap [
+        rr:predicate ex:amount ;
+        rr:objectMap [ rr:column "AMOUNT" ]
+    ] .
+"#;
+
+/// Two `rr:TriplesMap` subjects that resolve to the same IRI. This is the
+/// post-collapse shape the (now-fixed) Turtle parser used to produce silently;
+/// the hardening guard must reject it loudly rather than first-wins/union-merge.
+const COLLIDING_TRIPLES_MAP_TTL: &str = r#"
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix ex: <http://example.org/> .
+
+<http://example.org/mapping#Collide> a rr:TriplesMap ;
+    rr:logicalTable [ rr:tableName "DW.DIM_DATE" ] ;
+    rr:subjectMap [ rr:template "http://example.org/date/{DATE_KEY}" ; rr:class ex:Date ] ;
+    rr:predicateObjectMap [
+        rr:predicate ex:year ;
+        rr:objectMap [ rr:column "YEAR" ]
+    ] .
+
+<http://example.org/mapping#Collide> a rr:TriplesMap ;
+    rr:logicalTable [ rr:tableName "DW.DIM_PRODUCT" ] ;
+    rr:subjectMap [ rr:template "http://example.org/product/{PRODUCT_KEY}" ; rr:class ex:Product ] ;
+    rr:predicateObjectMap [
+        rr:predicate ex:productName ;
+        rr:objectMap [ rr:column "NAME" ]
+    ] .
+"#;
+
+/// Sample batch for the `DW.DIM_PRODUCT` table (subject key + name column).
+fn sample_product_batch() -> ColumnBatch {
+    let schema = BatchSchema::new(vec![
+        FieldInfo {
+            name: "PRODUCT_KEY".to_string(),
+            field_type: FieldType::Int64,
+            nullable: false,
+            field_id: 1,
+        },
+        FieldInfo {
+            name: "NAME".to_string(),
+            field_type: FieldType::String,
+            nullable: true,
+            field_id: 2,
+        },
+    ]);
+    let columns = vec![
+        Column::Int64(vec![Some(10), Some(20)]),
+        Column::String(vec![Some("Widget".to_string()), Some("Gadget".to_string())]),
+    ];
+    ColumnBatch::new(Arc::new(schema), columns).unwrap()
+}
+
+/// Mock provider that records which tables `scan_table` is asked to read, so a
+/// test can assert that a non-first TriplesMap scans its own table (and not the
+/// first map's table, which was the collapse symptom).
+#[derive(Debug)]
+struct RecordingTableProvider {
+    mapping: Arc<CompiledR2rmlMapping>,
+    batches: HashMap<String, ColumnBatch>,
+    scanned: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl R2rmlProvider for RecordingTableProvider {
+    async fn has_r2rml_mapping(&self, _graph_source_id: &str) -> bool {
+        true
+    }
+
+    async fn compiled_mapping(
+        &self,
+        _graph_source_id: &str,
+        _as_of_t: Option<i64>,
+    ) -> QueryResult<Arc<CompiledR2rmlMapping>> {
+        Ok(Arc::clone(&self.mapping))
+    }
+}
+
+#[async_trait]
+impl R2rmlTableProvider for RecordingTableProvider {
+    async fn scan_table(
+        &self,
+        _graph_source_id: &str,
+        table_name: &str,
+        _projection: &[String],
+        _filters: &[ScanFilter],
+        _as_of_t: Option<i64>,
+    ) -> QueryResult<ColumnBatchStream> {
+        self.scanned.lock().unwrap().push(table_name.to_string());
+        match self.batches.get(table_name) {
+            Some(batch) => Ok(vec_batch_stream(vec![batch.clone()])),
+            None => Ok(vec_batch_stream(vec![])),
+        }
+    }
+}
+
+/// Offline regression guard for issue #1395: an idiomatic `@base` + `<#Name>`
+/// multi-table mapping compiles to N distinct TriplesMaps over N distinct
+/// tables — not one merged map.
+#[test]
+fn test_base_fragment_multi_table_compiles_to_distinct_tables() {
+    let mapping = R2rmlLoader::from_turtle(BASE_FRAGMENT_MULTI_TABLE_TTL)
+        .expect("Failed to parse R2RML Turtle")
+        .compile()
+        .expect("Failed to compile R2RML mapping");
+
+    // Three TriplesMaps, not one collapsed map.
+    assert_eq!(mapping.triples_maps.len(), 3);
+
+    // Each `<#Name>` resolved to its own distinct IRI against `@base`.
+    assert!(mapping.get("http://ex/edw#DimDate").is_some());
+    assert!(mapping.get("http://ex/edw#DimProduct").is_some());
+    assert!(mapping.get("http://ex/edw#FactSales").is_some());
+
+    // Three distinct logical tables (the collapse produced exactly one).
+    let mut tables = mapping.table_names();
+    tables.sort_unstable();
+    assert_eq!(
+        tables,
+        vec!["DW.DIM_DATE", "DW.DIM_PRODUCT", "DW.FACT_SALES"]
+    );
+}
+
+/// Engine-level E2E for issue #1395: querying a predicate owned by a non-first
+/// TriplesMap scans that map's own table (`DW.DIM_PRODUCT`) and never the first
+/// map's table (`DW.DIM_DATE`). Pre-fix, every class scanned the first table.
+#[tokio::test]
+async fn engine_e2e_base_fragment_scans_non_first_table() {
+    let mapping = R2rmlLoader::from_turtle(BASE_FRAGMENT_MULTI_TABLE_TTL)
+        .expect("Failed to parse R2RML")
+        .compile()
+        .expect("Failed to compile");
+
+    let mut batches = HashMap::new();
+    batches.insert("DW.DIM_PRODUCT".to_string(), sample_product_batch());
+
+    let scanned = Arc::new(Mutex::new(Vec::new()));
+    let provider = RecordingTableProvider {
+        mapping: Arc::new(mapping),
+        batches,
+        scanned: Arc::clone(&scanned),
+    };
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let mut ledger = genesis_ledger(&fluree, "edw-multi:main");
+    std::sync::Arc::make_mut(&mut ledger.snapshot)
+        .insert_namespace_code(9_999, "http://example.org/".to_string())
+        .unwrap();
+
+    // Query: SELECT ?p ?n WHERE { GRAPH <edw-gs:main> { ?p ex:productName ?n } }
+    // ex:productName is owned only by <#DimProduct> → only DW.DIM_PRODUCT.
+    let mut vars = VarRegistry::new();
+    let product_var = vars.get_or_insert("?p");
+    let name_var = vars.get_or_insert("?n");
+
+    let ex_product_name_sid = ledger
+        .snapshot
+        .encode_iri("http://example.org/productName")
+        .expect("example.org namespace should be registered for Sid encoding");
+
+    let inner_patterns = vec![Pattern::Triple(TriplePattern::new(
+        Ref::Var(product_var),
+        Ref::Sid(ex_product_name_sid),
+        Term::Var(name_var),
+    ))];
+
+    let graph_pattern = Pattern::Graph {
+        name: GraphName::Iri("edw-gs:main".into()),
+        patterns: inner_patterns,
+    };
+
+    let mut parsed = Query::new(ParsedContext::default());
+    parsed.patterns = vec![graph_pattern];
+    parsed.output = QueryOutput::select_all(vec![product_var, name_var]);
+
+    let executable = ExecutableQuery::simple(parsed);
+    let tracker = Tracker::disabled();
+
+    let result_batches = execute(
+        GraphDbRef::new(&ledger.snapshot, 0, &NoOverlay, ledger.t()),
+        &vars,
+        &executable,
+        r2rml_test_config(&tracker, &provider),
+    )
+    .await
+    .expect("Query execution should succeed");
+
+    let total_rows: usize = result_batches.iter().map(fluree_db_api::Batch::len).sum();
+    assert_eq!(total_rows, 2, "Should return the 2 DW.DIM_PRODUCT rows");
+
+    let scanned_tables = scanned.lock().unwrap().clone();
+    assert_eq!(
+        scanned_tables,
+        vec!["DW.DIM_PRODUCT".to_string()],
+        "Non-first TriplesMap must scan its own table only; scanned: {scanned_tables:?}"
+    );
+    assert!(
+        !scanned_tables.contains(&"DW.DIM_DATE".to_string()),
+        "The first map's table must not be scanned for a non-first predicate"
+    );
+}
+
+/// Phase-2 hardening for issue #1395: two `rr:TriplesMap` subjects that resolve
+/// to the same IRI must be a hard error, not a silent first-wins/union merge.
+#[test]
+fn test_colliding_triples_map_iris_error() {
+    let result = R2rmlLoader::from_turtle(COLLIDING_TRIPLES_MAP_TTL)
+        .expect("Turtle should parse")
+        .compile();
+
+    assert!(
+        result.is_err(),
+        "Two TriplesMap subjects colliding to one IRI should be rejected, got Ok"
+    );
+
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("Duplicate TriplesMap IRI"),
+        "Error should be a DuplicateTriplesMap, got: {msg}"
+    );
+    assert!(
+        msg.contains("http://example.org/mapping#Collide"),
+        "Error should name the colliding IRI, got: {msg}"
+    );
 }
 
 /// Test that composite join keys work correctly.

--- a/fluree-db-cli/src/commands/iceberg.rs
+++ b/fluree-db-cli/src/commands/iceberg.rs
@@ -282,6 +282,24 @@ async fn run_iceberg_map_remote(
         {
             println!("  TriplesMaps: {count}");
         }
+        if let Some(table_count) = result
+            .get("table_count")
+            .and_then(serde_json::Value::as_u64)
+        {
+            let table_names: Vec<String> = result
+                .get("table_names")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default();
+            println!(
+                "  Tables:      {}",
+                format_table_summary(table_count as usize, &table_names)
+            );
+        }
         println!(
             "  Connection:  {}",
             if connection { "verified" } else { "not tested" }
@@ -593,6 +611,10 @@ async fn run_iceberg_map_local(args: IcebergMapArgs, dirs: &FlureeDir) -> CliRes
         println!("  R2RML:       {}", result.mapping_source);
         println!("  TriplesMaps: {}", result.triples_map_count);
         println!(
+            "  Tables:      {}",
+            format_table_summary(result.table_count, &result.table_names)
+        );
+        println!(
             "  Connection:  {}",
             if result.connection_tested {
                 "verified"
@@ -707,6 +729,16 @@ fn build_iceberg_config(args: &IcebergMapArgs) -> CliResult<fluree_db_api::Icebe
     }
 
     Ok(config)
+}
+
+/// Format the `Tables:` summary as `N (name1, name2, …)`, or just `N` when no
+/// table names are available (e.g. an unvalidated address-based mapping).
+fn format_table_summary(count: usize, names: &[String]) -> String {
+    if names.is_empty() {
+        count.to_string()
+    } else {
+        format!("{count} ({})", names.join(", "))
+    }
 }
 
 fn is_iceberg_family_source_type(st: &fluree_db_nameservice::GraphSourceType) -> bool {

--- a/fluree-db-r2rml/src/error.rs
+++ b/fluree-db-r2rml/src/error.rs
@@ -29,6 +29,10 @@ pub enum R2rmlError {
     #[error("Unknown TriplesMap: {0}")]
     UnknownTriplesMap(String),
 
+    /// Two or more rr:TriplesMap definitions resolve to the same subject IRI
+    #[error("Duplicate TriplesMap IRI: {0}")]
+    DuplicateTriplesMap(String),
+
     /// Column not found in table
     #[error("Column not found: {column} in table {table}")]
     ColumnNotFound { column: String, table: String },

--- a/fluree-db-r2rml/src/loader/extractor.rs
+++ b/fluree-db-r2rml/src/loader/extractor.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracts TriplesMap definitions from a Graph IR.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use fluree_graph_ir::{Graph, Term, Triple};
 
@@ -41,6 +41,7 @@ impl<'a> MappingExtractor<'a> {
     /// Extract all TriplesMap definitions from the graph
     pub fn extract_all(&self) -> R2rmlResult<Vec<TriplesMap>> {
         let mut triples_maps = Vec::new();
+        let mut seen: HashSet<&str> = HashSet::new();
 
         // Find all subjects that are rdf:type rr:TriplesMap
         for triple in self.graph.iter() {
@@ -48,6 +49,23 @@ impl<'a> MappingExtractor<'a> {
                 && triple.o.as_iri() == Some(R2RML::TRIPLES_MAP)
             {
                 if let Some(subj_iri) = triple.s.as_iri() {
+                    // Each TriplesMap IRI is extracted exactly once. A repeated
+                    // `a rr:TriplesMap` triple for an already-extracted subject is
+                    // harmless redundancy and is skipped here.
+                    if !seen.insert(subj_iri) {
+                        continue;
+                    }
+
+                    // Hardening: a single TriplesMap IRI must carry exactly one
+                    // logical table and one subject map. More than one means two
+                    // or more `rr:TriplesMap` definitions collapsed onto the same
+                    // IRI (classically: idiomatic relative `<#fragment>` subjects
+                    // resolved against `@base` to the same IRI) and silently
+                    // merged into first-wins table/subject + union-of-POMs data.
+                    // Reject the collision loudly instead of returning
+                    // plausible-but-wrong triples.
+                    self.ensure_no_collision(subj_iri)?;
+
                     let tm = self.extract_triples_map(subj_iri)?;
                     triples_maps.push(tm);
                 }
@@ -55,6 +73,34 @@ impl<'a> MappingExtractor<'a> {
         }
 
         Ok(triples_maps)
+    }
+
+    /// Reject a TriplesMap IRI that carries more than one logical table or
+    /// subject map — the signature of two `rr:TriplesMap` subjects colliding to
+    /// the same IRI and being merged.
+    fn ensure_no_collision(&self, tm_iri: &str) -> R2rmlResult<()> {
+        let triples = self.get_triples_for_subject(tm_iri);
+
+        let table_count = triples
+            .iter()
+            .filter(|t| t.p.as_iri() == Some(R2RML::LOGICAL_TABLE))
+            .count();
+        let subject_count = triples
+            .iter()
+            .filter(|t| t.p.as_iri() == Some(R2RML::SUBJECT_MAP))
+            .count();
+
+        if table_count > 1 || subject_count > 1 {
+            return Err(R2rmlError::DuplicateTriplesMap(format!(
+                "{tm_iri} (found {table_count} rr:logicalTable and {subject_count} rr:subjectMap \
+                 definitions). Two or more rr:TriplesMap subjects resolve to this IRI and would be \
+                 silently merged (first-wins table/subject, union of predicate-object maps). Give \
+                 each TriplesMap a distinct subject IRI — a common cause is relative <#fragment> \
+                 references collapsing against @base."
+            )));
+        }
+
+        Ok(())
     }
 
     /// Extract a single TriplesMap by its IRI

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -73,6 +73,10 @@ pub struct IcebergMapResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub triples_map_count: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub table_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table_names: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mapping_validated: Option<bool>,
 }
 
@@ -137,6 +141,8 @@ async fn iceberg_map_local(state: Arc<AppState>, request: Request) -> Result<imp
                 connection_tested: result.connection_tested,
                 mapping_source: Some(result.mapping_source),
                 triples_map_count: Some(result.triples_map_count),
+                table_count: Some(result.table_count),
+                table_names: Some(result.table_names),
                 mapping_validated: Some(result.mapping_validated),
             }
         } else {
@@ -153,6 +159,8 @@ async fn iceberg_map_local(state: Arc<AppState>, request: Request) -> Result<imp
                 connection_tested: result.connection_tested,
                 mapping_source: None,
                 triples_map_count: None,
+                table_count: None,
+                table_names: None,
                 mapping_validated: None,
             }
         };


### PR DESCRIPTION
> **Stacked PR.** Base branch: `fix/turtle-fragment-resolution` (#1399)

## Summary

This is **Phases 2 & 3** of issue #1395 — the R2RML half of the multi-table
collapse fix, layered on top of PR-1's Turtle parser fragment fix.

- **Phase 2 (hardening):** make a silent multi-`TriplesMap` collapse *impossible*.
  When two or more `rr:TriplesMap` subjects resolve to the same IRI, the extractor
  now returns a hard error instead of merging them (first-wins logical table /
  subject map, union of every predicate-object map) into plausible-but-wrong data.
- **Phase 3 (reporting):** surface table coverage at registration. The R2RML
  create result and `fluree iceberg map` now report `Tables: N (names…)` next to
  `TriplesMaps: N`, so a 16-table star schema that has silently collapsed shows
  `Tables: 1` immediately rather than failing mysteriously at query time.

Phase 1 (the parser fix) is the base branch. **Phase 4** (wiring the operator's
prebuilt `find_maps_for_*` selection indexes for O(1) map selection) is
intentionally **deferred** and out of scope here.

## What changed

### Phase 2 — collapse is now a hard error

`fluree-db-r2rml/src/loader/extractor.rs` — `MappingExtractor::extract_all`:

- Each `rr:TriplesMap` IRI is extracted exactly once (a repeated
  `a rr:TriplesMap` triple for an already-seen subject is harmless redundancy and
  is skipped).
- Before extracting, a new `ensure_no_collision` guard counts the `rr:logicalTable`
  and `rr:subjectMap` edges on the subject. A well-formed TriplesMap has exactly
  one of each; **more than one is the signature of two definitions merged onto one
  IRI**, and is now rejected with `R2rmlError::DuplicateTriplesMap`. This signal is
  independent of graph bag/set semantics (the merged subject always carries the
  distinct logical-table blank nodes) and produces **no false positive** for a
  redundant type triple on a single well-formed map.

`fluree-db-r2rml/src/error.rs` — new `R2rmlError::DuplicateTriplesMap(String)`
variant whose message names the colliding IRI and points at the usual cause
(relative `<#fragment>` subjects collapsing against `@base`).

### Phase 3 — `Tables: N (…)` at registration

- `fluree-db-api/src/graph_source/result.rs` — `R2rmlCreateResult` gains
  `table_count: usize` and `table_names: Vec<String>` (sorted, distinct).
- `fluree-db-api/src/graph_source/r2rml.rs` — both the CAS-stored
  (`R2rmlMappingInput::Content`) and address-validated
  (`R2rmlMappingInput::Address`) paths now derive the table list from the compiled
  mapping via a small `sorted_table_names` helper; `validate_r2rml_mapping_from_address`
  returns `(count, table_names)`.
- `fluree-db-cli/src/commands/iceberg.rs` — prints
  `Tables:      N (DW.X, DW.Y, …)` after `TriplesMaps:` on **both** the local and
  remote (`fluree iceberg map`) output paths, via a shared `format_table_summary`
  helper (falls back to bare `N` when no names are available, e.g. an unvalidated
  address mapping).
- `fluree-db-server/src/routes/iceberg.rs` — the `/iceberg/map` JSON response
  (`IcebergMapResponse`) carries optional `table_count` / `table_names` so the
  remote CLI path renders the same line. No behavior change for the raw (non-R2RML)
  Iceberg branch.

## Tests added

In `fluree-db-api/tests/it_graph_source_r2rml.rs`:

- `test_base_fragment_multi_table_compiles_to_distinct_tables` — the offline
  regression guard. An idiomatic `@base <http://ex/edw>` + `<#DimDate>` /
  `<#DimProduct>` / `<#FactSales>` fixture compiles to **3 distinct TriplesMaps**
  (`…edw#DimDate`, `…edw#DimProduct`, `…edw#FactSales`) over **3 distinct tables**
  (`DW.DIM_DATE`, `DW.DIM_PRODUCT`, `DW.FACT_SALES`) — not one merged map.
- `engine_e2e_base_fragment_scans_non_first_table` — drives the engine with a
  recording provider (the `MultiTableMockProvider` pattern). Querying a predicate
  owned only by the **non-first** map scans `DW.DIM_PRODUCT` and **never**
  `DW.DIM_DATE` (the first map's table — the exact collapse symptom), returning the
  correct rows.
- `test_colliding_triples_map_iris_error` — the Phase-2 hardening test: a document
  with two `rr:TriplesMap` subjects resolving to one IRI fails to compile with a
  `Duplicate TriplesMap IRI` error naming the colliding subject.

## Results

- `cargo test -p fluree-db-r2rml` — **46 passed, 0 failed** (+1 doctest);
  `--features turtle` — **55 passed, 0 failed** (+1 doctest).
- `cargo test -p fluree-db-api --features iceberg` — full suite green; the touched
  binary `it_graph_source_r2rml` is **32 passed, 0 failed** (2 ignored — external
  Polaris/MinIO), including the 3 new tests. No regressions across the rest of the
  api suite (640 unit + all `grp_*`/`it_*` integration binaries, 0 failures).
- `cargo clippy -- -D warnings` (all `--all-targets`) — clean on
  `fluree-db-r2rml --features turtle`, `fluree-db-api --features iceberg`,
  `fluree-db-cli --features iceberg`, and `fluree-db-server`.
- `cargo fmt` — applied. `cargo check -p fluree-db-cli --features iceberg` — clean.

## Risk / compatibility

- **Phase 2 may surface a previously "working" mapping as an error.** That mapping
  was already silently corrupt (first-wins table + union projection); a loud error
  is the correct, strictly-safer outcome. Only mappings that actually collide are
  affected — distinct-IRI multi-table mappings (the norm) are untouched.
- **Phase 3 is purely additive**: two new result fields and an extra output line;
  the server response fields are `skip_serializing_if = "Option::is_none"`, and the
  only `R2rmlCreateResult` constructor is updated. The raw-Iceberg path is
  unchanged.
- All existing R2RML fixtures use absolute or now-correctly-resolved IRIs and stay
  green.

Fixes #1395
