### PR TITLE
(Iceberg/R2RML) Deterministic Catalog --> R2RML Engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,6 +3055,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/fluree-db-api/src/graph_source/config.rs
+++ b/fluree-db-api/src/graph_source/config.rs
@@ -1208,6 +1208,41 @@ mod tests {
 
     #[cfg(feature = "iceberg")]
     #[test]
+    fn debug_of_connection_config_redacts_secrets() {
+        // A future `{:?}` on the connection (in a log or error) must not leak the
+        // bearer token or the OAuth2 client secret it transitively holds via the
+        // `AuthConfig` -> `ConfigValue` chain.
+        let bearer = IcebergConnectionConfig::rest("https://catalog.example.com")
+            .with_auth_bearer("super-secret-bearer-token");
+        let dbg = format!("{bearer:?}");
+        assert!(
+            !dbg.contains("super-secret-bearer-token"),
+            "bearer token leaked in Debug: {dbg}"
+        );
+
+        let oauth = IcebergConnectionConfig::rest("https://catalog.example.com").with_auth_oauth2(
+            "https://catalog.example.com/v1/oauth/tokens",
+            "client-id-ok-to-show",
+            "super-secret-oauth-secret",
+        );
+        let dbg = format!("{oauth:?}");
+        assert!(
+            !dbg.contains("super-secret-oauth-secret"),
+            "oauth client_secret leaked in Debug: {dbg}"
+        );
+
+        // The same guarantee must hold one level up, on IcebergCreateConfig,
+        // whose derived Debug prints the connection.
+        let create = IcebergCreateConfig::new("gs", "https://catalog.example.com", "ns.tbl")
+            .with_auth_bearer("super-secret-bearer-token");
+        assert!(
+            !format!("{create:?}").contains("super-secret-bearer-token"),
+            "bearer token leaked in IcebergCreateConfig Debug"
+        );
+    }
+
+    #[cfg(feature = "iceberg")]
+    #[test]
     fn test_oauth2_scope_setter_warns_without_oauth2() {
         // Bearer auth set, scope setter should be a no-op (and not panic).
         let config = IcebergCreateConfig::new("gs", "https://catalog.example.com", "ns.tbl")

--- a/fluree-db-api/src/graph_source/config.rs
+++ b/fluree-db-api/src/graph_source/config.rs
@@ -400,17 +400,29 @@ pub struct IcebergCreateConfig {
     /// Branch name (defaults to "main")
     pub branch: Option<String>,
 
+    /// The reusable connection block (catalog access + IO).
+    pub connection: IcebergConnectionConfig,
+
+    /// Table identifier (e.g., "openflights.airlines"). Empty for Direct mode
+    /// (derived from the table location).
+    pub table_identifier: String,
+}
+
+/// The reusable Iceberg connection block — catalog access + IO, with **no**
+/// table or mapping.
+///
+/// Factored out of [`IcebergCreateConfig`] so catalog browse / metadata preview
+/// can run against an **unsaved** connection during onboarding (before a graph
+/// source record is created). The relationship is:
+/// `IcebergCreateConfig` = `IcebergConnectionConfig` + `table_identifier`.
+#[cfg(feature = "iceberg")]
+#[derive(Debug, Clone)]
+pub struct IcebergConnectionConfig {
     /// Catalog mode: REST or Direct S3 access.
     pub catalog_mode: CatalogMode,
 
-    /// S3 region override
-    pub s3_region: Option<String>,
-
-    /// S3 endpoint override (for MinIO, LocalStack)
-    pub s3_endpoint: Option<String>,
-
-    /// Use path-style S3 URLs
-    pub s3_path_style: bool,
+    /// Storage / IO configuration (vended credentials + S3 region/endpoint/path-style).
+    pub io: fluree_db_iceberg::config::IoConfig,
 }
 
 /// How the Iceberg catalog is accessed.
@@ -428,63 +440,48 @@ pub enum CatalogMode {
 }
 
 /// REST catalog mode configuration.
+///
+/// This carries only the catalog-connection fields (`catalog_uri` / `warehouse`
+/// / `auth`); the table identifier lives on [`IcebergCreateConfig`] and
+/// vended-credential / S3 IO settings live on
+/// [`IcebergConnectionConfig::io`].
 #[cfg(feature = "iceberg")]
 #[derive(Debug, Clone)]
 pub struct RestCatalogMode {
     /// REST catalog URI
     pub catalog_uri: String,
-    /// Table identifier (e.g., "openflights.airlines")
-    pub table_identifier: String,
     /// Optional warehouse identifier
     pub warehouse: Option<String>,
     /// Authentication configuration
     pub auth: fluree_db_iceberg::auth::AuthConfig,
-    /// Whether to use vended credentials (default: true)
-    pub vended_credentials: bool,
 }
 
 #[cfg(feature = "iceberg")]
-impl IcebergCreateConfig {
-    /// Create a new Iceberg graph source config for REST catalog mode.
-    pub fn new(
-        name: impl Into<String>,
-        catalog_uri: impl Into<String>,
-        table_identifier: impl Into<String>,
-    ) -> Self {
+impl IcebergConnectionConfig {
+    /// Create a REST-catalog connection with default IO (vended credentials on).
+    pub fn rest(catalog_uri: impl Into<String>) -> Self {
         Self {
-            name: name.into(),
-            branch: None,
             catalog_mode: CatalogMode::Rest(Box::new(RestCatalogMode {
                 catalog_uri: catalog_uri.into(),
-                table_identifier: table_identifier.into(),
                 warehouse: None,
                 auth: fluree_db_iceberg::auth::AuthConfig::None,
-                vended_credentials: true,
             })),
-            s3_region: None,
-            s3_endpoint: None,
-            s3_path_style: false,
+            io: fluree_db_iceberg::config::IoConfig::default(),
         }
     }
 
-    /// Create a new Iceberg graph source config for direct S3 access (no REST catalog).
-    pub fn new_direct(name: impl Into<String>, table_location: impl Into<String>) -> Self {
+    /// Create a Direct S3 connection (no REST catalog). Vended credentials are
+    /// forced off — Direct mode uses ambient/IAM credentials.
+    pub fn direct(table_location: impl Into<String>) -> Self {
         Self {
-            name: name.into(),
-            branch: None,
             catalog_mode: CatalogMode::Direct {
                 table_location: table_location.into(),
             },
-            s3_region: None,
-            s3_endpoint: None,
-            s3_path_style: false,
+            io: fluree_db_iceberg::config::IoConfig {
+                vended_credentials: false,
+                ..Default::default()
+            },
         }
-    }
-
-    /// Set the branch name.
-    pub fn with_branch(mut self, branch: impl Into<String>) -> Self {
-        self.branch = Some(branch.into());
-        self
     }
 
     /// Set bearer token authentication (REST mode only).
@@ -589,8 +586,8 @@ impl IcebergCreateConfig {
 
     /// Enable or disable vended credentials (REST mode only).
     pub fn with_vended_credentials(mut self, enabled: bool) -> Self {
-        if let CatalogMode::Rest(ref mut rest) = self.catalog_mode {
-            rest.vended_credentials = enabled;
+        if self.is_rest() {
+            self.io.vended_credentials = enabled;
         } else {
             tracing::warn!("with_vended_credentials has no effect in Direct catalog mode");
         }
@@ -599,19 +596,137 @@ impl IcebergCreateConfig {
 
     /// Set S3 region.
     pub fn with_s3_region(mut self, region: impl Into<String>) -> Self {
-        self.s3_region = Some(region.into());
+        self.io.s3_region = Some(region.into());
         self
     }
 
     /// Set S3 endpoint (for MinIO, LocalStack).
     pub fn with_s3_endpoint(mut self, endpoint: impl Into<String>) -> Self {
-        self.s3_endpoint = Some(endpoint.into());
+        self.io.s3_endpoint = Some(endpoint.into());
         self
     }
 
     /// Enable path-style S3 URLs.
     pub fn with_s3_path_style(mut self, enabled: bool) -> Self {
-        self.s3_path_style = enabled;
+        self.io.s3_path_style = enabled;
+        self
+    }
+
+    /// Get the catalog URI (for REST mode) or table location (for direct mode).
+    pub fn catalog_uri_or_location(&self) -> &str {
+        match &self.catalog_mode {
+            CatalogMode::Rest(rest) => &rest.catalog_uri,
+            CatalogMode::Direct { table_location } => table_location,
+        }
+    }
+
+    /// Returns `true` if this connection uses REST catalog mode.
+    pub fn is_rest(&self) -> bool {
+        matches!(self.catalog_mode, CatalogMode::Rest(_))
+    }
+
+    /// Returns `true` if this connection uses direct S3 catalog mode.
+    pub fn is_direct(&self) -> bool {
+        matches!(self.catalog_mode, CatalogMode::Direct { .. })
+    }
+}
+
+#[cfg(feature = "iceberg")]
+impl IcebergCreateConfig {
+    /// Create a new Iceberg graph source config for REST catalog mode.
+    pub fn new(
+        name: impl Into<String>,
+        catalog_uri: impl Into<String>,
+        table_identifier: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            branch: None,
+            connection: IcebergConnectionConfig::rest(catalog_uri),
+            table_identifier: table_identifier.into(),
+        }
+    }
+
+    /// Create a new Iceberg graph source config for direct S3 access (no REST catalog).
+    pub fn new_direct(name: impl Into<String>, table_location: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            branch: None,
+            connection: IcebergConnectionConfig::direct(table_location),
+            table_identifier: String::new(),
+        }
+    }
+
+    /// Set the branch name.
+    pub fn with_branch(mut self, branch: impl Into<String>) -> Self {
+        self.branch = Some(branch.into());
+        self
+    }
+
+    /// Set bearer token authentication (REST mode only).
+    pub fn with_auth_bearer(mut self, token: impl Into<String>) -> Self {
+        self.connection = self.connection.with_auth_bearer(token);
+        self
+    }
+
+    /// Set OAuth2 client credentials authentication (REST mode only).
+    pub fn with_auth_oauth2(
+        mut self,
+        token_url: impl Into<String>,
+        client_id: impl Into<String>,
+        client_secret: impl Into<String>,
+    ) -> Self {
+        self.connection = self
+            .connection
+            .with_auth_oauth2(token_url, client_id, client_secret);
+        self
+    }
+
+    /// Set the OAuth2 `scope` for client-credentials auth (REST + OAuth2 only).
+    ///
+    /// Call after [`Self::with_auth_oauth2`]. See
+    /// [`IcebergConnectionConfig::with_oauth2_scope`].
+    pub fn with_oauth2_scope(mut self, scope: impl Into<String>) -> Self {
+        self.connection = self.connection.with_oauth2_scope(scope);
+        self
+    }
+
+    /// Set the OAuth2 `audience` for client-credentials auth (REST + OAuth2 only).
+    ///
+    /// Call after [`Self::with_auth_oauth2`]. See
+    /// [`IcebergConnectionConfig::with_oauth2_audience`].
+    pub fn with_oauth2_audience(mut self, audience: impl Into<String>) -> Self {
+        self.connection = self.connection.with_oauth2_audience(audience);
+        self
+    }
+
+    /// Set the warehouse identifier (REST mode only).
+    pub fn with_warehouse(mut self, warehouse: impl Into<String>) -> Self {
+        self.connection = self.connection.with_warehouse(warehouse);
+        self
+    }
+
+    /// Enable or disable vended credentials (REST mode only).
+    pub fn with_vended_credentials(mut self, enabled: bool) -> Self {
+        self.connection = self.connection.with_vended_credentials(enabled);
+        self
+    }
+
+    /// Set S3 region.
+    pub fn with_s3_region(mut self, region: impl Into<String>) -> Self {
+        self.connection = self.connection.with_s3_region(region);
+        self
+    }
+
+    /// Set S3 endpoint (for MinIO, LocalStack).
+    pub fn with_s3_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.connection = self.connection.with_s3_endpoint(endpoint);
+        self
+    }
+
+    /// Enable path-style S3 URLs.
+    pub fn with_s3_path_style(mut self, enabled: bool) -> Self {
+        self.connection = self.connection.with_s3_path_style(enabled);
         self
     }
 
@@ -627,16 +742,13 @@ impl IcebergCreateConfig {
 
     /// Get the catalog URI (for REST mode) or table location (for direct mode).
     pub fn catalog_uri_or_location(&self) -> &str {
-        match &self.catalog_mode {
-            CatalogMode::Rest(rest) => &rest.catalog_uri,
-            CatalogMode::Direct { table_location } => table_location,
-        }
+        self.connection.catalog_uri_or_location()
     }
 
     /// Get the table identifier string (for REST mode), or derive from location (for direct mode).
     pub fn table_identifier_display(&self) -> String {
-        match &self.catalog_mode {
-            CatalogMode::Rest(rest) => rest.table_identifier.clone(),
+        match &self.connection.catalog_mode {
+            CatalogMode::Rest(_) => self.table_identifier.clone(),
             CatalogMode::Direct { table_location } => {
                 let path = table_location
                     .trim_start_matches("s3://")
@@ -657,9 +769,9 @@ impl IcebergCreateConfig {
 
     /// Convert to the internal IcebergGsConfig structure for storage.
     pub fn to_iceberg_gs_config(&self) -> IcebergGsConfig {
-        use fluree_db_iceberg::config::{CatalogConfig, IoConfig, TableConfig};
+        use fluree_db_iceberg::config::{CatalogConfig, TableConfig};
 
-        match &self.catalog_mode {
+        match &self.connection.catalog_mode {
             CatalogMode::Rest(rest) => IcebergGsConfig {
                 catalog: CatalogConfig::Rest {
                     catalog_type: "polaris".to_string(),
@@ -667,26 +779,21 @@ impl IcebergCreateConfig {
                     auth: rest.auth.clone(),
                     warehouse: rest.warehouse.clone(),
                 },
-                table: TableConfig::Identifier(rest.table_identifier.clone()),
-                io: IoConfig {
-                    vended_credentials: rest.vended_credentials,
-                    s3_region: self.s3_region.clone(),
-                    s3_endpoint: self.s3_endpoint.clone(),
-                    s3_path_style: self.s3_path_style,
-                },
+                table: TableConfig::Identifier(self.table_identifier.clone()),
+                io: self.connection.io.clone(),
                 mapping: None,
             },
-            CatalogMode::Direct { table_location } => IcebergGsConfig {
-                catalog: CatalogConfig::direct(table_location),
-                table: TableConfig::Identifier(String::new()),
-                io: IoConfig {
-                    vended_credentials: false,
-                    s3_region: self.s3_region.clone(),
-                    s3_endpoint: self.s3_endpoint.clone(),
-                    s3_path_style: self.s3_path_style,
-                },
-                mapping: None,
-            },
+            CatalogMode::Direct { table_location } => {
+                // Direct never uses vended credentials, regardless of the io flag.
+                let mut io = self.connection.io.clone();
+                io.vended_credentials = false;
+                IcebergGsConfig {
+                    catalog: CatalogConfig::direct(table_location),
+                    table: TableConfig::Identifier(String::new()),
+                    io,
+                    mapping: None,
+                }
+            }
         }
     }
 
@@ -702,16 +809,16 @@ impl IcebergCreateConfig {
             ));
         }
 
-        match &self.catalog_mode {
+        match &self.connection.catalog_mode {
             CatalogMode::Rest(rest) => {
                 if rest.catalog_uri.trim().is_empty() {
                     return Err(crate::ApiError::config("Catalog URI cannot be empty"));
                 }
-                if rest.table_identifier.trim().is_empty() {
+                if self.table_identifier.trim().is_empty() {
                     return Err(crate::ApiError::config("Table identifier cannot be empty"));
                 }
                 use fluree_db_iceberg::catalog::parse_table_identifier;
-                parse_table_identifier(&rest.table_identifier).map_err(|e| {
+                parse_table_identifier(&self.table_identifier).map_err(|e| {
                     crate::ApiError::config(format!("Invalid table identifier: {e}"))
                 })?;
             }
@@ -734,12 +841,12 @@ impl IcebergCreateConfig {
 
     /// Returns `true` if this config uses REST catalog mode.
     pub fn is_rest(&self) -> bool {
-        matches!(self.catalog_mode, CatalogMode::Rest(_))
+        self.connection.is_rest()
     }
 
     /// Returns `true` if this config uses direct S3 catalog mode.
     pub fn is_direct(&self) -> bool {
-        matches!(self.catalog_mode, CatalogMode::Direct { .. })
+        self.connection.is_direct()
     }
 }
 
@@ -1072,7 +1179,7 @@ mod tests {
 
     #[cfg(feature = "iceberg")]
     fn oauth2_auth(config: &IcebergCreateConfig) -> &fluree_db_iceberg::auth::AuthConfig {
-        match &config.catalog_mode {
+        match &config.connection.catalog_mode {
             CatalogMode::Rest(rest) => &rest.auth,
             CatalogMode::Direct { .. } => panic!("expected REST catalog mode"),
         }

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -1,0 +1,221 @@
+//! Read-only Iceberg catalog browse + metadata preview API (metadata-only).
+//!
+//! This module exposes the catalog-browse and metadata-preview surface that
+//! feeds the deterministic R2RML generator (PR-1 item (c), a separate lane) and
+//! the solo onboarding flow (PR-2). Everything here is **metadata-only**: browse
+//! lists namespaces/tables via the REST catalog, Tier-A preview reads the inline
+//! `metadata` object the REST `loadTable` response already carries (no S3), and
+//! Tier-B preview aggregates per-column statistics from the snapshot's
+//! manifest-list + manifest Avro files (never a Parquet/data file).
+//!
+//! All entry points accept an inline [`IcebergConnectionConfig`] so onboarding
+//! can browse/preview **before** a graph source is saved.
+
+use serde::{Deserialize, Serialize};
+
+use crate::graph_source::config::{CatalogMode, IcebergConnectionConfig};
+use crate::Result;
+
+use fluree_db_iceberg::catalog::{RestCatalogClient, RestCatalogConfig, SendCatalogClient};
+
+// =============================================================================
+// Shared identifiers
+// =============================================================================
+
+/// A table reference: catalog namespace + table name (byte-for-byte catalog
+/// casing). Pinned shape `{ namespace, name }`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TableIdentifier {
+    /// Catalog namespace (e.g. `"DW"`).
+    pub namespace: String,
+    /// Table name (e.g. `"DIM_STORE"`).
+    pub name: String,
+}
+
+impl TableIdentifier {
+    /// Construct a table identifier.
+    pub fn new(namespace: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            namespace: namespace.into(),
+            name: name.into(),
+        }
+    }
+
+    /// The canonical `"NAMESPACE.NAME"` string (byte-for-byte catalog casing).
+    pub fn qualified(&self) -> String {
+        format!("{}.{}", self.namespace, self.name)
+    }
+}
+
+/// Alias for [`TableIdentifier`] — browse returns these under `tables`; the
+/// shape is identical (`{ namespace, name }`).
+pub type TableRef = TableIdentifier;
+
+// =============================================================================
+// (a) Browse
+// =============================================================================
+
+/// How deep a catalog browse should reach.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BrowseDepth {
+    /// List namespaces only.
+    Namespaces,
+    /// List namespaces and, for each, its tables.
+    Tables,
+}
+
+/// The result of browsing a catalog.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogBrowse {
+    /// The catalog URI that was browsed.
+    pub catalog_uri: String,
+    /// The warehouse (if any) the browse was scoped to.
+    pub warehouse: Option<String>,
+    /// The namespaces discovered in the catalog.
+    pub namespaces: Vec<String>,
+    /// The tables discovered (empty when `depth = Namespaces`).
+    pub tables: Vec<TableRef>,
+}
+
+/// Build a REST catalog client from a connection, or a clear typed error for
+/// Direct mode (which has no catalog to browse/list).
+fn rest_catalog_client(
+    conn: &IcebergConnectionConfig,
+    op: &str,
+) -> Result<(RestCatalogClient, String, Option<String>)> {
+    let rest = match &conn.catalog_mode {
+        CatalogMode::Rest(rest) => rest,
+        CatalogMode::Direct { .. } => {
+            return Err(crate::ApiError::config(format!(
+                "Direct catalog mode cannot be used for {op}: there is no REST catalog to query. \
+                 Provide a REST connection (catalog_uri + auth)."
+            )));
+        }
+    };
+
+    let auth = rest
+        .auth
+        .create_provider_arc()
+        .map_err(|e| crate::ApiError::config(format!("Failed to create auth provider: {e}")))?;
+
+    let catalog_config = RestCatalogConfig {
+        uri: rest.catalog_uri.clone(),
+        warehouse: rest.warehouse.clone(),
+        ..Default::default()
+    };
+
+    let catalog = RestCatalogClient::new(catalog_config, auth)
+        .map_err(|e| crate::ApiError::config(format!("Failed to create catalog client: {e}")))?;
+
+    Ok((catalog, rest.catalog_uri.clone(), rest.warehouse.clone()))
+}
+
+/// Browse an Iceberg REST catalog: list namespaces and, at `depth = Tables`,
+/// the tables in each namespace.
+///
+/// **Metadata-only** and stateless — it needs no `Fluree` instance and touches
+/// no S3. Direct catalog mode returns a clear [`crate::ApiError::Config`] (there
+/// is nothing to browse).
+pub async fn browse_iceberg_catalog(
+    conn: IcebergConnectionConfig,
+    depth: BrowseDepth,
+) -> Result<CatalogBrowse> {
+    let (catalog, catalog_uri, warehouse) = rest_catalog_client(&conn, "catalog browse")?;
+
+    let namespaces = SendCatalogClient::list_namespaces(&catalog)
+        .await
+        .map_err(|e| crate::ApiError::config(format!("Failed to list namespaces: {e}")))?;
+
+    let mut tables = Vec::new();
+    if depth == BrowseDepth::Tables {
+        for ns in &namespaces {
+            let ns_tables = SendCatalogClient::list_tables(&catalog, ns)
+                .await
+                .map_err(|e| {
+                    crate::ApiError::config(format!("Failed to list tables in namespace {ns}: {e}"))
+                })?;
+            for qualified in ns_tables {
+                tables.push(split_qualified_table(ns, &qualified));
+            }
+        }
+    }
+
+    Ok(CatalogBrowse {
+        catalog_uri,
+        warehouse,
+        namespaces,
+        tables,
+    })
+}
+
+/// Recover a `{ namespace, name }` ref from a queried namespace plus the
+/// `"ns.table"`-style identifier the catalog returns. The queried namespace is
+/// authoritative (namespaces can contain dots), so we strip its prefix; if the
+/// entry does not carry the prefix we fall back to a last-segment split.
+fn split_qualified_table(queried_ns: &str, qualified: &str) -> TableRef {
+    if let Some(name) = qualified.strip_prefix(&format!("{queried_ns}.")) {
+        return TableRef::new(queried_ns.to_string(), name.to_string());
+    }
+    match qualified.rsplit_once('.') {
+        Some((ns, name)) => TableRef::new(ns.to_string(), name.to_string()),
+        None => TableRef::new(queried_ns.to_string(), qualified.to_string()),
+    }
+}
+
+impl crate::Fluree {
+    /// Browse an Iceberg REST catalog (namespaces, and tables at
+    /// `depth = Tables`). Convenience wrapper over the stateless
+    /// [`browse_iceberg_catalog`] free function — browse needs no engine state.
+    pub async fn browse_iceberg_catalog(
+        &self,
+        conn: IcebergConnectionConfig,
+        depth: BrowseDepth,
+    ) -> Result<CatalogBrowse> {
+        browse_iceberg_catalog(conn, depth).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn browse_direct_mode_errors() {
+        // Direct mode has no catalog to browse — must return a clear typed error
+        // without any network access.
+        let conn = IcebergConnectionConfig::direct("s3://bucket/warehouse/ns/table");
+        let err = browse_iceberg_catalog(conn, BrowseDepth::Tables)
+            .await
+            .expect_err("Direct mode must not be browsable");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Direct catalog mode"),
+            "error should explain Direct mode is not browsable, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn split_qualified_table_recovers_name() {
+        assert_eq!(
+            split_qualified_table("DW", "DW.DIM_STORE"),
+            TableRef::new("DW", "DIM_STORE")
+        );
+        // Multi-level namespace with dots is handled via the queried prefix.
+        assert_eq!(
+            split_qualified_table("db.schema", "db.schema.events"),
+            TableRef::new("db.schema", "events")
+        );
+        // Missing prefix falls back to a last-segment split.
+        assert_eq!(
+            split_qualified_table("DW", "OTHER.TABLE"),
+            TableRef::new("OTHER", "TABLE")
+        );
+    }
+
+    #[test]
+    fn table_identifier_qualified() {
+        let t = TableIdentifier::new("DW", "DIM_STORE");
+        assert_eq!(t.qualified(), "DW.DIM_STORE");
+    }
+}

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -491,16 +491,23 @@ pub(crate) fn table_schema_from_metadata(
         },
     };
 
-    let (row_count, data_file_count, total_bytes) = current_snapshot.map_or((None, None, None), |s| {
-        (s.total_records(), s.total_data_files(), s.total_files_size())
-    });
+    let (row_count, data_file_count, total_bytes) =
+        current_snapshot.map_or((None, None, None), |s| {
+            (
+                s.total_records(),
+                s.total_data_files(),
+                s.total_files_size(),
+            )
+        });
 
-    let partition_spec = metadata.default_partition_spec().map_or_else(Vec::new, |spec| {
-        spec.fields
-            .iter()
-            .map(|pf| partition_field_info(pf, schema))
-            .collect()
-    });
+    let partition_spec = metadata
+        .default_partition_spec()
+        .map_or_else(Vec::new, |spec| {
+            spec.fields
+                .iter()
+                .map(|pf| partition_field_info(pf, schema))
+                .collect()
+        });
 
     let sort_order = metadata
         .sort_orders
@@ -619,7 +626,8 @@ pub async fn preview_iceberg_table(
                 }
                 None => {
                     warnings.push(
-                        "Table has no current snapshot; no column statistics available.".to_string(),
+                        "Table has no current snapshot; no column statistics available."
+                            .to_string(),
                     );
                     (0, false)
                 }
@@ -824,7 +832,10 @@ mod tests {
         assert_eq!(schema.sort_order[0].direction, "asc");
         assert_eq!(schema.sort_order[0].null_order, "nulls-first");
 
-        assert_eq!(schema.properties.get("owner").map(String::as_str), Some("analytics"));
+        assert_eq!(
+            schema.properties.get("owner").map(String::as_str),
+            Some("analytics")
+        );
 
         // Column type mapping: field_type + xsd_type per FieldType.
         let key = column(&schema, "SALE_KEY");
@@ -844,7 +855,10 @@ mod tests {
         assert_eq!(amount.iceberg_type, "decimal(18, 2)");
         assert_eq!(
             amount.field_type,
-            Some(FieldType::Decimal { precision: 18, scale: 2 })
+            Some(FieldType::Decimal {
+                precision: 18,
+                scale: 2
+            })
         );
         assert_eq!(amount.xsd_type.as_deref(), Some("xsd:decimal"));
 
@@ -882,15 +896,22 @@ mod tests {
         let back: ColumnInfo =
             serde_json::from_value(serde_json::to_value(column(&schema, "AMOUNT")).unwrap())
                 .unwrap();
-        assert_eq!(back.field_type, Some(FieldType::Decimal { precision: 18, scale: 2 }));
+        assert_eq!(
+            back.field_type,
+            Some(FieldType::Decimal {
+                precision: 18,
+                scale: 2
+            })
+        );
     }
 
     #[tokio::test]
     async fn preview_direct_mode_errors() {
         let conn = IcebergConnectionConfig::direct("s3://bucket/warehouse/ns/table");
-        let err = preview_iceberg_table(conn, TableIdentifier::new("ns", "table"), StatsTier::Schema)
-            .await
-            .expect_err("Direct mode must not be previewable");
+        let err =
+            preview_iceberg_table(conn, TableIdentifier::new("ns", "table"), StatsTier::Schema)
+                .await
+                .expect_err("Direct mode must not be previewable");
         assert!(err.to_string().contains("Direct catalog mode"));
     }
 
@@ -901,7 +922,10 @@ mod tests {
     #[test]
     fn xsd_map_matches_emitter() {
         assert_eq!(xsd_datatype(FieldType::Bytes, true), Some("xsd:hexBinary"));
-        assert_eq!(xsd_datatype(FieldType::Timestamp, true), Some("xsd:dateTime"));
+        assert_eq!(
+            xsd_datatype(FieldType::Timestamp, true),
+            Some("xsd:dateTime")
+        );
         assert_eq!(
             xsd_datatype(FieldType::TimestampTz, true),
             Some("xsd:dateTime")
@@ -914,7 +938,13 @@ mod tests {
         assert_eq!(xsd_datatype(FieldType::Int32, true), Some("xsd:integer"));
         assert_eq!(xsd_datatype(FieldType::Date, true), Some("xsd:date"));
         assert_eq!(
-            xsd_datatype(FieldType::Decimal { precision: 18, scale: 2 }, true),
+            xsd_datatype(
+                FieldType::Decimal {
+                    precision: 18,
+                    scale: 2
+                },
+                true
+            ),
             Some("xsd:decimal")
         );
     }

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -275,6 +275,11 @@ pub struct ColumnStats {
     pub on_disk_bytes: Option<i64>,
     /// Distinct value count — ALWAYS `None` in Phase-1 (NDV deferred to PR-5).
     pub distinct_count: Option<i64>,
+    /// Whether `min`/`max` are **truncated prefixes** rather than exact observed
+    /// values. Iceberg truncates variable-length (string/binary) bounds, so the
+    /// decoded value is a valid bound but not necessarily present in the column.
+    #[serde(default)]
+    pub bounds_truncated: bool,
 }
 
 /// A single column of a table, with type mapping and optional statistics.
@@ -348,6 +353,12 @@ pub struct StatsCompleteness {
     pub manifests_read: usize,
     /// Whether any column carried lower/upper bounds in the manifests read.
     pub had_column_bounds: bool,
+    /// Whether the snapshot carries **merge-on-read delete files**. When `true`,
+    /// the aggregated `row_count` / value / null counts are **upper bounds**:
+    /// they sum live data-file records without subtracting position/equality
+    /// deletes, so they are not exact.
+    #[serde(default)]
+    pub has_delete_files: bool,
 }
 
 /// The full preview of a table: schema, statistics completeness, warnings.
@@ -576,13 +587,16 @@ pub async fn preview_iceberg_table(
                 tier: "schema".to_string(),
                 manifests_read: 0,
                 had_column_bounds: false,
+                has_delete_files: false,
             },
             warnings: Vec::new(),
         }),
         StatsTier::Stats => {
             let mut warnings = vec![DISTINCT_COUNT_WARNING.to_string()];
 
-            let (manifests_read, had_column_bounds) = match metadata.current_snapshot() {
+            let (manifests_read, had_column_bounds, has_delete_files) = match metadata
+                .current_snapshot()
+            {
                 Some(snapshot) => {
                     let iceberg_schema = metadata.current_schema().ok_or_else(|| {
                         crate::ApiError::config("Table metadata has no current schema")
@@ -593,9 +607,9 @@ pub async fn preview_iceberg_table(
                     // the scan path.
                     let storage = build_preview_storage(&conn, load.credentials.as_ref()).await?;
 
-                    // Metadata-only: reads the manifest-list + manifests, never a
-                    // Parquet/data file (see fluree_db_iceberg::stats).
-                    let (data_files, manifests_read) =
+                    // Metadata-only: reads the manifest-list + manifests, never
+                    // a Parquet/data file (see fluree_db_iceberg::stats).
+                    let (data_files, manifests_read, has_delete_files) =
                         send_read_snapshot_data_files(&storage, snapshot)
                             .await
                             .map_err(|e| {
@@ -617,19 +631,30 @@ pub async fn preview_iceberg_table(
                     }
 
                     // Fill authoritative counts from the aggregation if the
-                    // snapshot summary omitted them.
+                    // snapshot summary omitted them. When the snapshot carries
+                    // merge-on-read deletes, the aggregated counts are upper
+                    // bounds (deletes are not subtracted), so warn.
                     schema.row_count = schema.row_count.or(Some(agg.row_count));
                     schema.data_file_count = schema.data_file_count.or(Some(agg.data_file_count));
                     schema.total_bytes = schema.total_bytes.or(Some(agg.total_bytes));
 
-                    (manifests_read, agg.had_column_bounds)
+                    if has_delete_files {
+                        warnings.push(
+                            "Table has merge-on-read delete files; aggregated row/value/null \
+                                 counts are upper bounds (position/equality deletes are not \
+                                 subtracted)."
+                                .to_string(),
+                        );
+                    }
+
+                    (manifests_read, agg.had_column_bounds, has_delete_files)
                 }
                 None => {
                     warnings.push(
                         "Table has no current snapshot; no column statistics available."
                             .to_string(),
                     );
-                    (0, false)
+                    (0, false, false)
                 }
             };
 
@@ -639,6 +664,7 @@ pub async fn preview_iceberg_table(
                     tier: "stats".to_string(),
                     manifests_read,
                     had_column_bounds,
+                    has_delete_files,
                 },
                 warnings,
             })
@@ -684,6 +710,7 @@ fn to_api_column_stats(a: &AggregatedColumnStats) -> ColumnStats {
         max: a.max.clone(),
         on_disk_bytes: a.on_disk_bytes,
         distinct_count: a.distinct_count,
+        bounds_truncated: a.bounds_truncated,
     }
 }
 

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -11,12 +11,19 @@
 //! All entry points accept an inline [`IcebergConnectionConfig`] so onboarding
 //! can browse/preview **before** a graph source is saved.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::graph_source::config::{CatalogMode, IcebergConnectionConfig};
 use crate::Result;
 
 use fluree_db_iceberg::catalog::{RestCatalogClient, RestCatalogConfig, SendCatalogClient};
+use fluree_db_iceberg::io::batch::IcebergFieldTypeExt;
+use fluree_db_iceberg::metadata::{
+    PartitionField, Schema, SchemaField, Snapshot, SortField, TableMetadata,
+};
+use fluree_db_iceberg::FieldType;
 
 // =============================================================================
 // Shared identifiers
@@ -44,6 +51,14 @@ impl TableIdentifier {
     /// The canonical `"NAMESPACE.NAME"` string (byte-for-byte catalog casing).
     pub fn qualified(&self) -> String {
         format!("{}.{}", self.namespace, self.name)
+    }
+
+    /// Convert to the iceberg-crate catalog identifier (`{ namespace, table }`).
+    pub(crate) fn to_catalog(&self) -> fluree_db_iceberg::catalog::TableIdentifier {
+        fluree_db_iceberg::catalog::TableIdentifier {
+            namespace: self.namespace.clone(),
+            table: self.name.clone(),
+        }
     }
 }
 
@@ -176,6 +191,427 @@ impl crate::Fluree {
     }
 }
 
+// =============================================================================
+// (b) Metadata preview — Tier-A schema (this section) + Tier-B stats (aggregated
+//     from manifests; see the ColumnStats wiring below).
+// =============================================================================
+
+/// Human-readable note attached to every Tier-B preview: NDV / distinct counts
+/// are not derivable from Iceberg metadata alone (Puffin/theta-sketch reading is
+/// deferred to PR-5), so `distinct_count` is always `None`.
+pub(crate) const DISTINCT_COUNT_WARNING: &str =
+    "distinct_count (NDV) is unavailable from metadata alone; it requires column \
+     profiling and is deferred to PR-5.";
+
+/// Which statistics tier a preview should compute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StatsTier {
+    /// Tier-A: schema only (columns/types/partition/sort/snapshot), from the
+    /// inline REST `loadTable` metadata. No S3 reads.
+    Schema,
+    /// Tier-A + Tier-B: additionally aggregate per-column statistics from the
+    /// snapshot's manifest-list + manifest Avro files (never a data file).
+    Stats,
+}
+
+/// A reference to a table snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotRef {
+    /// Snapshot ID.
+    pub id: i64,
+    /// Snapshot creation timestamp (epoch millis).
+    pub timestamp_ms: i64,
+    /// The schema ID that was current at snapshot time.
+    pub schema_id: Option<i32>,
+}
+
+/// A partition field, resolved to readable names.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartitionFieldInfo {
+    /// Partition field name.
+    pub name: String,
+    /// The source column the partition transform is applied to.
+    pub source_field: String,
+    /// The transform (`identity`, `bucket[N]`, `day`, `month`, …).
+    pub transform: String,
+}
+
+/// A sort field, resolved to a readable column name.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SortFieldInfo {
+    /// The sorted column name.
+    pub field: String,
+    /// Sort direction (`asc` / `desc`).
+    pub direction: String,
+    /// Null ordering (`nulls-first` / `nulls-last`).
+    pub null_order: String,
+}
+
+/// Per-column statistics aggregated from manifests (Tier-B). Every field is
+/// best-effort — a stat is `None` when the manifests do not carry it.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ColumnStats {
+    /// Number of null values across the snapshot's data files.
+    pub null_count: Option<i64>,
+    /// Number of values (including nulls) across the snapshot's data files.
+    pub value_count: Option<i64>,
+    /// `null_count / value_count`, when both are known and `value_count > 0`.
+    pub null_fraction: Option<f64>,
+    /// Number of NaN values (float/double columns only).
+    pub nan_count: Option<i64>,
+    /// Column-wide minimum (value_codec-decoded lower bound, JSON-rendered).
+    pub min: Option<serde_json::Value>,
+    /// Column-wide maximum (value_codec-decoded upper bound, JSON-rendered).
+    pub max: Option<serde_json::Value>,
+    /// On-disk size in bytes for this column across the snapshot's data files.
+    pub on_disk_bytes: Option<i64>,
+    /// Distinct value count — ALWAYS `None` in Phase-1 (NDV deferred to PR-5).
+    pub distinct_count: Option<i64>,
+}
+
+/// A single column of a table, with type mapping and optional statistics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnInfo {
+    /// Iceberg field ID (canonical).
+    pub field_id: i32,
+    /// Byte-for-byte Iceberg field name.
+    pub name: String,
+    /// Iceberg type string (`"long"`, `"decimal(18, 2)"`, `"struct"`, …).
+    pub iceberg_type: String,
+    /// Parsed [`FieldType`] (via `IcebergFieldTypeExt`); `None` for nested types.
+    #[serde(with = "field_type_serde", default)]
+    pub field_type: Option<FieldType>,
+    /// The emitter's chosen `xsd:` datatype CURIE; `None` for string/nested.
+    pub xsd_type: Option<String>,
+    /// Whether the column is required (non-nullable) per the schema.
+    pub required: bool,
+    /// Whether the column is a nested type (struct/list/map).
+    pub nested: bool,
+    /// Column documentation, if any.
+    pub doc: Option<String>,
+    /// Per-column statistics; present only for `tier = Stats`.
+    pub stats: Option<ColumnStats>,
+}
+
+/// The schema (and table-level metadata) of a table, Tier-A.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableSchema {
+    /// `"NAMESPACE.NAME"` (byte-for-byte catalog casing).
+    pub table: String,
+    /// Table UUID, if the metadata carries one.
+    pub table_uuid: Option<String>,
+    /// Iceberg format version (1 or 2).
+    pub format_version: i32,
+    /// The current schema ID.
+    pub current_schema_id: i32,
+    /// The current snapshot.
+    pub snapshot: SnapshotRef,
+    /// Authoritative row count from the snapshot summary.
+    pub row_count: Option<i64>,
+    /// Authoritative data-file count from the snapshot summary.
+    pub data_file_count: Option<i64>,
+    /// Authoritative on-disk byte count from the snapshot summary.
+    pub total_bytes: Option<i64>,
+    /// Iceberg row-identity hint (equality-delete identity) — the primary PK signal.
+    pub identifier_field_ids: Vec<i32>,
+    /// The default partition spec, resolved to readable names.
+    pub partition_spec: Vec<PartitionFieldInfo>,
+    /// The default sort order, resolved to readable names.
+    pub sort_order: Vec<SortFieldInfo>,
+    /// Table properties.
+    pub properties: HashMap<String, String>,
+    /// Columns in schema order.
+    pub columns: Vec<ColumnInfo>,
+    /// Snapshot history (additive beyond the pinned `snapshot`; scope item 3
+    /// asks for snapshot history alongside the current snapshot).
+    pub snapshot_log: Vec<SnapshotRef>,
+}
+
+/// How complete the statistics in a preview are.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatsCompleteness {
+    /// The tier that was computed (`"schema"` or `"stats"`).
+    pub tier: String,
+    /// Number of manifest files read (0 for Tier-A / Schema).
+    pub manifests_read: usize,
+    /// Whether any column carried lower/upper bounds in the manifests read.
+    pub had_column_bounds: bool,
+}
+
+/// The full preview of a table: schema, statistics completeness, warnings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TablePreview {
+    /// The table schema (+ per-column stats when `tier = Stats`).
+    pub schema: TableSchema,
+    /// How complete the statistics are.
+    pub stats_completeness: StatsCompleteness,
+    /// Non-fatal warnings (e.g. `distinct_count` unavailable).
+    pub warnings: Vec<String>,
+}
+
+/// The `xsd:` datatype CURIE for a [`FieldType`] (or `None` for strings / nested).
+///
+/// This is a deliberate, test-pinned mirror of the emitter's canonical
+/// `fluree_db_r2rml::emit::naming::xsd_datatype` (with the reference-matching
+/// `xsd_long_as_integer = true` convention). That function is the single source
+/// of truth, but it lives in a **private** module of the emitter lane which this
+/// PR must not edit; the parity is locked by [`tests::xsd_map_matches_emitter`].
+fn field_type_to_xsd(field_type: FieldType) -> Option<&'static str> {
+    let curie = match field_type {
+        FieldType::Boolean => "xsd:boolean",
+        // Reference (`enterprise.ttl`) convention: longs/ints as xsd:integer.
+        FieldType::Int32 | FieldType::Int64 => "xsd:integer",
+        FieldType::Float32 => "xsd:float",
+        FieldType::Float64 => "xsd:double",
+        FieldType::Decimal { .. } => "xsd:decimal",
+        FieldType::Date => "xsd:date",
+        FieldType::Timestamp | FieldType::TimestampTz => "xsd:dateTime",
+        FieldType::Bytes => "xsd:hexBinary",
+        FieldType::String => return None,
+    };
+    Some(curie)
+}
+
+/// Canonical Iceberg type string for a [`FieldType`], round-trippable through
+/// `FieldType::from_iceberg_type` (used for wire serialization of `field_type`).
+fn field_type_to_iceberg_string(field_type: FieldType) -> String {
+    match field_type {
+        FieldType::Boolean => "boolean".to_string(),
+        FieldType::Int32 => "int".to_string(),
+        FieldType::Int64 => "long".to_string(),
+        FieldType::Float32 => "float".to_string(),
+        FieldType::Float64 => "double".to_string(),
+        FieldType::String => "string".to_string(),
+        FieldType::Bytes => "binary".to_string(),
+        FieldType::Date => "date".to_string(),
+        FieldType::Timestamp => "timestamp".to_string(),
+        FieldType::TimestampTz => "timestamptz".to_string(),
+        FieldType::Decimal { precision, scale } => format!("decimal({precision}, {scale})"),
+    }
+}
+
+/// Serde adapter so `Option<FieldType>` (which is not itself `Serialize`) rides
+/// the wire as its Iceberg type string (`"long"`, `"decimal(18, 2)"`, …).
+mod field_type_serde {
+    use super::{field_type_to_iceberg_string, FieldType, IcebergFieldTypeExt};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        field_type: &Option<FieldType>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match field_type {
+            Some(ft) => serializer.serialize_some(&field_type_to_iceberg_string(*ft)),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<FieldType>, D::Error> {
+        let opt: Option<String> = Option::deserialize(deserializer)?;
+        Ok(opt.and_then(|s| FieldType::from_iceberg_type(&s)))
+    }
+}
+
+/// The Iceberg type string for a field: the primitive type for scalars, or the
+/// nested `type` tag (`struct` / `list` / `map`) for nested columns.
+fn iceberg_type_string(field: &SchemaField) -> String {
+    match field.type_string() {
+        Some(s) => s.to_string(),
+        None => field
+            .field_type
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("nested")
+            .to_string(),
+    }
+}
+
+/// Build the Tier-A [`ColumnInfo`] for a schema field (no statistics).
+fn column_info_tier_a(field: &SchemaField) -> ColumnInfo {
+    let nested = field.is_nested();
+    let field_type = if nested {
+        None
+    } else {
+        field.type_string().and_then(FieldType::from_iceberg_type)
+    };
+    let xsd_type = field_type
+        .and_then(field_type_to_xsd)
+        .map(str::to_string);
+    ColumnInfo {
+        field_id: field.id,
+        name: field.name.clone(),
+        iceberg_type: iceberg_type_string(field),
+        field_type,
+        xsd_type,
+        required: field.required,
+        nested,
+        doc: field.doc.clone(),
+        stats: None,
+    }
+}
+
+fn snapshot_ref(snapshot: &Snapshot) -> SnapshotRef {
+    SnapshotRef {
+        id: snapshot.snapshot_id,
+        timestamp_ms: snapshot.timestamp_ms,
+        schema_id: snapshot.schema_id,
+    }
+}
+
+fn partition_field_info(pf: &PartitionField, schema: &Schema) -> PartitionFieldInfo {
+    PartitionFieldInfo {
+        name: pf.name.clone(),
+        source_field: schema
+            .field(pf.source_id)
+            .map_or_else(|| pf.source_id.to_string(), |f| f.name.clone()),
+        transform: pf.transform.clone(),
+    }
+}
+
+fn sort_field_info(sf: &SortField, schema: &Schema) -> SortFieldInfo {
+    SortFieldInfo {
+        field: schema
+            .field(sf.source_id)
+            .map_or_else(|| sf.source_id.to_string(), |f| f.name.clone()),
+        direction: sf.direction.clone(),
+        null_order: sf.null_order.clone(),
+    }
+}
+
+/// Build the Tier-A [`TableSchema`] from retained inline table metadata. Pure —
+/// no I/O — so it is exercised offline over a metadata fixture.
+pub(crate) fn table_schema_from_metadata(
+    table: &TableIdentifier,
+    metadata: &TableMetadata,
+) -> Result<TableSchema> {
+    let schema = metadata
+        .current_schema()
+        .ok_or_else(|| crate::ApiError::config("Table metadata has no current schema"))?;
+
+    let current_snapshot = metadata.current_snapshot();
+    let snapshot = match current_snapshot {
+        Some(s) => snapshot_ref(s),
+        None => SnapshotRef {
+            id: metadata.current_snapshot_id.unwrap_or_default(),
+            timestamp_ms: metadata.last_updated_ms,
+            schema_id: Some(metadata.current_schema_id),
+        },
+    };
+
+    let (row_count, data_file_count, total_bytes) = current_snapshot.map_or((None, None, None), |s| {
+        (s.total_records(), s.total_data_files(), s.total_files_size())
+    });
+
+    let partition_spec = metadata.default_partition_spec().map_or_else(Vec::new, |spec| {
+        spec.fields
+            .iter()
+            .map(|pf| partition_field_info(pf, schema))
+            .collect()
+    });
+
+    let sort_order = metadata
+        .sort_orders
+        .iter()
+        .find(|so| so.order_id == metadata.default_sort_order_id)
+        .map_or_else(Vec::new, |so| {
+            so.fields
+                .iter()
+                .map(|sf| sort_field_info(sf, schema))
+                .collect()
+        });
+
+    Ok(TableSchema {
+        table: table.qualified(),
+        table_uuid: metadata.table_uuid.clone(),
+        format_version: metadata.format_version,
+        current_schema_id: metadata.current_schema_id,
+        snapshot,
+        row_count,
+        data_file_count,
+        total_bytes,
+        identifier_field_ids: schema.identifier_field_ids.clone(),
+        partition_spec,
+        sort_order,
+        properties: metadata.properties.clone(),
+        columns: schema.fields.iter().map(column_info_tier_a).collect(),
+        snapshot_log: metadata.snapshots.iter().map(snapshot_ref).collect(),
+    })
+}
+
+/// Preview an Iceberg table's schema (Tier-A) and, at `tier = Stats`, its
+/// per-column statistics (Tier-B).
+///
+/// **Metadata-only**: Tier-A reads the inline REST `loadTable` metadata (no S3);
+/// Tier-B additionally reads the snapshot's manifest-list + manifest Avro files
+/// (never a Parquet/data file). Direct catalog mode and a catalog that omits the
+/// inline metadata both return a clear typed error.
+pub async fn preview_iceberg_table(
+    conn: IcebergConnectionConfig,
+    table: TableIdentifier,
+    tier: StatsTier,
+) -> Result<TablePreview> {
+    let (catalog, _uri, _wh) = rest_catalog_client(&conn, "table preview")?;
+    let table_id = table.to_catalog();
+
+    let load = SendCatalogClient::load_table(&catalog, &table_id, conn.io.vended_credentials)
+        .await
+        .map_err(|e| {
+            crate::ApiError::config(format!("Failed to load table {}: {e}", table.qualified()))
+        })?;
+
+    let metadata = load.metadata.as_ref().ok_or_else(|| {
+        crate::ApiError::config(format!(
+            "Catalog did not return inline table metadata for {} — metadata preview requires a \
+             REST catalog whose loadTable response includes the `metadata` object.",
+            table.qualified()
+        ))
+    })?;
+
+    let schema = table_schema_from_metadata(&table, metadata)?;
+
+    match tier {
+        StatsTier::Schema => Ok(TablePreview {
+            schema,
+            stats_completeness: StatsCompleteness {
+                tier: "schema".to_string(),
+                manifests_read: 0,
+                had_column_bounds: false,
+            },
+            warnings: Vec::new(),
+        }),
+        StatsTier::Stats => {
+            // Tier-B per-column stats are aggregated from the manifest-list +
+            // manifests; wired in the Tier-B commit.
+            Ok(TablePreview {
+                schema,
+                stats_completeness: StatsCompleteness {
+                    tier: "stats".to_string(),
+                    manifests_read: 0,
+                    had_column_bounds: false,
+                },
+                warnings: vec![DISTINCT_COUNT_WARNING.to_string()],
+            })
+        }
+    }
+}
+
+impl crate::Fluree {
+    /// Preview an Iceberg table's schema (Tier-A) and optionally its per-column
+    /// statistics (Tier-B). Convenience wrapper over the stateless
+    /// [`preview_iceberg_table`] free function.
+    pub async fn preview_iceberg_table(
+        &self,
+        conn: IcebergConnectionConfig,
+        table: TableIdentifier,
+        tier: StatsTier,
+    ) -> Result<TablePreview> {
+        preview_iceberg_table(conn, table, tier).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,5 +653,184 @@ mod tests {
     fn table_identifier_qualified() {
         let t = TableIdentifier::new("DW", "DIM_STORE");
         assert_eq!(t.qualified(), "DW.DIM_STORE");
+    }
+
+    /// A representative table metadata fixture exercising every Tier-A facet:
+    /// identifier_field_ids, a partition spec, a sort order, a nested column,
+    /// scalars of several types, snapshot summary counts, and properties.
+    const SAMPLE_METADATA: &str = r#"{
+        "format-version": 2,
+        "table-uuid": "abc-123",
+        "location": "s3://bucket/dw/sales",
+        "last-updated-ms": 1700000000000,
+        "last-column-id": 7,
+        "current-schema-id": 0,
+        "schemas": [{
+            "schema-id": 0,
+            "identifier-field-ids": [1],
+            "fields": [
+                {"id": 1, "name": "SALE_KEY", "required": true, "type": "long"},
+                {"id": 2, "name": "NAME", "required": false, "type": "string"},
+                {"id": 3, "name": "AMOUNT", "required": false, "type": "decimal(18, 2)"},
+                {"id": 4, "name": "CREATED", "required": false, "type": "timestamp"},
+                {"id": 5, "name": "META", "required": false, "type": {
+                    "type": "struct",
+                    "fields": [{"id": 6, "name": "K", "required": true, "type": "int"}]
+                }},
+                {"id": 7, "name": "IS_OPEN", "required": false, "type": "boolean", "doc": "open flag"}
+            ]
+        }],
+        "current-snapshot-id": 55,
+        "snapshots": [
+            {"snapshot-id": 40, "timestamp-ms": 1699000000000, "schema-id": 0, "summary": {}},
+            {"snapshot-id": 55, "timestamp-ms": 1700000000000, "schema-id": 0, "summary": {
+                "total-records": "1000", "total-data-files": "4", "total-files-size": "204800"
+            }}
+        ],
+        "default-spec-id": 0,
+        "partition-specs": [{
+            "spec-id": 0,
+            "fields": [{"source-id": 4, "field-id": 1000, "name": "created_day", "transform": "day"}]
+        }],
+        "default-sort-order-id": 1,
+        "sort-orders": [{
+            "order-id": 1,
+            "fields": [{"source-id": 1, "transform": "identity", "direction": "asc", "null-order": "nulls-first"}]
+        }],
+        "properties": {"owner": "analytics"}
+    }"#;
+
+    fn column<'a>(schema: &'a TableSchema, name: &str) -> &'a ColumnInfo {
+        schema
+            .columns
+            .iter()
+            .find(|c| c.name == name)
+            .unwrap_or_else(|| panic!("column {name} not found"))
+    }
+
+    #[test]
+    fn tier_a_schema_from_inline_metadata() {
+        let metadata = TableMetadata::from_json_str(SAMPLE_METADATA).unwrap();
+        let table = TableIdentifier::new("DW", "SALES");
+        let schema = table_schema_from_metadata(&table, &metadata).unwrap();
+
+        assert_eq!(schema.table, "DW.SALES");
+        assert_eq!(schema.table_uuid.as_deref(), Some("abc-123"));
+        assert_eq!(schema.format_version, 2);
+        assert_eq!(schema.current_schema_id, 0);
+        assert_eq!(schema.columns.len(), 6);
+
+        // identifier_field_ids (the PK hint) survives.
+        assert_eq!(schema.identifier_field_ids, vec![1]);
+
+        // Snapshot + authoritative counts from the current snapshot summary.
+        assert_eq!(schema.snapshot.id, 55);
+        assert_eq!(schema.snapshot.timestamp_ms, 1_700_000_000_000);
+        assert_eq!(schema.snapshot.schema_id, Some(0));
+        assert_eq!(schema.row_count, Some(1000));
+        assert_eq!(schema.data_file_count, Some(4));
+        assert_eq!(schema.total_bytes, Some(204_800));
+        // Snapshot history (both snapshots).
+        assert_eq!(schema.snapshot_log.len(), 2);
+
+        // Partition + sort resolved to source column names.
+        assert_eq!(schema.partition_spec.len(), 1);
+        assert_eq!(schema.partition_spec[0].name, "created_day");
+        assert_eq!(schema.partition_spec[0].source_field, "CREATED");
+        assert_eq!(schema.partition_spec[0].transform, "day");
+        assert_eq!(schema.sort_order.len(), 1);
+        assert_eq!(schema.sort_order[0].field, "SALE_KEY");
+        assert_eq!(schema.sort_order[0].direction, "asc");
+        assert_eq!(schema.sort_order[0].null_order, "nulls-first");
+
+        assert_eq!(schema.properties.get("owner").map(String::as_str), Some("analytics"));
+
+        // Column type mapping: field_type + xsd_type per FieldType.
+        let key = column(&schema, "SALE_KEY");
+        assert_eq!(key.field_id, 1);
+        assert_eq!(key.iceberg_type, "long");
+        assert_eq!(key.field_type, Some(FieldType::Int64));
+        assert_eq!(key.xsd_type.as_deref(), Some("xsd:integer"));
+        assert!(key.required);
+        assert!(!key.nested);
+        assert!(key.stats.is_none());
+
+        let name = column(&schema, "NAME");
+        assert_eq!(name.field_type, Some(FieldType::String));
+        assert_eq!(name.xsd_type, None, "strings are left untyped");
+
+        let amount = column(&schema, "AMOUNT");
+        assert_eq!(amount.iceberg_type, "decimal(18, 2)");
+        assert_eq!(
+            amount.field_type,
+            Some(FieldType::Decimal { precision: 18, scale: 2 })
+        );
+        assert_eq!(amount.xsd_type.as_deref(), Some("xsd:decimal"));
+
+        let created = column(&schema, "CREATED");
+        assert_eq!(created.field_type, Some(FieldType::Timestamp));
+        assert_eq!(created.xsd_type.as_deref(), Some("xsd:dateTime"));
+
+        let is_open = column(&schema, "IS_OPEN");
+        assert_eq!(is_open.field_type, Some(FieldType::Boolean));
+        assert_eq!(is_open.xsd_type.as_deref(), Some("xsd:boolean"));
+        assert_eq!(is_open.doc.as_deref(), Some("open flag"));
+
+        // Nested column: no field_type, no xsd_type, nested flag set.
+        let meta = column(&schema, "META");
+        assert!(meta.nested);
+        assert_eq!(meta.field_type, None);
+        assert_eq!(meta.xsd_type, None);
+        assert_eq!(meta.iceberg_type, "struct");
+    }
+
+    #[test]
+    fn column_info_serde_roundtrips_field_type() {
+        let metadata = TableMetadata::from_json_str(SAMPLE_METADATA).unwrap();
+        let table = TableIdentifier::new("DW", "SALES");
+        let schema = table_schema_from_metadata(&table, &metadata).unwrap();
+
+        // field_type rides the wire as its iceberg type string and round-trips.
+        let json = serde_json::to_value(column(&schema, "SALE_KEY")).unwrap();
+        assert_eq!(json["field_type"], "long");
+        assert_eq!(json["xsd_type"], "xsd:integer");
+
+        let json = serde_json::to_value(column(&schema, "META")).unwrap();
+        assert!(json["field_type"].is_null());
+
+        let back: ColumnInfo =
+            serde_json::from_value(serde_json::to_value(column(&schema, "AMOUNT")).unwrap())
+                .unwrap();
+        assert_eq!(back.field_type, Some(FieldType::Decimal { precision: 18, scale: 2 }));
+    }
+
+    #[tokio::test]
+    async fn preview_direct_mode_errors() {
+        let conn = IcebergConnectionConfig::direct("s3://bucket/warehouse/ns/table");
+        let err = preview_iceberg_table(conn, TableIdentifier::new("ns", "table"), StatsTier::Schema)
+            .await
+            .expect_err("Direct mode must not be previewable");
+        assert!(err.to_string().contains("Direct catalog mode"));
+    }
+
+    /// Parity guard: our local `field_type_to_xsd` must agree with the emitter's
+    /// canonical `xsd_datatype` map (which lives in a private emit module we
+    /// cannot import). Pins the same load-bearing cases the emitter test pins.
+    #[test]
+    fn xsd_map_matches_emitter() {
+        assert_eq!(field_type_to_xsd(FieldType::Bytes), Some("xsd:hexBinary"));
+        assert_eq!(field_type_to_xsd(FieldType::Timestamp), Some("xsd:dateTime"));
+        assert_eq!(field_type_to_xsd(FieldType::TimestampTz), Some("xsd:dateTime"));
+        assert_eq!(field_type_to_xsd(FieldType::String), None);
+        assert_eq!(field_type_to_xsd(FieldType::Boolean), Some("xsd:boolean"));
+        assert_eq!(field_type_to_xsd(FieldType::Float64), Some("xsd:double"));
+        assert_eq!(field_type_to_xsd(FieldType::Float32), Some("xsd:float"));
+        assert_eq!(field_type_to_xsd(FieldType::Int64), Some("xsd:integer"));
+        assert_eq!(field_type_to_xsd(FieldType::Int32), Some("xsd:integer"));
+        assert_eq!(field_type_to_xsd(FieldType::Date), Some("xsd:date"));
+        assert_eq!(
+            field_type_to_xsd(FieldType::Decimal { precision: 18, scale: 2 }),
+            Some("xsd:decimal")
+        );
     }
 }

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -20,8 +20,12 @@ use crate::Result;
 
 use fluree_db_iceberg::catalog::{RestCatalogClient, RestCatalogConfig, SendCatalogClient};
 use fluree_db_iceberg::io::batch::IcebergFieldTypeExt;
+use fluree_db_iceberg::io::S3IcebergStorage;
 use fluree_db_iceberg::metadata::{
     PartitionField, Schema, SchemaField, Snapshot, SortField, TableMetadata,
+};
+use fluree_db_iceberg::stats::{
+    aggregate_column_stats, send_read_snapshot_data_files, AggregatedColumnStats,
 };
 use fluree_db_iceberg::FieldType;
 
@@ -570,7 +574,7 @@ pub async fn preview_iceberg_table(
         ))
     })?;
 
-    let schema = table_schema_from_metadata(&table, metadata)?;
+    let mut schema = table_schema_from_metadata(&table, metadata)?;
 
     match tier {
         StatsTier::Schema => Ok(TablePreview {
@@ -583,18 +587,109 @@ pub async fn preview_iceberg_table(
             warnings: Vec::new(),
         }),
         StatsTier::Stats => {
-            // Tier-B per-column stats are aggregated from the manifest-list +
-            // manifests; wired in the Tier-B commit.
+            let mut warnings = vec![DISTINCT_COUNT_WARNING.to_string()];
+
+            let (manifests_read, had_column_bounds) = match metadata.current_snapshot() {
+                Some(snapshot) => {
+                    let iceberg_schema = metadata.current_schema().ok_or_else(|| {
+                        crate::ApiError::config("Table metadata has no current schema")
+                    })?;
+
+                    // Build S3 storage from vended credentials (if the catalog
+                    // delegated them) or the ambient AWS chain — same policy as
+                    // the scan path.
+                    let storage = build_preview_storage(&conn, load.credentials.as_ref()).await?;
+
+                    // Metadata-only: reads the manifest-list + manifests, never a
+                    // Parquet/data file (see fluree_db_iceberg::stats).
+                    let (data_files, manifests_read) =
+                        send_read_snapshot_data_files(&storage, snapshot)
+                            .await
+                            .map_err(|e| {
+                                crate::ApiError::config(format!(
+                                    "Failed to read manifests for {}: {e}",
+                                    table.qualified()
+                                ))
+                            })?;
+
+                    let agg = aggregate_column_stats(&data_files, iceberg_schema);
+
+                    for col in &mut schema.columns {
+                        if col.nested {
+                            continue;
+                        }
+                        if let Some(a) = agg.columns.get(&col.field_id) {
+                            col.stats = Some(to_api_column_stats(a));
+                        }
+                    }
+
+                    // Fill authoritative counts from the aggregation if the
+                    // snapshot summary omitted them.
+                    schema.row_count = schema.row_count.or(Some(agg.row_count));
+                    schema.data_file_count = schema.data_file_count.or(Some(agg.data_file_count));
+                    schema.total_bytes = schema.total_bytes.or(Some(agg.total_bytes));
+
+                    (manifests_read, agg.had_column_bounds)
+                }
+                None => {
+                    warnings.push(
+                        "Table has no current snapshot; no column statistics available.".to_string(),
+                    );
+                    (0, false)
+                }
+            };
+
             Ok(TablePreview {
                 schema,
                 stats_completeness: StatsCompleteness {
                     tier: "stats".to_string(),
-                    manifests_read: 0,
-                    had_column_bounds: false,
+                    manifests_read,
+                    had_column_bounds,
                 },
-                warnings: vec![DISTINCT_COUNT_WARNING.to_string()],
+                warnings,
             })
         }
+    }
+}
+
+/// Build S3 storage for reading manifests during a Tier-B preview, mirroring the
+/// scan path's policy: vended credentials when the catalog delegated them,
+/// otherwise the ambient AWS credential chain.
+async fn build_preview_storage(
+    conn: &IcebergConnectionConfig,
+    credentials: Option<&fluree_db_iceberg::credential::VendedCredentials>,
+) -> Result<S3IcebergStorage> {
+    let io = &conn.io;
+    let storage = if let Some(creds) = credentials {
+        S3IcebergStorage::from_vended_credentials(
+            creds,
+            io.s3_region.as_deref(),
+            io.s3_endpoint.as_deref(),
+            io.s3_path_style,
+        )
+        .await
+    } else {
+        S3IcebergStorage::from_default_chain(
+            io.s3_region.as_deref(),
+            io.s3_endpoint.as_deref(),
+            io.s3_path_style,
+        )
+        .await
+    };
+    storage.map_err(|e| crate::ApiError::config(format!("Failed to create S3 storage: {e}")))
+}
+
+/// Map an iceberg-crate [`AggregatedColumnStats`] onto the API [`ColumnStats`].
+fn to_api_column_stats(a: &AggregatedColumnStats) -> ColumnStats {
+    ColumnStats {
+        null_count: a.null_count,
+        value_count: a.value_count,
+        null_fraction: a.null_fraction,
+        nan_count: a.nan_count,
+        min: a.min.clone(),
+        max: a.max.clone(),
+        on_disk_bytes: a.on_disk_bytes,
+        distinct_count: a.distinct_count,
     }
 }
 

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -33,6 +33,38 @@ use fluree_db_iceberg::FieldType;
 use fluree_db_r2rml::emit::naming::xsd_datatype;
 
 // =============================================================================
+// SSRF boundary guard
+// =============================================================================
+
+/// Up-front SSRF reject for the request-supplied outbound URLs on an Iceberg
+/// connection, for use at the (unauthenticated-by-default) route boundary.
+///
+/// This is a cheap literal-IP + scheme check; the AUTHORITATIVE enforcement is
+/// at the client layer, where the catalog / OAuth2 clients are built with a
+/// redirect-refusing, IP-denylisting resolver (see [`fluree_db_iceberg::net`]) —
+/// which is what closes the redirect / DNS-rebinding bypasses a boundary string
+/// check alone cannot. `catalog_uri` / `oauth2_token_url` get the full internal
+/// denylist; `s3_endpoint` gets the narrower metadata-only block (MinIO /
+/// LocalStack legitimately use loopback/private hosts).
+pub fn guard_iceberg_connection_urls(
+    catalog_uri: Option<&str>,
+    oauth2_token_url: Option<&str>,
+    s3_endpoint: Option<&str>,
+) -> Result<()> {
+    let to_err = |e: fluree_db_iceberg::IcebergError| crate::ApiError::config(e.to_string());
+    if let Some(u) = catalog_uri {
+        fluree_db_iceberg::net::validate_public_url(u).map_err(to_err)?;
+    }
+    if let Some(u) = oauth2_token_url {
+        fluree_db_iceberg::net::validate_public_url(u).map_err(to_err)?;
+    }
+    if let Some(u) = s3_endpoint {
+        fluree_db_iceberg::net::validate_s3_endpoint(u).map_err(to_err)?;
+    }
+    Ok(())
+}
+
+// =============================================================================
 // Shared identifiers
 // =============================================================================
 

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -28,6 +28,9 @@ use fluree_db_iceberg::stats::{
     aggregate_column_stats, send_read_snapshot_data_files, AggregatedColumnStats,
 };
 use fluree_db_iceberg::FieldType;
+// The emitter owns the canonical `FieldType → xsd:` map; the preview lane reuses
+// it (single source of truth) rather than duplicating it here.
+use fluree_db_r2rml::emit::naming::xsd_datatype;
 
 // =============================================================================
 // Shared identifiers
@@ -287,6 +290,10 @@ pub struct ColumnInfo {
     #[serde(with = "field_type_serde", default)]
     pub field_type: Option<FieldType>,
     /// The emitter's chosen `xsd:` datatype CURIE; `None` for string/nested.
+    ///
+    /// Pinned at `xsd_long_as_integer = true` (the reference convention); a
+    /// generate call overriding that to `false` makes this hint differ from the
+    /// emitted datatype for `Int32`/`Int64` columns.
     pub xsd_type: Option<String>,
     /// Whether the column is required (non-nullable) per the schema.
     pub required: bool,
@@ -354,29 +361,6 @@ pub struct TablePreview {
     pub warnings: Vec<String>,
 }
 
-/// The `xsd:` datatype CURIE for a [`FieldType`] (or `None` for strings / nested).
-///
-/// This is a deliberate, test-pinned mirror of the emitter's canonical
-/// `fluree_db_r2rml::emit::naming::xsd_datatype` (with the reference-matching
-/// `xsd_long_as_integer = true` convention). That function is the single source
-/// of truth, but it lives in a **private** module of the emitter lane which this
-/// PR must not edit; the parity is locked by [`tests::xsd_map_matches_emitter`].
-fn field_type_to_xsd(field_type: FieldType) -> Option<&'static str> {
-    let curie = match field_type {
-        FieldType::Boolean => "xsd:boolean",
-        // Reference (`enterprise.ttl`) convention: longs/ints as xsd:integer.
-        FieldType::Int32 | FieldType::Int64 => "xsd:integer",
-        FieldType::Float32 => "xsd:float",
-        FieldType::Float64 => "xsd:double",
-        FieldType::Decimal { .. } => "xsd:decimal",
-        FieldType::Date => "xsd:date",
-        FieldType::Timestamp | FieldType::TimestampTz => "xsd:dateTime",
-        FieldType::Bytes => "xsd:hexBinary",
-        FieldType::String => return None,
-    };
-    Some(curie)
-}
-
 /// Canonical Iceberg type string for a [`FieldType`], round-trippable through
 /// `FieldType::from_iceberg_type` (used for wire serialization of `field_type`).
 fn field_type_to_iceberg_string(field_type: FieldType) -> String {
@@ -441,8 +425,10 @@ fn column_info_tier_a(field: &SchemaField) -> ColumnInfo {
     } else {
         field.type_string().and_then(FieldType::from_iceberg_type)
     };
+    // Canonical emitter map, pinned at `xsd_long_as_integer = true` (see the
+    // `ColumnInfo::xsd_type` doc for the generate-override caveat).
     let xsd_type = field_type
-        .and_then(field_type_to_xsd)
+        .and_then(|ft| xsd_datatype(ft, true))
         .map(str::to_string);
     ColumnInfo {
         field_id: field.id,
@@ -908,23 +894,27 @@ mod tests {
         assert!(err.to_string().contains("Direct catalog mode"));
     }
 
-    /// Parity guard: our local `field_type_to_xsd` must agree with the emitter's
-    /// canonical `xsd_datatype` map (which lives in a private emit module we
-    /// cannot import). Pins the same load-bearing cases the emitter test pins.
+    /// Preview surfaces the emitter's canonical `xsd_datatype` map (pinned at
+    /// `xsd_long_as_integer = true`, the reference convention) as its `xsd_type`
+    /// hint. This pins the load-bearing cases the preview lane relies on; the map
+    /// is now the emitter's single source of truth (no api-side duplicate).
     #[test]
     fn xsd_map_matches_emitter() {
-        assert_eq!(field_type_to_xsd(FieldType::Bytes), Some("xsd:hexBinary"));
-        assert_eq!(field_type_to_xsd(FieldType::Timestamp), Some("xsd:dateTime"));
-        assert_eq!(field_type_to_xsd(FieldType::TimestampTz), Some("xsd:dateTime"));
-        assert_eq!(field_type_to_xsd(FieldType::String), None);
-        assert_eq!(field_type_to_xsd(FieldType::Boolean), Some("xsd:boolean"));
-        assert_eq!(field_type_to_xsd(FieldType::Float64), Some("xsd:double"));
-        assert_eq!(field_type_to_xsd(FieldType::Float32), Some("xsd:float"));
-        assert_eq!(field_type_to_xsd(FieldType::Int64), Some("xsd:integer"));
-        assert_eq!(field_type_to_xsd(FieldType::Int32), Some("xsd:integer"));
-        assert_eq!(field_type_to_xsd(FieldType::Date), Some("xsd:date"));
+        assert_eq!(xsd_datatype(FieldType::Bytes, true), Some("xsd:hexBinary"));
+        assert_eq!(xsd_datatype(FieldType::Timestamp, true), Some("xsd:dateTime"));
         assert_eq!(
-            field_type_to_xsd(FieldType::Decimal { precision: 18, scale: 2 }),
+            xsd_datatype(FieldType::TimestampTz, true),
+            Some("xsd:dateTime")
+        );
+        assert_eq!(xsd_datatype(FieldType::String, true), None);
+        assert_eq!(xsd_datatype(FieldType::Boolean, true), Some("xsd:boolean"));
+        assert_eq!(xsd_datatype(FieldType::Float64, true), Some("xsd:double"));
+        assert_eq!(xsd_datatype(FieldType::Float32, true), Some("xsd:float"));
+        assert_eq!(xsd_datatype(FieldType::Int64, true), Some("xsd:integer"));
+        assert_eq!(xsd_datatype(FieldType::Int32, true), Some("xsd:integer"));
+        assert_eq!(xsd_datatype(FieldType::Date, true), Some("xsd:date"));
+        assert_eq!(
+            xsd_datatype(FieldType::Decimal { precision: 18, scale: 2 }, true),
             Some("xsd:decimal")
         );
     }

--- a/fluree-db-api/src/graph_source/iceberg_generate.rs
+++ b/fluree-db-api/src/graph_source/iceberg_generate.rs
@@ -231,10 +231,41 @@ fn emit_from_previews(
 /// catalog-wide snapshot), so the returned `snapshot_id` is the first requested
 /// table's current snapshot — captured once and threaded through as the coherent
 /// pin for the whole generate (solo persists a single `snapshotId` per Dataset).
+/// Validate the request's `base_namespace` is an absolute IRI with no control
+/// characters. The emitter escapes it into the Turtle `@prefix` header, but a
+/// value carrying a newline / control char is rejected here for a clean `400`
+/// (defense in depth against Turtle header injection).
+fn validate_base_namespace(base: &str) -> Result<()> {
+    if base.is_empty() {
+        return Err(crate::ApiError::config("base_namespace must not be empty"));
+    }
+    if base.chars().any(|c| c.is_control() || c == ' ') {
+        return Err(crate::ApiError::config(
+            "base_namespace must not contain control characters or spaces",
+        ));
+    }
+    let has_scheme = base.split_once(':').is_some_and(|(scheme, _)| {
+        scheme
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic())
+            && scheme
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '-'))
+    });
+    if !has_scheme {
+        return Err(crate::ApiError::config(
+            "base_namespace must be an absolute IRI (with a scheme, e.g. https://…)",
+        ));
+    }
+    Ok(())
+}
+
 fn assemble_generate_response(
     previews: &[(TableIdentifier, TablePreview)],
     req: &GenerateR2rmlRequest,
 ) -> Result<GenerateR2rmlResponse> {
+    validate_base_namespace(&req.base_namespace)?;
     let snapshot_id = previews
         .first()
         .map(|(_, preview)| preview.schema.snapshot.clone())
@@ -558,6 +589,47 @@ mod tests {
         assert_eq!(unverified.len(), 1);
         assert_eq!(unverified[0].column.as_deref(), Some("ALT_KEY"));
         assert_eq!(unverified[0].table.as_deref(), Some("DW.DIM_WIDGET"));
+    }
+
+    // ---- base_namespace validation (Turtle header-injection defense) ----
+
+    #[test]
+    fn base_namespace_with_control_char_is_rejected() {
+        let (id, pv) = preview(
+            "DW",
+            "DIM_A",
+            vec![1],
+            vec![int_col(1, "A_KEY", true, 1, 100)],
+        );
+        let mut req = base_req(vec![id.clone()], HashMap::new());
+        req.base_namespace = "http://ns.example/x\n@prefix evil: <http://evil/> .".to_string();
+        let err = assemble_generate_response(&[(id, pv)], &req).unwrap_err();
+        assert!(err.to_string().contains("base_namespace"), "got: {err}");
+    }
+
+    #[test]
+    fn base_namespace_without_scheme_is_rejected() {
+        let (id, pv) = preview(
+            "DW",
+            "DIM_A",
+            vec![1],
+            vec![int_col(1, "A_KEY", true, 1, 100)],
+        );
+        let mut req = base_req(vec![id.clone()], HashMap::new());
+        req.base_namespace = "not-an-absolute-iri".to_string();
+        assert!(assemble_generate_response(&[(id, pv)], &req).is_err());
+    }
+
+    #[test]
+    fn base_namespace_valid_https_is_accepted() {
+        let (id, pv) = preview(
+            "DW",
+            "DIM_A",
+            vec![1],
+            vec![int_col(1, "A_KEY", true, 1, 100)],
+        );
+        let req = base_req(vec![id.clone()], HashMap::new()); // default http://ns.fluree.dev/edw#
+        assert!(assemble_generate_response(&[(id, pv)], &req).is_ok());
     }
 
     // ---- generated turtle round-trips + FK resolves ----

--- a/fluree-db-api/src/graph_source/iceberg_generate.rs
+++ b/fluree-db-api/src/graph_source/iceberg_generate.rs
@@ -111,9 +111,11 @@ pub struct GenerateR2rmlResponse {
     pub structured: StructuredR2rmlMapping,
     /// Every decision the emitter could not make from metadata alone.
     pub diagnostics: Vec<Diagnostic>,
-    /// The snapshot the mapping was generated against (pinned; persisted
-    /// end-to-end so queries observe the same snapshot the mapping was approved
-    /// against).
+    /// A REPRESENTATIVE snapshot: the first requested table's current snapshot at
+    /// generation time. Iceberg snapshots are per-table (there is no catalog-wide
+    /// snapshot), so this is NOT a true multi-table pin — it is threaded through as a
+    /// single coherent `snapshotId` (solo persists one per Dataset), not a guarantee
+    /// that every mapped table was read at this snapshot.
     pub snapshot_id: SnapshotRef,
 }
 

--- a/fluree-db-api/src/graph_source/iceberg_generate.rs
+++ b/fluree-db-api/src/graph_source/iceberg_generate.rs
@@ -325,6 +325,7 @@ mod tests {
                 max: Some(serde_json::json!(max)),
                 on_disk_bytes: None,
                 distinct_count: None,
+                bounds_truncated: false,
             }),
         }
     }
@@ -389,6 +390,7 @@ mod tests {
                     tier: "stats".to_string(),
                     manifests_read: 1,
                     had_column_bounds: true,
+                    has_delete_files: false,
                 },
                 warnings: Vec::new(),
             },

--- a/fluree-db-api/src/graph_source/iceberg_generate.rs
+++ b/fluree-db-api/src/graph_source/iceberg_generate.rs
@@ -130,7 +130,9 @@ pub struct GenerateR2rmlResponse {
 /// absent, or out-of-`i64`-range) becomes `None` — an unbounded column the
 /// range-containment FK check simply cannot confirm a join for.
 fn json_to_typed_bound(value: Option<&serde_json::Value>) -> Option<TypedBound> {
-    value.and_then(serde_json::Value::as_i64).map(TypedBound::Int)
+    value
+        .and_then(serde_json::Value::as_i64)
+        .map(TypedBound::Int)
 }
 
 /// Map Tier-B [`ColumnStats`] onto the emitter's [`EmitColumnStats`].
@@ -191,7 +193,12 @@ fn build_emit_options(req: &GenerateR2rmlRequest) -> EmitOptions {
     let per_table_overrides = req
         .per_table_overrides
         .iter()
-        .map(|(id, ov)| (TableKey::new(id.namespace.clone(), id.name.clone()), ov.clone()))
+        .map(|(id, ov)| {
+            (
+                TableKey::new(id.namespace.clone(), id.name.clone()),
+                ov.clone(),
+            )
+        })
         .collect();
 
     EmitOptions {
@@ -258,10 +265,7 @@ impl crate::Fluree {
     ///
     /// **Metadata-only and side-effect-free**: no Parquet scan, no graph source
     /// created. `target_model_ledger_id` is RESERVED for PR-4 and ignored here.
-    pub async fn generate_r2rml(
-        &self,
-        req: GenerateR2rmlRequest,
-    ) -> Result<GenerateR2rmlResponse> {
+    pub async fn generate_r2rml(&self, req: GenerateR2rmlRequest) -> Result<GenerateR2rmlResponse> {
         if req.tables.is_empty() {
             return Err(crate::ApiError::config(
                 "generate_r2rml requires at least one table",
@@ -355,7 +359,12 @@ mod tests {
         }
     }
 
-    fn preview(ns: &str, name: &str, ident: Vec<i32>, columns: Vec<ColumnInfo>) -> (TableIdentifier, TablePreview) {
+    fn preview(
+        ns: &str,
+        name: &str,
+        ident: Vec<i32>,
+        columns: Vec<ColumnInfo>,
+    ) -> (TableIdentifier, TablePreview) {
         let schema = TableSchema {
             table: format!("{ns}.{name}"),
             table_uuid: None,
@@ -483,8 +492,18 @@ mod tests {
     #[test]
     fn snapshot_is_pinned_from_first_table() {
         let previews = vec![
-            preview("DW", "DIM_A", vec![1], vec![int_col(1, "A_KEY", true, 1, 100)]),
-            preview("DW", "DIM_B", vec![1], vec![int_col(1, "B_KEY", true, 1, 100)]),
+            preview(
+                "DW",
+                "DIM_A",
+                vec![1],
+                vec![int_col(1, "A_KEY", true, 1, 100)],
+            ),
+            preview(
+                "DW",
+                "DIM_B",
+                vec![1],
+                vec![int_col(1, "B_KEY", true, 1, 100)],
+            ),
         ];
         let ids: Vec<TableIdentifier> = previews.iter().map(|(id, _)| id.clone()).collect();
         let resp = assemble_generate_response(&previews, &base_req(ids, HashMap::new())).unwrap();

--- a/fluree-db-api/src/graph_source/iceberg_generate.rs
+++ b/fluree-db-api/src/graph_source/iceberg_generate.rs
@@ -1,0 +1,629 @@
+//! End-to-end deterministic R2RML generation (PR-1 item (c), the capstone).
+//!
+//! This module glues the two halves already on the branch: track (a)'s
+//! metadata-only [`preview_iceberg_table`] API (the INPUT) and the deterministic
+//! [`emit_r2rml`] engine (the ENGINE). For each requested table it fetches the
+//! Tier-A schema + Tier-B stats preview, maps that preview onto the emitter's
+//! self-contained input model ([`EmitTableSchema`] / [`EmitColumn`] /
+//! [`EmitColumnStats`]) — closing the `TODO(track-a)` stand-in in
+//! `fluree-db-r2rml`'s `emit::input` — runs the emitter with the caller's
+//! `per_table_overrides`, and returns the authoritative
+//! [`StructuredR2rmlMapping`] IR + Turtle + diagnostics + the pinned snapshot.
+//!
+//! **Metadata-only**: preview reads REST `loadTable` + Avro manifests, never a
+//! Parquet/data file; generation adds no I/O beyond those previews. No graph
+//! source is created — this is the read-semantics surface solo's PR-2 lambda
+//! calls to obtain a mapping for review before saving.
+//!
+//! The fetch (async, network) is deliberately separable from the map+emit core
+//! ([`assemble_generate_response`], pure) so the mapping/emission is unit-tested
+//! offline against synthesized [`TablePreview`] fixtures.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use fluree_db_iceberg::FieldType;
+use fluree_db_r2rml::emit::{
+    emit_r2rml, EmitColumn, EmitColumnStats, EmitOptions, EmitOutput, EmitTableSchema, TableKey,
+    TypedBound,
+};
+
+use crate::graph_source::config::IcebergConnectionConfig;
+use crate::graph_source::iceberg_catalog::{
+    preview_iceberg_table, ColumnInfo, ColumnStats, SnapshotRef, StatsTier, TableIdentifier,
+    TablePreview,
+};
+use crate::Result;
+
+// Re-export the emitter's wire types that appear in this module's public API, so
+// callers (and the HTTP route) can name them straight off `fluree_db_api`.
+pub use fluree_db_r2rml::emit::{Diagnostic, StructuredR2rmlMapping, TableOverride};
+
+// =============================================================================
+// Request / response
+// =============================================================================
+
+/// The emit knobs a generate call may tune. Every field is a pure, deterministic
+/// switch — identical knobs + identical (pinned) metadata yield byte-identical
+/// output. The subject/vocab IRI bases are NOT here: they are derived from
+/// [`GenerateR2rmlRequest::base_namespace`] (see `emit::naming::subject_base`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenerateOptions {
+    /// Emit `xsd:integer` for `Int32`/`Int64` (the `enterprise.ttl` convention);
+    /// when `false`, use `xsd:int` / `xsd:long`. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub xsd_long_as_integer: bool,
+    /// Emit `rr:parentTriplesMap` joins for deterministically-resolved FKs.
+    /// Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub emit_fk_joins: bool,
+    /// Keep resolved-FK key columns as literal predicate-object maps too
+    /// (pushdown-friendly). Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub keep_fk_keys_as_literals: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for GenerateOptions {
+    fn default() -> Self {
+        Self {
+            xsd_long_as_integer: true,
+            emit_fk_joins: true,
+            keep_fk_keys_as_literals: true,
+        }
+    }
+}
+
+/// A deterministic R2RML generation request over one pinned snapshot.
+///
+/// Constructed by the caller (solo's lambda / the HTTP route) rather than
+/// deserialized directly: it holds a live [`IcebergConnectionConfig`] and a
+/// `HashMap` keyed by [`TableIdentifier`] (JSON object keys must be strings), so
+/// the wire form (a flat connection + an overrides list) is adapted by the route.
+#[derive(Debug, Clone)]
+pub struct GenerateR2rmlRequest {
+    /// The (possibly unsaved) Iceberg connection to preview against.
+    pub connection: IcebergConnectionConfig,
+    /// The tables to map, in output order (multi-table per Dataset).
+    pub tables: Vec<TableIdentifier>,
+    /// The SINGLE base namespace all IRIs derive from (== the emitted
+    /// `StructuredR2rmlMapping.baseNamespace`).
+    pub base_namespace: String,
+    /// Per-table subject-key / class-name overrides, keyed by table identity.
+    pub per_table_overrides: HashMap<TableIdentifier, TableOverride>,
+    /// The emit knobs.
+    pub options: GenerateOptions,
+    /// RESERVED for PR-4 (target-model IRI rewrite): accepted and ignored here.
+    pub target_model_ledger_id: Option<String>,
+}
+
+/// The deterministic generation result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerateR2rmlResponse {
+    /// R2RML Turtle, rendered from `structured`; compiles through `R2rmlLoader`.
+    pub turtle: String,
+    /// The AUTHORITATIVE wire IR (solo's camelCase `StructuredR2rmlMapping`) — the
+    /// object PR-2 persists, PR-3 reviews, PR-4 rewrites. NOT `Vec<TriplesMap>`.
+    pub structured: StructuredR2rmlMapping,
+    /// Every decision the emitter could not make from metadata alone.
+    pub diagnostics: Vec<Diagnostic>,
+    /// The snapshot the mapping was generated against (pinned; persisted
+    /// end-to-end so queries observe the same snapshot the mapping was approved
+    /// against).
+    pub snapshot_id: SnapshotRef,
+}
+
+// =============================================================================
+// Preview → emitter-input mapping (the closed `TODO(track-a)`) — pure
+// =============================================================================
+
+/// Map one column's JSON `min`/`max` bound to a comparable [`TypedBound`].
+///
+/// FK candidacy is integer-only (surrogate `*_KEY` spaces), so only JSON integer
+/// bounds become `TypedBound::Int`; every non-integer bound (float, string date,
+/// absent, or out-of-`i64`-range) becomes `None` — an unbounded column the
+/// range-containment FK check simply cannot confirm a join for.
+fn json_to_typed_bound(value: Option<&serde_json::Value>) -> Option<TypedBound> {
+    value.and_then(serde_json::Value::as_i64).map(TypedBound::Int)
+}
+
+/// Map Tier-B [`ColumnStats`] onto the emitter's [`EmitColumnStats`].
+///
+/// Only the three signals the deterministic heuristic consumes are carried:
+/// `null_fraction` (the NOT-NULL gate) and typed integer `min`/`max` (FK
+/// range-containment). NDV is deliberately absent (unavailable metadata-only).
+fn map_stats(stats: &ColumnStats) -> EmitColumnStats {
+    EmitColumnStats {
+        null_fraction: stats.null_fraction,
+        min: json_to_typed_bound(stats.min.as_ref()),
+        max: json_to_typed_bound(stats.max.as_ref()),
+    }
+}
+
+/// Map a preview [`ColumnInfo`] onto an emitter [`EmitColumn`].
+///
+/// A column the emitter must pass over — an actual nested struct/list/map, or one
+/// whose Iceberg type did not parse to a scalar `FieldType` — is marked
+/// `nested = true` (the only skip lever the emitter exposes: both Phase 1 and
+/// Phase 2 `continue` past a nested column). For such a skipped column the
+/// concrete `field_type` is never read, so a `String` placeholder is harmless.
+fn map_column(col: &ColumnInfo) -> EmitColumn {
+    let skip = col.nested || col.field_type.is_none();
+    EmitColumn {
+        field_id: col.field_id,
+        name: col.name.clone(),
+        iceberg_type: col.iceberg_type.clone(),
+        field_type: col.field_type.unwrap_or(FieldType::String),
+        required: col.required,
+        nested: skip,
+        doc: col.doc.clone(),
+        stats: col.stats.as_ref().map(map_stats).unwrap_or_default(),
+    }
+}
+
+/// Map a full [`TablePreview`] (schema + stats) onto one emitter input unit.
+///
+/// The `{namespace, name}` identity comes from the request's [`TableIdentifier`]
+/// (the preview's `schema.table` is only the pre-joined `"NS.NAME"` string);
+/// columns are carried in `field_id` order (the emitter's deterministic emission
+/// order), and `identifier_field_ids` (Iceberg's PK hint) passes straight through.
+fn preview_to_emit_schema(table: &TableIdentifier, preview: &TablePreview) -> EmitTableSchema {
+    EmitTableSchema {
+        namespace: table.namespace.clone(),
+        name: table.name.clone(),
+        columns: preview.schema.columns.iter().map(map_column).collect(),
+        identifier_field_ids: preview.schema.identifier_field_ids.clone(),
+    }
+}
+
+/// Build the emitter [`EmitOptions`] from the request. The caller's overrides —
+/// keyed by [`TableIdentifier`] — are re-keyed onto the emitter's [`TableKey`]
+/// (the same `{namespace, name}` identity the emitter iterates); the base
+/// namespace + emit knobs come from the request, the remaining IRI-base defaults
+/// from [`EmitOptions::new`].
+fn build_emit_options(req: &GenerateR2rmlRequest) -> EmitOptions {
+    let per_table_overrides = req
+        .per_table_overrides
+        .iter()
+        .map(|(id, ov)| (TableKey::new(id.namespace.clone(), id.name.clone()), ov.clone()))
+        .collect();
+
+    EmitOptions {
+        xsd_long_as_integer: req.options.xsd_long_as_integer,
+        emit_fk_joins: req.options.emit_fk_joins,
+        keep_fk_keys_as_literals: req.options.keep_fk_keys_as_literals,
+        per_table_overrides,
+        ..EmitOptions::new(&req.base_namespace)
+    }
+}
+
+/// Map every fetched preview onto emitter input and run the deterministic
+/// emitter. Pure — no I/O — so it is exercised offline over synthetic previews.
+fn emit_from_previews(
+    previews: &[(TableIdentifier, TablePreview)],
+    req: &GenerateR2rmlRequest,
+) -> EmitOutput {
+    let tables: Vec<EmitTableSchema> = previews
+        .iter()
+        .map(|(id, preview)| preview_to_emit_schema(id, preview))
+        .collect();
+    emit_r2rml(&tables, &build_emit_options(req))
+}
+
+/// Assemble the response from the fetched previews: pin the snapshot, run the
+/// map+emit core, and package `{turtle, structured, diagnostics, snapshot_id}`.
+/// Pure (no network) so the whole non-fetch path is unit-tested offline.
+///
+/// **Snapshot pinning.** Iceberg snapshots are per-table (there is no
+/// catalog-wide snapshot), so the returned `snapshot_id` is the first requested
+/// table's current snapshot — captured once and threaded through as the coherent
+/// pin for the whole generate (solo persists a single `snapshotId` per Dataset).
+fn assemble_generate_response(
+    previews: &[(TableIdentifier, TablePreview)],
+    req: &GenerateR2rmlRequest,
+) -> Result<GenerateR2rmlResponse> {
+    let snapshot_id = previews
+        .first()
+        .map(|(_, preview)| preview.schema.snapshot.clone())
+        .ok_or_else(|| crate::ApiError::config("generate_r2rml requires at least one table"))?;
+
+    let output = emit_from_previews(previews, req);
+
+    Ok(GenerateR2rmlResponse {
+        turtle: output.turtle,
+        structured: output.structured,
+        diagnostics: output.diagnostics,
+        snapshot_id,
+    })
+}
+
+// =============================================================================
+// Fluree surface
+// =============================================================================
+
+impl crate::Fluree {
+    /// Deterministically generate an R2RML mapping over a set of Iceberg tables.
+    ///
+    /// For each requested table it fetches the Tier-A+B [`preview_iceberg_table`]
+    /// at the table's current snapshot, maps the preview onto the emitter's input
+    /// model, runs the deterministic emitter with the request's
+    /// `per_table_overrides`, and returns the authoritative
+    /// [`StructuredR2rmlMapping`] + Turtle + diagnostics + the pinned snapshot.
+    ///
+    /// **Metadata-only and side-effect-free**: no Parquet scan, no graph source
+    /// created. `target_model_ledger_id` is RESERVED for PR-4 and ignored here.
+    pub async fn generate_r2rml(
+        &self,
+        req: GenerateR2rmlRequest,
+    ) -> Result<GenerateR2rmlResponse> {
+        if req.tables.is_empty() {
+            return Err(crate::ApiError::config(
+                "generate_r2rml requires at least one table",
+            ));
+        }
+
+        // Fetch each requested table's Tier-A+B preview (metadata-only). Pinning:
+        // the response snapshot is taken from the first table (see
+        // `assemble_generate_response`); each preview reads its table's current
+        // snapshot at fetch time.
+        let mut previews: Vec<(TableIdentifier, TablePreview)> =
+            Vec::with_capacity(req.tables.len());
+        for table in &req.tables {
+            let preview =
+                preview_iceberg_table(req.connection.clone(), table.clone(), StatsTier::Stats)
+                    .await?;
+            previews.push((table.clone(), preview));
+        }
+
+        assemble_generate_response(&previews, &req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::graph_source::iceberg_catalog::{StatsCompleteness, TableSchema};
+
+    // ---- synthetic preview fixtures (reuse track (a)'s shapes) ----
+
+    fn snapshot() -> SnapshotRef {
+        SnapshotRef {
+            id: 4242,
+            timestamp_ms: 1_700_000_000_000,
+            schema_id: Some(0),
+        }
+    }
+
+    /// An integer column carrying `[min, max]` integer bounds (a PK/FK surrogate).
+    fn int_col(field_id: i32, name: &str, required: bool, min: i64, max: i64) -> ColumnInfo {
+        ColumnInfo {
+            field_id,
+            name: name.to_string(),
+            iceberg_type: "long".to_string(),
+            field_type: Some(FieldType::Int64),
+            xsd_type: Some("xsd:integer".to_string()),
+            required,
+            nested: false,
+            doc: None,
+            stats: Some(ColumnStats {
+                null_count: None,
+                value_count: None,
+                null_fraction: if required { Some(0.0) } else { None },
+                nan_count: None,
+                min: Some(serde_json::json!(min)),
+                max: Some(serde_json::json!(max)),
+                on_disk_bytes: None,
+                distinct_count: None,
+            }),
+        }
+    }
+
+    /// A scalar column of `field_type`, no stats.
+    fn scalar_col(field_id: i32, name: &str, field_type: FieldType) -> ColumnInfo {
+        ColumnInfo {
+            field_id,
+            name: name.to_string(),
+            iceberg_type: "x".to_string(),
+            field_type: Some(field_type),
+            xsd_type: None,
+            required: false,
+            nested: false,
+            doc: None,
+            stats: None,
+        }
+    }
+
+    /// A nested (struct/list/map) column: `field_type = None`, `nested = true`.
+    fn nested_col(field_id: i32, name: &str) -> ColumnInfo {
+        ColumnInfo {
+            field_id,
+            name: name.to_string(),
+            iceberg_type: "struct".to_string(),
+            field_type: None,
+            xsd_type: None,
+            required: false,
+            nested: true,
+            doc: None,
+            stats: None,
+        }
+    }
+
+    fn preview(ns: &str, name: &str, ident: Vec<i32>, columns: Vec<ColumnInfo>) -> (TableIdentifier, TablePreview) {
+        let schema = TableSchema {
+            table: format!("{ns}.{name}"),
+            table_uuid: None,
+            format_version: 2,
+            current_schema_id: 0,
+            snapshot: snapshot(),
+            row_count: Some(1000),
+            data_file_count: Some(4),
+            total_bytes: Some(4096),
+            identifier_field_ids: ident,
+            partition_spec: Vec::new(),
+            sort_order: Vec::new(),
+            properties: HashMap::new(),
+            columns,
+            snapshot_log: Vec::new(),
+        };
+        (
+            TableIdentifier::new(ns, name),
+            TablePreview {
+                schema,
+                stats_completeness: StatsCompleteness {
+                    tier: "stats".to_string(),
+                    manifests_read: 1,
+                    had_column_bounds: true,
+                },
+                warnings: Vec::new(),
+            },
+        )
+    }
+
+    fn base_req(
+        tables: Vec<TableIdentifier>,
+        overrides: HashMap<TableIdentifier, TableOverride>,
+    ) -> GenerateR2rmlRequest {
+        GenerateR2rmlRequest {
+            // A dummy connection — the offline core never touches it.
+            connection: IcebergConnectionConfig::direct("s3://unused/warehouse/ns/table"),
+            tables,
+            base_namespace: "http://ns.fluree.dev/edw#".to_string(),
+            per_table_overrides: overrides,
+            options: GenerateOptions::default(),
+            target_model_ledger_id: None,
+        }
+    }
+
+    // ---- min/max JSON → TypedBound ----
+
+    #[test]
+    fn json_bounds_map_integers_only() {
+        assert_eq!(
+            json_to_typed_bound(Some(&serde_json::json!(42))),
+            Some(TypedBound::Int(42))
+        );
+        assert_eq!(
+            json_to_typed_bound(Some(&serde_json::json!(-7))),
+            Some(TypedBound::Int(-7))
+        );
+        // Non-integer bounds (float, string date) are not FK-usable → None.
+        assert_eq!(json_to_typed_bound(Some(&serde_json::json!(3.5))), None);
+        assert_eq!(
+            json_to_typed_bound(Some(&serde_json::json!("2021-01-01"))),
+            None
+        );
+        assert_eq!(json_to_typed_bound(None), None);
+    }
+
+    // ---- preview → EmitTableSchema mapping ----
+
+    #[test]
+    fn mapping_preserves_order_types_required_nested_skip_and_stats() {
+        let (id, pv) = preview(
+            "DW",
+            "DIM_WIDGET",
+            vec![1],
+            vec![
+                int_col(1, "WIDGET_KEY", true, 1, 100),
+                scalar_col(2, "NAME", FieldType::String),
+                nested_col(3, "META"),
+                scalar_col(4, "BAD_TYPE", FieldType::String), // will be forced field_type=None below
+                int_col(5, "OTHER_KEY", false, 3, 40),
+            ],
+        );
+        // Force a non-nested column whose Iceberg type did not parse (field_type
+        // None) — it must still pass through and be skipped like a nested column.
+        let mut pv = pv;
+        pv.schema.columns[3].field_type = None;
+        pv.schema.columns[3].nested = false;
+
+        let emit = preview_to_emit_schema(&id, &pv);
+
+        assert_eq!(emit.namespace, "DW");
+        assert_eq!(emit.name, "DIM_WIDGET");
+        assert_eq!(emit.identifier_field_ids, vec![1]);
+
+        // field_id order preserved 1:1.
+        let ids: Vec<i32> = emit.columns.iter().map(|c| c.field_id).collect();
+        assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+
+        // Types + required carried.
+        assert_eq!(emit.columns[0].field_type, FieldType::Int64);
+        assert!(emit.columns[0].required);
+        assert_eq!(emit.columns[1].field_type, FieldType::String);
+        assert!(!emit.columns[1].required);
+
+        // Nested struct AND unparsed-type column both become skip (nested=true);
+        // the unparsed column gets a harmless String placeholder type.
+        assert!(emit.columns[2].nested, "struct column must be skipped");
+        assert!(
+            emit.columns[3].nested,
+            "field_type=None column must be skipped"
+        );
+        assert_eq!(emit.columns[3].field_type, FieldType::String);
+
+        // Stats: integer bounds → TypedBound::Int; null_fraction carried.
+        assert_eq!(emit.columns[0].stats.min, Some(TypedBound::Int(1)));
+        assert_eq!(emit.columns[0].stats.max, Some(TypedBound::Int(100)));
+        assert_eq!(emit.columns[0].stats.null_fraction, Some(0.0));
+        assert_eq!(emit.columns[4].stats.min, Some(TypedBound::Int(3)));
+        assert_eq!(emit.columns[4].stats.max, Some(TypedBound::Int(40)));
+        // A stats-free column maps to default (bounds-free) stats.
+        assert_eq!(emit.columns[1].stats.min, None);
+        assert_eq!(emit.columns[1].stats.null_fraction, None);
+    }
+
+    #[test]
+    fn snapshot_is_pinned_from_first_table() {
+        let previews = vec![
+            preview("DW", "DIM_A", vec![1], vec![int_col(1, "A_KEY", true, 1, 100)]),
+            preview("DW", "DIM_B", vec![1], vec![int_col(1, "B_KEY", true, 1, 100)]),
+        ];
+        let ids: Vec<TableIdentifier> = previews.iter().map(|(id, _)| id.clone()).collect();
+        let resp = assemble_generate_response(&previews, &base_req(ids, HashMap::new())).unwrap();
+        assert_eq!(resp.snapshot_id.id, 4242);
+        assert_eq!(resp.snapshot_id.timestamp_ms, 1_700_000_000_000);
+    }
+
+    // ---- overrides flow through ----
+
+    #[test]
+    fn per_table_override_changes_subject_key_and_flags_unverified() {
+        // identifier_field_ids=[1] (WIDGET_KEY); override REPLACES it with ALT_KEY.
+        let (id, pv) = preview(
+            "DW",
+            "DIM_WIDGET",
+            vec![1],
+            vec![
+                int_col(1, "WIDGET_KEY", true, 1, 100),
+                int_col(2, "ALT_KEY", true, 1, 100),
+                scalar_col(3, "NAME", FieldType::String),
+            ],
+        );
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            id.clone(),
+            TableOverride {
+                primary_key: Some("ALT_KEY".to_string()),
+                class_name: None,
+            },
+        );
+        let req = base_req(vec![id.clone()], overrides);
+        let resp = assemble_generate_response(&[(id, pv)], &req).unwrap();
+
+        let tm = &resp.structured.table_mappings[0];
+        assert!(
+            tm.subject_template.ends_with("/{ALT_KEY}"),
+            "subject must key on the override column, got {}",
+            tm.subject_template
+        );
+        assert!(!tm.subject_template.contains("{WIDGET_KEY}"));
+
+        // An override PK ALWAYS earns SubjectKeyUnverified (uniqueness is
+        // unprovable metadata-only), on the override column.
+        use fluree_db_r2rml::emit::DiagCode;
+        let unverified: Vec<&Diagnostic> = resp
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == DiagCode::SubjectKeyUnverified)
+            .collect();
+        assert_eq!(unverified.len(), 1);
+        assert_eq!(unverified[0].column.as_deref(), Some("ALT_KEY"));
+        assert_eq!(unverified[0].table.as_deref(), Some("DW.DIM_WIDGET"));
+    }
+
+    // ---- generated turtle round-trips + FK resolves ----
+
+    #[test]
+    fn generated_turtle_round_trips_through_loader_and_resolves_fk() {
+        use fluree_db_r2rml::R2rmlLoader;
+
+        // DIM_GEOGRAPHY (PK GEOGRAPHY_KEY) + DIM_SUPPLIER (FK GEOGRAPHY_KEY) — the
+        // FK must resolve by name ∧ type ∧ range-containment.
+        let previews = vec![
+            preview(
+                "DW",
+                "DIM_GEOGRAPHY",
+                vec![1],
+                vec![
+                    int_col(1, "GEOGRAPHY_KEY", true, 1, 100_000),
+                    scalar_col(2, "COUNTRY", FieldType::String),
+                ],
+            ),
+            preview(
+                "DW",
+                "DIM_SUPPLIER",
+                vec![1],
+                vec![
+                    int_col(1, "SUPPLIER_KEY", true, 1, 100_000),
+                    scalar_col(2, "SUPPLIER_NAME", FieldType::String),
+                    int_col(3, "GEOGRAPHY_KEY", false, 1, 100_000),
+                ],
+            ),
+        ];
+        let ids: Vec<TableIdentifier> = previews.iter().map(|(id, _)| id.clone()).collect();
+        let resp = assemble_generate_response(&previews, &base_req(ids, HashMap::new())).unwrap();
+
+        // The wire IR carries both tables.
+        assert_eq!(resp.structured.table_mappings.len(), 2);
+
+        // The FK resolved as a join (DIM_SUPPLIER.GEOGRAPHY_KEY → DIM_GEOGRAPHY).
+        let supplier = resp
+            .structured
+            .table_mapping("DW.DIM_SUPPLIER")
+            .expect("supplier mapping");
+        let fk = supplier
+            .columns
+            .iter()
+            .find_map(|c| c.foreign_key.as_ref())
+            .expect("GEOGRAPHY_KEY must resolve to a join");
+        assert_eq!(fk.target_table, "DW.DIM_GEOGRAPHY");
+        assert_eq!(fk.child_column, "GEOGRAPHY_KEY");
+        assert_eq!(fk.parent_column, "GEOGRAPHY_KEY");
+
+        // The rendered Turtle compiles through the real loader to the same table
+        // count (the internal round-trip artifact — never on the wire).
+        let compiled = R2rmlLoader::from_turtle(&resp.turtle)
+            .expect("emitted turtle must parse")
+            .compile()
+            .expect("emitted turtle must compile");
+        assert_eq!(compiled.len(), resp.structured.table_mappings.len());
+    }
+
+    // ---- wire shape: camelCase StructuredR2rmlMapping, not Vec<TriplesMap> ----
+
+    #[test]
+    fn response_structured_is_camelcase_structured_mapping() {
+        let previews = vec![preview(
+            "DW",
+            "DIM_DATE",
+            vec![1],
+            vec![int_col(1, "DATE_KEY", true, 1, 100)],
+        )];
+        let ids: Vec<TableIdentifier> = previews.iter().map(|(id, _)| id.clone()).collect();
+        let resp = assemble_generate_response(&previews, &base_req(ids, HashMap::new())).unwrap();
+
+        let json = serde_json::to_value(&resp).unwrap();
+        // `structured` is solo's camelCase IR (an object), not a `Vec<TriplesMap>`.
+        assert!(json["structured"]["baseNamespace"].is_string());
+        assert!(json["structured"]["tableMappings"].is_array());
+        assert!(!json["structured"].is_array());
+        // The pinned snapshot rides along.
+        assert_eq!(json["snapshot_id"]["id"], serde_json::json!(4242));
+        assert!(json["turtle"].is_string());
+    }
+
+    // ---- empty-tables guard ----
+
+    #[test]
+    fn empty_tables_is_a_clean_error() {
+        let err = assemble_generate_response(&[], &base_req(Vec::new(), HashMap::new()))
+            .expect_err("no tables must error, not panic");
+        assert!(err.to_string().contains("at least one table"));
+    }
+}

--- a/fluree-db-api/src/graph_source/iceberg_validate.rs
+++ b/fluree-db-api/src/graph_source/iceberg_validate.rs
@@ -78,14 +78,14 @@ fn table_identifier_from_name(name: &str) -> TableIdentifier {
     }
 }
 
-/// Diagnostic for a mapping that failed to compile. There is no compile/parse
-/// `DiagCode` in the shared emitter enum (which this lane must not modify), so this
-/// reuses [`DiagCode::TableNotFound`] with no table — the mapping resolved zero
-/// tables — while `compiled_ok == false` remains the authoritative machine signal.
+/// Diagnostic for a mapping that failed to compile. Uses the dedicated
+/// [`DiagCode::CompileError`] (with no table — the mapping resolved zero tables) so a
+/// compile failure never collides on the wire with a `TableNotFound` cross-check
+/// diagnostic; `compiled_ok == false` remains the authoritative machine signal.
 fn compile_error_diagnostic(message: &str) -> Diagnostic {
     Diagnostic {
         severity: Severity::Error,
-        code: DiagCode::TableNotFound,
+        code: DiagCode::CompileError,
         table: None,
         column: None,
         message: format!("R2RML mapping failed to compile: {message}"),
@@ -725,6 +725,15 @@ mod tests {
             "{:?}",
             response.diagnostics
         );
+        // The compile-fail diagnostic carries the dedicated CompileError code, never
+        // TableNotFound — so on the wire it can't be confused with a dangling table
+        // reference produced by the cross-check.
+        assert!(
+            has_code(&response.diagnostics, DiagCode::CompileError),
+            "{:?}",
+            response.diagnostics
+        );
+        assert!(!has_code(&response.diagnostics, DiagCode::TableNotFound));
         assert!(response.diagnostics[0]
             .message
             .contains("failed to compile"));

--- a/fluree-db-api/src/graph_source/iceberg_validate.rs
+++ b/fluree-db-api/src/graph_source/iceberg_validate.rs
@@ -1,0 +1,771 @@
+//! R2RML **validate / dry-run**: compile an R2RML Turtle mapping through the real
+//! loader and cross-check its table / column / join references — plus subject-key
+//! **nullability** — against the live Iceberg schema + stats (track (a)'s preview).
+//!
+//! This is item **(d)** of PR-1. It is strictly **read-only**: it creates no graph
+//! source, writes nothing to CAS, and publishes nothing. It returns structured
+//! [`Diagnostic`]s (reusing the emitter's wire contract) describing every defect it
+//! found, so an operator can fix a hand-written or generated mapping before saving.
+//!
+//! # What is checked
+//!
+//! For a mapping that compiles, each [`TriplesMap`] is cross-checked against the
+//! metadata preview of its logical table (`tier = Stats`):
+//!
+//! * **table existence** — the logical table must resolve in the catalog, else
+//!   [`DiagCode::TableNotFound`].
+//! * **column existence + casing** — every referenced column (POM `rr:column`s and
+//!   object templates, subject `template_columns`, and join `child`/`parent`
+//!   columns) must exist with **exact** casing: missing ⇒ [`DiagCode::ColumnNotFound`];
+//!   present but case-differing ⇒ [`DiagCode::CasingMismatch`] (Iceberg field names
+//!   are case-sensitive).
+//! * **join key type compatibility** — a join's child-column `field_type` must equal
+//!   the parent table's parent-column `field_type`, else [`DiagCode::JoinTypeMismatch`].
+//! * **subject-key nullability** — every subject-key column must be `required` OR
+//!   have `null_fraction == 0` per stats, else [`DiagCode::NoSafeSubjectKey`] (a
+//!   nullable key silently drops rows). **Uniqueness is deliberately NOT checked**
+//!   — NDV requires column profiling and is deferred to PR-5.
+//!
+//! # Testability
+//!
+//! The catalog preview is separated from the pure cross-check: the async
+//! [`crate::Fluree::validate_r2rml`] resolves each table to a [`TableSchema`] via
+//! the preview, then the pure [`cross_check_mapping`] does all diagnostic logic over
+//! an injected `schemas` map. Unit tests drive `cross_check_mapping` directly with
+//! synthesized schemas/stats — no network, no catalog.
+
+use std::collections::{BTreeSet, HashMap};
+
+use serde::{Deserialize, Serialize};
+
+use fluree_db_r2rml::emit::{DiagCode, Diagnostic, Severity};
+use fluree_db_r2rml::loader::R2rmlLoader;
+use fluree_db_r2rml::mapping::{CompiledR2rmlMapping, ObjectMap, TriplesMap};
+
+use super::config::IcebergConnectionConfig;
+use super::iceberg_catalog::{
+    preview_iceberg_table, ColumnInfo, StatsTier, TableIdentifier, TableSchema,
+};
+use crate::Result;
+
+/// The structured result of a `validate_r2rml` dry-run.
+///
+/// `compiled_ok == false` is the authoritative signal that the Turtle failed to
+/// compile; in that case `diagnostics` carries a single error diagnostic with the
+/// compile message and the cross-check is skipped (`triples_map_count == 0`,
+/// `table_names` empty).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidateR2rmlResponse {
+    /// Whether the mapping compiled through `R2rmlLoader::from_turtle().compile()`.
+    pub compiled_ok: bool,
+    /// Number of `rr:TriplesMap` definitions in the mapping (0 if it did not compile).
+    pub triples_map_count: usize,
+    /// Distinct logical table names referenced by the mapping (sorted).
+    pub table_names: Vec<String>,
+    /// Structured diagnostics — every cross-check defect, plus any compile error.
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// Split an R2RML logical table name (`"NAMESPACE.NAME"`, dot-normalized) into a
+/// catalog [`TableIdentifier`]. Namespaces may themselves contain dots, so the
+/// **last** dot separates the namespace from the table name (mirrors the catalog's
+/// own `split_qualified_table`). A name with no dot becomes an empty-namespace
+/// identifier, which the catalog will reject — surfacing as `TableNotFound`.
+fn table_identifier_from_name(name: &str) -> TableIdentifier {
+    match name.rsplit_once('.') {
+        Some((namespace, table)) => TableIdentifier::new(namespace, table),
+        None => TableIdentifier::new("", name),
+    }
+}
+
+/// Diagnostic for a mapping that failed to compile. There is no compile/parse
+/// `DiagCode` in the shared emitter enum (which this lane must not modify), so this
+/// reuses [`DiagCode::TableNotFound`] with no table — the mapping resolved zero
+/// tables — while `compiled_ok == false` remains the authoritative machine signal.
+fn compile_error_diagnostic(message: &str) -> Diagnostic {
+    Diagnostic {
+        severity: Severity::Error,
+        code: DiagCode::TableNotFound,
+        table: None,
+        column: None,
+        message: format!("R2RML mapping failed to compile: {message}"),
+    }
+}
+
+/// How a referenced column resolves against a live schema.
+enum ColumnResolution<'a> {
+    /// Exact byte-for-byte name match.
+    Exact(&'a ColumnInfo),
+    /// Matches only case-insensitively (the schema spells it differently).
+    Casing(&'a ColumnInfo),
+    /// No column matches, even case-insensitively.
+    Missing,
+}
+
+fn resolve_column<'a>(schema: &'a TableSchema, name: &str) -> ColumnResolution<'a> {
+    if let Some(ci) = schema.columns.iter().find(|c| c.name == name) {
+        ColumnResolution::Exact(ci)
+    } else if let Some(ci) = schema
+        .columns
+        .iter()
+        .find(|c| c.name.eq_ignore_ascii_case(name))
+    {
+        ColumnResolution::Casing(ci)
+    } else {
+        ColumnResolution::Missing
+    }
+}
+
+/// Resolve a referenced column, pushing a [`DiagCode::CasingMismatch`] (warning) or
+/// [`DiagCode::ColumnNotFound`] (error) as appropriate. Returns the resolved
+/// [`ColumnInfo`] (exact or case-corrected) for downstream type / nullability
+/// checks, or `None` when the column does not exist at all.
+fn check_column<'a>(
+    schema: &'a TableSchema,
+    table: &str,
+    name: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<&'a ColumnInfo> {
+    match resolve_column(schema, name) {
+        ColumnResolution::Exact(ci) => Some(ci),
+        ColumnResolution::Casing(ci) => {
+            diagnostics.push(Diagnostic::new(
+                Severity::Warning,
+                DiagCode::CasingMismatch,
+                table.to_string(),
+                Some(name.to_string()),
+                format!(
+                    "Column '{name}' does not match the live schema's casing; the schema spells it \
+                     '{}'. Iceberg field names are case-sensitive — fix the casing to match.",
+                    ci.name
+                ),
+            ));
+            Some(ci)
+        }
+        ColumnResolution::Missing => {
+            diagnostics.push(Diagnostic::new(
+                Severity::Error,
+                DiagCode::ColumnNotFound,
+                table.to_string(),
+                Some(name.to_string()),
+                format!(
+                    "Column '{name}' referenced by the mapping does not exist in table '{table}'."
+                ),
+            ));
+            None
+        }
+    }
+}
+
+/// Pure cross-check of a compiled mapping against resolved live schemas.
+///
+/// `schemas` maps each **R2RML logical table name** to its [`TableSchema`] (only for
+/// tables the preview resolved). A mapping table absent from `schemas` yields
+/// [`DiagCode::TableNotFound`]; `load_errors` (table name → preview error string,
+/// empty in unit tests) enriches that message when the absence was a preview
+/// failure rather than a genuine miss.
+///
+/// This function performs **no I/O** — it is the whole diagnostic surface and is
+/// driven directly by unit tests with synthesized schemas.
+fn cross_check_mapping(
+    compiled: &CompiledR2rmlMapping,
+    schemas: &HashMap<String, TableSchema>,
+    load_errors: &HashMap<String, String>,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    // Deterministic order: iterate TriplesMaps sorted by IRI so diagnostics are stable.
+    let mut tms: Vec<&TriplesMap> = compiled.triples_maps.values().collect();
+    tms.sort_by(|a, b| a.iri.cmp(&b.iri));
+
+    for tm in tms {
+        let Some(table) = tm.table_name() else {
+            continue; // logical table is always a table name today; skip defensively.
+        };
+
+        let Some(schema) = schemas.get(table) else {
+            let detail = load_errors
+                .get(table)
+                .map(|e| format!(" (catalog preview failed: {e})"))
+                .unwrap_or_default();
+            diagnostics.push(Diagnostic::new(
+                Severity::Error,
+                DiagCode::TableNotFound,
+                table.to_string(),
+                None,
+                format!(
+                    "Table '{table}' referenced by TriplesMap <{}> was not found in the live \
+                     catalog schema{detail}.",
+                    tm.iri
+                ),
+            ));
+            continue; // no schema → can't check columns/joins/keys for this table.
+        };
+
+        // --- Existence + casing for every column referenced in THIS table ---
+        // `referenced_columns()` = subject template columns + POM predicate columns +
+        // POM object columns (for a RefObjectMap, the join *child* columns). The
+        // `rr:column` subject form is not covered by it, so add it explicitly. Each
+        // distinct name is resolved exactly once to avoid duplicate diagnostics.
+        let mut referenced: BTreeSet<&str> = tm.referenced_columns().into_iter().collect();
+        if let Some(col) = &tm.subject_map.column {
+            referenced.insert(col.as_str());
+        }
+        let mut resolved: HashMap<&str, Option<&ColumnInfo>> = HashMap::new();
+        for &name in &referenced {
+            let ci = check_column(schema, table, name, &mut diagnostics);
+            resolved.insert(name, ci);
+        }
+
+        // --- Join key type compatibility (child field_type vs parent field_type) ---
+        for pom in &tm.predicate_object_maps {
+            let ObjectMap::RefObjectMap(rom) = &pom.object_map else {
+                continue;
+            };
+
+            let parent_tm = compiled.get(&rom.parent_triples_map);
+            let parent_table = parent_tm.and_then(|p| p.table_name());
+            let parent_schema = parent_table.and_then(|t| schemas.get(t));
+
+            if parent_tm.is_none() {
+                // Dangling parentTriplesMap — there is no parent table to resolve.
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    code: DiagCode::TableNotFound,
+                    table: None,
+                    column: None,
+                    message: format!(
+                        "TriplesMap <{}> joins to parent TriplesMap <{}>, which is not defined in \
+                         the mapping.",
+                        tm.iri, rom.parent_triples_map
+                    ),
+                });
+            }
+
+            for jc in &rom.join_conditions {
+                // Child column was already resolved above (it is in referenced_columns()).
+                let child_ci = resolved.get(jc.child_column.as_str()).copied().flatten();
+
+                // Parent column is resolved against the PARENT table's schema. When
+                // the parent table/schema is absent its own TableNotFound already
+                // fired (parent is iterated as its own TriplesMap), so skip here.
+                let parent_ci = match (parent_table, parent_schema) {
+                    (Some(pt), Some(ps)) => {
+                        check_column(ps, pt, &jc.parent_column, &mut diagnostics)
+                    }
+                    _ => None,
+                };
+
+                if let (Some(cc), Some(pc)) = (child_ci, parent_ci) {
+                    // Compare parsed field types; skip when either is unknown
+                    // (nested / unparseable) — cannot prove a mismatch.
+                    if let (Some(ct), Some(pt_ty)) = (&cc.field_type, &pc.field_type) {
+                        if ct != pt_ty {
+                            diagnostics.push(Diagnostic::new(
+                                Severity::Error,
+                                DiagCode::JoinTypeMismatch,
+                                table.to_string(),
+                                Some(jc.child_column.clone()),
+                                format!(
+                                    "Join key type mismatch: child column '{}.{}' is {:?} but parent \
+                                     column '{}.{}' is {:?}; the join will never match.",
+                                    table,
+                                    jc.child_column,
+                                    ct,
+                                    parent_table.unwrap_or_default(),
+                                    jc.parent_column,
+                                    pt_ty
+                                ),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        // --- Subject-key nullability (NOT uniqueness — NDV deferred to PR-5) ---
+        let mut subject_key_cols: Vec<&str> = tm
+            .subject_map
+            .template_columns
+            .iter()
+            .map(String::as_str)
+            .collect();
+        if let Some(col) = &tm.subject_map.column {
+            subject_key_cols.push(col.as_str());
+        }
+        subject_key_cols.sort_unstable();
+        subject_key_cols.dedup();
+
+        for name in subject_key_cols {
+            // Use the already-resolved column (exact or case-corrected). If it could
+            // not be resolved at all, ColumnNotFound already fired — skip.
+            let Some(Some(ci)) = resolved.get(name) else {
+                continue;
+            };
+            // `null_fraction` is null_count/value_count over integer counts, so it is
+            // exactly 0.0 iff there are no nulls; `<= 0.0` is an exact, clippy-clean
+            // "no nulls" test.
+            let null_fraction = ci.stats.as_ref().and_then(|s| s.null_fraction);
+            let null_free = ci.required || matches!(null_fraction, Some(f) if f <= 0.0);
+            if !null_free {
+                let detail = match null_fraction {
+                    Some(f) => format!("stats report null_fraction = {f}"),
+                    None => "the column is not `required` and null-freeness could not be verified \
+                             from stats"
+                        .to_string(),
+                };
+                diagnostics.push(Diagnostic::new(
+                    Severity::Warning,
+                    DiagCode::NoSafeSubjectKey,
+                    table.to_string(),
+                    Some(name.to_string()),
+                    format!(
+                        "Subject-key column '{name}' is nullable ({detail}); rows with a NULL value \
+                         here produce no subject and are silently dropped. Uniqueness is NOT checked \
+                         here (NDV is deferred to PR-5)."
+                    ),
+                ));
+            }
+        }
+    }
+
+    diagnostics
+}
+
+/// Compile the Turtle for validation, or produce the `compiled_ok = false` response
+/// carrying the compile error. Factored out (no `self` / no catalog) so the
+/// compile-failure branch is unit-testable offline.
+fn compile_for_validate(
+    turtle: &str,
+) -> std::result::Result<CompiledR2rmlMapping, ValidateR2rmlResponse> {
+    match R2rmlLoader::from_turtle(turtle).and_then(R2rmlLoader::compile) {
+        Ok(compiled) => Ok(compiled),
+        Err(e) => Err(ValidateR2rmlResponse {
+            compiled_ok: false,
+            triples_map_count: 0,
+            table_names: Vec::new(),
+            diagnostics: vec![compile_error_diagnostic(&e.to_string())],
+        }),
+    }
+}
+
+impl crate::Fluree {
+    /// **Validate / dry-run** an R2RML mapping against a live Iceberg catalog,
+    /// creating **no** graph source (no CAS write, no publish).
+    ///
+    /// Compiles `turtle` and, on success, cross-checks every TriplesMap's table,
+    /// columns, joins, and subject-key nullability against the metadata preview
+    /// (`tier = Stats`) of each referenced table, returning structured
+    /// [`Diagnostic`]s. On a compile failure it returns immediately with
+    /// `compiled_ok = false` and a single error diagnostic.
+    ///
+    /// `snapshot` is an optional Iceberg snapshot id the caller intends to validate
+    /// against. The metadata preview resolves each table's **current** snapshot, so
+    /// this is recorded (traced) rather than enforced; historical-snapshot preview
+    /// is a preview-layer capability this read-only lane does not add.
+    ///
+    /// Catalog preview failures (unreachable catalog, Direct mode, a genuinely
+    /// missing table) are surfaced as [`DiagCode::TableNotFound`] diagnostics rather
+    /// than hard errors — a dry-run reports problems, it does not throw on them.
+    pub async fn validate_r2rml(
+        &self,
+        conn: IcebergConnectionConfig,
+        turtle: String,
+        snapshot: Option<i64>,
+    ) -> Result<ValidateR2rmlResponse> {
+        let compiled = match compile_for_validate(&turtle) {
+            Ok(compiled) => compiled,
+            Err(response) => return Ok(response),
+        };
+
+        // Distinct logical tables referenced by the mapping (sorted, deterministic).
+        let mut table_names_set: BTreeSet<String> = BTreeSet::new();
+        for tm in compiled.triples_maps.values() {
+            if let Some(t) = tm.table_name() {
+                table_names_set.insert(t.to_string());
+            }
+        }
+
+        // Resolve each table to its live schema via the preview (Tier-B stats, so
+        // subject-key null_fraction is available). Preview failures are recorded and
+        // become TableNotFound diagnostics in the pure cross-check below.
+        let mut schemas: HashMap<String, TableSchema> = HashMap::new();
+        let mut load_errors: HashMap<String, String> = HashMap::new();
+        for name in &table_names_set {
+            let table_id = table_identifier_from_name(name);
+            tracing::debug!(
+                table = %name,
+                requested_snapshot = ?snapshot,
+                "validate_r2rml: previewing table current snapshot for cross-check"
+            );
+            match preview_iceberg_table(conn.clone(), table_id, StatsTier::Stats).await {
+                Ok(preview) => {
+                    schemas.insert(name.clone(), preview.schema);
+                }
+                Err(e) => {
+                    tracing::debug!(table = %name, error = %e, "validate_r2rml: preview failed");
+                    load_errors.insert(name.clone(), e.to_string());
+                }
+            }
+        }
+
+        let diagnostics = cross_check_mapping(&compiled, &schemas, &load_errors);
+
+        Ok(ValidateR2rmlResponse {
+            compiled_ok: true,
+            triples_map_count: compiled.len(),
+            table_names: table_names_set.into_iter().collect(),
+            diagnostics,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use fluree_db_iceberg::FieldType;
+    use fluree_db_r2rml::mapping::{
+        JoinCondition, ObjectMap, PredicateMap, PredicateObjectMap, RefObjectMap, SubjectMap,
+        TriplesMap,
+    };
+
+    use super::super::iceberg_catalog::{ColumnStats, SnapshotRef};
+
+    // ----- synthesized-schema builders (stand in for the live preview) -----
+
+    fn snapshot_ref() -> SnapshotRef {
+        SnapshotRef {
+            id: 1,
+            timestamp_ms: 0,
+            schema_id: Some(0),
+        }
+    }
+
+    /// A column with a given type, requiredness, and (optional) null_fraction stat.
+    fn col(name: &str, ft: FieldType, required: bool, null_fraction: Option<f64>) -> ColumnInfo {
+        ColumnInfo {
+            field_id: 0,
+            name: name.to_string(),
+            iceberg_type: "n/a".to_string(),
+            field_type: Some(ft),
+            xsd_type: None,
+            required,
+            nested: false,
+            doc: None,
+            stats: null_fraction.map(|nf| ColumnStats {
+                null_fraction: Some(nf),
+                ..ColumnStats::default()
+            }),
+        }
+    }
+
+    fn schema(table: &str, columns: Vec<ColumnInfo>) -> TableSchema {
+        TableSchema {
+            table: table.to_string(),
+            table_uuid: None,
+            format_version: 2,
+            current_schema_id: 0,
+            snapshot: snapshot_ref(),
+            row_count: None,
+            data_file_count: None,
+            total_bytes: None,
+            identifier_field_ids: Vec::new(),
+            partition_spec: Vec::new(),
+            sort_order: Vec::new(),
+            properties: std::collections::HashMap::new(),
+            columns,
+            snapshot_log: Vec::new(),
+        }
+    }
+
+    fn no_errors() -> HashMap<String, String> {
+        HashMap::new()
+    }
+
+    /// `DIM_STORE` with a required subject key `STORE_KEY` (long) + a `NAME` (string).
+    fn dim_store_map() -> TriplesMap {
+        let mut tm = TriplesMap::new("<#DimStore>", "DW.DIM_STORE");
+        tm.subject_map =
+            SubjectMap::template("http://ex/store/{STORE_KEY}").with_class("http://ex/Store");
+        tm.predicate_object_maps = vec![PredicateObjectMap {
+            predicate_map: PredicateMap::constant("http://ex/name"),
+            object_map: ObjectMap::column("NAME"),
+        }];
+        tm
+    }
+
+    fn dim_store_schema() -> TableSchema {
+        schema(
+            "DW.DIM_STORE",
+            vec![
+                col("STORE_KEY", FieldType::Int64, true, Some(0.0)),
+                col("NAME", FieldType::String, false, Some(0.1)),
+            ],
+        )
+    }
+
+    fn has_code(diags: &[Diagnostic], code: DiagCode) -> bool {
+        diags.iter().any(|d| d.code == code)
+    }
+
+    fn has_error(diags: &[Diagnostic]) -> bool {
+        diags.iter().any(|d| d.severity == Severity::Error)
+    }
+
+    // ----------------------------- tests -----------------------------
+
+    #[test]
+    fn correct_mapping_validates_clean() {
+        let compiled = CompiledR2rmlMapping::new(vec![dim_store_map()]);
+        let mut schemas = HashMap::new();
+        schemas.insert("DW.DIM_STORE".to_string(), dim_store_schema());
+
+        let diags = cross_check_mapping(&compiled, &schemas, &no_errors());
+        assert!(
+            diags.is_empty(),
+            "a correct mapping must produce no diagnostics, got: {diags:?}"
+        );
+        assert!(!has_error(&diags));
+    }
+
+    #[test]
+    fn miscased_column_flags_casing_mismatch_not_column_not_found() {
+        // Subject key spelled `store_key`; schema has `STORE_KEY`.
+        let mut tm = TriplesMap::new("<#DimStore>", "DW.DIM_STORE");
+        tm.subject_map = SubjectMap::template("http://ex/store/{store_key}");
+        let compiled = CompiledR2rmlMapping::new(vec![tm]);
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "DW.DIM_STORE".to_string(),
+            schema(
+                "DW.DIM_STORE",
+                vec![col("STORE_KEY", FieldType::Int64, true, Some(0.0))],
+            ),
+        );
+
+        let diags = cross_check_mapping(&compiled, &schemas, &no_errors());
+        assert!(has_code(&diags, DiagCode::CasingMismatch), "{diags:?}");
+        assert!(!has_code(&diags, DiagCode::ColumnNotFound), "{diags:?}");
+        // Case-corrected key is required → no nullable-subject-key warning.
+        assert!(!has_code(&diags, DiagCode::NoSafeSubjectKey), "{diags:?}");
+    }
+
+    #[test]
+    fn nonexistent_column_flags_column_not_found() {
+        // Object column `BOGUS` does not exist on the table.
+        let mut tm = TriplesMap::new("<#DimStore>", "DW.DIM_STORE");
+        tm.subject_map = SubjectMap::template("http://ex/store/{STORE_KEY}");
+        tm.predicate_object_maps = vec![PredicateObjectMap {
+            predicate_map: PredicateMap::constant("http://ex/bogus"),
+            object_map: ObjectMap::column("BOGUS"),
+        }];
+        let compiled = CompiledR2rmlMapping::new(vec![tm]);
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "DW.DIM_STORE".to_string(),
+            schema(
+                "DW.DIM_STORE",
+                vec![col("STORE_KEY", FieldType::Int64, true, Some(0.0))],
+            ),
+        );
+
+        let diags = cross_check_mapping(&compiled, &schemas, &no_errors());
+        assert!(has_code(&diags, DiagCode::ColumnNotFound), "{diags:?}");
+        assert!(diags.iter().any(|d| d.column.as_deref() == Some("BOGUS")));
+    }
+
+    #[test]
+    fn missing_table_flags_table_not_found() {
+        // Schema map is empty → the referenced table cannot be resolved.
+        let compiled = CompiledR2rmlMapping::new(vec![dim_store_map()]);
+        let diags = cross_check_mapping(&compiled, &HashMap::new(), &no_errors());
+        assert!(has_code(&diags, DiagCode::TableNotFound), "{diags:?}");
+    }
+
+    #[test]
+    fn join_parent_column_absent_flags_column_not_found() {
+        // FACT_SALES joins DIM_STORE on STORE_KEY→STORE_KEY, but the parent schema
+        // lacks STORE_KEY entirely.
+        let compiled = CompiledR2rmlMapping::new(vec![fact_sales_map(), dim_store_map()]);
+
+        let mut schemas = HashMap::new();
+        schemas.insert("DW.FACT_SALES".to_string(), fact_sales_schema());
+        // Parent DIM_STORE exists but WITHOUT the STORE_KEY column.
+        schemas.insert(
+            "DW.DIM_STORE".to_string(),
+            schema(
+                "DW.DIM_STORE",
+                vec![col("NAME", FieldType::String, false, Some(0.0))],
+            ),
+        );
+
+        let diags = cross_check_mapping(&compiled, &schemas, &no_errors());
+        // Parent column STORE_KEY missing on DIM_STORE → ColumnNotFound on the parent.
+        assert!(has_code(&diags, DiagCode::ColumnNotFound), "{diags:?}");
+        assert!(diags
+            .iter()
+            .any(|d| d.table.as_deref() == Some("DW.DIM_STORE")
+                && d.column.as_deref() == Some("STORE_KEY")));
+    }
+
+    #[test]
+    fn join_parent_table_absent_flags_table_not_found() {
+        // Parent DIM_STORE not resolved at all (absent from schemas).
+        let compiled = CompiledR2rmlMapping::new(vec![fact_sales_map(), dim_store_map()]);
+        let mut schemas = HashMap::new();
+        schemas.insert("DW.FACT_SALES".to_string(), fact_sales_schema());
+
+        let diags = cross_check_mapping(&compiled, &schemas, &no_errors());
+        assert!(has_code(&diags, DiagCode::TableNotFound), "{diags:?}");
+        assert!(diags
+            .iter()
+            .any(|d| d.table.as_deref() == Some("DW.DIM_STORE")));
+    }
+
+    #[test]
+    fn join_type_mismatch_flags_join_type_mismatch() {
+        // Child STORE_KEY is a String, parent STORE_KEY is a Long → mismatch.
+        let compiled = CompiledR2rmlMapping::new(vec![fact_sales_map(), dim_store_map()]);
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "DW.FACT_SALES".to_string(),
+            schema(
+                "DW.FACT_SALES",
+                vec![
+                    col("SALE_KEY", FieldType::Int64, true, Some(0.0)),
+                    col("STORE_KEY", FieldType::String, false, Some(0.0)), // wrong type
+                ],
+            ),
+        );
+        schemas.insert("DW.DIM_STORE".to_string(), dim_store_schema()); // STORE_KEY is Int64
+
+        let diags = cross_check_mapping(&compiled, &schemas, &no_errors());
+        assert!(has_code(&diags, DiagCode::JoinTypeMismatch), "{diags:?}");
+    }
+
+    #[test]
+    fn nullable_subject_key_flags_no_safe_subject_key_but_not_uniqueness() {
+        // Subject key STORE_KEY is NOT required and stats show null_fraction > 0.
+        let mut tm = TriplesMap::new("<#DimStore>", "DW.DIM_STORE");
+        tm.subject_map = SubjectMap::template("http://ex/store/{STORE_KEY}");
+        let compiled = CompiledR2rmlMapping::new(vec![tm]);
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "DW.DIM_STORE".to_string(),
+            schema(
+                "DW.DIM_STORE",
+                vec![col("STORE_KEY", FieldType::Int64, false, Some(0.25))],
+            ),
+        );
+
+        let diags = cross_check_mapping(&compiled, &schemas, &no_errors());
+        assert!(
+            has_code(&diags, DiagCode::NoSafeSubjectKey),
+            "nullable subject key must be flagged: {diags:?}"
+        );
+        // Uniqueness (NDV) is deliberately NOT checked in PR-1.
+        assert!(
+            !has_code(&diags, DiagCode::SubjectKeyUnverified),
+            "uniqueness must NOT be flagged (NDV deferred to PR-5): {diags:?}"
+        );
+    }
+
+    #[test]
+    fn nullable_subject_key_not_flagged_when_null_fraction_zero() {
+        // Not required, but stats prove null_fraction == 0 → safe, no warning.
+        let mut tm = TriplesMap::new("<#DimStore>", "DW.DIM_STORE");
+        tm.subject_map = SubjectMap::template("http://ex/store/{STORE_KEY}");
+        let compiled = CompiledR2rmlMapping::new(vec![tm]);
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "DW.DIM_STORE".to_string(),
+            schema(
+                "DW.DIM_STORE",
+                vec![col("STORE_KEY", FieldType::Int64, false, Some(0.0))],
+            ),
+        );
+
+        let diags = cross_check_mapping(&compiled, &schemas, &no_errors());
+        assert!(!has_code(&diags, DiagCode::NoSafeSubjectKey), "{diags:?}");
+    }
+
+    #[test]
+    fn preview_failure_enriches_table_not_found_message() {
+        let compiled = CompiledR2rmlMapping::new(vec![dim_store_map()]);
+        let mut load_errors = HashMap::new();
+        load_errors.insert(
+            "DW.DIM_STORE".to_string(),
+            "Direct catalog mode cannot be used".to_string(),
+        );
+
+        let diags = cross_check_mapping(&compiled, &HashMap::new(), &load_errors);
+        assert!(has_code(&diags, DiagCode::TableNotFound));
+        assert!(diags
+            .iter()
+            .any(|d| d.message.contains("Direct catalog mode")));
+    }
+
+    #[test]
+    fn turtle_that_fails_to_compile_yields_compiled_ok_false_and_error() {
+        // Unterminated string literal → a hard Turtle parse error.
+        let bad = "@prefix ex: <http://ex/> .\nex:a ex:b \"oops .";
+        let response = compile_for_validate(bad).expect_err("malformed Turtle must not compile");
+
+        assert!(!response.compiled_ok);
+        assert_eq!(response.triples_map_count, 0);
+        assert!(response.table_names.is_empty());
+        assert!(
+            has_error(&response.diagnostics),
+            "{:?}",
+            response.diagnostics
+        );
+        assert!(response.diagnostics[0]
+            .message
+            .contains("failed to compile"));
+    }
+
+    #[test]
+    fn table_identifier_split_uses_last_dot() {
+        assert_eq!(
+            table_identifier_from_name("DW.DIM_STORE"),
+            TableIdentifier::new("DW", "DIM_STORE")
+        );
+        assert_eq!(
+            table_identifier_from_name("db.schema.events"),
+            TableIdentifier::new("db.schema", "events")
+        );
+    }
+
+    // A FACT table that joins DIM_STORE on STORE_KEY → STORE_KEY.
+    fn fact_sales_map() -> TriplesMap {
+        let mut tm = TriplesMap::new("<#FactSales>", "DW.FACT_SALES");
+        tm.subject_map = SubjectMap::template("http://ex/sale/{SALE_KEY}");
+        tm.predicate_object_maps = vec![PredicateObjectMap {
+            predicate_map: PredicateMap::constant("http://ex/store"),
+            object_map: ObjectMap::RefObjectMap(RefObjectMap {
+                parent_triples_map: "<#DimStore>".to_string(),
+                join_conditions: vec![JoinCondition {
+                    child_column: "STORE_KEY".to_string(),
+                    parent_column: "STORE_KEY".to_string(),
+                }],
+            }),
+        }];
+        tm
+    }
+
+    fn fact_sales_schema() -> TableSchema {
+        schema(
+            "DW.FACT_SALES",
+            vec![
+                col("SALE_KEY", FieldType::Int64, true, Some(0.0)),
+                col("STORE_KEY", FieldType::Int64, false, Some(0.0)),
+            ],
+        )
+    }
+}

--- a/fluree-db-api/src/graph_source/mod.rs
+++ b/fluree-db-api/src/graph_source/mod.rs
@@ -114,6 +114,9 @@ mod vector;
 #[cfg(feature = "iceberg")]
 mod r2rml;
 
+#[cfg(feature = "iceberg")]
+mod iceberg_catalog;
+
 // Re-export configuration types
 pub use config::Bm25CreateConfig;
 
@@ -122,6 +125,11 @@ pub use config::VectorCreateConfig;
 
 #[cfg(feature = "iceberg")]
 pub use config::{CatalogMode, IcebergConnectionConfig, IcebergCreateConfig, RestCatalogMode};
+
+#[cfg(feature = "iceberg")]
+pub use iceberg_catalog::{
+    browse_iceberg_catalog, BrowseDepth, CatalogBrowse, TableIdentifier, TableRef,
+};
 
 #[cfg(feature = "iceberg")]
 pub use config::{R2rmlCreateConfig, R2rmlMappingInput};

--- a/fluree-db-api/src/graph_source/mod.rs
+++ b/fluree-db-api/src/graph_source/mod.rs
@@ -117,6 +117,9 @@ mod r2rml;
 #[cfg(feature = "iceberg")]
 mod iceberg_catalog;
 
+#[cfg(feature = "iceberg")]
+mod iceberg_validate;
+
 // Re-export configuration types
 pub use config::Bm25CreateConfig;
 
@@ -132,6 +135,9 @@ pub use iceberg_catalog::{
     ColumnStats, PartitionFieldInfo, SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier,
     TableIdentifier, TablePreview, TableRef, TableSchema,
 };
+
+#[cfg(feature = "iceberg")]
+pub use iceberg_validate::ValidateR2rmlResponse;
 
 #[cfg(feature = "iceberg")]
 pub use config::{R2rmlCreateConfig, R2rmlMappingInput};

--- a/fluree-db-api/src/graph_source/mod.rs
+++ b/fluree-db-api/src/graph_source/mod.rs
@@ -128,7 +128,9 @@ pub use config::{CatalogMode, IcebergConnectionConfig, IcebergCreateConfig, Rest
 
 #[cfg(feature = "iceberg")]
 pub use iceberg_catalog::{
-    browse_iceberg_catalog, BrowseDepth, CatalogBrowse, TableIdentifier, TableRef,
+    browse_iceberg_catalog, preview_iceberg_table, BrowseDepth, CatalogBrowse, ColumnInfo,
+    ColumnStats, PartitionFieldInfo, SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier,
+    TableIdentifier, TablePreview, TableRef, TableSchema,
 };
 
 #[cfg(feature = "iceberg")]

--- a/fluree-db-api/src/graph_source/mod.rs
+++ b/fluree-db-api/src/graph_source/mod.rs
@@ -121,7 +121,7 @@ pub use config::Bm25CreateConfig;
 pub use config::VectorCreateConfig;
 
 #[cfg(feature = "iceberg")]
-pub use config::{CatalogMode, IcebergCreateConfig, RestCatalogMode};
+pub use config::{CatalogMode, IcebergConnectionConfig, IcebergCreateConfig, RestCatalogMode};
 
 #[cfg(feature = "iceberg")]
 pub use config::{R2rmlCreateConfig, R2rmlMappingInput};

--- a/fluree-db-api/src/graph_source/mod.rs
+++ b/fluree-db-api/src/graph_source/mod.rs
@@ -117,6 +117,9 @@ mod r2rml;
 #[cfg(feature = "iceberg")]
 mod iceberg_catalog;
 
+#[cfg(feature = "iceberg")]
+mod iceberg_generate;
+
 // Re-export configuration types
 pub use config::Bm25CreateConfig;
 
@@ -131,6 +134,12 @@ pub use iceberg_catalog::{
     browse_iceberg_catalog, preview_iceberg_table, BrowseDepth, CatalogBrowse, ColumnInfo,
     ColumnStats, PartitionFieldInfo, SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier,
     TableIdentifier, TablePreview, TableRef, TableSchema,
+};
+
+#[cfg(feature = "iceberg")]
+pub use iceberg_generate::{
+    Diagnostic, GenerateOptions, GenerateR2rmlRequest, GenerateR2rmlResponse, StructuredR2rmlMapping,
+    TableOverride,
 };
 
 #[cfg(feature = "iceberg")]

--- a/fluree-db-api/src/graph_source/mod.rs
+++ b/fluree-db-api/src/graph_source/mod.rs
@@ -141,8 +141,8 @@ pub use iceberg_catalog::{
 
 #[cfg(feature = "iceberg")]
 pub use iceberg_generate::{
-    Diagnostic, GenerateOptions, GenerateR2rmlRequest, GenerateR2rmlResponse, StructuredR2rmlMapping,
-    TableOverride,
+    Diagnostic, GenerateOptions, GenerateR2rmlRequest, GenerateR2rmlResponse,
+    StructuredR2rmlMapping, TableOverride,
 };
 
 #[cfg(feature = "iceberg")]

--- a/fluree-db-api/src/graph_source/mod.rs
+++ b/fluree-db-api/src/graph_source/mod.rs
@@ -137,9 +137,9 @@ pub use config::{CatalogMode, IcebergConnectionConfig, IcebergCreateConfig, Rest
 
 #[cfg(feature = "iceberg")]
 pub use iceberg_catalog::{
-    browse_iceberg_catalog, preview_iceberg_table, BrowseDepth, CatalogBrowse, ColumnInfo,
-    ColumnStats, PartitionFieldInfo, SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier,
-    TableIdentifier, TablePreview, TableRef, TableSchema,
+    browse_iceberg_catalog, guard_iceberg_connection_urls, preview_iceberg_table, BrowseDepth,
+    CatalogBrowse, ColumnInfo, ColumnStats, PartitionFieldInfo, SnapshotRef, SortFieldInfo,
+    StatsCompleteness, StatsTier, TableIdentifier, TablePreview, TableRef, TableSchema,
 };
 
 #[cfg(feature = "iceberg")]

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -764,6 +764,7 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                         metadata_location,
                         config: std::collections::HashMap::default(),
                         credentials: None,
+                        metadata: None,
                     }
                 } else {
                     debug!(table_location = %table_location, "Direct metadata-location cache miss");

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -269,7 +269,7 @@ impl crate::Fluree {
     async fn test_iceberg_connection(&self, config: &IcebergCreateConfig) -> Result<()> {
         use fluree_db_iceberg::catalog::parse_table_identifier;
 
-        let rest = match &config.catalog_mode {
+        let rest = match &config.connection.catalog_mode {
             CatalogMode::Rest(rest) => rest,
             CatalogMode::Direct { .. } => {
                 return Err(crate::ApiError::Config(
@@ -296,12 +296,12 @@ impl crate::Fluree {
         })?;
 
         // Parse table identifier
-        let table_id = parse_table_identifier(&rest.table_identifier)
+        let table_id = parse_table_identifier(&config.table_identifier)
             .map_err(|e| crate::ApiError::Config(format!("Invalid table identifier: {e}")))?;
 
         // Attempt to load table metadata (this tests the connection)
         catalog
-            .load_table(&table_id, rest.vended_credentials)
+            .load_table(&table_id, config.connection.io.vended_credentials)
             .await
             .map_err(|e| {
                 crate::ApiError::Config(format!("Failed to load table from catalog: {e}"))

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -189,13 +189,13 @@ pub use view::{
 
 #[cfg(feature = "iceberg")]
 pub use graph_source::{
-    browse_iceberg_catalog, preview_iceberg_table, BrowseDepth, CatalogBrowse, CatalogMode,
-    ColumnInfo, ColumnStats, Diagnostic, FlureeR2rmlProvider, GenerateOptions,
-    GenerateR2rmlRequest, GenerateR2rmlResponse, IcebergConnectionConfig, IcebergCreateConfig,
-    IcebergCreateResult, PartitionFieldInfo, R2rmlCreateConfig, R2rmlCreateResult,
-    R2rmlMappingInput, RestCatalogMode, SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier,
-    StructuredR2rmlMapping, TableIdentifier, TableOverride, TablePreview, TableRef, TableSchema,
-    ValidateR2rmlResponse,
+    browse_iceberg_catalog, guard_iceberg_connection_urls, preview_iceberg_table, BrowseDepth,
+    CatalogBrowse, CatalogMode, ColumnInfo, ColumnStats, Diagnostic, FlureeR2rmlProvider,
+    GenerateOptions, GenerateR2rmlRequest, GenerateR2rmlResponse, IcebergConnectionConfig,
+    IcebergCreateConfig, IcebergCreateResult, PartitionFieldInfo, R2rmlCreateConfig,
+    R2rmlCreateResult, R2rmlMappingInput, RestCatalogMode, SnapshotRef, SortFieldInfo,
+    StatsCompleteness, StatsTier, StructuredR2rmlMapping, TableIdentifier, TableOverride,
+    TablePreview, TableRef, TableSchema, ValidateR2rmlResponse,
 };
 
 pub use bm25_worker::{

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -193,7 +193,7 @@ pub use graph_source::{
     ColumnInfo, ColumnStats, FlureeR2rmlProvider, IcebergConnectionConfig, IcebergCreateConfig,
     IcebergCreateResult, PartitionFieldInfo, R2rmlCreateConfig, R2rmlCreateResult,
     R2rmlMappingInput, RestCatalogMode, SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier,
-    TableIdentifier, TablePreview, TableRef, TableSchema,
+    TableIdentifier, TablePreview, TableRef, TableSchema, ValidateR2rmlResponse,
 };
 
 pub use bm25_worker::{

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -190,10 +190,11 @@ pub use view::{
 #[cfg(feature = "iceberg")]
 pub use graph_source::{
     browse_iceberg_catalog, preview_iceberg_table, BrowseDepth, CatalogBrowse, CatalogMode,
-    ColumnInfo, ColumnStats, FlureeR2rmlProvider, IcebergConnectionConfig, IcebergCreateConfig,
+    ColumnInfo, ColumnStats, Diagnostic, FlureeR2rmlProvider, GenerateOptions,
+    GenerateR2rmlRequest, GenerateR2rmlResponse, IcebergConnectionConfig, IcebergCreateConfig,
     IcebergCreateResult, PartitionFieldInfo, R2rmlCreateConfig, R2rmlCreateResult,
     R2rmlMappingInput, RestCatalogMode, SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier,
-    TableIdentifier, TablePreview, TableRef, TableSchema,
+    StructuredR2rmlMapping, TableIdentifier, TableOverride, TablePreview, TableRef, TableSchema,
 };
 
 pub use bm25_worker::{

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -189,9 +189,11 @@ pub use view::{
 
 #[cfg(feature = "iceberg")]
 pub use graph_source::{
-    browse_iceberg_catalog, BrowseDepth, CatalogBrowse, CatalogMode, FlureeR2rmlProvider,
-    IcebergConnectionConfig, IcebergCreateConfig, IcebergCreateResult, R2rmlCreateConfig,
-    R2rmlCreateResult, R2rmlMappingInput, RestCatalogMode, TableIdentifier, TableRef,
+    browse_iceberg_catalog, preview_iceberg_table, BrowseDepth, CatalogBrowse, CatalogMode,
+    ColumnInfo, ColumnStats, FlureeR2rmlProvider, IcebergConnectionConfig, IcebergCreateConfig,
+    IcebergCreateResult, PartitionFieldInfo, R2rmlCreateConfig, R2rmlCreateResult,
+    R2rmlMappingInput, RestCatalogMode, SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier,
+    TableIdentifier, TablePreview, TableRef, TableSchema,
 };
 
 pub use bm25_worker::{

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -189,8 +189,9 @@ pub use view::{
 
 #[cfg(feature = "iceberg")]
 pub use graph_source::{
-    CatalogMode, FlureeR2rmlProvider, IcebergConnectionConfig, IcebergCreateConfig,
-    IcebergCreateResult, R2rmlCreateConfig, R2rmlCreateResult, R2rmlMappingInput, RestCatalogMode,
+    browse_iceberg_catalog, BrowseDepth, CatalogBrowse, CatalogMode, FlureeR2rmlProvider,
+    IcebergConnectionConfig, IcebergCreateConfig, IcebergCreateResult, R2rmlCreateConfig,
+    R2rmlCreateResult, R2rmlMappingInput, RestCatalogMode, TableIdentifier, TableRef,
 };
 
 pub use bm25_worker::{

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -189,8 +189,8 @@ pub use view::{
 
 #[cfg(feature = "iceberg")]
 pub use graph_source::{
-    CatalogMode, FlureeR2rmlProvider, IcebergCreateConfig, IcebergCreateResult, R2rmlCreateConfig,
-    R2rmlCreateResult, R2rmlMappingInput, RestCatalogMode,
+    CatalogMode, FlureeR2rmlProvider, IcebergConnectionConfig, IcebergCreateConfig,
+    IcebergCreateResult, R2rmlCreateConfig, R2rmlCreateResult, R2rmlMappingInput, RestCatalogMode,
 };
 
 pub use bm25_worker::{

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -1367,7 +1367,10 @@ fn test_iceberg_create_config_builder() {
         _ => panic!("Expected REST catalog mode"),
     }
     assert!(!config.connection.io.vended_credentials);
-    assert_eq!(config.connection.io.s3_region, Some("us-west-2".to_string()));
+    assert_eq!(
+        config.connection.io.s3_region,
+        Some("us-west-2".to_string())
+    );
     assert_eq!(
         config.connection.io.s3_endpoint,
         Some("http://localhost:9000".to_string())

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -1360,19 +1360,19 @@ fn test_iceberg_create_config_builder() {
         .with_s3_path_style(true);
 
     assert_eq!(config.graph_source_id(), "my-gs:dev");
-    match &config.catalog_mode {
+    match &config.connection.catalog_mode {
         fluree_db_api::CatalogMode::Rest(rest) => {
             assert_eq!(rest.warehouse, Some("my-warehouse".to_string()));
-            assert!(!rest.vended_credentials);
         }
         _ => panic!("Expected REST catalog mode"),
     }
-    assert_eq!(config.s3_region, Some("us-west-2".to_string()));
+    assert!(!config.connection.io.vended_credentials);
+    assert_eq!(config.connection.io.s3_region, Some("us-west-2".to_string()));
     assert_eq!(
-        config.s3_endpoint,
+        config.connection.io.s3_endpoint,
         Some("http://localhost:9000".to_string())
     );
-    assert!(config.s3_path_style);
+    assert!(config.connection.io.s3_path_style);
 
     // Validation should still pass
     assert!(config.validate().is_ok());
@@ -1438,7 +1438,7 @@ fn test_r2rml_create_config_builder() {
         matches!(&config.mapping, fluree_db_api::R2rmlMappingInput::Content(c) if c == "s3://bucket/mappings/airlines.ttl")
     );
     assert_eq!(config.mapping_media_type, Some("text/turtle".to_string()));
-    match &config.iceberg.catalog_mode {
+    match &config.iceberg.connection.catalog_mode {
         fluree_db_api::CatalogMode::Rest(rest) => {
             assert_eq!(rest.warehouse, Some("analytics".to_string()));
         }

--- a/fluree-db-iceberg/src/auth/bearer.rs
+++ b/fluree-db-iceberg/src/auth/bearer.rs
@@ -8,9 +8,17 @@ use async_trait::async_trait;
 ///
 /// Simple auth that returns a fixed token. Token is resolved at construction
 /// time (env vars expanded), then used unchanged.
-#[derive(Debug)]
 pub struct BearerTokenAuth {
     token: String,
+}
+
+/// Redacting `Debug`: the resolved bearer token is a live credential.
+impl std::fmt::Debug for BearerTokenAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BearerTokenAuth")
+            .field("token", &"***")
+            .finish()
+    }
 }
 
 impl BearerTokenAuth {
@@ -63,5 +71,13 @@ mod tests {
         // Token should be unchanged
         let header = SendCatalogAuth::authorization_header(&auth).await.unwrap();
         assert_eq!(header, Some("Bearer test-token".to_string()));
+    }
+
+    #[test]
+    fn debug_redacts_token() {
+        let auth = BearerTokenAuth::new("super-secret-token".to_string());
+        let dbg = format!("{auth:?}");
+        assert!(!dbg.contains("super-secret-token"), "token leaked: {dbg}");
+        assert!(dbg.contains("***"));
     }
 }

--- a/fluree-db-iceberg/src/auth/oauth2.rs
+++ b/fluree-db-iceberg/src/auth/oauth2.rs
@@ -87,8 +87,12 @@ impl std::fmt::Debug for OAuth2ClientCredentials {
 
 impl OAuth2ClientCredentials {
     /// Create a new OAuth2 auth provider.
+    ///
+    /// The HTTP client is SSRF-hardened (see [`crate::net::hardened_client_builder`]):
+    /// it follows no redirects and resolves the token endpoint through the guard
+    /// resolver, so the token request cannot be bounced to an internal address.
     pub fn new(config: OAuth2Config) -> Result<Self> {
-        let http_client = reqwest::Client::builder()
+        let http_client = crate::net::hardened_client_builder()
             .connect_timeout(std::time::Duration::from_secs(30))
             .timeout(std::time::Duration::from_secs(60))
             .build()

--- a/fluree-db-iceberg/src/auth/oauth2.rs
+++ b/fluree-db-iceberg/src/auth/oauth2.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// OAuth2 client credentials configuration.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct OAuth2Config {
     pub token_url: String,
     pub client_id: String,
@@ -18,12 +18,36 @@ pub struct OAuth2Config {
     pub audience: Option<String>,
 }
 
+/// Redacting `Debug`: never leak `client_secret` via a `{:?}` in a log or error.
+impl std::fmt::Debug for OAuth2Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuth2Config")
+            .field("token_url", &self.token_url)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"***")
+            .field("scope", &self.scope)
+            .field("audience", &self.audience)
+            .finish()
+    }
+}
+
 /// Cached token with expiration.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct CachedToken {
     access_token: String,
     token_type: String,
     expires_at: DateTime<Utc>,
+}
+
+/// Redacting `Debug`: the `access_token` is a live bearer credential.
+impl std::fmt::Debug for CachedToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachedToken")
+            .field("access_token", &"***")
+            .field("token_type", &self.token_type)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
 }
 
 impl CachedToken {

--- a/fluree-db-iceberg/src/catalog/direct.rs
+++ b/fluree-db-iceberg/src/catalog/direct.rs
@@ -121,6 +121,7 @@ impl<S: IcebergStorage> CatalogClient for DirectCatalogClient<S> {
             metadata_location,
             config: HashMap::new(),
             credentials: None, // Direct mode uses ambient credentials
+            metadata: None,    // Direct mode has no inline metadata (resolved via version-hint)
         })
     }
 }
@@ -211,6 +212,7 @@ impl<S: SendIcebergStorage + 'static> SendCatalogClient for SendDirectCatalogCli
             metadata_location,
             config: HashMap::new(),
             credentials: None,
+            metadata: None,
         })
     }
 }

--- a/fluree-db-iceberg/src/catalog/mod.rs
+++ b/fluree-db-iceberg/src/catalog/mod.rs
@@ -28,6 +28,12 @@ pub struct LoadTableResponse {
     pub config: HashMap<String, serde_json::Value>,
     /// Vended storage credentials (if catalog supports credential delegation)
     pub credentials: Option<VendedCredentials>,
+    /// The parsed inline `metadata` object the REST `loadTable` response carries,
+    /// when present and parseable. Retained so callers (e.g. metadata preview)
+    /// can read the full table schema/snapshot without a second S3 fetch of the
+    /// metadata JSON. `None` for Direct mode (no inline metadata) or when the
+    /// catalog omits it.
+    pub metadata: Option<crate::metadata::TableMetadata>,
 }
 
 /// Iceberg catalog client trait.

--- a/fluree-db-iceberg/src/catalog/rest.rs
+++ b/fluree-db-iceberg/src/catalog/rest.rs
@@ -251,10 +251,28 @@ impl CatalogClient for RestCatalogClient {
         // Parse vended credentials if present
         let credentials = VendedCredentials::from_config_map(&config)?;
 
+        // Retain the inline `metadata` object the REST loadTable response carries
+        // (Snowflake Horizon / Polaris include it). This lets metadata preview
+        // read the full schema/snapshot with no extra S3 fetch. A present-but-
+        // unparseable metadata object is logged and dropped, never fatal — the
+        // metadata_location fetch path still works.
+        let metadata = response.get("metadata").and_then(|m| {
+            match serde_json::from_value::<crate::metadata::TableMetadata>(m.clone()) {
+                Ok(md) => Some(md),
+                Err(e) => {
+                    tracing::debug!(
+                        "REST loadTable inline metadata present but failed to parse: {e}"
+                    );
+                    None
+                }
+            }
+        });
+
         Ok(LoadTableResponse {
             metadata_location,
             config,
             credentials,
+            metadata,
         })
     }
 }
@@ -348,10 +366,23 @@ impl super::SendCatalogClient for RestCatalogClient {
 
         let credentials = VendedCredentials::from_config_map(&config)?;
 
+        let metadata = response.get("metadata").and_then(|m| {
+            match serde_json::from_value::<crate::metadata::TableMetadata>(m.clone()) {
+                Ok(md) => Some(md),
+                Err(e) => {
+                    tracing::debug!(
+                        "REST loadTable inline metadata present but failed to parse: {e}"
+                    );
+                    None
+                }
+            }
+        });
+
         Ok(LoadTableResponse {
             metadata_location,
             config,
             credentials,
+            metadata,
         })
     }
 }

--- a/fluree-db-iceberg/src/catalog/rest.rs
+++ b/fluree-db-iceberg/src/catalog/rest.rs
@@ -56,8 +56,12 @@ impl std::fmt::Debug for RestCatalogClient {
 
 impl RestCatalogClient {
     /// Create a new REST catalog client.
+    ///
+    /// The HTTP client is SSRF-hardened (see [`crate::net::hardened_client_builder`]):
+    /// it follows no redirects and resolves through the guard resolver, so a
+    /// catalog request cannot be redirected or rebound to an internal address.
     pub fn new(config: RestCatalogConfig, auth: Arc<dyn SendCatalogAuth>) -> Result<Self> {
-        let http_client = reqwest::Client::builder()
+        let http_client = crate::net::hardened_client_builder()
             .connect_timeout(Duration::from_secs(config.connect_timeout_secs))
             .timeout(Duration::from_secs(config.request_timeout_secs))
             .build()

--- a/fluree-db-iceberg/src/config_value.rs
+++ b/fluree-db-iceberg/src/config_value.rs
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 /// ).unwrap();
 /// assert_eq!(with_default.resolve().unwrap(), "default");
 /// ```
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum ConfigValue {
     /// Literal string value
@@ -59,6 +59,28 @@ pub enum ConfigValue {
         #[serde(default)]
         default_val: Option<String>,
     },
+}
+
+/// Redacting `Debug`: `ConfigValue` carries auth secrets (bearer tokens, OAuth2
+/// client secrets), so a `{:?}` in a log or error must never leak them. The
+/// environment-variable *name* is shown (it aids debugging and is not secret);
+/// the literal value and any inline default are redacted.
+impl std::fmt::Debug for ConfigValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigValue::Literal(_) => f.write_str("Literal(\"***\")"),
+            ConfigValue::Dynamic {
+                env_var,
+                java_property,
+                default_val,
+            } => f
+                .debug_struct("Dynamic")
+                .field("env_var", env_var)
+                .field("java_property", java_property)
+                .field("default_val", &default_val.as_ref().map(|_| "***"))
+                .finish(),
+        }
+    }
 }
 
 impl ConfigValue {
@@ -220,5 +242,28 @@ mod tests {
         let value: ConfigValue = "test".into();
         assert!(value.is_literal());
         assert_eq!(value.resolve().unwrap(), "test");
+    }
+
+    #[test]
+    fn debug_redacts_literal_secret() {
+        let value = ConfigValue::literal("super-secret-token");
+        let dbg = format!("{value:?}");
+        assert!(
+            !dbg.contains("super-secret-token"),
+            "Debug must not leak the literal secret, got: {dbg}"
+        );
+        assert!(dbg.contains("***"), "got: {dbg}");
+    }
+
+    #[test]
+    fn debug_shows_env_var_name_but_redacts_default() {
+        let value = ConfigValue::from_env_with_default("POLARIS_TOKEN", "fallback-secret");
+        let dbg = format!("{value:?}");
+        // The env var NAME is safe to show; the inline default is a secret.
+        assert!(dbg.contains("POLARIS_TOKEN"), "got: {dbg}");
+        assert!(
+            !dbg.contains("fallback-secret"),
+            "Debug must not leak the default secret, got: {dbg}"
+        );
     }
 }

--- a/fluree-db-iceberg/src/credential/vended.rs
+++ b/fluree-db-iceberg/src/credential/vended.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// Temporary storage credentials vended by a REST catalog.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct VendedCredentials {
     /// AWS access key ID
     pub access_key_id: String,
@@ -23,6 +23,23 @@ pub struct VendedCredentials {
     pub region: Option<String>,
     /// Use path-style S3 access
     pub path_style: bool,
+}
+
+/// Redacting `Debug`: never leak the secret access key or session token via a
+/// `{:?}` in a log or error. The access key ID is an identifier (not usable
+/// without the secret) and is shown to aid debugging.
+impl std::fmt::Debug for VendedCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VendedCredentials")
+            .field("access_key_id", &self.access_key_id)
+            .field("secret_access_key", &"***")
+            .field("session_token", &self.session_token.as_ref().map(|_| "***"))
+            .field("expires_at", &self.expires_at)
+            .field("endpoint", &self.endpoint)
+            .field("region", &self.region)
+            .field("path_style", &self.path_style)
+            .finish()
+    }
 }
 
 impl VendedCredentials {
@@ -470,5 +487,26 @@ mod tests {
 
         cache.invalidate(&key).await;
         assert!(cache.get(&key).await.is_none());
+    }
+
+    #[test]
+    fn debug_redacts_secret_and_session_token() {
+        let creds = VendedCredentials {
+            access_key_id: "AKIAEXAMPLE".to_string(),
+            secret_access_key: "super-secret-key".to_string(),
+            session_token: Some("super-secret-session".to_string()),
+            expires_at: None,
+            endpoint: None,
+            region: Some("us-east-1".to_string()),
+            path_style: false,
+        };
+        let dbg = format!("{creds:?}");
+        assert!(!dbg.contains("super-secret-key"), "secret leaked: {dbg}");
+        assert!(
+            !dbg.contains("super-secret-session"),
+            "session token leaked: {dbg}"
+        );
+        // The access key ID (an identifier, unusable without the secret) is shown.
+        assert!(dbg.contains("AKIAEXAMPLE"));
     }
 }

--- a/fluree-db-iceberg/src/io/storage.rs
+++ b/fluree-db-iceberg/src/io/storage.rs
@@ -172,6 +172,9 @@ impl S3IcebergStorage {
         let mut s3_config = aws_sdk_s3::config::Builder::from(&sdk_config);
 
         if let Some(endpoint) = &endpoint {
+            // SSRF: reject a metadata/link-local endpoint (loopback/private are
+            // allowed here for MinIO / LocalStack).
+            crate::net::validate_s3_endpoint(endpoint)?;
             s3_config = s3_config.endpoint_url(endpoint);
         }
 
@@ -214,6 +217,9 @@ impl S3IcebergStorage {
         let mut s3_config = aws_sdk_s3::config::Builder::from(&sdk_config);
 
         if let Some(ep) = endpoint {
+            // SSRF: reject a metadata/link-local endpoint (loopback/private are
+            // allowed here for MinIO / LocalStack).
+            crate::net::validate_s3_endpoint(ep)?;
             s3_config = s3_config.endpoint_url(ep);
         }
 

--- a/fluree-db-iceberg/src/lib.rs
+++ b/fluree-db-iceberg/src/lib.rs
@@ -71,12 +71,12 @@ pub use error::{IcebergError, Result};
 // Re-export Phase 2 types for convenience
 pub use io::{BatchSchema, Column, ColumnBatch, FieldInfo, FieldType, IcebergStorage};
 pub use manifest::{DataFile, ManifestContent, ManifestEntry, ManifestListEntry, TypedValue};
+pub use scan::{
+    ComparisonOp, Expression, FileScanTask, LiteralValue, ScanConfig, ScanPlan, ScanPlanner,
+};
 pub use stats::{
     aggregate_column_stats, read_snapshot_data_files, typed_value_to_json, AggregatedColumnStats,
     TableStatsAggregation,
-};
-pub use scan::{
-    ComparisonOp, Expression, FileScanTask, LiteralValue, ScanConfig, ScanPlan, ScanPlanner,
 };
 
 // AWS/Send-safe types

--- a/fluree-db-iceberg/src/lib.rs
+++ b/fluree-db-iceberg/src/lib.rs
@@ -60,6 +60,7 @@ pub mod error;
 pub mod io;
 pub mod manifest;
 pub mod metadata;
+pub mod net;
 pub mod scan;
 pub mod stats;
 

--- a/fluree-db-iceberg/src/lib.rs
+++ b/fluree-db-iceberg/src/lib.rs
@@ -61,6 +61,7 @@ pub mod io;
 pub mod manifest;
 pub mod metadata;
 pub mod scan;
+pub mod stats;
 
 // Re-export commonly used types
 pub use config::{CatalogConfig, IcebergGsConfig, IoConfig, MappingSource, TableConfig};
@@ -70,6 +71,10 @@ pub use error::{IcebergError, Result};
 // Re-export Phase 2 types for convenience
 pub use io::{BatchSchema, Column, ColumnBatch, FieldInfo, FieldType, IcebergStorage};
 pub use manifest::{DataFile, ManifestContent, ManifestEntry, ManifestListEntry, TypedValue};
+pub use stats::{
+    aggregate_column_stats, read_snapshot_data_files, typed_value_to_json, AggregatedColumnStats,
+    TableStatsAggregation,
+};
 pub use scan::{
     ComparisonOp, Expression, FileScanTask, LiteralValue, ScanConfig, ScanPlan, ScanPlanner,
 };

--- a/fluree-db-iceberg/src/manifest/value_codec.rs
+++ b/fluree-db-iceberg/src/manifest/value_codec.rs
@@ -99,9 +99,52 @@ impl PartialOrd for TypedValue {
             (TypedValue::TimestampTz(a), TypedValue::TimestampTz(b)) => a.partial_cmp(b),
             (TypedValue::String(a), TypedValue::String(b)) => a.partial_cmp(b),
             (TypedValue::Bytes(a), TypedValue::Bytes(b)) => a.partial_cmp(b),
+            // UUIDs compare lexicographically by their 16 big-endian bytes
+            // (matching Iceberg's UUID bound ordering).
+            (TypedValue::Uuid(a), TypedValue::Uuid(b)) => Some(a.cmp(b)),
+            // Decimals compare by real value. Without these arms a multi-file
+            // decimal column's min/max aggregation kept the FIRST file's bound
+            // (partial_cmp → None → "keep current") instead of the true extremum.
+            (
+                TypedValue::Decimal {
+                    unscaled: a,
+                    scale: sa,
+                    ..
+                },
+                TypedValue::Decimal {
+                    unscaled: b,
+                    scale: sb,
+                    ..
+                },
+            ) => decimal_cmp(*a, *sa, *b, *sb),
             _ => None,
         }
     }
+}
+
+/// Compare two decimals by real value, normalizing to a common scale.
+///
+/// Same-scale decimals — the common case, since a single Iceberg column has one
+/// fixed scale — compare by unscaled value directly. Differing scales are
+/// brought to a common scale with checked arithmetic; an overflow yields `None`
+/// (incomparable) rather than a wrong answer.
+fn decimal_cmp(a: i128, sa: i8, b: i128, sb: i8) -> Option<std::cmp::Ordering> {
+    if sa == sb {
+        return Some(a.cmp(&b));
+    }
+    let common = sa.max(sb);
+    let a_adj = rescale(a, i32::from(common) - i32::from(sa))?;
+    let b_adj = rescale(b, i32::from(common) - i32::from(sb))?;
+    Some(a_adj.cmp(&b_adj))
+}
+
+/// Multiply `value` by `10^exp` (`exp >= 0`), returning `None` on i128 overflow.
+fn rescale(value: i128, exp: i32) -> Option<i128> {
+    let mut acc = value;
+    for _ in 0..exp {
+        acc = acc.checked_mul(10)?;
+    }
+    Some(acc)
 }
 
 /// Decode Iceberg-encoded bytes into a typed value.
@@ -535,6 +578,47 @@ mod tests {
 
         assert_eq!(a.lt(&b), Some(true));
         assert_eq!(b.gt(&a), Some(true));
+    }
+
+    #[test]
+    fn test_decimal_partial_cmp() {
+        use std::cmp::Ordering;
+        let d = |unscaled, scale| TypedValue::Decimal {
+            unscaled,
+            precision: 18,
+            scale,
+        };
+        // Same scale → compare unscaled directly.
+        assert_eq!(d(12345, 2).partial_cmp(&d(999, 2)), Some(Ordering::Greater));
+        assert_eq!(d(999, 2).partial_cmp(&d(12345, 2)), Some(Ordering::Less));
+        assert_eq!(d(500, 2).partial_cmp(&d(500, 2)), Some(Ordering::Equal));
+        // Negative values order correctly.
+        assert_eq!(d(-5, 2).partial_cmp(&d(5, 2)), Some(Ordering::Less));
+        // Differing scales normalize to the same real value: 1.0 (scale 1) ==
+        // 1.00 (scale 2) → Equal; 1.5 > 1.00.
+        assert_eq!(d(10, 1).partial_cmp(&d(100, 2)), Some(Ordering::Equal));
+        assert_eq!(d(15, 1).partial_cmp(&d(100, 2)), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn test_uuid_partial_cmp() {
+        use std::cmp::Ordering;
+        let mut lo = [0u8; 16];
+        lo[15] = 1;
+        let mut hi = [0u8; 16];
+        hi[0] = 1; // most-significant byte set → larger
+        assert_eq!(
+            TypedValue::Uuid(lo).partial_cmp(&TypedValue::Uuid(hi)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            TypedValue::Uuid(hi).partial_cmp(&TypedValue::Uuid(lo)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            TypedValue::Uuid(lo).partial_cmp(&TypedValue::Uuid(lo)),
+            Some(Ordering::Equal)
+        );
     }
 
     #[test]

--- a/fluree-db-iceberg/src/net.rs
+++ b/fluree-db-iceberg/src/net.rs
@@ -171,6 +171,15 @@ pub fn validate_public_url(raw: &str) -> Result<()> {
 /// Validation for the S3 `endpoint` override. Narrower than [`validate_public_url`]
 /// because MinIO / LocalStack legitimately run on loopback/private hosts — but the
 /// cloud-metadata / link-local range (the credential-exfil target) is still refused.
+///
+/// RESIDUAL (tracked follow-up): the S3 sink uses the AWS SDK, not `reqwest`, so —
+/// unlike the catalog / OAuth2 clients — there is no denylisting DNS resolver on
+/// its connector. A DNS-name `s3_endpoint` that RESOLVES to a private address is
+/// therefore only caught here when it is a literal metadata/link-local IP, not
+/// when it is a hostname. This is lower-risk (s3_endpoint is data-plane and the
+/// metadata IP is blocked). The full fix is to pin the AWS SDK's HTTP connector
+/// to a checked IP — the equivalent of [`hardened_client_builder`]'s resolver —
+/// which is deferred rather than done here.
 pub fn validate_s3_endpoint(raw: &str) -> Result<()> {
     let (scheme, host) = parse_scheme_host(raw)?;
     if scheme != "http" && scheme != "https" {

--- a/fluree-db-iceberg/src/net.rs
+++ b/fluree-db-iceberg/src/net.rs
@@ -1,0 +1,279 @@
+//! SSRF hardening for outbound HTTP to catalog / OAuth2 / S3 endpoints.
+//!
+//! A request-supplied `catalog_uri` / `oauth2_token_url` / `s3_endpoint` reaches
+//! an outbound HTTP client, and the onboarding routes are unauthenticated by
+//! default — so an attacker could aim the server at an internal address
+//! (`http://169.254.169.254/…` for cloud metadata, `http://10.0.0.1/…`, …).
+//!
+//! A URL-string allowlist alone is NOT enough: `reqwest` follows redirects by
+//! default (a public URL can 3xx to an internal one) and re-resolves DNS at
+//! connect time (a name can rebind public→private after a check). So the real
+//! enforcement lives at the client/connect layer:
+//!
+//! - [`hardened_client_builder`] builds a `reqwest::Client` that follows **no**
+//!   redirects and resolves through [`SsrfGuardResolver`], which denylists the
+//!   resolved IPs and hands the connector only the checked addresses (blocking
+//!   DNS-rebinding — there is no resolve-then-reconnect gap).
+//! - [`validate_public_url`] is a cheap up-front check (scheme + literal IP) for
+//!   the untrusted request boundary; it also covers decimal/octal/hex-encoded IP
+//!   literals, which the URL parser normalizes and the resolver never sees.
+//!
+//! The S3 `endpoint` override legitimately targets loopback/private hosts
+//! (MinIO / LocalStack), so it gets the narrower [`validate_s3_endpoint`], which
+//! still refuses the cloud-metadata / link-local range.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
+
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+
+use crate::error::{IcebergError, Result};
+
+/// Whether an IP must be blocked as a non-public / internal target.
+///
+/// IPv4: loopback (127/8), private (RFC1918), link-local (169.254/16 — includes
+/// the `169.254.169.254` cloud-metadata address), CGNAT shared space (100.64/10),
+/// unspecified (0.0.0.0) and broadcast. IPv6: loopback (`::1`), unspecified
+/// (`::`), unique-local (`fc00::/7`) and link-local (`fe80::/10`), plus
+/// IPv4-mapped addresses unwrapped to their v4 form. (`Ipv6Addr::is_unique_local`
+/// / `is_unicast_link_local` are still unstable, so those are checked by hand.)
+pub fn ip_is_blocked(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => ipv4_is_blocked(v4),
+        IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return ipv4_is_blocked(v4);
+            }
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || is_ipv6_unique_local(v6)
+                || is_ipv6_link_local(v6)
+        }
+    }
+}
+
+fn ipv4_is_blocked(v4: Ipv4Addr) -> bool {
+    v4.is_private()
+        || v4.is_loopback()
+        || v4.is_link_local()
+        || v4.is_unspecified()
+        || v4.is_broadcast()
+        || is_ipv4_shared(v4)
+}
+
+/// RFC 6598 shared address space (100.64.0.0/10, carrier-grade NAT).
+fn is_ipv4_shared(v4: Ipv4Addr) -> bool {
+    let o = v4.octets();
+    o[0] == 100 && (o[1] & 0xc0) == 0x40
+}
+
+/// `fc00::/7` unique-local addresses.
+fn is_ipv6_unique_local(v6: Ipv6Addr) -> bool {
+    (v6.octets()[0] & 0xfe) == 0xfc
+}
+
+/// `fe80::/10` link-local unicast addresses.
+fn is_ipv6_link_local(v6: Ipv6Addr) -> bool {
+    (v6.segments()[0] & 0xffc0) == 0xfe80
+}
+
+/// The cloud-metadata / link-local (+ unspecified/broadcast) range — the subset
+/// blocked even for the S3 endpoint, which otherwise permits loopback/private.
+fn ip_is_metadata_range(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_link_local() || v4.is_unspecified() || v4.is_broadcast(),
+        IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return v4.is_link_local() || v4.is_unspecified() || v4.is_broadcast();
+            }
+            v6.is_unspecified() || is_ipv6_link_local(v6)
+        }
+    }
+}
+
+/// A `reqwest` DNS resolver that denylists internal addresses at connect time.
+///
+/// It also pins: `reqwest` connects to exactly the addresses returned here, so
+/// there is no resolve-then-reconnect (TOCTOU) window a rebinding DNS could use.
+#[derive(Debug, Default)]
+struct SsrfGuardResolver;
+
+impl Resolve for SsrfGuardResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        Box::pin(async move {
+            let host = name.as_str().to_owned();
+            // Port 0 — we only need the resolved IPs; the connector supplies the
+            // real port.
+            let resolved = match tokio::net::lookup_host((host.as_str(), 0)).await {
+                Ok(it) => it,
+                Err(e) => return Err(Box::new(e) as Box<dyn std::error::Error + Send + Sync>),
+            };
+            let allowed: Vec<SocketAddr> = resolved.filter(|sa| !ip_is_blocked(sa.ip())).collect();
+            if allowed.is_empty() {
+                let msg = format!(
+                    "SSRF guard: host '{host}' resolves only to blocked internal addresses"
+                );
+                return Err(msg.into());
+            }
+            Ok(Box::new(allowed.into_iter()) as Addrs)
+        })
+    }
+}
+
+/// A `reqwest::ClientBuilder` hardened against SSRF: follows **no** redirects
+/// (so it only ever connects to the caller-validated URL) and resolves through
+/// [`SsrfGuardResolver`] (blocking names that map to internal addresses).
+///
+/// Callers add their own timeouts / TLS as before.
+pub fn hardened_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .dns_resolver(Arc::new(SsrfGuardResolver))
+}
+
+/// Up-front validation for a request-supplied outbound URL: an allowed scheme,
+/// and a literal-IP host that is not internal. Hostnames pass here and are
+/// enforced at connect time by [`hardened_client_builder`]'s resolver; literal
+/// IPs (including decimal/octal/hex encodings the URL parser normalizes) are
+/// blocked here because the resolver never sees them.
+pub fn validate_public_url(raw: &str) -> Result<()> {
+    let (scheme, host) = parse_scheme_host(raw)?;
+    if scheme != "http" && scheme != "https" {
+        return Err(IcebergError::Config(format!(
+            "SSRF guard: URL scheme '{scheme}' is not allowed (use https or http)"
+        )));
+    }
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if ip_is_blocked(ip) {
+            return Err(IcebergError::Config(format!(
+                "SSRF guard: host '{host}' is a blocked \
+                 (private/loopback/link-local/metadata) address"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validation for the S3 `endpoint` override. Narrower than [`validate_public_url`]
+/// because MinIO / LocalStack legitimately run on loopback/private hosts — but the
+/// cloud-metadata / link-local range (the credential-exfil target) is still refused.
+pub fn validate_s3_endpoint(raw: &str) -> Result<()> {
+    let (scheme, host) = parse_scheme_host(raw)?;
+    if scheme != "http" && scheme != "https" {
+        return Err(IcebergError::Config(format!(
+            "SSRF guard: s3_endpoint scheme '{scheme}' is not allowed (use https or http)"
+        )));
+    }
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if ip_is_metadata_range(ip) {
+            return Err(IcebergError::Config(format!(
+                "SSRF guard: s3_endpoint host '{host}' is a blocked \
+                 (link-local/metadata) address"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Parse a URL into `(scheme, host)` (host without brackets for IPv6). Uses the
+/// `reqwest`-re-exported `url` parser, which normalizes decimal/octal/hex IPv4
+/// literals to dotted form so they compare as the IP they encode.
+fn parse_scheme_host(raw: &str) -> Result<(String, String)> {
+    let url = reqwest::Url::parse(raw)
+        .map_err(|e| IcebergError::Config(format!("SSRF guard: invalid URL '{raw}': {e}")))?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| IcebergError::Config(format!("SSRF guard: URL '{raw}' has no host")))?;
+    // `host_str()` brackets IPv6 literals ("[::1]"); strip so it parses as an IP.
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host)
+        .to_owned();
+    Ok((url.scheme().to_owned(), host))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_internal_ipv4_including_encoded_and_cgnat() {
+        for ip in [
+            "169.254.169.254",
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.5.4",
+            "192.168.1.1",
+            "100.64.0.1",
+            "0.0.0.0",
+            "255.255.255.255",
+        ] {
+            assert!(ip_is_blocked(ip.parse().unwrap()), "{ip} must be blocked");
+        }
+    }
+
+    #[test]
+    fn allows_public_ipv4() {
+        for ip in ["8.8.8.8", "1.1.1.1", "93.184.216.34"] {
+            assert!(!ip_is_blocked(ip.parse().unwrap()), "{ip} must be allowed");
+        }
+    }
+
+    #[test]
+    fn blocks_internal_ipv6_including_mapped() {
+        for ip in [
+            "::1",
+            "::",
+            "fc00::1",
+            "fd12:3456::1",
+            "fe80::1",
+            "::ffff:10.0.0.1",
+            "::ffff:169.254.169.254",
+        ] {
+            assert!(ip_is_blocked(ip.parse().unwrap()), "{ip} must be blocked");
+        }
+        assert!(!ip_is_blocked("2606:4700:4700::1111".parse().unwrap()));
+    }
+
+    #[test]
+    fn validate_public_url_blocks_literals_and_bad_schemes() {
+        for url in [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.1/",
+            "https://192.168.0.5/catalog",
+            "http://[::1]:8080/",
+            "http://127.0.0.1:9000/",
+            // decimal / hex / octal encodings normalize to 127.0.0.1
+            "http://2130706433/",
+            "http://0x7f000001/",
+            "http://0177.0.0.1/",
+            // non-http schemes
+            "file:///etc/passwd",
+            "ftp://8.8.8.8/",
+            "not a url",
+        ] {
+            assert!(validate_public_url(url).is_err(), "{url} must be rejected");
+        }
+    }
+
+    #[test]
+    fn validate_public_url_allows_public_literal_and_domains() {
+        // Public literal IP and a bare domain (enforced later by the resolver).
+        assert!(validate_public_url("https://8.8.8.8/v1/config").is_ok());
+        assert!(validate_public_url("https://catalog.example.com/v1").is_ok());
+    }
+
+    #[test]
+    fn validate_s3_endpoint_allows_minio_but_blocks_metadata() {
+        // MinIO / LocalStack dev endpoints are permitted.
+        assert!(validate_s3_endpoint("http://127.0.0.1:9000").is_ok());
+        assert!(validate_s3_endpoint("http://10.0.0.5:9000").is_ok());
+        assert!(validate_s3_endpoint("http://minio.internal:9000").is_ok());
+        // The cloud-metadata / link-local range is still refused.
+        assert!(validate_s3_endpoint("http://169.254.169.254/").is_err());
+        assert!(validate_s3_endpoint("http://0.0.0.0:9000").is_err());
+        // Bad scheme rejected.
+        assert!(validate_s3_endpoint("ftp://minio.internal:9000").is_err());
+    }
+}

--- a/fluree-db-iceberg/src/net.rs
+++ b/fluree-db-iceberg/src/net.rs
@@ -41,6 +41,13 @@ pub fn ip_is_blocked(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => ipv4_is_blocked(v4),
         IpAddr::V6(v6) => {
+            // `::/96` IPv4-compatible (deprecated) embeds an IPv4 in the low 32
+            // bits — treat it as that IPv4 so `::10.0.0.1` is blocked like
+            // `10.0.0.1`. `::ffff:x` (mapped) is handled separately below.
+            if is_ipv6_v4_compatible(v6) {
+                let o = v6.octets();
+                return ipv4_is_blocked(Ipv4Addr::new(o[12], o[13], o[14], o[15]));
+            }
             if let Some(v4) = v6.to_ipv4_mapped() {
                 return ipv4_is_blocked(v4);
             }
@@ -59,6 +66,13 @@ fn ipv4_is_blocked(v4: Ipv4Addr) -> bool {
         || v4.is_unspecified()
         || v4.is_broadcast()
         || is_ipv4_shared(v4)
+        || v4.octets()[0] == 0 // 0.0.0.0/8 "this network" (RFC 1122)
+}
+
+/// `::/96` IPv4-compatible IPv6 (deprecated) — the first 96 bits are zero and the
+/// low 32 bits carry an IPv4 address (includes `::` and `::1`).
+fn is_ipv6_v4_compatible(v6: Ipv6Addr) -> bool {
+    v6.octets()[..12].iter().all(|&b| b == 0)
 }
 
 /// RFC 6598 shared address space (100.64.0.0/10, carrier-grade NAT).
@@ -221,7 +235,7 @@ mod tests {
     }
 
     #[test]
-    fn blocks_internal_ipv6_including_mapped() {
+    fn blocks_internal_ipv6_including_mapped_and_v4_compatible() {
         for ip in [
             "::1",
             "::",
@@ -230,10 +244,55 @@ mod tests {
             "fe80::1",
             "::ffff:10.0.0.1",
             "::ffff:169.254.169.254",
+            // ::/96 IPv4-compatible embeds an IPv4 in the low 32 bits.
+            "::0.0.0.1",
+            "::10.0.0.1",
+            "::169.254.169.254",
         ] {
             assert!(ip_is_blocked(ip.parse().unwrap()), "{ip} must be blocked");
         }
         assert!(!ip_is_blocked("2606:4700:4700::1111".parse().unwrap()));
+    }
+
+    #[test]
+    fn blocks_zero_network_ipv4() {
+        // 0.0.0.0/8 "this network" — not just the unspecified 0.0.0.0.
+        assert!(ip_is_blocked("0.0.0.0".parse().unwrap()));
+        assert!(ip_is_blocked("0.1.2.3".parse().unwrap()));
+        assert!(ip_is_blocked("0.255.255.255".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn hardened_client_does_not_follow_redirects() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/redirect"))
+            .respond_with(ResponseTemplate::new(302).insert_header("Location", "/landed"))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/landed"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("LANDED"))
+            .mount(&server)
+            .await;
+
+        let client = hardened_client_builder().build().unwrap();
+        let resp = client
+            .get(format!("{}/redirect", server.uri()))
+            .send()
+            .await
+            .unwrap();
+        // Policy::none() → the 302 is returned as-is, never followed to /landed
+        // (which is how a public catalog could bounce to an internal address).
+        assert_eq!(resp.status().as_u16(), 302, "redirect must not be followed");
+        assert_ne!(
+            resp.text().await.unwrap(),
+            "LANDED",
+            "redirect target must not be reached"
+        );
     }
 
     #[test]

--- a/fluree-db-iceberg/src/stats.rs
+++ b/fluree-db-iceberg/src/stats.rs
@@ -107,8 +107,12 @@ fn keep_max(cur: Option<TypedValue>, candidate: TypedValue) -> TypedValue {
 /// decodable). Every scalar column gets an entry, even when the manifests carry
 /// no statistics for it (all-`None`).
 pub fn aggregate_column_stats(data_files: &[DataFile], schema: &Schema) -> TableStatsAggregation {
-    let scalar_fields: Vec<&SchemaField> = schema.fields.iter().filter(|f| !f.is_nested()).collect();
-    let mut accs: HashMap<i32, Acc> = scalar_fields.iter().map(|f| (f.id, Acc::default())).collect();
+    let scalar_fields: Vec<&SchemaField> =
+        schema.fields.iter().filter(|f| !f.is_nested()).collect();
+    let mut accs: HashMap<i32, Acc> = scalar_fields
+        .iter()
+        .map(|f| (f.id, Acc::default()))
+        .collect();
 
     let mut row_count = 0i64;
     let mut total_bytes = 0i64;
@@ -196,7 +200,10 @@ pub fn typed_value_to_json(value: &TypedValue) -> JsonValue {
         TypedValue::Float32(v) => JsonValue::from(f64::from(*v)),
         TypedValue::Float64(v) => JsonValue::from(*v),
         TypedValue::Date(days) => DateTime::from_timestamp(i64::from(*days) * 86_400, 0)
-            .map_or_else(|| JsonValue::from(*days), |dt| JsonValue::from(dt.format("%Y-%m-%d").to_string())),
+            .map_or_else(
+                || JsonValue::from(*days),
+                |dt| JsonValue::from(dt.format("%Y-%m-%d").to_string()),
+            ),
         TypedValue::Timestamp(micros) | TypedValue::TimestampTz(micros) => {
             DateTime::from_timestamp_micros(*micros).map_or_else(
                 || JsonValue::from(*micros),
@@ -412,10 +419,10 @@ mod tests {
         let id = &agg.columns[&1];
         assert_eq!(id.null_count, Some(10)); // 3 + 7
         assert_eq!(id.value_count, Some(300)); // 100 + 200
-        // null_fraction = 10 / 300
+                                               // null_fraction = 10 / 300
         assert!((id.null_fraction.unwrap() - (10.0 / 300.0)).abs() < 1e-9);
         assert_eq!(id.on_disk_bytes, Some(3000)); // 1000 + 2000
-        // Typed min/max across files: min(10,5)=5, max(50,80)=80.
+                                                  // Typed min/max across files: min(10,5)=5, max(50,80)=80.
         assert_eq!(id.min, Some(serde_json::json!(5)));
         assert_eq!(id.max, Some(serde_json::json!(80)));
         // distinct_count is always None.
@@ -445,7 +452,10 @@ mod tests {
 
     #[test]
     fn typed_value_json_rendering() {
-        assert_eq!(typed_value_to_json(&TypedValue::Int64(42)), serde_json::json!(42));
+        assert_eq!(
+            typed_value_to_json(&TypedValue::Int64(42)),
+            serde_json::json!(42)
+        );
         assert_eq!(
             typed_value_to_json(&TypedValue::Boolean(true)),
             serde_json::json!(true)
@@ -590,20 +600,53 @@ mod tests {
         let schema = AvroSchema::parse_str(MANIFEST_SCHEMA).unwrap();
         let mut writer = Writer::new(&schema, Vec::new());
         let data_file = AvroValue::Record(vec![
-            ("file_path".to_string(), AvroValue::String(data_file_path.to_string())),
-            ("file_format".to_string(), AvroValue::String("PARQUET".to_string())),
+            (
+                "file_path".to_string(),
+                AvroValue::String(data_file_path.to_string()),
+            ),
+            (
+                "file_format".to_string(),
+                AvroValue::String("PARQUET".to_string()),
+            ),
             ("record_count".to_string(), AvroValue::Long(1000)),
             ("file_size_in_bytes".to_string(), AvroValue::Long(204_800)),
-            ("column_sizes".to_string(), AvroValue::Union(1, Box::new(long_map(&[(1, 4000), (2, 8000)])))),
-            ("value_counts".to_string(), AvroValue::Union(1, Box::new(long_map(&[(1, 1000), (2, 1000)])))),
-            ("null_value_counts".to_string(), AvroValue::Union(1, Box::new(long_map(&[(1, 0), (2, 5)])))),
-            ("nan_value_counts".to_string(), AvroValue::Union(0, Box::new(AvroValue::Null))),
-            ("lower_bounds".to_string(), AvroValue::Union(1, Box::new(bytes_map(&[(1, encode_value(&TypedValue::Int64(1)))])))),
-            ("upper_bounds".to_string(), AvroValue::Union(1, Box::new(bytes_map(&[(1, encode_value(&TypedValue::Int64(999)))])))),
+            (
+                "column_sizes".to_string(),
+                AvroValue::Union(1, Box::new(long_map(&[(1, 4000), (2, 8000)]))),
+            ),
+            (
+                "value_counts".to_string(),
+                AvroValue::Union(1, Box::new(long_map(&[(1, 1000), (2, 1000)]))),
+            ),
+            (
+                "null_value_counts".to_string(),
+                AvroValue::Union(1, Box::new(long_map(&[(1, 0), (2, 5)]))),
+            ),
+            (
+                "nan_value_counts".to_string(),
+                AvroValue::Union(0, Box::new(AvroValue::Null)),
+            ),
+            (
+                "lower_bounds".to_string(),
+                AvroValue::Union(
+                    1,
+                    Box::new(bytes_map(&[(1, encode_value(&TypedValue::Int64(1)))])),
+                ),
+            ),
+            (
+                "upper_bounds".to_string(),
+                AvroValue::Union(
+                    1,
+                    Box::new(bytes_map(&[(1, encode_value(&TypedValue::Int64(999)))])),
+                ),
+            ),
         ]);
         let entry = AvroValue::Record(vec![
             ("status".to_string(), AvroValue::Int(1)),
-            ("snapshot_id".to_string(), AvroValue::Union(1, Box::new(AvroValue::Long(100)))),
+            (
+                "snapshot_id".to_string(),
+                AvroValue::Union(1, Box::new(AvroValue::Long(100))),
+            ),
             ("data_file".to_string(), data_file),
         ]);
         writer.append_value_ref(&entry).unwrap();

--- a/fluree-db-iceberg/src/stats.rs
+++ b/fluree-db-iceberg/src/stats.rs
@@ -1,0 +1,706 @@
+//! Metadata-only per-column statistics aggregation (Tier-B).
+//!
+//! Given the data files listed by a snapshot's manifests, this module aggregates
+//! per-column statistics (null/value counts, typed min/max, NaN counts, on-disk
+//! bytes) plus authoritative row/file/byte totals. It reads **only** the
+//! manifest-list + manifest Avro files — never a Parquet/data file — so it is
+//! safe on the metadata-preview path.
+//!
+//! `distinct_count` is intentionally always `None`: NDV is not derivable from
+//! Iceberg metadata alone (Puffin/theta-sketch reading is deferred to PR-5).
+
+use std::collections::HashMap;
+
+use serde_json::Value as JsonValue;
+
+use crate::error::Result;
+use crate::io::IcebergStorage;
+use crate::manifest::value_codec::decode_bound;
+use crate::manifest::{parse_manifest, parse_manifest_list, DataFile, TypedValue};
+use crate::metadata::{Schema, SchemaField, Snapshot};
+
+/// Aggregated statistics for a single column across a snapshot's data files.
+#[derive(Debug, Clone, Default)]
+pub struct AggregatedColumnStats {
+    /// Iceberg field ID.
+    pub field_id: i32,
+    /// Summed null value count (best-effort; `None` if no file reported it).
+    pub null_count: Option<i64>,
+    /// Summed value count including nulls (best-effort).
+    pub value_count: Option<i64>,
+    /// `null_count / value_count`, when both known and `value_count > 0`.
+    pub null_fraction: Option<f64>,
+    /// Summed NaN count (float/double columns; best-effort).
+    pub nan_count: Option<i64>,
+    /// Column-wide minimum (value_codec-decoded, JSON-rendered).
+    pub min: Option<JsonValue>,
+    /// Column-wide maximum (value_codec-decoded, JSON-rendered).
+    pub max: Option<JsonValue>,
+    /// Summed on-disk column size in bytes (best-effort).
+    pub on_disk_bytes: Option<i64>,
+    /// Distinct value count — ALWAYS `None` (NDV deferred to PR-5).
+    pub distinct_count: Option<i64>,
+}
+
+/// Aggregated table-level statistics computed from a snapshot's data files.
+#[derive(Debug, Clone, Default)]
+pub struct TableStatsAggregation {
+    /// Per-column stats, keyed by field ID (one entry per scalar column).
+    pub columns: HashMap<i32, AggregatedColumnStats>,
+    /// Sum of `record_count` across the data files (authoritative row count).
+    pub row_count: i64,
+    /// Number of data files aggregated.
+    pub data_file_count: i64,
+    /// Sum of `file_size_in_bytes` across the data files.
+    pub total_bytes: i64,
+    /// Whether any column carried decodable lower/upper bounds.
+    pub had_column_bounds: bool,
+}
+
+/// Mutable per-column accumulator used during aggregation.
+#[derive(Default)]
+struct Acc {
+    null_count: Option<i64>,
+    value_count: Option<i64>,
+    nan_count: Option<i64>,
+    on_disk_bytes: Option<i64>,
+    min: Option<TypedValue>,
+    max: Option<TypedValue>,
+}
+
+fn add_opt(slot: &mut Option<i64>, add: i64) {
+    *slot = Some(slot.unwrap_or(0) + add);
+}
+
+fn lookup(map: Option<&HashMap<i32, i64>>, field_id: i32) -> Option<i64> {
+    map.and_then(|m| m.get(&field_id)).copied()
+}
+
+/// Keep the smaller of `cur` and `candidate` (by `TypedValue` ordering); on an
+/// incomparable pair (type mismatch) the existing value wins.
+fn keep_min(cur: Option<TypedValue>, candidate: TypedValue) -> TypedValue {
+    match cur {
+        Some(cur) => match candidate.partial_cmp(&cur) {
+            Some(std::cmp::Ordering::Less) => candidate,
+            _ => cur,
+        },
+        None => candidate,
+    }
+}
+
+/// Keep the larger of `cur` and `candidate`; on an incomparable pair the
+/// existing value wins.
+fn keep_max(cur: Option<TypedValue>, candidate: TypedValue) -> TypedValue {
+    match cur {
+        Some(cur) => match candidate.partial_cmp(&cur) {
+            Some(std::cmp::Ordering::Greater) => candidate,
+            _ => cur,
+        },
+        None => candidate,
+    }
+}
+
+/// Aggregate per-column statistics from a set of data files against a schema.
+///
+/// Pure and side-effect-free: it reads nothing. Only scalar (non-nested) schema
+/// fields are aggregated (R2RML addresses flat columns; nested bounds are not
+/// decodable). Every scalar column gets an entry, even when the manifests carry
+/// no statistics for it (all-`None`).
+pub fn aggregate_column_stats(data_files: &[DataFile], schema: &Schema) -> TableStatsAggregation {
+    let scalar_fields: Vec<&SchemaField> = schema.fields.iter().filter(|f| !f.is_nested()).collect();
+    let mut accs: HashMap<i32, Acc> = scalar_fields.iter().map(|f| (f.id, Acc::default())).collect();
+
+    let mut row_count = 0i64;
+    let mut total_bytes = 0i64;
+    let mut had_column_bounds = false;
+
+    for df in data_files {
+        row_count += df.record_count;
+        total_bytes += df.file_size_in_bytes;
+
+        for field in &scalar_fields {
+            let fid = field.id;
+            let Some(acc) = accs.get_mut(&fid) else {
+                continue;
+            };
+
+            if let Some(n) = lookup(df.null_value_counts.as_ref(), fid) {
+                add_opt(&mut acc.null_count, n);
+            }
+            if let Some(n) = lookup(df.value_counts.as_ref(), fid) {
+                add_opt(&mut acc.value_count, n);
+            }
+            if let Some(n) = lookup(df.nan_value_counts.as_ref(), fid) {
+                add_opt(&mut acc.nan_count, n);
+            }
+            if let Some(n) = lookup(df.column_sizes.as_ref(), fid) {
+                add_opt(&mut acc.on_disk_bytes, n);
+            }
+
+            if let Some(bytes) = df.lower_bound(fid) {
+                if let Ok(v) = decode_bound(bytes, field) {
+                    had_column_bounds = true;
+                    acc.min = Some(keep_min(acc.min.take(), v));
+                }
+            }
+            if let Some(bytes) = df.upper_bound(fid) {
+                if let Ok(v) = decode_bound(bytes, field) {
+                    had_column_bounds = true;
+                    acc.max = Some(keep_max(acc.max.take(), v));
+                }
+            }
+        }
+    }
+
+    let columns = accs
+        .into_iter()
+        .map(|(fid, acc)| {
+            let null_fraction = match (acc.null_count, acc.value_count) {
+                (Some(n), Some(v)) if v > 0 => Some(n as f64 / v as f64),
+                _ => None,
+            };
+            let stats = AggregatedColumnStats {
+                field_id: fid,
+                null_count: acc.null_count,
+                value_count: acc.value_count,
+                null_fraction,
+                nan_count: acc.nan_count,
+                min: acc.min.as_ref().map(typed_value_to_json),
+                max: acc.max.as_ref().map(typed_value_to_json),
+                on_disk_bytes: acc.on_disk_bytes,
+                distinct_count: None,
+            };
+            (fid, stats)
+        })
+        .collect();
+
+    TableStatsAggregation {
+        columns,
+        row_count,
+        data_file_count: data_files.len() as i64,
+        total_bytes,
+        had_column_bounds,
+    }
+}
+
+/// Render a decoded [`TypedValue`] as a JSON value. Numeric temporals are
+/// rendered as ISO-8601 strings for readability; the raw integer is used as a
+/// fallback if the timestamp is out of range.
+pub fn typed_value_to_json(value: &TypedValue) -> JsonValue {
+    use chrono::{DateTime, SecondsFormat};
+
+    match value {
+        TypedValue::Boolean(b) => JsonValue::Bool(*b),
+        TypedValue::Int32(v) => JsonValue::from(*v),
+        TypedValue::Int64(v) => JsonValue::from(*v),
+        TypedValue::Float32(v) => JsonValue::from(f64::from(*v)),
+        TypedValue::Float64(v) => JsonValue::from(*v),
+        TypedValue::Date(days) => DateTime::from_timestamp(i64::from(*days) * 86_400, 0)
+            .map_or_else(|| JsonValue::from(*days), |dt| JsonValue::from(dt.format("%Y-%m-%d").to_string())),
+        TypedValue::Timestamp(micros) | TypedValue::TimestampTz(micros) => {
+            DateTime::from_timestamp_micros(*micros).map_or_else(
+                || JsonValue::from(*micros),
+                |dt| JsonValue::from(dt.to_rfc3339_opts(SecondsFormat::Micros, true)),
+            )
+        }
+        TypedValue::String(s) => JsonValue::from(s.clone()),
+        TypedValue::Bytes(b) => JsonValue::from(hex_encode(b)),
+        TypedValue::Uuid(bytes) => JsonValue::from(format_uuid(bytes)),
+        TypedValue::Decimal {
+            unscaled, scale, ..
+        } => JsonValue::from(format_decimal(*unscaled, *scale)),
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+fn format_uuid(bytes: &[u8; 16]) -> String {
+    let h = hex_encode(bytes);
+    format!(
+        "{}-{}-{}-{}-{}",
+        &h[0..8],
+        &h[8..12],
+        &h[12..16],
+        &h[16..20],
+        &h[20..32]
+    )
+}
+
+/// Render an unscaled decimal as its scaled decimal string (e.g. `12345`,
+/// scale 2 → `"123.45"`). Handles negative values and `scale <= 0`.
+fn format_decimal(unscaled: i128, scale: i8) -> String {
+    if scale <= 0 {
+        // No fractional digits; a negative scale multiplies by 10^-scale.
+        let mut s = unscaled.to_string();
+        for _ in 0..(-scale) {
+            s.push('0');
+        }
+        return s;
+    }
+    let scale = scale as usize;
+    let negative = unscaled < 0;
+    let digits = unscaled.unsigned_abs().to_string();
+    let padded = if digits.len() <= scale {
+        format!("{:0>width$}", digits, width = scale + 1)
+    } else {
+        digits
+    };
+    let split = padded.len() - scale;
+    let (int_part, frac_part) = padded.split_at(split);
+    let sign = if negative { "-" } else { "" };
+    format!("{sign}{int_part}.{frac_part}")
+}
+
+/// Read the data files listed by a snapshot's manifests — **manifest-list +
+/// manifest Avro only**, never a data file. Returns the collected data files and
+/// the number of manifest files read.
+///
+/// Runtime-agnostic variant (`?Send`); server code should use
+/// [`send_read_snapshot_data_files`].
+pub async fn read_snapshot_data_files<S: IcebergStorage + ?Sized>(
+    storage: &S,
+    snapshot: &Snapshot,
+) -> Result<(Vec<DataFile>, usize)> {
+    let manifest_list_path = snapshot.manifest_list.as_ref().ok_or_else(|| {
+        crate::error::IcebergError::Manifest(
+            "Snapshot has no manifest list (v1 format not supported)".to_string(),
+        )
+    })?;
+
+    let manifest_list_data = storage.read(manifest_list_path).await?;
+    let manifest_entries = parse_manifest_list(&manifest_list_data)?;
+
+    let mut data_files = Vec::new();
+    let mut manifests_read = 0usize;
+    for me in &manifest_entries {
+        if me.is_deletes() {
+            continue;
+        }
+        let manifest_data = storage.read(&me.manifest_path).await?;
+        manifests_read += 1;
+        for entry in parse_manifest(&manifest_data)? {
+            data_files.push(entry.data_file);
+        }
+    }
+
+    Ok((data_files, manifests_read))
+}
+
+/// Send-safe variant of [`read_snapshot_data_files`] for server-side use.
+#[cfg(feature = "aws")]
+pub async fn send_read_snapshot_data_files<S: crate::io::SendIcebergStorage + ?Sized>(
+    storage: &S,
+    snapshot: &Snapshot,
+) -> Result<(Vec<DataFile>, usize)> {
+    let manifest_list_path = snapshot.manifest_list.as_ref().ok_or_else(|| {
+        crate::error::IcebergError::Manifest(
+            "Snapshot has no manifest list (v1 format not supported)".to_string(),
+        )
+    })?;
+
+    let manifest_list_data = storage.read(manifest_list_path).await?;
+    let manifest_entries = parse_manifest_list(&manifest_list_data)?;
+
+    let mut data_files = Vec::new();
+    let mut manifests_read = 0usize;
+    for me in &manifest_entries {
+        if me.is_deletes() {
+            continue;
+        }
+        let manifest_data = storage.read(&me.manifest_path).await?;
+        manifests_read += 1;
+        for entry in parse_manifest(&manifest_data)? {
+            data_files.push(entry.data_file);
+        }
+    }
+
+    Ok((data_files, manifests_read))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::value_codec::encode_value;
+    use crate::manifest::{FileFormat, PartitionData};
+
+    fn schema_id_amount() -> Schema {
+        Schema {
+            schema_id: 0,
+            identifier_field_ids: vec![1],
+            fields: vec![
+                SchemaField {
+                    id: 1,
+                    name: "ID".to_string(),
+                    required: true,
+                    field_type: serde_json::json!("long"),
+                    doc: None,
+                },
+                SchemaField {
+                    id: 2,
+                    name: "AMOUNT".to_string(),
+                    required: false,
+                    field_type: serde_json::json!("double"),
+                    doc: None,
+                },
+            ],
+        }
+    }
+
+    fn data_file(
+        path: &str,
+        record_count: i64,
+        size: i64,
+        id_range: (i64, i64),
+        id_nulls: i64,
+        amount_nan: i64,
+    ) -> DataFile {
+        let mut value_counts = HashMap::new();
+        value_counts.insert(1, record_count);
+        value_counts.insert(2, record_count);
+        let mut null_counts = HashMap::new();
+        null_counts.insert(1, id_nulls);
+        null_counts.insert(2, 0);
+        let mut nan_counts = HashMap::new();
+        nan_counts.insert(2, amount_nan);
+        let mut column_sizes = HashMap::new();
+        column_sizes.insert(1, size / 2);
+        column_sizes.insert(2, size / 2);
+        let mut lower = HashMap::new();
+        lower.insert(1, encode_value(&TypedValue::Int64(id_range.0)));
+        let mut upper = HashMap::new();
+        upper.insert(1, encode_value(&TypedValue::Int64(id_range.1)));
+
+        DataFile {
+            file_path: path.to_string(),
+            file_format: FileFormat::Parquet,
+            record_count,
+            file_size_in_bytes: size,
+            partition: PartitionData::default(),
+            column_sizes: Some(column_sizes),
+            value_counts: Some(value_counts),
+            null_value_counts: Some(null_counts),
+            nan_value_counts: Some(nan_counts),
+            lower_bounds: Some(lower),
+            upper_bounds: Some(upper),
+            split_offsets: None,
+            sort_order_id: None,
+        }
+    }
+
+    #[test]
+    fn aggregates_counts_bounds_and_totals() {
+        let schema = schema_id_amount();
+        let files = vec![
+            data_file("a.parquet", 100, 2000, (10, 50), 3, 1),
+            data_file("b.parquet", 200, 4000, (5, 80), 7, 0),
+        ];
+
+        let agg = aggregate_column_stats(&files, &schema);
+
+        // Authoritative totals summed across files.
+        assert_eq!(agg.row_count, 300);
+        assert_eq!(agg.data_file_count, 2);
+        assert_eq!(agg.total_bytes, 6000);
+        assert!(agg.had_column_bounds);
+
+        let id = &agg.columns[&1];
+        assert_eq!(id.null_count, Some(10)); // 3 + 7
+        assert_eq!(id.value_count, Some(300)); // 100 + 200
+        // null_fraction = 10 / 300
+        assert!((id.null_fraction.unwrap() - (10.0 / 300.0)).abs() < 1e-9);
+        assert_eq!(id.on_disk_bytes, Some(3000)); // 1000 + 2000
+        // Typed min/max across files: min(10,5)=5, max(50,80)=80.
+        assert_eq!(id.min, Some(serde_json::json!(5)));
+        assert_eq!(id.max, Some(serde_json::json!(80)));
+        // distinct_count is always None.
+        assert_eq!(id.distinct_count, None);
+
+        let amount = &agg.columns[&2];
+        assert_eq!(amount.nan_count, Some(1)); // 1 + 0
+        assert_eq!(amount.value_count, Some(300));
+        // AMOUNT carried no bounds → min/max None.
+        assert_eq!(amount.min, None);
+        assert_eq!(amount.max, None);
+    }
+
+    #[test]
+    fn had_column_bounds_false_when_absent() {
+        let schema = schema_id_amount();
+        let mut df = data_file("a.parquet", 100, 2000, (0, 0), 0, 0);
+        df.lower_bounds = None;
+        df.upper_bounds = None;
+        let agg = aggregate_column_stats(&[df], &schema);
+        assert!(!agg.had_column_bounds);
+        assert_eq!(agg.columns[&1].min, None);
+        assert_eq!(agg.columns[&1].max, None);
+        // Row count is still authoritative from record_count.
+        assert_eq!(agg.row_count, 100);
+    }
+
+    #[test]
+    fn typed_value_json_rendering() {
+        assert_eq!(typed_value_to_json(&TypedValue::Int64(42)), serde_json::json!(42));
+        assert_eq!(
+            typed_value_to_json(&TypedValue::Boolean(true)),
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            typed_value_to_json(&TypedValue::String("hi".to_string())),
+            serde_json::json!("hi")
+        );
+        // Date 19723 days since epoch = 2024-01-01.
+        assert_eq!(
+            typed_value_to_json(&TypedValue::Date(19723)),
+            serde_json::json!("2024-01-01")
+        );
+        // Timestamp micros render ISO-8601 with a trailing Z.
+        let ts = typed_value_to_json(&TypedValue::Timestamp(1_700_000_000_000_000));
+        assert!(ts.as_str().unwrap().ends_with('Z'), "got {ts}");
+        // Bytes → lowercase hex.
+        assert_eq!(
+            typed_value_to_json(&TypedValue::Bytes(vec![0x0a, 0xff])),
+            serde_json::json!("0aff")
+        );
+        // Decimal scaled string.
+        assert_eq!(
+            typed_value_to_json(&TypedValue::Decimal {
+                unscaled: 12345,
+                precision: 10,
+                scale: 2
+            }),
+            serde_json::json!("123.45")
+        );
+        assert_eq!(
+            typed_value_to_json(&TypedValue::Decimal {
+                unscaled: -5,
+                precision: 10,
+                scale: 2
+            }),
+            serde_json::json!("-0.05")
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Metadata-only guarantee: the Tier-B reader touches ONLY the
+    // manifest-list + manifest Avro files, never a Parquet/data file.
+    // ------------------------------------------------------------------
+
+    use apache_avro::{types::Record, types::Value as AvroValue, Schema as AvroSchema, Writer};
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use std::ops::Range;
+    use std::sync::Mutex;
+
+    const MANIFEST_LIST_SCHEMA: &str = r#"{
+      "type": "record",
+      "name": "manifest_file",
+      "fields": [
+        {"name": "manifest_path", "type": "string"},
+        {"name": "manifest_length", "type": "long"},
+        {"name": "partition_spec_id", "type": "int"},
+        {"name": "content", "type": "int", "default": 0},
+        {"name": "sequence_number", "type": "long", "default": 0},
+        {"name": "min_sequence_number", "type": "long", "default": 0},
+        {"name": "added_snapshot_id", "type": "long"},
+        {"name": "added_data_files_count", "type": "int", "default": 0},
+        {"name": "existing_data_files_count", "type": "int", "default": 0},
+        {"name": "deleted_data_files_count", "type": "int", "default": 0},
+        {"name": "added_rows_count", "type": "long", "default": 0},
+        {"name": "existing_rows_count", "type": "long", "default": 0},
+        {"name": "deleted_rows_count", "type": "long", "default": 0},
+        {"name": "partitions", "type": ["null", {"type": "array", "items": {
+          "type": "record", "name": "field_summary",
+          "fields": [{"name": "contains_null", "type": "boolean"}]
+        }}], "default": null}
+      ]
+    }"#;
+
+    const MANIFEST_SCHEMA: &str = r#"{
+      "type": "record",
+      "name": "manifest_entry",
+      "fields": [
+        {"name": "status", "type": "int"},
+        {"name": "snapshot_id", "type": ["null", "long"], "default": null},
+        {"name": "data_file", "type": {
+          "type": "record",
+          "name": "df_record",
+          "fields": [
+            {"name": "file_path", "type": "string"},
+            {"name": "file_format", "type": "string"},
+            {"name": "record_count", "type": "long"},
+            {"name": "file_size_in_bytes", "type": "long"},
+            {"name": "column_sizes", "type": ["null", {"type": "map", "values": "long"}], "default": null},
+            {"name": "value_counts", "type": ["null", {"type": "map", "values": "long"}], "default": null},
+            {"name": "null_value_counts", "type": ["null", {"type": "map", "values": "long"}], "default": null},
+            {"name": "nan_value_counts", "type": ["null", {"type": "map", "values": "long"}], "default": null},
+            {"name": "lower_bounds", "type": ["null", {"type": "map", "values": "bytes"}], "default": null},
+            {"name": "upper_bounds", "type": ["null", {"type": "map", "values": "bytes"}], "default": null}
+          ]
+        }}
+      ]
+    }"#;
+
+    fn build_manifest_list(manifest_path: &str) -> Bytes {
+        let schema = AvroSchema::parse_str(MANIFEST_LIST_SCHEMA).unwrap();
+        let mut writer = Writer::new(&schema, Vec::new());
+        let mut record = Record::new(writer.schema()).unwrap();
+        record.put("manifest_path", manifest_path);
+        record.put("manifest_length", 100i64);
+        record.put("partition_spec_id", 0i32);
+        record.put("content", 0i32);
+        record.put("sequence_number", 1i64);
+        record.put("min_sequence_number", 1i64);
+        record.put("added_snapshot_id", 100i64);
+        record.put("added_data_files_count", 1i32);
+        record.put("existing_data_files_count", 0i32);
+        record.put("deleted_data_files_count", 0i32);
+        record.put("added_rows_count", 1000i64);
+        record.put("existing_rows_count", 0i64);
+        record.put("deleted_rows_count", 0i64);
+        record.put("partitions", AvroValue::Union(0, Box::new(AvroValue::Null)));
+        writer.append(record).unwrap();
+        Bytes::from(writer.into_inner().unwrap())
+    }
+
+    fn long_map(entries: &[(i32, i64)]) -> AvroValue {
+        AvroValue::Map(
+            entries
+                .iter()
+                .map(|(k, v)| (k.to_string(), AvroValue::Long(*v)))
+                .collect(),
+        )
+    }
+
+    fn bytes_map(entries: &[(i32, Vec<u8>)]) -> AvroValue {
+        AvroValue::Map(
+            entries
+                .iter()
+                .map(|(k, v)| (k.to_string(), AvroValue::Bytes(v.clone())))
+                .collect(),
+        )
+    }
+
+    fn build_manifest(data_file_path: &str) -> Bytes {
+        let schema = AvroSchema::parse_str(MANIFEST_SCHEMA).unwrap();
+        let mut writer = Writer::new(&schema, Vec::new());
+        let data_file = AvroValue::Record(vec![
+            ("file_path".to_string(), AvroValue::String(data_file_path.to_string())),
+            ("file_format".to_string(), AvroValue::String("PARQUET".to_string())),
+            ("record_count".to_string(), AvroValue::Long(1000)),
+            ("file_size_in_bytes".to_string(), AvroValue::Long(204_800)),
+            ("column_sizes".to_string(), AvroValue::Union(1, Box::new(long_map(&[(1, 4000), (2, 8000)])))),
+            ("value_counts".to_string(), AvroValue::Union(1, Box::new(long_map(&[(1, 1000), (2, 1000)])))),
+            ("null_value_counts".to_string(), AvroValue::Union(1, Box::new(long_map(&[(1, 0), (2, 5)])))),
+            ("nan_value_counts".to_string(), AvroValue::Union(0, Box::new(AvroValue::Null))),
+            ("lower_bounds".to_string(), AvroValue::Union(1, Box::new(bytes_map(&[(1, encode_value(&TypedValue::Int64(1)))])))),
+            ("upper_bounds".to_string(), AvroValue::Union(1, Box::new(bytes_map(&[(1, encode_value(&TypedValue::Int64(999)))])))),
+        ]);
+        let entry = AvroValue::Record(vec![
+            ("status".to_string(), AvroValue::Int(1)),
+            ("snapshot_id".to_string(), AvroValue::Union(1, Box::new(AvroValue::Long(100)))),
+            ("data_file".to_string(), data_file),
+        ]);
+        writer.append_value_ref(&entry).unwrap();
+        Bytes::from(writer.into_inner().unwrap())
+    }
+
+    /// Storage wrapper that records every path read so a test can assert no
+    /// Parquet/data file is ever fetched.
+    #[derive(Debug)]
+    struct RecordingStorage {
+        inner: crate::io::MemoryStorage,
+        reads: Mutex<Vec<String>>,
+    }
+
+    impl RecordingStorage {
+        fn new(inner: crate::io::MemoryStorage) -> Self {
+            Self {
+                inner,
+                reads: Mutex::new(Vec::new()),
+            }
+        }
+        fn reads(&self) -> Vec<String> {
+            self.reads.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl IcebergStorage for RecordingStorage {
+        async fn read(&self, path: &str) -> Result<Bytes> {
+            self.reads.lock().unwrap().push(path.to_string());
+            self.inner.read(path).await
+        }
+        async fn read_range(&self, path: &str, range: Range<u64>) -> Result<Bytes> {
+            self.reads.lock().unwrap().push(path.to_string());
+            self.inner.read_range(path, range).await
+        }
+        async fn file_size(&self, path: &str) -> Result<u64> {
+            self.inner.file_size(path).await
+        }
+    }
+
+    fn snapshot_with_list(list_path: &str) -> Snapshot {
+        Snapshot {
+            snapshot_id: 100,
+            parent_snapshot_id: None,
+            sequence_number: 1,
+            timestamp_ms: 1000,
+            manifest_list: Some(list_path.to_string()),
+            manifests: None,
+            summary: HashMap::new(),
+            schema_id: Some(0),
+        }
+    }
+
+    #[tokio::test]
+    async fn tier_b_reads_only_avro_never_parquet() {
+        let list_path = "s3://b/t/metadata/snap.avro";
+        let manifest_path = "s3://b/t/metadata/m1.avro";
+        let data_path = "s3://b/t/data/f1.parquet";
+
+        let mut mem = crate::io::MemoryStorage::new();
+        mem.add_file(list_path, build_manifest_list(manifest_path));
+        mem.add_file(manifest_path, build_manifest(data_path));
+        // The Parquet data file is deliberately absent: if the reader touched it,
+        // MemoryStorage would return a not-found error and the read would fail.
+        let storage = RecordingStorage::new(mem);
+
+        let snapshot = snapshot_with_list(list_path);
+        let (data_files, manifests_read) =
+            read_snapshot_data_files(&storage, &snapshot).await.unwrap();
+
+        assert_eq!(manifests_read, 1);
+        assert_eq!(data_files.len(), 1);
+        assert_eq!(data_files[0].file_path, data_path);
+
+        // The load-bearing assertion: every fetched path is an Avro file; the
+        // Parquet data file is never read.
+        let reads = storage.reads();
+        assert!(!reads.is_empty());
+        assert!(
+            reads.iter().all(|p| p.ends_with(".avro")),
+            "a non-avro file was read: {reads:?}"
+        );
+        assert!(reads.iter().any(|p| p == list_path));
+        assert!(reads.iter().any(|p| p == manifest_path));
+        assert!(
+            !reads.iter().any(|p| p.ends_with(".parquet")),
+            "a parquet file was read: {reads:?}"
+        );
+
+        // And the aggregation over the manifest-derived data files is correct.
+        let schema = schema_id_amount();
+        let agg = aggregate_column_stats(&data_files, &schema);
+        assert_eq!(agg.row_count, 1000);
+        assert!(agg.had_column_bounds);
+        assert_eq!(agg.columns[&1].min, Some(serde_json::json!(1)));
+        assert_eq!(agg.columns[&1].max, Some(serde_json::json!(999)));
+        assert_eq!(agg.columns[&2].null_count, Some(5));
+    }
+}

--- a/fluree-db-iceberg/src/stats.rs
+++ b/fluree-db-iceberg/src/stats.rs
@@ -16,7 +16,7 @@ use serde_json::Value as JsonValue;
 use crate::error::Result;
 use crate::io::IcebergStorage;
 use crate::manifest::value_codec::decode_bound;
-use crate::manifest::{parse_manifest, parse_manifest_list, DataFile, TypedValue};
+use crate::manifest::{parse_manifest, parse_manifest_list_with_deletes, DataFile, TypedValue};
 use crate::metadata::{Schema, SchemaField, Snapshot};
 
 /// Aggregated statistics for a single column across a snapshot's data files.
@@ -40,6 +40,12 @@ pub struct AggregatedColumnStats {
     pub on_disk_bytes: Option<i64>,
     /// Distinct value count — ALWAYS `None` (NDV deferred to PR-5).
     pub distinct_count: Option<i64>,
+    /// Whether `min`/`max` are **truncated prefixes** rather than exact observed
+    /// values. Iceberg truncates variable-length (string/binary/fixed) bounds:
+    /// the decoded value is a valid bound (`min <= all values <= max`) but not
+    /// necessarily an observed value. Always `false` for fixed-width types
+    /// (numeric/temporal/uuid/boolean), whose bounds are exact.
+    pub bounds_truncated: bool,
 }
 
 /// Aggregated table-level statistics computed from a snapshot's data files.
@@ -66,6 +72,11 @@ struct Acc {
     on_disk_bytes: Option<i64>,
     min: Option<TypedValue>,
     max: Option<TypedValue>,
+    /// Number of data files that reported a null count for this column (for the
+    /// all-files-reported coverage gate).
+    null_reports: usize,
+    /// Number of data files that reported a value count for this column.
+    value_reports: usize,
 }
 
 fn add_opt(slot: &mut Option<i64>, add: i64) {
@@ -130,9 +141,11 @@ pub fn aggregate_column_stats(data_files: &[DataFile], schema: &Schema) -> Table
 
             if let Some(n) = lookup(df.null_value_counts.as_ref(), fid) {
                 add_opt(&mut acc.null_count, n);
+                acc.null_reports += 1;
             }
             if let Some(n) = lookup(df.value_counts.as_ref(), fid) {
                 add_opt(&mut acc.value_count, n);
+                acc.value_reports += 1;
             }
             if let Some(n) = lookup(df.nan_value_counts.as_ref(), fid) {
                 add_opt(&mut acc.nan_count, n);
@@ -156,23 +169,47 @@ pub fn aggregate_column_stats(data_files: &[DataFile], schema: &Schema) -> Table
         }
     }
 
+    let total_files = data_files.len();
     let columns = accs
         .into_iter()
         .map(|(fid, acc)| {
-            let null_fraction = match (acc.null_count, acc.value_count) {
+            // Coverage gate: a summed count is authoritative only when EVERY
+            // data file reported it. Under partial coverage the sum is unknown
+            // (`None`), never a partial total — a partial `null_count` of 0
+            // would otherwise read as a confident "no nulls" and let a nullable
+            // column masquerade as a safe non-null subject key.
+            let full = |reports: usize| total_files > 0 && reports == total_files;
+            let null_count = if full(acc.null_reports) {
+                acc.null_count
+            } else {
+                None
+            };
+            let value_count = if full(acc.value_reports) {
+                acc.value_count
+            } else {
+                None
+            };
+            let null_fraction = match (null_count, value_count) {
                 (Some(n), Some(v)) if v > 0 => Some(n as f64 / v as f64),
                 _ => None,
             };
+            // Iceberg truncates variable-length (string/binary/fixed) min/max
+            // bounds; the decoded value is a valid bound but not necessarily an
+            // observed value, so flag it rather than present it as exact.
+            let bounds_truncated =
+                matches!(&acc.min, Some(TypedValue::String(_) | TypedValue::Bytes(_)))
+                    || matches!(&acc.max, Some(TypedValue::String(_) | TypedValue::Bytes(_)));
             let stats = AggregatedColumnStats {
                 field_id: fid,
-                null_count: acc.null_count,
-                value_count: acc.value_count,
+                null_count,
+                value_count,
                 null_fraction,
                 nan_count: acc.nan_count,
                 min: acc.min.as_ref().map(typed_value_to_json),
                 max: acc.max.as_ref().map(typed_value_to_json),
                 on_disk_bytes: acc.on_disk_bytes,
                 distinct_count: None,
+                bounds_truncated,
             };
             (fid, stats)
         })
@@ -265,15 +302,20 @@ fn format_decimal(unscaled: i128, scale: i8) -> String {
 }
 
 /// Read the data files listed by a snapshot's manifests — **manifest-list +
-/// manifest Avro only**, never a data file. Returns the collected data files and
-/// the number of manifest files read.
+/// manifest Avro only**, never a data file. Returns the collected data files,
+/// the number of data-manifest files read, and whether the snapshot carries any
+/// **delete manifests** (merge-on-read position/equality deletes).
+///
+/// The delete flag matters because the aggregated `row_count`/value/null counts
+/// sum live data-file records and do **not** subtract deletes; when it is
+/// `true`, those totals are upper bounds, not exact.
 ///
 /// Runtime-agnostic variant (`?Send`); server code should use
 /// [`send_read_snapshot_data_files`].
 pub async fn read_snapshot_data_files<S: IcebergStorage + ?Sized>(
     storage: &S,
     snapshot: &Snapshot,
-) -> Result<(Vec<DataFile>, usize)> {
+) -> Result<(Vec<DataFile>, usize, bool)> {
     let manifest_list_path = snapshot.manifest_list.as_ref().ok_or_else(|| {
         crate::error::IcebergError::Manifest(
             "Snapshot has no manifest list (v1 format not supported)".to_string(),
@@ -281,12 +323,17 @@ pub async fn read_snapshot_data_files<S: IcebergStorage + ?Sized>(
     })?;
 
     let manifest_list_data = storage.read(manifest_list_path).await?;
-    let manifest_entries = parse_manifest_list(&manifest_list_data)?;
+    // Parse WITH delete manifests so we can DETECT (never read) them: a present
+    // delete manifest means the snapshot has merge-on-read deletes the
+    // record-count sum does not subtract.
+    let manifest_entries = parse_manifest_list_with_deletes(&manifest_list_data, true)?;
 
     let mut data_files = Vec::new();
     let mut manifests_read = 0usize;
+    let mut has_delete_manifests = false;
     for me in &manifest_entries {
         if me.is_deletes() {
+            has_delete_manifests = true;
             continue;
         }
         let manifest_data = storage.read(&me.manifest_path).await?;
@@ -296,7 +343,7 @@ pub async fn read_snapshot_data_files<S: IcebergStorage + ?Sized>(
         }
     }
 
-    Ok((data_files, manifests_read))
+    Ok((data_files, manifests_read, has_delete_manifests))
 }
 
 /// Send-safe variant of [`read_snapshot_data_files`] for server-side use.
@@ -304,7 +351,7 @@ pub async fn read_snapshot_data_files<S: IcebergStorage + ?Sized>(
 pub async fn send_read_snapshot_data_files<S: crate::io::SendIcebergStorage + ?Sized>(
     storage: &S,
     snapshot: &Snapshot,
-) -> Result<(Vec<DataFile>, usize)> {
+) -> Result<(Vec<DataFile>, usize, bool)> {
     let manifest_list_path = snapshot.manifest_list.as_ref().ok_or_else(|| {
         crate::error::IcebergError::Manifest(
             "Snapshot has no manifest list (v1 format not supported)".to_string(),
@@ -312,12 +359,16 @@ pub async fn send_read_snapshot_data_files<S: crate::io::SendIcebergStorage + ?S
     })?;
 
     let manifest_list_data = storage.read(manifest_list_path).await?;
-    let manifest_entries = parse_manifest_list(&manifest_list_data)?;
+    // See the runtime-agnostic variant: parse WITH deletes to detect merge-on-
+    // read delete manifests without reading them.
+    let manifest_entries = parse_manifest_list_with_deletes(&manifest_list_data, true)?;
 
     let mut data_files = Vec::new();
     let mut manifests_read = 0usize;
+    let mut has_delete_manifests = false;
     for me in &manifest_entries {
         if me.is_deletes() {
+            has_delete_manifests = true;
             continue;
         }
         let manifest_data = storage.read(&me.manifest_path).await?;
@@ -327,7 +378,7 @@ pub async fn send_read_snapshot_data_files<S: crate::io::SendIcebergStorage + ?S
         }
     }
 
-    Ok((data_files, manifests_read))
+    Ok((data_files, manifests_read, has_delete_manifests))
 }
 
 #[cfg(test)]
@@ -448,6 +499,102 @@ mod tests {
         assert_eq!(agg.columns[&1].max, None);
         // Row count is still authoritative from record_count.
         assert_eq!(agg.row_count, 100);
+    }
+
+    #[test]
+    fn null_count_unknown_under_partial_coverage() {
+        // Two files, but only one reports null/value counts for the column. A
+        // partial sum must NOT read as a confident count — the non-reporting
+        // file could hold nulls — so the counts (and null_fraction) are unknown.
+        let schema = schema_id_amount();
+        let a = data_file("a.parquet", 100, 2000, (10, 50), 0, 0);
+        let mut b = data_file("b.parquet", 200, 4000, (5, 80), 0, 0);
+        b.null_value_counts = None;
+        b.value_counts = None;
+
+        let agg = aggregate_column_stats(&[a, b], &schema);
+        let id = &agg.columns[&1];
+        assert_eq!(id.null_count, None, "partial null coverage → unknown");
+        assert_eq!(id.value_count, None, "partial value coverage → unknown");
+        assert_eq!(
+            id.null_fraction, None,
+            "null_fraction is uncomputable under partial coverage — a nullable \
+             column must not look like a safe non-null key"
+        );
+        // Authoritative totals (record_count/bytes) still sum across all files.
+        assert_eq!(agg.row_count, 300);
+        assert_eq!(agg.total_bytes, 6000);
+    }
+
+    #[test]
+    fn null_count_zero_when_all_files_report() {
+        // Full coverage with genuine zeros must stay Some(0) — the coverage gate
+        // must not turn a real, complete "no nulls" into unknown.
+        let schema = schema_id_amount();
+        let files = vec![
+            data_file("a.parquet", 100, 2000, (10, 50), 0, 0),
+            data_file("b.parquet", 200, 4000, (5, 80), 0, 0),
+        ];
+        let agg = aggregate_column_stats(&files, &schema);
+        let id = &agg.columns[&1];
+        assert_eq!(id.null_count, Some(0));
+        assert_eq!(id.value_count, Some(300));
+        assert_eq!(id.null_fraction, Some(0.0));
+    }
+
+    #[test]
+    fn bounds_truncated_flag_set_for_string_not_numeric() {
+        // Iceberg truncates string/binary min/max; numeric bounds are exact.
+        let schema = Schema {
+            schema_id: 0,
+            identifier_field_ids: vec![1],
+            fields: vec![
+                SchemaField {
+                    id: 1,
+                    name: "ID".to_string(),
+                    required: true,
+                    field_type: serde_json::json!("long"),
+                    doc: None,
+                },
+                SchemaField {
+                    id: 2,
+                    name: "NAME".to_string(),
+                    required: false,
+                    field_type: serde_json::json!("string"),
+                    doc: None,
+                },
+            ],
+        };
+        let mut lower = HashMap::new();
+        lower.insert(1, encode_value(&TypedValue::Int64(1)));
+        lower.insert(2, encode_value(&TypedValue::String("aaa".to_string())));
+        let mut upper = HashMap::new();
+        upper.insert(1, encode_value(&TypedValue::Int64(100)));
+        upper.insert(2, encode_value(&TypedValue::String("zzz".to_string())));
+        let df = DataFile {
+            file_path: "a.parquet".to_string(),
+            file_format: FileFormat::Parquet,
+            record_count: 10,
+            file_size_in_bytes: 100,
+            partition: PartitionData::default(),
+            column_sizes: None,
+            value_counts: None,
+            null_value_counts: None,
+            nan_value_counts: None,
+            lower_bounds: Some(lower),
+            upper_bounds: Some(upper),
+            split_offsets: None,
+            sort_order_id: None,
+        };
+        let agg = aggregate_column_stats(&[df], &schema);
+        assert!(
+            !agg.columns[&1].bounds_truncated,
+            "numeric bounds are exact"
+        );
+        assert!(
+            agg.columns[&2].bounds_truncated,
+            "string bounds are truncated prefixes"
+        );
     }
 
     #[test]
@@ -715,10 +862,11 @@ mod tests {
         let storage = RecordingStorage::new(mem);
 
         let snapshot = snapshot_with_list(list_path);
-        let (data_files, manifests_read) =
+        let (data_files, manifests_read, has_deletes) =
             read_snapshot_data_files(&storage, &snapshot).await.unwrap();
 
         assert_eq!(manifests_read, 1);
+        assert!(!has_deletes, "this snapshot has no delete manifests");
         assert_eq!(data_files.len(), 1);
         assert_eq!(data_files[0].file_path, data_path);
 
@@ -745,5 +893,62 @@ mod tests {
         assert_eq!(agg.columns[&1].min, Some(serde_json::json!(1)));
         assert_eq!(agg.columns[&1].max, Some(serde_json::json!(999)));
         assert_eq!(agg.columns[&2].null_count, Some(5));
+    }
+
+    /// A manifest list carrying one data manifest (`content=0`) and one delete
+    /// manifest (`content=1`).
+    fn build_manifest_list_with_delete(data_manifest: &str, delete_manifest: &str) -> Bytes {
+        let schema = AvroSchema::parse_str(MANIFEST_LIST_SCHEMA).unwrap();
+        let mut writer = Writer::new(&schema, Vec::new());
+        for (path, content) in [(data_manifest, 0i32), (delete_manifest, 1i32)] {
+            let mut record = Record::new(writer.schema()).unwrap();
+            record.put("manifest_path", path);
+            record.put("manifest_length", 100i64);
+            record.put("partition_spec_id", 0i32);
+            record.put("content", content);
+            record.put("sequence_number", 1i64);
+            record.put("min_sequence_number", 1i64);
+            record.put("added_snapshot_id", 100i64);
+            record.put("added_data_files_count", 1i32);
+            record.put("existing_data_files_count", 0i32);
+            record.put("deleted_data_files_count", 0i32);
+            record.put("added_rows_count", 1000i64);
+            record.put("existing_rows_count", 0i64);
+            record.put("deleted_rows_count", 0i64);
+            record.put("partitions", AvroValue::Union(0, Box::new(AvroValue::Null)));
+            writer.append(record).unwrap();
+        }
+        Bytes::from(writer.into_inner().unwrap())
+    }
+
+    #[tokio::test]
+    async fn detects_delete_manifests_without_reading_them() {
+        let list_path = "s3://b/t/metadata/snap.avro";
+        let data_manifest = "s3://b/t/metadata/m-data.avro";
+        let delete_manifest = "s3://b/t/metadata/m-del.avro";
+        let data_path = "s3://b/t/data/f1.parquet";
+
+        let mut mem = crate::io::MemoryStorage::new();
+        mem.add_file(
+            list_path,
+            build_manifest_list_with_delete(data_manifest, delete_manifest),
+        );
+        mem.add_file(data_manifest, build_manifest(data_path));
+        // The delete manifest is deliberately absent: the reader must DETECT it
+        // from the manifest list and skip it, never fetch it.
+        let storage = RecordingStorage::new(mem);
+        let snapshot = snapshot_with_list(list_path);
+
+        let (data_files, manifests_read, has_deletes) =
+            read_snapshot_data_files(&storage, &snapshot).await.unwrap();
+
+        assert!(has_deletes, "a content=1 delete manifest must be detected");
+        assert_eq!(manifests_read, 1, "only the data manifest is read");
+        assert_eq!(data_files.len(), 1);
+        let reads = storage.reads();
+        assert!(
+            !reads.iter().any(|p| p == delete_manifest),
+            "the delete manifest must never be fetched: {reads:?}"
+        );
     }
 }

--- a/fluree-db-r2rml/Cargo.toml
+++ b/fluree-db-r2rml/Cargo.toml
@@ -44,6 +44,8 @@ async-trait.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+# Tests-only: assert the wire IR serializes to solo's camelCase shape.
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/fluree-db-r2rml/src/emit/diagnostic.rs
+++ b/fluree-db-r2rml/src/emit/diagnostic.rs
@@ -36,6 +36,11 @@ pub enum DiagCode {
     AmbiguousFk,
     /// A candidate FK could not be proven referentially safe (reserved).
     DanglingFkNotProven,
+    /// The submitted R2RML mapping did not compile (parse/lower failure) — the validate
+    /// path's compile gate. `compiled_ok == false` is the authoritative signal and the
+    /// cross-check is skipped; kept distinct from `TableNotFound` so a compile failure and a
+    /// dangling table reference never collide on the wire.
+    CompileError,
     /// A referenced column does not exist (reserved for the validate cross-check).
     ColumnNotFound,
     /// A referenced table does not exist (reserved for the validate cross-check).

--- a/fluree-db-r2rml/src/emit/diagnostic.rs
+++ b/fluree-db-r2rml/src/emit/diagnostic.rs
@@ -1,0 +1,86 @@
+//! Structured diagnostics surfaced by the deterministic emitter.
+//!
+//! Diagnostics are the emitter's honest account of every decision it could NOT
+//! make from metadata alone: skipped nested columns, unverifiable subject keys,
+//! FK candidates it refused to fabricate, and perf advisories. They are part of
+//! the wire contract (PR-2 persists them, PR-3 surfaces them, PR-4 resolves the
+//! `UnresolvedFkCandidate`s).
+
+use serde::{Deserialize, Serialize};
+
+/// Severity of a [`Diagnostic`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Severity {
+    /// A blocking problem (e.g. no safe subject key → the table emits no subject).
+    Error,
+    /// A non-blocking concern the reviewer should see.
+    Warning,
+    /// A performance advisory (the mapping is correct but may be costly).
+    Advisory,
+}
+
+/// Machine-readable diagnostic code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DiagCode {
+    /// A nested (struct/list/map) column was skipped — R2RML addresses flat columns only.
+    NestedColumnSkipped,
+    /// No `required` / null-free key could be found — the table emits no subject.
+    NoSafeSubjectKey,
+    /// A subject key was chosen but its uniqueness is unverifiable metadata-only.
+    SubjectKeyUnverified,
+    /// A `*_KEY`/`*_ID` column looks like an FK but resolves to no known PK — kept literal, no join fabricated.
+    UnresolvedFkCandidate,
+    /// A key column matched more than one candidate parent — kept literal, no join fabricated.
+    AmbiguousFk,
+    /// A candidate FK could not be proven referentially safe (reserved).
+    DanglingFkNotProven,
+    /// A referenced column does not exist (reserved for the validate cross-check).
+    ColumnNotFound,
+    /// A referenced table does not exist (reserved for the validate cross-check).
+    TableNotFound,
+    /// A join's child/parent column types disagree (reserved for the validate cross-check).
+    JoinTypeMismatch,
+    /// A column reference's casing disagrees with the live schema (reserved).
+    CasingMismatch,
+    /// An emitted child-fact→hub join on the hub's PK — bounded, but a perf advisory.
+    FactHubJoinAdvisory,
+}
+
+/// A single structured diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Diagnostic {
+    /// Severity classification.
+    pub severity: Severity,
+    /// Machine-readable code.
+    pub code: DiagCode,
+    /// The table the diagnostic pertains to, if any (`"DW.DIM_STORE"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table: Option<String>,
+    /// The column the diagnostic pertains to, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<String>,
+    /// Human-readable explanation.
+    pub message: String,
+}
+
+impl Diagnostic {
+    /// Build a diagnostic with a given severity/code, table + column context.
+    pub fn new(
+        severity: Severity,
+        code: DiagCode,
+        table: impl Into<String>,
+        column: Option<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            severity,
+            code,
+            table: Some(table.into()),
+            column,
+            message: message.into(),
+        }
+    }
+}

--- a/fluree-db-r2rml/src/emit/fixtures.rs
+++ b/fluree-db-r2rml/src/emit/fixtures.rs
@@ -1,0 +1,358 @@
+//! Test fixtures: the 16 `ENTERPRISE_DEMO.DW` tables encoded as emitter INPUT.
+//!
+//! CRITICAL: these fixtures encode only SCHEMA + STATS — never the join answers.
+//! The `identifier_field_ids` are the surrogate `*_KEY` PKs; the min/max ranges
+//! are plausible integer surrogate spaces chosen so range-containment RESOLVES
+//! the resolvable FKs and the role-renamed employee FKs fail on NAME. The
+//! emitter must INDEPENDENTLY infer every FK from name∧type∧range; the tests then
+//! check the inferred graph matches `enterprise.ttl`'s hand-written joins.
+//!
+//! Column types are derived from `enterprise.ttl`'s `rr:datatype`s (integer →
+//! `Int64`, double → `Float64`, decimal → `Decimal`, date → `Date`, timestamp →
+//! `Timestamp`, boolean → `Boolean`, untyped → `String`). PKs are field id 1.
+
+#![cfg(test)]
+
+use fluree_db_tabular::FieldType;
+
+use crate::emit::input::{EmitColumn, EmitColumnStats, EmitTableSchema, TypedBound};
+
+/// Wide surrogate space shared by every dimension PK (child FK ranges ⊆ this).
+const DIM_MAX: i64 = 100_000;
+/// Wider surrogate space for fact PKs (fact rows outnumber dimension rows).
+const FACT_MAX: i64 = 500_000;
+
+/// A non-key scalar column with default (bounds-free) stats.
+fn s(field_id: i32, name: &str, ft: FieldType) -> EmitColumn {
+    EmitColumn {
+        field_id,
+        name: name.to_string(),
+        iceberg_type: iceberg_type_str(ft),
+        field_type: ft,
+        required: false,
+        nested: false,
+        doc: None,
+        stats: EmitColumnStats::default(),
+    }
+}
+
+/// An integer key column (PK or FK) with an explicit `[min, max]` surrogate
+/// range. `required` marks NOT-NULL (all surrogate PKs are required).
+fn k(field_id: i32, name: &str, min: i64, max: i64, required: bool) -> EmitColumn {
+    EmitColumn {
+        field_id,
+        name: name.to_string(),
+        iceberg_type: "long".to_string(),
+        field_type: FieldType::Int64,
+        required,
+        nested: false,
+        doc: None,
+        stats: EmitColumnStats {
+            null_fraction: if required { Some(0.0) } else { None },
+            min: Some(TypedBound::Int(min)),
+            max: Some(TypedBound::Int(max)),
+        },
+    }
+}
+
+fn iceberg_type_str(ft: FieldType) -> String {
+    match ft {
+        FieldType::Boolean => "boolean".to_string(),
+        FieldType::Int32 => "int".to_string(),
+        FieldType::Int64 => "long".to_string(),
+        FieldType::Float32 => "float".to_string(),
+        FieldType::Float64 => "double".to_string(),
+        FieldType::String => "string".to_string(),
+        FieldType::Bytes => "binary".to_string(),
+        FieldType::Date => "date".to_string(),
+        FieldType::Timestamp => "timestamp".to_string(),
+        FieldType::TimestampTz => "timestamptz".to_string(),
+        FieldType::Decimal { precision, scale } => format!("decimal({precision},{scale})"),
+    }
+}
+
+fn table(namespace: &str, name: &str, columns: Vec<EmitColumn>) -> EmitTableSchema {
+    EmitTableSchema {
+        namespace: namespace.to_string(),
+        name: name.to_string(),
+        columns,
+        identifier_field_ids: vec![1], // PK is always field id 1 in these fixtures
+    }
+}
+
+use FieldType::{Boolean as B, Date as Dt, Float64 as Db, String as St, Timestamp as Ts};
+const DEC: FieldType = FieldType::Decimal {
+    precision: 18,
+    scale: 2,
+};
+
+/// All 16 `ENTERPRISE_DEMO.DW` tables, 8 dimensions then 8 facts.
+pub fn enterprise_dw_tables() -> Vec<EmitTableSchema> {
+    vec![
+        // ===================== DIMENSIONS =====================
+        table(
+            "DW",
+            "DIM_DATE",
+            vec![
+                k(1, "DATE_KEY", 1, DIM_MAX, true),
+                s(2, "DATE", Dt),
+                s(3, "DAY_OF_WEEK", FieldType::Int64),
+                s(4, "DAY_NAME", St),
+                s(5, "DAY_OF_MONTH", FieldType::Int64),
+                s(6, "WEEK_OF_YEAR", FieldType::Int64),
+                s(7, "MONTH_NUM", FieldType::Int64),
+                s(8, "MONTH_NAME", St),
+                s(9, "QUARTER_NUM", FieldType::Int64),
+                s(10, "YEAR_NUM", FieldType::Int64),
+                s(11, "IS_WEEKEND", B),
+            ],
+        ),
+        table(
+            "DW",
+            "DIM_GEOGRAPHY",
+            vec![
+                k(1, "GEOGRAPHY_KEY", 1, DIM_MAX, true),
+                s(2, "COUNTRY_CODE", St),
+                s(3, "COUNTRY", St),
+                s(4, "REGION", St),
+                s(5, "STATE_PROVINCE", St),
+                s(6, "CITY", St),
+                s(7, "POSTAL_CODE", St),
+                s(8, "LATITUDE", Db),
+                s(9, "LONGITUDE", Db),
+            ],
+        ),
+        table(
+            "DW",
+            "DIM_SUPPLIER",
+            vec![
+                k(1, "SUPPLIER_KEY", 1, DIM_MAX, true),
+                s(2, "SUPPLIER_ID", St),
+                s(3, "SUPPLIER_NAME", St),
+                s(4, "CONTACT_EMAIL", St),
+                s(5, "LEAD_TIME_DAYS", FieldType::Int64),
+                s(6, "RATING", Db),
+                k(7, "GEOGRAPHY_KEY", 1, DIM_MAX, false),
+            ],
+        ),
+        table(
+            "DW",
+            "DIM_ACCOUNT",
+            vec![
+                k(1, "ACCOUNT_KEY", 1, DIM_MAX, true),
+                s(2, "ACCOUNT_ID", St),
+                s(3, "ACCOUNT_NAME", St),
+                s(4, "INDUSTRY", St),
+                s(5, "EMPLOYEE_COUNT", FieldType::Int64),
+                s(6, "ANNUAL_REVENUE", Db),
+                s(7, "TIER", St),
+                s(8, "CREATED_DATE", Dt),
+                k(9, "GEOGRAPHY_KEY", 1, DIM_MAX, false),
+            ],
+        ),
+        table(
+            "DW",
+            "DIM_EMPLOYEE",
+            vec![
+                k(1, "EMPLOYEE_KEY", 1, DIM_MAX, true),
+                s(2, "EMPLOYEE_ID", St),
+                s(3, "FULL_NAME", St),
+                s(4, "EMAIL", St),
+                s(5, "ROLE", St),
+                s(6, "DEPARTMENT", St),
+                s(7, "HIRE_DATE", Dt),
+                s(8, "IS_ACTIVE", B),
+                k(9, "STORE_KEY", 1, DIM_MAX, false),
+                k(10, "MANAGER_KEY", 1, DIM_MAX, false), // role-renamed → EMPLOYEE_KEY (unresolvable)
+            ],
+        ),
+        table(
+            "DW",
+            "DIM_STORE",
+            vec![
+                k(1, "STORE_KEY", 1, DIM_MAX, true),
+                s(2, "STORE_ID", St),
+                s(3, "STORE_NAME", St),
+                s(4, "CHANNEL", St),
+                s(5, "STORE_TYPE", St),
+                s(6, "OPEN_DATE", Dt),
+                k(7, "GEOGRAPHY_KEY", 1, DIM_MAX, false),
+                k(8, "REGION_MANAGER_KEY", 1, DIM_MAX, false), // role-renamed → EMPLOYEE_KEY
+            ],
+        ),
+        table(
+            "DW",
+            "DIM_CUSTOMER",
+            vec![
+                k(1, "CUSTOMER_KEY", 1, DIM_MAX, true),
+                s(2, "CUSTOMER_ID", St),
+                s(3, "FULL_NAME", St),
+                s(4, "EMAIL", St),
+                s(5, "PHONE", St),
+                s(6, "SEGMENT", St),
+                s(7, "GENDER", St),
+                s(8, "BIRTH_YEAR", FieldType::Int64),
+                s(9, "SIGNUP_DATE", Dt),
+                s(10, "SCD_VALID_FROM", Dt),
+                s(11, "SCD_VALID_TO", Dt),
+                s(12, "IS_CURRENT", B),
+                k(13, "GEOGRAPHY_KEY", 1, DIM_MAX, false),
+                k(14, "ACCOUNT_KEY", 1, DIM_MAX, false),
+            ],
+        ),
+        table(
+            "DW",
+            "DIM_PRODUCT",
+            vec![
+                k(1, "PRODUCT_KEY", 1, DIM_MAX, true),
+                s(2, "PRODUCT_ID", St),
+                s(3, "PRODUCT_NAME", St),
+                s(4, "BRAND", St),
+                s(5, "CATEGORY", St),
+                s(6, "SUBCATEGORY", St),
+                s(7, "DEPARTMENT", St),
+                s(8, "UNIT_COST", Db),
+                s(9, "LIST_PRICE", Db),
+                s(10, "IS_CURRENT", B),
+                k(11, "SUPPLIER_KEY", 1, DIM_MAX, false),
+            ],
+        ),
+        // ======================= FACTS ========================
+        table(
+            "DW",
+            "FACT_ORDER",
+            vec![
+                k(1, "ORDER_KEY", 1, FACT_MAX, true),
+                s(2, "ORDER_ID", St),
+                s(3, "ORDER_STATUS", St),
+                s(4, "ORDER_CHANNEL", St),
+                s(5, "ORDER_TOTAL", Db),
+                s(6, "CURRENCY", St),
+                s(7, "ORDER_DATE", Dt),
+                k(8, "CUSTOMER_KEY", 1, DIM_MAX, false),
+                k(9, "ACCOUNT_KEY", 1, DIM_MAX, false),
+                k(10, "STORE_KEY", 1, DIM_MAX, false),
+                k(11, "SALES_REP_KEY", 1, DIM_MAX, false), // role-renamed → EMPLOYEE_KEY
+                k(12, "ORDER_DATE_KEY", 1, DIM_MAX, false), // suffix → DATE_KEY
+            ],
+        ),
+        table(
+            "DW",
+            "FACT_ORDER_LINE",
+            vec![
+                k(1, "ORDER_LINE_KEY", 1, FACT_MAX, true),
+                s(2, "LINE_NUMBER", FieldType::Int64),
+                s(3, "QUANTITY", FieldType::Int64),
+                s(4, "UNIT_PRICE", Db),
+                s(5, "DISCOUNT_PCT", Db),
+                s(6, "EXTENDED_AMOUNT", Db),
+                s(7, "ORDER_DATE", Dt),
+                k(8, "ORDER_KEY", 1, FACT_MAX, false), // hub → FACT_ORDER.ORDER_KEY
+                k(9, "PRODUCT_KEY", 1, DIM_MAX, false),
+            ],
+        ),
+        table(
+            "DW",
+            "FACT_INVENTORY_SNAPSHOT",
+            vec![
+                k(1, "INVENTORY_KEY", 1, FACT_MAX, true),
+                s(2, "SNAPSHOT_DATE", Dt),
+                s(3, "ON_HAND_QTY", FieldType::Int64),
+                s(4, "RESERVED_QTY", FieldType::Int64),
+                s(5, "REORDER_POINT", FieldType::Int64),
+                s(6, "UNITS_ON_ORDER", FieldType::Int64),
+                k(7, "PRODUCT_KEY", 1, DIM_MAX, false),
+                k(8, "STORE_KEY", 1, DIM_MAX, false),
+                k(9, "SNAPSHOT_DATE_KEY", 1, DIM_MAX, false), // suffix → DATE_KEY
+            ],
+        ),
+        table(
+            "DW",
+            "FACT_SHIPMENT",
+            vec![
+                k(1, "SHIPMENT_KEY", 1, FACT_MAX, true),
+                s(2, "SHIPMENT_ID", St),
+                s(3, "SHIP_DATE", Dt),
+                s(4, "CARRIER", St),
+                s(5, "SHIP_METHOD", St),
+                s(6, "SHIP_STATUS", St),
+                s(7, "TRACKING_NUMBER", St),
+                s(8, "SHIP_COST", Db),
+                k(9, "ORDER_KEY", 1, FACT_MAX, false), // hub → FACT_ORDER.ORDER_KEY
+                k(10, "DEST_GEOGRAPHY_KEY", 1, DIM_MAX, false), // suffix → GEOGRAPHY_KEY
+                k(11, "SHIP_DATE_KEY", 1, DIM_MAX, false), // suffix → DATE_KEY
+            ],
+        ),
+        table(
+            "DW",
+            "FACT_PAYMENT",
+            vec![
+                k(1, "PAYMENT_KEY", 1, FACT_MAX, true),
+                s(2, "PAYMENT_ID", St),
+                s(3, "PAYMENT_DATE", Dt),
+                s(4, "TENDER_TYPE", St),
+                s(5, "AMOUNT", Db),
+                s(6, "CURRENCY", St),
+                s(7, "PAYMENT_STATUS", St),
+                k(8, "ORDER_KEY", 1, FACT_MAX, false), // hub → FACT_ORDER.ORDER_KEY
+                k(9, "CUSTOMER_KEY", 1, DIM_MAX, false),
+                k(10, "PAYMENT_DATE_KEY", 1, DIM_MAX, false), // suffix → DATE_KEY
+            ],
+        ),
+        table(
+            "DW",
+            "FACT_GL_JOURNAL",
+            vec![
+                k(1, "JOURNAL_KEY", 1, FACT_MAX, true),
+                s(2, "JOURNAL_ID", St),
+                s(3, "POSTING_DATE", Dt),
+                s(4, "GL_ACCOUNT_CODE", FieldType::Int64),
+                s(5, "GL_ACCOUNT_NAME", St),
+                s(6, "COST_CENTER", St),
+                s(7, "DEBIT_AMOUNT", DEC),
+                s(8, "CREDIT_AMOUNT", DEC),
+                s(9, "CURRENCY", St),
+                s(10, "SOURCE_MODULE", St),
+                k(11, "POSTING_DATE_KEY", 1, DIM_MAX, false), // suffix → DATE_KEY
+            ],
+        ),
+        table(
+            "DW",
+            "FACT_WEB_EVENT",
+            vec![
+                k(1, "EVENT_KEY", 1, FACT_MAX, true),
+                s(2, "EVENT_ID", St),
+                s(3, "SESSION_ID", FieldType::Int64), // integer *_ID, no matching PK → UnresolvedFkCandidate
+                s(4, "EVENT_DATE", Dt),
+                s(5, "EVENT_TS", Ts),
+                s(6, "EVENT_TYPE", St),
+                s(7, "PAGE_URL", St),
+                s(8, "DEVICE_TYPE", St),
+                s(9, "BROWSER", St),
+                s(10, "REFERRER", St),
+                k(11, "CUSTOMER_KEY", 1, DIM_MAX, false),
+                k(12, "PRODUCT_KEY", 1, DIM_MAX, false),
+                k(13, "EVENT_DATE_KEY", 1, DIM_MAX, false), // suffix → DATE_KEY
+            ],
+        ),
+        table(
+            "DW",
+            "FACT_SUPPORT_TICKET",
+            vec![
+                k(1, "TICKET_KEY", 1, FACT_MAX, true),
+                s(2, "TICKET_ID", St),
+                s(3, "OPEN_DATE", Dt),
+                s(4, "CLOSE_DATE", Dt),
+                s(5, "STATUS", St),
+                s(6, "PRIORITY", St),
+                s(7, "CATEGORY", St),
+                s(8, "CSAT_SCORE", FieldType::Int64),
+                s(9, "RESOLUTION_HOURS", Db),
+                k(10, "CUSTOMER_KEY", 1, DIM_MAX, false),
+                k(11, "PRODUCT_KEY", 1, DIM_MAX, false),
+                k(12, "AGENT_KEY", 1, DIM_MAX, false), // role-renamed → EMPLOYEE_KEY
+                k(13, "OPEN_DATE_KEY", 1, DIM_MAX, false), // suffix → DATE_KEY
+            ],
+        ),
+    ]
+}

--- a/fluree-db-r2rml/src/emit/heuristic.rs
+++ b/fluree-db-r2rml/src/emit/heuristic.rs
@@ -237,7 +237,9 @@ fn build_table_draft(
 /// uniqueness is unprovable metadata-only — it ALWAYS earns a `SubjectKeyUnverified`
 /// diagnostic. Never fabricate a surrogate.
 ///
-/// Otherwise: prefer `identifier_field_ids`; else a `required` / null-free
+/// Otherwise: prefer `identifier_field_ids` (each member gated on the same
+/// `required` / null-free check and, since uniqueness is unverifiable
+/// metadata-only, flagged `SubjectKeyUnverified`); else a `required` / null-free
 /// `<STEM>_KEY` / `<STEM>_ID` fallback (`SubjectKeyUnverified`); else
 /// `NoSafeSubjectKey` (no subject; never invent a surrogate row id).
 fn select_subject_key(
@@ -339,6 +341,20 @@ fn select_subject_key(
                     columns: Vec::new(),
                 };
             }
+            // Parity with the override / <STEM>_KEY-_ID branches: even a declared
+            // identifier's uniqueness is unverifiable metadata-only (NDV deferred),
+            // so flag it. One diagnostic per key column (composite keys included).
+            diagnostics.push(Diagnostic::new(
+                Severity::Warning,
+                DiagCode::SubjectKeyUnverified,
+                table.qualified_name(),
+                Some(col.name.clone()),
+                format!(
+                    "subject key '{}' from Iceberg identifier_field_ids; uniqueness is \
+                     unverifiable metadata-only (NDV deferred)",
+                    col.name
+                ),
+            ));
             columns.push(col.name.clone());
         }
         return SubjectKey { columns };

--- a/fluree-db-r2rml/src/emit/heuristic.rs
+++ b/fluree-db-r2rml/src/emit/heuristic.rs
@@ -133,10 +133,27 @@ fn build_table_draft(
     diagnostics: &mut Vec<Diagnostic>,
 ) -> TableDraft {
     let stem = table.stem();
-    let class_iri = format!("{}{}", opts.base_namespace, naming::class_local_name(stem));
+    let table_override = opts.per_table_overrides.get(&table.key());
 
-    // Subject key selection.
-    let subject_key = select_subject_key(table, diagnostics);
+    // Class name + subject slug. A per-table `class_name` override replaces the
+    // stem-derived pair: the override is used verbatim as the `rr:class`
+    // ClassName, and the subject slug is its kebab-case rendering (the same case
+    // rule `class_slug` applies to a stem). An absent/`None` override reproduces
+    // the stem-derived defaults byte-for-byte.
+    let (class_local_name, subject_slug) =
+        match table_override.and_then(|o| o.class_name.as_deref()) {
+            Some(class_name) => (class_name.to_string(), naming::kebab_case(class_name)),
+            None => (naming::class_local_name(stem), naming::class_slug(stem)),
+        };
+    let class_iri = format!("{}{}", opts.base_namespace, class_local_name);
+
+    // Subject key selection. A per-table `primary_key` override REPLACES
+    // `identifier_field_ids` as the subject key (validated + always unverified).
+    let subject_key = select_subject_key(
+        table,
+        table_override.and_then(|o| o.primary_key.as_deref()),
+        diagnostics,
+    );
     let subject_key_columns: HashSet<String> = subject_key.columns.iter().cloned().collect();
 
     let subject_template = if subject_key.columns.is_empty() {
@@ -151,7 +168,7 @@ fn build_table_draft(
         format!(
             "{}{}/{}",
             naming::subject_base(&opts.base_namespace),
-            naming::class_slug(stem),
+            subject_slug,
             placeholders
         )
     };
@@ -212,10 +229,74 @@ fn build_table_draft(
     }
 }
 
-/// Choose the subject key: prefer `identifier_field_ids`; else a `required` /
-/// null-free `<STEM>_KEY` / `<STEM>_ID` fallback (`SubjectKeyUnverified`); else
+/// Choose the subject key.
+///
+/// A per-table `primary_key` override (`override_primary_key`), when present,
+/// REPLACES `identifier_field_ids`: the named column must exist and pass the
+/// `required` / null-free gate (else `NoSafeSubjectKey`, no subject), and — because
+/// uniqueness is unprovable metadata-only — it ALWAYS earns a `SubjectKeyUnverified`
+/// diagnostic. Never fabricate a surrogate.
+///
+/// Otherwise: prefer `identifier_field_ids`; else a `required` / null-free
+/// `<STEM>_KEY` / `<STEM>_ID` fallback (`SubjectKeyUnverified`); else
 /// `NoSafeSubjectKey` (no subject; never invent a surrogate row id).
-fn select_subject_key(table: &EmitTableSchema, diagnostics: &mut Vec<Diagnostic>) -> SubjectKey {
+fn select_subject_key(
+    table: &EmitTableSchema,
+    override_primary_key: Option<&str>,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> SubjectKey {
+    // -- Per-table `primary_key` override: replaces identifier_field_ids. --
+    if let Some(pk_name) = override_primary_key {
+        let col = match table.columns.iter().find(|c| c.name == pk_name) {
+            Some(col) => col,
+            None => {
+                diagnostics.push(Diagnostic::new(
+                    Severity::Error,
+                    DiagCode::NoSafeSubjectKey,
+                    table.qualified_name(),
+                    Some(pk_name.to_string()),
+                    format!(
+                        "per-table primary_key override '{pk_name}' is not a column of the \
+                         table; no safe subject key"
+                    ),
+                ));
+                return SubjectKey {
+                    columns: Vec::new(),
+                };
+            }
+        };
+        if !col.is_non_null() {
+            diagnostics.push(Diagnostic::new(
+                Severity::Error,
+                DiagCode::NoSafeSubjectKey,
+                table.qualified_name(),
+                Some(col.name.clone()),
+                format!(
+                    "per-table primary_key override '{}' is nullable (fails required / \
+                     null_fraction==0); no safe subject key",
+                    col.name
+                ),
+            ));
+            return SubjectKey {
+                columns: Vec::new(),
+            };
+        }
+        diagnostics.push(Diagnostic::new(
+            Severity::Warning,
+            DiagCode::SubjectKeyUnverified,
+            table.qualified_name(),
+            Some(col.name.clone()),
+            format!(
+                "subject key '{}' set by per-table override; uniqueness is unverifiable \
+                 metadata-only (NDV deferred)",
+                col.name
+            ),
+        ));
+        return SubjectKey {
+            columns: vec![col.name.clone()],
+        };
+    }
+
     if !table.identifier_field_ids.is_empty() {
         let mut columns = Vec::new();
         for &fid in &table.identifier_field_ids {

--- a/fluree-db-r2rml/src/emit/heuristic.rs
+++ b/fluree-db-r2rml/src/emit/heuristic.rs
@@ -1,0 +1,442 @@
+//! The deterministic PK-selection + FK-inference heuristic.
+//!
+//! Two phases, mirroring the spec:
+//!
+//! - **Phase 1** builds one [`TableMapping`] per table — subject key, class,
+//!   subject template, and a literal predicate-object mapping for every scalar
+//!   column (nested columns skipped) — and indexes every single-column PK.
+//! - **Phase 2** infers foreign keys from the complete PK index using
+//!   name ∧ type ∧ range-containment, emits join mappings ONLY when exactly one
+//!   parent survives, and records a diagnostic for every case it refuses to
+//!   resolve. It never fabricates a join.
+//!
+//! The output IR encodes no answers the fixtures fed in — every FK is derived
+//! here from schema + stats alone.
+
+use std::collections::HashSet;
+
+use fluree_db_tabular::FieldType;
+
+use crate::emit::diagnostic::{DiagCode, Diagnostic, Severity};
+use crate::emit::input::{EmitColumn, EmitTableSchema, TypedBound};
+use crate::emit::ir::{
+    ColumnMapping, ForeignKey, PrefixDecl, StructuredR2rmlMapping, TableMapping,
+};
+use crate::emit::naming;
+use crate::emit::EmitOptions;
+use crate::vocab::R2RML;
+
+/// The XSD namespace IRI (for the `xsd:` prefix declaration).
+pub(crate) const XSD_NS: &str = "http://www.w3.org/2001/XMLSchema#";
+
+/// A single-column PK, indexed in Phase 1 and consulted in Phase 2.
+struct PkEntry {
+    /// Fully-qualified parent table name (`"DW.DIM_GEOGRAPHY"`).
+    table_name: String,
+    /// The parent key column name (`"GEOGRAPHY_KEY"`).
+    pk_column: String,
+    /// The parent key column type (for the type-match gate).
+    field_type: FieldType,
+    /// Typed lower/upper bounds (for range-containment), if known.
+    min: Option<TypedBound>,
+    max: Option<TypedBound>,
+    /// Whether the parent is a fact table (for the child-fact→hub advisory).
+    is_fact: bool,
+}
+
+/// Per-table Phase-1 intermediate carried into Phase 2.
+struct TableDraft {
+    class_iri: String,
+    subject_template: String,
+    /// Literal mappings for every scalar column, in `field_id` order.
+    literals: Vec<ColumnMapping>,
+    /// The set of camelCase predicate local-names used by literals (for join
+    /// predicate collision avoidance).
+    literal_locals: HashSet<String>,
+    /// The subject-key column names (excluded from the FK pass).
+    subject_key_columns: HashSet<String>,
+}
+
+/// Build the authoritative [`StructuredR2rmlMapping`] plus diagnostics from the
+/// table inputs. Pure and deterministic.
+pub fn build_mapping(
+    tables: &[EmitTableSchema],
+    opts: &EmitOptions,
+) -> (StructuredR2rmlMapping, Vec<Diagnostic>) {
+    let mut diagnostics = Vec::new();
+    let mut pk_index: Vec<PkEntry> = Vec::new();
+    let mut drafts: Vec<TableDraft> = Vec::with_capacity(tables.len());
+
+    // -- Phase 1: per-table subject + literals; build the PK index. --
+    for table in tables {
+        let draft = build_table_draft(table, opts, &mut pk_index, &mut diagnostics);
+        drafts.push(draft);
+    }
+
+    // -- Phase 2: FK inference against the complete PK index. --
+    let mut table_mappings = Vec::with_capacity(tables.len());
+    for (table, draft) in tables.iter().zip(drafts) {
+        let (joins, resolved_fk_cols) = if opts.emit_fk_joins {
+            infer_foreign_keys(table, &draft, &pk_index, opts, &mut diagnostics)
+        } else {
+            (Vec::new(), HashSet::new())
+        };
+
+        // Assemble columns: literals (optionally dropping resolved-FK keys) then
+        // joins. The subject-key literal is always retained.
+        let mut columns: Vec<ColumnMapping> = draft
+            .literals
+            .into_iter()
+            .filter(|lit| {
+                opts.keep_fk_keys_as_literals
+                    || lit.is_subject_id
+                    || !resolved_fk_cols.contains(&lit.column_name)
+            })
+            .collect();
+        columns.extend(joins);
+
+        table_mappings.push(TableMapping {
+            table_name: table.qualified_name(),
+            class_iri: draft.class_iri,
+            subject_template: draft.subject_template,
+            columns,
+        });
+    }
+
+    let mapping = StructuredR2rmlMapping {
+        base_namespace: opts.base_namespace.clone(),
+        prefixes: vec![
+            PrefixDecl {
+                prefix: "rr".to_string(),
+                namespace: R2RML::NS.to_string(),
+            },
+            PrefixDecl {
+                prefix: "xsd".to_string(),
+                namespace: XSD_NS.to_string(),
+            },
+            PrefixDecl {
+                prefix: opts.vocab_prefix.clone(),
+                namespace: opts.base_namespace.clone(),
+            },
+        ],
+        table_mappings,
+    };
+
+    (mapping, diagnostics)
+}
+
+/// Phase 1 for a single table.
+fn build_table_draft(
+    table: &EmitTableSchema,
+    opts: &EmitOptions,
+    pk_index: &mut Vec<PkEntry>,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> TableDraft {
+    let stem = table.stem();
+    let class_iri = format!("{}{}", opts.base_namespace, naming::class_local_name(stem));
+
+    // Subject key selection.
+    let subject_key = select_subject_key(table, diagnostics);
+    let subject_key_columns: HashSet<String> = subject_key.columns.iter().cloned().collect();
+
+    let subject_template = if subject_key.columns.is_empty() {
+        String::new()
+    } else {
+        let placeholders: String = subject_key
+            .columns
+            .iter()
+            .map(|c| format!("{{{c}}}"))
+            .collect::<Vec<_>>()
+            .join("/");
+        format!(
+            "{}{}/{}",
+            naming::subject_base(&opts.base_namespace),
+            naming::class_slug(stem),
+            placeholders
+        )
+    };
+
+    // Index a single-column PK for the FK pass.
+    if subject_key.columns.len() == 1 {
+        let pk_name = &subject_key.columns[0];
+        if let Some(col) = table.columns.iter().find(|c| &c.name == pk_name) {
+            pk_index.push(PkEntry {
+                table_name: table.qualified_name(),
+                pk_column: pk_name.clone(),
+                field_type: col.field_type,
+                min: col.stats.min,
+                max: col.stats.max,
+                is_fact: table.is_fact(),
+            });
+        }
+    }
+
+    // Literal predicate-object mappings for every scalar column.
+    let mut literals = Vec::new();
+    let mut literal_locals = HashSet::new();
+    for col in &table.columns {
+        if col.nested {
+            diagnostics.push(Diagnostic::new(
+                Severity::Warning,
+                DiagCode::NestedColumnSkipped,
+                table.qualified_name(),
+                Some(col.name.clone()),
+                format!(
+                    "column '{}' is a nested struct/list/map; R2RML addresses flat columns only",
+                    col.name
+                ),
+            ));
+            continue;
+        }
+
+        let local = naming::camel_case(&col.name);
+        let predicate_iri = format!("{}{}", opts.base_namespace, local);
+        let datatype = naming::xsd_datatype(col.field_type, opts.xsd_long_as_integer)
+            .map(std::string::ToString::to_string);
+        let is_subject_id = subject_key_columns.contains(&col.name);
+        literal_locals.insert(local);
+        literals.push(ColumnMapping::literal(
+            col.name.clone(),
+            predicate_iri,
+            datatype,
+            is_subject_id,
+        ));
+    }
+
+    TableDraft {
+        class_iri,
+        subject_template,
+        literals,
+        literal_locals,
+        subject_key_columns,
+    }
+}
+
+/// Choose the subject key: prefer `identifier_field_ids`; else a `required` /
+/// null-free `<STEM>_KEY` / `<STEM>_ID` fallback (`SubjectKeyUnverified`); else
+/// `NoSafeSubjectKey` (no subject; never invent a surrogate row id).
+fn select_subject_key(table: &EmitTableSchema, diagnostics: &mut Vec<Diagnostic>) -> SubjectKey {
+    if !table.identifier_field_ids.is_empty() {
+        let mut columns = Vec::new();
+        for &fid in &table.identifier_field_ids {
+            match table.column_by_field_id(fid) {
+                Some(col) => columns.push(col.name.clone()),
+                None => {
+                    diagnostics.push(Diagnostic::new(
+                        Severity::Error,
+                        DiagCode::NoSafeSubjectKey,
+                        table.qualified_name(),
+                        None,
+                        format!("identifier_field_ids references unknown field id {fid}"),
+                    ));
+                    return SubjectKey {
+                        columns: Vec::new(),
+                    };
+                }
+            }
+        }
+        return SubjectKey { columns };
+    }
+
+    // Fallback: a required / null-free column matching <STEM>_KEY or <STEM>_ID.
+    let marker_stem = naming::strip_table_marker(table.stem());
+    let candidates = [format!("{marker_stem}_KEY"), format!("{marker_stem}_ID")];
+    if let Some(col) = table
+        .columns
+        .iter()
+        .find(|c| candidates.iter().any(|cand| cand == &c.name))
+    {
+        if col.is_non_null() {
+            diagnostics.push(Diagnostic::new(
+                Severity::Warning,
+                DiagCode::SubjectKeyUnverified,
+                table.qualified_name(),
+                Some(col.name.clone()),
+                format!(
+                    "subject key '{}' chosen by name+required fallback; uniqueness is \
+                     unverifiable metadata-only (NDV deferred)",
+                    col.name
+                ),
+            ));
+            return SubjectKey {
+                columns: vec![col.name.clone()],
+            };
+        }
+        diagnostics.push(Diagnostic::new(
+            Severity::Error,
+            DiagCode::NoSafeSubjectKey,
+            table.qualified_name(),
+            Some(col.name.clone()),
+            format!(
+                "candidate subject key '{}' is nullable; no safe subject key",
+                col.name
+            ),
+        ));
+        return SubjectKey {
+            columns: Vec::new(),
+        };
+    }
+
+    diagnostics.push(Diagnostic::new(
+        Severity::Error,
+        DiagCode::NoSafeSubjectKey,
+        table.qualified_name(),
+        None,
+        "no identifier_field_ids and no required <STEM>_KEY/<STEM>_ID column; \
+         emitting no subject (never inventing a surrogate row id)"
+            .to_string(),
+    ));
+    SubjectKey {
+        columns: Vec::new(),
+    }
+}
+
+/// Selected subject key (empty `columns` ⇒ no safe subject key).
+struct SubjectKey {
+    columns: Vec<String>,
+}
+
+/// Phase 2 for a single table: returns the join mappings and the set of child
+/// columns that were resolved to a join.
+fn infer_foreign_keys(
+    table: &EmitTableSchema,
+    draft: &TableDraft,
+    pk_index: &[PkEntry],
+    opts: &EmitOptions,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> (Vec<ColumnMapping>, HashSet<String>) {
+    let mut joins = Vec::new();
+    let mut resolved = HashSet::new();
+
+    for col in &table.columns {
+        // FK candidacy: non-nested, integer-typed, non-subject-key columns only.
+        if col.nested || !col.is_integer() || draft.subject_key_columns.contains(&col.name) {
+            continue;
+        }
+
+        let survivors = candidate_parents(table, col, pk_index);
+
+        match survivors.as_slice() {
+            [parent] => {
+                let fk = ForeignKey {
+                    target_table: parent.table_name.clone(),
+                    child_column: col.name.clone(),
+                    parent_column: parent.pk_column.clone(),
+                };
+                let predicate_iri = join_predicate(&col.name, draft, opts);
+                joins.push(ColumnMapping::join(col.name.clone(), predicate_iri, fk));
+                resolved.insert(col.name.clone());
+
+                // Child-fact → hub advisory: both sides fact, joining on the
+                // parent's PK (always true here — we only ever join to a PK).
+                if table.is_fact() && parent.is_fact {
+                    diagnostics.push(Diagnostic::new(
+                        Severity::Advisory,
+                        DiagCode::FactHubJoinAdvisory,
+                        table.qualified_name(),
+                        Some(col.name.clone()),
+                        format!(
+                            "child-fact→hub join '{}' → {}.{} is a bounded PK point-lookup; \
+                             emitted, but flagged as a perf advisory",
+                            col.name, parent.table_name, parent.pk_column
+                        ),
+                    ));
+                }
+            }
+            [] => {
+                if col.is_key_like() {
+                    diagnostics.push(Diagnostic::new(
+                        Severity::Warning,
+                        DiagCode::UnresolvedFkCandidate,
+                        table.qualified_name(),
+                        Some(col.name.clone()),
+                        format!(
+                            "'{}' looks like a key but matches no known PK by name∧type∧range; \
+                             kept literal, no join fabricated",
+                            col.name
+                        ),
+                    ));
+                }
+                // Non-key-like integer: an ordinary measure — no diagnostic.
+            }
+            _ => {
+                let parents: Vec<String> = survivors
+                    .iter()
+                    .map(|p| format!("{}.{}", p.table_name, p.pk_column))
+                    .collect();
+                diagnostics.push(Diagnostic::new(
+                    Severity::Warning,
+                    DiagCode::AmbiguousFk,
+                    table.qualified_name(),
+                    Some(col.name.clone()),
+                    format!(
+                        "'{}' matches multiple candidate parents ({}); kept literal, no join \
+                         fabricated",
+                        col.name,
+                        parents.join(", ")
+                    ),
+                ));
+            }
+        }
+    }
+
+    (joins, resolved)
+}
+
+/// Collect the parents surviving name ∧ type ∧ range-containment for `col`.
+fn candidate_parents<'a>(
+    table: &EmitTableSchema,
+    col: &EmitColumn,
+    pk_index: &'a [PkEntry],
+) -> Vec<&'a PkEntry> {
+    pk_index
+        .iter()
+        .filter(|pk| {
+            // (1) Name: exact, or an unambiguous role-prefixed `_<PK>` suffix.
+            let name_match =
+                col.name == pk.pk_column || col.name.ends_with(&format!("_{}", pk.pk_column));
+            if !name_match {
+                return false;
+            }
+            // A PK never joins to its own row via its own name in its own table.
+            if pk.table_name == table.qualified_name() && pk.pk_column == col.name {
+                return false;
+            }
+            // (2) Type-match.
+            if col.field_type != pk.field_type {
+                return false;
+            }
+            // (3) Range-containment: child [min,max] ⊆ parent [min,max].
+            range_contained(col.stats.min, col.stats.max, pk.min, pk.max)
+        })
+        .collect()
+}
+
+/// True iff `child [min,max] ⊆ parent [min,max]`. Any missing bound ⇒ cannot
+/// confirm ⇒ `false` (never fabricate an unconfirmed join).
+fn range_contained(
+    child_min: Option<TypedBound>,
+    child_max: Option<TypedBound>,
+    parent_min: Option<TypedBound>,
+    parent_max: Option<TypedBound>,
+) -> bool {
+    match (child_min, child_max, parent_min, parent_max) {
+        (Some(cmin), Some(cmax), Some(pmin), Some(pmax)) => pmin <= cmin && cmax <= pmax,
+        _ => false,
+    }
+}
+
+/// Derive the join predicate IRI for a resolved FK on `child_column`.
+///
+/// Uses `camelCase(strip_key_suffix(child))` (readable: `geography`,
+/// `destGeography`), appending `Ref` only when that local would collide with an
+/// existing literal predicate in the same table (e.g. `orderDate` literal vs.
+/// `ORDER_DATE_KEY` join → `orderDateRef`). Predicate IRIs are not compared by
+/// any structural test; this only keeps the emitted document unambiguous.
+fn join_predicate(child_column: &str, draft: &TableDraft, opts: &EmitOptions) -> String {
+    let mut local = naming::camel_case(naming::strip_key_suffix(child_column));
+    if draft.literal_locals.contains(&local) {
+        local.push_str("Ref");
+    }
+    format!("{}{}", opts.base_namespace, local)
+}

--- a/fluree-db-r2rml/src/emit/heuristic.rs
+++ b/fluree-db-r2rml/src/emit/heuristic.rs
@@ -300,8 +300,8 @@ fn select_subject_key(
     if !table.identifier_field_ids.is_empty() {
         let mut columns = Vec::new();
         for &fid in &table.identifier_field_ids {
-            match table.column_by_field_id(fid) {
-                Some(col) => columns.push(col.name.clone()),
+            let col = match table.column_by_field_id(fid) {
+                Some(col) => col,
                 None => {
                     diagnostics.push(Diagnostic::new(
                         Severity::Error,
@@ -314,7 +314,32 @@ fn select_subject_key(
                         columns: Vec::new(),
                     };
                 }
+            };
+            // Non-null gate. Iceberg requires identifier fields to be `required`,
+            // but a non-conforming writer (e.g. Snowflake-managed Iceberg) can
+            // populate `identifier_field_ids` without marking the column required.
+            // A nullable identifier yields an unsafe subject template (silent row
+            // loss at query time) and, in the single-column case, would be indexed
+            // as a valid FK parent — so gate it exactly like the override and
+            // `<STEM>_KEY`/`_ID` paths, emitting no subject when it cannot be
+            // confirmed non-null.
+            if !col.is_non_null() {
+                diagnostics.push(Diagnostic::new(
+                    Severity::Error,
+                    DiagCode::NoSafeSubjectKey,
+                    table.qualified_name(),
+                    Some(col.name.clone()),
+                    format!(
+                        "identifier_field_ids column '{}' is nullable (fails required / \
+                         null_fraction==0); no safe subject key",
+                        col.name
+                    ),
+                ));
+                return SubjectKey {
+                    columns: Vec::new(),
+                };
             }
+            columns.push(col.name.clone());
         }
         return SubjectKey { columns };
     }
@@ -388,6 +413,9 @@ fn infer_foreign_keys(
 ) -> (Vec<ColumnMapping>, HashSet<String>) {
     let mut joins = Vec::new();
     let mut resolved = HashSet::new();
+    // Predicate locals already emitted by joins in THIS table, so a later join
+    // whose local collides with an earlier one is disambiguated (not merged).
+    let mut emitted_join_locals: HashSet<String> = HashSet::new();
 
     for col in &table.columns {
         // FK candidacy: non-nested, integer-typed, non-subject-key columns only.
@@ -404,7 +432,8 @@ fn infer_foreign_keys(
                     child_column: col.name.clone(),
                     parent_column: parent.pk_column.clone(),
                 };
-                let predicate_iri = join_predicate(&col.name, draft, opts);
+                let predicate_iri =
+                    join_predicate(&col.name, draft, &mut emitted_join_locals, opts);
                 joins.push(ColumnMapping::join(col.name.clone(), predicate_iri, fk));
                 resolved.insert(col.name.clone());
 
@@ -510,14 +539,31 @@ fn range_contained(
 /// Derive the join predicate IRI for a resolved FK on `child_column`.
 ///
 /// Uses `camelCase(strip_key_suffix(child))` (readable: `geography`,
-/// `destGeography`), appending `Ref` only when that local would collide with an
-/// existing literal predicate in the same table (e.g. `orderDate` literal vs.
-/// `ORDER_DATE_KEY` join → `orderDateRef`). Predicate IRIs are not compared by
-/// any structural test; this only keeps the emitted document unambiguous.
-fn join_predicate(child_column: &str, draft: &TableDraft, opts: &EmitOptions) -> String {
-    let mut local = naming::camel_case(naming::strip_key_suffix(child_column));
-    if draft.literal_locals.contains(&local) {
-        local.push_str("Ref");
+/// `destGeography`), disambiguating with a `Ref` suffix when that local would
+/// collide with EITHER an existing literal predicate (e.g. `orderDate` literal
+/// vs. `ORDER_DATE_KEY` join → `orderDateRef`) OR a local already emitted by an
+/// earlier join in the same table (e.g. `GEOGRAPHY_KEY` and `GEOGRAPHY_ID` both
+/// strip+camel to `geography` → the second becomes `geographyRef`). Without the
+/// second check, two FKs to different parents would emit the same predicate IRI
+/// and silently merge two distinct relationships. Further collisions append an
+/// increasing counter so the local always stays unique.
+fn join_predicate(
+    child_column: &str,
+    draft: &TableDraft,
+    emitted_join_locals: &mut HashSet<String>,
+    opts: &EmitOptions,
+) -> String {
+    let base_local = naming::camel_case(naming::strip_key_suffix(child_column));
+    let mut local = base_local.clone();
+    let mut suffix = 1u32;
+    while draft.literal_locals.contains(&local) || emitted_join_locals.contains(&local) {
+        local = if suffix == 1 {
+            format!("{base_local}Ref")
+        } else {
+            format!("{base_local}Ref{suffix}")
+        };
+        suffix += 1;
     }
+    emitted_join_locals.insert(local.clone());
     format!("{}{}", opts.base_namespace, local)
 }

--- a/fluree-db-r2rml/src/emit/input.rs
+++ b/fluree-db-r2rml/src/emit/input.rs
@@ -1,0 +1,133 @@
+//! Self-contained INPUT model for the deterministic Iceberg-metadata → R2RML
+//! emitter.
+//!
+//! This is a minimal stand-in for PR-1's `TableSchema` / `ColumnInfo` /
+//! `ColumnStats` (parts a/b, owned by other tracks). It carries exactly the
+//! schema + metadata-stats signals the deterministic heuristic needs:
+//!
+//! - the fully-qualified table identifier (`namespace` + `name`),
+//! - per-column type / nullability / nesting,
+//! - Iceberg's `identifier_field_ids` PK hint, and
+//! - the Tier-B per-column stats (`null_fraction`, typed `min`/`max`) used for
+//!   range-containment FK confirmation.
+//!
+//! TODO(track-a): map the real `preview_iceberg_table` Tier-A schema + Tier-B
+//! stats onto this model so the emitter consumes the live preview types instead
+//! of this stand-in. The [`FieldType`] here is already the shared
+//! `fluree-db-tabular` enum, so the type axis will unify for free.
+
+use fluree_db_tabular::FieldType;
+
+/// A comparable typed bound for range-containment FK confirmation.
+///
+/// Integers suffice for the surrogate `*_KEY` spaces exercised by this spike;
+/// the enum is kept open so temporal / decimal bounds can be added later
+/// without touching call sites.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TypedBound {
+    /// An integer bound (surrogate keys, counts, ...).
+    Int(i64),
+}
+
+impl TypedBound {
+    /// Return the integer payload, if this bound is integer-typed.
+    pub fn as_int(self) -> Option<i64> {
+        match self {
+            TypedBound::Int(v) => Some(v),
+        }
+    }
+}
+
+/// Tier-B per-column statistics (metadata-only; no Parquet scan).
+///
+/// `distinct_count` is intentionally absent — NDV is unavailable metadata-only
+/// (Puffin/theta-sketch reader is deferred to PR-5), which is exactly why the
+/// subject-key uniqueness check stays a heuristic (`SubjectKeyUnverified`).
+#[derive(Debug, Clone, Default)]
+pub struct EmitColumnStats {
+    /// Fraction of NULL values in `[0.0, 1.0]`, if known.
+    pub null_fraction: Option<f64>,
+    /// Typed minimum bound (value_codec-decoded upstream), if known.
+    pub min: Option<TypedBound>,
+    /// Typed maximum bound (value_codec-decoded upstream), if known.
+    pub max: Option<TypedBound>,
+}
+
+/// A single column of a table (Tier-A schema + Tier-B stats).
+#[derive(Debug, Clone)]
+pub struct EmitColumn {
+    /// Iceberg field id — the canonical identifier and the emission order key.
+    pub field_id: i32,
+    /// Byte-for-byte Iceberg field name (Snowflake folds to UPPERCASE).
+    pub name: String,
+    /// Raw Iceberg type string (`"long"`, `"decimal(18,2)"`, ...) — informational.
+    pub iceberg_type: String,
+    /// Parsed field type (shared `fluree-db-tabular` enum).
+    pub field_type: FieldType,
+    /// Whether the column is declared `required` (NOT NULL) in the schema.
+    pub required: bool,
+    /// Whether the column is a nested struct/list/map (skipped by R2RML).
+    pub nested: bool,
+    /// Optional column documentation.
+    pub doc: Option<String>,
+    /// Tier-B statistics for this column.
+    pub stats: EmitColumnStats,
+}
+
+impl EmitColumn {
+    /// A column is a NOT-NULL signal if declared `required` or proven null-free
+    /// by stats (`null_fraction == 0`).
+    pub fn is_non_null(&self) -> bool {
+        self.required || self.stats.null_fraction == Some(0.0)
+    }
+
+    /// Whether this column is integer-typed (FK candidacy is integer-only).
+    pub fn is_integer(&self) -> bool {
+        matches!(self.field_type, FieldType::Int32 | FieldType::Int64)
+    }
+
+    /// Whether the column name looks like a key by convention (`*_KEY` / `*_ID`).
+    pub fn is_key_like(&self) -> bool {
+        self.name.ends_with("_KEY") || self.name.ends_with("_ID")
+    }
+}
+
+/// A table's schema + PK hint + per-column stats — one emitter input unit.
+#[derive(Debug, Clone)]
+pub struct EmitTableSchema {
+    /// Catalog namespace (e.g. `"DW"`).
+    pub namespace: String,
+    /// Table name within the namespace (e.g. `"DIM_STORE"`).
+    pub name: String,
+    /// Columns in `field_id` order (the deterministic emission order).
+    pub columns: Vec<EmitColumn>,
+    /// Iceberg's declared row-identity hint — the primary PK signal.
+    pub identifier_field_ids: Vec<i32>,
+}
+
+impl EmitTableSchema {
+    /// Fully-qualified logical table name, byte-for-byte (`"DW.DIM_STORE"`).
+    ///
+    /// The namespace prefix is included deliberately — it is what the scan path
+    /// matches against, and `LogicalTable::normalize_table_name` leaves an
+    /// already-dotted identifier untouched.
+    pub fn qualified_name(&self) -> String {
+        format!("{}.{}", self.namespace, self.name)
+    }
+
+    /// The table stem (name without namespace), e.g. `"DIM_STORE"`.
+    pub fn stem(&self) -> &str {
+        &self.name
+    }
+
+    /// Whether this is a fact table (`FACT_*`) — used for the child-fact→hub
+    /// join advisory.
+    pub fn is_fact(&self) -> bool {
+        self.name.starts_with("FACT_")
+    }
+
+    /// Look up a column by field id.
+    pub fn column_by_field_id(&self, field_id: i32) -> Option<&EmitColumn> {
+        self.columns.iter().find(|c| c.field_id == field_id)
+    }
+}

--- a/fluree-db-r2rml/src/emit/input.rs
+++ b/fluree-db-r2rml/src/emit/input.rs
@@ -92,6 +92,45 @@ impl EmitColumn {
     }
 }
 
+/// A table's `{namespace, name}` identity — the key for [`crate::emit::EmitOptions::per_table_overrides`].
+///
+/// Mirrors PR-1's `TableIdentifier`: the same identity the input [`EmitTableSchema`]
+/// carries, so a `HashMap<TableKey, TableOverride>` keys on exactly what the
+/// emitter iterates. Case-sensitive and byte-for-byte (Snowflake folds UPPERCASE).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TableKey {
+    /// Catalog namespace (e.g. `"DW"`).
+    pub namespace: String,
+    /// Table name within the namespace (e.g. `"DIM_STORE"`).
+    pub name: String,
+}
+
+impl TableKey {
+    /// Build a table key from its namespace and name parts.
+    pub fn new(namespace: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            namespace: namespace.into(),
+            name: name.into(),
+        }
+    }
+}
+
+/// A per-table override for the subject key and/or class name (PR-1's `TableOverride`).
+///
+/// Every field is optional and additive: an all-`None` override (or no entry at
+/// all) leaves the deterministic stem-derived defaults untouched.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TableOverride {
+    /// REPLACES `identifier_field_ids` as the subject key K. The named column must
+    /// exist and still pass the `required` / `null_fraction == 0` gate (else
+    /// `NoSafeSubjectKey`); because uniqueness is unprovable metadata-only, an
+    /// override PK ALWAYS attaches a `SubjectKeyUnverified` diagnostic.
+    pub primary_key: Option<String>,
+    /// Overrides the stem-derived class name (`rr:class` local name) and the
+    /// subject-template `classSlug` for the table.
+    pub class_name: Option<String>,
+}
+
 /// A table's schema + PK hint + per-column stats — one emitter input unit.
 #[derive(Debug, Clone)]
 pub struct EmitTableSchema {
@@ -118,6 +157,14 @@ impl EmitTableSchema {
     /// The table stem (name without namespace), e.g. `"DIM_STORE"`.
     pub fn stem(&self) -> &str {
         &self.name
+    }
+
+    /// This table's `{namespace, name}` identity — its per-table-override key.
+    pub fn key(&self) -> TableKey {
+        TableKey {
+            namespace: self.namespace.clone(),
+            name: self.name.clone(),
+        }
     }
 
     /// Whether this is a fact table (`FACT_*`) — used for the child-fact→hub

--- a/fluree-db-r2rml/src/emit/ir.rs
+++ b/fluree-db-r2rml/src/emit/ir.rs
@@ -1,0 +1,151 @@
+//! The authoritative wire IR: solo's `StructuredR2rmlMapping` (camelCase).
+//!
+//! This is the object PR-2 persists verbatim, PR-3 renders in the review step,
+//! and PR-4 IRI-rewrites. It is the emitter's authoritative artifact — the
+//! Turtle is rendered FROM this IR, and the `fluree-db-r2rml` compiled
+//! `Vec<TriplesMap>` is produced only for the internal round-trip check and is
+//! never serialized onto the wire.
+//!
+//! Field names are Rust snake_case; `#[serde(rename_all = "camelCase")]` makes
+//! the JSON exactly `{ baseNamespace, prefixes[], tableMappings[]{ tableName,
+//! classIri, subjectTemplate, columns[]{ columnName, predicateIri, datatype,
+//! isSubjectId, foreignKey{ targetTable, childColumn, parentColumn }, isIri,
+//! iriTemplate } } }`.
+
+use serde::{Deserialize, Serialize};
+
+/// A prefix declaration carried on the wire (for renderers and reviewers).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrefixDecl {
+    /// The prefix label (e.g. `"rr"`, `"xsd"`, or the vocab prefix).
+    pub prefix: String,
+    /// The namespace IRI the label expands to.
+    pub namespace: String,
+}
+
+/// A foreign-key edge: the child column joins to the parent table's key column.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForeignKey {
+    /// The parent (referenced) table, byte-for-byte (`"DW.DIM_GEOGRAPHY"`).
+    pub target_table: String,
+    /// The child (referencing) column in this table.
+    pub child_column: String,
+    /// The parent key column in the target table.
+    pub parent_column: String,
+}
+
+/// A single predicate-object mapping for a table, keyed on a source column.
+///
+/// A resolved FK column contributes TWO `ColumnMapping`s: one literal
+/// (`datatype` set, `foreign_key` `None`) for pushdown, and one join
+/// (`foreign_key` set, `datatype` `None`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnMapping {
+    /// The source column name, byte-for-byte.
+    pub column_name: String,
+    /// The predicate IRI this mapping generates.
+    pub predicate_iri: String,
+    /// The XSD datatype (a CURIE such as `"xsd:integer"`) for literal objects;
+    /// `None` for strings (plain literal) and for FK/join objects.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub datatype: Option<String>,
+    /// Whether this column is (part of) the subject key.
+    pub is_subject_id: bool,
+    /// The foreign-key edge, when this mapping is a resolved join.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub foreign_key: Option<ForeignKey>,
+    /// Whether the object is an IRI produced from `iri_template` (unused in Phase-1).
+    pub is_iri: bool,
+    /// A template producing an IRI object (unused in Phase-1; FKs use `foreign_key`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iri_template: Option<String>,
+}
+
+impl ColumnMapping {
+    /// A literal (typed or plain) predicate-object mapping.
+    pub fn literal(
+        column_name: impl Into<String>,
+        predicate_iri: impl Into<String>,
+        datatype: Option<String>,
+        is_subject_id: bool,
+    ) -> Self {
+        Self {
+            column_name: column_name.into(),
+            predicate_iri: predicate_iri.into(),
+            datatype,
+            is_subject_id,
+            foreign_key: None,
+            is_iri: false,
+            iri_template: None,
+        }
+    }
+
+    /// A join (RefObjectMap) predicate-object mapping.
+    pub fn join(
+        column_name: impl Into<String>,
+        predicate_iri: impl Into<String>,
+        foreign_key: ForeignKey,
+    ) -> Self {
+        Self {
+            column_name: column_name.into(),
+            predicate_iri: predicate_iri.into(),
+            datatype: None,
+            is_subject_id: false,
+            foreign_key: Some(foreign_key),
+            is_iri: false,
+            iri_template: None,
+        }
+    }
+}
+
+/// One TriplesMap's worth of mapping — a base table, its class, subject
+/// template, and column mappings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TableMapping {
+    /// The logical table name, byte-for-byte (`"DW.DIM_STORE"`).
+    pub table_name: String,
+    /// The `rr:class` IRI for generated subjects.
+    pub class_iri: String,
+    /// The `rr:subjectMap` template (`"{subjectBase}{slug}/{KEY}"`).
+    ///
+    /// Empty when no safe subject key exists (a `NoSafeSubjectKey` diagnostic is
+    /// emitted and the table produces no subject).
+    pub subject_template: String,
+    /// Predicate-object mappings (literals first in `field_id` order, then joins).
+    pub columns: Vec<ColumnMapping>,
+}
+
+/// The authoritative structured mapping — solo's `StructuredR2rmlMapping`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StructuredR2rmlMapping {
+    /// The single base namespace all IRIs derive from.
+    pub base_namespace: String,
+    /// Prefix declarations (`rr`, `xsd`, and the vocab prefix).
+    pub prefixes: Vec<PrefixDecl>,
+    /// One entry per requested table, in request order.
+    pub table_mappings: Vec<TableMapping>,
+}
+
+impl StructuredR2rmlMapping {
+    /// Look up a table mapping by its logical table name.
+    pub fn table_mapping(&self, table_name: &str) -> Option<&TableMapping> {
+        self.table_mappings
+            .iter()
+            .find(|t| t.table_name == table_name)
+    }
+
+    /// The vocab prefix label (the prefix whose namespace equals `base_namespace`).
+    ///
+    /// Falls back to `"ns"` if — impossibly — no such prefix was declared.
+    pub fn vocab_prefix(&self) -> &str {
+        self.prefixes
+            .iter()
+            .find(|p| p.namespace == self.base_namespace)
+            .map_or("ns", |p| p.prefix.as_str())
+    }
+}

--- a/fluree-db-r2rml/src/emit/mod.rs
+++ b/fluree-db-r2rml/src/emit/mod.rs
@@ -1,0 +1,221 @@
+//! Deterministic Iceberg-metadata → R2RML emitter (greenfield).
+//!
+//! Given per-table schema + metadata-stats ([`EmitTableSchema`]), this module
+//! builds solo's authoritative [`StructuredR2rmlMapping`] IR, renders Turtle
+//! from it, and (behind the `turtle` feature) round-trips that Turtle back
+//! through [`crate::loader::R2rmlLoader`] to prove the emitted mapping compiles
+//! and its join graph reconnects.
+//!
+//! Pipeline: [`emit_r2rml`] → `heuristic::build_mapping` (PK/FK inference,
+//! producing the IR + diagnostics) → `render::render_turtle`. The compiled
+//! `Vec<TriplesMap>` produced during the round-trip check is INTERNAL-only and
+//! never leaves the emitter — the wire artifact is the camelCase
+//! [`StructuredR2rmlMapping`].
+//!
+//! Additive and self-contained: it adds no dependency (std + serde +
+//! `fluree-db-tabular`, all already present) and touches no existing code path,
+//! so it is always compiled. Only the round-trip verification and the
+//! enterprise-structural-match tests require the `turtle` feature.
+
+pub mod diagnostic;
+pub mod input;
+pub mod ir;
+
+mod heuristic;
+mod naming;
+mod render;
+
+#[cfg(test)]
+mod fixtures;
+#[cfg(test)]
+mod tests;
+
+pub use diagnostic::{DiagCode, Diagnostic, Severity};
+pub use input::{EmitColumn, EmitColumnStats, EmitTableSchema, TypedBound};
+pub use ir::{ColumnMapping, ForeignKey, PrefixDecl, StructuredR2rmlMapping, TableMapping};
+
+/// Emitter configuration. Every field is a pure knob — identical options plus
+/// identical inputs yield byte-identical output.
+#[derive(Debug, Clone)]
+pub struct EmitOptions {
+    /// The single base namespace all vocab IRIs derive from (== solo's
+    /// `StructuredR2rmlMapping.baseNamespace`). The subject-IRI base is derived
+    /// from it (trailing `#`→`/`, else append `/`).
+    pub base_namespace: String,
+    /// The `@base` for the mapping document's TriplesMap node IRIs (`<#Foo>`).
+    pub map_document_base: String,
+    /// The prefix label bound to `base_namespace` in the rendered Turtle.
+    pub vocab_prefix: String,
+    /// Emit `xsd:integer` for `Int32`/`Int64` (matches `enterprise.ttl`); when
+    /// `false`, use `xsd:int` / `xsd:long`.
+    pub xsd_long_as_integer: bool,
+    /// Emit `rr:parentTriplesMap` joins for resolved FKs (Phase 2).
+    pub emit_fk_joins: bool,
+    /// Keep resolved-FK key columns as literal predicate-object maps too
+    /// (pushdown-friendly).
+    pub keep_fk_keys_as_literals: bool,
+}
+
+impl EmitOptions {
+    /// Options with the given base namespace and reference-matching defaults.
+    pub fn new(base_namespace: impl Into<String>) -> Self {
+        Self {
+            base_namespace: base_namespace.into(),
+            ..Self::default()
+        }
+    }
+}
+
+impl Default for EmitOptions {
+    fn default() -> Self {
+        Self {
+            base_namespace: "http://ns.fluree.dev/edw#".to_string(),
+            map_document_base: "http://mapping.fluree.dev/r2rml".to_string(),
+            vocab_prefix: "v".to_string(),
+            xsd_long_as_integer: true,
+            emit_fk_joins: true,
+            keep_fk_keys_as_literals: true,
+        }
+    }
+}
+
+/// The emitter's output: the authoritative structured IR, the rendered Turtle,
+/// and the diagnostics.
+#[derive(Debug, Clone)]
+pub struct EmitOutput {
+    /// The authoritative wire IR (camelCase `StructuredR2rmlMapping`).
+    pub structured: StructuredR2rmlMapping,
+    /// Turtle rendered from `structured`; compiles through `R2rmlLoader`.
+    pub turtle: String,
+    /// Diagnostics for every decision the emitter could not make from metadata.
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// Run the deterministic emitter over a set of tables.
+pub fn emit_r2rml(tables: &[EmitTableSchema], opts: &EmitOptions) -> EmitOutput {
+    let (structured, diagnostics) = heuristic::build_mapping(tables, opts);
+    let turtle = render::render_turtle(&structured, opts);
+    EmitOutput {
+        structured,
+        turtle,
+        diagnostics,
+    }
+}
+
+/// Internal round-trip check: compile the emitted Turtle through the real
+/// loader and assert the compiled `Vec<TriplesMap>` reproduces the emitted IR's
+/// table count, subject templates, and FK join graph.
+///
+/// The compiled mapping is INTERNAL-only — this is a verification aid, not a
+/// wire artifact. Returns `Ok(())` on a faithful round-trip, or `Err` with the
+/// first discrepancy found.
+#[cfg(feature = "turtle")]
+pub fn roundtrip_check(output: &EmitOutput) -> Result<(), String> {
+    use std::collections::BTreeSet;
+
+    use crate::loader::R2rmlLoader;
+
+    let compiled = R2rmlLoader::from_turtle(&output.turtle)
+        .map_err(|e| format!("from_turtle failed: {e}"))?
+        .compile()
+        .map_err(|e| format!("compile failed: {e}"))?;
+
+    let structured = &output.structured;
+
+    if compiled.len() != structured.table_mappings.len() {
+        return Err(format!(
+            "table count mismatch: compiled {} vs structured {}",
+            compiled.len(),
+            structured.table_mappings.len()
+        ));
+    }
+
+    // FK tuples across the whole document: (childTable, childCol, parentTable, parentCol).
+    let mut structured_fks: BTreeSet<(String, String, String, String)> = BTreeSet::new();
+
+    for tm in &structured.table_mappings {
+        let maps = compiled.find_maps_for_table(&tm.table_name);
+        let compiled_tm = match maps.as_slice() {
+            [single] => *single,
+            [] => return Err(format!("compiled mapping missing table {}", tm.table_name)),
+            _ => {
+                return Err(format!(
+                    "compiled mapping has {} TriplesMaps for table {}",
+                    maps.len(),
+                    tm.table_name
+                ))
+            }
+        };
+
+        let expected_template = if tm.subject_template.is_empty() {
+            None
+        } else {
+            Some(tm.subject_template.clone())
+        };
+        if compiled_tm.subject_map.template != expected_template {
+            return Err(format!(
+                "subject template mismatch for {}: compiled {:?} vs structured {:?}",
+                tm.table_name, compiled_tm.subject_map.template, expected_template
+            ));
+        }
+
+        for col in &tm.columns {
+            if let Some(fk) = &col.foreign_key {
+                structured_fks.insert((
+                    tm.table_name.clone(),
+                    fk.child_column.clone(),
+                    fk.target_table.clone(),
+                    fk.parent_column.clone(),
+                ));
+            }
+        }
+    }
+
+    // Reconstruct the FK graph from the compiled maps, resolving each
+    // parentTriplesMap IRI back to its logical table name.
+    let mut compiled_fks: BTreeSet<(String, String, String, String)> = BTreeSet::new();
+    for tm in &structured.table_mappings {
+        let compiled_tm = compiled
+            .find_maps_for_table(&tm.table_name)
+            .into_iter()
+            .next()
+            .ok_or_else(|| format!("compiled mapping missing table {}", tm.table_name))?;
+        for pom in &compiled_tm.predicate_object_maps {
+            if let Some(rom) = pom.object_map.as_ref() {
+                let parent_tm = compiled.get(&rom.parent_triples_map).ok_or_else(|| {
+                    format!(
+                        "parentTriplesMap {} did not resolve to a compiled TriplesMap",
+                        rom.parent_triples_map
+                    )
+                })?;
+                let parent_table = parent_tm
+                    .table_name()
+                    .ok_or_else(|| {
+                        format!(
+                            "parent TriplesMap {} has no table name",
+                            rom.parent_triples_map
+                        )
+                    })?
+                    .to_string();
+                for jc in &rom.join_conditions {
+                    compiled_fks.insert((
+                        compiled_tm.table_name().unwrap_or_default().to_string(),
+                        jc.child_column.clone(),
+                        parent_table.clone(),
+                        jc.parent_column.clone(),
+                    ));
+                }
+            }
+        }
+    }
+
+    if structured_fks != compiled_fks {
+        let missing: Vec<_> = structured_fks.difference(&compiled_fks).collect();
+        let extra: Vec<_> = compiled_fks.difference(&structured_fks).collect();
+        return Err(format!(
+            "FK graph mismatch: in-IR-not-compiled {missing:?}; in-compiled-not-IR {extra:?}"
+        ));
+    }
+
+    Ok(())
+}

--- a/fluree-db-r2rml/src/emit/mod.rs
+++ b/fluree-db-r2rml/src/emit/mod.rs
@@ -31,8 +31,12 @@ mod fixtures;
 mod tests;
 
 pub use diagnostic::{DiagCode, Diagnostic, Severity};
-pub use input::{EmitColumn, EmitColumnStats, EmitTableSchema, TypedBound};
+pub use input::{
+    EmitColumn, EmitColumnStats, EmitTableSchema, TableKey, TableOverride, TypedBound,
+};
 pub use ir::{ColumnMapping, ForeignKey, PrefixDecl, StructuredR2rmlMapping, TableMapping};
+
+use std::collections::HashMap;
 
 /// Emitter configuration. Every field is a pure knob — identical options plus
 /// identical inputs yield byte-identical output.
@@ -54,6 +58,11 @@ pub struct EmitOptions {
     /// Keep resolved-FK key columns as literal predicate-object maps too
     /// (pushdown-friendly).
     pub keep_fk_keys_as_literals: bool,
+    /// Per-table subject-key / class-name overrides, keyed on the table's
+    /// `{namespace, name}` identity (PR-1's `per_table_overrides`). Default empty
+    /// — an empty map is a strict no-op, leaving every stem-derived default and
+    /// the byte-for-byte output unchanged.
+    pub per_table_overrides: HashMap<TableKey, TableOverride>,
 }
 
 impl EmitOptions {
@@ -75,6 +84,7 @@ impl Default for EmitOptions {
             xsd_long_as_integer: true,
             emit_fk_joins: true,
             keep_fk_keys_as_literals: true,
+            per_table_overrides: HashMap::new(),
         }
     }
 }

--- a/fluree-db-r2rml/src/emit/mod.rs
+++ b/fluree-db-r2rml/src/emit/mod.rs
@@ -22,7 +22,9 @@ pub mod input;
 pub mod ir;
 
 mod heuristic;
-mod naming;
+// `naming` is public so the api-side preview lane can call the canonical
+// `naming::xsd_datatype` map instead of duplicating it (single source of truth).
+pub mod naming;
 mod render;
 
 #[cfg(test)]

--- a/fluree-db-r2rml/src/emit/naming.rs
+++ b/fluree-db-r2rml/src/emit/naming.rs
@@ -1,0 +1,230 @@
+//! Pure, deterministic naming derivations: identifier case conversions, the
+//! `FieldType` → `xsd:` datatype map, and the single-`base_namespace` → two-base
+//! IRI derivation. Every function here is total and side-effect-free so that
+//! identical input yields byte-identical output.
+
+use fluree_db_tabular::FieldType;
+
+/// Split a Snowflake `UPPER_SNAKE` identifier into its `_`-separated words,
+/// dropping empty segments.
+fn words(ident: &str) -> Vec<&str> {
+    ident.split('_').filter(|w| !w.is_empty()).collect()
+}
+
+/// Capitalize the first character and lowercase the rest of an ASCII word.
+fn capitalize(word: &str) -> String {
+    let mut chars = word.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => {
+            let mut out = first.to_ascii_uppercase().to_string();
+            out.push_str(&chars.as_str().to_ascii_lowercase());
+            out
+        }
+    }
+}
+
+/// `DIM_ORDER_LINE` → `DimOrderLine` (PascalCase over `_`-separated words).
+pub fn pascal_case(ident: &str) -> String {
+    words(ident).into_iter().map(capitalize).collect()
+}
+
+/// `GEOGRAPHY_KEY` → `geographyKey` (camelCase: first word lowercased).
+pub fn camel_case(ident: &str) -> String {
+    let mut out = String::new();
+    for (i, word) in words(ident).into_iter().enumerate() {
+        if i == 0 {
+            out.push_str(&word.to_ascii_lowercase());
+        } else {
+            out.push_str(&capitalize(word));
+        }
+    }
+    out
+}
+
+/// `ORDER_LINE` → `order-line` (kebab-case, lowercased).
+pub fn kebab_case(ident: &str) -> String {
+    words(ident)
+        .into_iter()
+        .map(str::to_ascii_lowercase)
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+/// Strip a leading `DIM_` / `FACT_` dimension/fact marker from a table stem.
+///
+/// `DIM_GEOGRAPHY` → `GEOGRAPHY`, `FACT_ORDER_LINE` → `ORDER_LINE`, and any stem
+/// without a recognized marker is returned unchanged.
+pub fn strip_table_marker(stem: &str) -> &str {
+    stem.strip_prefix("DIM_")
+        .or_else(|| stem.strip_prefix("FACT_"))
+        .unwrap_or(stem)
+}
+
+/// The TriplesMap node local name for a table stem (`DIM_DATE` → `DimDate`).
+pub fn triples_map_node(stem: &str) -> String {
+    pascal_case(stem)
+}
+
+/// The class local name for a table stem (`DIM_GEOGRAPHY` → `Geography`,
+/// `FACT_ORDER` → `Order`).
+pub fn class_local_name(stem: &str) -> String {
+    pascal_case(strip_table_marker(stem))
+}
+
+/// The subject-template slug for a table stem (`DIM_GEOGRAPHY` → `geography`,
+/// `FACT_ORDER_LINE` → `order-line`).
+pub fn class_slug(stem: &str) -> String {
+    kebab_case(strip_table_marker(stem))
+}
+
+/// Strip a trailing `_KEY` / `_ID` from a key column name, for readable
+/// relationship predicate derivation (`DEST_GEOGRAPHY_KEY` → `DEST_GEOGRAPHY`).
+/// A bare `KEY` / `ID` (nothing left after stripping) is returned unchanged.
+pub fn strip_key_suffix(column: &str) -> &str {
+    for suffix in ["_KEY", "_ID"] {
+        if let Some(stem) = column.strip_suffix(suffix) {
+            if !stem.is_empty() {
+                return stem;
+            }
+        }
+    }
+    column
+}
+
+/// The `xsd:` datatype CURIE for a `FieldType`, or `None` for strings (plain
+/// literal) — matching `enterprise.ttl` and the lexical output of
+/// `materialize/term.rs`.
+///
+/// `xsd_long_as_integer` (default `true`) picks `xsd:integer` for `Int32`/`Int64`
+/// to match the reference; `false` uses `xsd:int` / `xsd:long`. Both share the
+/// decimal-string lexical space, so either round-trips.
+///
+/// `Bytes` maps to **`xsd:hexBinary`** — `term.rs`'s `base64_encode` is a
+/// misnomer that emits lowercase hex, so hex is the datatype whose lexical space
+/// matches the materializer (guarded by a regression test).
+pub fn xsd_datatype(field_type: FieldType, xsd_long_as_integer: bool) -> Option<&'static str> {
+    let curie = match field_type {
+        FieldType::Boolean => "xsd:boolean",
+        FieldType::Int32 => {
+            if xsd_long_as_integer {
+                "xsd:integer"
+            } else {
+                "xsd:int"
+            }
+        }
+        FieldType::Int64 => {
+            if xsd_long_as_integer {
+                "xsd:integer"
+            } else {
+                "xsd:long"
+            }
+        }
+        FieldType::Float32 => "xsd:float",
+        FieldType::Float64 => "xsd:double",
+        FieldType::Decimal { .. } => "xsd:decimal",
+        FieldType::Date => "xsd:date",
+        FieldType::Timestamp | FieldType::TimestampTz => "xsd:dateTime",
+        FieldType::Bytes => "xsd:hexBinary",
+        FieldType::String => return None,
+    };
+    Some(curie)
+}
+
+/// Derive the subject-IRI base from the single `base_namespace`.
+///
+/// A trailing `#` is normalized to `/`; otherwise `/` is appended unless the
+/// base already ends in `/`. `http://x/edw#` → `http://x/edw/`.
+pub fn subject_base(base_namespace: &str) -> String {
+    if let Some(stripped) = base_namespace.strip_suffix('#') {
+        format!("{stripped}/")
+    } else if base_namespace.ends_with('/') {
+        base_namespace.to_string()
+    } else {
+        format!("{base_namespace}/")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn case_conversions() {
+        assert_eq!(pascal_case("DIM_DATE"), "DimDate");
+        assert_eq!(pascal_case("FACT_ORDER_LINE"), "FactOrderLine");
+        assert_eq!(pascal_case("GL_JOURNAL"), "GlJournal");
+        assert_eq!(camel_case("GEOGRAPHY_KEY"), "geographyKey");
+        assert_eq!(camel_case("DAY_OF_WEEK"), "dayOfWeek");
+        assert_eq!(camel_case("IS_WEEKEND"), "isWeekend");
+        assert_eq!(camel_case("DATE"), "date");
+        assert_eq!(kebab_case("ORDER_LINE"), "order-line");
+        assert_eq!(kebab_case("INVENTORY_SNAPSHOT"), "inventory-snapshot");
+    }
+
+    #[test]
+    fn table_stem_derivations() {
+        assert_eq!(strip_table_marker("DIM_GEOGRAPHY"), "GEOGRAPHY");
+        assert_eq!(strip_table_marker("FACT_ORDER_LINE"), "ORDER_LINE");
+        assert_eq!(strip_table_marker("WEATHER"), "WEATHER");
+        assert_eq!(triples_map_node("DIM_DATE"), "DimDate");
+        assert_eq!(triples_map_node("FACT_ORDER_LINE"), "FactOrderLine");
+        assert_eq!(class_local_name("DIM_GEOGRAPHY"), "Geography");
+        assert_eq!(class_local_name("FACT_ORDER"), "Order");
+        assert_eq!(class_slug("DIM_DATE"), "date");
+        assert_eq!(class_slug("FACT_ORDER_LINE"), "order-line");
+    }
+
+    #[test]
+    fn key_suffix_stripping() {
+        assert_eq!(strip_key_suffix("DEST_GEOGRAPHY_KEY"), "DEST_GEOGRAPHY");
+        assert_eq!(strip_key_suffix("GEOGRAPHY_KEY"), "GEOGRAPHY");
+        assert_eq!(strip_key_suffix("SESSION_ID"), "SESSION");
+        assert_eq!(strip_key_suffix("KEY"), "KEY");
+    }
+
+    #[test]
+    fn datatype_map_pins_hexbinary_and_datetime() {
+        // The load-bearing cases: bytes are hex (not base64), both timestamp
+        // flavors are dateTime, strings are untyped.
+        assert_eq!(xsd_datatype(FieldType::Bytes, true), Some("xsd:hexBinary"));
+        assert_eq!(
+            xsd_datatype(FieldType::Timestamp, true),
+            Some("xsd:dateTime")
+        );
+        assert_eq!(
+            xsd_datatype(FieldType::TimestampTz, true),
+            Some("xsd:dateTime")
+        );
+        assert_eq!(xsd_datatype(FieldType::String, true), None);
+        assert_eq!(xsd_datatype(FieldType::Boolean, true), Some("xsd:boolean"));
+        assert_eq!(xsd_datatype(FieldType::Float64, true), Some("xsd:double"));
+        assert_eq!(xsd_datatype(FieldType::Float32, true), Some("xsd:float"));
+        assert_eq!(
+            xsd_datatype(
+                FieldType::Decimal {
+                    precision: 18,
+                    scale: 2
+                },
+                true
+            ),
+            Some("xsd:decimal")
+        );
+        assert_eq!(xsd_datatype(FieldType::Date, true), Some("xsd:date"));
+    }
+
+    #[test]
+    fn long_as_integer_knob() {
+        assert_eq!(xsd_datatype(FieldType::Int64, true), Some("xsd:integer"));
+        assert_eq!(xsd_datatype(FieldType::Int32, true), Some("xsd:integer"));
+        assert_eq!(xsd_datatype(FieldType::Int64, false), Some("xsd:long"));
+        assert_eq!(xsd_datatype(FieldType::Int32, false), Some("xsd:int"));
+    }
+
+    #[test]
+    fn subject_base_derivation() {
+        assert_eq!(subject_base("http://x/edw#"), "http://x/edw/");
+        assert_eq!(subject_base("http://x/edw/"), "http://x/edw/");
+        assert_eq!(subject_base("http://x/edw"), "http://x/edw/");
+    }
+}

--- a/fluree-db-r2rml/src/emit/render.rs
+++ b/fluree-db-r2rml/src/emit/render.rs
@@ -20,9 +20,16 @@ pub fn render_turtle(mapping: &StructuredR2rmlMapping, opts: &EmitOptions) -> St
     let vocab_prefix = mapping.vocab_prefix();
 
     // -- Header: @base then @prefix declarations, in IR order. --
-    let mut header = format!("@base <{}> .\n", opts.map_document_base);
+    // The `@base` / `@prefix` IRIs bypass `curie()`, so escape them here too: the
+    // vocab prefix's namespace IS the request-controlled `base_namespace`, and an
+    // unescaped newline/`>` would otherwise inject arbitrary Turtle statements.
+    let mut header = format!("@base <{}> .\n", escape_iri(&opts.map_document_base));
     for p in &mapping.prefixes {
-        header.push_str(&format!("@prefix {}: <{}> .\n", p.prefix, p.namespace));
+        header.push_str(&format!(
+            "@prefix {}: <{}> .\n",
+            p.prefix,
+            escape_iri(&p.namespace)
+        ));
     }
 
     // -- One block per table. --

--- a/fluree-db-r2rml/src/emit/render.rs
+++ b/fluree-db-r2rml/src/emit/render.rs
@@ -1,0 +1,108 @@
+//! Deterministic `StructuredR2rmlMapping` → Turtle renderer.
+//!
+//! The Turtle is rendered FROM the authoritative IR (never the other way): one
+//! `@base` + `@prefix` header, then one block per table in IR order, columns in
+//! IR order. Exact column/table casing is preserved; predicate and class IRIs
+//! are emitted as prefixed names against the vocab prefix. Output is a pure
+//! function of the IR + options, so two runs are byte-identical.
+//!
+//! TriplesMap node IRIs and `rr:parentTriplesMap` references both use the same
+//! `<#PascalCaseStem>` relative form, so they resolve against `@base` to the
+//! same absolute IRI and the round-trip join graph reconnects.
+
+use crate::emit::ir::{ColumnMapping, StructuredR2rmlMapping, TableMapping};
+use crate::emit::naming;
+use crate::emit::EmitOptions;
+
+/// Render the mapping to a Turtle document.
+pub fn render_turtle(mapping: &StructuredR2rmlMapping, opts: &EmitOptions) -> String {
+    let base = &mapping.base_namespace;
+    let vocab_prefix = mapping.vocab_prefix();
+
+    // -- Header: @base then @prefix declarations, in IR order. --
+    let mut header = format!("@base <{}> .\n", opts.map_document_base);
+    for p in &mapping.prefixes {
+        header.push_str(&format!("@prefix {}: <{}> .\n", p.prefix, p.namespace));
+    }
+
+    // -- One block per table. --
+    let blocks: Vec<String> = mapping
+        .table_mappings
+        .iter()
+        .map(|tm| render_table(tm, base, vocab_prefix))
+        .collect();
+
+    format!("{}\n{}\n", header, blocks.join("\n\n"))
+}
+
+/// Render a single TriplesMap block.
+fn render_table(tm: &TableMapping, base: &str, vocab_prefix: &str) -> String {
+    let node = tm_node_for_table(&tm.table_name);
+
+    let mut stmts: Vec<String> = Vec::with_capacity(tm.columns.len() + 2);
+    stmts.push(format!(
+        "rr:logicalTable [ rr:tableName \"{}\" ]",
+        tm.table_name
+    ));
+    stmts.push(render_subject(tm, base, vocab_prefix));
+    for col in &tm.columns {
+        stmts.push(render_pom(col, base, vocab_prefix));
+    }
+
+    format!("<#{node}> a rr:TriplesMap ;\n  {} .", stmts.join(" ;\n  "))
+}
+
+/// Render the `rr:subjectMap`. Falls back to a class-only subject map when no
+/// safe subject key was found (an edge case flagged by `NoSafeSubjectKey`).
+fn render_subject(tm: &TableMapping, base: &str, vocab_prefix: &str) -> String {
+    let class = curie(&tm.class_iri, base, vocab_prefix);
+    if tm.subject_template.is_empty() {
+        format!("rr:subjectMap [ rr:class {class} ]")
+    } else {
+        format!(
+            "rr:subjectMap [ rr:template \"{}\" ; rr:class {class} ]",
+            tm.subject_template
+        )
+    }
+}
+
+/// Render one predicate-object mapping — a join when `foreign_key` is set, a
+/// literal otherwise.
+fn render_pom(col: &ColumnMapping, base: &str, vocab_prefix: &str) -> String {
+    let predicate = curie(&col.predicate_iri, base, vocab_prefix);
+
+    if let Some(fk) = &col.foreign_key {
+        let parent_node = tm_node_for_table(&fk.target_table);
+        format!(
+            "rr:predicateObjectMap [ rr:predicate {predicate} ;\n    rr:objectMap [ \
+             rr:parentTriplesMap <#{parent_node}> ; rr:joinCondition [ rr:child \"{}\" ; \
+             rr:parent \"{}\" ] ] ]",
+            fk.child_column, fk.parent_column
+        )
+    } else {
+        let datatype_clause = col
+            .datatype
+            .as_ref()
+            .map(|dt| format!(" ; rr:datatype {dt}"))
+            .unwrap_or_default();
+        format!(
+            "rr:predicateObjectMap [ rr:predicate {predicate} ; rr:objectMap [ rr:column \"{}\"{} ] ]",
+            col.column_name, datatype_clause
+        )
+    }
+}
+
+/// The `<#PascalCaseStem>` TriplesMap node local name for a logical table name.
+fn tm_node_for_table(table_name: &str) -> String {
+    let stem = table_name.rsplit('.').next().unwrap_or(table_name);
+    naming::triples_map_node(stem)
+}
+
+/// Render a full IRI as a prefixed name against the vocab base, or as an
+/// absolute `<IRI>` if it does not sit under that base.
+fn curie(iri: &str, base: &str, vocab_prefix: &str) -> String {
+    match iri.strip_prefix(base) {
+        Some(local) => format!("{vocab_prefix}:{local}"),
+        None => format!("<{iri}>"),
+    }
+}

--- a/fluree-db-r2rml/src/emit/render.rs
+++ b/fluree-db-r2rml/src/emit/render.rs
@@ -42,14 +42,18 @@ fn render_table(tm: &TableMapping, base: &str, vocab_prefix: &str) -> String {
     let mut stmts: Vec<String> = Vec::with_capacity(tm.columns.len() + 2);
     stmts.push(format!(
         "rr:logicalTable [ rr:tableName \"{}\" ]",
-        tm.table_name
+        escape_turtle_string(&tm.table_name)
     ));
     stmts.push(render_subject(tm, base, vocab_prefix));
     for col in &tm.columns {
         stmts.push(render_pom(col, base, vocab_prefix));
     }
 
-    format!("<#{node}> a rr:TriplesMap ;\n  {} .", stmts.join(" ;\n  "))
+    format!(
+        "<#{}> a rr:TriplesMap ;\n  {} .",
+        escape_iri(&node),
+        stmts.join(" ;\n  ")
+    )
 }
 
 /// Render the `rr:subjectMap`. Falls back to a class-only subject map when no
@@ -61,7 +65,7 @@ fn render_subject(tm: &TableMapping, base: &str, vocab_prefix: &str) -> String {
     } else {
         format!(
             "rr:subjectMap [ rr:template \"{}\" ; rr:class {class} ]",
-            tm.subject_template
+            escape_turtle_string(&tm.subject_template)
         )
     }
 }
@@ -75,9 +79,11 @@ fn render_pom(col: &ColumnMapping, base: &str, vocab_prefix: &str) -> String {
         let parent_node = tm_node_for_table(&fk.target_table);
         format!(
             "rr:predicateObjectMap [ rr:predicate {predicate} ;\n    rr:objectMap [ \
-             rr:parentTriplesMap <#{parent_node}> ; rr:joinCondition [ rr:child \"{}\" ; \
+             rr:parentTriplesMap <#{}> ; rr:joinCondition [ rr:child \"{}\" ; \
              rr:parent \"{}\" ] ] ]",
-            fk.child_column, fk.parent_column
+            escape_iri(&parent_node),
+            escape_turtle_string(&fk.child_column),
+            escape_turtle_string(&fk.parent_column)
         )
     } else {
         let datatype_clause = col
@@ -87,7 +93,7 @@ fn render_pom(col: &ColumnMapping, base: &str, vocab_prefix: &str) -> String {
             .unwrap_or_default();
         format!(
             "rr:predicateObjectMap [ rr:predicate {predicate} ; rr:objectMap [ rr:column \"{}\"{} ] ]",
-            col.column_name, datatype_clause
+            escape_turtle_string(&col.column_name), datatype_clause
         )
     }
 }
@@ -99,10 +105,143 @@ fn tm_node_for_table(table_name: &str) -> String {
 }
 
 /// Render a full IRI as a prefixed name against the vocab base, or as an
-/// absolute `<IRI>` if it does not sit under that base.
+/// absolute `<IRI>` otherwise.
+///
+/// A prefixed name is emitted ONLY when the local part is a safe `PN_LOCAL`
+/// (see [`is_safe_pn_local`]); anything else — an IRI outside the vocab base, or
+/// a base-relative local carrying characters that are illegal or injection-prone
+/// in a prefixed name (e.g. a class-name override with a quote) — falls back to
+/// the escaped absolute `<IRI>` form, which is always valid Turtle.
 fn curie(iri: &str, base: &str, vocab_prefix: &str) -> String {
-    match iri.strip_prefix(base) {
-        Some(local) => format!("{vocab_prefix}:{local}"),
-        None => format!("<{iri}>"),
+    if let Some(local) = iri.strip_prefix(base) {
+        if is_safe_pn_local(local) {
+            return format!("{vocab_prefix}:{local}");
+        }
+    }
+    format!("<{}>", escape_iri(iri))
+}
+
+/// Escape a string for use inside a Turtle `"..."` (`STRING_LITERAL_QUOTE`)
+/// literal: backslash, double-quote, and C0/DEL control characters. This is what
+/// keeps an adversarial catalog identifier from either breaking the parse or
+/// injecting extra predicate-object maps (a bare `"` would close `rr:column`).
+/// A string free of these characters is returned unchanged, so ordinary
+/// identifiers render byte-for-byte as before.
+fn escape_turtle_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0C}' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 || c as u32 == 0x7F => {
+                out.push_str(&format!("\\u{:04X}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Escape a string for use inside a Turtle `<...>` `IRIREF`: every character the
+/// grammar forbids raw (`< > " { } | ^ \` `` ` ``, space, and control chars)
+/// becomes a `\uXXXX` escape. An IRI free of these is returned unchanged.
+fn escape_iri(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '<' | '>' | '"' | '{' | '}' | '|' | '^' | '`' | '\\' => {
+                out.push_str(&format!("\\u{:04X}", c as u32));
+            }
+            c if (c as u32) <= 0x20 || c as u32 == 0x7F => {
+                out.push_str(&format!("\\u{:04X}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Whether `local` is safe to emit verbatim as a prefixed-name local part.
+///
+/// A deliberately conservative subset of `PN_LOCAL` — ASCII letters, digits and
+/// `_`, with a letter/`_` first character — every member of which is a valid
+/// `PN_LOCAL`. Anything it rejects (punctuation, quotes, leading digits, empty)
+/// falls back to the always-valid escaped `<IRI>` form in [`curie`]. This admits
+/// every deterministic camelCase/PascalCase local the emitter produces, so the
+/// prefixed output is unchanged for normal input.
+fn is_safe_pn_local(local: &str) -> bool {
+    let mut chars = local.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    local.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_turtle_string_is_noop_for_ordinary_identifiers() {
+        assert_eq!(escape_turtle_string("DW.DIM_DATE"), "DW.DIM_DATE");
+        assert_eq!(escape_turtle_string("GEOGRAPHY_KEY"), "GEOGRAPHY_KEY");
+    }
+
+    #[test]
+    fn escape_turtle_string_escapes_quotes_backslash_and_controls() {
+        assert_eq!(escape_turtle_string("a\"b"), "a\\\"b");
+        assert_eq!(escape_turtle_string("a\\b"), "a\\\\b");
+        assert_eq!(escape_turtle_string("a\nb\tc\rd"), "a\\nb\\tc\\rd");
+        // A bare NUL becomes a \u escape, not a raw control byte.
+        assert_eq!(escape_turtle_string("a\u{0}b"), "a\\u0000b");
+    }
+
+    #[test]
+    fn escape_iri_is_noop_for_ordinary_iris() {
+        let iri = "http://ns.fluree.dev/edw#geographyKey";
+        assert_eq!(escape_iri(iri), iri);
+    }
+
+    #[test]
+    fn escape_iri_escapes_delimiters_and_spaces() {
+        assert_eq!(escape_iri("a>b"), "a\\u003Eb");
+        assert_eq!(escape_iri("a b"), "a\\u0020b");
+        assert_eq!(escape_iri("a\"b"), "a\\u0022b");
+        assert_eq!(escape_iri("a\\b"), "a\\u005Cb");
+    }
+
+    #[test]
+    fn safe_pn_local_accepts_camel_and_pascal_case() {
+        assert!(is_safe_pn_local("geographyKey"));
+        assert!(is_safe_pn_local("DimDate"));
+        assert!(is_safe_pn_local("Order"));
+        assert!(is_safe_pn_local("_private"));
+    }
+
+    #[test]
+    fn safe_pn_local_rejects_injection_and_leading_digit() {
+        assert!(!is_safe_pn_local(""));
+        assert!(!is_safe_pn_local("2023Revenue")); // leading digit → full-IRI form
+        assert!(!is_safe_pn_local("has space"));
+        assert!(!is_safe_pn_local("has\"quote"));
+        assert!(!is_safe_pn_local("a.b")); // dot → full-IRI form
+    }
+
+    #[test]
+    fn curie_falls_back_to_escaped_iri_for_unsafe_local() {
+        let base = "http://ns.fluree.dev/edw#";
+        // Safe local → prefixed name (byte-for-byte as before).
+        assert_eq!(curie(&format!("{base}Geography"), base, "v"), "v:Geography");
+        // Unsafe local (injected quote) → escaped absolute IRI, never `v:..."`.
+        let hostile = format!("{base}Ev\"il");
+        let rendered = curie(&hostile, base, "v");
+        assert_eq!(rendered, "<http://ns.fluree.dev/edw#Ev\\u0022il>");
+        assert!(!rendered.contains('"'));
     }
 }

--- a/fluree-db-r2rml/src/emit/testdata/enterprise_default.ttl
+++ b/fluree-db-r2rml/src/emit/testdata/enterprise_default.ttl
@@ -1,0 +1,293 @@
+@base <http://mapping.fluree.dev/r2rml> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix v: <http://ns.fluree.dev/edw#> .
+
+<#DimDate> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.DIM_DATE" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/date/{DATE_KEY}" ; rr:class v:Date ] ;
+  rr:predicateObjectMap [ rr:predicate v:dateKey ; rr:objectMap [ rr:column "DATE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:date ; rr:objectMap [ rr:column "DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:dayOfWeek ; rr:objectMap [ rr:column "DAY_OF_WEEK" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:dayName ; rr:objectMap [ rr:column "DAY_NAME" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:dayOfMonth ; rr:objectMap [ rr:column "DAY_OF_MONTH" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:weekOfYear ; rr:objectMap [ rr:column "WEEK_OF_YEAR" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:monthNum ; rr:objectMap [ rr:column "MONTH_NUM" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:monthName ; rr:objectMap [ rr:column "MONTH_NAME" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:quarterNum ; rr:objectMap [ rr:column "QUARTER_NUM" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:yearNum ; rr:objectMap [ rr:column "YEAR_NUM" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:isWeekend ; rr:objectMap [ rr:column "IS_WEEKEND" ; rr:datatype xsd:boolean ] ] .
+
+<#DimGeography> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.DIM_GEOGRAPHY" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/geography/{GEOGRAPHY_KEY}" ; rr:class v:Geography ] ;
+  rr:predicateObjectMap [ rr:predicate v:geographyKey ; rr:objectMap [ rr:column "GEOGRAPHY_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:countryCode ; rr:objectMap [ rr:column "COUNTRY_CODE" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:country ; rr:objectMap [ rr:column "COUNTRY" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:region ; rr:objectMap [ rr:column "REGION" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:stateProvince ; rr:objectMap [ rr:column "STATE_PROVINCE" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:city ; rr:objectMap [ rr:column "CITY" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:postalCode ; rr:objectMap [ rr:column "POSTAL_CODE" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:latitude ; rr:objectMap [ rr:column "LATITUDE" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:longitude ; rr:objectMap [ rr:column "LONGITUDE" ; rr:datatype xsd:double ] ] .
+
+<#DimSupplier> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.DIM_SUPPLIER" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/supplier/{SUPPLIER_KEY}" ; rr:class v:Supplier ] ;
+  rr:predicateObjectMap [ rr:predicate v:supplierKey ; rr:objectMap [ rr:column "SUPPLIER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:supplierId ; rr:objectMap [ rr:column "SUPPLIER_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:supplierName ; rr:objectMap [ rr:column "SUPPLIER_NAME" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:contactEmail ; rr:objectMap [ rr:column "CONTACT_EMAIL" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:leadTimeDays ; rr:objectMap [ rr:column "LEAD_TIME_DAYS" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:rating ; rr:objectMap [ rr:column "RATING" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:geographyKey ; rr:objectMap [ rr:column "GEOGRAPHY_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:geography ;
+    rr:objectMap [ rr:parentTriplesMap <#DimGeography> ; rr:joinCondition [ rr:child "GEOGRAPHY_KEY" ; rr:parent "GEOGRAPHY_KEY" ] ] ] .
+
+<#DimAccount> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.DIM_ACCOUNT" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/account/{ACCOUNT_KEY}" ; rr:class v:Account ] ;
+  rr:predicateObjectMap [ rr:predicate v:accountKey ; rr:objectMap [ rr:column "ACCOUNT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:accountId ; rr:objectMap [ rr:column "ACCOUNT_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:accountName ; rr:objectMap [ rr:column "ACCOUNT_NAME" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:industry ; rr:objectMap [ rr:column "INDUSTRY" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:employeeCount ; rr:objectMap [ rr:column "EMPLOYEE_COUNT" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:annualRevenue ; rr:objectMap [ rr:column "ANNUAL_REVENUE" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:tier ; rr:objectMap [ rr:column "TIER" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:createdDate ; rr:objectMap [ rr:column "CREATED_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:geographyKey ; rr:objectMap [ rr:column "GEOGRAPHY_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:geography ;
+    rr:objectMap [ rr:parentTriplesMap <#DimGeography> ; rr:joinCondition [ rr:child "GEOGRAPHY_KEY" ; rr:parent "GEOGRAPHY_KEY" ] ] ] .
+
+<#DimEmployee> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.DIM_EMPLOYEE" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/employee/{EMPLOYEE_KEY}" ; rr:class v:Employee ] ;
+  rr:predicateObjectMap [ rr:predicate v:employeeKey ; rr:objectMap [ rr:column "EMPLOYEE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:employeeId ; rr:objectMap [ rr:column "EMPLOYEE_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:fullName ; rr:objectMap [ rr:column "FULL_NAME" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:email ; rr:objectMap [ rr:column "EMAIL" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:role ; rr:objectMap [ rr:column "ROLE" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:department ; rr:objectMap [ rr:column "DEPARTMENT" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:hireDate ; rr:objectMap [ rr:column "HIRE_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:isActive ; rr:objectMap [ rr:column "IS_ACTIVE" ; rr:datatype xsd:boolean ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:storeKey ; rr:objectMap [ rr:column "STORE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:managerKey ; rr:objectMap [ rr:column "MANAGER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:store ;
+    rr:objectMap [ rr:parentTriplesMap <#DimStore> ; rr:joinCondition [ rr:child "STORE_KEY" ; rr:parent "STORE_KEY" ] ] ] .
+
+<#DimStore> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.DIM_STORE" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/store/{STORE_KEY}" ; rr:class v:Store ] ;
+  rr:predicateObjectMap [ rr:predicate v:storeKey ; rr:objectMap [ rr:column "STORE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:storeId ; rr:objectMap [ rr:column "STORE_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:storeName ; rr:objectMap [ rr:column "STORE_NAME" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:channel ; rr:objectMap [ rr:column "CHANNEL" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:storeType ; rr:objectMap [ rr:column "STORE_TYPE" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:openDate ; rr:objectMap [ rr:column "OPEN_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:geographyKey ; rr:objectMap [ rr:column "GEOGRAPHY_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:regionManagerKey ; rr:objectMap [ rr:column "REGION_MANAGER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:geography ;
+    rr:objectMap [ rr:parentTriplesMap <#DimGeography> ; rr:joinCondition [ rr:child "GEOGRAPHY_KEY" ; rr:parent "GEOGRAPHY_KEY" ] ] ] .
+
+<#DimCustomer> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.DIM_CUSTOMER" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/customer/{CUSTOMER_KEY}" ; rr:class v:Customer ] ;
+  rr:predicateObjectMap [ rr:predicate v:customerKey ; rr:objectMap [ rr:column "CUSTOMER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:customerId ; rr:objectMap [ rr:column "CUSTOMER_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:fullName ; rr:objectMap [ rr:column "FULL_NAME" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:email ; rr:objectMap [ rr:column "EMAIL" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:phone ; rr:objectMap [ rr:column "PHONE" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:segment ; rr:objectMap [ rr:column "SEGMENT" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:gender ; rr:objectMap [ rr:column "GENDER" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:birthYear ; rr:objectMap [ rr:column "BIRTH_YEAR" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:signupDate ; rr:objectMap [ rr:column "SIGNUP_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:scdValidFrom ; rr:objectMap [ rr:column "SCD_VALID_FROM" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:scdValidTo ; rr:objectMap [ rr:column "SCD_VALID_TO" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:isCurrent ; rr:objectMap [ rr:column "IS_CURRENT" ; rr:datatype xsd:boolean ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:geographyKey ; rr:objectMap [ rr:column "GEOGRAPHY_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:accountKey ; rr:objectMap [ rr:column "ACCOUNT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:geography ;
+    rr:objectMap [ rr:parentTriplesMap <#DimGeography> ; rr:joinCondition [ rr:child "GEOGRAPHY_KEY" ; rr:parent "GEOGRAPHY_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:account ;
+    rr:objectMap [ rr:parentTriplesMap <#DimAccount> ; rr:joinCondition [ rr:child "ACCOUNT_KEY" ; rr:parent "ACCOUNT_KEY" ] ] ] .
+
+<#DimProduct> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.DIM_PRODUCT" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/product/{PRODUCT_KEY}" ; rr:class v:Product ] ;
+  rr:predicateObjectMap [ rr:predicate v:productKey ; rr:objectMap [ rr:column "PRODUCT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:productId ; rr:objectMap [ rr:column "PRODUCT_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:productName ; rr:objectMap [ rr:column "PRODUCT_NAME" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:brand ; rr:objectMap [ rr:column "BRAND" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:category ; rr:objectMap [ rr:column "CATEGORY" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:subcategory ; rr:objectMap [ rr:column "SUBCATEGORY" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:department ; rr:objectMap [ rr:column "DEPARTMENT" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:unitCost ; rr:objectMap [ rr:column "UNIT_COST" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:listPrice ; rr:objectMap [ rr:column "LIST_PRICE" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:isCurrent ; rr:objectMap [ rr:column "IS_CURRENT" ; rr:datatype xsd:boolean ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:supplierKey ; rr:objectMap [ rr:column "SUPPLIER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:supplier ;
+    rr:objectMap [ rr:parentTriplesMap <#DimSupplier> ; rr:joinCondition [ rr:child "SUPPLIER_KEY" ; rr:parent "SUPPLIER_KEY" ] ] ] .
+
+<#FactOrder> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.FACT_ORDER" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/order/{ORDER_KEY}" ; rr:class v:Order ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderKey ; rr:objectMap [ rr:column "ORDER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderId ; rr:objectMap [ rr:column "ORDER_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderStatus ; rr:objectMap [ rr:column "ORDER_STATUS" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderChannel ; rr:objectMap [ rr:column "ORDER_CHANNEL" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderTotal ; rr:objectMap [ rr:column "ORDER_TOTAL" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:currency ; rr:objectMap [ rr:column "CURRENCY" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderDate ; rr:objectMap [ rr:column "ORDER_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:customerKey ; rr:objectMap [ rr:column "CUSTOMER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:accountKey ; rr:objectMap [ rr:column "ACCOUNT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:storeKey ; rr:objectMap [ rr:column "STORE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:salesRepKey ; rr:objectMap [ rr:column "SALES_REP_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderDateKey ; rr:objectMap [ rr:column "ORDER_DATE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:customer ;
+    rr:objectMap [ rr:parentTriplesMap <#DimCustomer> ; rr:joinCondition [ rr:child "CUSTOMER_KEY" ; rr:parent "CUSTOMER_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:account ;
+    rr:objectMap [ rr:parentTriplesMap <#DimAccount> ; rr:joinCondition [ rr:child "ACCOUNT_KEY" ; rr:parent "ACCOUNT_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:store ;
+    rr:objectMap [ rr:parentTriplesMap <#DimStore> ; rr:joinCondition [ rr:child "STORE_KEY" ; rr:parent "STORE_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderDateRef ;
+    rr:objectMap [ rr:parentTriplesMap <#DimDate> ; rr:joinCondition [ rr:child "ORDER_DATE_KEY" ; rr:parent "DATE_KEY" ] ] ] .
+
+<#FactOrderLine> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.FACT_ORDER_LINE" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/order-line/{ORDER_LINE_KEY}" ; rr:class v:OrderLine ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderLineKey ; rr:objectMap [ rr:column "ORDER_LINE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:lineNumber ; rr:objectMap [ rr:column "LINE_NUMBER" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:quantity ; rr:objectMap [ rr:column "QUANTITY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:unitPrice ; rr:objectMap [ rr:column "UNIT_PRICE" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:discountPct ; rr:objectMap [ rr:column "DISCOUNT_PCT" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:extendedAmount ; rr:objectMap [ rr:column "EXTENDED_AMOUNT" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderDate ; rr:objectMap [ rr:column "ORDER_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderKey ; rr:objectMap [ rr:column "ORDER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:productKey ; rr:objectMap [ rr:column "PRODUCT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:order ;
+    rr:objectMap [ rr:parentTriplesMap <#FactOrder> ; rr:joinCondition [ rr:child "ORDER_KEY" ; rr:parent "ORDER_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:product ;
+    rr:objectMap [ rr:parentTriplesMap <#DimProduct> ; rr:joinCondition [ rr:child "PRODUCT_KEY" ; rr:parent "PRODUCT_KEY" ] ] ] .
+
+<#FactInventorySnapshot> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.FACT_INVENTORY_SNAPSHOT" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/inventory-snapshot/{INVENTORY_KEY}" ; rr:class v:InventorySnapshot ] ;
+  rr:predicateObjectMap [ rr:predicate v:inventoryKey ; rr:objectMap [ rr:column "INVENTORY_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:snapshotDate ; rr:objectMap [ rr:column "SNAPSHOT_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:onHandQty ; rr:objectMap [ rr:column "ON_HAND_QTY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:reservedQty ; rr:objectMap [ rr:column "RESERVED_QTY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:reorderPoint ; rr:objectMap [ rr:column "REORDER_POINT" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:unitsOnOrder ; rr:objectMap [ rr:column "UNITS_ON_ORDER" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:productKey ; rr:objectMap [ rr:column "PRODUCT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:storeKey ; rr:objectMap [ rr:column "STORE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:snapshotDateKey ; rr:objectMap [ rr:column "SNAPSHOT_DATE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:product ;
+    rr:objectMap [ rr:parentTriplesMap <#DimProduct> ; rr:joinCondition [ rr:child "PRODUCT_KEY" ; rr:parent "PRODUCT_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:store ;
+    rr:objectMap [ rr:parentTriplesMap <#DimStore> ; rr:joinCondition [ rr:child "STORE_KEY" ; rr:parent "STORE_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:snapshotDateRef ;
+    rr:objectMap [ rr:parentTriplesMap <#DimDate> ; rr:joinCondition [ rr:child "SNAPSHOT_DATE_KEY" ; rr:parent "DATE_KEY" ] ] ] .
+
+<#FactShipment> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.FACT_SHIPMENT" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/shipment/{SHIPMENT_KEY}" ; rr:class v:Shipment ] ;
+  rr:predicateObjectMap [ rr:predicate v:shipmentKey ; rr:objectMap [ rr:column "SHIPMENT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:shipmentId ; rr:objectMap [ rr:column "SHIPMENT_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:shipDate ; rr:objectMap [ rr:column "SHIP_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:carrier ; rr:objectMap [ rr:column "CARRIER" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:shipMethod ; rr:objectMap [ rr:column "SHIP_METHOD" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:shipStatus ; rr:objectMap [ rr:column "SHIP_STATUS" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:trackingNumber ; rr:objectMap [ rr:column "TRACKING_NUMBER" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:shipCost ; rr:objectMap [ rr:column "SHIP_COST" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderKey ; rr:objectMap [ rr:column "ORDER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:destGeographyKey ; rr:objectMap [ rr:column "DEST_GEOGRAPHY_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:shipDateKey ; rr:objectMap [ rr:column "SHIP_DATE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:order ;
+    rr:objectMap [ rr:parentTriplesMap <#FactOrder> ; rr:joinCondition [ rr:child "ORDER_KEY" ; rr:parent "ORDER_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:destGeography ;
+    rr:objectMap [ rr:parentTriplesMap <#DimGeography> ; rr:joinCondition [ rr:child "DEST_GEOGRAPHY_KEY" ; rr:parent "GEOGRAPHY_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:shipDateRef ;
+    rr:objectMap [ rr:parentTriplesMap <#DimDate> ; rr:joinCondition [ rr:child "SHIP_DATE_KEY" ; rr:parent "DATE_KEY" ] ] ] .
+
+<#FactPayment> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.FACT_PAYMENT" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/payment/{PAYMENT_KEY}" ; rr:class v:Payment ] ;
+  rr:predicateObjectMap [ rr:predicate v:paymentKey ; rr:objectMap [ rr:column "PAYMENT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:paymentId ; rr:objectMap [ rr:column "PAYMENT_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:paymentDate ; rr:objectMap [ rr:column "PAYMENT_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:tenderType ; rr:objectMap [ rr:column "TENDER_TYPE" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:amount ; rr:objectMap [ rr:column "AMOUNT" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:currency ; rr:objectMap [ rr:column "CURRENCY" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:paymentStatus ; rr:objectMap [ rr:column "PAYMENT_STATUS" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:orderKey ; rr:objectMap [ rr:column "ORDER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:customerKey ; rr:objectMap [ rr:column "CUSTOMER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:paymentDateKey ; rr:objectMap [ rr:column "PAYMENT_DATE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:order ;
+    rr:objectMap [ rr:parentTriplesMap <#FactOrder> ; rr:joinCondition [ rr:child "ORDER_KEY" ; rr:parent "ORDER_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:customer ;
+    rr:objectMap [ rr:parentTriplesMap <#DimCustomer> ; rr:joinCondition [ rr:child "CUSTOMER_KEY" ; rr:parent "CUSTOMER_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:paymentDateRef ;
+    rr:objectMap [ rr:parentTriplesMap <#DimDate> ; rr:joinCondition [ rr:child "PAYMENT_DATE_KEY" ; rr:parent "DATE_KEY" ] ] ] .
+
+<#FactGlJournal> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.FACT_GL_JOURNAL" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/gl-journal/{JOURNAL_KEY}" ; rr:class v:GlJournal ] ;
+  rr:predicateObjectMap [ rr:predicate v:journalKey ; rr:objectMap [ rr:column "JOURNAL_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:journalId ; rr:objectMap [ rr:column "JOURNAL_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:postingDate ; rr:objectMap [ rr:column "POSTING_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:glAccountCode ; rr:objectMap [ rr:column "GL_ACCOUNT_CODE" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:glAccountName ; rr:objectMap [ rr:column "GL_ACCOUNT_NAME" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:costCenter ; rr:objectMap [ rr:column "COST_CENTER" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:debitAmount ; rr:objectMap [ rr:column "DEBIT_AMOUNT" ; rr:datatype xsd:decimal ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:creditAmount ; rr:objectMap [ rr:column "CREDIT_AMOUNT" ; rr:datatype xsd:decimal ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:currency ; rr:objectMap [ rr:column "CURRENCY" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:sourceModule ; rr:objectMap [ rr:column "SOURCE_MODULE" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:postingDateKey ; rr:objectMap [ rr:column "POSTING_DATE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:postingDateRef ;
+    rr:objectMap [ rr:parentTriplesMap <#DimDate> ; rr:joinCondition [ rr:child "POSTING_DATE_KEY" ; rr:parent "DATE_KEY" ] ] ] .
+
+<#FactWebEvent> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.FACT_WEB_EVENT" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/web-event/{EVENT_KEY}" ; rr:class v:WebEvent ] ;
+  rr:predicateObjectMap [ rr:predicate v:eventKey ; rr:objectMap [ rr:column "EVENT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:eventId ; rr:objectMap [ rr:column "EVENT_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:sessionId ; rr:objectMap [ rr:column "SESSION_ID" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:eventDate ; rr:objectMap [ rr:column "EVENT_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:eventTs ; rr:objectMap [ rr:column "EVENT_TS" ; rr:datatype xsd:dateTime ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:eventType ; rr:objectMap [ rr:column "EVENT_TYPE" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:pageUrl ; rr:objectMap [ rr:column "PAGE_URL" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:deviceType ; rr:objectMap [ rr:column "DEVICE_TYPE" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:browser ; rr:objectMap [ rr:column "BROWSER" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:referrer ; rr:objectMap [ rr:column "REFERRER" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:customerKey ; rr:objectMap [ rr:column "CUSTOMER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:productKey ; rr:objectMap [ rr:column "PRODUCT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:eventDateKey ; rr:objectMap [ rr:column "EVENT_DATE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:customer ;
+    rr:objectMap [ rr:parentTriplesMap <#DimCustomer> ; rr:joinCondition [ rr:child "CUSTOMER_KEY" ; rr:parent "CUSTOMER_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:product ;
+    rr:objectMap [ rr:parentTriplesMap <#DimProduct> ; rr:joinCondition [ rr:child "PRODUCT_KEY" ; rr:parent "PRODUCT_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:eventDateRef ;
+    rr:objectMap [ rr:parentTriplesMap <#DimDate> ; rr:joinCondition [ rr:child "EVENT_DATE_KEY" ; rr:parent "DATE_KEY" ] ] ] .
+
+<#FactSupportTicket> a rr:TriplesMap ;
+  rr:logicalTable [ rr:tableName "DW.FACT_SUPPORT_TICKET" ] ;
+  rr:subjectMap [ rr:template "http://ns.fluree.dev/edw/support-ticket/{TICKET_KEY}" ; rr:class v:SupportTicket ] ;
+  rr:predicateObjectMap [ rr:predicate v:ticketKey ; rr:objectMap [ rr:column "TICKET_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:ticketId ; rr:objectMap [ rr:column "TICKET_ID" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:openDate ; rr:objectMap [ rr:column "OPEN_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:closeDate ; rr:objectMap [ rr:column "CLOSE_DATE" ; rr:datatype xsd:date ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:status ; rr:objectMap [ rr:column "STATUS" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:priority ; rr:objectMap [ rr:column "PRIORITY" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:category ; rr:objectMap [ rr:column "CATEGORY" ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:csatScore ; rr:objectMap [ rr:column "CSAT_SCORE" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:resolutionHours ; rr:objectMap [ rr:column "RESOLUTION_HOURS" ; rr:datatype xsd:double ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:customerKey ; rr:objectMap [ rr:column "CUSTOMER_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:productKey ; rr:objectMap [ rr:column "PRODUCT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:agentKey ; rr:objectMap [ rr:column "AGENT_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:openDateKey ; rr:objectMap [ rr:column "OPEN_DATE_KEY" ; rr:datatype xsd:integer ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:customer ;
+    rr:objectMap [ rr:parentTriplesMap <#DimCustomer> ; rr:joinCondition [ rr:child "CUSTOMER_KEY" ; rr:parent "CUSTOMER_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:product ;
+    rr:objectMap [ rr:parentTriplesMap <#DimProduct> ; rr:joinCondition [ rr:child "PRODUCT_KEY" ; rr:parent "PRODUCT_KEY" ] ] ] ;
+  rr:predicateObjectMap [ rr:predicate v:openDateRef ;
+    rr:objectMap [ rr:parentTriplesMap <#DimDate> ; rr:joinCondition [ rr:child "OPEN_DATE_KEY" ; rr:parent "DATE_KEY" ] ] ] .

--- a/fluree-db-r2rml/src/emit/tests.rs
+++ b/fluree-db-r2rml/src/emit/tests.rs
@@ -1,0 +1,874 @@
+//! Tests for the deterministic emitter.
+//!
+//! Unit tests (subject-key selection, FK heuristic cases, determinism, wire
+//! shape) run without the `turtle` feature. The round-trip, enterprise
+//! structural-match, and hex-guard tests are gated on `turtle` because they
+//! compile the emitted Turtle back through `R2rmlLoader`.
+
+#![cfg(test)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use fluree_db_tabular::FieldType;
+
+use crate::emit::diagnostic::DiagCode;
+use crate::emit::fixtures::enterprise_dw_tables;
+use crate::emit::input::{EmitColumn, EmitColumnStats, EmitTableSchema, TypedBound};
+use crate::emit::{emit_r2rml, EmitOptions, EmitOutput};
+
+// =============================================================================
+// Synthetic-input helpers (for focused FK-heuristic unit tests)
+// =============================================================================
+
+/// An integer key column with an explicit `[min, max]` range.
+fn ik(field_id: i32, name: &str, min: i64, max: i64, required: bool) -> EmitColumn {
+    EmitColumn {
+        field_id,
+        name: name.to_string(),
+        iceberg_type: "long".to_string(),
+        field_type: FieldType::Int64,
+        required,
+        nested: false,
+        doc: None,
+        stats: EmitColumnStats {
+            null_fraction: if required { Some(0.0) } else { None },
+            min: Some(TypedBound::Int(min)),
+            max: Some(TypedBound::Int(max)),
+        },
+    }
+}
+
+/// A bounds-free scalar column.
+fn sc(field_id: i32, name: &str, ft: FieldType) -> EmitColumn {
+    EmitColumn {
+        field_id,
+        name: name.to_string(),
+        iceberg_type: "x".to_string(),
+        field_type: ft,
+        required: false,
+        nested: false,
+        doc: None,
+        stats: EmitColumnStats::default(),
+    }
+}
+
+fn tbl(name: &str, identifier_field_ids: Vec<i32>, columns: Vec<EmitColumn>) -> EmitTableSchema {
+    EmitTableSchema {
+        namespace: "DW".to_string(),
+        name: name.to_string(),
+        columns,
+        identifier_field_ids,
+    }
+}
+
+/// The resolved FK edges in an emit output, as `(childTable, child, parentTable, parent)`.
+fn resolved_fks(out: &EmitOutput) -> BTreeSet<(String, String, String, String)> {
+    let mut set = BTreeSet::new();
+    for tm in &out.structured.table_mappings {
+        for col in &tm.columns {
+            if let Some(fk) = &col.foreign_key {
+                set.insert((
+                    tm.table_name.clone(),
+                    fk.child_column.clone(),
+                    fk.target_table.clone(),
+                    fk.parent_column.clone(),
+                ));
+            }
+        }
+    }
+    set
+}
+
+/// The `(table, column)` pairs carrying a given diagnostic code.
+fn diag_cols(out: &EmitOutput, code: DiagCode) -> BTreeSet<(String, String)> {
+    out.diagnostics
+        .iter()
+        .filter(|d| d.code == code)
+        .filter_map(|d| Some((d.table.clone()?, d.column.clone()?)))
+        .collect()
+}
+
+// =============================================================================
+// Subject-key selection
+// =============================================================================
+
+#[test]
+fn subject_key_from_identifier_field_ids() {
+    let t = tbl(
+        "DIM_WIDGET",
+        vec![1],
+        vec![
+            ik(1, "WIDGET_KEY", 1, 100, true),
+            sc(2, "NAME", FieldType::String),
+        ],
+    );
+    let out = emit_r2rml(&[t], &EmitOptions::default());
+    let tm = &out.structured.table_mappings[0];
+    assert!(
+        tm.subject_template.ends_with("/{WIDGET_KEY}"),
+        "{}",
+        tm.subject_template
+    );
+    // No NoSafeSubjectKey / SubjectKeyUnverified for a clean identifier hint.
+    assert!(diag_cols(&out, DiagCode::NoSafeSubjectKey).is_empty());
+    assert!(diag_cols(&out, DiagCode::SubjectKeyUnverified).is_empty());
+    // The subject-key column is retained as a literal marked isSubjectId.
+    let pk = tm
+        .columns
+        .iter()
+        .find(|c| c.column_name == "WIDGET_KEY")
+        .unwrap();
+    assert!(pk.is_subject_id);
+}
+
+#[test]
+fn subject_key_name_fallback_is_unverified() {
+    // No identifier_field_ids, but a required WIDGET_KEY matching <STEM>_KEY.
+    let t = tbl(
+        "DIM_WIDGET",
+        vec![],
+        vec![
+            ik(1, "WIDGET_KEY", 1, 100, true),
+            sc(2, "NAME", FieldType::String),
+        ],
+    );
+    let out = emit_r2rml(&[t], &EmitOptions::default());
+    assert!(out.structured.table_mappings[0]
+        .subject_template
+        .ends_with("/{WIDGET_KEY}"));
+    assert_eq!(
+        diag_cols(&out, DiagCode::SubjectKeyUnverified),
+        BTreeSet::from([("DW.DIM_WIDGET".to_string(), "WIDGET_KEY".to_string())])
+    );
+}
+
+#[test]
+fn subject_key_fallback_rejects_nullable_key() {
+    // A name-matching key that is nullable fails the gate → NoSafeSubjectKey.
+    let t = tbl(
+        "DIM_WIDGET",
+        vec![],
+        vec![
+            ik(1, "WIDGET_KEY", 1, 100, false),
+            sc(2, "NAME", FieldType::String),
+        ],
+    );
+    let out = emit_r2rml(&[t], &EmitOptions::default());
+    assert!(out.structured.table_mappings[0].subject_template.is_empty());
+    assert!(!diag_cols(&out, DiagCode::NoSafeSubjectKey).is_empty());
+}
+
+#[test]
+fn no_safe_subject_key_emits_no_subject_and_never_invents_one() {
+    let t = tbl(
+        "WEIRD",
+        vec![],
+        vec![sc(1, "A", FieldType::String), sc(2, "B", FieldType::Int64)],
+    );
+    let out = emit_r2rml(&[t], &EmitOptions::default());
+    assert!(out.structured.table_mappings[0].subject_template.is_empty());
+    let codes: Vec<_> = out.diagnostics.iter().map(|d| d.code).collect();
+    assert!(codes.contains(&DiagCode::NoSafeSubjectKey));
+}
+
+#[test]
+fn composite_subject_key_uses_multi_placeholder_template() {
+    let t = tbl(
+        "BRIDGE",
+        vec![1, 2],
+        vec![
+            ik(1, "LEFT_KEY", 1, 100, true),
+            ik(2, "RIGHT_KEY", 1, 100, true),
+            sc(3, "V", FieldType::String),
+        ],
+    );
+    let out = emit_r2rml(&[t], &EmitOptions::default());
+    assert!(out.structured.table_mappings[0]
+        .subject_template
+        .ends_with("/{LEFT_KEY}/{RIGHT_KEY}"));
+}
+
+// =============================================================================
+// FK heuristic — focused cases on synthetic inputs
+// =============================================================================
+
+#[test]
+fn fk_exact_name_match_resolves() {
+    let parent = tbl(
+        "DIM_PARENT",
+        vec![1],
+        vec![ik(1, "PARENT_KEY", 1, 100, true)],
+    );
+    let child = tbl(
+        "FACT_CHILD",
+        vec![1],
+        vec![
+            ik(1, "CHILD_KEY", 1, 100, true),
+            ik(2, "PARENT_KEY", 1, 100, false),
+        ],
+    );
+    let out = emit_r2rml(&[parent, child], &EmitOptions::default());
+    assert!(resolved_fks(&out).contains(&(
+        "DW.FACT_CHILD".to_string(),
+        "PARENT_KEY".to_string(),
+        "DW.DIM_PARENT".to_string(),
+        "PARENT_KEY".to_string(),
+    )));
+}
+
+#[test]
+fn fk_unambiguous_suffix_match_resolves() {
+    let parent = tbl("DIM_NODE", vec![1], vec![ik(1, "NODE_KEY", 1, 100, true)]);
+    let child = tbl(
+        "FACT_EDGE",
+        vec![1],
+        vec![
+            ik(1, "EDGE_KEY", 1, 100, true),
+            ik(2, "SOURCE_NODE_KEY", 1, 100, false),
+        ],
+    );
+    let out = emit_r2rml(&[parent, child], &EmitOptions::default());
+    assert!(resolved_fks(&out).contains(&(
+        "DW.FACT_EDGE".to_string(),
+        "SOURCE_NODE_KEY".to_string(),
+        "DW.DIM_NODE".to_string(),
+        "NODE_KEY".to_string(),
+    )));
+}
+
+#[test]
+fn fk_ambiguous_multiple_parents_not_fabricated() {
+    // Two parents share the PK name FOO_KEY → a child FOO_KEY is ambiguous.
+    let a = tbl("DIM_A", vec![1], vec![ik(1, "FOO_KEY", 1, 100, true)]);
+    let b = tbl("DIM_B", vec![1], vec![ik(1, "FOO_KEY", 1, 100, true)]);
+    let child = tbl(
+        "FACT_C",
+        vec![1],
+        vec![
+            ik(1, "C_KEY", 1, 100, true),
+            ik(2, "FOO_KEY", 1, 100, false),
+        ],
+    );
+    let out = emit_r2rml(&[a, b, child], &EmitOptions::default());
+    // No join fabricated for the ambiguous column.
+    assert!(!resolved_fks(&out)
+        .iter()
+        .any(|(ct, cc, _, _)| ct == "DW.FACT_C" && cc == "FOO_KEY"));
+    assert!(diag_cols(&out, DiagCode::AmbiguousFk)
+        .contains(&("DW.FACT_C".to_string(), "FOO_KEY".to_string())));
+}
+
+#[test]
+fn fk_role_renamed_key_is_unresolved_not_fabricated() {
+    // MANAGER_KEY never matches EMPLOYEE_KEY by name → unresolved, no join.
+    let emp = tbl(
+        "DIM_EMPLOYEE",
+        vec![1],
+        vec![
+            ik(1, "EMPLOYEE_KEY", 1, 100, true),
+            ik(2, "MANAGER_KEY", 1, 100, false),
+        ],
+    );
+    let out = emit_r2rml(&[emp], &EmitOptions::default());
+    assert!(
+        resolved_fks(&out).is_empty(),
+        "role-renamed FK must not resolve"
+    );
+    assert!(diag_cols(&out, DiagCode::UnresolvedFkCandidate)
+        .contains(&("DW.DIM_EMPLOYEE".to_string(), "MANAGER_KEY".to_string())));
+}
+
+#[test]
+fn fk_self_join_resolves_when_name_aligned() {
+    // A name-aligned self reference (PARENT_NODE_KEY → NODE_KEY) resolves.
+    let node = tbl(
+        "DIM_NODE",
+        vec![1],
+        vec![
+            ik(1, "NODE_KEY", 1, 100, true),
+            ik(2, "PARENT_NODE_KEY", 1, 100, false),
+        ],
+    );
+    let out = emit_r2rml(&[node], &EmitOptions::default());
+    assert!(resolved_fks(&out).contains(&(
+        "DW.DIM_NODE".to_string(),
+        "PARENT_NODE_KEY".to_string(),
+        "DW.DIM_NODE".to_string(),
+        "NODE_KEY".to_string(),
+    )));
+}
+
+#[test]
+fn fk_range_out_of_bounds_rejected() {
+    // Name + type match, but the child range ⊄ parent range → no join.
+    let parent = tbl(
+        "DIM_PARENT",
+        vec![1],
+        vec![ik(1, "PARENT_KEY", 1000, 2000, true)],
+    );
+    let child = tbl(
+        "FACT_CHILD",
+        vec![1],
+        vec![
+            ik(1, "CHILD_KEY", 1, 100, true),
+            ik(2, "PARENT_KEY", 1, 500, false),
+        ],
+    );
+    let out = emit_r2rml(&[parent, child], &EmitOptions::default());
+    assert!(
+        !resolved_fks(&out)
+            .iter()
+            .any(|(ct, cc, _, _)| ct == "DW.FACT_CHILD" && cc == "PARENT_KEY"),
+        "range-incompatible FK must not resolve"
+    );
+}
+
+#[test]
+fn fk_child_fact_to_hub_emitted_with_advisory() {
+    let hub = tbl(
+        "FACT_ORDER",
+        vec![1],
+        vec![ik(1, "ORDER_KEY", 1, 100, true)],
+    );
+    let line = tbl(
+        "FACT_ORDER_LINE",
+        vec![1],
+        vec![
+            ik(1, "ORDER_LINE_KEY", 1, 100, true),
+            ik(2, "ORDER_KEY", 1, 100, false),
+        ],
+    );
+    let out = emit_r2rml(&[hub, line], &EmitOptions::default());
+    assert!(resolved_fks(&out).contains(&(
+        "DW.FACT_ORDER_LINE".to_string(),
+        "ORDER_KEY".to_string(),
+        "DW.FACT_ORDER".to_string(),
+        "ORDER_KEY".to_string(),
+    )));
+    assert!(diag_cols(&out, DiagCode::FactHubJoinAdvisory)
+        .contains(&("DW.FACT_ORDER_LINE".to_string(), "ORDER_KEY".to_string())));
+}
+
+#[test]
+fn non_pk_fact_link_is_not_fabricated() {
+    // A fact key column whose name matches no PK (only a non-PK measure) stays
+    // literal — non-PK targets are never join targets.
+    let a = tbl(
+        "FACT_A",
+        vec![1],
+        vec![
+            ik(1, "A_KEY", 1, 100, true),
+            sc(2, "WIDGET_COUNT", FieldType::Int64),
+        ],
+    );
+    let b = tbl(
+        "FACT_B",
+        vec![1],
+        vec![
+            ik(1, "B_KEY", 1, 100, true),
+            ik(2, "WIDGET_KEY", 1, 100, false),
+        ],
+    );
+    let out = emit_r2rml(&[a, b], &EmitOptions::default());
+    assert!(resolved_fks(&out).is_empty());
+    // WIDGET_KEY is key-like but unmatched → surfaced, never fabricated.
+    assert!(diag_cols(&out, DiagCode::UnresolvedFkCandidate)
+        .contains(&("DW.FACT_B".to_string(), "WIDGET_KEY".to_string())));
+}
+
+#[test]
+fn nested_column_is_skipped() {
+    let mut nested = sc(2, "PAYLOAD", FieldType::String);
+    nested.nested = true;
+    let t = tbl(
+        "DIM_THING",
+        vec![1],
+        vec![ik(1, "THING_KEY", 1, 100, true), nested],
+    );
+    let out = emit_r2rml(&[t], &EmitOptions::default());
+    let tm = &out.structured.table_mappings[0];
+    assert!(tm.columns.iter().all(|c| c.column_name != "PAYLOAD"));
+    assert!(diag_cols(&out, DiagCode::NestedColumnSkipped)
+        .contains(&("DW.DIM_THING".to_string(), "PAYLOAD".to_string())));
+}
+
+// =============================================================================
+// Datatype map (via a full emit) + determinism
+// =============================================================================
+
+#[test]
+fn every_non_string_column_carries_a_datatype() {
+    let out = emit_r2rml(&enterprise_dw_tables(), &EmitOptions::default());
+    for tm in &out.structured.table_mappings {
+        for col in &tm.columns {
+            if col.foreign_key.is_some() {
+                continue; // join POMs carry no datatype
+            }
+            // The only untyped literals are strings.
+            if col.datatype.is_none() {
+                // Confirm it really is a string column in the source schema.
+                // (COUNTRY, names, ids, ... — all String.)
+                assert!(
+                    is_string_column(&tm.table_name, &col.column_name),
+                    "non-string column {}.{} is missing a datatype",
+                    tm.table_name,
+                    col.column_name
+                );
+            }
+        }
+    }
+}
+
+/// The known string columns (used to justify a missing datatype).
+fn is_string_column(table: &str, column: &str) -> bool {
+    let tables = enterprise_dw_tables();
+    tables
+        .iter()
+        .find(|t| t.qualified_name() == table)
+        .and_then(|t| t.columns.iter().find(|c| c.name == column))
+        .map(|c| c.field_type == FieldType::String)
+        .unwrap_or(false)
+}
+
+#[test]
+fn emit_is_byte_deterministic() {
+    let tables = enterprise_dw_tables();
+    let opts = EmitOptions::default();
+    let a = emit_r2rml(&tables, &opts);
+    let b = emit_r2rml(&tables, &opts);
+    assert_eq!(a.turtle, b.turtle, "two emit runs must be byte-identical");
+}
+
+// =============================================================================
+// Wire shape: `structured` is solo's camelCase StructuredR2rmlMapping
+// =============================================================================
+
+#[test]
+fn structured_serializes_to_solo_camelcase_shape() {
+    let out = emit_r2rml(&enterprise_dw_tables(), &EmitOptions::default());
+    let v = serde_json::to_value(&out.structured).unwrap();
+    let obj = v
+        .as_object()
+        .expect("structured must be a JSON object, not an array");
+
+    assert!(obj.contains_key("baseNamespace"));
+    assert!(obj.contains_key("prefixes"));
+    let table_mappings = obj
+        .get("tableMappings")
+        .and_then(|t| t.as_array())
+        .expect("tableMappings array");
+    assert_eq!(table_mappings.len(), 16);
+
+    let first = table_mappings[0].as_object().unwrap();
+    for key in ["tableName", "classIri", "subjectTemplate", "columns"] {
+        assert!(first.contains_key(key), "tableMapping missing {key}");
+    }
+
+    // Find a foreign-key column somewhere and check its camelCase shape.
+    let fk = table_mappings
+        .iter()
+        .flat_map(|t| t["columns"].as_array().unwrap())
+        .find_map(|c| c.get("foreignKey").filter(|f| !f.is_null()))
+        .expect("at least one foreignKey column");
+    let fk = fk.as_object().unwrap();
+    for key in ["targetTable", "childColumn", "parentColumn"] {
+        assert!(fk.contains_key(key), "foreignKey missing {key}");
+    }
+
+    // A literal column entry has the camelCase scalar fields.
+    let col = table_mappings[0]["columns"][0].as_object().unwrap();
+    for key in ["columnName", "predicateIri", "isSubjectId", "isIri"] {
+        assert!(col.contains_key(key), "column missing {key}");
+    }
+}
+
+// =============================================================================
+// Enterprise structural match (the full 16-table graph)
+// =============================================================================
+
+/// The 29 deterministically-resolvable FK edges of `enterprise.ttl`.
+const EXPECTED_RESOLVED: &[(&str, &str, &str, &str)] = &[
+    // dimension → dimension (7)
+    (
+        "DW.DIM_SUPPLIER",
+        "GEOGRAPHY_KEY",
+        "DW.DIM_GEOGRAPHY",
+        "GEOGRAPHY_KEY",
+    ),
+    (
+        "DW.DIM_ACCOUNT",
+        "GEOGRAPHY_KEY",
+        "DW.DIM_GEOGRAPHY",
+        "GEOGRAPHY_KEY",
+    ),
+    ("DW.DIM_EMPLOYEE", "STORE_KEY", "DW.DIM_STORE", "STORE_KEY"),
+    (
+        "DW.DIM_STORE",
+        "GEOGRAPHY_KEY",
+        "DW.DIM_GEOGRAPHY",
+        "GEOGRAPHY_KEY",
+    ),
+    (
+        "DW.DIM_CUSTOMER",
+        "GEOGRAPHY_KEY",
+        "DW.DIM_GEOGRAPHY",
+        "GEOGRAPHY_KEY",
+    ),
+    (
+        "DW.DIM_CUSTOMER",
+        "ACCOUNT_KEY",
+        "DW.DIM_ACCOUNT",
+        "ACCOUNT_KEY",
+    ),
+    (
+        "DW.DIM_PRODUCT",
+        "SUPPLIER_KEY",
+        "DW.DIM_SUPPLIER",
+        "SUPPLIER_KEY",
+    ),
+    // fact → dimension / hub (22)
+    (
+        "DW.FACT_ORDER",
+        "CUSTOMER_KEY",
+        "DW.DIM_CUSTOMER",
+        "CUSTOMER_KEY",
+    ),
+    (
+        "DW.FACT_ORDER",
+        "ACCOUNT_KEY",
+        "DW.DIM_ACCOUNT",
+        "ACCOUNT_KEY",
+    ),
+    ("DW.FACT_ORDER", "STORE_KEY", "DW.DIM_STORE", "STORE_KEY"),
+    ("DW.FACT_ORDER", "ORDER_DATE_KEY", "DW.DIM_DATE", "DATE_KEY"),
+    (
+        "DW.FACT_ORDER_LINE",
+        "ORDER_KEY",
+        "DW.FACT_ORDER",
+        "ORDER_KEY",
+    ),
+    (
+        "DW.FACT_ORDER_LINE",
+        "PRODUCT_KEY",
+        "DW.DIM_PRODUCT",
+        "PRODUCT_KEY",
+    ),
+    (
+        "DW.FACT_INVENTORY_SNAPSHOT",
+        "PRODUCT_KEY",
+        "DW.DIM_PRODUCT",
+        "PRODUCT_KEY",
+    ),
+    (
+        "DW.FACT_INVENTORY_SNAPSHOT",
+        "STORE_KEY",
+        "DW.DIM_STORE",
+        "STORE_KEY",
+    ),
+    (
+        "DW.FACT_INVENTORY_SNAPSHOT",
+        "SNAPSHOT_DATE_KEY",
+        "DW.DIM_DATE",
+        "DATE_KEY",
+    ),
+    (
+        "DW.FACT_SHIPMENT",
+        "ORDER_KEY",
+        "DW.FACT_ORDER",
+        "ORDER_KEY",
+    ),
+    (
+        "DW.FACT_SHIPMENT",
+        "DEST_GEOGRAPHY_KEY",
+        "DW.DIM_GEOGRAPHY",
+        "GEOGRAPHY_KEY",
+    ),
+    (
+        "DW.FACT_SHIPMENT",
+        "SHIP_DATE_KEY",
+        "DW.DIM_DATE",
+        "DATE_KEY",
+    ),
+    ("DW.FACT_PAYMENT", "ORDER_KEY", "DW.FACT_ORDER", "ORDER_KEY"),
+    (
+        "DW.FACT_PAYMENT",
+        "CUSTOMER_KEY",
+        "DW.DIM_CUSTOMER",
+        "CUSTOMER_KEY",
+    ),
+    (
+        "DW.FACT_PAYMENT",
+        "PAYMENT_DATE_KEY",
+        "DW.DIM_DATE",
+        "DATE_KEY",
+    ),
+    (
+        "DW.FACT_GL_JOURNAL",
+        "POSTING_DATE_KEY",
+        "DW.DIM_DATE",
+        "DATE_KEY",
+    ),
+    (
+        "DW.FACT_WEB_EVENT",
+        "CUSTOMER_KEY",
+        "DW.DIM_CUSTOMER",
+        "CUSTOMER_KEY",
+    ),
+    (
+        "DW.FACT_WEB_EVENT",
+        "PRODUCT_KEY",
+        "DW.DIM_PRODUCT",
+        "PRODUCT_KEY",
+    ),
+    (
+        "DW.FACT_WEB_EVENT",
+        "EVENT_DATE_KEY",
+        "DW.DIM_DATE",
+        "DATE_KEY",
+    ),
+    (
+        "DW.FACT_SUPPORT_TICKET",
+        "CUSTOMER_KEY",
+        "DW.DIM_CUSTOMER",
+        "CUSTOMER_KEY",
+    ),
+    (
+        "DW.FACT_SUPPORT_TICKET",
+        "PRODUCT_KEY",
+        "DW.DIM_PRODUCT",
+        "PRODUCT_KEY",
+    ),
+    (
+        "DW.FACT_SUPPORT_TICKET",
+        "OPEN_DATE_KEY",
+        "DW.DIM_DATE",
+        "DATE_KEY",
+    ),
+];
+
+/// The 4 role-renamed employee FKs `enterprise.ttl` has but that are
+/// unresolvable from metadata (name never matches `EMPLOYEE_KEY`).
+const EXPECTED_UNRESOLVED_ROLE_RENAMED: &[(&str, &str)] = &[
+    ("DW.DIM_EMPLOYEE", "MANAGER_KEY"),
+    ("DW.DIM_STORE", "REGION_MANAGER_KEY"),
+    ("DW.FACT_ORDER", "SALES_REP_KEY"),
+    ("DW.FACT_SUPPORT_TICKET", "AGENT_KEY"),
+];
+
+/// The 3 child-fact → `FACT_ORDER` hub joins (emitted, but perf-advisory).
+const EXPECTED_HUB: &[(&str, &str)] = &[
+    ("DW.FACT_ORDER_LINE", "ORDER_KEY"),
+    ("DW.FACT_SHIPMENT", "ORDER_KEY"),
+    ("DW.FACT_PAYMENT", "ORDER_KEY"),
+];
+
+/// The surrogate subject key per table.
+const EXPECTED_SUBJECT_KEYS: &[(&str, &str)] = &[
+    ("DW.DIM_DATE", "DATE_KEY"),
+    ("DW.DIM_GEOGRAPHY", "GEOGRAPHY_KEY"),
+    ("DW.DIM_SUPPLIER", "SUPPLIER_KEY"),
+    ("DW.DIM_ACCOUNT", "ACCOUNT_KEY"),
+    ("DW.DIM_EMPLOYEE", "EMPLOYEE_KEY"),
+    ("DW.DIM_STORE", "STORE_KEY"),
+    ("DW.DIM_CUSTOMER", "CUSTOMER_KEY"),
+    ("DW.DIM_PRODUCT", "PRODUCT_KEY"),
+    ("DW.FACT_ORDER", "ORDER_KEY"),
+    ("DW.FACT_ORDER_LINE", "ORDER_LINE_KEY"),
+    ("DW.FACT_INVENTORY_SNAPSHOT", "INVENTORY_KEY"),
+    ("DW.FACT_SHIPMENT", "SHIPMENT_KEY"),
+    ("DW.FACT_PAYMENT", "PAYMENT_KEY"),
+    ("DW.FACT_GL_JOURNAL", "JOURNAL_KEY"),
+    ("DW.FACT_WEB_EVENT", "EVENT_KEY"),
+    ("DW.FACT_SUPPORT_TICKET", "TICKET_KEY"),
+];
+
+#[test]
+fn enterprise_fk_graph_matches_29_of_33() {
+    let out = emit_r2rml(&enterprise_dw_tables(), &EmitOptions::default());
+
+    let got = resolved_fks(&out);
+    let expected: BTreeSet<_> = EXPECTED_RESOLVED
+        .iter()
+        .map(|(ct, cc, pt, pc)| {
+            (
+                ct.to_string(),
+                cc.to_string(),
+                pt.to_string(),
+                pc.to_string(),
+            )
+        })
+        .collect();
+
+    assert_eq!(got.len(), 29, "expected exactly 29 resolved FKs");
+    assert_eq!(
+        got, expected,
+        "resolved FK graph must match enterprise.ttl's resolvable joins"
+    );
+
+    // The 4 role-renamed FKs are surfaced as UnresolvedFkCandidate, not fabricated.
+    let unresolved = diag_cols(&out, DiagCode::UnresolvedFkCandidate);
+    for (t, c) in EXPECTED_UNRESOLVED_ROLE_RENAMED {
+        assert!(
+            unresolved.contains(&(t.to_string(), c.to_string())),
+            "{t}.{c} must be UnresolvedFkCandidate"
+        );
+        // ...and must NOT appear as a resolved join.
+        assert!(
+            !got.iter().any(|(ct, cc, _, _)| ct == t && cc == c),
+            "{t}.{c} must not be fabricated as a join"
+        );
+    }
+
+    // The 3 hub joins carry a FactHubJoinAdvisory.
+    let hub = diag_cols(&out, DiagCode::FactHubJoinAdvisory);
+    let expected_hub: BTreeSet<_> = EXPECTED_HUB
+        .iter()
+        .map(|(t, c)| (t.to_string(), c.to_string()))
+        .collect();
+    assert_eq!(
+        hub, expected_hub,
+        "hub advisories must be exactly the 3 child-fact→FACT_ORDER joins"
+    );
+}
+
+#[test]
+fn enterprise_subject_keys_match() {
+    let out = emit_r2rml(&enterprise_dw_tables(), &EmitOptions::default());
+    for (table, key) in EXPECTED_SUBJECT_KEYS {
+        let tm = out
+            .structured
+            .table_mapping(table)
+            .unwrap_or_else(|| panic!("missing table {table}"));
+        assert!(
+            tm.subject_template.contains(&format!("{{{key}}}")),
+            "table {table} subject template {} must key on {key}",
+            tm.subject_template
+        );
+        // Exactly one class per table.
+        assert!(!tm.class_iri.is_empty());
+    }
+}
+
+#[test]
+fn enterprise_datatypes_match_reference() {
+    let out = emit_r2rml(&enterprise_dw_tables(), &EmitOptions::default());
+    // (table, column, expected datatype) covering every non-string datatype used
+    // in enterprise.ttl, plus a string (untyped) control.
+    let checks: &[(&str, &str, Option<&str>)] = &[
+        ("DW.DIM_DATE", "DATE_KEY", Some("xsd:integer")),
+        ("DW.DIM_DATE", "DATE", Some("xsd:date")),
+        ("DW.DIM_DATE", "IS_WEEKEND", Some("xsd:boolean")),
+        ("DW.DIM_GEOGRAPHY", "LATITUDE", Some("xsd:double")),
+        ("DW.FACT_GL_JOURNAL", "DEBIT_AMOUNT", Some("xsd:decimal")),
+        ("DW.FACT_WEB_EVENT", "EVENT_TS", Some("xsd:dateTime")),
+        ("DW.DIM_GEOGRAPHY", "COUNTRY", None), // string → plain literal
+    ];
+    let mut by_table: BTreeMap<&str, BTreeMap<String, Option<String>>> = BTreeMap::new();
+    for tm in &out.structured.table_mappings {
+        let entry = by_table.entry(tm.table_name.as_str()).or_default();
+        for col in &tm.columns {
+            if col.foreign_key.is_none() {
+                entry.insert(col.column_name.clone(), col.datatype.clone());
+            }
+        }
+    }
+    for (table, column, expected) in checks {
+        let got = by_table
+            .get(table)
+            .and_then(|m| m.get(*column))
+            .unwrap_or_else(|| panic!("missing {table}.{column}"));
+        assert_eq!(
+            got.as_deref(),
+            *expected,
+            "{table}.{column} datatype mismatch"
+        );
+    }
+}
+
+#[test]
+fn session_id_is_the_only_extra_unresolved_candidate() {
+    // Documented deviation: SESSION_ID is an integer *_ID with no matching PK,
+    // so the spec's *_KEY/*_ID rule flags it. It is NOT one of the 33 enterprise
+    // FKs, so "29/33 resolved + 4 role-renamed" still holds.
+    let out = emit_r2rml(&enterprise_dw_tables(), &EmitOptions::default());
+    let unresolved = diag_cols(&out, DiagCode::UnresolvedFkCandidate);
+    let mut expected: BTreeSet<(String, String)> = EXPECTED_UNRESOLVED_ROLE_RENAMED
+        .iter()
+        .map(|(t, c)| (t.to_string(), c.to_string()))
+        .collect();
+    expected.insert(("DW.FACT_WEB_EVENT".to_string(), "SESSION_ID".to_string()));
+    assert_eq!(unresolved, expected);
+}
+
+// =============================================================================
+// Round-trip through the real loader (turtle feature)
+// =============================================================================
+
+#[cfg(feature = "turtle")]
+#[test]
+fn all_16_tables_round_trip_through_loader() {
+    let out = emit_r2rml(&enterprise_dw_tables(), &EmitOptions::default());
+    crate::emit::roundtrip_check(&out).expect("round-trip must reproduce the emitted IR");
+
+    // And the compiled mapping has exactly 16 TriplesMaps.
+    let compiled = crate::loader::R2rmlLoader::from_turtle(&out.turtle)
+        .unwrap()
+        .compile()
+        .unwrap();
+    assert_eq!(compiled.len(), 16);
+}
+
+#[cfg(feature = "turtle")]
+#[test]
+fn single_table_round_trips() {
+    // The simplest increment: DIM_DATE (no FKs) renders and round-trips.
+    let tables = enterprise_dw_tables();
+    let dim_date = tables.into_iter().find(|t| t.name == "DIM_DATE").unwrap();
+    let out = emit_r2rml(&[dim_date], &EmitOptions::default());
+    crate::emit::roundtrip_check(&out).expect("DIM_DATE must round-trip");
+    assert!(out.turtle.contains("rr:tableName \"DW.DIM_DATE\""));
+    assert!(out.turtle.contains("{DATE_KEY}"));
+}
+
+// =============================================================================
+// hex-not-base64 regression guard (rule 2)
+// =============================================================================
+
+#[test]
+fn bytes_datatype_is_hexbinary_coupled_to_materializer_output() {
+    use std::sync::Arc;
+
+    use fluree_db_tabular::{BatchSchema, Column, ColumnBatch, FieldInfo};
+
+    use crate::emit::naming::xsd_datatype;
+    use crate::mapping::ObjectMap;
+    use crate::materialize::materialize_object_from_batch;
+
+    // The emitter's choice for bytes.
+    assert_eq!(xsd_datatype(FieldType::Bytes, true), Some("xsd:hexBinary"));
+
+    // The materializer's ACTUAL lexical output for a bytes column. If anyone
+    // "fixes" term.rs::base64_encode into real base64, this becomes "3q2+7w=="
+    // and the assertion fails — loudly coupling the datatype choice to reality.
+    let schema = Arc::new(BatchSchema::new(vec![FieldInfo {
+        name: "PAYLOAD".to_string(),
+        field_type: FieldType::Bytes,
+        nullable: true,
+        field_id: 1,
+    }]));
+    let batch = ColumnBatch::new(
+        schema,
+        vec![Column::Bytes(vec![Some(vec![0xde, 0xad, 0xbe, 0xef])])],
+    )
+    .unwrap();
+    let om = ObjectMap::column_typed("PAYLOAD", "http://www.w3.org/2001/XMLSchema#hexBinary");
+    let term = materialize_object_from_batch(&om, &batch, 0)
+        .unwrap()
+        .unwrap();
+    match term {
+        crate::materialize::RdfTerm::Literal { value, .. } => {
+            assert_eq!(value, "deadbeef", "bytes must materialize as lowercase hex");
+        }
+        other => panic!("expected literal, got {other:?}"),
+    }
+}

--- a/fluree-db-r2rml/src/emit/tests.rs
+++ b/fluree-db-r2rml/src/emit/tests.rs
@@ -109,9 +109,13 @@ fn subject_key_from_identifier_field_ids() {
         "{}",
         tm.subject_template
     );
-    // No NoSafeSubjectKey / SubjectKeyUnverified for a clean identifier hint.
+    // A clean identifier hint has no NoSafeSubjectKey, but — since uniqueness is
+    // unverifiable metadata-only — it earns a SubjectKeyUnverified on the key.
     assert!(diag_cols(&out, DiagCode::NoSafeSubjectKey).is_empty());
-    assert!(diag_cols(&out, DiagCode::SubjectKeyUnverified).is_empty());
+    assert_eq!(
+        diag_cols(&out, DiagCode::SubjectKeyUnverified),
+        BTreeSet::from([("DW.DIM_WIDGET".to_string(), "WIDGET_KEY".to_string())])
+    );
     // The subject-key column is retained as a literal marked isSubjectId.
     let pk = tm
         .columns
@@ -199,6 +203,54 @@ fn identifier_field_ids_nullable_column_yields_no_safe_subject_key() {
             .any(|(ct, cc, _, _)| ct == "DW.FACT_USE" && cc == "WIDGET_KEY"),
         "a nullable identifier must not be a valid FK parent"
     );
+}
+
+#[test]
+fn identifier_with_unknown_null_fraction_from_partial_stats_is_not_safe() {
+    // Partial-coverage Tier-B stats leave null_fraction == None (unknown). An
+    // identifier column that is neither `required` nor proven null-free
+    // (null_fraction == 0) must NOT be treated as a safe subject key — is_non_null
+    // is false — so the partial-coverage fix (#5) and the non-null gate (#4)
+    // compose correctly at the emitter level. The shared fixtures only ever set
+    // null_fraction from `required`, so this builds the column explicitly.
+    let key = |null_fraction: Option<f64>| EmitColumn {
+        field_id: 1,
+        name: "WIDGET_KEY".to_string(),
+        iceberg_type: "long".to_string(),
+        field_type: FieldType::Int64,
+        required: false, // not declared NOT NULL; safety must come from stats
+        nested: false,
+        doc: None,
+        stats: EmitColumnStats {
+            null_fraction,
+            min: Some(TypedBound::Int(1)),
+            max: Some(TypedBound::Int(100)),
+        },
+    };
+
+    // Unknown coverage → no subject.
+    let out = emit_r2rml(
+        &[tbl("DIM_WIDGET", vec![1], vec![key(None)])],
+        &EmitOptions::default(),
+    );
+    assert!(out.structured.table_mappings[0].subject_template.is_empty());
+    assert!(diag_cols(&out, DiagCode::NoSafeSubjectKey)
+        .contains(&("DW.DIM_WIDGET".to_string(), "WIDGET_KEY".to_string())));
+
+    // Full coverage proving null_fraction == 0 → the SAME column is safe (only
+    // unverified for uniqueness).
+    let out2 = emit_r2rml(
+        &[tbl("DIM_WIDGET", vec![1], vec![key(Some(0.0))])],
+        &EmitOptions::default(),
+    );
+    assert!(out2.structured.table_mappings[0]
+        .subject_template
+        .ends_with("/{WIDGET_KEY}"));
+    assert_eq!(
+        diag_cols(&out2, DiagCode::SubjectKeyUnverified),
+        BTreeSet::from([("DW.DIM_WIDGET".to_string(), "WIDGET_KEY".to_string())])
+    );
+    assert!(diag_cols(&out2, DiagCode::NoSafeSubjectKey).is_empty());
 }
 
 #[test]
@@ -1090,9 +1142,14 @@ fn override_class_name_changes_class_and_slug_only() {
         tm.subject_template
     );
     // Predicate-object mappings (predicates derive from column names, not the
-    // class) are byte-identical, and no subject-key diagnostics fire.
+    // class) are byte-identical, and the class-name override changes no
+    // diagnostics (both runs carry the identifier_field_ids SubjectKeyUnverified).
     assert_eq!(default_tm.columns, tm.columns);
-    assert!(out.diagnostics.is_empty());
+    assert_eq!(out.diagnostics, default_out.diagnostics);
+    assert_eq!(
+        diag_cols(&out, DiagCode::SubjectKeyUnverified),
+        BTreeSet::from([("DW.DIM_WIDGET".to_string(), "WIDGET_KEY".to_string())])
+    );
 }
 
 #[test]

--- a/fluree-db-r2rml/src/emit/tests.rs
+++ b/fluree-db-r2rml/src/emit/tests.rs
@@ -14,7 +14,7 @@ use fluree_db_tabular::FieldType;
 use crate::emit::diagnostic::DiagCode;
 use crate::emit::fixtures::enterprise_dw_tables;
 use crate::emit::input::{EmitColumn, EmitColumnStats, EmitTableSchema, TypedBound};
-use crate::emit::{emit_r2rml, EmitOptions, EmitOutput};
+use crate::emit::{emit_r2rml, EmitOptions, EmitOutput, TableKey, TableOverride};
 
 // =============================================================================
 // Synthetic-input helpers (for focused FK-heuristic unit tests)
@@ -798,6 +798,229 @@ fn session_id_is_the_only_extra_unresolved_candidate() {
         .collect();
     expected.insert(("DW.FACT_WEB_EVENT".to_string(), "SESSION_ID".to_string()));
     assert_eq!(unresolved, expected);
+}
+
+// =============================================================================
+// Per-table overrides (primary_key / class_name)
+// =============================================================================
+
+/// `EmitOptions::default()` plus a single `{namespace,name}` override entry.
+fn opts_with_override(namespace: &str, name: &str, ov: TableOverride) -> EmitOptions {
+    let mut opts = EmitOptions::default();
+    opts.per_table_overrides
+        .insert(TableKey::new(namespace, name), ov);
+    opts
+}
+
+#[test]
+fn override_primary_key_replaces_identifier_field_ids() {
+    // identifier_field_ids=[1] would key on WIDGET_KEY with no unverified diag;
+    // the override REPLACES it with ALT_KEY and always earns SubjectKeyUnverified.
+    let t = tbl(
+        "DIM_WIDGET",
+        vec![1],
+        vec![
+            ik(1, "WIDGET_KEY", 1, 100, true),
+            ik(2, "ALT_KEY", 1, 100, true),
+            sc(3, "NAME", FieldType::String),
+        ],
+    );
+    let opts = opts_with_override(
+        "DW",
+        "DIM_WIDGET",
+        TableOverride {
+            primary_key: Some("ALT_KEY".to_string()),
+            class_name: None,
+        },
+    );
+    let out = emit_r2rml(&[t], &opts);
+    let tm = &out.structured.table_mappings[0];
+
+    // Subject keys on the override column, not the identifier_field_ids column.
+    assert!(
+        tm.subject_template.ends_with("/{ALT_KEY}"),
+        "subject template {} must key on the override column",
+        tm.subject_template
+    );
+    assert!(!tm.subject_template.contains("{WIDGET_KEY}"));
+    // The override column is the isSubjectId literal.
+    let pk = tm
+        .columns
+        .iter()
+        .find(|c| c.column_name == "ALT_KEY")
+        .unwrap();
+    assert!(pk.is_subject_id);
+    assert!(tm
+        .columns
+        .iter()
+        .find(|c| c.column_name == "WIDGET_KEY")
+        .is_some_and(|c| !c.is_subject_id));
+
+    // An override PK ALWAYS attaches SubjectKeyUnverified, and never NoSafeSubjectKey.
+    assert_eq!(
+        diag_cols(&out, DiagCode::SubjectKeyUnverified),
+        BTreeSet::from([("DW.DIM_WIDGET".to_string(), "ALT_KEY".to_string())])
+    );
+    assert!(diag_cols(&out, DiagCode::NoSafeSubjectKey).is_empty());
+}
+
+#[test]
+fn override_primary_key_failing_null_gate_yields_no_safe_subject_key() {
+    // The override column exists but is nullable (required=false, null_fraction
+    // unknown) → fails the required / null_fraction==0 gate → NoSafeSubjectKey,
+    // no subject, and NOT SubjectKeyUnverified.
+    let t = tbl(
+        "DIM_WIDGET",
+        vec![1],
+        vec![
+            ik(1, "WIDGET_KEY", 1, 100, true),
+            ik(2, "NULLABLE_COL", 1, 100, false),
+        ],
+    );
+    let opts = opts_with_override(
+        "DW",
+        "DIM_WIDGET",
+        TableOverride {
+            primary_key: Some("NULLABLE_COL".to_string()),
+            class_name: None,
+        },
+    );
+    let out = emit_r2rml(&[t], &opts);
+    let tm = &out.structured.table_mappings[0];
+
+    assert!(
+        tm.subject_template.is_empty(),
+        "a failing override gate must emit no subject"
+    );
+    assert!(diag_cols(&out, DiagCode::NoSafeSubjectKey)
+        .contains(&("DW.DIM_WIDGET".to_string(), "NULLABLE_COL".to_string())));
+    assert!(diag_cols(&out, DiagCode::SubjectKeyUnverified).is_empty());
+}
+
+#[test]
+fn override_primary_key_gate_passes_via_null_fraction_zero() {
+    // required=false but null_fraction==0.0 (stats-proven null-free) passes the gate.
+    let mut col = ik(2, "PROVEN_COL", 1, 100, false);
+    col.stats.null_fraction = Some(0.0);
+    let t = tbl(
+        "DIM_WIDGET",
+        vec![1],
+        vec![ik(1, "WIDGET_KEY", 1, 100, true), col],
+    );
+    let opts = opts_with_override(
+        "DW",
+        "DIM_WIDGET",
+        TableOverride {
+            primary_key: Some("PROVEN_COL".to_string()),
+            class_name: None,
+        },
+    );
+    let out = emit_r2rml(&[t], &opts);
+    assert!(out.structured.table_mappings[0]
+        .subject_template
+        .ends_with("/{PROVEN_COL}"));
+    assert_eq!(
+        diag_cols(&out, DiagCode::SubjectKeyUnverified),
+        BTreeSet::from([("DW.DIM_WIDGET".to_string(), "PROVEN_COL".to_string())])
+    );
+    assert!(diag_cols(&out, DiagCode::NoSafeSubjectKey).is_empty());
+}
+
+#[test]
+fn override_primary_key_on_missing_column_is_clean_diagnostic_not_panic() {
+    // A nonexistent override column must produce a clean NoSafeSubjectKey (no
+    // subject), never a panic.
+    let t = tbl(
+        "DIM_WIDGET",
+        vec![1],
+        vec![ik(1, "WIDGET_KEY", 1, 100, true)],
+    );
+    let opts = opts_with_override(
+        "DW",
+        "DIM_WIDGET",
+        TableOverride {
+            primary_key: Some("DOES_NOT_EXIST".to_string()),
+            class_name: None,
+        },
+    );
+    let out = emit_r2rml(&[t], &opts);
+    assert!(out.structured.table_mappings[0].subject_template.is_empty());
+    assert!(diag_cols(&out, DiagCode::NoSafeSubjectKey)
+        .contains(&("DW.DIM_WIDGET".to_string(), "DOES_NOT_EXIST".to_string())));
+    // No fabricated subject key column exists in the output.
+    assert!(out.structured.table_mappings[0]
+        .columns
+        .iter()
+        .all(|c| !c.is_subject_id));
+}
+
+#[test]
+fn override_class_name_changes_class_and_slug_only() {
+    // DIM_WIDGET derives class "Widget" / slug "widget"; the override forces
+    // "Gadget" / "gadget" and changes NOTHING else (columns, subject key column).
+    let t = tbl(
+        "DIM_WIDGET",
+        vec![1],
+        vec![
+            ik(1, "WIDGET_KEY", 1, 100, true),
+            sc(2, "NAME", FieldType::String),
+        ],
+    );
+    let default_out = emit_r2rml(std::slice::from_ref(&t), &EmitOptions::default());
+    let opts = opts_with_override(
+        "DW",
+        "DIM_WIDGET",
+        TableOverride {
+            primary_key: None,
+            class_name: Some("Gadget".to_string()),
+        },
+    );
+    let out = emit_r2rml(&[t], &opts);
+
+    let default_tm = &default_out.structured.table_mappings[0];
+    let tm = &out.structured.table_mappings[0];
+
+    // rr:class + subject slug reflect the override.
+    assert!(default_tm.class_iri.ends_with("Widget"));
+    assert!(tm.class_iri.ends_with("Gadget"), "{}", tm.class_iri);
+    assert!(tm.subject_template.contains("/gadget/{WIDGET_KEY}"));
+    // ONLY the slug portion of the template changed (subject key column intact).
+    assert_eq!(
+        default_tm.subject_template.replace("/widget/", "/gadget/"),
+        tm.subject_template
+    );
+    // Predicate-object mappings (predicates derive from column names, not the
+    // class) are byte-identical, and no subject-key diagnostics fire.
+    assert_eq!(default_tm.columns, tm.columns);
+    assert!(out.diagnostics.is_empty());
+}
+
+#[test]
+fn empty_and_unmatched_overrides_are_byte_identical_to_pre_change_golden() {
+    // The golden was captured from the pre-override emitter over the 16-table
+    // fixture; empty overrides must reproduce it byte-for-byte (no-op safety).
+    const GOLDEN: &str = include_str!("testdata/enterprise_default.ttl");
+    let default_out = emit_r2rml(&enterprise_dw_tables(), &EmitOptions::default());
+    assert_eq!(
+        default_out.turtle, GOLDEN,
+        "default (empty-overrides) output must be byte-identical to the pre-change emitter"
+    );
+
+    // An override keyed on a table NOT in the input is inert — same bytes.
+    let opts = opts_with_override(
+        "DW",
+        "NOT_A_REAL_TABLE",
+        TableOverride {
+            primary_key: Some("X".to_string()),
+            class_name: Some("Y".to_string()),
+        },
+    );
+    let unmatched_out = emit_r2rml(&enterprise_dw_tables(), &opts);
+    assert_eq!(
+        unmatched_out.turtle, GOLDEN,
+        "an override on a table not in the request must be a no-op"
+    );
+    assert_eq!(unmatched_out.diagnostics, default_out.diagnostics);
 }
 
 // =============================================================================

--- a/fluree-db-r2rml/src/emit/tests.rs
+++ b/fluree-db-r2rml/src/emit/tests.rs
@@ -1264,6 +1264,49 @@ fn adversarial_names_escape_and_do_not_inject_predicate_object_maps() {
     assert!(tm.columns.iter().any(|c| c.column_name == evil));
 }
 
+#[cfg(feature = "turtle")]
+#[test]
+fn hostile_base_namespace_is_escaped_in_header_and_cannot_inject() {
+    // `base_namespace` reaches the `@prefix v: <…>` header, which bypasses
+    // curie(). A crafted newline + `@prefix`/triple must not inject real Turtle.
+    let hostile =
+        "http://ns.example/x\n@prefix evil: <http://evil/> .\n<#Inj> a <http://evil/T> .\n#";
+    let opts = EmitOptions {
+        base_namespace: hostile.to_string(),
+        ..EmitOptions::default()
+    };
+    let t = tbl(
+        "DIM_WIDGET",
+        vec![1],
+        vec![ik(1, "WIDGET_KEY", 1, 100, true)],
+    );
+    let out = emit_r2rml(&[t], &opts);
+
+    // Still compiles and round-trips to exactly ONE TriplesMap — the injected
+    // statements did not parse as real triples.
+    crate::emit::roundtrip_check(&out).expect("hostile base_namespace must still round-trip");
+    let compiled = crate::loader::R2rmlLoader::from_turtle(&out.turtle)
+        .unwrap()
+        .compile()
+        .unwrap();
+    assert_eq!(compiled.len(), 1, "no injected TriplesMap");
+
+    // The injection vector is a RAW newline that ends the @prefix line and starts
+    // a new directive/triple. Escaping turns every base newline into a \uXXXX
+    // (header IRI) or \n (rr:template) escape — neither a real 0x0A — so the
+    // crafted payload can never reach statement position.
+    assert!(
+        !out.turtle.contains("\n@prefix evil"),
+        "raw-newline prefix injection: {}",
+        out.turtle
+    );
+    assert!(
+        !out.turtle.contains("\n<#Inj>"),
+        "raw-newline triple injection: {}",
+        out.turtle
+    );
+}
+
 // =============================================================================
 // hex-not-base64 regression guard (rule 2)
 // =============================================================================

--- a/fluree-db-r2rml/src/emit/tests.rs
+++ b/fluree-db-r2rml/src/emit/tests.rs
@@ -159,6 +159,49 @@ fn subject_key_fallback_rejects_nullable_key() {
 }
 
 #[test]
+fn identifier_field_ids_nullable_column_yields_no_safe_subject_key() {
+    // identifier_field_ids points at a NULLABLE column (not required, no proven
+    // null_fraction==0). Unlike a clean identifier hint, this must fail the
+    // non-null gate: no subject, a NoSafeSubjectKey diagnostic, and — crucially —
+    // it must NOT be indexed as an FK parent.
+    let parent = tbl(
+        "DIM_WIDGET",
+        vec![1],
+        vec![
+            ik(1, "WIDGET_KEY", 1, 100, false), // nullable identifier
+            sc(2, "NAME", FieldType::String),
+        ],
+    );
+    // A child that WOULD join to WIDGET_KEY if the nullable identifier were
+    // (wrongly) indexed as a PK.
+    let child = tbl(
+        "FACT_USE",
+        vec![1],
+        vec![
+            ik(1, "USE_KEY", 1, 100, true),
+            ik(2, "WIDGET_KEY", 1, 100, false),
+        ],
+    );
+    let out = emit_r2rml(&[parent, child], &EmitOptions::default());
+
+    let widget = out.structured.table_mapping("DW.DIM_WIDGET").unwrap();
+    assert!(
+        widget.subject_template.is_empty(),
+        "a nullable identifier must emit no subject"
+    );
+    assert!(diag_cols(&out, DiagCode::NoSafeSubjectKey)
+        .contains(&("DW.DIM_WIDGET".to_string(), "WIDGET_KEY".to_string())));
+
+    // Never indexed as a PK → the child's WIDGET_KEY resolves to no parent.
+    assert!(
+        !resolved_fks(&out)
+            .iter()
+            .any(|(ct, cc, _, _)| ct == "DW.FACT_USE" && cc == "WIDGET_KEY"),
+        "a nullable identifier must not be a valid FK parent"
+    );
+}
+
+#[test]
 fn no_safe_subject_key_emits_no_subject_and_never_invents_one() {
     let t = tbl(
         "WEIRD",
@@ -296,6 +339,63 @@ fn fk_self_join_resolves_when_name_aligned() {
         "DW.DIM_NODE".to_string(),
         "NODE_KEY".to_string(),
     )));
+}
+
+#[test]
+fn fk_join_locals_disambiguate_across_joins_not_just_literals() {
+    // Two parents whose PKs strip+camel to the SAME local: GEOGRAPHY_KEY and
+    // GEOGRAPHY_ID both → `geography`. A child referencing both must emit two
+    // DISTINCT predicate IRIs (the second `Ref`-suffixed), never one merged
+    // predicate that would collapse two relationships.
+    let geo_a = tbl(
+        "DIM_GEO_A",
+        vec![1],
+        vec![ik(1, "GEOGRAPHY_KEY", 1, 100, true)],
+    );
+    let geo_b = tbl(
+        "DIM_GEO_B",
+        vec![1],
+        vec![ik(1, "GEOGRAPHY_ID", 1, 100, true)],
+    );
+    let child = tbl(
+        "FACT_C",
+        vec![1],
+        vec![
+            ik(1, "C_KEY", 1, 100, true),
+            ik(2, "GEOGRAPHY_KEY", 1, 100, false),
+            ik(3, "GEOGRAPHY_ID", 1, 100, false),
+        ],
+    );
+    let out = emit_r2rml(&[geo_a, geo_b, child], &EmitOptions::default());
+
+    // Both FKs resolve to their distinct parents.
+    let fks = resolved_fks(&out);
+    assert!(fks.contains(&(
+        "DW.FACT_C".to_string(),
+        "GEOGRAPHY_KEY".to_string(),
+        "DW.DIM_GEO_A".to_string(),
+        "GEOGRAPHY_KEY".to_string(),
+    )));
+    assert!(fks.contains(&(
+        "DW.FACT_C".to_string(),
+        "GEOGRAPHY_ID".to_string(),
+        "DW.DIM_GEO_B".to_string(),
+        "GEOGRAPHY_ID".to_string(),
+    )));
+
+    // The two join predicate IRIs are DISTINCT.
+    let child_tm = out.structured.table_mapping("DW.FACT_C").unwrap();
+    let join_preds: Vec<&str> = child_tm
+        .columns
+        .iter()
+        .filter(|c| c.foreign_key.is_some())
+        .map(|c| c.predicate_iri.as_str())
+        .collect();
+    assert_eq!(join_preds.len(), 2);
+    assert_ne!(
+        join_preds[0], join_preds[1],
+        "colliding FK locals must not merge to one predicate IRI"
+    );
 }
 
 #[test]
@@ -1051,6 +1151,60 @@ fn single_table_round_trips() {
     crate::emit::roundtrip_check(&out).expect("DIM_DATE must round-trip");
     assert!(out.turtle.contains("rr:tableName \"DW.DIM_DATE\""));
     assert!(out.turtle.contains("{DATE_KEY}"));
+}
+
+#[cfg(feature = "turtle")]
+#[test]
+fn adversarial_names_escape_and_do_not_inject_predicate_object_maps() {
+    // A column name carrying Turtle-significant characters (`"`, `\`, newline)
+    // plus a crafted `] ; rr:predicate ... ; rr:column "` injection payload.
+    // Unescaped, the bare `"` closes `rr:column` and the tail becomes extra
+    // predicate-object maps; escaped, the document still parses and gains none.
+    let evil = "E\"VIL\\\n ] ; rr:predicate <http://x/inject> ; rr:column \"X";
+    let t = EmitTableSchema {
+        namespace: "DW".to_string(),
+        name: "DIM_WIDGET".to_string(),
+        identifier_field_ids: vec![1],
+        columns: vec![
+            ik(1, "WIDGET_KEY", 1, 100, true),
+            EmitColumn {
+                field_id: 2,
+                name: evil.to_string(),
+                iceberg_type: "string".to_string(),
+                field_type: FieldType::String,
+                required: false,
+                nested: false,
+                doc: None,
+                stats: EmitColumnStats::default(),
+            },
+        ],
+    };
+    let out = emit_r2rml(&[t], &EmitOptions::default());
+
+    // (a) The emitted Turtle compiles through the real loader and the IR
+    // reconstructs — proving the escaping is valid and lossless.
+    crate::emit::roundtrip_check(&out).expect("adversarial names must round-trip");
+
+    // (b) Exactly ONE TriplesMap, with exactly TWO predicate-object maps (the
+    // subject-key literal + the evil column's literal). The crafted name
+    // injected no extra map.
+    let compiled = crate::loader::R2rmlLoader::from_turtle(&out.turtle)
+        .unwrap()
+        .compile()
+        .unwrap();
+    assert_eq!(compiled.len(), 1, "no extra TriplesMap may be injected");
+    let maps = compiled.find_maps_for_table("DW.DIM_WIDGET");
+    assert_eq!(maps.len(), 1);
+    assert_eq!(
+        maps[0].predicate_object_maps.len(),
+        2,
+        "the crafted column name must not inject extra predicate-object maps"
+    );
+
+    // (c) The evil name survives verbatim in the IR (rendered escaped, parsed
+    // back intact) — no lossy mangling.
+    let tm = &out.structured.table_mappings[0];
+    assert!(tm.columns.iter().any(|c| c.column_name == evil));
 }
 
 // =============================================================================

--- a/fluree-db-r2rml/src/lib.rs
+++ b/fluree-db-r2rml/src/lib.rs
@@ -30,12 +30,14 @@
 //! indexed lookup methods like `find_maps_for_class()` for efficient pattern matching
 //! during query execution.
 
+pub mod emit;
 pub mod error;
 pub mod loader;
 pub mod mapping;
 pub mod materialize;
 pub mod vocab;
 
+pub use emit::{emit_r2rml, EmitOptions, EmitOutput, EmitTableSchema, StructuredR2rmlMapping};
 pub use error::{R2rmlError, R2rmlResult};
 pub use loader::R2rmlLoader;
 pub use mapping::{

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -252,6 +252,189 @@ fn build_iceberg_config(req: &IcebergMapRequest) -> Result<fluree_db_api::Iceber
     Ok(config)
 }
 
+// =============================================================================
+// Read-only catalog browse + metadata preview (metadata-only, no graph source
+// created). POST-with-read-semantics: the connection carries a secret in the
+// body, so these are POSTs, but they mutate nothing.
+// =============================================================================
+
+/// The reusable Iceberg connection fields shared by browse/preview requests
+/// (a subset of [`IcebergMapRequest`], minus `name`/`table`/`r2rml`).
+#[derive(Deserialize)]
+pub struct IcebergConnectionRequest {
+    /// Catalog mode: "rest" (default) or "direct"
+    #[serde(default = "default_mode")]
+    pub mode: String,
+    /// REST catalog URI
+    pub catalog_uri: Option<String>,
+    /// S3 table location (direct mode)
+    pub table_location: Option<String>,
+    /// Bearer token for catalog auth
+    pub auth_bearer: Option<String>,
+    /// OAuth2 token URL
+    pub oauth2_token_url: Option<String>,
+    /// OAuth2 client ID
+    pub oauth2_client_id: Option<String>,
+    /// OAuth2 client secret
+    pub oauth2_client_secret: Option<String>,
+    /// OAuth2 scope (e.g. "session:role:<ROLE>" for Snowflake Horizon / Polaris)
+    pub oauth2_scope: Option<String>,
+    /// OAuth2 audience
+    pub oauth2_audience: Option<String>,
+    /// Warehouse identifier
+    pub warehouse: Option<String>,
+    /// Disable vended credentials
+    #[serde(default)]
+    pub no_vended_credentials: bool,
+    /// S3 region override
+    pub s3_region: Option<String>,
+    /// S3 endpoint override
+    pub s3_endpoint: Option<String>,
+    /// Use path-style S3 URLs
+    #[serde(default)]
+    pub s3_path_style: bool,
+}
+
+fn build_iceberg_connection(
+    req: &IcebergConnectionRequest,
+) -> Result<fluree_db_api::IcebergConnectionConfig> {
+    use fluree_db_api::IcebergConnectionConfig;
+
+    let mode = req.mode.to_lowercase();
+    let mut conn = match mode.as_str() {
+        "rest" => {
+            let catalog_uri = req
+                .catalog_uri
+                .as_ref()
+                .ok_or_else(|| ServerError::bad_request("catalog_uri is required for rest mode"))?;
+            IcebergConnectionConfig::rest(catalog_uri)
+        }
+        "direct" => {
+            let location = req.table_location.as_ref().ok_or_else(|| {
+                ServerError::bad_request("table_location is required for direct mode")
+            })?;
+            IcebergConnectionConfig::direct(location)
+        }
+        other => {
+            return Err(ServerError::bad_request(format!(
+                "unknown catalog mode '{other}'. Use 'rest' or 'direct'."
+            )));
+        }
+    };
+
+    if let Some(ref token) = req.auth_bearer {
+        conn = conn.with_auth_bearer(token);
+    }
+    // OAuth2 activates on token_url + client_secret; client_id defaults to ""
+    // so Horizon / PAT callers can omit it (mirrors iceberg/map).
+    if let (Some(ref url), Some(ref secret)) = (&req.oauth2_token_url, &req.oauth2_client_secret) {
+        let id = req.oauth2_client_id.as_deref().unwrap_or("");
+        conn = conn.with_auth_oauth2(url, id, secret);
+        if let Some(ref scope) = req.oauth2_scope {
+            conn = conn.with_oauth2_scope(scope);
+        }
+        if let Some(ref audience) = req.oauth2_audience {
+            conn = conn.with_oauth2_audience(audience);
+        }
+    }
+    if let Some(ref wh) = req.warehouse {
+        conn = conn.with_warehouse(wh);
+    }
+    if req.no_vended_credentials {
+        conn = conn.with_vended_credentials(false);
+    }
+    if let Some(ref region) = req.s3_region {
+        conn = conn.with_s3_region(region);
+    }
+    if let Some(ref endpoint) = req.s3_endpoint {
+        conn = conn.with_s3_endpoint(endpoint);
+    }
+    if req.s3_path_style {
+        conn = conn.with_s3_path_style(true);
+    }
+
+    Ok(conn)
+}
+
+/// Read the request span, parse the JSON body into `T`.
+async fn parse_iceberg_body<T: serde::de::DeserializeOwned>(request: Request) -> Result<T> {
+    let body_bytes = axum::body::to_bytes(request.into_body(), 50 * 1024 * 1024)
+        .await
+        .map_err(|e| ServerError::bad_request(format!("Failed to read body: {e}")))?;
+    serde_json::from_slice(&body_bytes)
+        .map_err(|e| ServerError::bad_request(format!("Invalid JSON: {e}")))
+}
+
+/// Request body for `POST /v1/fluree/iceberg/catalog/browse`
+#[derive(Deserialize)]
+pub struct IcebergBrowseRequest {
+    #[serde(flatten)]
+    pub connection: IcebergConnectionRequest,
+    /// Browse depth: "namespaces" or "tables" (default "tables")
+    pub depth: Option<String>,
+}
+
+/// Browse an Iceberg catalog (namespaces + tables). Read-only.
+///
+/// POST /v1/fluree/iceberg/catalog/browse
+pub async fn iceberg_catalog_browse(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Response {
+    iceberg_catalog_browse_local(state, request)
+        .await
+        .into_response()
+}
+
+async fn iceberg_catalog_browse_local(
+    state: Arc<AppState>,
+    request: Request,
+) -> Result<impl IntoResponse> {
+    use fluree_db_api::BrowseDepth;
+
+    let headers = FlureeHeaders::from_headers(request.headers())?;
+    let request_id = extract_request_id(&headers.raw, &state.telemetry_config);
+    let trace_id = extract_trace_id(&headers.raw);
+    let req: IcebergBrowseRequest = parse_iceberg_body(request).await?;
+
+    let span = create_request_span(
+        "iceberg:catalog:browse",
+        request_id.as_deref(),
+        trace_id.as_deref(),
+        None,
+        None,
+        None,
+    );
+    async move {
+        let conn = build_iceberg_connection(&req.connection)?;
+        let depth = match req.depth.as_deref().map(str::to_lowercase).as_deref() {
+            Some("namespaces") => BrowseDepth::Namespaces,
+            None | Some("tables") => BrowseDepth::Tables,
+            Some(other) => {
+                return Err(ServerError::bad_request(format!(
+                    "unknown depth '{other}'. Use 'namespaces' or 'tables'."
+                )));
+            }
+        };
+
+        let browse = state
+            .fluree
+            .browse_iceberg_catalog(conn, depth)
+            .await
+            .map_err(ServerError::Api)?;
+
+        tracing::info!(
+            status = "success",
+            namespaces = browse.namespaces.len(),
+            tables = browse.tables.len(),
+            "iceberg catalog browsed"
+        );
+        Ok((StatusCode::OK, Json(browse)))
+    }
+    .instrument(span)
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,5 +483,51 @@ mod tests {
         let gs = config.to_iceberg_gs_config();
         let v = serde_json::to_value(&gs).unwrap();
         assert_eq!(v["catalog"]["auth"]["type"], "none");
+    }
+
+    #[test]
+    fn browse_request_flattens_connection_and_builds_config() {
+        // The flattened connection fields must deserialize alongside `depth`,
+        // and build a REST connection carrying the OAuth2 scope.
+        let body = serde_json::json!({
+            "mode": "rest",
+            "catalog_uri": "https://catalog.example.com",
+            "warehouse": "wh1",
+            "oauth2_token_url": "https://catalog.example.com/v1/oauth/tokens",
+            "oauth2_client_secret": "pat",
+            "oauth2_scope": "session:role:ICEBERG_READER",
+            "depth": "namespaces"
+        });
+        let req: IcebergBrowseRequest = serde_json::from_value(body).unwrap();
+        assert_eq!(req.depth.as_deref(), Some("namespaces"));
+        assert_eq!(req.connection.warehouse.as_deref(), Some("wh1"));
+
+        // Build a create config from the same connection so we can inspect the
+        // serialized auth block (the server crate can't name fluree_db_iceberg
+        // types directly).
+        let create = fluree_db_api::IcebergCreateConfig {
+            name: "gs".to_string(),
+            branch: None,
+            connection: build_iceberg_connection(&req.connection).unwrap(),
+            table_identifier: "ns.tbl".to_string(),
+        };
+        assert!(create.is_rest());
+        let gs = create.to_iceberg_gs_config();
+        let v = serde_json::to_value(&gs).unwrap();
+        assert_eq!(v["catalog"]["warehouse"], "wh1");
+        assert_eq!(v["catalog"]["auth"]["type"], "oauth2_client_credentials");
+        assert_eq!(v["catalog"]["auth"]["scope"], "session:role:ICEBERG_READER");
+    }
+
+    #[test]
+    fn browse_request_direct_mode_builds_direct_connection() {
+        let body = serde_json::json!({
+            "mode": "direct",
+            "table_location": "s3://bucket/warehouse/ns/table"
+        });
+        let req: IcebergBrowseRequest = serde_json::from_value(body).unwrap();
+        assert!(req.depth.is_none());
+        let conn = build_iceberg_connection(&req.connection).unwrap();
+        assert!(conn.is_direct());
     }
 }

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -129,8 +129,7 @@ async fn iceberg_map_local(state: Arc<AppState>, request: Request) -> Result<imp
             req.catalog_uri.as_deref(),
             req.oauth2_token_url.as_deref(),
             req.s3_endpoint.as_deref(),
-        )
-        .await?;
+        )?;
 
         let fluree = &state.fluree;
         let iceberg_config = build_iceberg_config(&req)?;
@@ -420,8 +419,7 @@ async fn iceberg_catalog_browse_local(
             req.connection.catalog_uri.as_deref(),
             req.connection.oauth2_token_url.as_deref(),
             req.connection.s3_endpoint.as_deref(),
-        )
-        .await?;
+        )?;
         let conn = build_iceberg_connection(&req.connection)?;
         let depth = match req.depth.as_deref().map(str::to_lowercase).as_deref() {
             Some("namespaces") => BrowseDepth::Namespaces,
@@ -500,8 +498,7 @@ async fn iceberg_catalog_preview_local(
             req.connection.catalog_uri.as_deref(),
             req.connection.oauth2_token_url.as_deref(),
             req.connection.s3_endpoint.as_deref(),
-        )
-        .await?;
+        )?;
         let conn = build_iceberg_connection(&req.connection)?;
         let tier = match req.tier.as_deref().map(str::to_lowercase).as_deref() {
             None | Some("schema") => StatsTier::Schema,
@@ -616,8 +613,7 @@ async fn iceberg_r2rml_generate_local(
             req.connection.catalog_uri.as_deref(),
             req.connection.oauth2_token_url.as_deref(),
             req.connection.s3_endpoint.as_deref(),
-        )
-        .await?;
+        )?;
         let connection = build_iceberg_connection(&req.connection)?;
         let per_table_overrides = req
             .per_table_overrides
@@ -707,8 +703,7 @@ async fn iceberg_r2rml_validate_local(
             req.connection.catalog_uri.as_deref(),
             req.connection.oauth2_token_url.as_deref(),
             req.connection.s3_endpoint.as_deref(),
-        )
-        .await?;
+        )?;
         let conn = build_iceberg_connection(&req.connection)?;
 
         let response = state

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::Instrument;
 
+use super::iceberg_ssrf::guard_connection_urls;
 use super::ledger::forward_write_request;
 
 /// Request body for `POST /v1/fluree/iceberg/map`
@@ -121,6 +122,15 @@ async fn iceberg_map_local(state: Arc<AppState>, request: Request) -> Result<imp
     );
     async move {
         tracing::info!(status = "start", name = %req.name, "iceberg map requested");
+
+        // SSRF guard: reject request-supplied URLs that target internal hosts,
+        // before any outbound HTTP client sees them (unauthenticated by default).
+        guard_connection_urls(
+            req.catalog_uri.as_deref(),
+            req.oauth2_token_url.as_deref(),
+            req.s3_endpoint.as_deref(),
+        )
+        .await?;
 
         let fluree = &state.fluree;
         let iceberg_config = build_iceberg_config(&req)?;
@@ -406,6 +416,12 @@ async fn iceberg_catalog_browse_local(
         None,
     );
     async move {
+        guard_connection_urls(
+            req.connection.catalog_uri.as_deref(),
+            req.connection.oauth2_token_url.as_deref(),
+            req.connection.s3_endpoint.as_deref(),
+        )
+        .await?;
         let conn = build_iceberg_connection(&req.connection)?;
         let depth = match req.depth.as_deref().map(str::to_lowercase).as_deref() {
             Some("namespaces") => BrowseDepth::Namespaces,
@@ -480,6 +496,12 @@ async fn iceberg_catalog_preview_local(
         None,
     );
     async move {
+        guard_connection_urls(
+            req.connection.catalog_uri.as_deref(),
+            req.connection.oauth2_token_url.as_deref(),
+            req.connection.s3_endpoint.as_deref(),
+        )
+        .await?;
         let conn = build_iceberg_connection(&req.connection)?;
         let tier = match req.tier.as_deref().map(str::to_lowercase).as_deref() {
             None | Some("schema") => StatsTier::Schema,
@@ -590,6 +612,12 @@ async fn iceberg_r2rml_generate_local(
                 "at least one table is required for generate",
             ));
         }
+        guard_connection_urls(
+            req.connection.catalog_uri.as_deref(),
+            req.connection.oauth2_token_url.as_deref(),
+            req.connection.s3_endpoint.as_deref(),
+        )
+        .await?;
         let connection = build_iceberg_connection(&req.connection)?;
         let per_table_overrides = req
             .per_table_overrides
@@ -675,6 +703,12 @@ async fn iceberg_r2rml_validate_local(
         None,
     );
     async move {
+        guard_connection_urls(
+            req.connection.catalog_uri.as_deref(),
+            req.connection.oauth2_token_url.as_deref(),
+            req.connection.s3_endpoint.as_deref(),
+        )
+        .await?;
         let conn = build_iceberg_connection(&req.connection)?;
 
         let response = state

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -510,6 +510,128 @@ async fn iceberg_catalog_preview_local(
     .await
 }
 
+// =============================================================================
+// Deterministic R2RML generation (metadata-only; creates no graph source).
+// =============================================================================
+
+/// One `per_table_overrides` entry (its `{namespace, name}` key + values). JSON
+/// object keys must be strings, so overrides ride the wire as a list rather than
+/// a struct-keyed map.
+#[derive(Deserialize)]
+pub struct TableOverrideEntry {
+    /// Table namespace (e.g. "DW").
+    pub namespace: String,
+    /// Table name (e.g. "DIM_STORE").
+    pub name: String,
+    /// Replaces identifier_field_ids as the subject key (still gated on
+    /// required / null_fraction==0; always earns a SubjectKeyUnverified diagnostic).
+    #[serde(default)]
+    pub primary_key: Option<String>,
+    /// Overrides the derived class name / subject slug for the table.
+    #[serde(default)]
+    pub class_name: Option<String>,
+}
+
+/// Request body for `POST /v1/fluree/iceberg/r2rml/generate`.
+#[derive(Deserialize)]
+pub struct IcebergGenerateRequest {
+    #[serde(flatten)]
+    pub connection: IcebergConnectionRequest,
+    /// Tables to map, in output order: `[{ "namespace": .., "name": .. }]`.
+    pub tables: Vec<fluree_db_api::TableIdentifier>,
+    /// The SINGLE base namespace all IRIs derive from.
+    pub base_namespace: String,
+    /// Per-table subject-key / class-name overrides.
+    #[serde(default)]
+    pub per_table_overrides: Vec<TableOverrideEntry>,
+    /// Emit knobs (xsd_long_as_integer / emit_fk_joins / keep_fk_keys_as_literals).
+    #[serde(default)]
+    pub options: fluree_db_api::GenerateOptions,
+    /// RESERVED for PR-4 (target-model IRI rewrite); accepted and ignored.
+    #[serde(default)]
+    pub target_model_ledger_id: Option<String>,
+}
+
+/// Deterministically generate an R2RML mapping over Iceberg tables. Read-only
+/// (metadata-only; creates no graph source).
+///
+/// POST /v1/fluree/iceberg/r2rml/generate
+pub async fn iceberg_r2rml_generate(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Response {
+    iceberg_r2rml_generate_local(state, request)
+        .await
+        .into_response()
+}
+
+async fn iceberg_r2rml_generate_local(
+    state: Arc<AppState>,
+    request: Request,
+) -> Result<impl IntoResponse> {
+    use fluree_db_api::{GenerateR2rmlRequest, TableIdentifier, TableOverride};
+
+    let headers = FlureeHeaders::from_headers(request.headers())?;
+    let request_id = extract_request_id(&headers.raw, &state.telemetry_config);
+    let trace_id = extract_trace_id(&headers.raw);
+    let req: IcebergGenerateRequest = parse_iceberg_body(request).await?;
+
+    let span = create_request_span(
+        "iceberg:r2rml:generate",
+        request_id.as_deref(),
+        trace_id.as_deref(),
+        None,
+        None,
+        None,
+    );
+    async move {
+        if req.tables.is_empty() {
+            return Err(ServerError::bad_request(
+                "at least one table is required for generate",
+            ));
+        }
+        let connection = build_iceberg_connection(&req.connection)?;
+        let per_table_overrides = req
+            .per_table_overrides
+            .into_iter()
+            .map(|e| {
+                (
+                    TableIdentifier::new(e.namespace, e.name),
+                    TableOverride {
+                        primary_key: e.primary_key,
+                        class_name: e.class_name,
+                    },
+                )
+            })
+            .collect();
+
+        let api_req = GenerateR2rmlRequest {
+            connection,
+            tables: req.tables,
+            base_namespace: req.base_namespace,
+            per_table_overrides,
+            options: req.options,
+            target_model_ledger_id: req.target_model_ledger_id,
+        };
+
+        let response = state
+            .fluree
+            .generate_r2rml(api_req)
+            .await
+            .map_err(ServerError::Api)?;
+
+        tracing::info!(
+            status = "success",
+            tables = response.structured.table_mappings.len(),
+            diagnostics = response.diagnostics.len(),
+            "iceberg r2rml generated"
+        );
+        Ok((StatusCode::OK, Json(response)))
+    }
+    .instrument(span)
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -604,5 +726,72 @@ mod tests {
         assert!(req.depth.is_none());
         let conn = build_iceberg_connection(&req.connection).unwrap();
         assert!(conn.is_direct());
+    }
+
+    #[test]
+    fn generate_request_flattens_connection_tables_overrides_and_options() {
+        // The flattened connection fields deserialize alongside the generate
+        // body: tables, base_namespace, an overrides list, options, and the
+        // reserved target_model_ledger_id.
+        let body = serde_json::json!({
+            "mode": "rest",
+            "catalog_uri": "https://catalog.example.com",
+            "warehouse": "wh1",
+            "oauth2_token_url": "https://catalog.example.com/v1/oauth/tokens",
+            "oauth2_client_secret": "pat",
+            "oauth2_scope": "session:role:ICEBERG_READER",
+            "tables": [
+                {"namespace": "DW", "name": "DIM_GEOGRAPHY"},
+                {"namespace": "DW", "name": "DIM_SUPPLIER"}
+            ],
+            "base_namespace": "http://ns.fluree.dev/edw#",
+            "per_table_overrides": [
+                {"namespace": "DW", "name": "DIM_SUPPLIER", "primary_key": "ALT_KEY"}
+            ],
+            "options": {"xsd_long_as_integer": false},
+            "target_model_ledger_id": "model:main"
+        });
+        let req: IcebergGenerateRequest = serde_json::from_value(body).unwrap();
+
+        assert_eq!(req.tables.len(), 2);
+        assert_eq!(req.tables[0].namespace, "DW");
+        assert_eq!(req.tables[0].name, "DIM_GEOGRAPHY");
+        assert_eq!(req.base_namespace, "http://ns.fluree.dev/edw#");
+
+        assert_eq!(req.per_table_overrides.len(), 1);
+        assert_eq!(req.per_table_overrides[0].name, "DIM_SUPPLIER");
+        assert_eq!(
+            req.per_table_overrides[0].primary_key.as_deref(),
+            Some("ALT_KEY")
+        );
+        assert!(req.per_table_overrides[0].class_name.is_none());
+
+        // Explicit `false` overrides the default; the other knobs default `true`.
+        assert!(!req.options.xsd_long_as_integer);
+        assert!(req.options.emit_fk_joins);
+        assert!(req.options.keep_fk_keys_as_literals);
+
+        assert_eq!(req.target_model_ledger_id.as_deref(), Some("model:main"));
+
+        // The flattened connection builds a REST connection carrying the scope.
+        let conn = build_iceberg_connection(&req.connection).unwrap();
+        assert!(conn.is_rest());
+    }
+
+    #[test]
+    fn generate_request_defaults_overrides_and_options() {
+        // Overrides and options are optional; options default to all-`true`.
+        let body = serde_json::json!({
+            "mode": "rest",
+            "catalog_uri": "https://catalog.example.com",
+            "tables": [{"namespace": "DW", "name": "DIM_DATE"}],
+            "base_namespace": "http://ns.fluree.dev/edw#"
+        });
+        let req: IcebergGenerateRequest = serde_json::from_value(body).unwrap();
+        assert!(req.per_table_overrides.is_empty());
+        assert!(req.options.xsd_long_as_integer);
+        assert!(req.options.emit_fk_joins);
+        assert!(req.options.keep_fk_keys_as_literals);
+        assert!(req.target_model_ledger_id.is_none());
     }
 }

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -435,6 +435,81 @@ async fn iceberg_catalog_browse_local(
     .await
 }
 
+/// Request body for `POST /v1/fluree/iceberg/catalog/preview`
+#[derive(Deserialize)]
+pub struct IcebergPreviewRequest {
+    #[serde(flatten)]
+    pub connection: IcebergConnectionRequest,
+    /// Table namespace (e.g. "DW")
+    pub namespace: String,
+    /// Table name (e.g. "DIM_STORE")
+    pub name: String,
+    /// Stats tier: "schema" (Tier-A) or "stats" (Tier-A + Tier-B). Default "schema".
+    pub tier: Option<String>,
+}
+
+/// Preview an Iceberg table's schema (+ optional per-column stats). Read-only.
+///
+/// POST /v1/fluree/iceberg/catalog/preview
+pub async fn iceberg_catalog_preview(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Response {
+    iceberg_catalog_preview_local(state, request)
+        .await
+        .into_response()
+}
+
+async fn iceberg_catalog_preview_local(
+    state: Arc<AppState>,
+    request: Request,
+) -> Result<impl IntoResponse> {
+    use fluree_db_api::{StatsTier, TableIdentifier};
+
+    let headers = FlureeHeaders::from_headers(request.headers())?;
+    let request_id = extract_request_id(&headers.raw, &state.telemetry_config);
+    let trace_id = extract_trace_id(&headers.raw);
+    let req: IcebergPreviewRequest = parse_iceberg_body(request).await?;
+
+    let span = create_request_span(
+        "iceberg:catalog:preview",
+        request_id.as_deref(),
+        trace_id.as_deref(),
+        Some(&format!("{}.{}", req.namespace, req.name)),
+        None,
+        None,
+    );
+    async move {
+        let conn = build_iceberg_connection(&req.connection)?;
+        let tier = match req.tier.as_deref().map(str::to_lowercase).as_deref() {
+            None | Some("schema") => StatsTier::Schema,
+            Some("stats") => StatsTier::Stats,
+            Some(other) => {
+                return Err(ServerError::bad_request(format!(
+                    "unknown tier '{other}'. Use 'schema' or 'stats'."
+                )));
+            }
+        };
+        let table = TableIdentifier::new(&req.namespace, &req.name);
+
+        let preview = state
+            .fluree
+            .preview_iceberg_table(conn, table, tier)
+            .await
+            .map_err(ServerError::Api)?;
+
+        tracing::info!(
+            status = "success",
+            table = %format!("{}.{}", req.namespace, req.name),
+            columns = preview.schema.columns.len(),
+            "iceberg table previewed"
+        );
+        Ok((StatusCode::OK, Json(preview)))
+    }
+    .instrument(span)
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -510,6 +510,70 @@ async fn iceberg_catalog_preview_local(
     .await
 }
 
+/// Request body for `POST /v1/fluree/iceberg/r2rml/validate`
+#[derive(Deserialize)]
+pub struct IcebergValidateRequest {
+    #[serde(flatten)]
+    pub connection: IcebergConnectionRequest,
+    /// R2RML mapping to validate, in Turtle format.
+    pub r2rml: String,
+    /// Optional Iceberg snapshot id to validate against. The metadata preview
+    /// resolves each table's current snapshot, so this is recorded, not enforced.
+    pub snapshot: Option<i64>,
+}
+
+/// Validate an R2RML mapping against a live catalog (compile + cross-check).
+/// Read-only: creates no graph source, writes nothing.
+///
+/// POST /v1/fluree/iceberg/r2rml/validate
+pub async fn iceberg_r2rml_validate(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Response {
+    iceberg_r2rml_validate_local(state, request)
+        .await
+        .into_response()
+}
+
+async fn iceberg_r2rml_validate_local(
+    state: Arc<AppState>,
+    request: Request,
+) -> Result<impl IntoResponse> {
+    let headers = FlureeHeaders::from_headers(request.headers())?;
+    let request_id = extract_request_id(&headers.raw, &state.telemetry_config);
+    let trace_id = extract_trace_id(&headers.raw);
+    let req: IcebergValidateRequest = parse_iceberg_body(request).await?;
+
+    let span = create_request_span(
+        "iceberg:r2rml:validate",
+        request_id.as_deref(),
+        trace_id.as_deref(),
+        None,
+        None,
+        None,
+    );
+    async move {
+        let conn = build_iceberg_connection(&req.connection)?;
+
+        let response = state
+            .fluree
+            .validate_r2rml(conn, req.r2rml, req.snapshot)
+            .await
+            .map_err(ServerError::Api)?;
+
+        tracing::info!(
+            status = "success",
+            compiled_ok = response.compiled_ok,
+            triples_maps = response.triples_map_count,
+            diagnostics = response.diagnostics.len(),
+            "iceberg r2rml validated"
+        );
+        Ok((StatusCode::OK, Json(response)))
+    }
+    .instrument(span)
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/fluree-db-server/src/routes/iceberg_ssrf.rs
+++ b/fluree-db-server/src/routes/iceberg_ssrf.rs
@@ -1,0 +1,247 @@
+//! SSRF guard for the Iceberg onboarding endpoints.
+//!
+//! The Iceberg map / browse / preview / generate / validate routes take catalog
+//! URLs straight from the request body — which is pass-through-unauthenticated
+//! when `admin_auth.mode == None` (the default) — and hand them to an outbound
+//! HTTP client. Without a guard, `catalog_uri` / `oauth2_token_url` /
+//! `s3_endpoint` are a server-side request forgery vector (e.g.
+//! `http://169.254.169.254/latest/meta-data/…` to reach cloud metadata).
+//!
+//! This module blocks that **regardless of auth mode**: only `http(s)` schemes
+//! are allowed, and the host — or, for a DNS name, *every* address it resolves
+//! to — must be a public unicast address. Resolving and checking every returned
+//! address also blunts DNS-rebinding to an internal address.
+//!
+//! Residual risk: `reqwest` re-resolves at connect time, so a name that flips
+//! from public to private *between* this check and the request could still slip
+//! through. Fully closing that needs IP-pinned connections; the checks here stop
+//! the practical vectors (literal internal IPs and names that resolve internal).
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use crate::error::{Result, ServerError};
+
+/// Guard the request-supplied outbound URLs on an Iceberg connection: the REST
+/// `catalog_uri`, the `oauth2_token_url`, and any `s3_endpoint` override. Each,
+/// when present, must pass [`guard_outbound_url`].
+pub async fn guard_connection_urls(
+    catalog_uri: Option<&str>,
+    oauth2_token_url: Option<&str>,
+    s3_endpoint: Option<&str>,
+) -> Result<()> {
+    if let Some(u) = catalog_uri {
+        guard_outbound_url(u, "catalog_uri").await?;
+    }
+    if let Some(u) = oauth2_token_url {
+        guard_outbound_url(u, "oauth2_token_url").await?;
+    }
+    if let Some(u) = s3_endpoint {
+        guard_outbound_url(u, "s3_endpoint").await?;
+    }
+    Ok(())
+}
+
+/// Validate a single request-supplied outbound URL: an allowed scheme plus a
+/// host that neither is, nor resolves to, a private / loopback / link-local /
+/// metadata address. `field` names the offending field for the error message.
+pub async fn guard_outbound_url(raw: &str, field: &str) -> Result<()> {
+    let url = reqwest::Url::parse(raw)
+        .map_err(|e| ServerError::bad_request(format!("{field} is not a valid URL: {e}")))?;
+
+    match url.scheme() {
+        "https" | "http" => {}
+        other => {
+            return Err(ServerError::bad_request(format!(
+                "{field} scheme '{other}' is not allowed (use https or http)"
+            )));
+        }
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| ServerError::bad_request(format!("{field} has no host")))?;
+
+    // Literal IP host: check directly, no DNS.
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if ip_is_blocked(ip) {
+            return Err(blocked(field, host, ip));
+        }
+        return Ok(());
+    }
+
+    // Hostname: resolve and check EVERY address it maps to — an attacker
+    // controls their own DNS, so a name pointing at an internal address (incl.
+    // via DNS rebinding) must be rejected. The port is irrelevant to the
+    // address check; use the scheme default.
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addrs = tokio::net::lookup_host((host, port)).await.map_err(|e| {
+        ServerError::bad_request(format!("{field} host '{host}' did not resolve: {e}"))
+    })?;
+    let mut any = false;
+    for sa in addrs {
+        any = true;
+        if ip_is_blocked(sa.ip()) {
+            return Err(blocked(field, host, sa.ip()));
+        }
+    }
+    if !any {
+        return Err(ServerError::bad_request(format!(
+            "{field} host '{host}' did not resolve to any address"
+        )));
+    }
+    Ok(())
+}
+
+fn blocked(field: &str, host: &str, ip: IpAddr) -> ServerError {
+    ServerError::bad_request(format!(
+        "{field} host '{host}' resolves to a blocked \
+         (private/loopback/link-local/metadata) address {ip}"
+    ))
+}
+
+/// Whether an IP must be blocked as a non-public / internal target.
+///
+/// IPv4: loopback (127/8), private (RFC1918), link-local (169.254/16, which
+/// includes the `169.254.169.254` cloud-metadata address), CGNAT shared space
+/// (100.64/10), unspecified (0.0.0.0), and broadcast. IPv6: loopback (`::1`),
+/// unspecified (`::`), unique-local (`fc00::/7`) and link-local (`fe80::/10`),
+/// plus IPv4-mapped addresses unwrapped to their v4 form. (`Ipv6Addr`'s
+/// `is_unique_local` / `is_unicast_link_local` are still unstable, so those two
+/// ranges are checked by hand.)
+fn ip_is_blocked(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => ipv4_is_blocked(v4),
+        IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return ipv4_is_blocked(v4);
+            }
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || is_ipv6_unique_local(v6)
+                || is_ipv6_link_local(v6)
+        }
+    }
+}
+
+fn ipv4_is_blocked(v4: Ipv4Addr) -> bool {
+    v4.is_private()
+        || v4.is_loopback()
+        || v4.is_link_local()
+        || v4.is_unspecified()
+        || v4.is_broadcast()
+        || is_ipv4_shared(v4)
+}
+
+/// RFC 6598 shared address space (100.64.0.0/10, carrier-grade NAT).
+fn is_ipv4_shared(v4: Ipv4Addr) -> bool {
+    let o = v4.octets();
+    o[0] == 100 && (o[1] & 0xc0) == 0x40
+}
+
+/// `fc00::/7` unique-local addresses.
+fn is_ipv6_unique_local(v6: Ipv6Addr) -> bool {
+    (v6.octets()[0] & 0xfe) == 0xfc
+}
+
+/// `fe80::/10` link-local unicast addresses.
+fn is_ipv6_link_local(v6: Ipv6Addr) -> bool {
+    (v6.segments()[0] & 0xffc0) == 0xfe80
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_internal_ipv4_ranges() {
+        for ip in [
+            "169.254.169.254", // cloud metadata (link-local)
+            "127.0.0.1",       // loopback
+            "10.0.0.1",        // private
+            "172.16.5.4",      // private
+            "192.168.1.1",     // private
+            "100.64.0.1",      // CGNAT shared
+            "0.0.0.0",         // unspecified
+            "255.255.255.255", // broadcast
+        ] {
+            assert!(ip_is_blocked(ip.parse().unwrap()), "{ip} must be blocked");
+        }
+    }
+
+    #[test]
+    fn allows_public_ipv4() {
+        for ip in ["8.8.8.8", "1.1.1.1", "93.184.216.34"] {
+            assert!(!ip_is_blocked(ip.parse().unwrap()), "{ip} must be allowed");
+        }
+    }
+
+    #[test]
+    fn blocks_internal_ipv6_including_mapped() {
+        for ip in [
+            "::1",                    // loopback
+            "::",                     // unspecified
+            "fc00::1",                // unique-local
+            "fd12:3456::1",           // unique-local
+            "fe80::1",                // link-local
+            "::ffff:10.0.0.1",        // v4-mapped private
+            "::ffff:169.254.169.254", // v4-mapped metadata
+        ] {
+            assert!(ip_is_blocked(ip.parse().unwrap()), "{ip} must be blocked");
+        }
+        // A public IPv6 (Cloudflare) is allowed.
+        assert!(!ip_is_blocked("2606:4700:4700::1111".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn guard_blocks_metadata_and_private_literals() {
+        for url in [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.1/",
+            "https://192.168.0.5/catalog",
+            "http://[::1]:8080/",
+            "http://127.0.0.1:9000/",
+        ] {
+            assert!(
+                guard_outbound_url(url, "catalog_uri").await.is_err(),
+                "{url} must be blocked"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn guard_blocks_non_http_schemes() {
+        for url in [
+            "file:///etc/passwd",
+            "ftp://8.8.8.8/x",
+            "gopher://8.8.8.8/",
+            "not even a url",
+        ] {
+            assert!(
+                guard_outbound_url(url, "catalog_uri").await.is_err(),
+                "{url} must be rejected"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn guard_allows_public_literal_ip() {
+        // A literal public IP needs no DNS, so this stays network-free.
+        assert!(
+            guard_outbound_url("https://8.8.8.8/v1/config", "catalog_uri")
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_blocks_localhost_by_resolution() {
+        // `localhost` resolves (via the system resolver / hosts file) to a
+        // loopback address and must be blocked through the resolve-and-check
+        // path, not just literal-IP matching.
+        assert!(
+            guard_outbound_url("http://localhost:8181/catalog", "catalog_uri")
+                .await
+                .is_err()
+        );
+    }
+}

--- a/fluree-db-server/src/routes/iceberg_ssrf.rs
+++ b/fluree-db-server/src/routes/iceberg_ssrf.rs
@@ -1,151 +1,26 @@
-//! SSRF guard for the Iceberg onboarding endpoints.
+//! SSRF guard applied at the Iceberg onboarding route boundary.
 //!
-//! The Iceberg map / browse / preview / generate / validate routes take catalog
-//! URLs straight from the request body — which is pass-through-unauthenticated
-//! when `admin_auth.mode == None` (the default) — and hand them to an outbound
-//! HTTP client. Without a guard, `catalog_uri` / `oauth2_token_url` /
-//! `s3_endpoint` are a server-side request forgery vector (e.g.
-//! `http://169.254.169.254/latest/meta-data/…` to reach cloud metadata).
-//!
-//! This module blocks that **regardless of auth mode**: only `http(s)` schemes
-//! are allowed, and the host — or, for a DNS name, *every* address it resolves
-//! to — must be a public unicast address. Resolving and checking every returned
-//! address also blunts DNS-rebinding to an internal address.
-//!
-//! Residual risk: `reqwest` re-resolves at connect time, so a name that flips
-//! from public to private *between* this check and the request could still slip
-//! through. Fully closing that needs IP-pinned connections; the checks here stop
-//! the practical vectors (literal internal IPs and names that resolve internal).
-
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+//! A cheap up-front reject of request-supplied URLs that target internal hosts,
+//! before any client work. It delegates the scheme/IP policy to the api
+//! (`fluree_db_api::guard_iceberg_connection_urls`), where the AUTHORITATIVE
+//! enforcement also lives: the catalog / OAuth2 HTTP clients are built with a
+//! hardened, redirect-refusing, IP-denylisting resolver, so a redirect or
+//! DNS-rebind to an internal address is blocked at connect time — which a
+//! boundary string check alone cannot cover. `catalog_uri` / `oauth2_token_url`
+//! get the full internal denylist; `s3_endpoint` gets the narrower metadata-only
+//! block (MinIO / LocalStack legitimately use loopback/private hosts).
 
 use crate::error::{Result, ServerError};
 
-/// Guard the request-supplied outbound URLs on an Iceberg connection: the REST
-/// `catalog_uri`, the `oauth2_token_url`, and any `s3_endpoint` override. Each,
-/// when present, must pass [`guard_outbound_url`].
-pub async fn guard_connection_urls(
+/// Guard the request-supplied outbound URLs on an Iceberg connection. Returns a
+/// `400` (via [`ServerError::Api`]) when a URL targets a blocked host.
+pub fn guard_connection_urls(
     catalog_uri: Option<&str>,
     oauth2_token_url: Option<&str>,
     s3_endpoint: Option<&str>,
 ) -> Result<()> {
-    if let Some(u) = catalog_uri {
-        guard_outbound_url(u, "catalog_uri").await?;
-    }
-    if let Some(u) = oauth2_token_url {
-        guard_outbound_url(u, "oauth2_token_url").await?;
-    }
-    if let Some(u) = s3_endpoint {
-        guard_outbound_url(u, "s3_endpoint").await?;
-    }
-    Ok(())
-}
-
-/// Validate a single request-supplied outbound URL: an allowed scheme plus a
-/// host that neither is, nor resolves to, a private / loopback / link-local /
-/// metadata address. `field` names the offending field for the error message.
-pub async fn guard_outbound_url(raw: &str, field: &str) -> Result<()> {
-    let url = reqwest::Url::parse(raw)
-        .map_err(|e| ServerError::bad_request(format!("{field} is not a valid URL: {e}")))?;
-
-    match url.scheme() {
-        "https" | "http" => {}
-        other => {
-            return Err(ServerError::bad_request(format!(
-                "{field} scheme '{other}' is not allowed (use https or http)"
-            )));
-        }
-    }
-
-    let host = url
-        .host_str()
-        .ok_or_else(|| ServerError::bad_request(format!("{field} has no host")))?;
-
-    // Literal IP host: check directly, no DNS.
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        if ip_is_blocked(ip) {
-            return Err(blocked(field, host, ip));
-        }
-        return Ok(());
-    }
-
-    // Hostname: resolve and check EVERY address it maps to — an attacker
-    // controls their own DNS, so a name pointing at an internal address (incl.
-    // via DNS rebinding) must be rejected. The port is irrelevant to the
-    // address check; use the scheme default.
-    let port = url.port_or_known_default().unwrap_or(443);
-    let addrs = tokio::net::lookup_host((host, port)).await.map_err(|e| {
-        ServerError::bad_request(format!("{field} host '{host}' did not resolve: {e}"))
-    })?;
-    let mut any = false;
-    for sa in addrs {
-        any = true;
-        if ip_is_blocked(sa.ip()) {
-            return Err(blocked(field, host, sa.ip()));
-        }
-    }
-    if !any {
-        return Err(ServerError::bad_request(format!(
-            "{field} host '{host}' did not resolve to any address"
-        )));
-    }
-    Ok(())
-}
-
-fn blocked(field: &str, host: &str, ip: IpAddr) -> ServerError {
-    ServerError::bad_request(format!(
-        "{field} host '{host}' resolves to a blocked \
-         (private/loopback/link-local/metadata) address {ip}"
-    ))
-}
-
-/// Whether an IP must be blocked as a non-public / internal target.
-///
-/// IPv4: loopback (127/8), private (RFC1918), link-local (169.254/16, which
-/// includes the `169.254.169.254` cloud-metadata address), CGNAT shared space
-/// (100.64/10), unspecified (0.0.0.0), and broadcast. IPv6: loopback (`::1`),
-/// unspecified (`::`), unique-local (`fc00::/7`) and link-local (`fe80::/10`),
-/// plus IPv4-mapped addresses unwrapped to their v4 form. (`Ipv6Addr`'s
-/// `is_unique_local` / `is_unicast_link_local` are still unstable, so those two
-/// ranges are checked by hand.)
-fn ip_is_blocked(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => ipv4_is_blocked(v4),
-        IpAddr::V6(v6) => {
-            if let Some(v4) = v6.to_ipv4_mapped() {
-                return ipv4_is_blocked(v4);
-            }
-            v6.is_loopback()
-                || v6.is_unspecified()
-                || is_ipv6_unique_local(v6)
-                || is_ipv6_link_local(v6)
-        }
-    }
-}
-
-fn ipv4_is_blocked(v4: Ipv4Addr) -> bool {
-    v4.is_private()
-        || v4.is_loopback()
-        || v4.is_link_local()
-        || v4.is_unspecified()
-        || v4.is_broadcast()
-        || is_ipv4_shared(v4)
-}
-
-/// RFC 6598 shared address space (100.64.0.0/10, carrier-grade NAT).
-fn is_ipv4_shared(v4: Ipv4Addr) -> bool {
-    let o = v4.octets();
-    o[0] == 100 && (o[1] & 0xc0) == 0x40
-}
-
-/// `fc00::/7` unique-local addresses.
-fn is_ipv6_unique_local(v6: Ipv6Addr) -> bool {
-    (v6.octets()[0] & 0xfe) == 0xfc
-}
-
-/// `fe80::/10` link-local unicast addresses.
-fn is_ipv6_link_local(v6: Ipv6Addr) -> bool {
-    (v6.segments()[0] & 0xffc0) == 0xfe80
+    fluree_db_api::guard_iceberg_connection_urls(catalog_uri, oauth2_token_url, s3_endpoint)
+        .map_err(ServerError::Api)
 }
 
 #[cfg(test)]
@@ -153,95 +28,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn blocks_internal_ipv4_ranges() {
-        for ip in [
-            "169.254.169.254", // cloud metadata (link-local)
-            "127.0.0.1",       // loopback
-            "10.0.0.1",        // private
-            "172.16.5.4",      // private
-            "192.168.1.1",     // private
-            "100.64.0.1",      // CGNAT shared
-            "0.0.0.0",         // unspecified
-            "255.255.255.255", // broadcast
-        ] {
-            assert!(ip_is_blocked(ip.parse().unwrap()), "{ip} must be blocked");
-        }
+    fn blocks_metadata_and_private_catalog_and_token_uris() {
+        assert!(guard_connection_urls(Some("http://169.254.169.254/"), None, None).is_err());
+        assert!(guard_connection_urls(Some("http://10.0.0.1/"), None, None).is_err());
+        assert!(guard_connection_urls(None, Some("http://127.0.0.1:9000/token"), None).is_err());
     }
 
     #[test]
-    fn allows_public_ipv4() {
-        for ip in ["8.8.8.8", "1.1.1.1", "93.184.216.34"] {
-            assert!(!ip_is_blocked(ip.parse().unwrap()), "{ip} must be allowed");
-        }
+    fn rejects_non_http_schemes() {
+        assert!(guard_connection_urls(Some("file:///etc/passwd"), None, None).is_err());
     }
 
     #[test]
-    fn blocks_internal_ipv6_including_mapped() {
-        for ip in [
-            "::1",                    // loopback
-            "::",                     // unspecified
-            "fc00::1",                // unique-local
-            "fd12:3456::1",           // unique-local
-            "fe80::1",                // link-local
-            "::ffff:10.0.0.1",        // v4-mapped private
-            "::ffff:169.254.169.254", // v4-mapped metadata
-        ] {
-            assert!(ip_is_blocked(ip.parse().unwrap()), "{ip} must be blocked");
-        }
-        // A public IPv6 (Cloudflare) is allowed.
-        assert!(!ip_is_blocked("2606:4700:4700::1111".parse().unwrap()));
+    fn allows_public_catalog_with_minio_s3_endpoint() {
+        // A public catalog plus a MinIO-style loopback s3_endpoint (permitted).
+        assert!(guard_connection_urls(
+            Some("https://catalog.example.com"),
+            None,
+            Some("http://127.0.0.1:9000"),
+        )
+        .is_ok());
     }
 
-    #[tokio::test]
-    async fn guard_blocks_metadata_and_private_literals() {
-        for url in [
-            "http://169.254.169.254/latest/meta-data/",
-            "http://10.0.0.1/",
-            "https://192.168.0.5/catalog",
-            "http://[::1]:8080/",
-            "http://127.0.0.1:9000/",
-        ] {
-            assert!(
-                guard_outbound_url(url, "catalog_uri").await.is_err(),
-                "{url} must be blocked"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn guard_blocks_non_http_schemes() {
-        for url in [
-            "file:///etc/passwd",
-            "ftp://8.8.8.8/x",
-            "gopher://8.8.8.8/",
-            "not even a url",
-        ] {
-            assert!(
-                guard_outbound_url(url, "catalog_uri").await.is_err(),
-                "{url} must be rejected"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn guard_allows_public_literal_ip() {
-        // A literal public IP needs no DNS, so this stays network-free.
-        assert!(
-            guard_outbound_url("https://8.8.8.8/v1/config", "catalog_uri")
-                .await
-                .is_ok()
-        );
-    }
-
-    #[tokio::test]
-    async fn guard_blocks_localhost_by_resolution() {
-        // `localhost` resolves (via the system resolver / hosts file) to a
-        // loopback address and must be blocked through the resolve-and-check
-        // path, not just literal-IP matching.
-        assert!(
-            guard_outbound_url("http://localhost:8181/catalog", "catalog_uri")
-                .await
-                .is_err()
-        );
+    #[test]
+    fn s3_endpoint_metadata_address_still_blocked() {
+        assert!(guard_connection_urls(None, None, Some("http://169.254.169.254/")).is_err());
     }
 }

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -130,7 +130,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     // create no graph source, so they sit in the reads block (no leader-forward).
     #[cfg(feature = "iceberg")]
     let v1_admin_protected_reads = v1_admin_protected_reads
-        .route("/iceberg/catalog/browse", post(iceberg::iceberg_catalog_browse))
+        .route(
+            "/iceberg/catalog/browse",
+            post(iceberg::iceberg_catalog_browse),
+        )
         .route(
             "/iceberg/catalog/preview",
             post(iceberg::iceberg_catalog_preview),

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -134,6 +134,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/iceberg/catalog/preview",
             post(iceberg::iceberg_catalog_preview),
+        )
+        .route(
+            "/iceberg/r2rml/validate",
+            post(iceberg::iceberg_r2rml_validate),
         );
 
     let v1_admin_protected_reads = v1_admin_protected_reads

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -125,6 +125,13 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // `state.import_jobs` map (each node owns the jobs it minted).
         .route("/import-upload/:import_id", get(import::import_status));
 
+    // Read-only Iceberg catalog browse / metadata preview. POSTs (the inline
+    // connection carries a secret in the body) but they mutate nothing and
+    // create no graph source, so they sit in the reads block (no leader-forward).
+    #[cfg(feature = "iceberg")]
+    let v1_admin_protected_reads = v1_admin_protected_reads
+        .route("/iceberg/catalog/browse", post(iceberg::iceberg_catalog_browse));
+
     let v1_admin_protected_reads = v1_admin_protected_reads
         .layer(middleware::from_fn_with_state(
             state.clone(),

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -130,7 +130,11 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     // create no graph source, so they sit in the reads block (no leader-forward).
     #[cfg(feature = "iceberg")]
     let v1_admin_protected_reads = v1_admin_protected_reads
-        .route("/iceberg/catalog/browse", post(iceberg::iceberg_catalog_browse));
+        .route("/iceberg/catalog/browse", post(iceberg::iceberg_catalog_browse))
+        .route(
+            "/iceberg/catalog/preview",
+            post(iceberg::iceberg_catalog_preview),
+        );
 
     let v1_admin_protected_reads = v1_admin_protected_reads
         .layer(middleware::from_fn_with_state(

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -134,6 +134,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/iceberg/catalog/preview",
             post(iceberg::iceberg_catalog_preview),
+        )
+        .route(
+            "/iceberg/r2rml/generate",
+            post(iceberg::iceberg_r2rml_generate),
         );
 
     let v1_admin_protected_reads = v1_admin_protected_reads

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -8,6 +8,7 @@ mod events;
 mod export;
 #[cfg(feature = "iceberg")]
 mod iceberg;
+mod iceberg_ssrf;
 mod import;
 mod ledger;
 mod log;


### PR DESCRIPTION
## Summary

This PR gives the fluree/db engine everything needed to turn a live Iceberg catalog (Snowflake Horizon / Apache Polaris REST, or direct S3) into a **deterministically generated, queryable R2RML mapping** — with no hand-written R2RML and no LLM in the happy path. It is the engine-side foundation of the [Iceberg → R2RML → Dataset epic](https://github.com/fluree/solo/issues/728): Fluree Solo's backend (next PR) will call this API so a user can connect a catalog, preview its tables, auto-generate a mapping, review it, and save it as a virtual (query-in-place) Dataset.

Everything here is **additive and metadata-only** (no Parquet/data scans), gated behind the existing `iceberg` / `aws` / `turtle` feature flags, and it does not touch the query scan path or any performance-critical files.

Closes fluree/solo#724.

## What's included

Four new, independently testable capabilities plus one supporting refactor:

- **Catalog browse** — wires the (previously present but unused) `list_namespaces` / `list_tables` catalog primitives into a read-only API.
- **Table preview (Tier-A schema + Tier-B stats)** — a metadata-only preview returning the table schema (columns, types, `identifier_field_ids`, partition/sort specs, snapshot + history, properties, row/file/byte counts) and per-column statistics (null/value counts, NaN counts, typed min/max, on-disk bytes) aggregated from Avro manifests. No Parquet is read.
- **Deterministic R2RML generation** — a greenfield metadata→R2RML emitter and structured→Turtle renderer (the `fluree-db-r2rml` crate was parse/compile-only before this). It builds Solo's `StructuredR2rmlMapping` IR from the preview, renders Turtle, and round-trips that Turtle back through the existing `R2rmlLoader` as a correctness check.
- **Validate / dry-run** — compiles an R2RML mapping through the loader and cross-checks every table/column/join reference and subject-key nullability against the live schema + stats, returning structured diagnostics, without creating a graph source.
- **`IcebergConnectionConfig` refactor** — factors the reusable connection block (catalog URI / warehouse / auth / IO) out of `IcebergCreateConfig` so browse/preview/generate/validate can all run against an unsaved connection during onboarding. Behavior-identical for the existing create path.

## New public API (the surface the Solo backend PR will bind)

Rust methods on `Fluree` (feature `iceberg`), mirrored by thin HTTP wrappers in `fluree-db-server`:

```
Fluree::browse_iceberg_catalog(conn, depth)       -> CatalogBrowse
Fluree::preview_iceberg_table(conn, table, tier)  -> TablePreview          // tier = Schema | Stats
Fluree::generate_r2rml(request)                   -> GenerateR2rmlResponse
Fluree::validate_r2rml(conn, turtle, snapshot)    -> ValidateR2rmlResponse
```

```
POST /v1/fluree/iceberg/catalog/browse
POST /v1/fluree/iceberg/catalog/preview
POST /v1/fluree/iceberg/r2rml/generate
POST /v1/fluree/iceberg/r2rml/validate
```

All four accept an inline `IcebergConnectionConfig` (so onboarding can browse/preview before anything is saved) and are read-semantic — no graph source is created and nothing is published. `generate_r2rml` returns `{ turtle, structured, diagnostics, snapshot_id }`, where `structured` is Solo's camelCase `StructuredR2rmlMapping` — the authoritative wire IR that the Solo backend persists, the UI reviews, and Phase-2 target-matching later rewrites. There are no pre-save sample triples (Phase-1 is metadata-only; real triples come from a post-save `LIMIT` / Explore query).

## How generation works (deterministic, no LLM)

Per table, the emitter:

- **Picks the subject key** from Iceberg's declared `identifier_field_ids` (or an explicit per-table `primary_key` override). A key must be non-null (`required` or `null_fraction == 0`); a name-based fallback earns a `SubjectKeyUnverified` diagnostic; if none is safe it emits `NoSafeSubjectKey` and no subject — it never invents a surrogate row id.
- **Emits one `rr:TriplesMap` per table**, keeping filterable scalar columns (keys, dates, partition/sort columns) as literal predicate-object maps for pushdown.
- **Infers foreign keys** from Iceberg metadata alone: a candidate column must match a target table's primary-key name (exact, or an unambiguous `_<PK>` suffix) **and** type **and** pass typed min/max range-containment. An exactly-one-survivor becomes an `rr:parentTriplesMap` + `rr:joinCondition`; ambiguous or unresolved key-like columns are surfaced as diagnostics and kept as literals — a join is never fabricated.
- **Renders deterministic Turtle** from the structured IR and round-trips it through `R2rmlLoader::from_turtle().compile()` as an internal correctness check. Two runs over the same snapshot produce byte-identical output.

## Correctness properties (enforced and tested)

- **Every non-string column carries an `rr:datatype`.** Runtime materialization does no datatype inference, so omitting it would silently produce plain-string literals for numerics/temporals. Strings are intentionally left untyped.
- **`bytes → xsd:hexBinary`** (not base64). The materializer's byte formatter emits lowercase hex despite its misleading name; a regression test couples the emitter's datatype choice to the materializer's actual output so that a future "fix" fails loudly.
- **Foreign keys are only ever emitted as `rr:parentTriplesMap` + `rr:joinCondition`**, never as a bare templated IRI built from the child key — so a dangling FK yields no triple (correct R2RML RefObjectMap semantics).
- **Byte-for-byte column casing** on `rr:tableName` / `rr:column` / template placeholders (Snowflake folds identifiers to uppercase; a mismatch would silently scan nothing).
- **Metadata-only.** Browse/preview/generate/validate read REST `loadTable` plus Avro manifest-lists and manifests only; a test asserts that no `.parquet` file is ever fetched.

## Foreign-key coverage (honest)

Against the 16-table `ENTERPRISE_DEMO.DW` reference mapping (33 FK joins), the emitter deterministically reproduces **29 of 33**:

- The **4 role-renamed** FKs (`MANAGER_KEY`, `REGION_MANAGER_KEY`, `SALES_REP_KEY`, `AGENT_KEY` → `EMPLOYEE_KEY`) are not resolvable from metadata (the column name doesn't match the target PK, and overlapping surrogate-key ranges can't disambiguate). They are surfaced as `UnresolvedFkCandidate` and kept as literal columns — **not fabricated** — and get resolved later by Phase-2 target-model matching.
- The **3 child-fact → `FACT_ORDER` hub joins** (`ORDER_KEY → ORDER_KEY`) are emitted, each flagged with a `FactHubJoinAdvisory` performance advisory.

## Known limitations / deferred

- **Subject-key uniqueness is unverifiable from metadata** (no NDV — `distinct_counts` / Puffin sketches are not parsed). Generation relies on `identifier_field_ids` or a required key and flags `SubjectKeyUnverified` when falling back; true uniqueness verification (via NDV or a `COUNT(DISTINCT)` pushdown) is a fast-follow.
- **Snapshot pinning is per-table.** `preview_iceberg_table` reads each table's current snapshot, and `generate_r2rml` returns the first requested table's snapshot as a representative `snapshot_id` (documented as such), not a true catalog-wide pin. A follow-up can add an explicit snapshot selection to preview.
- **Secret-at-rest is unchanged here.** Inbound connection tokens are still wrapped as literals in the persisted graph-source config; moving them to a reference/vault is the Solo backend PR's concern (and a later hardening pass).

## Testing

All green across the relevant feature gates:

| Suite | Result |
|---|---|
| `cargo test -p fluree-db-r2rml --features turtle` | 96 passed |
| `cargo test -p fluree-db-iceberg --features aws --lib` | 159 passed |
| `cargo test -p fluree-db-api --features iceberg,aws --lib` | 671 passed |
| `cargo test -p fluree-db-server --features iceberg --lib routes::iceberg` | 6 passed |

Coverage highlights: the emitter's structural match to the `ENTERPRISE_DEMO.DW` reference mapping (29/33 joins, including the role-renamed and hub cases), the Turtle round-trip through `R2rmlLoader`, byte-determinism, the hex-not-base64 guard, the Tier-B "manifests only, never Parquet" guard, and the validate cross-check across every reference class (table / column / casing / join-type / nullable subject key). `cargo check -p fluree-db-api` with default (non-iceberg) features still compiles, and both `cargo fmt --all -- --check` and clippy are clean.

## Scope and safety

- **Additive.** New modules under `fluree-db-iceberg` (Tier-B stats), `fluree-db-api` (browse / preview / generate / validate), and `fluree-db-r2rml/src/emit` (the emitter). The only edits to existing code are the `IcebergConnectionConfig` extraction (behavior-identical), retaining the previously-discarded inline `loadTable` metadata, exposing `emit::naming`, and route registration.
- **No scan-path or performance-critical files are touched** — this is deliberately kept out of the Iceberg query/scan hot path and the ongoing performance work.

## Not in this PR (tracked separately under the epic)

- **Solo backend (fluree/solo#725):** promote the contracts to `@fluree/contracts`, call this API, persist the mapping, wire catalog-connect + OAuth2 scope + secret handling, and the Dataset↔mapping binding.
- **Solo UI (fluree/solo#726):** the onboarding wizard, structured-form review, and save-as-Dataset.
- **Phase-2 (fluree/solo#727):** target-model matching, which resolves the role-renamed FKs.
- **Fast-follow:** NDV / Puffin reader (subject-key uniqueness) and secret-vault hardening.

## How to review

The branch is a linear-ish build-up you can read part by part:

- `refactor(api): factor IcebergConnectionConfig …` — the connection-type extraction (start here).
- `feat(api): catalog browse …` / `feat(api): Tier-A metadata preview …` / `feat(iceberg,api): Tier-B per-column stats …` — the read/preview API.
- `feat(r2rml): deterministic Iceberg metadata → R2RML emitter …` + `feat(r2rml): per-table primary_key/class_name overrides …` — the emitter (`fluree-db-r2rml/src/emit`).
- `feat(api,server): wire end-to-end generate_r2rml …` + `feat(iceberg,api): R2RML validate/dry-run …` — the generate/validate surface + routes.
- `fix(iceberg): dedicated DiagCode::CompileError …` and `style(iceberg): rustfmt …` — a diagnostics-code fix and formatting.
