### PR TITLE
Fix `select *` Stack Overflow on the `query_from` / `build_client` Path

### DIFF
--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -227,6 +227,10 @@ name = "it_vector_flatrank"
 path = "tests/it_vector_flatrank.rs"
 required-features = ["vector"]
 
+[[test]]
+name = "it_select_star_deep_crawl_stack"
+path = "tests/it_select_star_deep_crawl_stack.rs"
+
 [[bench]]
 name = "vector_query"
 harness = false

--- a/fluree-db-api/src/query/builder.rs
+++ b/fluree-db-api/src/query/builder.rs
@@ -1332,21 +1332,83 @@ impl<'a> FromQueryBuilder<'a> {
         // `connection_opts`. Resolves & applies policy from the merged opts.
         if let (Some(qc_opts), QueryInput::Sparql(sparql)) = (self.connection_opts.as_ref(), input)
         {
-            return self
-                .fluree
-                .query_connection_sparql_tracked_with_opts_options(
-                    sparql,
-                    qc_opts,
-                    format_config,
-                    tracking,
-                    execution.clone(),
-                )
-                .await;
+            // Box the dispatched future: this async fn `.await`s one of ~9
+            // large `query_connection_*` futures, and (especially in debug
+            // builds) the compiler stores each awaited sub-future inline in
+            // this fn's state machine rather than overlapping the mutually
+            // exclusive arms. That inflated `execute_tracked`'s stack frame to
+            // ~470 KB, which — stacked with the deep ledger-load / novelty-
+            // rebuild chain — overflowed the default ~2 MB worker stack on a
+            // plain `select *` connection query (fluree/db#1408). Boxing moves
+            // the sub-future's state to the heap so the frame holds only a
+            // pointer.
+            return Box::pin(
+                self.fluree
+                    .query_connection_sparql_tracked_with_opts_options(
+                        sparql,
+                        qc_opts,
+                        format_config,
+                        tracking,
+                        execution.clone(),
+                    ),
+            )
+            .await;
         }
-        match input {
+        // Dispatch to the chosen `query_connection_*` variant via a separate,
+        // non-inlined fn that RETURNS the boxed future. The large per-arm future
+        // is materialized transiently inside that helper's frame during
+        // `Box::pin`; the helper returns (and its frame is popped) before we
+        // await here, so that transient never coexists on the stack with the
+        // deep query / load / novelty-rebuild chain the future then drives.
+        // Constructed inline here instead, the dispatcher frame would reserve
+        // stack for the largest arm's future for the whole descent — one of the
+        // frames that overflowed the default ~2 MB worker stack on a plain
+        // `select *` connection query (fluree/db#1408).
+        self.dispatch_connection_query(input, format_config, tracking, execution, r2rml.as_ref())
+            .await
+    }
+
+    /// Build the boxed connection-query future for the chosen input / policy /
+    /// r2rml combination (helper for [`execute_tracked`](Self::execute_tracked)).
+    ///
+    /// Returns an already-heap-allocated future so the caller's frame holds only
+    /// a pointer while driving it. `#[inline(never)]` is load-bearing: it keeps
+    /// the transient materialization of the selected (large) arm future in this
+    /// short-lived frame instead of the caller's long-lived one — see the call
+    /// site and fluree/db#1408.
+    #[inline(never)]
+    #[allow(clippy::type_complexity)]
+    fn dispatch_connection_query<'s>(
+        &'s self,
+        input: QueryInput<'s>,
+        format_config: Option<FormatterConfig>,
+        tracking: Option<TrackingOptions>,
+        execution: QueryExecutionOptions,
+        r2rml: Option<&'s (
+            Arc<dyn R2rmlProvider + 'a>,
+            Arc<dyn R2rmlTableProvider + 'a>,
+        )>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = std::result::Result<TrackedQueryResponse, TrackedErrorResponse>,
+                > + Send
+                + 's,
+        >,
+    > {
+        // `let`-bind with the trait-object type so each arm's distinct
+        // `impl Future` unsize-coerces to the shared `dyn` future type.
+        let dispatched: std::pin::Pin<
+            Box<
+                dyn std::future::Future<
+                        Output = std::result::Result<TrackedQueryResponse, TrackedErrorResponse>,
+                    > + Send
+                    + 's,
+            >,
+        > = match input {
             QueryInput::JsonLd(json) => match &self.policy {
-                Some(policy) => match r2rml.as_ref() {
-                    Some((provider, table_provider)) => {
+                Some(policy) => match r2rml {
+                    Some((provider, table_provider)) => Box::pin(
                         self.fluree
                             .query_connection_jsonld_tracked_with_policy_and_r2rml_options(
                                 json,
@@ -1358,10 +1420,9 @@ impl<'a> FromQueryBuilder<'a> {
                                     table_provider: table_provider.as_ref(),
                                 },
                                 execution,
-                            )
-                            .await
-                    }
-                    None => {
+                            ),
+                    ),
+                    None => Box::pin(
                         self.fluree
                             .query_connection_jsonld_tracked_with_policy_options(
                                 json,
@@ -1369,12 +1430,11 @@ impl<'a> FromQueryBuilder<'a> {
                                 format_config,
                                 tracking,
                                 execution,
-                            )
-                            .await
-                    }
+                            ),
+                    ),
                 },
-                None => match r2rml.as_ref() {
-                    Some((provider, table_provider)) => {
+                None => match r2rml {
+                    Some((provider, table_provider)) => Box::pin(
                         self.fluree
                             .query_connection_jsonld_tracked_with_r2rml_options(
                                 json,
@@ -1383,24 +1443,19 @@ impl<'a> FromQueryBuilder<'a> {
                                 provider.as_ref(),
                                 table_provider.as_ref(),
                                 execution,
-                            )
-                            .await
-                    }
-                    None => {
-                        self.fluree
-                            .query_connection_jsonld_tracked_with_options(
-                                json,
-                                format_config,
-                                tracking,
-                                execution,
-                            )
-                            .await
-                    }
+                            ),
+                    ),
+                    None => Box::pin(self.fluree.query_connection_jsonld_tracked_with_options(
+                        json,
+                        format_config,
+                        tracking,
+                        execution,
+                    )),
                 },
             },
             QueryInput::Sparql(sparql) => match &self.policy {
-                Some(policy) => match r2rml.as_ref() {
-                    Some((provider, table_provider)) => {
+                Some(policy) => match r2rml {
+                    Some((provider, table_provider)) => Box::pin(
                         self.fluree
                             .query_connection_sparql_tracked_with_policy_and_r2rml_options(
                                 sparql,
@@ -1412,10 +1467,9 @@ impl<'a> FromQueryBuilder<'a> {
                                     table_provider: table_provider.as_ref(),
                                 },
                                 execution,
-                            )
-                            .await
-                    }
-                    None => {
+                            ),
+                    ),
+                    None => Box::pin(
                         self.fluree
                             .query_connection_sparql_tracked_with_policy_options(
                                 sparql,
@@ -1423,12 +1477,11 @@ impl<'a> FromQueryBuilder<'a> {
                                 format_config,
                                 tracking,
                                 execution,
-                            )
-                            .await
-                    }
+                            ),
+                    ),
                 },
-                None => match r2rml.as_ref() {
-                    Some((provider, table_provider)) => {
+                None => match r2rml {
+                    Some((provider, table_provider)) => Box::pin(
                         self.fluree
                             .query_connection_sparql_tracked_with_r2rml_options(
                                 sparql,
@@ -1437,22 +1490,18 @@ impl<'a> FromQueryBuilder<'a> {
                                 provider.as_ref(),
                                 table_provider.as_ref(),
                                 execution,
-                            )
-                            .await
-                    }
-                    None => {
-                        self.fluree
-                            .query_connection_sparql_tracked_with_options(
-                                sparql,
-                                format_config,
-                                tracking,
-                                execution,
-                            )
-                            .await
-                    }
+                            ),
+                    ),
+                    None => Box::pin(self.fluree.query_connection_sparql_tracked_with_options(
+                        sparql,
+                        format_config,
+                        tracking,
+                        execution,
+                    )),
                 },
             },
-        }
+        };
+        dispatched
     }
 }
 

--- a/fluree-db-api/src/query/connection.rs
+++ b/fluree-db-api/src/query/connection.rs
@@ -50,8 +50,11 @@ impl Fluree {
         spec: &DatasetSpec,
         qc_opts: &GovernanceOptions,
     ) -> TrackedResult<Option<GraphDb>> {
-        let view = self
-            .try_single_view_from_spec(spec)
+        // Box the view-load future: it drives the deep ledger-load / novelty-
+        // rebuild chain, whose inline future would otherwise inflate this frame
+        // (and the dispatcher frames above it) enough to overflow the default
+        // ~2 MB worker stack on a plain `select *` query (fluree/db#1408).
+        let view = Box::pin(self.try_single_view_from_spec(spec))
             .await
             .map_err(|e| crate::query::TrackedErrorResponse::new(500, e.to_string(), None))?;
 
@@ -60,8 +63,7 @@ impl Fluree {
         };
 
         let source = &spec.default_graphs[0];
-        let view = self
-            .apply_source_or_global_policy(view, source, qc_opts)
+        let view = Box::pin(self.apply_source_or_global_policy(view, source, qc_opts))
             .await
             .map_err(|e| crate::query::TrackedErrorResponse::new(500, e.to_string(), None))?;
         let view = self.apply_config_defaults(view, None);
@@ -307,33 +309,35 @@ impl Fluree {
             ));
         }
 
-        if let Some(view) = self
-            .prepare_single_view_for_connection_tracked(&spec, &qc_opts)
-            .await?
+        // Box each downstream future (view prep, query execution, dataset
+        // build): both the load-side (view prep) and the execute-side (query
+        // run + hydration crawl) are deep async chains, and inlining their
+        // futures here — plus in the dispatcher frames above — overflowed the
+        // default ~2 MB worker stack on a plain `select *` query
+        // (fluree/db#1408). Boxing keeps each on the heap so this frame is O(1).
+        if let Some(view) =
+            Box::pin(self.prepare_single_view_for_connection_tracked(&spec, &qc_opts)).await?
         {
-            return self
-                .query_tracked_with_options(
-                    &view,
-                    query_json,
-                    format_config,
-                    tracking_override,
-                    options,
-                )
-                .await;
+            return Box::pin(self.query_tracked_with_options(
+                &view,
+                query_json,
+                format_config,
+                tracking_override,
+                options,
+            ))
+            .await;
         }
 
         // Multi-ledger: use DataSetDb
-        let dataset = self
-            .build_dataset_for_connection_tracked(&spec, &qc_opts)
-            .await?;
+        let dataset = Box::pin(self.build_dataset_for_connection_tracked(&spec, &qc_opts)).await?;
 
-        self.query_dataset_tracked_with_options(
+        Box::pin(self.query_dataset_tracked_with_options(
             &dataset,
             query_json,
             format_config,
             tracking_override,
             options,
-        )
+        ))
         .await
     }
 

--- a/fluree-db-api/src/view/dataset_builder.rs
+++ b/fluree-db-api/src/view/dataset_builder.rs
@@ -201,11 +201,19 @@ impl Fluree {
     ) -> Result<GraphDb> {
         let view = match &source.time_spec {
             None => {
-                let result = self.db(&source.identifier).await;
+                // Box the ledger-load future: the load chain (get_or_load →
+                // load → load_novelty → bulk_apply_commits) is deep, and in
+                // debug builds its inline future would balloon this frame — and
+                // every dispatcher frame above it that materializes this future
+                // before awaiting — pushing the plain `select *` connection
+                // query past the default ~2 MB worker stack (fluree/db#1408).
+                // Boxing keeps the load future's state on the heap so it costs
+                // O(1) stack here and in the callers above.
+                let result = Box::pin(self.db(&source.identifier)).await;
                 match result {
                     Ok(v) => v,
                     Err(ref e) if e.is_not_found() => {
-                        self.resolve_as_graph_source(&source.identifier).await?
+                        Box::pin(self.resolve_as_graph_source(&source.identifier)).await?
                     }
                     Err(e) => {
                         return Err(e);
@@ -214,7 +222,7 @@ impl Fluree {
             }
             Some(time_spec) => {
                 let ts = convert_time_spec(time_spec)?;
-                match self.db_at(&source.identifier, ts).await {
+                match Box::pin(self.db_at(&source.identifier, ts)).await {
                     Ok(v) => v,
                     Err(ref e) if e.is_not_found() => {
                         // Check if it's a graph source — reject time travel explicitly

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -371,22 +371,29 @@ impl Fluree {
         // Auto-wrap for graph source context
         maybe_wrap_for_graph_source(db, &mut parsed);
 
-        // Build executable with reasoning
-        let executable = self
-            .build_executable_for_view(db, &parsed)
+        // Build executable with reasoning.
+        //
+        // The plan-build, execution, and format futures below are each boxed
+        // before awaiting. They are deep async chains (operator trees, overlay
+        // reads, the hydration crawl), and inlining them here would make this
+        // frame — an ancestor for the whole descent — reserve stack for the
+        // largest of them, contributing to the ~2 MB worker-stack overflow on a
+        // plain `select *` query (fluree/db#1408). Boxing keeps their state on
+        // the heap so this frame stays O(1).
+        let executable = Box::pin(self.build_executable_for_view(db, &parsed))
             .await
             .map_err(|e| {
                 crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
             })?;
 
         // Execute with tracking
-        let batches = self
-            .execute_view_tracked(db, &vars, &executable, &tracker, &options)
-            .await
-            .map_err(|e| {
-                let status = query_error_to_status(&e);
-                crate::query::TrackedErrorResponse::new(status, e.to_string(), tracker.tally())
-            })?;
+        let batches =
+            Box::pin(self.execute_view_tracked(db, &vars, &executable, &tracker, &options))
+                .await
+                .map_err(|e| {
+                    let status = query_error_to_status(&e);
+                    crate::query::TrackedErrorResponse::new(status, e.to_string(), tracker.tally())
+                })?;
 
         // Build result
         let query_result = build_query_result(
@@ -405,25 +412,28 @@ impl Fluree {
             format_config = crate::format::FormatterConfig::jsonld();
         }
 
-        // Format with tracking
+        // Format with tracking (boxed — the hydration crawl can itself recurse;
+        // see the note above and fluree/db#1408).
         let result_json = match db.policy() {
-            Some(policy) => query_result
-                .format_async_with_policy_tracked(
-                    db.as_graph_db_ref(),
-                    &format_config,
-                    policy,
-                    &tracker,
-                )
-                .await
-                .map_err(|e| {
-                    crate::query::TrackedErrorResponse::new(500, e.to_string(), tracker.tally())
-                })?,
-            None => query_result
-                .format_async_tracked(db.as_graph_db_ref(), &format_config, &tracker)
-                .await
-                .map_err(|e| {
-                    crate::query::TrackedErrorResponse::new(500, e.to_string(), tracker.tally())
-                })?,
+            Some(policy) => Box::pin(query_result.format_async_with_policy_tracked(
+                db.as_graph_db_ref(),
+                &format_config,
+                policy,
+                &tracker,
+            ))
+            .await
+            .map_err(|e| {
+                crate::query::TrackedErrorResponse::new(500, e.to_string(), tracker.tally())
+            })?,
+            None => Box::pin(query_result.format_async_tracked(
+                db.as_graph_db_ref(),
+                &format_config,
+                &tracker,
+            ))
+            .await
+            .map_err(|e| {
+                crate::query::TrackedErrorResponse::new(500, e.to_string(), tracker.tally())
+            })?,
         };
 
         Ok(crate::query::TrackedQueryResponse::success(

--- a/fluree-db-api/tests/it_select_star_deep_crawl_stack.rs
+++ b/fluree-db-api/tests/it_select_star_deep_crawl_stack.rs
@@ -1,0 +1,180 @@
+//! Regression guard for fluree/db#1408:
+//! `SELECT *` over the type-erased `build_client()` / `query_from()` path must
+//! not overflow the default ~2 MB worker-thread stack.
+//!
+//! ## What overflowed
+//!
+//! A plain `{"select": {iri: ["*"]}}` connection query (no `depth`, so the
+//! hydration crawl does *not* recurse) drove a deep async call chain:
+//! `execute_tracked` → `query_connection_*` → view prep → **ledger load +
+//! novelty rebuild** → and then query execution + hydration. In debug builds
+//! each of those `async fn`s stores its awaited sub-futures *inline* in its own
+//! state machine, so the frames are fat; `execute_tracked` alone reserved
+//! ~470 KB (it materialized the largest of its ~8 dispatch arms). Stacked up
+//! across the chain this exceeded the default ~2 MB stack and SIGABRT'd —
+//! breaking solo CI (`cargo test --workspace --all-features`, no
+//! `RUST_MIN_STACK`) and risking a SIGABRT on AWS Lambda's ~2 MB worker stacks.
+//!
+//! The fix boxes the fat futures along that path (`fluree-db-api`
+//! `query/builder.rs`, `query/connection.rs`, `view/dataset_builder.rs`,
+//! `view/query.rs`) so each frame costs O(1) stack.
+//!
+//! ## Why a small synthetic ledger reproduces it
+//!
+//! The peak is the *depth/fatness of the async chain*, which is independent of
+//! the data volume (`Novelty::bulk_apply_commits` is a flat loop). All that's
+//! required is (a) the type-erased `build_client()` connection, (b) inserted-
+//! but-unindexed data so `query_from` rebuilds novelty on load, and (c) a
+//! `select *` hydration query. This mirrors solo's
+//! `select_star_crawl::file_build_client_select_star_via_query_from`, which is
+//! where the regression was first observed.
+//!
+//! The query runs on a thread with a fixed 2 MB stack so the outcome is
+//! independent of the ambient `RUST_MIN_STACK`. Set `CRAWL_STACK_KB` to probe
+//! the overflow threshold / headroom.
+
+#![cfg(feature = "native")]
+
+use fluree_db_api::{FlureeBuilder, FormatterConfig};
+use serde_json::{json, Value};
+
+/// 2 MB — AWS Lambda tokio worker default; the issue's "default ~2MB" stack.
+const STACK_2MB: usize = 2 * 1024 * 1024;
+
+/// Stack size for the crawl thread. Defaults to 2 MB (the prod/CI default);
+/// override with `CRAWL_STACK_KB` to probe the overflow threshold / margin.
+fn crawl_stack_bytes() -> usize {
+    std::env::var("CRAWL_STACK_KB")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .map(|kb| kb * 1024)
+        .unwrap_or(STACK_2MB)
+}
+
+fn context() -> Value {
+    json!({
+        "ex": "http://example.org/",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    })
+}
+
+/// Number of extra classes padded into the ontology.
+///
+/// Calibrated so the query holds a large-enough ontology `Value` that, *before*
+/// the fix, the deep async chain overflows the 2 MB stack (empirically it starts
+/// overflowing around ~200 extra subjects; 500 leaves margin). *After* the fix
+/// the same query clears 2 MB with ~600 KB of headroom. This keeps the test a
+/// real regression guard (red pre-fix, green post-fix) rather than a query that
+/// always fit. Override with `ONTO_N` when probing.
+const CALIBRATION_SUBJECTS: usize = 500;
+
+/// A realistic ontology (classes + typed properties), padded to
+/// [`CALIBRATION_SUBJECTS`] extra classes — see that constant for why.
+fn ontology() -> Value {
+    let n: usize = std::env::var("ONTO_N")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(CALIBRATION_SUBJECTS);
+    let mut graph = vec![
+        json!({"@id": "ex:Provider", "@type": "rdfs:Class", "rdfs:label": "Provider"}),
+        json!({"@id": "ex:User", "@type": "rdfs:Class", "rdfs:label": "User"}),
+        json!({"@id": "ex:providerId", "@type": "rdf:Property", "rdfs:range": {"@id": "xsd:string"}}),
+        json!({"@id": "ex:name", "@type": "rdf:Property", "rdfs:range": {"@id": "xsd:string"}}),
+        json!({"@id": "ex:kind", "@type": "rdf:Property", "rdfs:range": {"@id": "xsd:string"}}),
+        json!({"@id": "ex:enabled", "@type": "rdf:Property", "rdfs:range": {"@id": "xsd:boolean"}}),
+        json!({"@id": "ex:createdBy", "@type": "rdf:Property", "rdfs:range": {"@id": "ex:User"}}),
+        json!({"@id": "ex:config", "@type": "rdf:Property", "rdfs:range": {"@id": "rdf:JSON"}}),
+    ];
+    for i in 0..n {
+        graph.push(json!({"@id": format!("ex:Class{i}"), "@type": "rdfs:Class", "rdfs:label": format!("Class {i}"), "rdfs:comment": "calibration subject"}));
+    }
+    json!({"@context": context(), "@graph": graph})
+}
+
+const IRI: &str = "ex:provider-1";
+
+/// One flat entity: several literals, a `@json` value, and a ref.
+fn entity() -> Value {
+    json!({
+        "@context": context(),
+        "@id": IRI,
+        "@type": "ex:Provider",
+        "ex:providerId": "provider-1",
+        "ex:name": "Crawl Test",
+        "ex:kind": "saml",
+        "ex:enabled": true,
+        "ex:config": {"@value": {"email": "email", "groups": "groups"}, "@type": "@json"},
+        "ex:createdBy": {"@id": "ex:user-1"}
+    })
+}
+
+/// The actual crawl, run inside a fixed-stack thread's tokio runtime.
+fn run_crawl() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build current-thread runtime");
+
+    rt.block_on(async {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        // `build_client()` yields the type-erased `FlureeClient`
+        // (`AnyStorage` / `AnyNameService`) — the production Lambda connection
+        // path, and the one #1408 overflowed on.
+        let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+            .build_client()
+            .await
+            .expect("build_client");
+
+        let ledger0 = fluree.create_ledger("test:main").await.expect("create");
+        let receipt = fluree
+            .insert(ledger0, &ontology())
+            .await
+            .expect("bootstrap ontology");
+        // Insert-without-reindex: the entity stays in novelty, so `query_from`
+        // rebuilds novelty on load (the deep `bulk_apply_commits` path).
+        let _receipt = fluree
+            .insert(receipt.ledger, &entity())
+            .await
+            .expect("insert entity");
+
+        let query = json!({"@context": context(), "select": { IRI: ["*"] }, "from": "test:main"});
+        let config = FormatterConfig::typed_json().with_normalize_arrays();
+
+        let result = fluree
+            .query_from()
+            .jsonld(&query)
+            .format(config)
+            .execute_tracked()
+            .await
+            .expect("query_from select *");
+
+        let formatted = serde_json::to_value(&result.result).expect("serialize");
+        let node = formatted
+            .as_array()
+            .and_then(|arr| arr.first())
+            .expect("should return one result");
+        let keys: Vec<&String> = node.as_object().expect("object").keys().collect();
+        assert!(
+            keys.len() > 1,
+            "select * should return properties beyond @id, got only: {keys:?}\nfull: {node}"
+        );
+    });
+}
+
+#[test]
+fn file_build_client_select_star_via_query_from_2mb_stack() {
+    let child = std::thread::Builder::new()
+        .name("crawl-2mb".into())
+        .stack_size(crawl_stack_bytes())
+        .spawn(run_crawl)
+        .expect("spawn crawl thread");
+
+    // Before the fix this thread overflows the 2 MB stack and the process
+    // aborts (SIGABRT) — the fluree/db#1408 repro. After the fix the crawl
+    // completes and `join()` returns cleanly.
+    child
+        .join()
+        .expect("crawl thread panicked / overflowed its stack");
+}


### PR DESCRIPTION
Closes #1408

## Summary

A plain `{"select": {iri: ["*"]}}` connection query, run through the type-erased `build_client()` / `query_from()` path, overflowed the default ~2 MB worker-thread stack **in debug builds** and aborted the process (`SIGABRT`). That broke solo CI (`cargo test --workspace --all-features`, which does not set `RUST_MIN_STACK`). This PR boxes a handful of futures along the query path so the stack stays bounded. Debug peak for the repro drops from **>2 MB to ~1.4 MB**; release builds are unchanged (they already peaked well under 0.5 MB). No change to query behavior or results.

## What was actually happening (the issue's hypothesis was wrong)

The issue guessed a *depth-recursive* `SELECT *` graph crawl and suggested rewriting the crawl iteratively. That is **not** the cause. The failing query has no `depth` parameter, so `depth` defaults to `0` and the hydration crawl provably does **not** recurse through references. I confirmed this under `lldb`: at the moment of overflow the stack is only ~57 frames deep with **no repeating cycle** — it is not runaway recursion.

The real cause is that query execution is a **deep chain of ~16 `async fn`s** — query dispatch → ledger load → novelty rebuild → query execution → hydration — and in **debug builds** each of those async state machines is large. Measuring the individual stack frames (via `lldb`, at the deepest point) showed the query dispatch/load chain alone consuming ~1.5 MB, dominated by:

| frame | debug frame size (before) |
|---|---|
| `FromQueryBuilder::execute_tracked` | **~470 KB** |
| `query_connection_jsonld_tracked_with_options` | ~166 KB |
| `prepare_single_view_for_connection_tracked` | ~110 KB |
| `load_view_from_source` | ~104 KB |
| ~12 more frames (view load, ledger load, novelty rebuild) | ~25–60 KB each |

`execute_tracked` is just a dispatcher, yet it reserved ~470 KB. That is the tell.

## Why an `async fn` can have a 470 KB stack frame (background for reviewers)

An `async fn` does not run like a normal function. The compiler turns it into a **state-machine struct** that has to store *every local variable that is still alive across an `.await`*. Crucially, when function `A` does `B().await` and `B` is itself an `async fn`, `A`'s state machine embeds **all of `B`'s state inline** (and `B` embeds `C`'s, and so on). Down a 16-level-deep call chain, the top-level future becomes enormous because it transitively contains every level below it.

When that future is *polled*, the poll executes on the stack, and the stack frame is as large as the state it has to touch. Release builds pack and reuse these slots aggressively, so the frames stay small. **Debug builds do almost none of that packing**, so the frames balloon — which is exactly why this bites CI (debug) but not production (release).

`execute_tracked` is a `match` that dispatches to one of ~8 `query_connection_*` variant futures. Even though only one arm ever runs, the compiler statically reserves stack for constructing the *largest* arm's future — hence ~470 KB.

## The fix: box the fat futures at chokepoints

`Box::pin(some_future)` moves a future's state to the **heap** and leaves behind an 8-byte pointer. So if `A` does `Box::pin(B()).await` instead of `B().await`, `A`'s state machine stores only a pointer to `B` (on the heap) rather than all of `B` inline. `A`'s frame shrinks accordingly. Applied at the right chokepoints, the whole chain's stack footprint drops from "sum of everything inline" to "a few small frames plus some heap".

Concretely:

- **`FromQueryBuilder::execute_tracked`** — the 8-way dispatch is moved into a small, `#[inline(never)]` helper (`dispatch_connection_query`) that *returns an already-boxed future*. Boxing at the call site alone would not help, because the compiler would still materialize the chosen arm's future on `execute_tracked`'s frame before boxing it. By constructing-and-boxing inside a separate non-inlined function, that transient lives in a short-lived frame that **returns (and is popped) before** we await the boxed future and descend into the deep work. Result: **470 KB → 26 KB**.
- **`query_connection_jsonld_tracked_with_options`**, **`prepare_single_view_for_connection_tracked`**, **`load_view_from_source`**, **`query_tracked_with_options`** — box the load-path and execute-path awaits (view prep, ledger load, plan build, execution, hydration formatting). Each `Box::pin` shrinks its caller's frame and cascades: a boxed callee future is smaller, so its caller's transient is smaller too.

Files touched: `fluree-db-api/src/query/builder.rs`, `fluree-db-api/src/query/connection.rs`, `fluree-db-api/src/view/dataset_builder.rs`, `fluree-db-api/src/view/query.rs`.

## Performance impact — full candor (speed **and** memory, release **and** debug)

I want to be explicit here because "box futures" can sound like it trades runtime cost for a stack win. I measured it; it does not rob release performance in any meaningful way.

**Release stack was never at risk.** I built the repro in `--release` and swept the thread stack size:

| build | peak stack for the repro query |
|---|---|
| debug, before fix | **> 2 MB** (SIGABRT) |
| debug, after fix | ~1.4 MB (passes 2 MB with ~600 KB headroom) |
| release, before fix | **< 0.5 MB** (already fit 2 MB with ~1.5 MB headroom) |
| release, after fix | ~0.45 MB (essentially unchanged) |

So the fix rescues **debug/CI only**. In release the frames were already small; the fix neither needs to nor does meaningfully change the release stack. (This also means the issue's "potential production overflow" framing does not apply to this query: it is a fixed-depth query, not a depth-scaling one, and release fits comfortably.)

**Speed (release):** the change adds roughly **6–10 `Box::pin` heap allocations per query**, all on the one-time query-setup / ledger-load path. They are **not** in any per-row, per-flake, or per-result hot loop, and they **do not scale** with data size, result size, or crawl depth. There is also a pointer indirection (one vtable hop) when polling each boxed future — again a handful of polls, not a tight loop. Next to what a real query already does (storage I/O, index scans, novelty merge, parsing, hydration — thousands of allocations), this is unmeasurable. There is **no algorithmic change**; query planning, execution, and results are byte-for-byte identical.

**Memory (release):** boxing relocates a few futures' state from the stack to the heap. This is **transient** (freed the moment the query future completes), on the order of a few KB per in-flight query, and does **not** scale with data. Net process memory is ~neutral — the same state, just on the heap instead of the stack, plus a small allocator-overhead constant. Stack usage strictly goes **down**.

**The honest "peter/paul" answer:** nothing meaningful is being robbed from release. The cost is a small, fixed, per-query allocation/indirection overhead on a non-hot path; the benefit is that the query can no longer SIGABRT a 2 MB worker. If someone micro-benchmarked a tight loop of trivial queries they might see a sub-percent difference from the extra allocations; for any real workload it is noise. Boxing recursive/deep async futures is the standard, idiomatic Rust remedy for exactly this class of problem.

## Testing

- New regression guard `fluree-db-api/tests/it_select_star_deep_crawl_stack.rs`: builds a type-erased `build_client()` connection, inserts (unindexed) data so `query_from` rebuilds novelty on load, and runs `select *` on a thread with a fixed 2 MB stack. It is **red before this change** (SIGABRT) and **green after** — I verified both directions by stashing the fix. It uses a self-contained synthetic ontology (no external fixtures) sized so the pre-fix code overflows at 2 MB with margin.
- Full `fluree-db-api --features native` suite: **~2,700 tests, 0 failures**.
- `--all-features` build clean; `clippy` clean on the changed crate.

## Out of scope (noted for completeness)

There is a *separate*, genuinely depth-driven consideration: a `SELECT *` with a large explicit `depth:` on a deep graph will recurse `format_subject` in the hydration formatter. That path is already boxed per level (`BoxFuture`), so it is O(depth) with a small constant, and it is **not** what #1408 hit (depth 0). Hardening it further is a distinct follow-up and is not addressed here.
