### PR TITLE
perf: Iceberg/R2RML graph-source performance — planning, catalog caching, LIMIT + row-group pruning

### DIFF
--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -1003,6 +1003,7 @@ reasonable behavior out of the box.
 |----------|---------|---------|
 | `FLUREE_ICEBERG_LOADTABLE_CACHE` | on | Master switch for all REST catalog caching. Set to `0`/`false`/`off` to build a fresh catalog client and reload the table on **every** scan (restores a per-scan OAuth exchange + `loadTable` round-trip). Disables the client/OAuth reuse, the cross-query `loadTable` cache, and the per-query snapshot pin. |
 | `FLUREE_ICEBERG_LOADTABLE_TTL_SECS` | `60` | TTL (seconds) for the **cross-query** `loadTable`-response cache. A REST `loadTable` GET against a catalog such as Snowflake Horizon costs ~1.3–3 s, so caching it lets a burst of queries against the same table skip the round-trip. The TTL bounds how stale a snapshot a *new* query may observe; `0` disables the cross-query layer (leaving only the per-query pin). Every cache read is additionally gated on vended-credential expiry (30 s buffer), so a long TTL never hands out about-to-expire credentials. |
+| `FLUREE_ICEBERG_REST_CLIENT_TTL_SECS` | `900` | TTL (seconds) for the process-wide REST **catalog-client** cache (the reused OAuth token + HTTPS pool). The cache is keyed by a fingerprint of the raw config JSON, which does **not** change when a secret referenced by env var / secret store is rotated; this TTL bounds how long a rotated secret stays stale before the client is rebuilt and re-authenticated. `0` rebuilds the client every query (restoring a per-query OAuth exchange). |
 | `FLUREE_R2RML_SCAN_CACHE` | on | Toggles the correlated-join inner-scan cache, which reuses a materialized inner (dimension) table across a join's child batches instead of re-scanning it per batch. Set to `0`/`false`/`off` to restore per-child-batch re-scans. |
 | `FLUREE_R2RML_MATERIALIZE_WINDOW_ROWS` | `524288` | Target table rows materialized into RDF-term bindings per parallel window. Bounds resident memory during a scan (materialization explodes the compact columnar form into fat binding rows). Also caps the size of an inner scan eligible for the inner-scan cache above. |
 | `FLUREE_ICEBERG_SCAN_CONCURRENCY` | `min(cores, files, 8)` | Number of data files read concurrently within one scan. Raise it for high-latency remote object stores (it is not capped, but is bounded by the number of files in the scan). |
@@ -1017,7 +1018,12 @@ second and later queries against a table typically skip both the OAuth exchange
 and the `loadTable` GET entirely. The cross-query cache always records the
 catalog's current state, never a query's pinned snapshot, so pin preservation
 cannot leak a stale location to other queries. The client cache is keyed by a
-config fingerprint, so rotating the source's access token rebuilds the client.
+fingerprint of the raw config JSON: editing the config (including an inline
+secret) rebuilds the client immediately, but a secret referenced by env var or
+secret store is invisible to the fingerprint, so a rotation of that secret is
+picked up only when the client cache entry expires
+(`FLUREE_ICEBERG_REST_CLIENT_TTL_SECS`, default 15 min) — until then the reused
+client keeps presenting the old credential.
 
 **Freshness vs. latency.** The only knob with a data-freshness tradeoff is
 `FLUREE_ICEBERG_LOADTABLE_TTL_SECS`: a new query may read a snapshot up to that

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -993,6 +993,38 @@ Iceberg table: ~62s with the system allocator vs ~31s with mimalloc).
 Pair it with bounded query parallelism so a single large scan cannot monopolize
 cores and allocator pressure under concurrent load.
 
+## Iceberg / R2RML Graph-Source Tuning
+
+Queries against an Iceberg-backed R2RML graph source are tuned by a set of
+environment-only knobs. All are optional; the defaults are chosen for correct,
+reasonable behavior out of the box.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `FLUREE_ICEBERG_LOADTABLE_CACHE` | on | Master switch for all REST catalog caching. Set to `0`/`false`/`off` to build a fresh catalog client and reload the table on **every** scan (restores a per-scan OAuth exchange + `loadTable` round-trip). Disables the client/OAuth reuse, the cross-query `loadTable` cache, and the per-query snapshot pin. |
+| `FLUREE_ICEBERG_LOADTABLE_TTL_SECS` | `60` | TTL (seconds) for the **cross-query** `loadTable`-response cache. A REST `loadTable` GET against a catalog such as Snowflake Horizon costs ~1.3–3 s, so caching it lets a burst of queries against the same table skip the round-trip. The TTL bounds how stale a snapshot a *new* query may observe; `0` disables the cross-query layer (leaving only the per-query pin). Every cache read is additionally gated on vended-credential expiry (30 s buffer), so a long TTL never hands out about-to-expire credentials. |
+| `FLUREE_R2RML_SCAN_CACHE` | on | Toggles the correlated-join inner-scan cache, which reuses a materialized inner (dimension) table across a join's child batches instead of re-scanning it per batch. Set to `0`/`false`/`off` to restore per-child-batch re-scans. |
+| `FLUREE_R2RML_MATERIALIZE_WINDOW_ROWS` | `524288` | Target table rows materialized into RDF-term bindings per parallel window. Bounds resident memory during a scan (materialization explodes the compact columnar form into fat binding rows). Also caps the size of an inner scan eligible for the inner-scan cache above. |
+| `FLUREE_ICEBERG_SCAN_CONCURRENCY` | `min(cores, files, 8)` | Number of data files read concurrently within one scan. Raise it for high-latency remote object stores (it is not capped, but is bounded by the number of files in the scan). |
+
+**Caching model.** Catalog access is cached at two scopes. Within a single query,
+the first scan of a table pins its `metadata_location`, so every scan in that
+query reads one consistent Iceberg snapshot even if the table commits mid-query.
+Across queries, a process-wide cache reuses the REST client (so its OAuth token —
+valid ~1 h — and HTTPS connection pool survive) and the `loadTable` response
+(bounded by `FLUREE_ICEBERG_LOADTABLE_TTL_SECS`). On a warm server this means the
+second and later queries against a table typically skip both the OAuth exchange
+and the `loadTable` GET entirely. The cross-query cache always records the
+catalog's current state, never a query's pinned snapshot, so pin preservation
+cannot leak a stale location to other queries. The client cache is keyed by a
+config fingerprint, so rotating the source's access token rebuilds the client.
+
+**Freshness vs. latency.** The only knob with a data-freshness tradeoff is
+`FLUREE_ICEBERG_LOADTABLE_TTL_SECS`: a new query may read a snapshot up to that
+many seconds old. This is well within typical warehouse ETL latency; lower it (or
+set `0`) if you need each query to always resolve the newest snapshot, at the cost
+of paying the `loadTable` GET per query.
+
 ## Related Documentation
 
 - [Query Peers](query-peers.md) - Peer mode and replication

--- a/fluree-db-api/src/graph_source/cache.rs
+++ b/fluree-db-api/src/graph_source/cache.rs
@@ -11,6 +11,10 @@ use fluree_db_r2rml::mapping::CompiledR2rmlMapping;
 use std::sync::Arc;
 
 #[cfg(feature = "iceberg")]
+use super::catalog_session::CachedLoadTable;
+#[cfg(feature = "iceberg")]
+use fluree_db_iceberg::catalog::RestCatalogClient;
+#[cfg(feature = "iceberg")]
 use fluree_db_iceberg::{io::parquet::ParquetFooterCache, metadata::TableMetadata, DataFile};
 #[cfg(feature = "iceberg")]
 use std::time::Duration;
@@ -26,6 +30,24 @@ pub(crate) struct CachedScanFiles {
 
 #[cfg(feature = "iceberg")]
 const DIRECT_METADATA_LOCATION_TTL: Duration = Duration::from_secs(2);
+
+/// Default cross-query `loadTable`-response cache TTL. A REST `loadTable` GET
+/// costs ~1.3–3s against Snowflake Horizon, so caching it across queries lets a
+/// burst of queries against the same tables skip the round-trip. The TTL bounds
+/// how stale a snapshot a *new* query can observe (an in-flight query pins its
+/// own snapshot regardless). Every read is also gated on vended-credential
+/// expiry. Override with `FLUREE_ICEBERG_LOADTABLE_TTL_SECS` (`0` disables the
+/// cross-query layer, leaving only the per-query pin).
+#[cfg(feature = "iceberg")]
+const DEFAULT_REST_LOADTABLE_TTL_SECS: u64 = 60;
+
+#[cfg(feature = "iceberg")]
+fn rest_loadtable_ttl_secs() -> u64 {
+    std::env::var("FLUREE_ICEBERG_LOADTABLE_TTL_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_REST_LOADTABLE_TTL_SECS)
+}
 
 /// Cache for R2RML compiled mappings and Iceberg table metadata.
 ///
@@ -66,6 +88,20 @@ pub struct R2rmlCache {
     /// Uses moka's native TTL (`time_to_live`) so entries auto-expire.
     #[cfg(feature = "iceberg")]
     direct_metadata_locations: moka::sync::Cache<String, String>,
+
+    /// Process-wide REST catalog clients keyed by source config fingerprint.
+    /// Reused across queries so the OAuth `CachedToken` and the HTTPS connection
+    /// pool survive — one token exchange per ~hour instead of one per query.
+    /// Keyed by a config fingerprint so a rotated PAT invalidates the client.
+    #[cfg(feature = "iceberg")]
+    rest_clients: moka::sync::Cache<String, Arc<RestCatalogClient>>,
+
+    /// Process-wide `loadTable` responses keyed by `(graph_source_id, ns.table)`,
+    /// with a short TTL (see [`DEFAULT_REST_LOADTABLE_TTL_SECS`]) and a
+    /// credential-expiry gate. Lets a burst of queries against the same table
+    /// skip the ~1.3–3s catalog GET.
+    #[cfg(feature = "iceberg")]
+    rest_load_tables: moka::sync::Cache<String, Arc<CachedLoadTable>>,
 }
 
 // moka::sync::Cache is Send+Sync but doesn't implement Debug
@@ -103,6 +139,13 @@ impl R2rmlCache {
                 direct_metadata_locations: moka::sync::Cache::builder()
                     .max_capacity(metadata_cap)
                     .time_to_live(DIRECT_METADATA_LOCATION_TTL)
+                    .build(),
+                // A process serves few distinct graph sources; a small cap is
+                // plenty and bounds retained clients/connection pools.
+                rest_clients: moka::sync::Cache::new(64),
+                rest_load_tables: moka::sync::Cache::builder()
+                    .max_capacity(metadata_cap)
+                    .time_to_live(Duration::from_secs(rest_loadtable_ttl_secs()))
                     .build(),
             }
         }
@@ -191,6 +234,52 @@ impl R2rmlCache {
             .insert(table_location, metadata_location);
     }
 
+    /// Get a process-wide REST catalog client for a source config `fingerprint`,
+    /// or `None` on miss (or when catalog caching is disabled).
+    #[cfg(feature = "iceberg")]
+    pub(crate) fn rest_client(&self, fingerprint: &str) -> Option<Arc<RestCatalogClient>> {
+        if !super::catalog_session::cache_enabled() {
+            return None;
+        }
+        self.rest_clients.get(fingerprint)
+    }
+
+    /// Store a REST catalog client for cross-query reuse (no-op when disabled).
+    #[cfg(feature = "iceberg")]
+    pub(crate) fn put_rest_client(&self, fingerprint: String, client: Arc<RestCatalogClient>) {
+        if !super::catalog_session::cache_enabled() {
+            return;
+        }
+        self.rest_clients.insert(fingerprint, client);
+    }
+
+    /// Get a cross-query `loadTable` response if cached, within TTL, and its
+    /// vended credentials are not near expiry; otherwise `None` (an expired
+    /// entry is invalidated). Returns `None` when caching or the cross-query
+    /// layer (TTL=0) is disabled.
+    #[cfg(feature = "iceberg")]
+    pub(crate) fn get_rest_load_table(&self, key: &str) -> Option<Arc<CachedLoadTable>> {
+        if !super::catalog_session::cache_enabled() || rest_loadtable_ttl_secs() == 0 {
+            return None;
+        }
+        let hit = self.rest_load_tables.get(key)?;
+        if hit.creds_expired() {
+            self.rest_load_tables.invalidate(key);
+            return None;
+        }
+        Some(hit)
+    }
+
+    /// Store a `loadTable` response in the cross-query cache (no-op when disabled
+    /// or TTL=0).
+    #[cfg(feature = "iceberg")]
+    pub(crate) fn put_rest_load_table(&self, key: String, value: Arc<CachedLoadTable>) {
+        if !super::catalog_session::cache_enabled() || rest_loadtable_ttl_secs() == 0 {
+            return;
+        }
+        self.rest_load_tables.insert(key, value);
+    }
+
     /// Clear all caches.
     pub async fn clear(&self) {
         self.compiled_mappings.invalidate_all();
@@ -201,6 +290,8 @@ impl R2rmlCache {
             self.scan_files.invalidate_all();
             self.parquet_footers.clear().await;
             self.direct_metadata_locations.invalidate_all();
+            self.rest_clients.invalidate_all();
+            self.rest_load_tables.invalidate_all();
         }
     }
 
@@ -278,4 +369,79 @@ pub struct R2rmlCacheStats {
     pub metadata_entries: usize,
     /// Maximum metadata cache capacity
     pub metadata_capacity: usize,
+}
+
+#[cfg(all(test, feature = "iceberg"))]
+mod iceberg_tests {
+    use super::*;
+    use crate::graph_source::catalog_session::CachedLoadTable;
+    use chrono::{Duration, Utc};
+    use fluree_db_iceberg::credential::VendedCredentials;
+
+    fn creds(expires_in_secs: i64) -> VendedCredentials {
+        VendedCredentials {
+            access_key_id: "AKIA".to_string(),
+            secret_access_key: "secret".to_string(),
+            session_token: Some("token".to_string()),
+            expires_at: Some(Utc::now() + Duration::seconds(expires_in_secs)),
+            endpoint: None,
+            region: Some("us-east-2".to_string()),
+            path_style: false,
+        }
+    }
+
+    fn entry(loc: &str, creds: Option<VendedCredentials>) -> Arc<CachedLoadTable> {
+        Arc::new(CachedLoadTable {
+            metadata_location: loc.to_string(),
+            credentials: creds,
+        })
+    }
+
+    #[test]
+    fn cross_query_loadtable_put_get() {
+        let cache = R2rmlCache::with_defaults();
+        assert!(
+            cache.get_rest_load_table("k1").is_none(),
+            "empty cache misses"
+        );
+        cache.put_rest_load_table("k1".to_string(), entry("s3://m.json", Some(creds(3600))));
+        assert_eq!(
+            cache.get_rest_load_table("k1").unwrap().metadata_location,
+            "s3://m.json"
+        );
+        assert!(
+            cache.get_rest_load_table("k2").is_none(),
+            "different key misses"
+        );
+    }
+
+    #[test]
+    fn cross_query_near_expiry_creds_is_a_miss() {
+        let cache = R2rmlCache::with_defaults();
+        // Inside the 30s refresh buffer → treated as expired.
+        cache.put_rest_load_table("k".to_string(), entry("s3://m.json", Some(creds(10))));
+        assert!(
+            cache.get_rest_load_table("k").is_none(),
+            "about-to-expire vended creds must not be served cross-query"
+        );
+    }
+
+    #[test]
+    fn cross_query_no_creds_never_expires() {
+        let cache = R2rmlCache::with_defaults();
+        cache.put_rest_load_table("k".to_string(), entry("s3://m.json", None));
+        assert!(cache.get_rest_load_table("k").is_some());
+    }
+
+    #[tokio::test]
+    async fn clear_empties_cross_query_loadtable() {
+        let cache = R2rmlCache::with_defaults();
+        cache.put_rest_load_table("k".to_string(), entry("s3://m.json", Some(creds(3600))));
+        assert!(cache.get_rest_load_table("k").is_some());
+        cache.clear().await;
+        assert!(
+            cache.get_rest_load_table("k").is_none(),
+            "clear() drops cross-query entries"
+        );
+    }
 }

--- a/fluree-db-api/src/graph_source/cache.rs
+++ b/fluree-db-api/src/graph_source/cache.rs
@@ -49,6 +49,26 @@ fn rest_loadtable_ttl_secs() -> u64 {
         .unwrap_or(DEFAULT_REST_LOADTABLE_TTL_SECS)
 }
 
+/// Default TTL for the process-wide REST catalog client cache. Reusing a client
+/// preserves its OAuth `CachedToken` and HTTPS connection pool, but the cache is
+/// keyed by a fingerprint of the *raw* config JSON. When a Bearer/OAuth secret is
+/// sourced from an env var or secret store, that JSON stores the reference, not
+/// the secret, so rotating the secret does not change the fingerprint — without a
+/// TTL the stale client (and its cached token) would serve 401s until LRU
+/// eviction or a process restart. A bounded TTL lets a rotated secret self-heal:
+/// the client rebuilds and re-authenticates within the window. Override with
+/// `FLUREE_ICEBERG_REST_CLIENT_TTL_SECS` (`0` rebuilds the client every query).
+#[cfg(feature = "iceberg")]
+const DEFAULT_REST_CLIENT_TTL_SECS: u64 = 900;
+
+#[cfg(feature = "iceberg")]
+fn rest_client_ttl_secs() -> u64 {
+    std::env::var("FLUREE_ICEBERG_REST_CLIENT_TTL_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_REST_CLIENT_TTL_SECS)
+}
+
 /// Cache for R2RML compiled mappings and Iceberg table metadata.
 ///
 /// This cache is shared across queries to avoid repeated:
@@ -92,7 +112,11 @@ pub struct R2rmlCache {
     /// Process-wide REST catalog clients keyed by source config fingerprint.
     /// Reused across queries so the OAuth `CachedToken` and the HTTPS connection
     /// pool survive — one token exchange per ~hour instead of one per query.
-    /// Keyed by a config fingerprint so a rotated PAT invalidates the client.
+    /// The fingerprint is over the raw config JSON, so a secret changed *inline*
+    /// in the config invalidates the client, but a secret referenced by env var
+    /// / secret store does not (the JSON is unchanged). A TTL
+    /// (`DEFAULT_REST_CLIENT_TTL_SECS`) bounds how long such a rotation stays
+    /// stale before the client is rebuilt and re-authenticated.
     #[cfg(feature = "iceberg")]
     rest_clients: moka::sync::Cache<String, Arc<RestCatalogClient>>,
 
@@ -141,8 +165,14 @@ impl R2rmlCache {
                     .time_to_live(DIRECT_METADATA_LOCATION_TTL)
                     .build(),
                 // A process serves few distinct graph sources; a small cap is
-                // plenty and bounds retained clients/connection pools.
-                rest_clients: moka::sync::Cache::new(64),
+                // plenty and bounds retained clients/connection pools. A TTL lets
+                // an env-var/secret-store secret rotation self-heal (see
+                // `DEFAULT_REST_CLIENT_TTL_SECS`) since the config fingerprint
+                // does not change when the referenced secret does.
+                rest_clients: moka::sync::Cache::builder()
+                    .max_capacity(64)
+                    .time_to_live(Duration::from_secs(rest_client_ttl_secs()))
+                    .build(),
                 rest_load_tables: moka::sync::Cache::builder()
                     .max_capacity(metadata_cap)
                     .time_to_live(Duration::from_secs(rest_loadtable_ttl_secs()))

--- a/fluree-db-api/src/graph_source/catalog_session.rs
+++ b/fluree-db-api/src/graph_source/catalog_session.rs
@@ -20,14 +20,16 @@
 //! `FLUREE_ICEBERG_LOADTABLE_CACHE=0`, restoring per-scan loads.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Mutex, OnceLock};
 
-use fluree_db_iceberg::catalog::{LoadTableResponse, RestCatalogClient};
+use fluree_db_iceberg::catalog::LoadTableResponse;
 use fluree_db_iceberg::credential::VendedCredentials;
 
-/// Whether the query-scoped catalog cache is enabled. Read once from
-/// `FLUREE_ICEBERG_LOADTABLE_CACHE` (only `0`/`false`/`off` disable it).
-fn cache_enabled() -> bool {
+/// Master switch for all Iceberg catalog caching. Read once from
+/// `FLUREE_ICEBERG_LOADTABLE_CACHE` (only `0`/`false`/`off` disable it). When
+/// off, every scan builds a fresh REST client and reloads the table (per-scan
+/// OAuth + `loadTable` restored).
+pub(crate) fn cache_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| match std::env::var("FLUREE_ICEBERG_LOADTABLE_CACHE") {
         Ok(v) => !matches!(
@@ -39,31 +41,47 @@ fn cache_enabled() -> bool {
 }
 
 /// The fields a later scan needs to rebuild a [`LoadTableResponse`] without
-/// another REST round-trip.
+/// another REST round-trip. Shared by the per-query snapshot pin (this module)
+/// and the process-wide cross-query `loadTable` cache (`R2rmlCache`).
 #[derive(Clone)]
-struct CachedLoadTable {
-    metadata_location: String,
-    credentials: Option<VendedCredentials>,
+pub(crate) struct CachedLoadTable {
+    pub(crate) metadata_location: String,
+    pub(crate) credentials: Option<VendedCredentials>,
 }
 
 impl CachedLoadTable {
+    pub(crate) fn from_response(resp: &LoadTableResponse) -> Self {
+        Self {
+            metadata_location: resp.metadata_location.clone(),
+            credentials: resp.credentials.clone(),
+        }
+    }
+
+    /// Rebuild a `LoadTableResponse` (the `config` map is debug-only and dropped).
+    pub(crate) fn to_response(&self) -> LoadTableResponse {
+        LoadTableResponse {
+            metadata_location: self.metadata_location.clone(),
+            credentials: self.credentials.clone(),
+            config: HashMap::default(),
+        }
+    }
+
     /// True when vended credentials are present and at/after their (30s-buffered)
     /// expiry, so a later scan must reload rather than hand out stale creds.
-    fn creds_expired(&self) -> bool {
+    pub(crate) fn creds_expired(&self) -> bool {
         self.credentials
             .as_ref()
             .is_some_and(VendedCredentials::is_expired)
     }
 }
 
-/// Query-scoped catalog state shared across every scan of one query.
+/// Per-query catalog state: the `loadTable` snapshot pin. `FlureeR2rmlProvider`
+/// is built once per query, so this map is naturally query-scoped — every scan
+/// in one query reads one pinned Iceberg snapshot. Process-wide client reuse
+/// (the OAuth token) and the cross-query `loadTable` cache live in `R2rmlCache`.
 #[derive(Default)]
 pub(crate) struct IcebergCatalogSession {
-    /// Reused REST clients keyed by graph source id. One client per source means
-    /// one OAuth token cache, hence one token exchange for the whole query.
-    /// `RestCatalogClient` is not `Clone`, so it is shared via `Arc`.
-    clients: Mutex<HashMap<String, Arc<RestCatalogClient>>>,
-    /// Cached `loadTable` responses keyed by `(graph_source_id, namespace.table)`.
+    /// Pinned `loadTable` responses keyed by `(graph_source_id, namespace.table)`.
     load_tables: Mutex<HashMap<String, CachedLoadTable>>,
 }
 
@@ -71,27 +89,6 @@ impl IcebergCatalogSession {
     /// Cache key for a `loadTable` response: source id + fully-qualified table.
     pub(crate) fn load_table_key(graph_source_id: &str, namespace: &str, table: &str) -> String {
         format!("{graph_source_id}\u{1f}{namespace}.{table}")
-    }
-
-    /// Get the cached REST client for `key`, or build one with `build` and cache
-    /// it. The build closure is synchronous (client construction performs no
-    /// I/O), so the lock is never held across an `await`. With the cache
-    /// disabled, every call builds a fresh client (per-scan OAuth restored).
-    pub(crate) fn rest_client_or_build<E>(
-        &self,
-        key: &str,
-        build: impl FnOnce() -> Result<RestCatalogClient, E>,
-    ) -> Result<Arc<RestCatalogClient>, E> {
-        if !cache_enabled() {
-            return Ok(Arc::new(build()?));
-        }
-        let mut clients = self.clients.lock().unwrap();
-        if let Some(c) = clients.get(key) {
-            return Ok(Arc::clone(c));
-        }
-        let client = Arc::new(build()?);
-        clients.insert(key.to_string(), Arc::clone(&client));
-        Ok(client)
     }
 
     /// Return a cached [`LoadTableResponse`] for `key` if present and its vended
@@ -105,11 +102,7 @@ impl IcebergCatalogSession {
         if hit.creds_expired() {
             return None;
         }
-        Some(LoadTableResponse {
-            metadata_location: hit.metadata_location.clone(),
-            credentials: hit.credentials.clone(),
-            config: HashMap::default(),
-        })
+        Some(hit.to_response())
     }
 
     /// The `metadata_location` pinned for `key` on its first load this query,
@@ -140,13 +133,7 @@ impl IcebergCatalogSession {
         match lts.get_mut(&key) {
             Some(existing) => existing.credentials = resp.credentials.clone(),
             None => {
-                lts.insert(
-                    key,
-                    CachedLoadTable {
-                        metadata_location: resp.metadata_location.clone(),
-                        credentials: resp.credentials.clone(),
-                    },
-                );
+                lts.insert(key, CachedLoadTable::from_response(resp));
             }
         }
     }

--- a/fluree-db-api/src/graph_source/catalog_session.rs
+++ b/fluree-db-api/src/graph_source/catalog_session.rs
@@ -1,0 +1,210 @@
+//! Query-scoped Iceberg catalog session.
+//!
+//! A [`crate::graph_source::FlureeR2rmlProvider`] is constructed once per query,
+//! so a session held on it is naturally query-scoped. It eliminates the per-scan
+//! REST storm that dominates Iceberg/R2RML query latency:
+//!
+//! - one [`RestCatalogClient`] (carrying its OAuth `CachedToken`) is reused
+//!   across every scan of a source, instead of a fresh provider + token exchange
+//!   per scan;
+//! - one `loadTable` response (metadata location + vended credentials) is cached
+//!   per `(source, table)` for the query, instead of a `GET /tables/<t>` REST
+//!   round-trip per scan.
+//!
+//! Per-query scope is also a correctness improvement: every scan in the query
+//! reads one pinned Iceberg snapshot. Independent per-scan loads could otherwise
+//! observe different snapshots if the table commits mid-query.
+//!
+//! Cached vended credentials are never served at/after their (30s-buffered)
+//! expiry — a late scan transparently reloads. The cache can be disabled with
+//! `FLUREE_ICEBERG_LOADTABLE_CACHE=0`, restoring per-scan loads.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use fluree_db_iceberg::catalog::{LoadTableResponse, RestCatalogClient};
+use fluree_db_iceberg::credential::VendedCredentials;
+
+/// Whether the query-scoped catalog cache is enabled. Read once from
+/// `FLUREE_ICEBERG_LOADTABLE_CACHE` (only `0`/`false`/`off` disable it).
+fn cache_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var("FLUREE_ICEBERG_LOADTABLE_CACHE") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off"
+        ),
+        Err(_) => true,
+    })
+}
+
+/// The fields a later scan needs to rebuild a [`LoadTableResponse`] without
+/// another REST round-trip.
+#[derive(Clone)]
+struct CachedLoadTable {
+    metadata_location: String,
+    credentials: Option<VendedCredentials>,
+}
+
+impl CachedLoadTable {
+    /// True when vended credentials are present and at/after their (30s-buffered)
+    /// expiry, so a later scan must reload rather than hand out stale creds.
+    fn creds_expired(&self) -> bool {
+        self.credentials
+            .as_ref()
+            .is_some_and(VendedCredentials::is_expired)
+    }
+}
+
+/// Query-scoped catalog state shared across every scan of one query.
+#[derive(Default)]
+pub(crate) struct IcebergCatalogSession {
+    /// Reused REST clients keyed by graph source id. One client per source means
+    /// one OAuth token cache, hence one token exchange for the whole query.
+    /// `RestCatalogClient` is not `Clone`, so it is shared via `Arc`.
+    clients: Mutex<HashMap<String, Arc<RestCatalogClient>>>,
+    /// Cached `loadTable` responses keyed by `(graph_source_id, namespace.table)`.
+    load_tables: Mutex<HashMap<String, CachedLoadTable>>,
+}
+
+impl IcebergCatalogSession {
+    /// Cache key for a `loadTable` response: source id + fully-qualified table.
+    pub(crate) fn load_table_key(graph_source_id: &str, namespace: &str, table: &str) -> String {
+        format!("{graph_source_id}\u{1f}{namespace}.{table}")
+    }
+
+    /// Get the cached REST client for `key`, or build one with `build` and cache
+    /// it. The build closure is synchronous (client construction performs no
+    /// I/O), so the lock is never held across an `await`. With the cache
+    /// disabled, every call builds a fresh client (per-scan OAuth restored).
+    pub(crate) fn rest_client_or_build<E>(
+        &self,
+        key: &str,
+        build: impl FnOnce() -> Result<RestCatalogClient, E>,
+    ) -> Result<Arc<RestCatalogClient>, E> {
+        if !cache_enabled() {
+            return Ok(Arc::new(build()?));
+        }
+        let mut clients = self.clients.lock().unwrap();
+        if let Some(c) = clients.get(key) {
+            return Ok(Arc::clone(c));
+        }
+        let client = Arc::new(build()?);
+        clients.insert(key.to_string(), Arc::clone(&client));
+        Ok(client)
+    }
+
+    /// Return a cached [`LoadTableResponse`] for `key` if present and its vended
+    /// credentials have not expired; otherwise `None` (the caller reloads).
+    pub(crate) fn cached_load_table(&self, key: &str) -> Option<LoadTableResponse> {
+        if !cache_enabled() {
+            return None;
+        }
+        let lts = self.load_tables.lock().unwrap();
+        let hit = lts.get(key)?;
+        if hit.creds_expired() {
+            return None;
+        }
+        Some(LoadTableResponse {
+            metadata_location: hit.metadata_location.clone(),
+            credentials: hit.credentials.clone(),
+            config: HashMap::default(),
+        })
+    }
+
+    /// Cache a freshly loaded `loadTable` response for reuse by later scans of
+    /// the same `(source, table)` in this query. No-op when the cache is disabled.
+    pub(crate) fn store_load_table(&self, key: String, resp: &LoadTableResponse) {
+        if !cache_enabled() {
+            return;
+        }
+        self.load_tables.lock().unwrap().insert(
+            key,
+            CachedLoadTable {
+                metadata_location: resp.metadata_location.clone(),
+                credentials: resp.credentials.clone(),
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+
+    fn creds(expires_in_secs: Option<i64>) -> VendedCredentials {
+        VendedCredentials {
+            access_key_id: "AKIA".to_string(),
+            secret_access_key: "secret".to_string(),
+            session_token: Some("token".to_string()),
+            expires_at: expires_in_secs.map(|s| Utc::now() + Duration::seconds(s)),
+            endpoint: None,
+            region: Some("us-east-2".to_string()),
+            path_style: false,
+        }
+    }
+
+    fn resp(loc: &str, creds: Option<VendedCredentials>) -> LoadTableResponse {
+        LoadTableResponse {
+            metadata_location: loc.to_string(),
+            config: HashMap::default(),
+            credentials: creds,
+        }
+    }
+
+    #[test]
+    fn cache_hit_returns_stored_response() {
+        let s = IcebergCatalogSession::default();
+        let key = IcebergCatalogSession::load_table_key("gs:main", "DW", "DIM_STORE");
+        assert!(s.cached_load_table(&key).is_none(), "empty cache misses");
+        s.store_load_table(
+            key.clone(),
+            &resp("s3://meta/1.json", Some(creds(Some(3600)))),
+        );
+        let hit = s.cached_load_table(&key).expect("hit after store");
+        assert_eq!(hit.metadata_location, "s3://meta/1.json");
+        assert!(hit.credentials.is_some());
+    }
+
+    #[test]
+    fn expired_creds_entry_is_a_miss() {
+        let s = IcebergCatalogSession::default();
+        let key = IcebergCatalogSession::load_table_key("gs:main", "DW", "DIM_STORE");
+        // Already inside the 30s refresh buffer → treated as expired.
+        s.store_load_table(
+            key.clone(),
+            &resp("s3://meta/1.json", Some(creds(Some(10)))),
+        );
+        assert!(
+            s.cached_load_table(&key).is_none(),
+            "about-to-expire vended creds must not be served"
+        );
+    }
+
+    #[test]
+    fn no_creds_entry_never_expires() {
+        let s = IcebergCatalogSession::default();
+        let key = IcebergCatalogSession::load_table_key("gs:main", "DW", "DIM_STORE");
+        s.store_load_table(key.clone(), &resp("s3://meta/1.json", None));
+        assert!(
+            s.cached_load_table(&key).is_some(),
+            "ambient-credential entries have no expiry"
+        );
+    }
+
+    #[test]
+    fn keys_isolate_by_source_and_table() {
+        let s = IcebergCatalogSession::default();
+        let k1 = IcebergCatalogSession::load_table_key("gs:main", "DW", "DIM_STORE");
+        let k2 = IcebergCatalogSession::load_table_key("gs:main", "DW", "DIM_GEOGRAPHY");
+        let k3 = IcebergCatalogSession::load_table_key("other:main", "DW", "DIM_STORE");
+        s.store_load_table(k1.clone(), &resp("s3://store.json", None));
+        assert!(s.cached_load_table(&k1).is_some());
+        assert!(s.cached_load_table(&k2).is_none(), "different table misses");
+        assert!(
+            s.cached_load_table(&k3).is_none(),
+            "different source misses"
+        );
+    }
+}

--- a/fluree-db-api/src/graph_source/catalog_session.rs
+++ b/fluree-db-api/src/graph_source/catalog_session.rs
@@ -112,19 +112,43 @@ impl IcebergCatalogSession {
         })
     }
 
-    /// Cache a freshly loaded `loadTable` response for reuse by later scans of
-    /// the same `(source, table)` in this query. No-op when the cache is disabled.
+    /// The `metadata_location` pinned for `key` on its first load this query,
+    /// regardless of credential freshness. A creds-expiry reload uses this to
+    /// keep the query on one Iceberg snapshot even if the table commits mid-query
+    /// (the reload refreshes only the credentials). `None` if never loaded.
+    pub(crate) fn pinned_metadata_location(&self, key: &str) -> Option<String> {
+        if !cache_enabled() {
+            return None;
+        }
+        self.load_tables
+            .lock()
+            .unwrap()
+            .get(key)
+            .map(|e| e.metadata_location.clone())
+    }
+
+    /// Cache a `loadTable` response for reuse by later scans of the same
+    /// `(source, table)` in this query. The `metadata_location` is pinned on the
+    /// first store and never changes; a later store (a creds refresh) updates
+    /// only the credentials, so the query stays on one snapshot. No-op when the
+    /// cache is disabled.
     pub(crate) fn store_load_table(&self, key: String, resp: &LoadTableResponse) {
         if !cache_enabled() {
             return;
         }
-        self.load_tables.lock().unwrap().insert(
-            key,
-            CachedLoadTable {
-                metadata_location: resp.metadata_location.clone(),
-                credentials: resp.credentials.clone(),
-            },
-        );
+        let mut lts = self.load_tables.lock().unwrap();
+        match lts.get_mut(&key) {
+            Some(existing) => existing.credentials = resp.credentials.clone(),
+            None => {
+                lts.insert(
+                    key,
+                    CachedLoadTable {
+                        metadata_location: resp.metadata_location.clone(),
+                        credentials: resp.credentials.clone(),
+                    },
+                );
+            }
+        }
     }
 }
 
@@ -190,6 +214,38 @@ mod tests {
         assert!(
             s.cached_load_table(&key).is_some(),
             "ambient-credential entries have no expiry"
+        );
+    }
+
+    #[test]
+    fn refresh_keeps_pinned_metadata_location() {
+        // First load pins the snapshot. A later store (as happens after a
+        // creds-expiry reload that observed a NEWER metadata_location because the
+        // table committed mid-query) must NOT move the pin — only refresh creds.
+        let s = IcebergCatalogSession::default();
+        let key = IcebergCatalogSession::load_table_key("gs:main", "DW", "DIM_STORE");
+        s.store_load_table(
+            key.clone(),
+            &resp("s3://snap-A.json", Some(creds(Some(10)))),
+        );
+        assert_eq!(
+            s.pinned_metadata_location(&key).as_deref(),
+            Some("s3://snap-A.json")
+        );
+        // Simulate the reload landing on a newer snapshot with fresh creds.
+        s.store_load_table(
+            key.clone(),
+            &resp("s3://snap-B.json", Some(creds(Some(3600)))),
+        );
+        assert_eq!(
+            s.pinned_metadata_location(&key).as_deref(),
+            Some("s3://snap-A.json"),
+            "snapshot must stay pinned across a credential refresh"
+        );
+        let hit = s.cached_load_table(&key).expect("fresh creds now valid");
+        assert_eq!(
+            hit.metadata_location, "s3://snap-A.json",
+            "later scans read the pinned snapshot, not the reloaded one"
         );
     }
 

--- a/fluree-db-api/src/graph_source/mod.rs
+++ b/fluree-db-api/src/graph_source/mod.rs
@@ -112,6 +112,9 @@ mod result;
 mod vector;
 
 #[cfg(feature = "iceberg")]
+mod catalog_session;
+
+#[cfg(feature = "iceberg")]
 mod r2rml;
 
 // Re-export configuration types

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -47,6 +47,16 @@ fn iceberg_scan_concurrency(num_files: usize) -> usize {
     cpus.min(num_files.max(1)).clamp(1, 8)
 }
 
+/// Stable hash of a graph source's raw config JSON. Keys the process-wide REST
+/// catalog client cache, so a rotated PAT (or any config change) yields a new
+/// fingerprint and a freshly built client.
+fn config_fingerprint(config: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    config.hash(&mut h);
+    h.finish()
+}
+
 /// Translate resolved scan filters into an Iceberg pushdown `Expression` for
 /// file pruning. Filters on unknown columns are skipped; an empty result is
 /// `None`. Conservative — pruning never drops matching rows because the
@@ -667,74 +677,106 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                 auth,
                 ..
             } => {
-                // One REST client per source for the whole query: its OAuth
-                // `CachedToken` then services every scan from a single token
-                // exchange instead of one fresh provider + token per scan.
-                let catalog = self.session.rest_client_or_build(graph_source_id, || {
-                    let auth_provider = auth.create_provider_arc().map_err(|e| {
-                        QueryError::Internal(format!("Failed to create auth provider: {e}"))
-                    })?;
-                    let catalog_config = RestCatalogConfig {
-                        uri: uri.clone(),
-                        warehouse: warehouse.clone(),
-                        ..Default::default()
-                    };
-                    RestCatalogClient::new(catalog_config, auth_provider).map_err(|e| {
-                        QueryError::Internal(format!("Failed to create catalog client: {e}"))
-                    })
-                })?;
+                let cache = self.fluree.r2rml_cache();
 
-                // Query-scoped `loadTable` cache: the first scan of a table does
-                // the REST round-trip (one `GET /tables/<t>` + OAuth); later scans
-                // of the same table reuse the pinned snapshot + vended creds.
+                // Process-wide REST client keyed by the source config fingerprint:
+                // its OAuth `CachedToken` and HTTPS connection pool are reused
+                // across queries, so a warm server does one token exchange per
+                // ~hour instead of one per query. The fingerprint hashes the full
+                // source config, so a rotated PAT (or any config change) builds a
+                // fresh client.
+                let client_fp = format!(
+                    "{graph_source_id}\u{1f}{:016x}",
+                    config_fingerprint(&record.config)
+                );
+                let catalog = match cache.rest_client(&client_fp) {
+                    Some(c) => c,
+                    None => {
+                        let auth_provider = auth.create_provider_arc().map_err(|e| {
+                            QueryError::Internal(format!("Failed to create auth provider: {e}"))
+                        })?;
+                        let catalog_config = RestCatalogConfig {
+                            uri: uri.clone(),
+                            warehouse: warehouse.clone(),
+                            ..Default::default()
+                        };
+                        let client = Arc::new(
+                            RestCatalogClient::new(catalog_config, auth_provider).map_err(|e| {
+                                QueryError::Internal(format!(
+                                    "Failed to create catalog client: {e}"
+                                ))
+                            })?,
+                        );
+                        cache.put_rest_client(client_fp, Arc::clone(&client));
+                        client
+                    }
+                };
+
                 let lt_key = super::catalog_session::IcebergCatalogSession::load_table_key(
                     graph_source_id,
                     &table_id.namespace,
                     &table_id.table,
                 );
+
+                // Resolve `loadTable`, cheapest first: (1) the per-query pin (one
+                // snapshot for the whole query); (2) the cross-query cache (skips
+                // the ~1.3–3s catalog GET, TTL + creds gated); (3) a real REST
+                // load, which populates both caches.
                 let load_response = if let Some(cached) = self.session.cached_load_table(&lt_key) {
-                    debug!(
-                        catalog_uri = %uri,
-                        namespace = %table_id.namespace,
-                        table = %table_id.table,
-                        "REST loadTable cache hit (query-scoped)"
-                    );
+                    debug!(namespace = %table_id.namespace, table = %table_id.table,
+                        "loadTable pin hit (query-scoped)");
                     cached
                 } else {
-                    info!(
-                        catalog_uri = %uri,
-                        namespace = %table_id.namespace,
-                        table = %table_id.table,
-                        "Loading table from REST catalog"
-                    );
-                    let mut resp = catalog
-                        .load_table(&table_id, iceberg_config.io.vended_credentials)
-                        .await
-                        .map_err(|e| {
-                            QueryError::Internal(format!("Failed to load table from catalog: {e}"))
-                        })?;
-                    // If this table was already loaded earlier in the query, only
-                    // the (expired) vended credentials needed refreshing — keep the
-                    // originally pinned metadata_location so a mid-query table
-                    // commit cannot shift this query onto a newer Iceberg snapshot.
-                    // Vended creds are bucket/prefix-scoped, so the fresh creds
-                    // still read the pinned snapshot's immutable data files.
-                    if let Some(pinned) = self.session.pinned_metadata_location(&lt_key) {
-                        if pinned != resp.metadata_location {
-                            debug!(
-                                pinned = %pinned,
-                                reloaded = %resp.metadata_location,
-                                "Refreshed vended credentials; keeping the query's pinned snapshot"
-                            );
-                            resp.metadata_location = pinned;
+                    let pinned = self.session.pinned_metadata_location(&lt_key);
+                    // A cross-query hit applies only on the FIRST resolution of
+                    // this table in the query. Once pinned, a reload is a creds
+                    // refresh that must keep the pinned snapshot.
+                    let cross_query = if pinned.is_none() {
+                        cache.get_rest_load_table(&lt_key)
+                    } else {
+                        None
+                    };
+                    let resp = if let Some(cq) = cross_query {
+                        debug!(namespace = %table_id.namespace, table = %table_id.table,
+                            "loadTable cache hit (cross-query)");
+                        cq.to_response()
+                    } else {
+                        info!(catalog_uri = %uri, namespace = %table_id.namespace,
+                            table = %table_id.table, "Loading table from REST catalog");
+                        let actual = catalog
+                            .load_table(&table_id, iceberg_config.io.vended_credentials)
+                            .await
+                            .map_err(|e| {
+                                QueryError::Internal(format!(
+                                    "Failed to load table from catalog: {e}"
+                                ))
+                            })?;
+                        // The cross-query cache reflects the CURRENT catalog state
+                        // (never this query's pin), so other queries see the newest
+                        // snapshot within the TTL.
+                        cache.put_rest_load_table(
+                            lt_key.clone(),
+                            Arc::new(super::catalog_session::CachedLoadTable::from_response(
+                                &actual,
+                            )),
+                        );
+                        // This query keeps its pinned snapshot across a creds
+                        // refresh: vended creds are bucket/prefix-scoped, so the
+                        // fresh creds still read the pinned snapshot's immutable
+                        // data files.
+                        let mut r = actual;
+                        if let Some(ref pinned_loc) = pinned {
+                            if *pinned_loc != r.metadata_location {
+                                debug!(pinned = %pinned_loc, reloaded = %r.metadata_location,
+                                    "Refreshed vended credentials; keeping the query's pinned snapshot");
+                                r.metadata_location = pinned_loc.clone();
+                            }
                         }
-                    }
+                        info!(metadata_location = %r.metadata_location,
+                            has_credentials = r.credentials.is_some(), "Loaded table metadata location");
+                        r
+                    };
                     self.session.store_load_table(lt_key, &resp);
-                    info!(
-                        metadata_location = %resp.metadata_location,
-                        has_credentials = resp.credentials.is_some(),
-                        "Loaded table metadata location"
-                    );
                     resp
                 };
 

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -707,12 +707,28 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                         table = %table_id.table,
                         "Loading table from REST catalog"
                     );
-                    let resp = catalog
+                    let mut resp = catalog
                         .load_table(&table_id, iceberg_config.io.vended_credentials)
                         .await
                         .map_err(|e| {
                             QueryError::Internal(format!("Failed to load table from catalog: {e}"))
                         })?;
+                    // If this table was already loaded earlier in the query, only
+                    // the (expired) vended credentials needed refreshing — keep the
+                    // originally pinned metadata_location so a mid-query table
+                    // commit cannot shift this query onto a newer Iceberg snapshot.
+                    // Vended creds are bucket/prefix-scoped, so the fresh creds
+                    // still read the pinned snapshot's immutable data files.
+                    if let Some(pinned) = self.session.pinned_metadata_location(&lt_key) {
+                        if pinned != resp.metadata_location {
+                            debug!(
+                                pinned = %pinned,
+                                reloaded = %resp.metadata_location,
+                                "Refreshed vended credentials; keeping the query's pinned snapshot"
+                            );
+                            resp.metadata_location = pinned;
+                        }
+                    }
                     self.session.store_load_table(lt_key, &resp);
                     info!(
                         metadata_location = %resp.metadata_location,

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -48,8 +48,12 @@ fn iceberg_scan_concurrency(num_files: usize) -> usize {
 }
 
 /// Stable hash of a graph source's raw config JSON. Keys the process-wide REST
-/// catalog client cache, so a rotated PAT (or any config change) yields a new
-/// fingerprint and a freshly built client.
+/// catalog client cache. A config *edit* (including a secret written inline)
+/// yields a new fingerprint and a freshly built client. Note this hashes the raw
+/// JSON only: a secret referenced by env var / secret store is stored as that
+/// reference, so rotating the underlying secret leaves the fingerprint unchanged
+/// — the client cache's TTL (see `cache::DEFAULT_REST_CLIENT_TTL_SECS`), not this
+/// fingerprint, is what bounds staleness in that case.
 fn config_fingerprint(config: &str) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();
@@ -736,7 +740,7 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                     } else {
                         None
                     };
-                    let resp = if let Some(cq) = cross_query {
+                    let mut resp = if let Some(cq) = cross_query {
                         debug!(namespace = %table_id.namespace, table = %table_id.table,
                             "loadTable cache hit (cross-query)");
                         cq.to_response()
@@ -776,7 +780,18 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                             has_credentials = r.credentials.is_some(), "Loaded table metadata location");
                         r
                     };
-                    self.session.store_load_table(lt_key, &resp);
+                    self.session.store_load_table(lt_key.clone(), &resp);
+                    // Converge on the pinned snapshot. `store_load_table` keeps the
+                    // first writer's `metadata_location`, so if a concurrent first
+                    // load of this table pinned a different location between our
+                    // pin check above and this store, adopt the winning pin rather
+                    // than scan our own freshly loaded location — otherwise two
+                    // scans in one query could read different snapshots
+                    // (fluree/db#1406 review). Sequential execution makes this a
+                    // no-op; it holds the invariant unconditionally.
+                    if let Some(pinned_loc) = self.session.pinned_metadata_location(&lt_key) {
+                        resp.metadata_location = pinned_loc;
+                    }
                     resp
                 };
 

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -399,12 +399,20 @@ impl crate::Fluree {
 /// ```
 pub struct FlureeR2rmlProvider<'a> {
     fluree: &'a crate::Fluree,
+    /// Query-scoped catalog state. The provider is constructed once per query, so
+    /// this caches the REST client (OAuth token) and `loadTable` responses for
+    /// the lifetime of one query — collapsing the per-scan REST round-trip storm
+    /// and pinning a single Iceberg snapshot across the query.
+    session: std::sync::Arc<super::catalog_session::IcebergCatalogSession>,
 }
 
 impl<'a> FlureeR2rmlProvider<'a> {
     /// Create a new R2RML provider wrapping a Fluree instance.
     pub fn new(fluree: &'a crate::Fluree) -> Self {
-        Self { fluree }
+        Self {
+            fluree,
+            session: std::sync::Arc::new(super::catalog_session::IcebergCatalogSession::default()),
+        }
     }
 }
 
@@ -659,40 +667,60 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                 auth,
                 ..
             } => {
-                info!(
-                    catalog_uri = %uri,
-                    namespace = %table_id.namespace,
-                    table = %table_id.table,
-                    "Loading table from REST catalog"
-                );
-
-                let auth_provider = auth.create_provider_arc().map_err(|e| {
-                    QueryError::Internal(format!("Failed to create auth provider: {e}"))
-                })?;
-
-                let catalog_config = RestCatalogConfig {
-                    uri: uri.clone(),
-                    warehouse: warehouse.clone(),
-                    ..Default::default()
-                };
-
-                let catalog =
+                // One REST client per source for the whole query: its OAuth
+                // `CachedToken` then services every scan from a single token
+                // exchange instead of one fresh provider + token per scan.
+                let catalog = self.session.rest_client_or_build(graph_source_id, || {
+                    let auth_provider = auth.create_provider_arc().map_err(|e| {
+                        QueryError::Internal(format!("Failed to create auth provider: {e}"))
+                    })?;
+                    let catalog_config = RestCatalogConfig {
+                        uri: uri.clone(),
+                        warehouse: warehouse.clone(),
+                        ..Default::default()
+                    };
                     RestCatalogClient::new(catalog_config, auth_provider).map_err(|e| {
                         QueryError::Internal(format!("Failed to create catalog client: {e}"))
-                    })?;
+                    })
+                })?;
 
-                let load_response = catalog
-                    .load_table(&table_id, iceberg_config.io.vended_credentials)
-                    .await
-                    .map_err(|e| {
-                        QueryError::Internal(format!("Failed to load table from catalog: {e}"))
-                    })?;
-
-                info!(
-                    metadata_location = %load_response.metadata_location,
-                    has_credentials = load_response.credentials.is_some(),
-                    "Loaded table metadata location"
+                // Query-scoped `loadTable` cache: the first scan of a table does
+                // the REST round-trip (one `GET /tables/<t>` + OAuth); later scans
+                // of the same table reuse the pinned snapshot + vended creds.
+                let lt_key = super::catalog_session::IcebergCatalogSession::load_table_key(
+                    graph_source_id,
+                    &table_id.namespace,
+                    &table_id.table,
                 );
+                let load_response = if let Some(cached) = self.session.cached_load_table(&lt_key) {
+                    debug!(
+                        catalog_uri = %uri,
+                        namespace = %table_id.namespace,
+                        table = %table_id.table,
+                        "REST loadTable cache hit (query-scoped)"
+                    );
+                    cached
+                } else {
+                    info!(
+                        catalog_uri = %uri,
+                        namespace = %table_id.namespace,
+                        table = %table_id.table,
+                        "Loading table from REST catalog"
+                    );
+                    let resp = catalog
+                        .load_table(&table_id, iceberg_config.io.vended_credentials)
+                        .await
+                        .map_err(|e| {
+                            QueryError::Internal(format!("Failed to load table from catalog: {e}"))
+                        })?;
+                    self.session.store_load_table(lt_key, &resp);
+                    info!(
+                        metadata_location = %resp.metadata_location,
+                        has_credentials = resp.credentials.is_some(),
+                        "Loaded table metadata location"
+                    );
+                    resp
+                };
 
                 let storage = if let Some(ref credentials) = load_response.credentials {
                     info!(

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -3210,3 +3210,163 @@ async fn guard_inner_scan_reused_across_child_batches() {
     );
     assert_eq!(rows, 2500, "every store row joins to a geography");
 }
+
+/// `dw.store` streamed as `n_chunks` batches of `per_chunk` rows, so a scan's
+/// consumption is observable at batch granularity.
+fn store_chunks(n_chunks: usize, per_chunk: usize) -> Vec<ColumnBatch> {
+    (0..n_chunks)
+        .map(|c| {
+            let base = (c * per_chunk) as i64;
+            let keys: Vec<Option<i64>> =
+                (0..per_chunk as i64).map(|i| Some(base + i + 1)).collect();
+            let ids: Vec<Option<String>> = (0..per_chunk)
+                .map(|i| Some(format!("STORE-{}", base as usize + i + 1)))
+                .collect();
+            batch_from(vec![
+                (
+                    FieldInfo {
+                        name: "store_key".to_string(),
+                        field_type: FieldType::Int64,
+                        nullable: false,
+                        field_id: 1,
+                    },
+                    Column::Int64(keys),
+                ),
+                (
+                    FieldInfo {
+                        name: "store_id".to_string(),
+                        field_type: FieldType::String,
+                        nullable: true,
+                        field_id: 2,
+                    },
+                    Column::String(ids),
+                ),
+            ])
+        })
+        .collect()
+}
+
+/// Provider that streams pre-chunked batches and counts how many are pulled, so a
+/// test can prove a `LIMIT` stops the scan early instead of draining the table.
+#[derive(Debug)]
+struct LimitProbeProvider {
+    mapping: Arc<CompiledR2rmlMapping>,
+    chunks: Vec<ColumnBatch>,
+    polls: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[async_trait]
+impl R2rmlProvider for LimitProbeProvider {
+    async fn has_r2rml_mapping(&self, graph_source_id: &str) -> bool {
+        graph_source_id == "edw-gs:main"
+    }
+    async fn compiled_mapping(
+        &self,
+        _graph_source_id: &str,
+        _as_of_t: Option<i64>,
+    ) -> QueryResult<Arc<CompiledR2rmlMapping>> {
+        Ok(Arc::clone(&self.mapping))
+    }
+}
+
+#[async_trait]
+impl R2rmlTableProvider for LimitProbeProvider {
+    async fn scan_table(
+        &self,
+        _graph_source_id: &str,
+        _table_name: &str,
+        _projection: &[String],
+        _filters: &[ScanFilter],
+        _as_of_t: Option<i64>,
+    ) -> QueryResult<ColumnBatchStream> {
+        use futures::StreamExt;
+        let polls = Arc::clone(&self.polls);
+        Ok(Box::pin(futures::stream::iter(self.chunks.clone()).map(
+            move |b| {
+                polls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(b)
+            },
+        )))
+    }
+}
+
+async fn run_store_probe(
+    provider: &LimitProbeProvider,
+    ledger: &support::MemoryLedger,
+    vars: &VarRegistry,
+    inner: Vec<Pattern>,
+    select: Vec<VarId>,
+    limit: Option<usize>,
+) -> usize {
+    let graph = Pattern::Graph {
+        name: GraphName::Iri("edw-gs:main".into()),
+        patterns: inner,
+    };
+    let mut parsed = Query::new(ParsedContext::default());
+    parsed.patterns = vec![graph];
+    parsed.output = QueryOutput::select_all(select);
+    parsed.limit = limit;
+    let executable = ExecutableQuery::simple(parsed);
+    let tracker = Tracker::disabled();
+    let result = execute(
+        GraphDbRef::new(&ledger.snapshot, 0, &NoOverlay, ledger.t()),
+        vars,
+        &executable,
+        r2rml_test_config(&tracker, provider),
+    )
+    .await
+    .expect("store probe query should execute");
+    result.iter().fold(0, |acc, b| acc + b.len())
+}
+
+/// 4a: a `LIMIT n` above the scan must terminate it early. Store is streamed as 40
+/// chunks of 50 rows (2000); `LIMIT 5` must stop after ~one chunk, while the same
+/// query without a LIMIT drains all 40 — proving the row budget reaches the scan
+/// (through Project) and caps its work.
+#[tokio::test]
+async fn guard_limit_terminates_scan_early() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let (_fluree, ledger) = edw_guard_ledger();
+    let mut vars = VarRegistry::new();
+    let s = vars.get_or_insert("?s");
+    let id = vars.get_or_insert("?id");
+    let p_id = ledger
+        .snapshot
+        .encode_iri("http://example.org/storeId")
+        .unwrap();
+    let inner = || {
+        vec![
+            type_triple(s, "http://example.org/Store"),
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(s),
+                Ref::Sid(p_id.clone()),
+                Term::Var(id),
+            )),
+        ]
+    };
+
+    let limited = LimitProbeProvider {
+        mapping: Arc::new(edw_guard_mapping()),
+        chunks: store_chunks(40, 50),
+        polls: Arc::new(AtomicUsize::new(0)),
+    };
+    let rows = run_store_probe(&limited, &ledger, &vars, inner(), vec![s, id], Some(5)).await;
+    let limited_polls = limited.polls.load(Ordering::SeqCst);
+    assert_eq!(rows, 5, "LIMIT 5 returns exactly 5 rows");
+    assert!(
+        limited_polls <= 2,
+        "LIMIT 5 must stop after ~one chunk, pulled {limited_polls} of 40"
+    );
+
+    let full = LimitProbeProvider {
+        mapping: Arc::new(edw_guard_mapping()),
+        chunks: store_chunks(40, 50),
+        polls: Arc::new(AtomicUsize::new(0)),
+    };
+    let _ = run_store_probe(&full, &ledger, &vars, inner(), vec![s, id], None).await;
+    assert_eq!(
+        full.polls.load(Ordering::SeqCst),
+        40,
+        "without a LIMIT the whole table streams"
+    );
+}

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -1137,6 +1137,187 @@ async fn engine_e2e_graph_pattern_r2rml_scan() {
     );
 }
 
+/// Regression (fluree/db#1406 review): a class and a predicate that live in
+/// SEPARATE TriplesMaps sharing a subject template must NOT be fused. Fusing the
+/// class into the predicate star would make TriplesMap resolution require one map
+/// with both the class and the predicate; the split mapping has none, so a fused
+/// scan resolves zero maps and silently returns no rows. The rewrite must instead
+/// leave the class as its own subject-only scan and join it with the predicate
+/// scan on the shared subject.
+#[tokio::test]
+async fn engine_e2e_split_triples_map_class_and_predicate_not_fused() {
+    /// Returns different batches per logical table so the two TriplesMaps back
+    /// distinct data (unlike `MockR2rmlProvider`, which serves one batch set).
+    #[derive(Debug)]
+    struct SplitTableProvider {
+        mapping: Arc<CompiledR2rmlMapping>,
+        people: Vec<ColumnBatch>,
+        names: Vec<ColumnBatch>,
+    }
+
+    #[async_trait]
+    impl R2rmlProvider for SplitTableProvider {
+        async fn has_r2rml_mapping(&self, _gs: &str) -> bool {
+            true
+        }
+        async fn compiled_mapping(
+            &self,
+            _gs: &str,
+            _t: Option<i64>,
+        ) -> QueryResult<Arc<CompiledR2rmlMapping>> {
+            Ok(Arc::clone(&self.mapping))
+        }
+    }
+
+    #[async_trait]
+    impl R2rmlTableProvider for SplitTableProvider {
+        async fn scan_table(
+            &self,
+            _gs: &str,
+            table: &str,
+            _p: &[String],
+            _f: &[ScanFilter],
+            _t: Option<i64>,
+        ) -> QueryResult<ColumnBatchStream> {
+            let batches = if table == "names" {
+                self.names.clone()
+            } else {
+                self.people.clone()
+            };
+            Ok(vec_batch_stream(batches))
+        }
+    }
+
+    const SPLIT_MAPPING_TTL: &str = r#"
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix ex: <http://example.org/> .
+
+<http://example.org/mapping#PersonClass> a rr:TriplesMap ;
+    rr:logicalTable [ rr:tableName "people" ] ;
+    rr:subjectMap [
+        rr:template "http://example.org/person/{id}" ;
+        rr:class ex:Person
+    ] .
+
+<http://example.org/mapping#PersonName> a rr:TriplesMap ;
+    rr:logicalTable [ rr:tableName "names" ] ;
+    rr:subjectMap [ rr:template "http://example.org/person/{id}" ] ;
+    rr:predicateObjectMap [
+        rr:predicate ex:name ;
+        rr:objectMap [ rr:column "name" ]
+    ] .
+"#;
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let mut ledger = genesis_ledger(&fluree, "r2rml-split:main");
+    std::sync::Arc::make_mut(&mut ledger.snapshot)
+        .insert_namespace_code(9_999, "http://example.org/".to_string())
+        .unwrap();
+
+    let mapping = R2rmlLoader::from_turtle(SPLIT_MAPPING_TTL)
+        .expect("parse split mapping")
+        .compile()
+        .expect("compile split mapping");
+
+    // people (class table): subject id only.
+    let people_schema = BatchSchema::new(vec![FieldInfo {
+        name: "id".to_string(),
+        field_type: FieldType::Int64,
+        nullable: false,
+        field_id: 1,
+    }]);
+    let people = ColumnBatch::new(
+        Arc::new(people_schema),
+        vec![Column::Int64(vec![Some(1), Some(2)])],
+    )
+    .unwrap();
+
+    // names (predicate table): same subjects, plus the name column.
+    let names_schema = BatchSchema::new(vec![
+        FieldInfo {
+            name: "id".to_string(),
+            field_type: FieldType::Int64,
+            nullable: false,
+            field_id: 1,
+        },
+        FieldInfo {
+            name: "name".to_string(),
+            field_type: FieldType::String,
+            nullable: true,
+            field_id: 2,
+        },
+    ]);
+    let names = ColumnBatch::new(
+        Arc::new(names_schema),
+        vec![
+            Column::Int64(vec![Some(1), Some(2)]),
+            Column::String(vec![Some("Alice".to_string()), Some("Bob".to_string())]),
+        ],
+    )
+    .unwrap();
+
+    let provider = SplitTableProvider {
+        mapping: Arc::new(mapping),
+        people: vec![people],
+        names: vec![names],
+    };
+
+    // SELECT ?s ?name WHERE { GRAPH <r2rml-split:main> { ?s a ex:Person ; ex:name ?name } }
+    let mut vars = VarRegistry::new();
+    let s = vars.get_or_insert("?s");
+    let name = vars.get_or_insert("?name");
+    let rdf_type = ledger
+        .snapshot
+        .encode_iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+        .expect("rdf:type encodable");
+    let person = ledger
+        .snapshot
+        .encode_iri("http://example.org/Person")
+        .expect("ex:Person encodable");
+    let ex_name = ledger
+        .snapshot
+        .encode_iri("http://example.org/name")
+        .expect("ex:name encodable");
+
+    let inner = vec![
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(s),
+            Ref::Sid(rdf_type),
+            Term::Sid(person),
+        )),
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(s),
+            Ref::Sid(ex_name),
+            Term::Var(name),
+        )),
+    ];
+    let graph_pattern = Pattern::Graph {
+        name: GraphName::Iri("r2rml-split:main".into()),
+        patterns: inner,
+    };
+    let mut parsed = Query::new(ParsedContext::default());
+    parsed.patterns = vec![graph_pattern];
+    parsed.output = QueryOutput::select_all(vec![s, name]);
+    let executable = ExecutableQuery::simple(parsed);
+    let tracker = Tracker::disabled();
+
+    let batches = execute(
+        GraphDbRef::new(&ledger.snapshot, 0, &NoOverlay, ledger.t()),
+        &vars,
+        &executable,
+        r2rml_test_config(&tracker, &provider),
+    )
+    .await
+    .expect("split-TriplesMap query should execute");
+
+    let total_rows: usize = batches.iter().map(fluree_db_api::Batch::len).sum();
+    assert_eq!(
+        total_rows, 2,
+        "class and predicate in separate TriplesMaps must join to 2 rows, not silently \
+         collapse to 0 via unsafe fusion; got {total_rows}"
+    );
+}
+
 /// Engine-level E2E test: Verify R2RML provider is consulted for GRAPH patterns.
 ///
 /// This test uses a custom provider that tracks method calls to verify

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -2673,3 +2673,416 @@ async fn fused_fallback_applies_offset_once() {
         "3 groups with OFFSET 1 must yield 2 rows (offset applied once, not twice)"
     );
 }
+
+// =============================================================================
+// Scan-plan guardrails: rdf:type / class-pattern over-scan (Issue 1)
+// =============================================================================
+//
+// These lock the class/star planning behavior so future changes cannot
+// reintroduce the over-scan that made a 2-attribute query issue 6 Iceberg
+// scans (DIM_STORE ×4 + two unreferenced parent tables) against live Snowflake.
+//
+// Fixture: a 3-TriplesMap star schema where `ex:name` is shared by two maps
+// (Store and Employee) — the predicate fan-out that caused unrelated dimension
+// tables to be scanned — and Store has a RefObjectMap to Geography, so we can
+// assert parents are pruned for unreferenced predicates yet kept for referenced
+// ones (R2RML dangling-FK semantics are not weakened).
+
+const EDW_GUARD_MAPPING_TTL: &str = r#"
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix ex: <http://example.org/> .
+
+<http://example.org/mapping#Store> a rr:TriplesMap ;
+    rr:logicalTable [ rr:tableName "dw.store" ] ;
+    rr:subjectMap [ rr:template "http://example.org/store/{store_key}" ; rr:class ex:Store ] ;
+    rr:predicateObjectMap [ rr:predicate ex:storeId ; rr:objectMap [ rr:column "store_id" ] ] ;
+    rr:predicateObjectMap [ rr:predicate ex:name ; rr:objectMap [ rr:column "store_name" ] ] ;
+    rr:predicateObjectMap [
+        rr:predicate ex:geography ;
+        rr:objectMap [
+            rr:parentTriplesMap <http://example.org/mapping#Geography> ;
+            rr:joinCondition [ rr:child "geo_key" ; rr:parent "geo_key" ]
+        ]
+    ] .
+
+<http://example.org/mapping#Geography> a rr:TriplesMap ;
+    rr:logicalTable [ rr:tableName "dw.geography" ] ;
+    rr:subjectMap [ rr:template "http://example.org/geo/{geo_key}" ; rr:class ex:Geography ] ;
+    rr:predicateObjectMap [ rr:predicate ex:city ; rr:objectMap [ rr:column "city" ] ] ;
+    rr:predicateObjectMap [ rr:predicate ex:region ; rr:objectMap [ rr:column "region" ] ] .
+
+<http://example.org/mapping#Employee> a rr:TriplesMap ;
+    rr:logicalTable [ rr:tableName "dw.employee" ] ;
+    rr:subjectMap [ rr:template "http://example.org/emp/{emp_key}" ; rr:class ex:Employee ] ;
+    rr:predicateObjectMap [ rr:predicate ex:name ; rr:objectMap [ rr:column "emp_name" ] ] .
+"#;
+
+fn edw_guard_mapping() -> CompiledR2rmlMapping {
+    R2rmlLoader::from_turtle(EDW_GUARD_MAPPING_TTL)
+        .expect("parse EDW guard mapping")
+        .compile()
+        .expect("compile EDW guard mapping")
+}
+
+fn col_i64(name: &str, field_id: i32, vals: Vec<Option<i64>>) -> (FieldInfo, Column) {
+    (
+        FieldInfo {
+            name: name.to_string(),
+            field_type: FieldType::Int64,
+            nullable: false,
+            field_id,
+        },
+        Column::Int64(vals),
+    )
+}
+
+fn col_str(name: &str, field_id: i32, vals: &[&str]) -> (FieldInfo, Column) {
+    (
+        FieldInfo {
+            name: name.to_string(),
+            field_type: FieldType::String,
+            nullable: true,
+            field_id,
+        },
+        Column::String(vals.iter().map(|s| Some((*s).to_string())).collect()),
+    )
+}
+
+fn batch_from(parts: Vec<(FieldInfo, Column)>) -> ColumnBatch {
+    let (fields, cols): (Vec<_>, Vec<_>) = parts.into_iter().unzip();
+    ColumnBatch::new(Arc::new(BatchSchema::new(fields)), cols).unwrap()
+}
+
+fn edw_store_batch() -> ColumnBatch {
+    batch_from(vec![
+        col_i64("store_key", 1, vec![Some(1), Some(2)]),
+        col_str("store_id", 2, &["STORE-1", "STORE-2"]),
+        col_str("store_name", 3, &["Store One", "Store Two"]),
+        col_i64("geo_key", 4, vec![Some(10), Some(20)]),
+    ])
+}
+
+fn edw_geography_batch() -> ColumnBatch {
+    batch_from(vec![
+        col_i64("geo_key", 1, vec![Some(10), Some(20)]),
+        col_str("city", 2, &["Akron", "Boston"]),
+        col_str("region", 3, &["Midwest", "Northeast"]),
+    ])
+}
+
+fn edw_employee_batch() -> ColumnBatch {
+    batch_from(vec![
+        col_i64("emp_key", 1, vec![Some(100), Some(200)]),
+        col_str("emp_name", 2, &["Ann", "Bob"]),
+    ])
+}
+
+/// Provider that records every `scan_table` call by table name and returns the
+/// per-table fixture batch, so a test can assert exactly which tables a query
+/// shape touches.
+#[derive(Debug)]
+struct CountingProvider {
+    mapping: Arc<CompiledR2rmlMapping>,
+    batches_by_table: HashMap<String, Vec<ColumnBatch>>,
+    /// Every scan as `(table_name, sorted projection columns)`, in call order.
+    scans: Mutex<Vec<(String, Vec<String>)>>,
+}
+
+impl CountingProvider {
+    fn edw() -> Self {
+        let mut batches_by_table = HashMap::new();
+        batches_by_table.insert("dw.store".to_string(), vec![edw_store_batch()]);
+        batches_by_table.insert("dw.geography".to_string(), vec![edw_geography_batch()]);
+        batches_by_table.insert("dw.employee".to_string(), vec![edw_employee_batch()]);
+        Self {
+            mapping: Arc::new(edw_guard_mapping()),
+            batches_by_table,
+            scans: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Scan count per table name across the whole query.
+    fn scan_counts(&self) -> HashMap<String, usize> {
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for (t, _) in self.scans.lock().unwrap().iter() {
+            *counts.entry(t.clone()).or_default() += 1;
+        }
+        counts
+    }
+
+    /// Sorted projection columns of the FIRST scan of `table` (every scan of a
+    /// given table in these fixtures uses the same projection). Panics if the
+    /// table was never scanned, so callers assert the scan happened first.
+    fn projection_of(&self, table: &str) -> Vec<String> {
+        self.scans
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(t, _)| t == table)
+            .unwrap_or_else(|| panic!("table {table} was never scanned"))
+            .1
+            .clone()
+    }
+}
+
+#[async_trait]
+impl R2rmlProvider for CountingProvider {
+    async fn has_r2rml_mapping(&self, graph_source_id: &str) -> bool {
+        graph_source_id == "edw-gs:main"
+    }
+
+    async fn compiled_mapping(
+        &self,
+        _graph_source_id: &str,
+        _as_of_t: Option<i64>,
+    ) -> QueryResult<Arc<CompiledR2rmlMapping>> {
+        Ok(Arc::clone(&self.mapping))
+    }
+}
+
+#[async_trait]
+impl R2rmlTableProvider for CountingProvider {
+    async fn scan_table(
+        &self,
+        _graph_source_id: &str,
+        table_name: &str,
+        projection: &[String],
+        _filters: &[ScanFilter],
+        _as_of_t: Option<i64>,
+    ) -> QueryResult<ColumnBatchStream> {
+        let mut proj = projection.to_vec();
+        proj.sort();
+        self.scans
+            .lock()
+            .unwrap()
+            .push((table_name.to_string(), proj));
+        let batches = self
+            .batches_by_table
+            .get(table_name)
+            .cloned()
+            .unwrap_or_default();
+        Ok(vec_batch_stream(batches))
+    }
+}
+
+/// Build a memory ledger with the example.org namespace registered so subject
+/// templates and predicate IRIs encode/decode cleanly.
+fn edw_guard_ledger() -> (support::MemoryFluree, support::MemoryLedger) {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let mut ledger = genesis_ledger(&fluree, "edw-guard:main");
+    std::sync::Arc::make_mut(&mut ledger.snapshot)
+        .insert_namespace_code(9_999, "http://example.org/".to_string())
+        .unwrap();
+    (fluree, ledger)
+}
+
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+/// `?s a ex:<Class>` triple (class as a constant IRI, no object var).
+fn type_triple(subject: VarId, class_iri: &str) -> Pattern {
+    Pattern::Triple(TriplePattern::new(
+        Ref::Var(subject),
+        Ref::Iri(RDF_TYPE.into()),
+        Term::Iri(class_iri.into()),
+    ))
+}
+
+/// Run a GRAPH query against the `edw-gs:main` graph source and return the
+/// per-table scan counts plus the produced row total.
+async fn run_edw_guard(
+    provider: &CountingProvider,
+    ledger: &support::MemoryLedger,
+    vars: &VarRegistry,
+    inner: Vec<Pattern>,
+    select: Vec<VarId>,
+) -> (HashMap<String, usize>, usize) {
+    let graph = Pattern::Graph {
+        name: GraphName::Iri("edw-gs:main".into()),
+        patterns: inner,
+    };
+    let mut parsed = Query::new(ParsedContext::default());
+    parsed.patterns = vec![graph];
+    parsed.output = QueryOutput::select_all(select);
+    let executable = ExecutableQuery::simple(parsed);
+    let tracker = Tracker::disabled();
+    let result = execute(
+        GraphDbRef::new(&ledger.snapshot, 0, &NoOverlay, ledger.t()),
+        vars,
+        &executable,
+        r2rml_test_config(&tracker, provider),
+    )
+    .await
+    .expect("EDW guard query should execute");
+    let rows = result.iter().fold(0, |acc, b| acc + b.len());
+    (provider.scan_counts(), rows)
+}
+
+/// `?s a ex:Store ; ex:storeId ?id ; ex:name ?name` must scan ONLY dw.store,
+/// exactly once: the class fuses into the same-subject star (no separate class
+/// scan, no per-batch re-scan), the shared `ex:name` predicate does NOT fan out
+/// to dw.employee, and the unreferenced `ex:geography` parent is not scanned.
+#[tokio::test]
+async fn guard_class_star_scans_only_store_once() {
+    let provider = CountingProvider::edw();
+    let (_fluree, ledger) = edw_guard_ledger();
+    let mut vars = VarRegistry::new();
+    let s = vars.get_or_insert("?s");
+    let id = vars.get_or_insert("?id");
+    let name = vars.get_or_insert("?name");
+    let p_store_id = ledger
+        .snapshot
+        .encode_iri("http://example.org/storeId")
+        .unwrap();
+    let p_name = ledger
+        .snapshot
+        .encode_iri("http://example.org/name")
+        .unwrap();
+
+    let inner = vec![
+        type_triple(s, "http://example.org/Store"),
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(s),
+            Ref::Sid(p_store_id),
+            Term::Var(id),
+        )),
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(s),
+            Ref::Sid(p_name),
+            Term::Var(name),
+        )),
+    ];
+    let (counts, rows) = run_edw_guard(&provider, &ledger, &vars, inner, vec![s, id, name]).await;
+
+    assert_eq!(
+        counts.get("dw.store").copied(),
+        Some(1),
+        "Store must be scanned exactly once (class fused into star), got {counts:?}"
+    );
+    assert_eq!(
+        counts.get("dw.employee"),
+        None,
+        "shared ex:name must NOT fan out to dw.employee, got {counts:?}"
+    );
+    assert_eq!(
+        counts.get("dw.geography"),
+        None,
+        "unreferenced ex:geography parent must NOT be scanned, got {counts:?}"
+    );
+    // Fix A under fusion: the star projects exactly the subject key + the two
+    // queried predicate columns — NOT geo_key (the unreferenced RefObjectMap FK
+    // that the old `columns_for_predicate(None)` would have pulled in).
+    assert_eq!(
+        provider.projection_of("dw.store"),
+        vec![
+            "store_id".to_string(),
+            "store_key".to_string(),
+            "store_name".to_string()
+        ],
+        "fused star must project only subject key + storeId + name"
+    );
+    assert_eq!(rows, 2, "two store rows expected");
+}
+
+/// `?s a ex:Store` alone must scan ONLY dw.store once (subject-only): no POMs,
+/// no RefObjectMap parent, and the class filter keeps it off Employee/Geography.
+#[tokio::test]
+async fn guard_subject_only_type_pattern_scans_no_parents() {
+    let provider = CountingProvider::edw();
+    let (_fluree, ledger) = edw_guard_ledger();
+    let mut vars = VarRegistry::new();
+    let s = vars.get_or_insert("?s");
+
+    let inner = vec![type_triple(s, "http://example.org/Store")];
+    let (counts, rows) = run_edw_guard(&provider, &ledger, &vars, inner, vec![s]).await;
+
+    assert_eq!(counts.get("dw.store").copied(), Some(1), "got {counts:?}");
+    assert_eq!(
+        counts.len(),
+        1,
+        "subject-only type pattern scans only its own table, got {counts:?}"
+    );
+    // Fix A: a subject-only pattern projects ONLY the subject template column,
+    // never any POM/FK column. A regression to projecting all POMs would add
+    // store_id/store_name/geo_key here and this would catch it.
+    assert_eq!(
+        provider.projection_of("dw.store"),
+        vec!["store_key".to_string()],
+        "subject-only type pattern must project only the subject key column"
+    );
+    assert_eq!(rows, 2, "two store subjects expected");
+}
+
+/// A referenced RefObjectMap predicate keeps its parent scan: `?s a ex:Store ;
+/// ex:geography ?g` MUST still scan dw.geography (dangling-FK semantics are not
+/// weakened — Fixes A/B only prune parents for UNreferenced predicates).
+#[tokio::test]
+async fn guard_referenced_refobjectmap_still_scans_parent() {
+    let provider = CountingProvider::edw();
+    let (_fluree, ledger) = edw_guard_ledger();
+    let mut vars = VarRegistry::new();
+    let s = vars.get_or_insert("?s");
+    let g = vars.get_or_insert("?g");
+    let p_geo = ledger
+        .snapshot
+        .encode_iri("http://example.org/geography")
+        .unwrap();
+
+    let inner = vec![
+        type_triple(s, "http://example.org/Store"),
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(s),
+            Ref::Sid(p_geo),
+            Term::Var(g),
+        )),
+    ];
+    let (counts, rows) = run_edw_guard(&provider, &ledger, &vars, inner, vec![s, g]).await;
+
+    // This shape is now optimal: one scan of the base table and exactly one scan
+    // of the referenced parent (no per-batch parent re-scan). Lock the exact
+    // counts so a regression reintroducing parent re-scans is caught.
+    assert_eq!(
+        counts.get("dw.store").copied(),
+        Some(1),
+        "Store scanned exactly once, got {counts:?}"
+    );
+    assert_eq!(
+        counts.get("dw.geography").copied(),
+        Some(1),
+        "referenced ex:geography parent scanned exactly once, got {counts:?}"
+    );
+    assert_eq!(counts.get("dw.employee"), None, "got {counts:?}");
+    assert_eq!(rows, 2, "two store→geography joins expected");
+}
+
+/// A true wildcard `?s ?p ?o` is unchanged: it still materializes every
+/// TriplesMap and RefObjectMap parent (the all-POMs branch fires only for
+/// `object_var = Some`, which a wildcard is).
+#[tokio::test]
+async fn guard_wildcard_still_scans_all_maps() {
+    let provider = CountingProvider::edw();
+    let (_fluree, ledger) = edw_guard_ledger();
+    let mut vars = VarRegistry::new();
+    let s = vars.get_or_insert("?s");
+    let p = vars.get_or_insert("?p");
+    let o = vars.get_or_insert("?o");
+
+    let inner = vec![Pattern::Triple(TriplePattern::new(
+        Ref::Var(s),
+        Ref::Var(p),
+        Term::Var(o),
+    ))];
+    let (counts, _rows) = run_edw_guard(&provider, &ledger, &vars, inner, vec![s, p, o]).await;
+
+    assert!(
+        counts.contains_key("dw.store"),
+        "wildcard scans Store, got {counts:?}"
+    );
+    assert!(
+        counts.contains_key("dw.geography"),
+        "wildcard still materializes Geography (TM and/or parent), got {counts:?}"
+    );
+    assert!(
+        counts.contains_key("dw.employee"),
+        "wildcard still scans Employee, got {counts:?}"
+    );
+}

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -2790,8 +2790,14 @@ struct CountingProvider {
 
 impl CountingProvider {
     fn edw() -> Self {
+        Self::edw_with_stores(vec![edw_store_batch()])
+    }
+
+    /// Like [`Self::edw`] but with a caller-supplied `dw.store` scan (used to
+    /// drive a multi-batch outer for the inner-scan-reuse guardrail).
+    fn edw_with_stores(store: Vec<ColumnBatch>) -> Self {
         let mut batches_by_table = HashMap::new();
-        batches_by_table.insert("dw.store".to_string(), vec![edw_store_batch()]);
+        batches_by_table.insert("dw.store".to_string(), store);
         batches_by_table.insert("dw.geography".to_string(), vec![edw_geography_batch()]);
         batches_by_table.insert("dw.employee".to_string(), vec![edw_employee_batch()]);
         Self {
@@ -2808,6 +2814,18 @@ impl CountingProvider {
             *counts.entry(t.clone()).or_default() += 1;
         }
         counts
+    }
+
+    /// Count scans of `table` whose projection includes column `col` — used to
+    /// isolate a table's main scan (by a scalar column it projects) from an
+    /// unrelated RefObjectMap parent-lookup scan of the same table.
+    fn scans_projecting(&self, table: &str, col: &str) -> usize {
+        self.scans
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(t, proj)| t == table && proj.iter().any(|c| c == col))
+            .count()
     }
 
     /// Sorted projection columns of the FIRST scan of `table` (every scan of a
@@ -3085,4 +3103,110 @@ async fn guard_wildcard_still_scans_all_maps() {
         counts.contains_key("dw.employee"),
         "wildcard still scans Employee, got {counts:?}"
     );
+}
+
+/// `dw.store` scan with `n` rows, each pointing at geo_key 10 or 20 (both present
+/// in `edw_geography_batch`), so a `?store -> geography` join emits every row.
+fn edw_store_batch_n(n: usize) -> ColumnBatch {
+    let store_key: Vec<Option<i64>> = (1..=n as i64).map(Some).collect();
+    let ids: Vec<Option<String>> = (1..=n).map(|i| Some(format!("STORE-{i}"))).collect();
+    let names: Vec<Option<String>> = (1..=n).map(|i| Some(format!("Store {i}"))).collect();
+    let geo: Vec<Option<i64>> = (0..n)
+        .map(|i| Some(if i % 2 == 0 { 10 } else { 20 }))
+        .collect();
+    batch_from(vec![
+        (
+            FieldInfo {
+                name: "store_key".to_string(),
+                field_type: FieldType::Int64,
+                nullable: false,
+                field_id: 1,
+            },
+            Column::Int64(store_key),
+        ),
+        (
+            FieldInfo {
+                name: "store_id".to_string(),
+                field_type: FieldType::String,
+                nullable: true,
+                field_id: 2,
+            },
+            Column::String(ids),
+        ),
+        (
+            FieldInfo {
+                name: "store_name".to_string(),
+                field_type: FieldType::String,
+                nullable: true,
+                field_id: 3,
+            },
+            Column::String(names),
+        ),
+        (
+            FieldInfo {
+                name: "geo_key".to_string(),
+                field_type: FieldType::Int64,
+                nullable: false,
+                field_id: 4,
+            },
+            Column::Int64(geo),
+        ),
+    ])
+}
+
+/// Issue 3: a correlated join must scan the inner table's data ONCE, not once per
+/// child batch. With a 2500-row store outer (3 batches at the 1000-row default),
+/// the Geography star (`?g city ; region`) is driven by 3 child batches; the
+/// inner-scan cache must collapse its main scan to a single call. The scan is
+/// isolated from Store's separate geography parent-lookup (which projects
+/// `geo_key`, not `city`) by matching on the `city` column.
+#[tokio::test]
+async fn guard_inner_scan_reused_across_child_batches() {
+    let provider = CountingProvider::edw_with_stores(vec![edw_store_batch_n(2500)]);
+    let (_fluree, ledger) = edw_guard_ledger();
+    let mut vars = VarRegistry::new();
+    let s = vars.get_or_insert("?s");
+    let g = vars.get_or_insert("?g");
+    let c = vars.get_or_insert("?c");
+    let r = vars.get_or_insert("?r");
+    let p_geo = ledger
+        .snapshot
+        .encode_iri("http://example.org/geography")
+        .unwrap();
+    let p_city = ledger
+        .snapshot
+        .encode_iri("http://example.org/city")
+        .unwrap();
+    let p_region = ledger
+        .snapshot
+        .encode_iri("http://example.org/region")
+        .unwrap();
+
+    let inner = vec![
+        type_triple(s, "http://example.org/Store"),
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(s),
+            Ref::Sid(p_geo),
+            Term::Var(g),
+        )),
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(g),
+            Ref::Sid(p_city),
+            Term::Var(c),
+        )),
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(g),
+            Ref::Sid(p_region),
+            Term::Var(r),
+        )),
+    ];
+    let (_counts, rows) = run_edw_guard(&provider, &ledger, &vars, inner, vec![s, g, c, r]).await;
+
+    let geo_main_scans = provider.scans_projecting("dw.geography", "city");
+    assert_eq!(
+        geo_main_scans, 1,
+        "Geography main scan must be cached to 1 despite a multi-batch outer \
+         (would be one-per-child-batch without the cache)"
+    );
+    assert_eq!(rows, 2500, "every store row joins to a geography");
 }

--- a/fluree-db-iceberg/src/io/send_parquet.rs
+++ b/fluree-db-iceberg/src/io/send_parquet.rs
@@ -28,11 +28,14 @@ use crate::io::batch::ColumnBatch;
 use crate::io::chunk_reader::RangeBackedChunkReader;
 use crate::io::parquet::{
     build_batch_schema, build_batch_schema_with_iceberg, build_columns_from_values,
-    build_projected_schema, calculate_column_chunk_ranges, convert_field_to_column_value,
-    parse_parquet_metadata_from_bytes, ColumnValue, ParquetFooterCache, NULL_COLUMN_SENTINEL,
+    build_field_id_to_column_mapping, build_projected_schema, calculate_column_chunk_ranges,
+    convert_field_to_column_value, parse_parquet_metadata_from_bytes, ColumnValue,
+    ParquetFooterCache, NULL_COLUMN_SENTINEL,
 };
 use crate::io::SendIcebergStorage;
 use crate::metadata::Schema;
+use crate::scan::predicate::Expression;
+use crate::scan::pruning::row_group_can_contain;
 use crate::scan::FileScanTask;
 
 use parquet::file::metadata::ParquetMetaData;
@@ -41,6 +44,53 @@ use parquet::file::serialized_reader::SerializedFileReader;
 
 /// Parquet magic bytes (footer ends with "PAR1").
 const PARQUET_MAGIC: [u8; 4] = [b'P', b'A', b'R', b'1'];
+
+/// Whether row-group / row-level predicate pushdown is enabled. Read once from
+/// `FLUREE_ICEBERG_PREDICATE_PUSHDOWN` (only `0`/`false`/`off` disable it).
+fn predicate_pushdown_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(
+        || match std::env::var("FLUREE_ICEBERG_PREDICATE_PUSHDOWN") {
+            Ok(v) => !matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "0" | "false" | "off"
+            ),
+            Err(_) => true,
+        },
+    )
+}
+
+/// The row groups to decode: those whose column statistics do not rule out
+/// `residual`. Returns every row group (no pruning) when pushdown is disabled or
+/// there is no residual filter. Pruning is conservative — a row group is dropped
+/// only when its min/max bounds prove no row can match, so results are unchanged.
+fn surviving_row_groups(
+    metadata: &ParquetMetaData,
+    residual: Option<&Expression>,
+    iceberg_schema: Option<&Schema>,
+) -> Vec<usize> {
+    let n = metadata.num_row_groups();
+    let Some(expr) = residual.filter(|_| predicate_pushdown_enabled()) else {
+        return (0..n).collect();
+    };
+    let field_to_col =
+        build_field_id_to_column_mapping(metadata.file_metadata().schema(), iceberg_schema);
+    let mut keep = Vec::with_capacity(n);
+    for rg in 0..n {
+        if row_group_can_contain(expr, metadata.row_group(rg), &field_to_col) {
+            keep.push(rg);
+        }
+    }
+    let pruned = n - keep.len();
+    if pruned > 0 {
+        tracing::debug!(
+            row_groups_total = n,
+            row_groups_pruned = pruned,
+            "Row-group pruning skipped non-matching row groups"
+        );
+    }
+    keep
+}
 
 /// Maximum file size for sparse buffer allocation (64MB).
 ///
@@ -378,8 +428,16 @@ impl<'a, S: SendIcebergStorage> SendParquetReader<'a, S> {
 
         let mut batches = Vec::new();
 
-        // Process each row group separately to emit streaming batches
-        for rg_idx in 0..metadata.num_row_groups() {
+        // Row-group pruning: skip groups whose statistics rule out the residual
+        // filter (safe — bounds only exclude non-matching rows).
+        let surviving = surviving_row_groups(
+            metadata,
+            task.residual_filter.as_ref(),
+            task.iceberg_schema.as_deref(),
+        );
+
+        // Process each surviving row group separately to emit streaming batches
+        for rg_idx in surviving {
             let row_group_reader = reader.get_row_group(rg_idx).map_err(|e| {
                 IcebergError::Storage(format!("Failed to get row group {rg_idx}: {e}"))
             })?;
@@ -450,6 +508,7 @@ impl<'a, S: SendIcebergStorage> SendParquetReader<'a, S> {
         let path = task.data_file.file_path.clone();
         let file_size = task.data_file.file_size_in_bytes as u64;
         let projected_field_ids = task.projected_field_ids.clone();
+        let residual_filter = task.residual_filter.clone();
         let iceberg_schema = task.iceberg_schema.clone();
         let runtime = Handle::current();
 
@@ -467,6 +526,7 @@ impl<'a, S: SendIcebergStorage> SendParquetReader<'a, S> {
                     path,
                     file_size,
                     projected_field_ids,
+                    residual_filter,
                     iceberg_schema,
                     runtime,
                 )
@@ -501,6 +561,7 @@ impl<'a, S: SendIcebergStorage> SendParquetReader<'a, S> {
                         path,
                         file_size,
                         projected_field_ids,
+                        residual_filter,
                         iceberg_schema,
                         runtime,
                     )
@@ -516,6 +577,7 @@ impl<'a, S: SendIcebergStorage> SendParquetReader<'a, S> {
             path,
             file_size,
             projected_field_ids,
+            residual_filter,
             iceberg_schema,
             runtime,
         )
@@ -531,6 +593,7 @@ impl<'a, S: SendIcebergStorage> SendParquetReader<'a, S> {
         path: String,
         file_size: u64,
         projected_field_ids: Vec<i32>,
+        residual_filter: Option<Expression>,
         iceberg_schema: Option<Arc<Schema>>,
         runtime: Handle,
     ) -> Result<Vec<ColumnBatch>> {
@@ -582,8 +645,18 @@ impl<'a, S: SendIcebergStorage> SendParquetReader<'a, S> {
 
             let mut batches = Vec::new();
 
-            // Process each row group
-            for rg_idx in 0..metadata.num_row_groups() {
+            // Row-group pruning: skip groups whose statistics rule out the
+            // residual filter. For this range-backed reader, a skipped group's
+            // column chunks are never requested, so the on-demand reads are
+            // avoided too.
+            let surviving = surviving_row_groups(
+                metadata,
+                residual_filter.as_ref(),
+                iceberg_schema.as_deref(),
+            );
+
+            // Process each surviving row group
+            for rg_idx in surviving {
                 let row_group_reader = reader.get_row_group(rg_idx).map_err(|e| {
                     IcebergError::Storage(format!("Failed to get row group {rg_idx}: {e}"))
                 })?;

--- a/fluree-db-iceberg/src/scan/pruning.rs
+++ b/fluree-db-iceberg/src/scan/pruning.rs
@@ -10,9 +10,13 @@
 //! They are conservative: returning `true` is always safe (may include extra files),
 //! but returning `false` means we can definitively skip this manifest/file.
 
+use crate::manifest::value_codec::TypedValue;
 use crate::manifest::{decode_by_type_string, DataFile, PartitionFieldSummary};
 use crate::metadata::Schema;
 use crate::scan::predicate::{ComparisonOp, Expression, LiteralValue};
+use parquet::file::metadata::RowGroupMetaData;
+use parquet::file::statistics::Statistics;
+use std::collections::HashMap;
 
 /// Evaluate expression against manifest partition summary.
 ///
@@ -163,63 +167,120 @@ fn can_contain_comparison(
     // Convert literal to typed value
     let lit_typed = value.to_typed_value();
 
-    // Evaluate based on operator
-    match op {
-        ComparisonOp::Eq => {
-            // value must be in [lower, upper]
+    bounds_can_contain(op, &lit_typed, lower_typed, upper_typed)
+}
 
-            match (&lower_typed, &upper_typed) {
-                (Some(l), Some(u)) => {
-                    lit_typed.ge(l).unwrap_or(true) && lit_typed.le(u).unwrap_or(true)
-                }
-                (Some(l), None) => lit_typed.ge(l).unwrap_or(true),
-                (None, Some(u)) => lit_typed.le(u).unwrap_or(true),
-                (None, None) => true,
-            }
+/// Shared min/max reasoning for a `column <op> value` predicate. `lower`/`upper`
+/// are the column's decoded bounds (from an Iceberg `DataFile` or a Parquet
+/// row-group `Statistics`); a missing bound is treated conservatively (cannot
+/// prune). Returns `true` if a value satisfying the predicate could lie within
+/// the bounds.
+fn bounds_can_contain(
+    op: ComparisonOp,
+    lit: &TypedValue,
+    lower: Option<TypedValue>,
+    upper: Option<TypedValue>,
+) -> bool {
+    match op {
+        // value ∈ [lower, upper]
+        ComparisonOp::Eq => match (&lower, &upper) {
+            (Some(l), Some(u)) => lit.ge(l).unwrap_or(true) && lit.le(u).unwrap_or(true),
+            (Some(l), None) => lit.ge(l).unwrap_or(true),
+            (None, Some(u)) => lit.le(u).unwrap_or(true),
+            (None, None) => true,
+        },
+        // Prunable only when every value equals the excluded one (lower==upper==value).
+        ComparisonOp::NotEq => match (&lower, &upper) {
+            (Some(l), Some(u)) if l == u => l != lit,
+            _ => true,
+        },
+        // column < value can occur iff lower < value.
+        ComparisonOp::Lt => lower.as_ref().is_none_or(|l| lit.gt(l).unwrap_or(true)),
+        ComparisonOp::LtEq => lower.as_ref().is_none_or(|l| lit.ge(l).unwrap_or(true)),
+        // column > value can occur iff upper > value.
+        ComparisonOp::Gt => upper.as_ref().is_none_or(|u| lit.lt(u).unwrap_or(true)),
+        ComparisonOp::GtEq => upper.as_ref().is_none_or(|u| lit.le(u).unwrap_or(true)),
+    }
+}
+
+/// Row-group-level pruning: can this Parquet row group contain a row matching
+/// `expr`? Conservative — returns `true` unless the row group's column
+/// statistics prove no row can match. `field_to_col` maps an Iceberg field id to
+/// the Parquet column index in this file.
+pub fn row_group_can_contain(
+    expr: &Expression,
+    row_group: &RowGroupMetaData,
+    field_to_col: &HashMap<i32, usize>,
+) -> bool {
+    match expr {
+        Expression::AlwaysTrue => true,
+        Expression::AlwaysFalse => false,
+        Expression::And(exprs) => exprs
+            .iter()
+            .all(|e| row_group_can_contain(e, row_group, field_to_col)),
+        Expression::Or(exprs) => exprs
+            .iter()
+            .any(|e| row_group_can_contain(e, row_group, field_to_col)),
+        Expression::Comparison {
+            field_id,
+            op,
+            value,
+            ..
+        } => {
+            let Some(&col_idx) = field_to_col.get(field_id) else {
+                return true;
+            };
+            let Some(stats) = row_group.column(col_idx).statistics() else {
+                return true;
+            };
+            let lit = value.to_typed_value();
+            let (lower, upper) = stat_bounds(stats, &lit);
+            bounds_can_contain(*op, &lit, lower, upper)
         }
-        ComparisonOp::NotEq => {
-            // Can only prune if all values equal the excluded value
-            // That means lower == upper == value, which means we can exclude
-            match (&lower_typed, &upper_typed) {
-                (Some(l), Some(u)) if l == u => {
-                    // All values are the same
-                    l != &lit_typed
-                }
-                _ => true, // Can't prune
-            }
+        Expression::In {
+            field_id, values, ..
+        } => {
+            let Some(&col_idx) = field_to_col.get(field_id) else {
+                return true;
+            };
+            let Some(stats) = row_group.column(col_idx).statistics() else {
+                return true;
+            };
+            values.iter().any(|v| {
+                let lit = v.to_typed_value();
+                let (lower, upper) = stat_bounds(stats, &lit);
+                bounds_can_contain(ComparisonOp::Eq, &lit, lower, upper)
+            })
         }
-        ComparisonOp::Lt => {
-            // value < column => column > value => lower > value won't match
-            // File can contain if lower < value
-            match &lower_typed {
-                Some(l) => lit_typed.gt(l).unwrap_or(true),
-                None => true,
-            }
-        }
-        ComparisonOp::LtEq => {
-            // value <= column => column >= value => lower > value won't match
-            // File can contain if lower <= value
-            match &lower_typed {
-                Some(l) => lit_typed.ge(l).unwrap_or(true),
-                None => true,
-            }
-        }
-        ComparisonOp::Gt => {
-            // value > column => column < value => upper < value won't match
-            // File can contain if upper > value
-            match &upper_typed {
-                Some(u) => lit_typed.lt(u).unwrap_or(true),
-                None => true,
-            }
-        }
-        ComparisonOp::GtEq => {
-            // value >= column => column <= value => upper <= value won't match
-            // File can contain if upper >= value
-            match &upper_typed {
-                Some(u) => lit_typed.le(u).unwrap_or(true),
-                None => true,
-            }
-        }
+        // Null predicates and negations keep the row group (conservative).
+        _ => true,
+    }
+}
+
+/// Extract a Parquet row-group column's min/max as `TypedValue`s coerced to the
+/// same variant as `like` (the predicate literal). Only the pushdown-supported
+/// physical types are read (bool / int32 / int64, including int32-backed dates);
+/// anything else yields `(None, None)` so pruning stays conservative.
+fn stat_bounds(stats: &Statistics, like: &TypedValue) -> (Option<TypedValue>, Option<TypedValue>) {
+    match (stats, like) {
+        (Statistics::Boolean(s), TypedValue::Boolean(_)) => (
+            s.min_opt().map(|&v| TypedValue::Boolean(v)),
+            s.max_opt().map(|&v| TypedValue::Boolean(v)),
+        ),
+        (Statistics::Int32(s), TypedValue::Int32(_)) => (
+            s.min_opt().map(|&v| TypedValue::Int32(v)),
+            s.max_opt().map(|&v| TypedValue::Int32(v)),
+        ),
+        // Iceberg dates are physically int32 (days since 1970-01-01).
+        (Statistics::Int32(s), TypedValue::Date(_)) => (
+            s.min_opt().map(|&v| TypedValue::Date(v)),
+            s.max_opt().map(|&v| TypedValue::Date(v)),
+        ),
+        (Statistics::Int64(s), TypedValue::Int64(_)) => (
+            s.min_opt().map(|&v| TypedValue::Int64(v)),
+            s.max_opt().map(|&v| TypedValue::Int64(v)),
+        ),
+        _ => (None, None),
     }
 }
 
@@ -569,5 +630,82 @@ mod tests {
         );
         let result = evaluate_batch(&expr, &batch);
         assert_eq!(result, vec![0, 2, 4]);
+    }
+
+    /// Write a Parquet file with two row groups over one INT64 column `v`:
+    /// row group 0 holds 0..=4, row group 1 holds 100..=104. The default writer
+    /// properties emit chunk statistics, so each row group carries real min/max.
+    fn two_row_group_parquet() -> bytes::Bytes {
+        use parquet::data_type::Int64Type;
+        use parquet::file::properties::WriterProperties;
+        use parquet::file::writer::SerializedFileWriter;
+        use parquet::schema::parser::parse_message_type;
+
+        let schema = Arc::new(parse_message_type("message s { REQUIRED INT64 v; }").unwrap());
+        let props = Arc::new(WriterProperties::builder().build());
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut writer = SerializedFileWriter::new(&mut buf, schema, props).unwrap();
+            for vals in [[0i64, 1, 2, 3, 4], [100, 101, 102, 103, 104]] {
+                let mut rg = writer.next_row_group().unwrap();
+                let mut col = rg.next_column().unwrap().unwrap();
+                col.typed::<Int64Type>()
+                    .write_batch(&vals, None, None)
+                    .unwrap();
+                col.close().unwrap();
+                rg.close().unwrap();
+            }
+            writer.close().unwrap();
+        }
+        bytes::Bytes::from(buf)
+    }
+
+    #[test]
+    fn row_group_pruning_uses_real_parquet_stats() {
+        use parquet::file::reader::{FileReader, SerializedFileReader};
+
+        let reader = SerializedFileReader::new(two_row_group_parquet()).unwrap();
+        let meta = reader.metadata();
+        assert_eq!(meta.num_row_groups(), 2);
+
+        // Iceberg field id 1 maps to Parquet column 0 (the sole column).
+        let field_to_col = HashMap::from([(1i32, 0usize)]);
+        let cmp = |op, v| Expression::Comparison {
+            field_id: 1,
+            column: "v".to_string(),
+            op,
+            value: LiteralValue::Int64(v),
+        };
+
+        // v >= 50: rg0 (max 4) pruned, rg1 (min 100) kept.
+        let ge = cmp(ComparisonOp::GtEq, 50);
+        assert!(!row_group_can_contain(
+            &ge,
+            meta.row_group(0),
+            &field_to_col
+        ));
+        assert!(row_group_can_contain(&ge, meta.row_group(1), &field_to_col));
+
+        // v < 50: rg0 kept, rg1 pruned.
+        let lt = cmp(ComparisonOp::Lt, 50);
+        assert!(row_group_can_contain(&lt, meta.row_group(0), &field_to_col));
+        assert!(!row_group_can_contain(
+            &lt,
+            meta.row_group(1),
+            &field_to_col
+        ));
+
+        // v == 2: only rg0 can contain it.
+        let eq = cmp(ComparisonOp::Eq, 2);
+        assert!(row_group_can_contain(&eq, meta.row_group(0), &field_to_col));
+        assert!(!row_group_can_contain(
+            &eq,
+            meta.row_group(1),
+            &field_to_col
+        ));
+
+        // A field the query does not map is conservative — keep the row group.
+        let unmapped = HashMap::from([(2i32, 0usize)]);
+        assert!(row_group_can_contain(&ge, meta.row_group(0), &unmapped));
     }
 }

--- a/fluree-db-iceberg/src/scan/pruning.rs
+++ b/fluree-db-iceberg/src/scan/pruning.rs
@@ -14,7 +14,7 @@ use crate::manifest::value_codec::TypedValue;
 use crate::manifest::{decode_by_type_string, DataFile, PartitionFieldSummary};
 use crate::metadata::Schema;
 use crate::scan::predicate::{ComparisonOp, Expression, LiteralValue};
-use parquet::file::metadata::RowGroupMetaData;
+use parquet::file::metadata::{ColumnChunkMetaData, RowGroupMetaData};
 use parquet::file::statistics::Statistics;
 use std::collections::HashMap;
 
@@ -230,7 +230,7 @@ pub fn row_group_can_contain(
             let Some(&col_idx) = field_to_col.get(field_id) else {
                 return true;
             };
-            let Some(stats) = row_group.column(col_idx).statistics() else {
+            let Some(stats) = prunable_stats(row_group.column(col_idx)) else {
                 return true;
             };
             let lit = value.to_typed_value();
@@ -243,7 +243,7 @@ pub fn row_group_can_contain(
             let Some(&col_idx) = field_to_col.get(field_id) else {
                 return true;
             };
-            let Some(stats) = row_group.column(col_idx).statistics() else {
+            let Some(stats) = prunable_stats(row_group.column(col_idx)) else {
                 return true;
             };
             values.iter().any(|v| {
@@ -255,6 +255,30 @@ pub fn row_group_can_contain(
         // Null predicates and negations keep the row group (conservative).
         _ => true,
     }
+}
+
+/// Statistics usable for row-group pruning, or `None` (→ keep the row group
+/// conservatively) when the column has no statistics or is a Decimal type.
+///
+/// [`stat_bounds`] keys purely on the Parquet *physical* variant. A decimal
+/// stored as INT32/INT64 holds unscaled integers, so comparing a scaled query
+/// literal (`5`) against unscaled bounds (`[500, 504]` for `Decimal(_, 2)`) could
+/// prune a row group that actually matches. The Iceberg spec currently mandates
+/// `fixed_len_byte_array` for decimals — whose statistics already fall through to
+/// the conservative `(None, None)` — so this guard is defensive rather than a live
+/// bug, keeping correctness off the implicit encoding assumption (fluree/db#1406
+/// review).
+fn prunable_stats(col: &ColumnChunkMetaData) -> Option<&Statistics> {
+    let info = col.column_descr().self_type().get_basic_info();
+    let is_decimal = info.converted_type() == parquet::basic::ConvertedType::DECIMAL
+        || matches!(
+            info.logical_type(),
+            Some(parquet::basic::LogicalType::Decimal { .. })
+        );
+    if is_decimal {
+        return None;
+    }
+    col.statistics()
 }
 
 /// Extract a Parquet row-group column's min/max as `TypedValue`s coerced to the

--- a/fluree-db-query/src/graph.rs
+++ b/fluree-db-query/src/graph.rs
@@ -43,8 +43,28 @@ use crate::var_registry::VarId;
 use async_trait::async_trait;
 use fluree_db_core::DatatypeConstraint;
 use fluree_db_core::FlakeValue;
+use fluree_db_r2rml::mapping::CompiledR2rmlMapping;
 use std::sync::Arc;
 // Note: tracing::debug removed to fix compilation - add tracing dependency if needed
+
+/// Best-effort load of the compiled R2RML mapping for `graph_iri`, used only to
+/// let [`rewrite_patterns_for_r2rml`] decide whether a same-subject `rdf:type`
+/// may be safely fused into a star scan. Returns `None` (which disables class
+/// fusion but stays correct) when there is no provider or the load fails; the
+/// R2RML operator loads the mapping again at setup, so within a query this is a
+/// cache hit under the query-scoped catalog session.
+async fn r2rml_mapping_for_rewrite(
+    ctx: &ExecutionContext<'_>,
+    graph_iri: &str,
+) -> Option<Arc<CompiledR2rmlMapping>> {
+    let provider = ctx.r2rml_provider?;
+    let as_of_t = if ctx.dataset.is_some() {
+        None
+    } else {
+        Some(ctx.to_t)
+    };
+    provider.compiled_mapping(graph_iri, as_of_t).await.ok()
+}
 
 /// GRAPH pattern operator - scopes inner patterns to a specific graph
 ///
@@ -207,8 +227,13 @@ impl GraphOperator {
         // Determine which patterns to use (rewritten for R2RML or original)
         let patterns_to_execute: std::borrow::Cow<'_, [Pattern]> = if is_r2rml_gs {
             // Rewrite triple patterns to R2RML patterns
-            let rewrite_result =
-                rewrite_patterns_for_r2rml(&self.inner_patterns, &graph_iri, ctx.active_snapshot);
+            let mapping = r2rml_mapping_for_rewrite(ctx, &graph_iri).await;
+            let rewrite_result = rewrite_patterns_for_r2rml(
+                &self.inner_patterns,
+                &graph_iri,
+                ctx.active_snapshot,
+                mapping.as_deref(),
+            );
 
             // If there are unconverted patterns in an R2RML graph source, return an error.
             // R2RML graph sources don't have ledger-backed indexes, so unconverted patterns
@@ -352,8 +377,13 @@ impl GraphOperator {
             graph_ctx.eager_materialization = true;
         }
 
-        let rewrite_result =
-            rewrite_patterns_for_r2rml(&self.inner_patterns, &graph_iri, ctx.active_snapshot);
+        let mapping = r2rml_mapping_for_rewrite(ctx, &graph_iri).await;
+        let rewrite_result = rewrite_patterns_for_r2rml(
+            &self.inner_patterns,
+            &graph_iri,
+            ctx.active_snapshot,
+            mapping.as_deref(),
+        );
         if rewrite_result.unconverted_count > 0 {
             return Err(crate::error::QueryError::InvalidQuery(format!(
                 "R2RML graph source '{}' contains {} pattern(s) that cannot be converted \

--- a/fluree-db-query/src/graph.rs
+++ b/fluree-db-query/src/graph.rs
@@ -69,6 +69,11 @@ pub struct GraphOperator {
     buffer_pos: usize,
     /// Planning context captured at planner-time for the per-row inner subplan.
     planning: PlanningContext,
+    /// LIMIT budget forwarded from a downstream `LIMIT` (via row-preserving
+    /// operators). Threaded into the per-parent-batch inner subplan so a scan
+    /// under a GRAPH wrapper (notably an R2RML graph source) can early-terminate
+    /// instead of draining the whole table into `result_buffer`.
+    row_budget: Option<usize>,
 }
 
 impl GraphOperator {
@@ -121,6 +126,7 @@ impl GraphOperator {
             result_buffer: Vec::new(),
             buffer_pos: 0,
             planning,
+            row_budget: None,
         }
     }
 
@@ -234,6 +240,9 @@ impl GraphOperator {
             &self.planning,
         )?;
 
+        if let Some(budget) = self.row_budget {
+            inner.set_row_budget(budget);
+        }
         inner.open(&graph_ctx).await?;
 
         // NumBig arena handles are scoped per (graph, predicate). When this
@@ -361,6 +370,13 @@ impl GraphOperator {
             None,
             &self.planning,
         )?;
+        // Forward a downstream LIMIT budget so the inner scan early-terminates
+        // instead of draining the whole table into `result_buffer`. Correctness
+        // is bounded by the outer LIMIT; a per-parent-batch budget can over-read
+        // across parent batches but never under-reads.
+        if let Some(budget) = self.row_budget {
+            inner.set_row_budget(budget);
+        }
         inner.open(&graph_ctx).await?;
 
         let numbig_exit_gv = if graph_ctx.binary_g_id != ctx.binary_g_id {
@@ -457,6 +473,14 @@ impl Operator for GraphOperator {
     }
     fn schema(&self) -> &[VarId] {
         &self.schema
+    }
+
+    fn set_row_budget(&mut self, budget: usize) {
+        // Record the budget and thread it into the per-parent-batch inner subplan
+        // (see the execute helpers). Do NOT forward to `self.child`: the child
+        // produces parent rows that seed the correlated inner execution, which is
+        // not row-preserving, so it must still yield every row the inner needs.
+        self.row_budget = Some(budget);
     }
 
     async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {

--- a/fluree-db-query/src/r2rml/fused_aggregate.rs
+++ b/fluree-db-query/src/r2rml/fused_aggregate.rs
@@ -1085,11 +1085,34 @@ impl Operator for FusedR2rmlAggregateOperator {
 impl FusedR2rmlAggregateOperator {
     /// Rewrite inner triples → R2RML at `open` and resolve column folds.
     async fn resolve_at_open(&self, ctx: &ExecutionContext<'_>) -> Result<Option<Resolved>> {
+        // Load the compiled mapping first so the rewrite can decide whether a
+        // same-subject `rdf:type` is safe to fuse into the star (see
+        // `rewrite::class_fusion_is_safe`); it is then reused as the resolved
+        // mapping below. A missing provider / load failure leaves `mapping` as
+        // `None`, which disables fusion and, for a genuine R2RML scan, falls
+        // back to the normal path.
+        let as_of_t = if ctx.dataset.is_some() {
+            None
+        } else {
+            Some(ctx.to_t)
+        };
+        let mapping = match ctx.r2rml_provider {
+            Some(provider) => provider
+                .compiled_mapping(&self.graph_iri, as_of_t)
+                .await
+                .ok(),
+            None => None,
+        };
+
         // Rewrite the inner triples for this graph using the active snapshot.
         // A non-R2RML graph (or an unconvertible pattern) leaves triples
         // unconverted → fall back.
-        let rr =
-            rewrite_patterns_for_r2rml(&self.inner_patterns, &self.graph_iri, ctx.active_snapshot);
+        let rr = rewrite_patterns_for_r2rml(
+            &self.inner_patterns,
+            &self.graph_iri,
+            ctx.active_snapshot,
+            mapping.as_deref(),
+        );
         if rr.unconverted_count > 0 {
             return Ok(None);
         }
@@ -1098,17 +1121,11 @@ impl FusedR2rmlAggregateOperator {
             _ => return Ok(None), // multiple scans / star not handled in slice 1
         };
 
-        let provider = ctx
-            .r2rml_provider
-            .ok_or_else(|| QueryError::InvalidQuery("R2RML provider not configured".to_string()))?;
-        let as_of_t = if ctx.dataset.is_some() {
-            None
-        } else {
-            Some(ctx.to_t)
+        // The graph is genuinely R2RML-backed here; without the mapping fall back
+        // to the normal path (which surfaces any real load error).
+        let Some(mapping) = mapping else {
+            return Ok(None);
         };
-        let mapping = provider
-            .compiled_mapping(&pattern.graph_source_id, as_of_t)
-            .await?;
 
         let Some(tm) = Self::resolve_triples_map(&pattern, &mapping) else {
             return Ok(None);

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -207,6 +207,18 @@ impl R2rmlScanOperator {
         preds
     }
 
+    /// True for a pure `rdf:type`/subject-only pattern: no object var, no
+    /// predicate filter, no star members. Such a pattern derives only the subject
+    /// (its `rr:class` constraint is enforced by TriplesMap selection), so it
+    /// needs only the subject columns and scans no RefObjectMap parents. A true
+    /// wildcard `?s ?p ?o` is excluded — it has `object_var = Some` and must
+    /// still materialize every POM/parent.
+    fn is_subject_only_pattern(&self) -> bool {
+        self.pattern.object_var.is_none()
+            && self.pattern.predicate_filter.is_none()
+            && self.pattern.star_bindings.is_empty()
+    }
+
     /// Resolve this pattern's pushdown predicates (keyed by query variable) to
     /// table columns for the given TriplesMap, producing scan filters. A
     /// variable maps to a column via its predicate IRI; predicates backed by a
@@ -414,11 +426,23 @@ impl R2rmlScanOperator {
             // union of columns needed for every star predicate so the whole star
             // is satisfied by one scan.
             let projection: Vec<String> = if self.pattern.star_bindings.is_empty() {
-                triples_map
-                    .columns_for_predicate(self.pattern.predicate_filter.as_deref())
-                    .into_iter()
-                    .map(std::string::ToString::to_string)
-                    .collect()
+                if self.is_subject_only_pattern() {
+                    // rdf:type / subject-only pattern: only the subject columns are
+                    // load-bearing. Projecting every POM column (the
+                    // `columns_for_predicate(None)` fallback) reads FK/value columns
+                    // that subject-only materialization never consults.
+                    triples_map
+                        .subject_columns()
+                        .into_iter()
+                        .map(std::string::ToString::to_string)
+                        .collect()
+                } else {
+                    triples_map
+                        .columns_for_predicate(self.pattern.predicate_filter.as_deref())
+                        .into_iter()
+                        .map(std::string::ToString::to_string)
+                        .collect()
+                }
             } else {
                 let mut cols: Vec<String> = Vec::new();
                 for pred in self.pattern_predicates() {
@@ -467,6 +491,13 @@ impl R2rmlScanOperator {
                             .is_some_and(|p| star_preds.contains(&p))
                     } else if let Some(ref pred_filter) = self.pattern.predicate_filter {
                         pom.predicate_map.as_constant() == Some(pred_filter.as_str())
+                    } else if self.pattern.object_var.is_none() {
+                        // rdf:type / subject-only pattern: no POM is load-bearing
+                        // (the parent scans it would trigger are pure dead work, as
+                        // subject-only materialization never reads object/parent
+                        // values). The all-POMs branch below is for a TRUE wildcard
+                        // `?s ?p ?o`, where `?p`/`?o` range over every predicate.
+                        false
                     } else {
                         true
                     }

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -76,6 +76,20 @@ fn materialize_window_rows() -> usize {
         .unwrap_or(DEFAULT_MATERIALIZE_WINDOW_ROWS)
 }
 
+/// Whether LIMIT early-termination (row-budget) pushdown into the scan is
+/// enabled. Read once from `FLUREE_R2RML_LIMIT_PUSHDOWN` (only `0`/`false`/`off`
+/// disable it); disabling restores full-window materialization under a LIMIT.
+fn limit_pushdown_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var("FLUREE_R2RML_LIMIT_PUSHDOWN") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off"
+        ),
+        Err(_) => true,
+    })
+}
+
 /// How a window of produced rows is combined with the buffered child rows.
 ///
 /// The join is *flipped* relative to a naive per-child probe: the (small,
@@ -149,6 +163,15 @@ pub struct R2rmlScanOperator {
     /// Only UNFILTERED scans are cached — a filtered scan may return a pruned
     /// subset, which the filter-agnostic key must never replay for another scan.
     scan_cache: HashMap<(String, Vec<String>), Arc<Vec<ColumnBatch>>>,
+    /// LIMIT early-termination budget: the max output rows a downstream `LIMIT`
+    /// needs from this operator. `None` = unbounded. Set only when this is the
+    /// topmost row-preserving scan (a scan feeding a join/FILTER never receives
+    /// one), so once `emitted` reaches it the scan can stop without changing
+    /// results. Also caps the materialize window so a `LIMIT n` does not
+    /// materialize a full window before the first row.
+    row_budget: Option<usize>,
+    /// Output rows emitted so far, counted against `row_budget`.
+    emitted: usize,
     /// State
     state: OperatorState,
 }
@@ -199,6 +222,8 @@ impl R2rmlScanOperator {
             pending: VecDeque::new(),
             progress: None,
             scan_cache: HashMap::new(),
+            row_budget: None,
+            emitted: 0,
             state: OperatorState::Created,
         }
     }
@@ -489,7 +514,14 @@ impl R2rmlScanOperator {
             // pruned subset for a differently-filtered (or unfiltered) scan of the
             // same table/projection would drop rows. Filtered scans therefore
             // bypass the cache entirely (both read and write).
-            let cacheable = scan_cache_enabled() && scan_filters.is_empty();
+            //
+            // A budgeted scan (under a LIMIT) also bypasses the cache: caching
+            // collects a full window before the operator can stop early, which
+            // would defeat the LIMIT. A budgeted scan is the topmost
+            // row-preserving scan, so it stops after ~a batch and gains little
+            // from cross-batch reuse anyway.
+            let cacheable =
+                scan_cache_enabled() && scan_filters.is_empty() && self.row_budget.is_none();
             let cache_key = (table_name.to_string(), projection.clone());
             let stream: ColumnBatchStream = if !cacheable {
                 table_provider
@@ -635,12 +667,20 @@ impl R2rmlScanOperator {
             });
         }
 
+        // Under a LIMIT, cap the materialize window at the remaining budget so a
+        // `LIMIT n` does not explode a full 512K-row window into bindings before
+        // the first output row.
+        let window_rows = match self.row_budget {
+            Some(b) => materialize_window_rows().min(b.saturating_sub(self.emitted).max(1)),
+            None => materialize_window_rows(),
+        };
+
         Ok(Some(ScanProgress {
             child_batch,
             child_schema,
             tms,
             tm_idx: 0,
-            window_rows: materialize_window_rows(),
+            window_rows,
         }))
     }
 
@@ -1218,9 +1258,22 @@ impl Operator for R2rmlScanOperator {
         &self.schema
     }
 
+    fn set_row_budget(&mut self, budget: usize) {
+        // Record the budget but do NOT forward it to the child: the child feeds
+        // this operator's correlated scan/join, which is not row-preserving, so
+        // an inner scan must still produce every row the join needs. Only the
+        // topmost row-preserving scan is budgeted — `LimitOperator` forwards a
+        // budget solely through row-preserving operators, so if this operator
+        // received one, its output flows 1:1 to the LIMIT.
+        if limit_pushdown_enabled() {
+            self.row_budget = Some(budget);
+        }
+    }
+
     async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {
         // Open child first
         self.child.open(ctx).await?;
+        self.emitted = 0;
 
         // Load the compiled mapping from the provider
         let provider = ctx
@@ -1263,7 +1316,17 @@ impl Operator for R2rmlScanOperator {
                     columns[col_idx].push(binding);
                 }
             }
-            if columns[0].len() >= ctx.batch_size {
+            // Emit once a full batch is accumulated, or once the LIMIT budget is
+            // met — the latter stops the scan early without pulling/materializing
+            // more (the downstream LIMIT truncates to the exact count).
+            let budget_met = self
+                .row_budget
+                .is_some_and(|b| self.emitted + columns[0].len() >= b);
+            if columns[0].len() >= ctx.batch_size || (budget_met && !columns[0].is_empty()) {
+                self.emitted += columns[0].len();
+                if self.row_budget.is_some_and(|b| self.emitted >= b) {
+                    self.state = OperatorState::Exhausted;
+                }
                 return Ok(Some(Batch::new(Arc::clone(&self.schema), columns)?));
             }
 
@@ -1293,6 +1356,7 @@ impl Operator for R2rmlScanOperator {
                         self.state = OperatorState::Exhausted;
                         return Ok(None);
                     }
+                    self.emitted += columns[0].len();
                     return Ok(Some(Batch::new(Arc::clone(&self.schema), columns)?));
                 }
             }

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -761,6 +761,22 @@ impl R2rmlScanOperator {
                     ctx,
                 )?;
             }
+            // Geometric window growth. A budgeted (LIMIT) scan starts with a small
+            // window (~the remaining budget) so a selective query does not explode
+            // a full window into bindings before the first output row. But when the
+            // produced rows feed an internal join that filters most of them out,
+            // the output budget is never met, and a fixed tiny window would re-scan
+            // the whole table in many small passes (slower than the un-budgeted
+            // full-window path — fluree/db#1406 review). Growing the window each
+            // pass ramps it up to the full materialize size after a handful of
+            // low-yield passes, so the pathological case self-corrects while a
+            // genuinely selective LIMIT still stops after its cheap first window.
+            // The un-budgeted window already starts at the full size, so `.min`
+            // makes this a no-op there.
+            progress.window_rows = progress
+                .window_rows
+                .saturating_mul(4)
+                .min(materialize_window_rows());
             // `window` is dropped here, freeing the batches before the next pull.
             return Ok(true);
         }

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -140,6 +140,13 @@ pub struct R2rmlScanOperator {
     /// In-flight streaming scan for the current buffered child batch, advanced
     /// one window per `next_batch` so the whole table is never materialized.
     progress: Option<ScanProgress>,
+    /// Inner-table scans cached across child batches, keyed by
+    /// `(table_name, projection)`. A correlated join re-invokes `build_progress`
+    /// once per child batch; without this the (dimension-sized) inner table is
+    /// re-scanned every batch. Only inners up to one materialize window are
+    /// cached, so a cached inner never exceeds the resident footprint a single
+    /// scan window already holds; larger inners fall back to per-batch streaming.
+    scan_cache: HashMap<(String, Vec<String>), Arc<Vec<ColumnBatch>>>,
     /// State
     state: OperatorState,
 }
@@ -189,6 +196,7 @@ impl R2rmlScanOperator {
             mapping: None,
             pending: VecDeque::new(),
             progress: None,
+            scan_cache: HashMap::new(),
             state: OperatorState::Created,
         }
     }
@@ -348,7 +356,7 @@ impl R2rmlScanOperator {
     /// build the per-TriplesMap join plan against the child. Returns `None` when
     /// no TriplesMap matches this pattern (the caller pulls the next child).
     async fn build_progress(
-        &self,
+        &mut self,
         ctx: &ExecutionContext<'_>,
         child_batch: Batch,
     ) -> Result<Option<ScanProgress>> {
@@ -466,15 +474,46 @@ impl R2rmlScanOperator {
             } else {
                 Some(ctx.to_t)
             };
-            let stream = table_provider
-                .scan_table(
-                    &self.pattern.graph_source_id,
-                    table_name,
-                    &projection,
-                    &scan_filters,
-                    as_of_t,
-                )
-                .await?;
+            // Reuse an already-materialized inner scan across child batches: a
+            // correlated join calls `build_progress` once per child batch, so
+            // without this the (dimension-sized) inner table is re-scanned every
+            // batch. The first scan of a `(table, projection)` is collected (up to
+            // one window) and replayed for later batches; a larger inner streams
+            // fresh each batch as before.
+            let cache_key = (table_name.to_string(), projection.clone());
+            let stream: ColumnBatchStream = if !scan_cache_enabled() {
+                table_provider
+                    .scan_table(
+                        &self.pattern.graph_source_id,
+                        table_name,
+                        &projection,
+                        &scan_filters,
+                        as_of_t,
+                    )
+                    .await?
+            } else if let Some(cached) = self.scan_cache.get(&cache_key) {
+                replay_stream(Arc::clone(cached))
+            } else {
+                let fresh = table_provider
+                    .scan_table(
+                        &self.pattern.graph_source_id,
+                        table_name,
+                        &projection,
+                        &scan_filters,
+                        as_of_t,
+                    )
+                    .await?;
+                match collect_scan_capped(fresh, materialize_window_rows()).await? {
+                    CollectedScan::Complete(batches) => {
+                        let arc = Arc::new(batches);
+                        self.scan_cache.insert(cache_key, Arc::clone(&arc));
+                        replay_stream(arc)
+                    }
+                    CollectedScan::Overflow(prefix, remainder) => {
+                        Box::pin(futures::stream::iter(prefix.into_iter().map(Ok)).chain(remainder))
+                    }
+                }
+            };
 
             // Build parent lookup tables for RefObjectMap POMs that pass the
             // predicate filter. Parent (dimension) tables are small and consumed
@@ -687,6 +726,57 @@ async fn collect_stream(mut stream: ColumnBatchStream) -> Result<Vec<ColumnBatch
         out.push(batch?);
     }
     Ok(out)
+}
+
+/// Whether the correlated inner-scan cache is enabled. Read once from
+/// `FLUREE_R2RML_SCAN_CACHE` (only `0`/`false`/`off` disable it); disabling
+/// restores the per-child-batch re-scan behavior.
+fn scan_cache_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var("FLUREE_R2RML_SCAN_CACHE") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off"
+        ),
+        Err(_) => true,
+    })
+}
+
+/// Outcome of trying to fully collect an inner scan for caching.
+enum CollectedScan {
+    /// The whole inner fit within the cap — safe to cache and replay.
+    Complete(Vec<ColumnBatch>),
+    /// The inner exceeded the cap — too large to cache. The prefix already
+    /// pulled plus the still-open remainder serve this one batch.
+    Overflow(Vec<ColumnBatch>, ColumnBatchStream),
+}
+
+/// Collect `stream` until it ends (→ `Complete`, cacheable) or its row count
+/// reaches `cap` with more remaining (→ `Overflow`, too large to cache). The cap
+/// equals one materialize window, so a cached inner never exceeds the resident
+/// footprint a single scan window already materializes.
+async fn collect_scan_capped(mut stream: ColumnBatchStream, cap: usize) -> Result<CollectedScan> {
+    let mut collected = Vec::new();
+    let mut rows = 0usize;
+    while rows < cap {
+        match stream.next().await {
+            Some(batch) => {
+                let batch = batch?;
+                rows += batch.num_rows;
+                collected.push(batch);
+            }
+            None => return Ok(CollectedScan::Complete(collected)),
+        }
+    }
+    Ok(CollectedScan::Overflow(collected, stream))
+}
+
+/// A [`ColumnBatchStream`] that replays cached batches. `ColumnBatch` clones are
+/// cheap (its columns are `Arc`-backed), so replay does not re-copy the data.
+fn replay_stream(batches: Arc<Vec<ColumnBatch>>) -> ColumnBatchStream {
+    Box::pin(futures::stream::iter(
+        (0..batches.len()).map(move |i| Ok(batches[i].clone())),
+    ))
 }
 
 /// Emit one combined output row: the child row's bindings overlaid with a

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -146,6 +146,8 @@ pub struct R2rmlScanOperator {
     /// re-scanned every batch. Only inners up to one materialize window are
     /// cached, so a cached inner never exceeds the resident footprint a single
     /// scan window already holds; larger inners fall back to per-batch streaming.
+    /// Only UNFILTERED scans are cached — a filtered scan may return a pruned
+    /// subset, which the filter-agnostic key must never replay for another scan.
     scan_cache: HashMap<(String, Vec<String>), Arc<Vec<ColumnBatch>>>,
     /// State
     state: OperatorState,
@@ -480,8 +482,16 @@ impl R2rmlScanOperator {
             // batch. The first scan of a `(table, projection)` is collected (up to
             // one window) and replayed for later batches; a larger inner streams
             // fresh each batch as before.
+            //
+            // Only unfiltered scans are cached. A pushdown `scan_filter` can prune
+            // files, so a filtered scan may yield a row SUBSET; the cache key is
+            // `(table, projection)` and does not carry the filter, so replaying a
+            // pruned subset for a differently-filtered (or unfiltered) scan of the
+            // same table/projection would drop rows. Filtered scans therefore
+            // bypass the cache entirely (both read and write).
+            let cacheable = scan_cache_enabled() && scan_filters.is_empty();
             let cache_key = (table_name.to_string(), projection.clone());
-            let stream: ColumnBatchStream = if !scan_cache_enabled() {
+            let stream: ColumnBatchStream = if !cacheable {
                 table_provider
                     .scan_table(
                         &self.pattern.graph_source_id,
@@ -1294,6 +1304,7 @@ impl Operator for R2rmlScanOperator {
         self.mapping = None;
         self.pending.clear();
         self.progress = None;
+        self.scan_cache.clear();
         self.state = OperatorState::Closed;
     }
 

--- a/fluree-db-query/src/r2rml/rewrite.rs
+++ b/fluree-db-query/src/r2rml/rewrite.rs
@@ -71,6 +71,11 @@ pub fn rewrite_patterns_for_r2rml(
     // (const predicate + fresh object var) by subject so they can be merged into
     // a single scan, eliminating the O(N^2) self-join. First-seen order preserved.
     let mut star_groups: Vec<(VarId, Vec<R2rmlPattern>)> = Vec::new();
+    // Same-subject `rdf:type` patterns, by subject. A single class per subject is
+    // fused into that subject's star (constraining its TriplesMap resolution to
+    // the class and dropping a redundant correlated re-scan); a subject with no
+    // star members, or multiple classes, is emitted as a subject-only scan.
+    let mut class_groups: Vec<(VarId, Vec<R2rmlPattern>)> = Vec::new();
 
     for pattern in patterns {
         match pattern {
@@ -86,6 +91,16 @@ pub fn rewrite_patterns_for_r2rml(
                             Some((_, members)) => members.push(r2rml_pattern),
                             None => {
                                 star_groups.push((r2rml_pattern.subject_var, vec![r2rml_pattern]));
+                            }
+                        }
+                    } else if is_class_only(&r2rml_pattern) {
+                        match class_groups
+                            .iter_mut()
+                            .find(|(s, _)| *s == r2rml_pattern.subject_var)
+                        {
+                            Some((_, members)) => members.push(r2rml_pattern),
+                            None => {
+                                class_groups.push((r2rml_pattern.subject_var, vec![r2rml_pattern]));
                             }
                         }
                     } else {
@@ -138,9 +153,16 @@ pub fn rewrite_patterns_for_r2rml(
 
     // Emit star groups. Single-member groups stay on the normal single-object
     // path; multi-member groups with distinct object vars merge into one scan.
-    for (_subject, mut members) in star_groups {
+    // A same-subject `rdf:type` is fused into the base by setting its
+    // `class_filter`, which constrains TriplesMap resolution to the class and
+    // removes the separate class operator's correlated re-scan.
+    for (subject, mut members) in star_groups {
         if members.len() == 1 {
-            result_patterns.push(Pattern::R2rml(members.pop().unwrap()));
+            let mut base = members.pop().unwrap();
+            if let Some(class) = take_single_class(&mut class_groups, subject) {
+                base.class_filter = Some(class);
+            }
+            result_patterns.push(Pattern::R2rml(base));
             continue;
         }
         let mut seen_obj = HashSet::new();
@@ -149,12 +171,17 @@ pub fn rewrite_patterns_for_r2rml(
             .all(|m| m.object_var.is_some_and(|v| seen_obj.insert(v)));
         if !distinct {
             // Shared object var implies a self-join constraint; keep separate.
+            // Leave any same-subject class pattern in `class_groups` so it is
+            // emitted as a subject-only scan below.
             for m in members {
                 result_patterns.push(Pattern::R2rml(m));
             }
             continue;
         }
         let mut base = members.remove(0);
+        if let Some(class) = take_single_class(&mut class_groups, subject) {
+            base.class_filter = Some(class);
+        }
         base.star_bindings = members
             .into_iter()
             .map(|m| {
@@ -165,6 +192,15 @@ pub fn rewrite_patterns_for_r2rml(
             })
             .collect();
         result_patterns.push(Pattern::R2rml(base));
+    }
+
+    // Class patterns not fused into a star (no same-subject star members, or
+    // multiple classes on one subject) become subject-only scans: the operator
+    // projects only the subject columns and scans no RefObjectMap parents.
+    for (_subject, members) in class_groups {
+        for m in members {
+            result_patterns.push(Pattern::R2rml(m));
+        }
     }
 
     // Attach pushable FILTER comparisons to the R2RML pattern that produces
@@ -281,6 +317,33 @@ fn is_star_eligible(p: &R2rmlPattern) -> bool {
             Some(obj) => obj != p.subject_var,
             None => false,
         }
+}
+
+/// A pure `rdf:type` pattern (`?s a ex:Class`): a class filter, no object var, no
+/// predicate, no star members. These are candidates to fuse into a same-subject
+/// star (or, failing that, to run as a subject-only scan).
+fn is_class_only(p: &R2rmlPattern) -> bool {
+    p.class_filter.is_some()
+        && p.object_var.is_none()
+        && p.predicate_filter.is_none()
+        && p.triples_map_iri.is_none()
+        && p.star_bindings.is_empty()
+}
+
+/// Remove and return the lone class IRI for `subject` from `class_groups`, but
+/// only when that subject has exactly one `rdf:type` pattern. A subject with
+/// multiple classes is left in place (each emitted as its own subject-only scan)
+/// because `class_filter` holds a single class.
+fn take_single_class(
+    class_groups: &mut Vec<(VarId, Vec<R2rmlPattern>)>,
+    subject: VarId,
+) -> Option<String> {
+    let idx = class_groups.iter().position(|(s, _)| *s == subject)?;
+    if class_groups[idx].1.len() != 1 {
+        return None;
+    }
+    let (_, mut members) = class_groups.remove(idx);
+    members.pop().and_then(|p| p.class_filter)
 }
 
 /// Convert a triple pattern to an R2RML pattern.

--- a/fluree-db-query/src/r2rml/rewrite.rs
+++ b/fluree-db-query/src/r2rml/rewrite.rs
@@ -30,6 +30,7 @@ use crate::ir::{Expression, Function, Pattern, R2rmlPattern};
 use crate::r2rml::{ScanCmpOp, ScanValue};
 use crate::var_registry::VarId;
 use fluree_db_core::{FlakeValue, LedgerSnapshot};
+use fluree_db_r2rml::mapping::CompiledR2rmlMapping;
 use std::collections::HashSet;
 
 /// Result of rewriting patterns for R2RML.
@@ -54,6 +55,11 @@ pub struct R2rmlRewriteResult {
 /// * `patterns` - The patterns to rewrite
 /// * `graph_source_id` - The graph source alias (e.g., "airlines-gs:main")
 /// * `snapshot` - Database for Sid-to-IRI conversion
+/// * `mapping` - The compiled R2RML mapping, when available. Used to decide
+///   whether a same-subject `rdf:type` may be safely fused into a star scan
+///   (see [`class_fusion_is_safe`]). `None` disables class fusion — always
+///   correct, just less optimal — so callers that can cheaply load the mapping
+///   should pass it.
 ///
 /// # Returns
 ///
@@ -62,6 +68,7 @@ pub fn rewrite_patterns_for_r2rml(
     patterns: &[Pattern],
     graph_source_id: &str,
     snapshot: &LedgerSnapshot,
+    mapping: Option<&CompiledR2rmlMapping>,
 ) -> R2rmlRewriteResult {
     let mut result_patterns = Vec::with_capacity(patterns.len());
     let mut converted = 0;
@@ -122,7 +129,7 @@ pub fn rewrite_patterns_for_r2rml(
             | Pattern::NotExists(_)
             | Pattern::Service(_) => {
                 let rewritten = pattern.clone().map_subpatterns(&mut |inner| {
-                    let r = rewrite_patterns_for_r2rml(&inner, graph_source_id, snapshot);
+                    let r = rewrite_patterns_for_r2rml(&inner, graph_source_id, snapshot, mapping);
                     converted += r.converted_count;
                     unconverted += r.unconverted_count;
                     r.patterns
@@ -159,9 +166,7 @@ pub fn rewrite_patterns_for_r2rml(
     for (subject, mut members) in star_groups {
         if members.len() == 1 {
             let mut base = members.pop().unwrap();
-            if let Some(class) = take_single_class(&mut class_groups, subject) {
-                base.class_filter = Some(class);
-            }
+            fuse_class_if_safe(&mut base, &mut class_groups, subject, mapping);
             result_patterns.push(Pattern::R2rml(base));
             continue;
         }
@@ -179,9 +184,7 @@ pub fn rewrite_patterns_for_r2rml(
             continue;
         }
         let mut base = members.remove(0);
-        if let Some(class) = take_single_class(&mut class_groups, subject) {
-            base.class_filter = Some(class);
-        }
+        fuse_class_if_safe(&mut base, &mut class_groups, subject, mapping);
         base.star_bindings = members
             .into_iter()
             .map(|m| {
@@ -330,20 +333,75 @@ fn is_class_only(p: &R2rmlPattern) -> bool {
         && p.star_bindings.is_empty()
 }
 
-/// Remove and return the lone class IRI for `subject` from `class_groups`, but
-/// only when that subject has exactly one `rdf:type` pattern. A subject with
-/// multiple classes is left in place (each emitted as its own subject-only scan)
-/// because `class_filter` holds a single class.
-fn take_single_class(
+/// Fuse a subject's lone `rdf:type` into its star `base` by setting
+/// `base.class_filter`, but only when doing so cannot change the result set.
+///
+/// Fusion constrains TriplesMap resolution in
+/// [`operator::build_progress`](super::operator) to maps that satisfy the class
+/// **and** the star's base predicate. That is only equivalent to the pre-fusion
+/// two-pattern plan (a subject-only class scan joined with the predicate scan)
+/// when the class and predicate co-locate in the same TriplesMap. A vertically
+/// partitioned mapping (`TM_A` = subject+class, `TM_B` = subject+predicate, same
+/// subject template) has no single map with both, so a fused scan resolves zero
+/// maps and silently returns no rows (fluree/db#1406 review).
+///
+/// So fuse only when [`class_fusion_is_safe`] holds; otherwise leave the class
+/// pattern in `class_groups` to be emitted as its own subject-only scan, which
+/// the engine joins on the shared subject — the always-correct pre-fusion path.
+/// Fusion is also skipped when the subject carries more than one class (a single
+/// `class_filter` cannot represent them) or when the mapping is unavailable.
+fn fuse_class_if_safe(
+    base: &mut R2rmlPattern,
     class_groups: &mut Vec<(VarId, Vec<R2rmlPattern>)>,
     subject: VarId,
-) -> Option<String> {
-    let idx = class_groups.iter().position(|(s, _)| *s == subject)?;
+    mapping: Option<&CompiledR2rmlMapping>,
+) {
+    let Some(idx) = class_groups.iter().position(|(s, _)| *s == subject) else {
+        return;
+    };
     if class_groups[idx].1.len() != 1 {
-        return None;
+        return;
     }
-    let (_, mut members) = class_groups.remove(idx);
-    members.pop().and_then(|p| p.class_filter)
+    let Some(class) = class_groups[idx].1[0].class_filter.clone() else {
+        return;
+    };
+    // The base predicate drives TriplesMap selection; a star always has one.
+    let Some(base_pred) = base.predicate_filter.as_deref() else {
+        return;
+    };
+    if !mapping.is_some_and(|m| class_fusion_is_safe(m, &class, base_pred)) {
+        return;
+    }
+    class_groups.remove(idx);
+    base.class_filter = Some(class);
+}
+
+/// Whether fusing `class_iri` into the star for `base_predicate` preserves the
+/// result set: every TriplesMap that resolves `base_predicate` must also declare
+/// the class. Then adding the class as a TriplesMap-selection constraint cannot
+/// drop any map the predicate scan would otherwise select, and every scanned row
+/// genuinely carries the class. If some predicate map lacks the class (the
+/// vertically partitioned / split-TriplesMap shape), fusion is unsafe.
+fn class_fusion_is_safe(
+    mapping: &CompiledR2rmlMapping,
+    class_iri: &str,
+    base_predicate: &str,
+) -> bool {
+    let mut saw_predicate_map = false;
+    for tm in mapping.triples_maps.values() {
+        let has_predicate = tm
+            .predicate_object_maps
+            .iter()
+            .any(|pom| pom.predicate_map.as_constant() == Some(base_predicate));
+        if !has_predicate {
+            continue;
+        }
+        saw_predicate_map = true;
+        if !tm.classes().iter().any(|c| c == class_iri) {
+            return false;
+        }
+    }
+    saw_predicate_map
 }
 
 /// Convert a triple pattern to an R2RML pattern.
@@ -448,5 +506,71 @@ mod tests {
         assert!(tp.s.is_var());
         assert!(tp.p.is_var());
         assert!(tp.o.is_var());
+    }
+
+    use fluree_db_r2rml::mapping::{ObjectMap, PredicateMap, PredicateObjectMap, TriplesMap};
+
+    const CLASS: &str = "http://example.org/Person";
+    const PRED: &str = "http://example.org/name";
+
+    fn pom(pred: &str, col: &str) -> PredicateObjectMap {
+        PredicateObjectMap {
+            predicate_map: PredicateMap::constant(pred),
+            object_map: ObjectMap::column(col),
+        }
+    }
+
+    #[test]
+    fn class_fusion_safe_when_class_and_predicate_colocate() {
+        // One TriplesMap declares the class and the predicate — the star-schema
+        // shape fusion optimizes for.
+        let tm = TriplesMap::new("#TM", "people")
+            .with_subject_template("http://example.org/person/{id}")
+            .with_class(CLASS)
+            .with_predicate_object(pom(PRED, "name"));
+        let mapping = CompiledR2rmlMapping::new(vec![tm]);
+        assert!(class_fusion_is_safe(&mapping, CLASS, PRED));
+    }
+
+    #[test]
+    fn class_fusion_unsafe_when_split_across_triples_maps() {
+        // Vertically partitioned: TM_A holds the class, TM_B holds the predicate,
+        // sharing a subject template. No single map has both, so fusing the class
+        // into the predicate star would resolve zero maps → silent empty result.
+        let tm_class = TriplesMap::new("#TM_A", "people_class")
+            .with_subject_template("http://example.org/person/{id}")
+            .with_class(CLASS);
+        let tm_pred = TriplesMap::new("#TM_B", "people_name")
+            .with_subject_template("http://example.org/person/{id}")
+            .with_predicate_object(pom(PRED, "name"));
+        let mapping = CompiledR2rmlMapping::new(vec![tm_class, tm_pred]);
+        assert!(!class_fusion_is_safe(&mapping, CLASS, PRED));
+    }
+
+    #[test]
+    fn class_fusion_unsafe_when_a_predicate_map_lacks_the_class() {
+        // One predicate map co-locates the class, another resolves the same
+        // predicate without it. Fusing would drop rows from the classless map.
+        let tm_both = TriplesMap::new("#TM_both", "people")
+            .with_subject_template("http://example.org/person/{id}")
+            .with_class(CLASS)
+            .with_predicate_object(pom(PRED, "name"));
+        let tm_pred_only = TriplesMap::new("#TM_pred", "aliases")
+            .with_subject_template("http://example.org/person/{id}")
+            .with_predicate_object(pom(PRED, "alias"));
+        let mapping = CompiledR2rmlMapping::new(vec![tm_both, tm_pred_only]);
+        assert!(!class_fusion_is_safe(&mapping, CLASS, PRED));
+    }
+
+    #[test]
+    fn class_fusion_unsafe_when_no_map_resolves_the_predicate() {
+        // Guards against fusing (and thus dropping the separate class scan) when
+        // the predicate resolves nowhere — the result must stay whatever the
+        // unfused plan produces, not silently collapse.
+        let tm = TriplesMap::new("#TM", "people")
+            .with_subject_template("http://example.org/person/{id}")
+            .with_class(CLASS);
+        let mapping = CompiledR2rmlMapping::new(vec![tm]);
+        assert!(!class_fusion_is_safe(&mapping, CLASS, PRED));
     }
 }

--- a/fluree-db-r2rml/src/mapping/triples_map.rs
+++ b/fluree-db-r2rml/src/mapping/triples_map.rs
@@ -163,6 +163,29 @@ impl TriplesMap {
         columns
     }
 
+    /// Columns needed to materialize only the subject IRI (subject template
+    /// columns plus an `rr:column` subject, if any).
+    ///
+    /// An `rdf:type`/subject-only triple pattern derives solely from the subject
+    /// map — no predicate-object map or RefObjectMap parent participates — so
+    /// reading any POM or parent column for it is wasted I/O. Use this instead of
+    /// `columns_for_predicate(None)` (which projects every POM column) when the
+    /// pattern has no object variable.
+    pub fn subject_columns(&self) -> Vec<&str> {
+        let mut columns: Vec<&str> = self
+            .subject_map
+            .template_columns
+            .iter()
+            .map(std::string::String::as_str)
+            .collect();
+        if let Some(ref col) = self.subject_map.column {
+            columns.push(col.as_str());
+        }
+        columns.sort();
+        columns.dedup();
+        columns
+    }
+
     /// Get columns that must be non-null to produce triples for a pattern.
     ///
     /// This method returns the minimal set of columns where a NULL value would


### PR DESCRIPTION
## Summary

Performance work on the Iceberg/R2RML graph-source read path, from a live diagnosis against Snowflake Horizon (`ENTERPRISE_DEMO.DW`). Correct-but-slow queries — a 10-row join took ~4 minutes with 36 Snowflake round-trips — traced to R2RML query planning amplifying REST and Parquet costs, **not** to IO (every data read in every trace was a disk-cache hit). Each change is independently shippable and kill-switchable.

## What's here

**Query planning**
- Fuse `rdf:type` into the same-subject star + prune subject-only scans: a subject-only/`rdf:type` pattern no longer projects every POM column, scans RefObjectMap parent tables it never reads, or fans out to predicate-sharing TriplesMaps. Simple Store query 6 scans → 1; Store ⋈ Geography 36 → 5.
- Reuse the inner scan across child batches: a correlated join no longer re-scans the inner dimension table per child batch. Store ⋈ Geography 5 → 3 scans.

**Catalog access**
- Query-scoped Iceberg catalog session: one REST client + one `loadTable` response reused across a query's scans, with the Iceberg snapshot pinned. OAuth 36 → 1, `loadTable` 36 → 2 within a query.
- Pin `metadata_location` across a mid-query credential refresh so a creds refresh cannot shift the query onto a newer snapshot.
- Process-wide OAuth token reuse + cross-query `loadTable` cache (60s TTL, vended-credential-expiry gated): on a warm server the 2nd query against a table skips OAuth + `loadTable` entirely.

**Scan execution**
- LIMIT early-termination: a `LIMIT n` now reaches the scan (`GraphOperator` forwards the row budget through the R2RML subplan), so it stops after ~one materialize window instead of draining the table.
- Row-group pruning via Parquet statistics: the reader skips row groups whose min/max rule out a pushed date/int/bool filter. Conservative — an unsupported or decimal-typed column keeps the group; results are unchanged.

## Live results (Snowflake Horizon; results byte-identical to baseline)

| Query | Before | After |
|---|---|---|
| `Store; storeId; name` LIMIT 5 | 6 scans / 19.6s | 1 scan |
| `Store ⋈ Geography` LIMIT 10 | 36 scans / 229s | 3 scans / ~9s · OAuth 36→1 · loadTable 36→2 |
| `FACT_ORDER_LINE` LIMIT 5 | >90s (was timing out) | ~4.4s |
| warm server, 2nd identical query | 3.0s | 0.2s |

## Config (all default-on, kill-switchable)

Documented in `docs/operations/configuration.md`: `FLUREE_ICEBERG_LOADTABLE_CACHE`, `FLUREE_ICEBERG_LOADTABLE_TTL_SECS` (default 60), `FLUREE_R2RML_SCAN_CACHE`, `FLUREE_R2RML_LIMIT_PUSHDOWN`, `FLUREE_ICEBERG_PREDICATE_PUSHDOWN`, plus the existing `FLUREE_R2RML_MATERIALIZE_WINDOW_ROWS` and `FLUREE_ICEBERG_SCAN_CONCURRENCY`.

## Testing

- `cargo fmt --all -- --check` clean; `cargo clippy --all --all-features --all-targets` clean.
- Guardrails: scan-count / projection / dangling-FK / wildcard invariants; catalog-cache hit + credential-expiry + key isolation; snapshot-pin-across-refresh; LIMIT early-termination (a `LIMIT 5` pulls ~1 of 40 streamed chunks); row-group pruning against a real two-row-group Parquet fixture.
- Live A/B on the `enterprise` graph source for every change, with byte-identical results pushdown on vs off.

## Not included

Row-level residual filtering + planner FILTER-consumption (so a `FILTER + LIMIT` fact query early-terminates) is deferred. Live testing surfaced that `xsd:integer` R2RML columns are physically Iceberg `Decimal`, and a residual filter needs conservative "keep on unevaluable" semantics distinct from the existing row matcher — a follow-up, scoped in the branch notes.
