### PR TITLE
fix(query): honor @type in JSON-LD select-crawl projections

### DIFF
--- a/docs/query/jsonld-query.md
+++ b/docs/query/jsonld-query.md
@@ -83,7 +83,7 @@ Specifies what to return in results. The shape of `select` determines the shape 
 }
 ```
 
-The array value is the selection spec — `"*"` for all forward properties, individual property names (`"schema:name"`), or nested object forms for sub-selections. Add `"depth": N` at the query top level to bound auto-expansion of unselected references.
+The array value is the selection spec — `"*"` for all forward properties, `"@id"` for the subject IRI, `"@type"` (equivalently `"rdf:type"`) for the subject's types, individual property names (`"schema:name"`), or nested object forms for sub-selections. Add `"depth": N` at the query top level to bound auto-expansion of unselected references.
 
 **Mixed array** — combine flat variables and subject expansions in one row, in any order. Each object is an independent expansion with its own root and selection spec:
 

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -2000,7 +2000,9 @@ impl<'a> HydrationFormatter<'a> {
                                 "language" => want_language = true,
                                 _ => {}
                             }
-                        } else if self.compactor.decode_sid(predicate)? == RDF_TYPE_IRI {
+                        } else if self.compactor.decode_sid(predicate).ok().as_deref()
+                            == Some(RDF_TYPE_IRI)
+                        {
                             // `@type` lowers to the rdf:type predicate; on a
                             // literal value that means "emit the datatype".
                             want_type = true;

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -2000,6 +2000,10 @@ impl<'a> HydrationFormatter<'a> {
                                 "language" => want_language = true,
                                 _ => {}
                             }
+                        } else if self.compactor.decode_sid(predicate)? == RDF_TYPE_IRI {
+                            // `@type` lowers to the rdf:type predicate; on a
+                            // literal value that means "emit the datatype".
+                            want_type = true;
                         }
                     }
                 }

--- a/fluree-db-api/tests/it_query_jsonld_basic.rs
+++ b/fluree-db-api/tests/it_query_jsonld_basic.rs
@@ -227,6 +227,90 @@ async fn jsonld_basic_single_subject_query_explicit_fields() {
 }
 
 #[tokio::test]
+async fn jsonld_basic_single_subject_query_explicit_type() {
+    // Regression: `@type` in an explicit select-crawl projection must return
+    // the subject's rdf:type values (parity with `rdf:type` and `*`), rather
+    // than being silently dropped as an unknown predicate.
+    let (fluree, ledger) = seed_movie_graph().await;
+
+    let query = json!({
+        "@context": ctx(),
+        "select": { "wiki:Qmovie": ["@id", "@type"] }
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let json = result
+        .to_jsonld_async(ledger.as_graph_db_ref(0))
+        .await
+        .expect("to_jsonld_async");
+
+    let arr = json.as_array().expect("array result");
+    assert_eq!(arr.len(), 1);
+    let obj = arr[0].as_object().expect("object row");
+
+    assert_eq!(obj.get("@id").and_then(|v| v.as_str()), Some("wiki:Qmovie"));
+    assert_eq!(
+        obj.get("@type").and_then(|v| v.as_str()),
+        Some("schema:Movie"),
+        "expected @type to be honored in explicit select-crawl; got {obj:?}"
+    );
+}
+
+#[tokio::test]
+async fn jsonld_basic_type_matches_rdf_type_in_crawl() {
+    // `@type` must return the same values as the equivalent `rdf:type`
+    // selection at every crawl level, including nested ref expansions.
+    let (fluree, ledger) = seed_movie_graph().await;
+
+    let context = json!({
+        "schema": "http://schema.org/",
+        "wiki": "http://www.wikidata.org/entity/",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    });
+
+    let with_type = json!({
+        "@context": context,
+        "selectOne": { "wiki:Qmovie": ["@id", "@type", {"schema:isBasedOn": ["@id", "@type"]}] }
+    });
+    let with_rdf_type = json!({
+        "@context": context,
+        "selectOne": { "wiki:Qmovie": ["@id", "rdf:type", {"schema:isBasedOn": ["@id", "rdf:type"]}] }
+    });
+
+    let run = |q: JsonValue| {
+        let fluree = &fluree;
+        let ledger = &ledger;
+        async move {
+            support::query_jsonld(fluree, ledger, &q)
+                .await
+                .expect("query")
+                .to_jsonld_async(ledger.as_graph_db_ref(0))
+                .await
+                .expect("to_jsonld_async")
+        }
+    };
+
+    let type_out = run(with_type).await;
+    let rdf_type_out = run(with_rdf_type).await;
+
+    assert_eq!(
+        type_out, rdf_type_out,
+        "@type and rdf:type must produce identical crawl output"
+    );
+    // And the nested ref actually carries its type.
+    assert_eq!(
+        type_out
+            .get("schema:isBasedOn")
+            .and_then(|b| b.get("@type"))
+            .and_then(|v| v.as_str()),
+        Some("schema:Book"),
+        "nested ref @type missing; got {type_out}"
+    );
+}
+
+#[tokio::test]
 async fn jsonld_basic_single_subject_query_select_one() {
     let (fluree, ledger) = seed_movie_graph().await;
 

--- a/fluree-db-query/src/parse/mod.rs
+++ b/fluree-db-query/src/parse/mod.rs
@@ -1103,6 +1103,19 @@ fn parse_selection_level(
             JsonValue::String(s) if s == "@id" || s == "id" || s == ctx.context.id_key.as_str() => {
                 forward.push(UnresolvedForwardItem::Id);
             }
+            // Explicit @type selection on a node is an alias for the rdf:type
+            // predicate, so `["@id", "@type"]` behaves identically to
+            // `["@id", "rdf:type"]` and the `*` wildcard (both surface types).
+            // On a literal value, the hydration formatter re-interprets an
+            // rdf:type forward item as "emit the literal's datatype".
+            JsonValue::String(s)
+                if s == "@type" || s == "type" || s == ctx.context.type_key.as_str() =>
+            {
+                forward.push(UnresolvedForwardItem::Property {
+                    predicate: node_map::RDF_TYPE.to_string(),
+                    sub_spec: None,
+                });
+            }
             // Property name: "ex:name" or inline "@reverse:ex:friend"
             JsonValue::String(s) => {
                 if let Some(rev_iri) = parse_inline_reverse_key(s, ctx)? {
@@ -1138,6 +1151,17 @@ fn parse_selection_level(
 
                 if let Some(rev_iri) = parse_inline_reverse_key(pred_str, ctx)? {
                     reverse.insert(rev_iri, nested);
+                } else if pred_str == "@type"
+                    || pred_str == "type"
+                    || pred_str == ctx.context.type_key.as_str()
+                {
+                    // Nested `{"@type": [...]}` selects rdf:type, same as the
+                    // bare `"@type"` string form. Type values always render as
+                    // compact IRI strings, so any sub-spec is inert here.
+                    forward.push(UnresolvedForwardItem::Property {
+                        predicate: node_map::RDF_TYPE.to_string(),
+                        sub_spec: nested,
+                    });
                 } else {
                     let (expanded, entry) = ctx.expand_vocab(pred_str)?;
                     let context_reverse = entry.as_ref().and_then(|e| e.reverse.as_ref());


### PR DESCRIPTION
## Problem

A JSON-LD select-crawl selection spec such as `{"select": {"m:California": ["@id", "@type"]}}` **silently dropped** the subject's types, returning only `{"@id": "m:California"}`. Meanwhile `rdf:type` and `*` both returned the types correctly:

| Query | Result |
|-------|--------|
| `["@id", "@type"]` | `{"@id": "m:California"}` — types dropped ❌ |
| `["@id", "rdf:type"]` | `@type: [skos:Concept, m:State]` ✅ |
| `["*"]` | `@type: [Concept, State]` ✅ |
| WHERE `@type: ?type` | binds Concept, State ✅ |

So `@type` was honored in WHERE but silently dropped in a select-crawl projection.

## Root cause

The bare `@type` key in a selection array encodes to the JSON-LD **sentinel** Sid (namespace `JSON_LD`, name `"type"`), not the real rdf:type Sid. The hydration formatter fetched the subject's properties filtered by that sentinel predicate, so the subject's actual rdf:type flakes never matched and were never emitted. `rdf:type` worked because it encodes to the real Sid; `*` worked because it fetches every predicate and already special-cases rdf:type → `@type`.

The sentinel is genuinely dual-purpose: on a **literal** value (`{"schema:name": ["@type"]}`) it means "emit the literal's datatype", which is resolved only at format time.

## Fix

- **Parser** (`parse/mod.rs`): lower `@type` / `type` / the context type key — both the bare-string form and the nested `{"@type": [...]}` object form — to a `ForwardItem::Property` on the rdf:type predicate, so a node crawl flows through the existing rdf:type rendering identically to `rdf:type` and `*`.
- **Formatter** (`format/hydration.rs`): `format_literal_virtual` now also treats an rdf:type forward item as a datatype request, preserving `{"schema:name": ["@type"]}` → `{"@type": "xsd:string"}`. `@value` / `@language` keep the sentinel.
- **Docs**: note `@type` (≡ `rdf:type`) as a valid selection key in `docs/query/jsonld-query.md`.

## Tests

- `jsonld_basic_single_subject_query_explicit_type` — node case regression.
- `jsonld_basic_type_matches_rdf_type_in_crawl` — asserts `@type` ≡ `rdf:type` at the top level and at a nested-ref level, and that the nested ref carries its type.
- `grp_query` (300) and `grp_query_sparql` (258) pass; `fluree-db-query` unit/doctests pass; fmt + clippy (`-D warnings`) clean on both crates.