### PR TITLE
(Iceberg) Expose OAuth2 `scope`/`audience` for REST Catalog Auth

### DIFF
--- a/fluree-db-api/src/graph_source/config.rs
+++ b/fluree-db-api/src/graph_source/config.rs
@@ -520,6 +520,63 @@ impl IcebergCreateConfig {
         self
     }
 
+    /// Set the OAuth2 `scope` for client-credentials auth (REST + OAuth2 only).
+    ///
+    /// Mutates the existing OAuth2 auth config in place, so call this AFTER
+    /// [`Self::with_auth_oauth2`]. It has no effect (and warns) if OAuth2
+    /// client-credentials auth has not been configured. Required for
+    /// scope-gated REST catalogs such as Snowflake Horizon / Apache Polaris,
+    /// where the catalog session role is selected via
+    /// `scope=session:role:<ROLE>`.
+    pub fn with_oauth2_scope(mut self, scope: impl Into<String>) -> Self {
+        match &mut self.catalog_mode {
+            CatalogMode::Rest(rest) => {
+                if let fluree_db_iceberg::auth::AuthConfig::OAuth2ClientCredentials {
+                    scope: slot,
+                    ..
+                } = &mut rest.auth
+                {
+                    *slot = Some(scope.into());
+                } else {
+                    tracing::warn!(
+                        "with_oauth2_scope has no effect unless OAuth2 client-credentials auth is set first (call with_auth_oauth2)"
+                    );
+                }
+            }
+            CatalogMode::Direct { .. } => {
+                tracing::warn!("with_oauth2_scope has no effect in Direct catalog mode");
+            }
+        }
+        self
+    }
+
+    /// Set the OAuth2 `audience` for client-credentials auth (REST + OAuth2 only).
+    ///
+    /// Mutates the existing OAuth2 auth config in place, so call this AFTER
+    /// [`Self::with_auth_oauth2`]. It has no effect (and warns) if OAuth2
+    /// client-credentials auth has not been configured.
+    pub fn with_oauth2_audience(mut self, audience: impl Into<String>) -> Self {
+        match &mut self.catalog_mode {
+            CatalogMode::Rest(rest) => {
+                if let fluree_db_iceberg::auth::AuthConfig::OAuth2ClientCredentials {
+                    audience: slot,
+                    ..
+                } = &mut rest.auth
+                {
+                    *slot = Some(audience.into());
+                } else {
+                    tracing::warn!(
+                        "with_oauth2_audience has no effect unless OAuth2 client-credentials auth is set first (call with_auth_oauth2)"
+                    );
+                }
+            }
+            CatalogMode::Direct { .. } => {
+                tracing::warn!("with_oauth2_audience has no effect in Direct catalog mode");
+            }
+        }
+        self
+    }
+
     /// Set the warehouse identifier (REST mode only).
     pub fn with_warehouse(mut self, warehouse: impl Into<String>) -> Self {
         if let CatalogMode::Rest(ref mut rest) = self.catalog_mode {
@@ -790,6 +847,24 @@ impl R2rmlCreateConfig {
         self
     }
 
+    /// Set the OAuth2 `scope` (delegates to the underlying Iceberg config).
+    ///
+    /// Call after [`Self::with_auth_oauth2`]. See
+    /// [`IcebergCreateConfig::with_oauth2_scope`].
+    pub fn with_oauth2_scope(mut self, scope: impl Into<String>) -> Self {
+        self.iceberg = self.iceberg.with_oauth2_scope(scope);
+        self
+    }
+
+    /// Set the OAuth2 `audience` (delegates to the underlying Iceberg config).
+    ///
+    /// Call after [`Self::with_auth_oauth2`]. See
+    /// [`IcebergCreateConfig::with_oauth2_audience`].
+    pub fn with_oauth2_audience(mut self, audience: impl Into<String>) -> Self {
+        self.iceberg = self.iceberg.with_oauth2_audience(audience);
+        self
+    }
+
     /// Set the warehouse identifier.
     pub fn with_warehouse(mut self, warehouse: impl Into<String>) -> Self {
         self.iceberg = self.iceberg.with_warehouse(warehouse);
@@ -981,5 +1056,108 @@ mod tests {
         // selectOne is also valid
         let config = Bm25CreateConfig::new("search", "docs:main", json!({"selectOne": ["?x"]}));
         assert!(config.validate().is_ok());
+    }
+
+    #[cfg(feature = "iceberg")]
+    fn oauth2_auth(config: &IcebergCreateConfig) -> &fluree_db_iceberg::auth::AuthConfig {
+        match &config.catalog_mode {
+            CatalogMode::Rest(rest) => &rest.auth,
+            CatalogMode::Direct { .. } => panic!("expected REST catalog mode"),
+        }
+    }
+
+    #[cfg(feature = "iceberg")]
+    #[test]
+    fn test_iceberg_with_oauth2_scope_and_audience() {
+        let config = IcebergCreateConfig::new("gs", "https://catalog.example.com", "ns.tbl")
+            .with_auth_oauth2("https://catalog.example.com/v1/oauth/tokens", "", "secret")
+            .with_oauth2_scope("session:role:ICEBERG_READER")
+            .with_oauth2_audience("polaris");
+
+        match oauth2_auth(&config) {
+            fluree_db_iceberg::auth::AuthConfig::OAuth2ClientCredentials {
+                scope,
+                audience,
+                ..
+            } => {
+                assert_eq!(scope.as_deref(), Some("session:role:ICEBERG_READER"));
+                assert_eq!(audience.as_deref(), Some("polaris"));
+            }
+            other => panic!("expected OAuth2 auth, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "iceberg")]
+    #[test]
+    fn test_oauth2_scope_setter_warns_without_oauth2() {
+        // Bearer auth set, scope setter should be a no-op (and not panic).
+        let config = IcebergCreateConfig::new("gs", "https://catalog.example.com", "ns.tbl")
+            .with_auth_bearer("tok")
+            .with_oauth2_scope("session:role:READER");
+        assert!(matches!(
+            oauth2_auth(&config),
+            fluree_db_iceberg::auth::AuthConfig::Bearer { .. }
+        ));
+    }
+
+    #[cfg(feature = "iceberg")]
+    #[test]
+    fn test_iceberg_oauth2_scope_roundtrip_no_migration() {
+        // Locks the "no migration" claim: scope/audience survive the
+        // to_iceberg_gs_config -> serialize -> deserialize round-trip that the
+        // persistence layer performs.
+        let config = IcebergCreateConfig::new("gs", "https://catalog.example.com", "ns.tbl")
+            .with_auth_oauth2(
+                "https://catalog.example.com/v1/oauth/tokens",
+                "client",
+                "secret",
+            )
+            .with_oauth2_scope("session:role:ICEBERG_READER")
+            .with_oauth2_audience("polaris");
+
+        let gs = config.to_iceberg_gs_config();
+        let serialized = serde_json::to_string(&gs).unwrap();
+        let back: IcebergGsConfig = serde_json::from_str(&serialized).unwrap();
+
+        match back.catalog {
+            fluree_db_iceberg::config::CatalogConfig::Rest { auth, .. } => match auth {
+                fluree_db_iceberg::auth::AuthConfig::OAuth2ClientCredentials {
+                    scope,
+                    audience,
+                    ..
+                } => {
+                    assert_eq!(scope.as_deref(), Some("session:role:ICEBERG_READER"));
+                    assert_eq!(audience.as_deref(), Some("polaris"));
+                }
+                other => panic!("expected OAuth2 auth after round-trip, got {other:?}"),
+            },
+            other => panic!("expected REST catalog after round-trip, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "iceberg")]
+    #[test]
+    fn test_r2rml_with_oauth2_scope_delegates() {
+        let config = R2rmlCreateConfig::new(
+            "gs",
+            "https://catalog.example.com",
+            "ns.tbl",
+            "@prefix rr: <http://www.w3.org/ns/r2rml#> .",
+        )
+        .with_auth_oauth2("https://catalog.example.com/v1/oauth/tokens", "", "secret")
+        .with_oauth2_scope("session:role:ICEBERG_READER")
+        .with_oauth2_audience("polaris");
+
+        match oauth2_auth(&config.iceberg) {
+            fluree_db_iceberg::auth::AuthConfig::OAuth2ClientCredentials {
+                scope,
+                audience,
+                ..
+            } => {
+                assert_eq!(scope.as_deref(), Some("session:role:ICEBERG_READER"));
+                assert_eq!(audience.as_deref(), Some("polaris"));
+            }
+            other => panic!("expected OAuth2 auth, got {other:?}"),
+        }
     }
 }

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -2167,6 +2167,14 @@ pub struct IcebergMapArgs {
     #[arg(long)]
     pub oauth2_client_secret: Option<String>,
 
+    /// OAuth2 scope (e.g. "session:role:ICEBERG_READER" for Snowflake Horizon / Polaris)
+    #[arg(long)]
+    pub oauth2_scope: Option<String>,
+
+    /// OAuth2 audience
+    #[arg(long)]
+    pub oauth2_audience: Option<String>,
+
     /// Warehouse identifier (REST mode)
     #[arg(long)]
     pub warehouse: Option<String>,

--- a/fluree-db-cli/src/commands/iceberg.rs
+++ b/fluree-db-cli/src/commands/iceberg.rs
@@ -357,6 +357,12 @@ fn args_to_json(args: &IcebergMapArgs) -> CliResult<serde_json::Value> {
     if let Some(ref v) = args.oauth2_client_secret {
         obj.insert("oauth2_client_secret".into(), v.clone().into());
     }
+    if let Some(ref v) = args.oauth2_scope {
+        obj.insert("oauth2_scope".into(), v.clone().into());
+    }
+    if let Some(ref v) = args.oauth2_audience {
+        obj.insert("oauth2_audience".into(), v.clone().into());
+    }
     if let Some(ref v) = args.warehouse {
         obj.insert("warehouse".into(), v.clone().into());
     }
@@ -683,12 +689,19 @@ fn build_iceberg_config(args: &IcebergMapArgs) -> CliResult<fluree_db_api::Icebe
     if let Some(ref token) = args.auth_bearer {
         config = config.with_auth_bearer(token);
     }
-    if let (Some(ref url), Some(ref id), Some(ref secret)) = (
-        &args.oauth2_token_url,
-        &args.oauth2_client_id,
-        &args.oauth2_client_secret,
-    ) {
+    // OAuth2 activates on token_url + client_secret; client_id defaults to "" so
+    // Horizon / PAT users can omit it (an empty client_id is what Snowflake
+    // Horizon's `session:role:` exchange requires).
+    if let (Some(ref url), Some(ref secret)) = (&args.oauth2_token_url, &args.oauth2_client_secret)
+    {
+        let id = args.oauth2_client_id.as_deref().unwrap_or("");
         config = config.with_auth_oauth2(url, id, secret);
+        if let Some(ref scope) = args.oauth2_scope {
+            config = config.with_oauth2_scope(scope);
+        }
+        if let Some(ref audience) = args.oauth2_audience {
+            config = config.with_oauth2_audience(audience);
+        }
     }
     if let Some(ref wh) = args.warehouse {
         config = config.with_warehouse(wh);
@@ -729,5 +742,85 @@ fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) -> String {
         fluree_db_nameservice::GraphSourceType::R2rml => "R2RML".to_string(),
         fluree_db_nameservice::GraphSourceType::Iceberg => "Iceberg".to_string(),
         fluree_db_nameservice::GraphSourceType::Unknown(s) => format!("Unknown({s})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_rest_args() -> IcebergMapArgs {
+        IcebergMapArgs {
+            name: "gs".to_string(),
+            remote: None,
+            mode: "rest".to_string(),
+            catalog_uri: Some("https://catalog.example.com".to_string()),
+            table: Some("ns.tbl".to_string()),
+            table_location: None,
+            r2rml: None,
+            r2rml_type: None,
+            branch: None,
+            auth_bearer: None,
+            oauth2_token_url: None,
+            oauth2_client_id: None,
+            oauth2_client_secret: None,
+            oauth2_scope: None,
+            oauth2_audience: None,
+            warehouse: None,
+            no_vended_credentials: false,
+            s3_region: None,
+            s3_endpoint: None,
+            s3_path_style: false,
+        }
+    }
+
+    #[test]
+    fn args_to_json_includes_oauth2_scope_and_audience() {
+        let mut args = base_rest_args();
+        args.oauth2_token_url = Some("https://catalog.example.com/v1/oauth/tokens".to_string());
+        args.oauth2_client_secret = Some("pat".to_string());
+        args.oauth2_scope = Some("session:role:ICEBERG_READER".to_string());
+        args.oauth2_audience = Some("polaris".to_string());
+
+        let body = args_to_json(&args).unwrap();
+        assert_eq!(body["oauth2_scope"], "session:role:ICEBERG_READER");
+        assert_eq!(body["oauth2_audience"], "polaris");
+        // Omitting client_id leaves it out of the remote body entirely.
+        assert!(body.get("oauth2_client_id").is_none());
+    }
+
+    #[cfg(feature = "iceberg")]
+    #[test]
+    fn build_iceberg_config_activates_oauth2_without_client_id_and_threads_scope() {
+        let mut args = base_rest_args();
+        args.oauth2_token_url = Some("https://catalog.example.com/v1/oauth/tokens".to_string());
+        // No client_id -> defaults to "" so OAuth2 still activates.
+        args.oauth2_client_secret = Some("pat".to_string());
+        args.oauth2_scope = Some("session:role:ICEBERG_READER".to_string());
+        args.oauth2_audience = Some("polaris".to_string());
+
+        let config = build_iceberg_config(&args).unwrap();
+        let gs = config.to_iceberg_gs_config();
+        let v = serde_json::to_value(&gs).unwrap();
+        let auth = &v["catalog"]["auth"];
+
+        assert_eq!(auth["type"], "oauth2_client_credentials");
+        assert_eq!(auth["client_id"], "");
+        assert_eq!(auth["client_secret"], "pat");
+        assert_eq!(auth["scope"], "session:role:ICEBERG_READER");
+        assert_eq!(auth["audience"], "polaris");
+    }
+
+    #[cfg(feature = "iceberg")]
+    #[test]
+    fn build_iceberg_config_no_oauth2_without_secret() {
+        let mut args = base_rest_args();
+        // token_url alone (no client_secret) must NOT activate OAuth2.
+        args.oauth2_token_url = Some("https://catalog.example.com/v1/oauth/tokens".to_string());
+
+        let config = build_iceberg_config(&args).unwrap();
+        let gs = config.to_iceberg_gs_config();
+        let v = serde_json::to_value(&gs).unwrap();
+        assert_eq!(v["catalog"]["auth"]["type"], "none");
     }
 }

--- a/fluree-db-iceberg/src/auth/oauth2.rs
+++ b/fluree-db-iceberg/src/auth/oauth2.rs
@@ -81,9 +81,16 @@ impl OAuth2ClientCredentials {
     async fn fetch_token(&self) -> Result<CachedToken> {
         let mut form = vec![
             ("grant_type", "client_credentials".to_string()),
-            ("client_id", self.config.client_id.clone()),
             ("client_secret", self.config.client_secret.clone()),
         ];
+
+        // Only send `client_id` when non-empty. Some catalogs (notably Snowflake
+        // Horizon / Polaris for the `session:role:` token exchange) reject the
+        // request with `invalid_scope` if a non-empty `client_id` is present, and
+        // require it to be omitted entirely.
+        if !self.config.client_id.is_empty() {
+            form.push(("client_id", self.config.client_id.clone()));
+        }
 
         if let Some(scope) = &self.config.scope {
             form.push(("scope", scope.clone()));
@@ -247,5 +254,145 @@ mod tests {
             expires_at: Utc::now() + Duration::hours(1),
         };
         assert_eq!(custom_token.authorization_header(), "MAC my-access-token");
+    }
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Parse a `application/x-www-form-urlencoded` body into key/value pairs,
+    /// percent-decoding each component so value assertions are encoding-agnostic.
+    fn parse_form(body: &[u8]) -> Vec<(String, String)> {
+        let s = std::str::from_utf8(body).unwrap();
+        s.split('&')
+            .filter(|kv| !kv.is_empty())
+            .map(|kv| {
+                let mut it = kv.splitn(2, '=');
+                let k = decode(it.next().unwrap_or(""));
+                let v = decode(it.next().unwrap_or(""));
+                (k, v)
+            })
+            .collect()
+    }
+
+    /// Minimal `application/x-www-form-urlencoded` component decoder (`+` -> space,
+    /// `%XX` -> byte). Sufficient for the ASCII scope/audience values under test.
+    fn decode(s: &str) -> String {
+        let bytes = s.as_bytes();
+        let mut out = Vec::with_capacity(bytes.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'+' => {
+                    out.push(b' ');
+                    i += 1;
+                }
+                b'%' if i + 2 < bytes.len() => {
+                    let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap();
+                    out.push(u8::from_str_radix(hex, 16).unwrap());
+                    i += 3;
+                }
+                b => {
+                    out.push(b);
+                    i += 1;
+                }
+            }
+        }
+        String::from_utf8(out).unwrap()
+    }
+
+    async fn mock_token_server() -> MockServer {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/oauth/tokens"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/json")
+                    .set_body_string(
+                        r#"{"access_token":"abc123","token_type":"Bearer","expires_in":3600}"#,
+                    ),
+            )
+            .mount(&server)
+            .await;
+        server
+    }
+
+    #[tokio::test]
+    async fn fetch_token_encodes_scope_and_omits_empty_client_id() {
+        let server = mock_token_server().await;
+        let config = OAuth2Config {
+            token_url: format!("{}/v1/oauth/tokens", server.uri()),
+            client_id: String::new(), // empty -> must be omitted
+            client_secret: "pat-secret".to_string(),
+            scope: Some("session:role:ICEBERG_READER".to_string()),
+            audience: None,
+        };
+        let auth = OAuth2ClientCredentials::new(config).unwrap();
+        let token = auth.fetch_token().await.unwrap();
+        assert_eq!(token.access_token, "abc123");
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1);
+        let form = parse_form(&reqs[0].body);
+
+        // (a) scope IS form-encoded in the token request
+        assert_eq!(
+            form.iter()
+                .find(|(k, _)| k == "scope")
+                .map(|(_, v)| v.as_str()),
+            Some("session:role:ICEBERG_READER")
+        );
+        // (b) client_id is OMITTED when empty
+        assert!(
+            !form.iter().any(|(k, _)| k == "client_id"),
+            "client_id must be omitted when empty, got: {form:?}"
+        );
+        // client_secret + grant_type always present
+        assert_eq!(
+            form.iter()
+                .find(|(k, _)| k == "client_secret")
+                .map(|(_, v)| v.as_str()),
+            Some("pat-secret")
+        );
+        // (c) audience absent when None
+        assert!(!form.iter().any(|(k, _)| k == "audience"));
+    }
+
+    #[tokio::test]
+    async fn fetch_token_includes_client_id_when_non_empty_and_audience() {
+        let server = mock_token_server().await;
+        let config = OAuth2Config {
+            token_url: format!("{}/v1/oauth/tokens", server.uri()),
+            client_id: "my-client".to_string(),
+            client_secret: "the-secret".to_string(),
+            scope: Some("PRINCIPAL_ROLE:ALL".to_string()),
+            audience: Some("polaris".to_string()),
+        };
+        let auth = OAuth2ClientCredentials::new(config).unwrap();
+        auth.fetch_token().await.unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1);
+        let form = parse_form(&reqs[0].body);
+
+        // (b) client_id is PRESENT when non-empty
+        assert_eq!(
+            form.iter()
+                .find(|(k, _)| k == "client_id")
+                .map(|(_, v)| v.as_str()),
+            Some("my-client")
+        );
+        // (c) audience sent when Some
+        assert_eq!(
+            form.iter()
+                .find(|(k, _)| k == "audience")
+                .map(|(_, v)| v.as_str()),
+            Some("polaris")
+        );
+        assert_eq!(
+            form.iter()
+                .find(|(k, _)| k == "scope")
+                .map(|(_, v)| v.as_str()),
+            Some("PRINCIPAL_ROLE:ALL")
+        );
     }
 }

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -43,6 +43,10 @@ pub struct IcebergMapRequest {
     pub oauth2_client_id: Option<String>,
     /// OAuth2 client secret
     pub oauth2_client_secret: Option<String>,
+    /// OAuth2 scope (e.g. "session:role:<ROLE>" for Snowflake Horizon / Polaris)
+    pub oauth2_scope: Option<String>,
+    /// OAuth2 audience
+    pub oauth2_audience: Option<String>,
     /// Warehouse identifier
     pub warehouse: Option<String>,
     /// Disable vended credentials
@@ -208,12 +212,18 @@ fn build_iceberg_config(req: &IcebergMapRequest) -> Result<fluree_db_api::Iceber
     if let Some(ref token) = req.auth_bearer {
         config = config.with_auth_bearer(token);
     }
-    if let (Some(ref url), Some(ref id), Some(ref secret)) = (
-        &req.oauth2_token_url,
-        &req.oauth2_client_id,
-        &req.oauth2_client_secret,
-    ) {
+    // OAuth2 activates on oauth2_token_url + oauth2_client_secret; client_id
+    // defaults to "" so Horizon / PAT callers can omit it (Snowflake Horizon's
+    // `session:role:` token exchange requires an absent/empty client_id).
+    if let (Some(ref url), Some(ref secret)) = (&req.oauth2_token_url, &req.oauth2_client_secret) {
+        let id = req.oauth2_client_id.as_deref().unwrap_or("");
         config = config.with_auth_oauth2(url, id, secret);
+        if let Some(ref scope) = req.oauth2_scope {
+            config = config.with_oauth2_scope(scope);
+        }
+        if let Some(ref audience) = req.oauth2_audience {
+            config = config.with_oauth2_audience(audience);
+        }
     }
     if let Some(ref wh) = req.warehouse {
         config = config.with_warehouse(wh);
@@ -232,4 +242,55 @@ fn build_iceberg_config(req: &IcebergMapRequest) -> Result<fluree_db_api::Iceber
     }
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_deserializes_oauth2_scope_and_reaches_auth_config() {
+        // Omit client_id (Horizon case); provide token_url + secret + scope.
+        let body = serde_json::json!({
+            "name": "gs",
+            "mode": "rest",
+            "catalog_uri": "https://catalog.example.com",
+            "table": "ns.tbl",
+            "oauth2_token_url": "https://catalog.example.com/v1/oauth/tokens",
+            "oauth2_client_secret": "pat",
+            "oauth2_scope": "session:role:ICEBERG_READER",
+            "oauth2_audience": "polaris"
+        });
+        let req: IcebergMapRequest = serde_json::from_value(body).unwrap();
+        assert_eq!(
+            req.oauth2_scope.as_deref(),
+            Some("session:role:ICEBERG_READER")
+        );
+        assert_eq!(req.oauth2_audience.as_deref(), Some("polaris"));
+
+        let config = build_iceberg_config(&req).unwrap();
+        let gs = config.to_iceberg_gs_config();
+        let v = serde_json::to_value(&gs).unwrap();
+        let auth = &v["catalog"]["auth"];
+
+        assert_eq!(auth["type"], "oauth2_client_credentials");
+        assert_eq!(auth["client_id"], ""); // defaulted to empty
+        assert_eq!(auth["scope"], "session:role:ICEBERG_READER");
+        assert_eq!(auth["audience"], "polaris");
+    }
+
+    #[test]
+    fn request_without_secret_does_not_activate_oauth2() {
+        let body = serde_json::json!({
+            "name": "gs",
+            "catalog_uri": "https://catalog.example.com",
+            "table": "ns.tbl",
+            "oauth2_token_url": "https://catalog.example.com/v1/oauth/tokens"
+        });
+        let req: IcebergMapRequest = serde_json::from_value(body).unwrap();
+        let config = build_iceberg_config(&req).unwrap();
+        let gs = config.to_iceberg_gs_config();
+        let v = serde_json::to_value(&gs).unwrap();
+        assert_eq!(v["catalog"]["auth"]["type"], "none");
+    }
 }


### PR DESCRIPTION
## Summary

Iceberg REST-catalog OAuth2 *client-credentials* auth already form-encodes a
`scope` at the engine level (`OAuth2Config.scope`), but `scope` and `audience`
were not exposed through **any** public config surface — the builders, the CLI,
and the HTTP API all hardcoded them to `None`. As a result, connecting to a
scope-gated Iceberg REST catalog was impossible via supported config. The
concrete blocked case is **Snowflake Horizon** (Snowflake's built-in
Apache-Polaris Iceberg REST endpoint), which **requires**
`scope=session:role:<ROLE>` on the `/v1/oauth/tokens` client-credentials
exchange — and **rejects a non-empty `client_id`** on that exchange with
`400 invalid_scope`.

This PR threads `scope`/`audience` through every layer and makes the empty
`client_id` case work.

## What changed (the middle-layer builder gap)

The engine already knew how to send `scope`; the gap was purely the user-facing
plumbing between the public config types and the engine `AuthConfig`. Nothing in
the token-exchange or downstream read path changed.

- **`fluree-db-api` (builders):** added fluent `with_oauth2_scope` /
  `with_oauth2_audience` setters on `IcebergCreateConfig` that mutate the
  existing `AuthConfig::OAuth2ClientCredentials` in place (warn-and-no-op if
  OAuth2 client-credentials auth has not been set first, or in Direct catalog
  mode). Added delegating setters on `R2rmlCreateConfig`. The existing 3-arg
  `with_auth_oauth2(token_url, client_id, client_secret)` is **unchanged**.
- **`fluree-db-iceberg` (engine):** `fetch_token` now **omits `client_id` from
  the `client_credentials` form when it is empty** (Snowflake Horizon's
  `session:role:` exchange requires an absent/empty `client_id`; a non-empty one
  is interpreted as the principal flow and rejected).
- **`fluree-db-cli`:** added `--oauth2-scope` / `--oauth2-audience` to
  `fluree iceberg map`, wired into both the local `with_oauth2_*` chaining and
  the `args_to_json` remote body. **Relaxed activation:** OAuth2 now engages on
  `token_url + client_secret`, with `client_id` defaulting to `""`.
- **`fluree-db-server`:** added `oauth2_scope` / `oauth2_audience` to the
  `IcebergMapRequest` body with matching activation + build wiring.

## Files

| File | +/- |
|---|---|
| `fluree-db-api/src/graph_source/config.rs` | +178 |
| `fluree-db-iceberg/src/auth/oauth2.rs` | +149 |
| `fluree-db-cli/src/commands/iceberg.rs` | +103 |
| `fluree-db-server/src/routes/iceberg.rs` | +71 |
| `fluree-db-cli/src/cli.rs` | +8 |

498 insertions, 11 deletions.

## Tests + results

All tests are hermetic (no network — OAuth2 tests run against a `wiremock` mock
token server).

- **`fluree-db-iceberg`** (`--features aws`): 146 lib tests pass, including the
  two new wiremock tests:
  - `fetch_token_encodes_scope_and_omits_empty_client_id` — `scope` is
    form-encoded into the token request; `client_id` is omitted when empty;
    `audience` absent when `None`.
  - `fetch_token_includes_client_id_when_non_empty_and_audience` — `client_id`
    is present when non-empty; `audience` and `scope` are sent.
- **`fluree-db-api`** (`--features iceberg`): 644 lib tests pass, including
  builder, warns-without-oauth2 no-op, no-migration serde round-trip, and R2RML
  delegation tests.
- **`fluree-db-server`** (`--features iceberg`): route deserialize tests pass —
  `oauth2_scope` reaches the engine `AuthConfig`; a request without
  `client_secret` does not activate OAuth2.
- **`fluree-db-cli`** (`--features iceberg`): `args_to_json` includes
  scope/audience and omits `client_id`; `build_iceberg_config` activates OAuth2
  without `client_id` and threads scope/audience; no secret -> no OAuth2.
- **`cargo clippy`** clean on all four crates; **`cargo fmt --check`** clean.

## Risk / compatibility

- **Additive, no migration.** New optional fields/flags/setters only. The stored
  `AuthConfig` JSON already supported `scope`/`audience`; a round-trip test locks
  the "no migration" claim. Existing 3-arg `with_auth_oauth2` callers (incl. the
  `it_graph_source_r2rml` integration test) compile and pass unchanged.
- **Behavior change 1 — empty `client_id` omitted from the token form.**
  Previously `client_id` was sent unconditionally (even as an empty string); now
  an empty `client_id` is omitted entirely. This is required by Snowflake
  Horizon. For standard OAuth2 servers a non-empty `client_id` is still sent
  exactly as before, so only the empty-string case is affected.
- **Behavior change 2 — relaxed OAuth2 activation (CLI + HTTP).** Previously
  activation required `token_url + client_id + client_secret` all present; now it
  triggers on `token_url + client_secret`, with `client_id` defaulting to `""`.
  A caller that supplies `token_url` + `client_secret` but no `client_id` now
  activates OAuth2 (previously it silently did not). Supplying only `token_url`
  (no secret) still does **not** activate OAuth2.

## Follow-up (out of scope for this code PR)

Issue #1394 also asks for docs — a "Snowflake Horizon" section in
`docs/graph-sources/iceberg.md` and `docs/cli/iceberg.md` showing the happy path
(`token_url=.../v1/oauth/tokens`, `client_id=""`, `scope=session:role:<ROLE>`,
`vended_credentials=true`, UPPERCASE identifiers). Those are intentionally left
out of this code-only slice and can land as a separate docs change.

Fixes #1394
