### PR TITLE
(R2RML) Default Mapping `media_type` to Turtle at Both Compile Sites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,7 @@ dependencies = [
  "fluree-db-nameservice-sync",
  "fluree-db-novelty",
  "fluree-db-query",
+ "fluree-db-r2rml",
  "fluree-db-server",
  "fluree-vocab",
  "futures",

--- a/fluree-db-api/src/graph_source/config.rs
+++ b/fluree-db-api/src/graph_source/config.rs
@@ -911,9 +911,21 @@ impl R2rmlCreateConfig {
     /// `mapping_address` is the CAS address where the mapping was stored.
     pub fn to_iceberg_gs_config(&self, mapping_address: &str) -> IcebergGsConfig {
         let mut config = self.iceberg.to_iceberg_gs_config();
+        // Persist a concrete, resolved media type so the query path reuses it
+        // instead of re-defaulting a `null` to JSON-LD (issue #1397). An explicit
+        // media type is kept verbatim; an omitted one is filled with the resolved
+        // default (Turtle for inline/CID mappings). This needs no migration:
+        // `MappingSource::media_type` is already `Option<String>` with serde
+        // `default`, so pre-existing `null` records still deserialize and are
+        // fixed in place by the query-side default.
+        let media_type = self.mapping_media_type.clone().unwrap_or_else(|| {
+            fluree_db_r2rml::loader::MappingFormat::resolve(None, mapping_address)
+                .media_type()
+                .to_string()
+        });
         config.mapping = Some(fluree_db_iceberg::config::MappingSource {
             source: mapping_address.to_string(),
-            media_type: self.mapping_media_type.clone(),
+            media_type: Some(media_type),
         });
         config
     }
@@ -1159,5 +1171,46 @@ mod tests {
             }
             other => panic!("expected OAuth2 auth, got {other:?}"),
         }
+    }
+
+    #[cfg(feature = "iceberg")]
+    #[test]
+    fn test_r2rml_persists_resolved_media_type_no_migration() {
+        // Issue #1397: an omitted media type must be persisted as a concrete
+        // `text/turtle` (not `null`) so the query path reuses it; an explicit
+        // media type is preserved verbatim. The value survives the
+        // to_iceberg_gs_config -> serialize -> deserialize round-trip with no
+        // schema migration (`MappingSource::media_type` is `Option` + serde
+        // `default`).
+        let cid = "bagiibqexampleciddoesnotendwithanextension";
+        let mapping = "@prefix rr: <http://www.w3.org/ns/r2rml#> .";
+
+        // No explicit media type -> the resolved Turtle default is persisted.
+        let config = R2rmlCreateConfig::new("gs", "https://catalog.example.com", "ns.tbl", mapping);
+        let gs = config.to_iceberg_gs_config(cid);
+        assert_eq!(
+            gs.mapping.as_ref().and_then(|m| m.media_type.as_deref()),
+            Some("text/turtle"),
+            "an omitted media type must be filled with the resolved Turtle default"
+        );
+
+        // ...and survives serialize -> deserialize unchanged (no migration).
+        let serialized = serde_json::to_string(&gs).unwrap();
+        let back: IcebergGsConfig = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(
+            back.mapping.as_ref().and_then(|m| m.media_type.as_deref()),
+            Some("text/turtle")
+        );
+
+        // An explicit media type is preserved verbatim.
+        let explicit =
+            R2rmlCreateConfig::new("gs", "https://catalog.example.com", "ns.tbl", mapping)
+                .with_mapping_media_type("application/ld+json");
+        let gs = explicit.to_iceberg_gs_config(cid);
+        assert_eq!(
+            gs.mapping.as_ref().and_then(|m| m.media_type.as_deref()),
+            Some("application/ld+json"),
+            "an explicit media type must be preserved"
+        );
     }
 }

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -187,7 +187,11 @@ impl crate::Fluree {
         // Resolve mapping: validate and store to CAS if inline content
         let (mapping_address, triples_map_count, mapping_validated) = match &config.mapping {
             R2rmlMappingInput::Content(content) => {
-                let compiled = Self::compile_r2rml_content(content, &config)?;
+                // Inline content has no filename to sniff; the shared resolver
+                // defaults a missing media type to Turtle (matching the eventual
+                // CID address, which is also extensionless).
+                let compiled =
+                    Self::compile_r2rml_content(content, config.mapping_media_type.as_deref(), "")?;
                 let count = compiled.len();
                 let gs_id = config.graph_source_id();
                 let cs = self.content_store(&gs_id);
@@ -301,25 +305,28 @@ impl crate::Fluree {
     }
 
     /// Compile R2RML content and return the compiled mapping.
+    ///
+    /// `source` is the mapping's filename, storage address, or content-addressed
+    /// CID; it is only consulted to infer the format when no explicit
+    /// `media_type` is given. Format selection goes through the shared
+    /// [`fluree_db_r2rml::loader::MappingFormat`] resolver (default Turtle) so
+    /// registration and query time can never disagree (issue #1397).
     fn compile_r2rml_content(
         content: &str,
-        config: &R2rmlCreateConfig,
+        media_type: Option<&str>,
+        source: &str,
     ) -> Result<fluree_db_r2rml::mapping::CompiledR2rmlMapping> {
-        let is_turtle = config
-            .mapping_media_type
-            .as_ref()
-            .is_none_or(|mt| mt.contains("turtle"));
-        if is_turtle {
-            fluree_db_r2rml::loader::R2rmlLoader::from_turtle(content)
+        use fluree_db_r2rml::loader::MappingFormat;
+        match MappingFormat::resolve(media_type, source) {
+            MappingFormat::Turtle => fluree_db_r2rml::loader::R2rmlLoader::from_turtle(content)
                 .map_err(|e| crate::ApiError::Config(format!("Failed to parse R2RML Turtle: {e}")))?
                 .compile()
                 .map_err(|e| {
                     crate::ApiError::Config(format!("Failed to compile R2RML mapping: {e}"))
-                })
-        } else {
-            Err(crate::ApiError::Config(
+                }),
+            MappingFormat::JsonLd => Err(crate::ApiError::Config(
                 "R2RML mapping must be in Turtle format. JSON-LD is not yet supported.".into(),
-            ))
+            )),
         }
     }
 
@@ -342,7 +349,12 @@ impl crate::Fluree {
         let content = String::from_utf8(bytes).map_err(|e| {
             crate::ApiError::Config(format!("R2RML mapping is not valid UTF-8: {e}"))
         })?;
-        Ok(Self::compile_r2rml_content(&content, config)?.len())
+        // `address` may carry an extension (e.g. `.ttl`/`.jsonld`); pass it so the
+        // resolver can infer the format when no explicit media type is set.
+        Ok(
+            Self::compile_r2rml_content(&content, config.mapping_media_type.as_deref(), address)?
+                .len(),
+        )
     }
 }
 
@@ -507,32 +519,32 @@ impl R2rmlProvider for FlureeR2rmlProvider<'_> {
             ))
         })?;
 
-        // Parse and compile the mapping
-        let media_type = mapping_config.media_type.as_deref();
-
-        let is_turtle = media_type.map_or_else(
-            || mapping_source.ends_with(".ttl") || mapping_source.ends_with(".turtle"),
-            |mt| mt.contains("turtle"),
-        );
-
-        let compiled = if is_turtle {
-            fluree_db_r2rml::loader::R2rmlLoader::from_turtle(&mapping_content)
-                .map_err(|e| {
-                    QueryError::InvalidQuery(format!(
-                        "Failed to parse R2RML Turtle from '{mapping_source}': {e}"
-                    ))
-                })?
-                .compile()
-                .map_err(|e| {
-                    QueryError::InvalidQuery(format!(
-                        "Failed to compile R2RML mapping from '{mapping_source}': {e}"
-                    ))
-                })?
-        } else {
-            return Err(QueryError::InvalidQuery(format!(
-                "R2RML mapping for '{graph_source_id}' uses JSON-LD format, which is not yet supported. \
-                 Please use Turtle format (.ttl)."
-            )));
+        // Parse and compile the mapping. Format selection goes through the same
+        // shared resolver the registration path uses, so a mapping stored
+        // without an explicit media type (e.g. a CAS CID) defaults to Turtle
+        // here too instead of erroring as JSON-LD (issue #1397).
+        use fluree_db_r2rml::loader::MappingFormat;
+        let compiled = match MappingFormat::resolve(media_type, mapping_source) {
+            MappingFormat::Turtle => {
+                fluree_db_r2rml::loader::R2rmlLoader::from_turtle(&mapping_content)
+                    .map_err(|e| {
+                        QueryError::InvalidQuery(format!(
+                            "Failed to parse R2RML Turtle from '{mapping_source}': {e}"
+                        ))
+                    })?
+                    .compile()
+                    .map_err(|e| {
+                        QueryError::InvalidQuery(format!(
+                            "Failed to compile R2RML mapping from '{mapping_source}': {e}"
+                        ))
+                    })?
+            }
+            MappingFormat::JsonLd => {
+                return Err(QueryError::InvalidQuery(format!(
+                    "R2RML mapping for '{graph_source_id}' uses JSON-LD format, which is not yet supported. \
+                     Please use Turtle format (.ttl)."
+                )));
+            }
         };
 
         let compiled = Arc::new(compiled);

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -1612,6 +1612,74 @@ async fn integration_create_r2rml_graph_source_with_mapping() {
     );
 }
 
+/// Regression test for issue #1397: a Turtle mapping registered WITHOUT an
+/// explicit media type must still compile at query time.
+///
+/// Before the shared `MappingFormat` resolver, registration defaulted a missing
+/// media type to Turtle (so creation succeeded) but the query path defaulted it
+/// to JSON-LD and failed with "...uses JSON-LD format, which is not yet
+/// supported". The stored `mapping_source` is a content-addressed CID with no
+/// extension, so the query-time extension sniff could never recover Turtle.
+///
+/// This test deliberately omits `.with_mapping_media_type(...)` — mirroring
+/// `fluree iceberg map` of a `.ttl` file without `--r2rml-type` — and asserts
+/// both that the resolved media type is persisted (not `null`) and that the
+/// real `FlureeR2rmlProvider::compiled_mapping` now returns `Ok`.
+#[tokio::test]
+async fn integration_r2rml_turtle_without_media_type_compiles_at_query_time() {
+    use fluree_db_api::{FlureeR2rmlProvider, R2rmlCreateConfig};
+
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // NOTE: no `.with_mapping_media_type(...)` — this is the reported flow.
+    let config = R2rmlCreateConfig::new(
+        "airlines-rdf",
+        "https://polaris.example.com",
+        "openflights.airlines",
+        AIRLINE_MAPPING_TTL,
+    );
+
+    let create_result = fluree
+        .create_r2rml_graph_source(config)
+        .await
+        .expect("registering a Turtle mapping without an explicit media type should succeed");
+    assert!(
+        create_result.mapping_validated,
+        "mapping should validate at registration"
+    );
+
+    // Persistence: the stored config must carry a concrete `text/turtle` media
+    // type (not `null`) so the query path reuses it instead of re-defaulting.
+    let record = fluree
+        .nameservice()
+        .lookup_graph_source("airlines-rdf:main")
+        .await
+        .expect("lookup should succeed")
+        .expect("graph source record should exist");
+    let config_json: serde_json::Value = serde_json::from_str(&record.config).unwrap();
+    assert_eq!(
+        config_json["mapping"]["media_type"], "text/turtle",
+        "resolved media type must be persisted (not null) so query-time reuses it"
+    );
+
+    // Regression: the real provider's `compiled_mapping` must now succeed. Before
+    // the fix this returned `Err(InvalidQuery(\"...uses JSON-LD format...\"))`.
+    let provider = FlureeR2rmlProvider::new(&fluree);
+    let compiled = provider
+        .compiled_mapping("airlines-rdf:main", Some(0))
+        .await;
+    assert!(
+        compiled.is_ok(),
+        "compiled_mapping must succeed for a Turtle mapping with no explicit media type (issue #1397); got: {:?}",
+        compiled.err()
+    );
+    assert_eq!(
+        compiled.unwrap().len(),
+        1,
+        "the airline mapping defines exactly one TriplesMap"
+    );
+}
+
 // =============================================================================
 // query_graph_source API Tests (GraphSourcePublisher impl)
 // =============================================================================

--- a/fluree-db-cli/Cargo.toml
+++ b/fluree-db-cli/Cargo.toml
@@ -49,6 +49,9 @@ fluree-db-indexer = { path = "../fluree-db-indexer" }
 fluree-vocab = { path = "../fluree-vocab" }
 fluree-db-query = { path = "../fluree-db-query" }
 fluree-db-binary-index = { path = "../fluree-db-binary-index" }
+# Shared R2RML media-type resolver (MappingFormat) so the CLI infers the same
+# ext→format table the server uses, instead of a divergent local copy (#1397).
+fluree-db-r2rml = { path = "../fluree-db-r2rml" }
 
 # Developer memory layer (store + CLI subcommands)
 fluree-db-memory = { path = "../fluree-db-memory" }

--- a/fluree-db-cli/src/commands/iceberg.rs
+++ b/fluree-db-cli/src/commands/iceberg.rs
@@ -316,6 +316,21 @@ async fn run_iceberg_map_remote(
 }
 
 /// Convert CLI args to a JSON body for the server endpoint.
+/// Infer an R2RML mapping media type from a file extension.
+///
+/// `.ttl`/`.turtle` → `text/turtle`, `.jsonld`/`.json` → `application/ld+json`
+/// (case-insensitive). Returns `None` for unrecognized extensions so the caller
+/// falls back to the server-side default (Turtle, per issue #1397). This makes
+/// the `--r2rml-type` flag's documented "inferred from extension" behavior real.
+fn infer_mapping_media_type(path: &std::path::Path) -> Option<String> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "ttl" | "turtle" => Some("text/turtle".to_string()),
+        "jsonld" | "json" => Some("application/ld+json".to_string()),
+        _ => None,
+    }
+}
+
 fn args_to_json(args: &IcebergMapArgs) -> CliResult<serde_json::Value> {
     let mut body = serde_json::json!({
         "name": args.name,
@@ -339,8 +354,15 @@ fn args_to_json(args: &IcebergMapArgs) -> CliResult<serde_json::Value> {
         })?;
         obj.insert("r2rml".into(), content.into());
     }
-    if let Some(ref v) = args.r2rml_type {
-        obj.insert("r2rml_type".into(), v.clone().into());
+    // Explicit `--r2rml-type` wins; otherwise infer from the mapping file
+    // extension so the server records a concrete, self-describing media type
+    // (issue #1397).
+    let r2rml_type = args
+        .r2rml_type
+        .clone()
+        .or_else(|| args.r2rml.as_deref().and_then(infer_mapping_media_type));
+    if let Some(v) = r2rml_type {
+        obj.insert("r2rml_type".into(), v.into());
     }
     if let Some(ref v) = args.branch {
         obj.insert("branch".into(), v.clone().into());
@@ -585,7 +607,12 @@ async fn run_iceberg_map_local(args: IcebergMapArgs, dirs: &FlureeDir) -> CliRes
         let config = fluree_db_api::R2rmlCreateConfig {
             iceberg: iceberg_config,
             mapping: fluree_db_api::R2rmlMappingInput::Content(mapping_content),
-            mapping_media_type: args.r2rml_type.clone(),
+            // Explicit `--r2rml-type` wins; otherwise infer from the file
+            // extension (issue #1397).
+            mapping_media_type: args
+                .r2rml_type
+                .clone()
+                .or_else(|| infer_mapping_media_type(r2rml_path)),
         };
 
         let result = fluree.create_r2rml_graph_source(config).await?;
@@ -822,5 +849,61 @@ mod tests {
         let gs = config.to_iceberg_gs_config();
         let v = serde_json::to_value(&gs).unwrap();
         assert_eq!(v["catalog"]["auth"]["type"], "none");
+    }
+
+    #[test]
+    fn infer_mapping_media_type_maps_known_extensions() {
+        use std::path::Path;
+        assert_eq!(
+            infer_mapping_media_type(Path::new("mapping.ttl")).as_deref(),
+            Some("text/turtle")
+        );
+        assert_eq!(
+            infer_mapping_media_type(Path::new("mapping.turtle")).as_deref(),
+            Some("text/turtle")
+        );
+        assert_eq!(
+            infer_mapping_media_type(Path::new("mapping.jsonld")).as_deref(),
+            Some("application/ld+json")
+        );
+        assert_eq!(
+            infer_mapping_media_type(Path::new("mapping.json")).as_deref(),
+            Some("application/ld+json")
+        );
+        // Extension matching is case-insensitive.
+        assert_eq!(
+            infer_mapping_media_type(Path::new("MAPPING.TTL")).as_deref(),
+            Some("text/turtle")
+        );
+        // Unknown or missing extension -> None (caller uses the server default).
+        assert_eq!(infer_mapping_media_type(Path::new("mapping.rdf")), None);
+        assert_eq!(infer_mapping_media_type(Path::new("mapping")), None);
+    }
+
+    #[test]
+    fn args_to_json_infers_r2rml_type_from_ttl_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("airlines.ttl");
+        std::fs::write(&path, "@prefix rr: <http://www.w3.org/ns/r2rml#> .").unwrap();
+
+        let mut args = base_rest_args();
+        args.r2rml = Some(path);
+        // No explicit --r2rml-type: inferred from the `.ttl` extension.
+        let body = args_to_json(&args).unwrap();
+        assert_eq!(body["r2rml_type"], "text/turtle");
+    }
+
+    #[test]
+    fn args_to_json_explicit_r2rml_type_overrides_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("airlines.ttl");
+        std::fs::write(&path, "@prefix rr: <http://www.w3.org/ns/r2rml#> .").unwrap();
+
+        let mut args = base_rest_args();
+        args.r2rml = Some(path);
+        // Explicit flag wins over the conflicting `.ttl` extension.
+        args.r2rml_type = Some("application/ld+json".to_string());
+        let body = args_to_json(&args).unwrap();
+        assert_eq!(body["r2rml_type"], "application/ld+json");
     }
 }

--- a/fluree-db-cli/src/commands/iceberg.rs
+++ b/fluree-db-cli/src/commands/iceberg.rs
@@ -333,22 +333,27 @@ async fn run_iceberg_map_remote(
     Ok(())
 }
 
-/// Convert CLI args to a JSON body for the server endpoint.
 /// Infer an R2RML mapping media type from a file extension.
 ///
-/// `.ttl`/`.turtle` → `text/turtle`, `.jsonld`/`.json` → `application/ld+json`
-/// (case-insensitive). Returns `None` for unrecognized extensions so the caller
-/// falls back to the server-side default (Turtle, per issue #1397). This makes
-/// the `--r2rml-type` flag's documented "inferred from extension" behavior real.
+/// Delegates to the shared [`fluree_db_r2rml::loader::MappingFormat`] resolver so
+/// the CLI and the server share one ext→format table and cannot drift (issue
+/// #1397): `.jsonld`/`.json` → `application/ld+json`, any other extension →
+/// `text/turtle` (the resolver's default), case-insensitively. Returns `None`
+/// only when the path has no extension at all, leaving the server to apply the
+/// same default. An explicit `--r2rml-type` still overrides this at the call site.
 fn infer_mapping_media_type(path: &std::path::Path) -> Option<String> {
-    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
-    match ext.as_str() {
-        "ttl" | "turtle" => Some("text/turtle".to_string()),
-        "jsonld" | "json" => Some("application/ld+json".to_string()),
-        _ => None,
-    }
+    use fluree_db_r2rml::loader::MappingFormat;
+    // No extension means no signal to infer from — defer to the server default.
+    path.extension()?;
+    let source = path.to_str()?;
+    Some(
+        MappingFormat::resolve(None, source)
+            .media_type()
+            .to_string(),
+    )
 }
 
+/// Convert CLI args to a JSON body for the server endpoint.
 fn args_to_json(args: &IcebergMapArgs) -> CliResult<serde_json::Value> {
     let mut body = serde_json::json!({
         "name": args.name,
@@ -907,8 +912,14 @@ mod tests {
             infer_mapping_media_type(Path::new("MAPPING.TTL")).as_deref(),
             Some("text/turtle")
         );
-        // Unknown or missing extension -> None (caller uses the server default).
-        assert_eq!(infer_mapping_media_type(Path::new("mapping.rdf")), None);
+        // An unrecognized extension defers to the shared resolver's default
+        // (Turtle) — the same decision the server makes, so the two never drift.
+        assert_eq!(
+            infer_mapping_media_type(Path::new("mapping.rdf")).as_deref(),
+            Some("text/turtle")
+        );
+        // No extension at all -> None, so the caller leaves the type unset and the
+        // server applies the same default.
         assert_eq!(infer_mapping_media_type(Path::new("mapping")), None);
     }
 

--- a/fluree-db-r2rml/src/loader/mod.rs
+++ b/fluree-db-r2rml/src/loader/mod.rs
@@ -81,6 +81,147 @@ impl R2rmlLoader {
     }
 }
 
+/// Serialization format of an R2RML mapping document.
+///
+/// Resolving the format once — from an optional media-type hint plus the
+/// mapping source identifier — and using the result at every compile site keeps
+/// registration-time and query-time format selection provably identical. This
+/// is the single source of truth that fixes the asymmetric default in
+/// <https://github.com/fluree/db/issues/1397>, where registration defaulted a
+/// missing media type to Turtle but the query path defaulted it to JSON-LD.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MappingFormat {
+    /// Turtle (`text/turtle`) — the only format the loader supports today.
+    Turtle,
+    /// JSON-LD (`application/ld+json`) — recognized but not yet implemented.
+    JsonLd,
+}
+
+impl MappingFormat {
+    /// Resolve the mapping format from an optional media type and the mapping
+    /// `source` (a filename, storage address, or content-addressed CID).
+    ///
+    /// Precedence: an explicit, recognized `media_type` wins; otherwise the
+    /// `source` extension decides (`.jsonld`/`.json` → JSON-LD); otherwise the
+    /// format defaults to [`MappingFormat::Turtle`]. An unrecognized media type
+    /// falls through to the extension/default rules rather than erroring.
+    ///
+    /// Turtle is the sole supported format, so defaulting an unknown input to
+    /// Turtle only ever turns a guaranteed failure into a working mapping — a
+    /// genuine JSON-LD document (recognized media type or `.jsonld`/`.json`
+    /// extension) still resolves to [`MappingFormat::JsonLd`] and errors clearly
+    /// at the call site. A CID or extensionless address therefore resolves to
+    /// Turtle, which is what registration always assumed.
+    pub fn resolve(media_type: Option<&str>, source: &str) -> Self {
+        if let Some(mt) = media_type {
+            let mt = mt.to_ascii_lowercase();
+            if mt.contains("turtle") {
+                return Self::Turtle;
+            }
+            if mt.contains("json") {
+                return Self::JsonLd;
+            }
+            // Unrecognized media type: fall through to extension inference.
+        }
+
+        let source = source.to_ascii_lowercase();
+        if source.ends_with(".jsonld") || source.ends_with(".json") {
+            Self::JsonLd
+        } else {
+            Self::Turtle
+        }
+    }
+
+    /// The canonical IANA media type for this format.
+    ///
+    /// Persisting this concrete value on a registered graph source keeps stored
+    /// configs self-describing, so the query path reuses the resolved format
+    /// instead of re-defaulting a `null` media type.
+    pub fn media_type(self) -> &'static str {
+        match self {
+            Self::Turtle => "text/turtle",
+            Self::JsonLd => "application/ld+json",
+        }
+    }
+}
+
+#[cfg(test)]
+mod format_tests {
+    use super::MappingFormat;
+
+    #[test]
+    fn resolve_defaults_to_turtle_for_no_media_type_and_no_extension() {
+        // Regression guard for #1397: a CAS CID (no extension) and no media type
+        // must resolve to Turtle, not JSON-LD.
+        assert_eq!(
+            MappingFormat::resolve(None, "bagiibqexamplecidwithnoextension"),
+            MappingFormat::Turtle
+        );
+        assert_eq!(MappingFormat::resolve(None, ""), MappingFormat::Turtle);
+    }
+
+    #[test]
+    fn resolve_infers_format_from_source_extension() {
+        assert_eq!(
+            MappingFormat::resolve(None, "mapping.ttl"),
+            MappingFormat::Turtle
+        );
+        assert_eq!(
+            MappingFormat::resolve(None, "mapping.turtle"),
+            MappingFormat::Turtle
+        );
+        assert_eq!(
+            MappingFormat::resolve(None, "mapping.jsonld"),
+            MappingFormat::JsonLd
+        );
+        assert_eq!(
+            MappingFormat::resolve(None, "mapping.json"),
+            MappingFormat::JsonLd
+        );
+        // Extension matching is case-insensitive.
+        assert_eq!(
+            MappingFormat::resolve(None, "MAPPING.JSONLD"),
+            MappingFormat::JsonLd
+        );
+    }
+
+    #[test]
+    fn resolve_explicit_media_type_overrides_extension() {
+        // Explicit media type beats a conflicting extension in both directions.
+        assert_eq!(
+            MappingFormat::resolve(Some("application/ld+json"), "mapping.ttl"),
+            MappingFormat::JsonLd
+        );
+        assert_eq!(
+            MappingFormat::resolve(Some("text/turtle"), "mapping.jsonld"),
+            MappingFormat::Turtle
+        );
+        // Media type comparison is case-insensitive.
+        assert_eq!(
+            MappingFormat::resolve(Some("Text/Turtle"), "mapping.jsonld"),
+            MappingFormat::Turtle
+        );
+    }
+
+    #[test]
+    fn resolve_unrecognized_media_type_falls_back_to_extension_then_turtle() {
+        assert_eq!(
+            MappingFormat::resolve(Some("application/octet-stream"), "mapping.jsonld"),
+            MappingFormat::JsonLd
+        );
+        assert_eq!(
+            MappingFormat::resolve(Some("application/octet-stream"), "cid-no-ext"),
+            MappingFormat::Turtle
+        );
+    }
+
+    #[test]
+    fn media_type_returns_canonical_strings() {
+        assert_eq!(MappingFormat::Turtle.media_type(), "text/turtle");
+        assert_eq!(MappingFormat::JsonLd.media_type(), "application/ld+json");
+    }
+}
+
 #[cfg(all(test, feature = "turtle"))]
 mod tests {
     use super::*;


### PR DESCRIPTION
> **Stacks on #1402** (`fix/iceberg-oauth2-scope`, issue #1394). 

## Summary

R2RML mapping content was compiled with an **asymmetric default media-type**:
the registration path defaulted to **Turtle**, but the query-time path defaulted
to **JSON-LD**. A mapping registered as Turtle *without* an explicit `media_type`
therefore registered fine but failed to recompile at query time with a
"JSON-LD not supported" / parse error. The only workaround was to always pass an
explicit `--r2rml-type text/turtle`.

This PR introduces a single shared format resolver (defaulting to **Turtle**),
routes **both** compile sites through it, and **persists** the resolved
`media_type` so the registration-time and query-time decisions are provably
identical.

## Root cause — two independent format decisions

- **Registration** (`compile_r2rml_content` in
  `fluree-db-api/src/graph_source/r2rml.rs`) treated content as Turtle by default.
- **Query** (`compiled_mapping` in the same module) sniffed `source.ends_with(".ttl")`
  and otherwise fell through to a JSON-LD default — a *different* rule from the
  registration path.
- The persisted `MappingSource.media_type` was left `None` when the user didn't
  pass one, so the query path had nothing authoritative to read and re-derived the
  format with its divergent rule.

## What changed

- **`fluree-db-r2rml/src/loader/mod.rs`** — new shared, dependency-free resolver
  (not behind the `turtle` feature; pure logic):
  - `pub enum MappingFormat { Turtle, JsonLd }`
  - `pub fn resolve(media_type: Option<&str>, source: &str) -> MappingFormat` —
    precedence: **explicit recognized `media_type` > source extension
    (`.jsonld`/`.json` → JSON-LD) > default Turtle**. An unrecognized explicit
    media_type falls through to the extension, then to Turtle. Case-insensitive.
  - `pub fn media_type(self) -> &'static str` → `"text/turtle"` /
    `"application/ld+json"`.
- **`fluree-db-api/src/graph_source/r2rml.rs`** — both compile sites now route
  through `MappingFormat::resolve`. Registration `compile_r2rml_content` is
  re-signatured to `(content, media_type, source)`; the query `compiled_mapping`
  drops the ad-hoc `.ends_with(".ttl")` sniff. The two paths are now identical by
  construction.
- **`fluree-db-api/src/graph_source/config.rs`** — `to_iceberg_gs_config` persists
  the resolved canonical `media_type` into `MappingSource.media_type`: an explicit
  user value is kept verbatim; `None` resolves to `"text/turtle"`.
- **`fluree-db-cli/src/commands/iceberg.rs`** — `infer_mapping_media_type` wired
  into **both** the remote (`args_to_json`) and local (`run_iceberg_map_local`)
  paths, so `.ttl`/`.jsonld` files get the right type without `--r2rml-type`; an
  explicit `--r2rml-type` still overrides inference.

## Persistence / no migration

`MappingSource.media_type` is already `Option<String>` with `#[serde(default)]`,
so pre-existing records with `null`/missing `media_type` still deserialize — the
query-side default (now Turtle, via the resolver) handles them. The only semantic
change is **"None/unknown → Turtle"** at the query site (previously JSON-LD).
Persisting a concrete value is a one-time change to the mapping cache key (pure
perf; no behavioral effect).

## Tests

Resolver (`fluree-db-r2rml`, no features required):
- `resolve_defaults_to_turtle_for_no_media_type_and_no_extension` — the regression
  guard + default-Turtle.
- `resolve_infers_format_from_source_extension`
- `resolve_explicit_media_type_overrides_extension`
- `resolve_unrecognized_media_type_falls_back_to_extension_then_turtle`
- `media_type_returns_canonical_strings`

API (`fluree-db-api --features iceberg`):
- `integration_r2rml_turtle_without_media_type_compiles_at_query_time` — registers
  a `.ttl` mapping with **no** media_type, asserts it persists `text/turtle` **and**
  that the real `FlureeR2rmlProvider::compiled_mapping` returns `Ok` (exercises the
  actual query path, not a mock). This is the bug, captured.
- `test_r2rml_persists_resolved_media_type_no_migration` — serialize→deserialize
  round-trip stays `text/turtle`; an explicit `application/ld+json` is preserved
  verbatim.

CLI (`fluree-db-cli --features iceberg`):
- `infer_mapping_media_type_maps_known_extensions`
- `args_to_json_infers_r2rml_type_from_ttl_extension`
- `args_to_json_explicit_r2rml_type_overrides_extension`

### Results

- `cargo test -p fluree-db-r2rml` (and `--features turtle`) — pass.
- `cargo test -p fluree-db-api --features iceberg` — pass (incl. the two new
  integration tests; `it_graph_source_r2rml` green).
- `cargo test -p fluree-db-cli --features iceberg` — pass.
- `cargo clippy -p fluree-db-r2rml -p fluree-db-api -p fluree-db-cli --all-targets
  --features iceberg` — clean.
- `cargo fmt --all -- --check` — clean.

## Risk / compatibility

- Intended behavior change: a mapping whose format can't be determined from an
  explicit media_type or a source extension now defaults to **Turtle** at the query
  site (it already did at registration) — this is the fix, and it removes the need
  to always pass `--r2rml-type text/turtle`.
- No migration: old `null`/missing `media_type` records still load.
- An explicit user-supplied `media_type` is always preserved verbatim.

Fixes #1397
