### PR TITLE
(CLI) Route Queries Targeting Iceberg/R2RML Graph Sources

### DIFF
--- a/docs/cli/iceberg.md
+++ b/docs/cli/iceberg.md
@@ -154,10 +154,16 @@ Once mapped, the graph source appears in standard commands:
 fluree list
 
 # Inspect configuration
-fluree info warehouse-orders
+fluree iceberg info warehouse-orders
 
-# Query via SPARQL GRAPH pattern
-fluree query mydb 'SELECT ?id ?total FROM <mydb:main> WHERE { GRAPH <warehouse-orders:main> { ?o ex:id ?id ; ex:total ?total } }'
+# Query the graph source directly (single-target): name it as the target, with
+# no FROM. The CLI resolves it as a graph source and runs it through the
+# R2RML/Iceberg engine. Requires the `iceberg` feature.
+fluree query warehouse-orders 'SELECT ?id ?total WHERE { ?o ex:id ?id ; ex:total ?total }'
+
+# Federate into it: a query whose FROM names the source routes to the
+# connection-scoped path automatically (or force it with --connection).
+fluree query --connection 'SELECT ?id ?total FROM <warehouse-orders:main> WHERE { ?o ex:id ?id ; ex:total ?total }'
 
 # Remove the mapping
 fluree drop warehouse-orders --force

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -609,6 +609,24 @@ pub enum Commands {
         #[arg(long)]
         remote: Option<String>,
 
+        /// Force the connection-scoped query path (server root `/query`, with the
+        /// dataset carried by the query's own `FROM` clause) instead of the
+        /// ledger-scoped path. Use this to query a registered Iceberg/R2RML graph
+        /// source by federating into it, or to run a cross-source `FROM` query.
+        ///
+        /// Optionally name a remote that hosts the connection
+        /// (`--connection=origin`); given with no value, the local connection (or
+        /// an auto-routed local server) is used. Queries that already reference a
+        /// non-endpoint source via `FROM` route here automatically.
+        #[arg(
+            long,
+            value_name = "REMOTE",
+            num_args = 0..=1,
+            default_missing_value = "",
+            require_equals = true
+        )]
+        connection: Option<String>,
+
         /// Report tracking tally (fuel + time + policy) to stderr after results.
         /// Shorthand for `--track-fuel --track-time --track-policy`.
         #[arg(long)]

--- a/fluree-db-cli/src/commands/query.rs
+++ b/fluree-db-cli/src/commands/query.rs
@@ -227,6 +227,7 @@ pub async fn run(
     at: Option<&str>,
     dirs: &FlureeDir,
     remote_flag: Option<&str>,
+    connection: Option<&str>,
     direct: bool,
     tracking: TrackingFlags,
     policy: &PolicyArgs,
@@ -331,20 +332,59 @@ pub async fn run(
     let tracking_opts = tracking.as_options();
     let tracking_metrics = tracking.effective();
 
-    // Resolve ledger mode: --remote flag, local, tracked, or auto-route to local server
-    let mode = if let Some(remote_name) = remote_flag {
+    // `--connection [REMOTE]`: force the connection-scoped query path (server
+    // root `/query`, dataset in the body's FROM). An explicit REMOTE targets
+    // that remote's connection; an empty value (bare flag) uses the locally
+    // resolved transport.
+    let force_connection = connection.is_some();
+    let connection_remote = connection.filter(|c| !c.is_empty());
+
+    // Resolve the query target: --remote / --connection <remote> build a remote
+    // client; otherwise probe local ledgers, then graph sources, then tracked
+    // config, auto-routing to a local server unless --direct. A graph-source
+    // single target executes locally and is never auto-routed.
+    let target = if let Some(remote_name) = remote_flag {
         let alias = context::resolve_ledger(explicit_ledger, dirs)?;
-        context::build_remote_mode(remote_name, &alias, dirs).await?
+        context::QueryTarget::Ledger(context::build_remote_mode(remote_name, &alias, dirs).await?)
+    } else if let Some(conn_remote) = connection_remote {
+        // The connection path carries its dataset in the query's FROM clause, so
+        // no ledger alias is required; default to empty when none is given.
+        let alias = context::resolve_ledger(explicit_ledger, dirs).unwrap_or_default();
+        context::QueryTarget::Ledger(context::build_remote_mode(conn_remote, &alias, dirs).await?)
     } else {
-        let mode = context::resolve_ledger_mode(explicit_ledger, dirs).await?;
-        if direct {
-            mode
-        } else {
-            context::try_server_route(mode, dirs)
+        // Bare `--connection` (no remote, no ledger): a pure-federation query
+        // names its sources in its own FROM clause, so the local connection path
+        // needs only a `Fluree` handle — not an active ledger. When no ledger is
+        // active or provided, fall back to a bare local target instead of erroring
+        // with `NoActiveLedger` (symmetric with the `=REMOTE` arm above). A
+        // provided or active ledger still resolves normally.
+        match context::resolve_query_target(explicit_ledger, dirs).await {
+            Ok(context::QueryTarget::Ledger(mode)) => context::QueryTarget::Ledger(if direct {
+                mode
+            } else {
+                context::try_server_route(mode, dirs)
+            }),
+            Ok(gs) => gs,
+            Err(CliError::NoActiveLedger) if force_connection => {
+                context::QueryTarget::Ledger(LedgerMode::Local {
+                    fluree: Box::new(context::build_fluree(dirs)?),
+                    alias: String::new(),
+                })
+            }
+            Err(e) => return Err(e),
         }
     };
 
     if is_cypher {
+        // Cypher is local-only; it has no graph-source or connection form.
+        let mode = match target {
+            context::QueryTarget::Ledger(mode) => mode,
+            context::QueryTarget::GraphSource { .. } => {
+                return Err(CliError::Usage(
+                    "Cypher queries are not supported on graph source targets".to_string(),
+                ));
+            }
+        };
         return run_cypher_query(
             mode,
             &content,
@@ -357,6 +397,47 @@ pub async fn run(
         )
         .await;
     }
+
+    // Federation / connection-scoped routing: an explicit `--connection`, or a
+    // query body that targets a source other than the endpoint via FROM/from,
+    // routes to the connection-scoped path. A plain same-endpoint query is left
+    // on the single-target path below.
+    let endpoint_id = target_endpoint_id(&target);
+    let use_connection =
+        force_connection || query_targets_foreign_source(query_format, &content, &endpoint_id)?;
+    if use_connection {
+        return run_connection_query(
+            target,
+            query_format,
+            &content,
+            output_format,
+            normalize_arrays,
+            at,
+            explain,
+            limit,
+            dirs,
+        )
+        .await;
+    }
+
+    // A single graph-source target runs through the R2RML-aware local builder
+    // (subject to the same restrictions the server enforces for graph sources).
+    let mode = match target {
+        context::QueryTarget::GraphSource { fluree, alias } => {
+            reject_graph_source_unsupported(at, explain, output_format)?;
+            return run_graph_source_query(
+                &fluree,
+                &alias,
+                query_format,
+                &content,
+                output_format,
+                normalize_arrays,
+                limit,
+            )
+            .await;
+        }
+        context::QueryTarget::Ledger(mode) => mode,
+    };
 
     match mode {
         LedgerMode::Tracked {
@@ -1400,9 +1481,334 @@ fn print_footer(total_rows: usize, limit: Option<usize>, elapsed: std::time::Dur
     }
 }
 
+// ---------------------------------------------------------------------------
+// Graph-source / connection (federated) query routing
+// ---------------------------------------------------------------------------
+
+/// Strip the branch (`:branch`), time-travel (`@t:` / `@iso:` / `@commit:`), and
+/// named-graph fragment (`#…`) suffixes from a ledger / graph-source identifier,
+/// leaving the bare base name. Lets a query's `FROM` targets be compared to the
+/// endpoint regardless of how either is spelled (`mydb`, `mydb:main`,
+/// `mydb:main@t:3`, `mydb:main#g` all share the base `mydb`).
+fn base_ledger_id(id: &str) -> &str {
+    let id = id.split('#').next().unwrap_or(id);
+    let id = id.split('@').next().unwrap_or(id);
+    id.split(':').next().unwrap_or(id)
+}
+
+/// Extract the `from` targets declared in a JSON-LD query body (a string or an
+/// array of strings). Missing / non-string values yield an empty list.
+fn jsonld_from_targets(body: &serde_json::Value) -> Vec<String> {
+    match body.get("from") {
+        Some(serde_json::Value::String(s)) => vec![s.clone()],
+        Some(serde_json::Value::Array(items)) => items
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Whether the query body targets a source *other than* the endpoint via
+/// `FROM`/`FROM NAMED` (SPARQL) or `from` (JSON-LD). This is the gate for
+/// auto-routing a federated query to the connection-scoped path: a plain
+/// same-endpoint query (no `FROM`, or `FROM <self>`) returns `false` and stays
+/// on the single-target path.
+fn query_targets_foreign_source(
+    query_format: detect::QueryFormat,
+    content: &str,
+    endpoint_id: &str,
+) -> CliResult<bool> {
+    let endpoint_base = base_ledger_id(endpoint_id);
+    let targets: Vec<String> = match query_format {
+        detect::QueryFormat::Sparql => {
+            fluree_db_api::sparql_dataset_ledger_ids(content).unwrap_or_default()
+        }
+        detect::QueryFormat::JsonLd => match serde_json::from_str::<serde_json::Value>(content) {
+            Ok(body) => jsonld_from_targets(&body),
+            // A body we can't parse here will fail later with a clearer error;
+            // don't divert it to the connection path on a parse hiccup.
+            Err(_) => Vec::new(),
+        },
+    };
+    Ok(targets.iter().any(|t| base_ledger_id(t) != endpoint_base))
+}
+
+/// The endpoint identifier a query is scoped to, used to decide whether the
+/// body's `FROM`/`from` references a *foreign* source. For a graph source it's
+/// the source alias; for a ledger it's the local alias (Local) or remote alias
+/// (Tracked).
+fn target_endpoint_id(target: &context::QueryTarget) -> String {
+    match target {
+        context::QueryTarget::GraphSource { alias, .. } => alias.clone(),
+        context::QueryTarget::Ledger(LedgerMode::Local { alias, .. }) => alias.clone(),
+        context::QueryTarget::Ledger(LedgerMode::Tracked { remote_alias, .. }) => {
+            remote_alias.clone()
+        }
+    }
+}
+
+/// Reject the flags the server also refuses for graph-source targets: time
+/// travel, explain plans, and the streaming / delimited output formats. A graph
+/// source is queried at its live source state and returns JSON only.
+fn reject_graph_source_unsupported(
+    at: Option<&str>,
+    explain: bool,
+    output_format: OutputFormatKind,
+) -> CliResult<()> {
+    if at.is_some() {
+        return Err(CliError::Usage(
+            "`--at` (time travel) is not supported for graph source targets; a graph source is \
+             queried at its live source state"
+                .to_string(),
+        ));
+    }
+    if explain {
+        return Err(CliError::Usage(
+            "`--explain` is not supported for graph source targets".to_string(),
+        ));
+    }
+    if matches!(
+        output_format,
+        OutputFormatKind::Ndjson | OutputFormatKind::Csv | OutputFormatKind::Tsv
+    ) {
+        return Err(CliError::Usage(format!(
+            "`--format {output_format}` is not supported for graph source targets; \
+             use json, typed-json, or table"
+        )));
+    }
+    Ok(())
+}
+
+/// Build the formatter config for the JSON-returning graph-source / connection
+/// paths from the requested output format.
+fn json_path_formatter_config(
+    query_format: detect::QueryFormat,
+    output_format: OutputFormatKind,
+    normalize_arrays: bool,
+) -> fluree_db_api::FormatterConfig {
+    match output_format {
+        OutputFormatKind::TypedJson => fluree_db_api::FormatterConfig::typed_json(),
+        _ => match query_format {
+            detect::QueryFormat::Sparql => fluree_db_api::FormatterConfig::sparql_json(),
+            detect::QueryFormat::JsonLd => {
+                let config = fluree_db_api::FormatterConfig::jsonld();
+                if normalize_arrays {
+                    config.with_normalize_arrays()
+                } else {
+                    config
+                }
+            }
+        },
+    }
+}
+
+/// Map the requested output format to the display format for a JSON-returning
+/// path (graph-source / connection). Mirrors the local ledger path: JSON-LD has
+/// no table renderer, so any non-typed format falls back to JSON for JSON-LD
+/// queries. (NDJSON/CSV/TSV are rejected up front by the guardrails.)
+fn json_path_display_format(
+    query_format: detect::QueryFormat,
+    output_format: OutputFormatKind,
+) -> OutputFormatKind {
+    match output_format {
+        OutputFormatKind::TypedJson => OutputFormatKind::TypedJson,
+        _ if query_format == detect::QueryFormat::JsonLd => OutputFormatKind::Json,
+        _ => output_format,
+    }
+}
+
+/// Render a formatted JSON result (graph-source or connection query) through the
+/// shared output pipeline and print the standard footer.
+fn render_json_path_result(
+    result_json: &serde_json::Value,
+    query_format: detect::QueryFormat,
+    output_format: OutputFormatKind,
+    limit: Option<usize>,
+    elapsed: std::time::Duration,
+) -> CliResult<()> {
+    let display_format = json_path_display_format(query_format, output_format);
+    let output = output::format_result(result_json, display_format, query_format, limit)?;
+    println!("{}", output.text);
+    print_footer(output.total_rows, limit, elapsed);
+    Ok(())
+}
+
+/// Execute a single-target query against a local Iceberg/R2RML graph source via
+/// the R2RML-aware `graph().query()` builder — the same path the server uses for
+/// `POST /query/<graph-source>`. Requires the `iceberg` feature.
+#[cfg(feature = "iceberg")]
+async fn run_graph_source_query(
+    fluree: &fluree_db_api::Fluree,
+    alias: &str,
+    query_format: detect::QueryFormat,
+    content: &str,
+    output_format: OutputFormatKind,
+    normalize_arrays: bool,
+    limit: Option<usize>,
+) -> CliResult<()> {
+    let fmt = json_path_formatter_config(query_format, output_format, normalize_arrays);
+    let timer = Instant::now();
+    let result_json = match query_format {
+        detect::QueryFormat::Sparql => {
+            fluree
+                .graph(alias)
+                .query()
+                .sparql(content)
+                .format(fmt)
+                .execute_formatted()
+                .await?
+        }
+        detect::QueryFormat::JsonLd => {
+            let json: serde_json::Value = serde_json::from_str(content)?;
+            fluree
+                .graph(alias)
+                .query()
+                .jsonld(&json)
+                .format(fmt)
+                .execute_formatted()
+                .await?
+        }
+    };
+    let elapsed = timer.elapsed();
+    render_json_path_result(&result_json, query_format, output_format, limit, elapsed)
+}
+
+/// Without the `iceberg` feature the local R2RML/Iceberg engine isn't compiled,
+/// so a graph-source single-target query can't run locally. Resolution still
+/// succeeds (so the message is clear), but execution points the user at the fix.
+#[cfg(not(feature = "iceberg"))]
+async fn run_graph_source_query(
+    _fluree: &fluree_db_api::Fluree,
+    alias: &str,
+    _query_format: detect::QueryFormat,
+    _content: &str,
+    _output_format: OutputFormatKind,
+    _normalize_arrays: bool,
+    _limit: Option<usize>,
+) -> CliResult<()> {
+    Err(CliError::Usage(format!(
+        "'{alias}' is a graph source, but this `fluree` build lacks Iceberg/R2RML support.\n  \
+         Rebuild with `--features iceberg`, or query it through a server with \
+         `fluree query --remote <name> {alias}`."
+    )))
+}
+
+/// Execute a query through the connection-scoped path: the dataset is selected
+/// by the query body's own `FROM`/`from`, not by a ledger in the request path.
+/// Local targets run `fluree.query_from()`; tracked/remote targets POST to the
+/// connection root (`/query`). This is how a federated query reaches an
+/// Iceberg/R2RML graph source.
+#[allow(clippy::too_many_arguments)]
+async fn run_connection_query(
+    target: context::QueryTarget,
+    query_format: detect::QueryFormat,
+    content: &str,
+    output_format: OutputFormatKind,
+    normalize_arrays: bool,
+    at: Option<&str>,
+    explain: bool,
+    limit: Option<usize>,
+    dirs: &FlureeDir,
+) -> CliResult<()> {
+    // The connection path returns JSON and doesn't plumb time travel or explain.
+    if at.is_some() {
+        return Err(CliError::Usage(
+            "`--at` is not supported on the connection/federated query path; encode time travel \
+             in the FROM IRI (e.g. `FROM <ledger@t:1>`)"
+                .to_string(),
+        ));
+    }
+    if explain {
+        return Err(CliError::Usage(
+            "`--explain` is not supported on the connection/federated query path".to_string(),
+        ));
+    }
+    if matches!(
+        output_format,
+        OutputFormatKind::Ndjson | OutputFormatKind::Csv | OutputFormatKind::Tsv
+    ) {
+        return Err(CliError::Usage(format!(
+            "`--format {output_format}` is not supported on the connection/federated path; \
+             use json, typed-json, or table"
+        )));
+    }
+
+    let timer = Instant::now();
+    let result_json = match target {
+        context::QueryTarget::Ledger(LedgerMode::Tracked {
+            client,
+            remote_name,
+            ..
+        }) => {
+            let result = match query_format {
+                detect::QueryFormat::Sparql => client.query_connection_sparql(content).await?,
+                detect::QueryFormat::JsonLd => {
+                    let json: serde_json::Value = serde_json::from_str(content)?;
+                    client.query_connection_jsonld(&json).await?
+                }
+            };
+            context::persist_refreshed_tokens(&client, &remote_name, dirs).await;
+            result
+        }
+        context::QueryTarget::Ledger(LedgerMode::Local { fluree, .. })
+        | context::QueryTarget::GraphSource { fluree, .. } => {
+            connection_query_local(
+                &fluree,
+                query_format,
+                content,
+                output_format,
+                normalize_arrays,
+            )
+            .await?
+        }
+    };
+    let elapsed = timer.elapsed();
+    render_json_path_result(&result_json, query_format, output_format, limit, elapsed)
+}
+
+/// Local connection query via `fluree.query_from()`. Under the `iceberg`
+/// feature this resolves R2RML/Iceberg graph sources referenced by `FROM`;
+/// without it, it still federates across native ledgers. Returns formatted JSON.
+async fn connection_query_local(
+    fluree: &fluree_db_api::Fluree,
+    query_format: detect::QueryFormat,
+    content: &str,
+    output_format: OutputFormatKind,
+    normalize_arrays: bool,
+) -> CliResult<serde_json::Value> {
+    let fmt = json_path_formatter_config(query_format, output_format, normalize_arrays);
+    let result = match query_format {
+        detect::QueryFormat::Sparql => {
+            fluree
+                .query_from()
+                .sparql(content)
+                .format(fmt)
+                .execute_formatted()
+                .await?
+        }
+        detect::QueryFormat::JsonLd => {
+            let json: serde_json::Value = serde_json::from_str(content)?;
+            fluree
+                .query_from()
+                .jsonld(&json)
+                .format(fmt)
+                .execute_formatted()
+                .await?
+        }
+    };
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{attach_time_suffix_preserving_fragment, inject_sparql_from_before_where};
+    use super::{
+        attach_time_suffix_preserving_fragment, base_ledger_id, inject_sparql_from_before_where,
+        json_path_display_format, jsonld_from_targets, query_targets_foreign_source,
+        reject_graph_source_unsupported,
+    };
+    use crate::detect::QueryFormat;
+    use crate::output::OutputFormatKind;
 
     #[test]
     fn attach_time_suffix_preserves_fragment() {
@@ -1421,5 +1827,120 @@ mod tests {
         let q = "SELECT * WHERE { ?s ?p ?o }";
         let out = inject_sparql_from_before_where(q, "myledger:main@t:1").unwrap();
         assert_eq!(out, "SELECT * FROM <myledger:main@t:1> WHERE { ?s ?p ?o }");
+    }
+
+    #[test]
+    fn base_ledger_id_strips_branch_time_and_fragment() {
+        assert_eq!(base_ledger_id("mydb"), "mydb");
+        assert_eq!(base_ledger_id("mydb:main"), "mydb");
+        assert_eq!(base_ledger_id("mydb:feature-x"), "mydb");
+        assert_eq!(base_ledger_id("mydb:main@t:3"), "mydb");
+        assert_eq!(base_ledger_id("mydb:main#txn-meta"), "mydb");
+        assert_eq!(base_ledger_id("warehouse-orders:main"), "warehouse-orders");
+    }
+
+    #[test]
+    fn jsonld_from_targets_handles_string_and_array() {
+        let s: serde_json::Value =
+            serde_json::from_str(r#"{"from":"mydb","select":["*"]}"#).unwrap();
+        assert_eq!(jsonld_from_targets(&s), vec!["mydb".to_string()]);
+
+        let a: serde_json::Value =
+            serde_json::from_str(r#"{"from":["a:main","b:main"],"select":["*"]}"#).unwrap();
+        assert_eq!(
+            jsonld_from_targets(&a),
+            vec!["a:main".to_string(), "b:main".to_string()]
+        );
+
+        let none: serde_json::Value = serde_json::from_str(r#"{"select":["*"]}"#).unwrap();
+        assert!(jsonld_from_targets(&none).is_empty());
+    }
+
+    #[test]
+    fn foreign_source_detection_sparql() {
+        // No FROM → same-endpoint single target.
+        assert!(!query_targets_foreign_source(
+            QueryFormat::Sparql,
+            "SELECT ?s WHERE { ?s ?p ?o }",
+            "mydb:main",
+        )
+        .unwrap());
+
+        // FROM the same ledger (any branch spelling) → not foreign.
+        assert!(!query_targets_foreign_source(
+            QueryFormat::Sparql,
+            "SELECT ?s FROM <mydb:main> WHERE { ?s ?p ?o }",
+            "mydb",
+        )
+        .unwrap());
+
+        // FROM a different source → foreign → connection path.
+        assert!(query_targets_foreign_source(
+            QueryFormat::Sparql,
+            "SELECT ?s FROM <warehouse-orders:main> WHERE { ?s ?p ?o }",
+            "mydb:main",
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn foreign_source_detection_jsonld() {
+        // `from` equal to the endpoint → not foreign.
+        assert!(!query_targets_foreign_source(
+            QueryFormat::JsonLd,
+            r#"{"from":"mydb:main","select":["*"],"where":{"@id":"?s"}}"#,
+            "mydb",
+        )
+        .unwrap());
+
+        // `from` a different source → foreign.
+        assert!(query_targets_foreign_source(
+            QueryFormat::JsonLd,
+            r#"{"from":"warehouse-orders:main","select":["*"],"where":{"@id":"?s"}}"#,
+            "mydb",
+        )
+        .unwrap());
+
+        // No `from` → not foreign.
+        assert!(!query_targets_foreign_source(
+            QueryFormat::JsonLd,
+            r#"{"select":["*"],"where":{"@id":"?s"}}"#,
+            "mydb",
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn graph_source_guardrails_reject_unsupported_flags() {
+        assert!(
+            reject_graph_source_unsupported(Some("3"), false, OutputFormatKind::Table).is_err()
+        );
+        assert!(reject_graph_source_unsupported(None, true, OutputFormatKind::Table).is_err());
+        assert!(reject_graph_source_unsupported(None, false, OutputFormatKind::Ndjson).is_err());
+        assert!(reject_graph_source_unsupported(None, false, OutputFormatKind::Csv).is_err());
+        assert!(reject_graph_source_unsupported(None, false, OutputFormatKind::Tsv).is_err());
+        // Supported combinations pass.
+        assert!(reject_graph_source_unsupported(None, false, OutputFormatKind::Json).is_ok());
+        assert!(reject_graph_source_unsupported(None, false, OutputFormatKind::Table).is_ok());
+        assert!(reject_graph_source_unsupported(None, false, OutputFormatKind::TypedJson).is_ok());
+    }
+
+    #[test]
+    fn json_display_format_falls_back_for_jsonld() {
+        // SPARQL keeps its requested format.
+        assert_eq!(
+            json_path_display_format(QueryFormat::Sparql, OutputFormatKind::Table),
+            OutputFormatKind::Table
+        );
+        // JSON-LD has no table renderer → JSON.
+        assert_eq!(
+            json_path_display_format(QueryFormat::JsonLd, OutputFormatKind::Table),
+            OutputFormatKind::Json
+        );
+        // typed-json is preserved on both.
+        assert_eq!(
+            json_path_display_format(QueryFormat::JsonLd, OutputFormatKind::TypedJson),
+            OutputFormatKind::TypedJson
+        );
     }
 }

--- a/fluree-db-cli/src/context.rs
+++ b/fluree-db-cli/src/context.rs
@@ -45,18 +45,41 @@ pub enum LedgerMode {
     },
 }
 
-/// Resolve which ledger to operate on and how (local vs tracked).
+/// A resolved `fluree query` target.
 ///
-/// Resolution precedence:
-/// 1. `--remote <name>` flag → temporary RemoteLedgerClient (caller provides this)
-/// 2. Compound `remote/ledger` syntax (e.g., "origin/mydb") → remote query
-/// 3. Local ledger with this alias exists → LedgerMode::Local
-/// 4. Tracked config for this alias exists → LedgerMode::Tracked
-/// 5. Error
-pub async fn resolve_ledger_mode(
+/// Extends [`LedgerMode`] with a graph-source arm: a name that isn't a native
+/// ledger (or tracked config) but *is* a locally-registered Iceberg/R2RML graph
+/// source resolves here instead of failing with `NotFound`. The query command
+/// runs it through the R2RML-aware single-target builder (`fluree.graph().query()`),
+/// which the standalone `db()` + `query()` snapshot path can't reach.
+pub enum QueryTarget {
+    /// A native ledger (local or tracked) — the traditional query path.
+    Ledger(LedgerMode),
+    /// A locally-registered graph source (Iceberg/R2RML). `alias` is normalized
+    /// to `<name>:main` for routing.
+    GraphSource { fluree: Box<Fluree>, alias: String },
+}
+
+/// Resolve a `fluree query` target, distinguishing native ledgers from
+/// registered graph sources.
+///
+/// Resolution precedence (first match wins):
+/// 1. Compound `remote/ledger` syntax (e.g., "origin/mydb") → tracked remote.
+/// 2. Local native ledger with this alias → [`LedgerMode::Local`].
+/// 3. Local graph source (Iceberg/R2RML) with this name → [`QueryTarget::GraphSource`].
+///    Graph sources live under a separate nameservice key than native ledgers,
+///    so the `ledger_exists` check (a `lookup`) never sees them; this probe is
+///    what lets `fluree query <graph-source>` resolve instead of returning
+///    NotFound.
+/// 4. Tracked config for this alias → [`LedgerMode::Tracked`].
+/// 5. Error (NotFound).
+///
+/// A locally-registered graph source wins over a tracked remote of the same
+/// name, mirroring the "local wins" rule already applied to native ledgers.
+pub async fn resolve_query_target(
     explicit: Option<&str>,
     dirs: &FlureeDir,
-) -> CliResult<LedgerMode> {
+) -> CliResult<QueryTarget> {
     let alias = resolve_ledger(explicit, dirs)?;
 
     // Strip `#fragment` (e.g., `#txn-meta`) for ledger resolution.
@@ -73,7 +96,7 @@ pub async fn resolve_ledger_mode(
         // For remote mode, pass through the full alias (with fragment) so the
         // server can resolve the graph. Currently remote doesn't support this,
         // but it avoids silently dropping the fragment.
-        return Ok(mode);
+        return Ok(QueryTarget::Ledger(mode));
     }
 
     let fluree = build_fluree(dirs)?;
@@ -81,22 +104,55 @@ pub async fn resolve_ledger_mode(
     // Check if local ledger exists (local wins)
     let ledger_id = to_ledger_id(ledger_part);
     if fluree.ledger_exists(&ledger_id).await.unwrap_or(false) {
-        return Ok(LedgerMode::Local {
+        return Ok(QueryTarget::Ledger(LedgerMode::Local {
             fluree: Box::new(fluree),
             alias,
-        });
+        }));
+    }
+
+    // Check if a graph source (Iceberg/R2RML) is registered under this name.
+    // Graph sources are keyed separately from native ledgers in the
+    // nameservice, so the `ledger_exists` check above never sees them — this is
+    // the fix for #1398 (`fluree query <graph-source>` → "ledger not found").
+    // A non-retracted local graph source wins over a tracked remote of the same
+    // name, consistent with the "local wins" rule for native ledgers.
+    //
+    // This probe now runs for every command that resolves a ledger (via the
+    // `resolve_ledger_mode` wrapper), so a graph-source-store *read error* must
+    // not break ledger resolution: treat any `Err` as "not a graph source" and
+    // fall through to the tracked-config / NotFound path exactly as before.
+    match fluree.nameservice().lookup_graph_source(&ledger_id).await {
+        Ok(Some(record)) if !record.retracted => {
+            return Ok(QueryTarget::GraphSource {
+                fluree: Box::new(fluree),
+                alias: ledger_id,
+            });
+        }
+        // Absent or retracted — not a queryable graph source; fall through.
+        Ok(_) => {}
+        Err(e) => {
+            tracing::debug!(
+                graph_source = %ledger_id,
+                error = ?e,
+                "graph-source probe failed; treating as not a graph source"
+            );
+        }
     }
 
     // Check tracked config
     let store = TomlSyncConfigStore::new(dirs.config_dir().to_path_buf());
     if let Some(tracked) = store.get_tracked(ledger_part) {
-        return build_tracked_mode(&store, &tracked, ledger_part).await;
+        return Ok(QueryTarget::Ledger(
+            build_tracked_mode(&store, &tracked, ledger_part).await?,
+        ));
     }
 
     // Also try the normalized ledger_id (user might have typed "mydb" but tracked as "mydb:main")
     if ledger_part != ledger_id {
         if let Some(tracked) = store.get_tracked(&ledger_id) {
-            return build_tracked_mode(&store, &tracked, &ledger_id).await;
+            return Ok(QueryTarget::Ledger(
+                build_tracked_mode(&store, &tracked, &ledger_id).await?,
+            ));
         }
     }
 
@@ -105,7 +161,9 @@ pub async fn resolve_ledger_mode(
     if let Some(base) = ledger_part.split(':').next() {
         if base != ledger_part && base != ledger_id {
             if let Some(tracked) = store.get_tracked(base) {
-                return build_tracked_mode(&store, &tracked, ledger_part).await;
+                return Ok(QueryTarget::Ledger(
+                    build_tracked_mode(&store, &tracked, ledger_part).await?,
+                ));
             }
         }
     }
@@ -117,6 +175,31 @@ pub async fn resolve_ledger_mode(
          Use `fluree create {display}` to create locally, `fluree track add {display}` to track a remote,\n  \
          or use remote/ledger syntax (e.g., origin/{display})."
     )))
+}
+
+/// Resolve which ledger to operate on and how (local vs tracked).
+///
+/// This is the ledger-only view of [`resolve_query_target`]: every command
+/// except `query` operates on a native ledger, so a name that resolves to a
+/// graph source is reported here as a (clear) error pointing at `fluree query`.
+///
+/// Resolution precedence:
+/// 1. `--remote <name>` flag → temporary RemoteLedgerClient (caller provides this)
+/// 2. Compound `remote/ledger` syntax (e.g., "origin/mydb") → remote query
+/// 3. Local ledger with this alias exists → LedgerMode::Local
+/// 4. Tracked config for this alias exists → LedgerMode::Tracked
+/// 5. Error
+pub async fn resolve_ledger_mode(
+    explicit: Option<&str>,
+    dirs: &FlureeDir,
+) -> CliResult<LedgerMode> {
+    match resolve_query_target(explicit, dirs).await? {
+        QueryTarget::Ledger(mode) => Ok(mode),
+        QueryTarget::GraphSource { alias, .. } => Err(CliError::NotFound(format!(
+            "'{alias}' is a registered graph source, not a ledger.\n  \
+             Query it with `fluree query {alias}`, or inspect it with `fluree iceberg info {alias}`."
+        ))),
+    }
 }
 
 /// Try to parse `alias` as `remote_name/ledger_alias` compound syntax.
@@ -551,4 +634,87 @@ fn is_fluree_process(pid: u32) -> bool {
 #[cfg(not(unix))]
 fn is_fluree_process(_pid: u32) -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_db_nameservice::GraphSourceType;
+
+    /// A fresh, isolated `FlureeDir` backed by a temp directory. `build_fluree`
+    /// falls back to `<dir>/storage`, so no `fluree init` is needed.
+    fn temp_dirs() -> (tempfile::TempDir, FlureeDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = FlureeDir::unified(tmp.path().to_path_buf());
+        (tmp, dirs)
+    }
+
+    /// Register a graph source directly through the publisher. This bypasses
+    /// `fluree iceberg map` (which needs a live catalog) so the resolution
+    /// branch can be tested in isolation.
+    async fn register_graph_source(dirs: &FlureeDir, name: &str) {
+        let fluree = build_fluree(dirs).unwrap();
+        fluree
+            .publisher()
+            .unwrap()
+            .publish_graph_source(name, "main", GraphSourceType::R2rml, "{}", &[])
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn resolves_registered_graph_source_to_graph_source_target() {
+        let (_tmp, dirs) = temp_dirs();
+        register_graph_source(&dirs, "warehouse-orders").await;
+
+        // The query path resolves it as a graph source (normalized to :main),
+        // not as a missing ledger.
+        let target = resolve_query_target(Some("warehouse-orders"), &dirs)
+            .await
+            .unwrap();
+        match target {
+            QueryTarget::GraphSource { alias, .. } => {
+                assert_eq!(alias, "warehouse-orders:main");
+            }
+            QueryTarget::Ledger(_) => panic!("expected a GraphSource target, got a ledger"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ledger_only_resolution_reports_graph_source_as_clear_error() {
+        let (_tmp, dirs) = temp_dirs();
+        register_graph_source(&dirs, "warehouse-orders").await;
+
+        // Non-query commands resolve through `resolve_ledger_mode`, which must
+        // not treat the graph source as a ledger — it errors with a pointer to
+        // `fluree query` rather than the generic "not found" message.
+        // (`LedgerMode` isn't `Debug`, so match rather than `unwrap_err`.)
+        match resolve_ledger_mode(Some("warehouse-orders"), &dirs).await {
+            Err(CliError::NotFound(msg)) => {
+                assert!(msg.contains("graph source"), "unexpected message: {msg}");
+                assert!(msg.contains("fluree query"), "unexpected message: {msg}");
+            }
+            Ok(_) => panic!("expected an error, resolved as a ledger"),
+            Err(other) => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_target_still_reports_not_found() {
+        let (_tmp, dirs) = temp_dirs();
+
+        // A genuinely-missing name keeps the original, ledger-oriented message
+        // on both resolution paths (regression guard).
+        // (`QueryTarget` isn't `Debug`, so match rather than `unwrap_err`.)
+        match resolve_query_target(Some("nope"), &dirs).await {
+            Err(CliError::NotFound(msg)) => {
+                assert!(
+                    msg.contains("not found locally or in tracked config"),
+                    "unexpected message: {msg}"
+                );
+            }
+            Ok(_) => panic!("expected NotFound for a missing target"),
+            Err(other) => panic!("expected NotFound, got {other:?}"),
+        }
+    }
 }

--- a/fluree-db-cli/src/lib.rs
+++ b/fluree-db-cli/src/lib.rs
@@ -278,6 +278,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             cypher,
             at,
             remote,
+            connection,
             track,
             track_fuel,
             track_time,
@@ -302,6 +303,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
                 at.as_deref(),
                 &fluree_dir,
                 remote.as_deref(),
+                connection.as_deref(),
                 direct,
                 commands::query::TrackingFlags {
                     track,

--- a/fluree-db-cli/tests/integration.rs
+++ b/fluree-db-cli/tests/integration.rs
@@ -456,6 +456,71 @@ fn query_ndjson_local_sparql_at_rejects_inline_from() {
 }
 
 #[test]
+fn query_connection_remote_routes_to_named_remote() {
+    // `--connection=<remote>` forces the connection-scoped path against a named
+    // remote. With `require_equals`, the `=value` form is parsed as the remote
+    // (not the following query string), and the request routes through the
+    // remote resolver — which errors for an unknown remote.
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    fluree_cmd(&tmp)
+        .args([
+            "query",
+            "--connection=definitely-no-such-remote",
+            "SELECT ?s WHERE { ?s ?p ?o }",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("definitely-no-such-remote"));
+}
+
+#[test]
+fn query_bare_connection_keeps_positional_query() {
+    // A bare `--connection` (no `=value`) must not swallow the following query
+    // string: the SPARQL stays the positional input and is executed via the
+    // local connection path. With no `FROM` dataset it fails at execution, but
+    // crucially NOT with a clap parsing error about the argument.
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+    fluree_cmd(&tmp).args(["create", "mydb"]).assert().success();
+
+    fluree_cmd(&tmp)
+        .args([
+            "query",
+            "mydb",
+            "--connection",
+            "SELECT ?s WHERE { ?s <http://example.org/p> ?o }",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unexpected argument").not())
+        .stderr(predicate::str::contains("invalid value").not());
+}
+
+#[test]
+fn query_bare_connection_without_active_ledger_routes_to_connection_path() {
+    // #1398 review must-fix: a pure-federation query names its sources in FROM,
+    // so bare `--connection` with no active ledger (and no ledger argument) must
+    // route to the local connection path — NOT error with `NoActiveLedger`.
+    // The FROM target doesn't exist here, so the query still fails, but it fails
+    // at source resolution rather than for lack of an active ledger.
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+    // Deliberately no `create` / `use`: there is no active ledger.
+
+    fluree_cmd(&tmp)
+        .args([
+            "query",
+            "--connection",
+            "SELECT ?id WHERE { ?o <http://example.org/id> ?id }",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no active ledger").not());
+}
+
+#[test]
 fn query_ndjson_local_with_default_allow_policy_streams() {
     let tmp = TempDir::new().unwrap();
     seed_named_people(&tmp, "streamdb");


### PR DESCRIPTION
## Summary

`fluree query <name>` could only resolve **native ledgers**:
`context.rs::resolve_ledger_mode` had no notion of a registered Iceberg/R2RML
**graph source**, so querying one from the CLI failed even though the source was
registered and the server could serve it. This PR teaches the CLI to resolve a
graph-source name and route the query to the graph-source-aware execution path
(local single-target, or the connection path for `FROM`-federation).

## What changed

- **`fluree-db-cli/src/context.rs`** — the body of `resolve_ledger_mode` is
  refactored into `resolve_query_target` returning a `QueryTarget { Ledger | GraphSource }`.
  A `lookup_graph_source` probe runs **after** the native-ledger check
  (ledger-wins), normalizing the bare name to `<name>:main`, preferring a local
  registration, and skipping retracted sources. `resolve_ledger_mode` becomes a
  thin wrapper that maps a graph-source name to a clear `NotFound` for the ~10
  other commands that still only handle ledgers (no behavior change for real
  ledger names). The graph-source probe is error-tolerant: a graph-source-store
  read error is debug-logged and treated as "not a graph source" (fall through),
  so it cannot break native-ledger resolution for the commands that call
  `resolve_ledger_mode`.
- **`fluree-db-cli/src/commands/query.rs`** — graph-source execution:
  - Implicit `fluree query <graph-source>` runs **locally** via
    `fluree.graph(alias).query()…execute_formatted()` (gated on the `iceberg`
    feature; a clear "rebuild with `--features iceberg`" message otherwise).
  - A query whose `FROM` / `from` references a **foreign** graph source
    auto-routes to the connection path — `query_from` (local) or
    `query_connection_sparql` / `query_connection_jsonld` (remote), wiring methods
    that were previously unreachable.
  - A bare `--connection` federation query does **not** require an active native
    ledger: when no ledger is active/provided, the local connection path falls back
    to a bare `Fluree` handle (symmetric with the `--connection=REMOTE` arm), since
    the query's `FROM` already names its sources. A normal `fluree query` with no
    ledger still errors `NoActiveLedger` (the relaxation is gated on the connection
    path), and a provided ledger still resolves normally.
  - Guardrails reject flags unsupported on the graph-source single-target path with
    a clear message.
- **`fluree-db-cli/src/cli.rs`** — adds `--connection[=REMOTE]` to the **Query**
  command only, using `require_equals` so a bare `--connection` forces the
  connection path while `--connection=REMOTE` targets a named remote (and neither
  swallows the following positional query string).
- **`fluree-db-cli/src/lib.rs`** — threads `connection` into `query::run`.
- **`docs/cli/iceberg.md`** — fixes the broken example at line 160 (single-target
  form + a `--connection` federation example; and `fluree info <gs>` →
  `fluree iceberg info <gs>`, since bare `info` on a graph-source name now returns
  the clear graph-source error).

## Design decisions (intentional deviations from #1398's literal wording)

1. **`QueryTarget` enum instead of a new `LedgerMode` variant.** ~10 command files
   exhaustively match `LedgerMode::{Local,Tracked}`; adding a variant/field there
   would break all of them. The probe still lives in `context.rs` (per the issue's
   critical-files list) and query behavior is exactly as specified; other commands
   simply get a clearer error for a graph-source name.
2. **`--connection[=REMOTE]` with `require_equals`** resolves the issue's ambiguous
   "positional optional" and prevents the flag from eating the query string.
3. **Implicit `fluree query <gs>` executes locally** (`graph().query()`), matching
   the issue's primary "execute locally" design; server-routed forms remain
   reachable via `--remote` / `--connection`.
4. **`--policy` / `--track` are not plumbed** into the graph-source single-target
   path — consistent with the server's graph-source fallback, which doesn't apply
   them either. Noted as a minor limitation, not a silent surprise.
5. **No live-rows E2E test** — a queryable Iceberg/R2RML source needs a live
   catalog (the issue itself defers that). Covered instead by a real
   graph-source *resolution* test plus deterministic unit tests of every routing
   decision.

## Tests

`context::tests` (register a real graph source via the nameservice publisher — no
live catalog):
- `resolves_registered_graph_source_to_graph_source_target`
- `ledger_only_resolution_reports_graph_source_as_clear_error`
- `missing_target_still_reports_not_found`

`commands::query::tests`:
- `base_ledger_id_strips_branch_time_and_fragment`
- `jsonld_from_targets_handles_string_and_array`
- `foreign_source_detection_sparql`, `foreign_source_detection_jsonld`
- `graph_source_guardrails_reject_unsupported_flags`
- `json_display_format_falls_back_for_jsonld`

`tests/integration.rs`:
- `query_connection_remote_routes_to_named_remote`
- `query_bare_connection_keeps_positional_query`
- `query_bare_connection_without_active_ledger_routes_to_connection_path` — bare
  `--connection` with no active ledger routes onward instead of erroring
  `NoActiveLedger`.

### Results

- `cargo build -p fluree-db-cli --features iceberg` — success.
- `cargo test -p fluree-db-cli --features iceberg` — 110 lib + 102 integration
  passed, 0 failed.
- `cargo clippy -p fluree-db-cli --all-targets --features iceberg` — zero warnings.
- `cargo fmt -p fluree-db-cli -- --check` — clean.
- `cargo build -p fluree-db-cli --no-default-features --features "server,shacl,aws"`
  (non-iceberg path) — success (exercises the `cfg(not(feature="iceberg"))`
  rebuild-message branch).

Fixes #1398
