### PR TITLE
fix(query): cross-ledger explicit projection drops foreign-namespace predicates

### DIFF
--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -492,12 +492,46 @@ async fn format_hydration_column(
     };
 
     let formatter = set.pick(root.ledger_alias.as_ref());
+
+    // Re-encode the projection level's predicate Sids into the routed view's
+    // namespace dict when the root subject lives in a non-primary ledger
+    // (issue #1295, root path). The level is lowered once against the primary
+    // dict, so predicate Sids carry the primary ledger's namespace codes; a
+    // root routed to a non-primary view would otherwise miss that ledger's
+    // index for any divergent-code predicate (reserved-namespace predicates
+    // survive only because their codes are stable). A root that stays on the
+    // primary view needs no rebind — keep the original level (no allocation,
+    // byte-identical output). This mirrors the nested `expand_ref` rebind and
+    // shares its memo (per target view + level address). The lowering/decode
+    // source is the primary view's compactor, never the routed view's.
+    let rebound_arc;
+    let level = if formatter.active_idx == set.primary {
+        &spec.level
+    } else {
+        let key = (
+            formatter.active_idx,
+            &spec.level as *const NestedSelectSpec as usize,
+        );
+        rebound_arc = cache
+            .rebinds
+            .entry(key)
+            .or_insert_with(|| {
+                Arc::new(rebind_level_to_view(
+                    &spec.level,
+                    set.primary().compactor,
+                    formatter.db.snapshot,
+                ))
+            })
+            .clone();
+        &*rebound_arc
+    };
+
     let mut visited = HashSet::new();
     formatter
         .format_subject(
             &root.sid,
             root.iri,
-            &spec.level,
+            level,
             DepthBudget::root(spec.depth),
             &mut visited,
             cache,

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -49,7 +49,7 @@ use fluree_db_core::comparator::IndexType;
 use fluree_db_core::query_bounds::RangeOptions;
 use fluree_db_core::range::{RangeMatch, RangeTest};
 use fluree_db_core::value::FlakeValue;
-use fluree_db_core::{Flake, GraphDbRef, Sid, Tracker};
+use fluree_db_core::{Flake, GraphDbRef, LedgerSnapshot, Sid, Tracker};
 use fluree_db_policy::{is_schema_flake, PolicyContext};
 use fluree_db_query::binding::Binding;
 use fluree_db_query::ir::{Column, ForwardItem, HydrationSpec, NestedSelectSpec, Root};
@@ -81,6 +81,24 @@ use std::sync::Arc;
 /// query can never serve one ledger's rendering for another ledger's subject
 /// (issue #1259).
 type CacheKey = (usize, Sid, u64, usize, Option<Arc<str>>);
+
+/// Per-response hydration caches, threaded through the recursive formatter.
+///
+/// - `results`: memoizes a subject's finished JSON so a subject reached many
+///   times in one response (shared ancestors/units, multiply-referenced
+///   entities) is hydrated once.
+/// - `rebinds`: memoizes a projection level re-encoded into a target ledger's
+///   namespace dict (issue #1295), keyed by `(target view index, level
+///   address)`, so each `(level, target)` is rebound at most once per response
+///   and reused via a shared `Arc` instead of re-cloning the sub-tree on every
+///   cross-ledger crossing. The address key is stable for the response
+///   (originals live in the `HydrationSpec`, rebounds are held here) and is only
+///   ever compared, never dereferenced.
+#[derive(Default)]
+struct HydrationCaches {
+    results: HashMap<CacheKey, JsonValue>,
+    rebinds: HashMap<(usize, usize), Arc<NestedSelectSpec>>,
+}
 
 /// Depth bookkeeping for one hydration call.
 ///
@@ -161,6 +179,70 @@ fn predicate_filter_for_level(level: &NestedSelectSpec) -> Option<Arc<[Sid]>> {
                 .collect();
             Some(Arc::from(preds))
         }
+    }
+}
+
+/// Re-encode one hydration level's IMMEDIATE predicate `Sid`s from the lowering
+/// (primary) namespace dict into `target`'s dict, for cross-ledger hydration.
+///
+/// A dataset query is lowered once against the primary ledger's dict, so every
+/// predicate `Sid` in a [`NestedSelectSpec`] carries the *primary* ledger's
+/// namespace code. When [`HydrationFormatter::expand_ref`] crosses into another
+/// ledger, those codes no longer match the target ledger's `Sid`s, so the
+/// predicate filter (`predicate_filter_for_level`) misses the target's SPOT
+/// index and `select_predicate` fails its `Sid`-equality match — predicates in
+/// divergent namespaces are silently dropped (issue #1295). Reserved namespaces
+/// (rdf, rdfs, …) survive because their codes are stable across ledgers.
+///
+/// This rebinds the immediate forward/reverse (and wildcard-refinement) keys by
+/// `lowering.decode_sid` → IRI → `target.encode_iri_strict`. It is **shallow**:
+/// `sub_spec`s (and refinement/reverse values) are left in lowering-dict form —
+/// each is rebound at *its own* crossing, so the decode source is ALWAYS the
+/// lowering (primary) view, never `self`, even in depth-N chains where `self`
+/// is a non-primary view. A predicate the target can't encode is dropped: the
+/// target ledger has no code for that namespace, so it can hold no such flake —
+/// mirroring the subject-side `encode_iri_strict … else continue` in `expand_ref`.
+fn rebind_level_to_view(
+    level: &NestedSelectSpec,
+    lowering: &IriCompactor,
+    target: &LedgerSnapshot,
+) -> NestedSelectSpec {
+    let rebind = |sid: &Sid| -> Option<Sid> {
+        let iri = lowering.decode_sid(sid).ok()?;
+        target.encode_iri_strict(&iri)
+    };
+    let rebind_map = |m: &std::collections::HashMap<Sid, Option<Box<NestedSelectSpec>>>| {
+        m.iter()
+            .filter_map(|(k, v)| Some((rebind(k)?, v.clone())))
+            .collect()
+    };
+    match level {
+        NestedSelectSpec::Explicit { forward, reverse } => NestedSelectSpec::Explicit {
+            forward: forward
+                .iter()
+                .filter_map(|item| match item {
+                    ForwardItem::Id => Some(ForwardItem::Id),
+                    ForwardItem::Property {
+                        predicate,
+                        sub_spec,
+                    } => Some(ForwardItem::Property {
+                        predicate: rebind(predicate)?,
+                        sub_spec: sub_spec.clone(),
+                    }),
+                })
+                .collect(),
+            reverse: rebind_map(reverse),
+        },
+        NestedSelectSpec::Wildcard {
+            refinements,
+            reverse,
+        } => NestedSelectSpec::Wildcard {
+            refinements: refinements
+                .iter()
+                .filter_map(|(k, v)| Some((rebind(k)?, v.clone())))
+                .collect(),
+            reverse: rebind_map(reverse),
+        },
     }
 }
 
@@ -391,7 +473,7 @@ async fn format_hydration_column(
     result: &QueryResult,
     batch: &fluree_db_query::Batch,
     row_idx: usize,
-    cache: &mut HashMap<CacheKey, JsonValue>,
+    cache: &mut HydrationCaches,
 ) -> Result<JsonValue> {
     // Resolve the root. For an `IriMatch` root, `iri` is the ledger-correct
     // canonical IRI (used for the `@id`) and `ledger_alias` names its home
@@ -666,7 +748,7 @@ async fn run_hydration_rows(set: &FormatterSet<'_>, result: &QueryResult) -> Res
     // includes the active ledger + a hash of the current `NestedSelectSpec`, so
     // columns with structurally identical levels share entries while different
     // levels (and different ledgers) stay separate.
-    let mut cache: HashMap<CacheKey, JsonValue> = HashMap::new();
+    let mut cache = HydrationCaches::default();
     let mut rows: Vec<JsonValue> = Vec::new();
 
     // If the underlying query produced no solutions, expansion produces no
@@ -866,7 +948,7 @@ impl<'a> HydrationFormatter<'a> {
         level: &'b NestedSelectSpec,
         depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
-        cache: &'b mut HashMap<CacheKey, JsonValue>,
+        cache: &'b mut HydrationCaches,
     ) -> BoxFuture<'b, Result<JsonValue>> {
         async move {
             let cache_key = (
@@ -878,7 +960,7 @@ impl<'a> HydrationFormatter<'a> {
             );
 
             // Check cache first (same Sid + spec + depth = same result)
-            if let Some(cached) = cache.get(&cache_key) {
+            if let Some(cached) = cache.results.get(&cache_key) {
                 return Ok(cached.clone());
             }
 
@@ -1080,7 +1162,7 @@ impl<'a> HydrationFormatter<'a> {
             let result = JsonValue::Object(obj.into_iter().collect());
 
             // Cache the result
-            cache.insert(cache_key, result.clone());
+            cache.results.insert(cache_key, result.clone());
 
             Ok(result)
         }
@@ -1104,7 +1186,7 @@ impl<'a> HydrationFormatter<'a> {
         level: &'b NestedSelectSpec,
         depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
-        cache: &'b mut HashMap<CacheKey, JsonValue>,
+        cache: &'b mut HydrationCaches,
     ) -> BoxFuture<'b, Result<JsonValue>> {
         async move {
             let Some(ctx) = self.dataset else {
@@ -1135,8 +1217,45 @@ impl<'a> HydrationFormatter<'a> {
                     continue;
                 };
                 let tfmt = ctx.formatter_for(tidx);
+                // Re-encode the projection's predicate Sids into this target
+                // ledger's namespace dict (issue #1295). The level is lowered
+                // once against the primary dict, so a same-ledger ref
+                // (`tidx == primary`) needs no rebind — keep the original level
+                // (no allocation, byte-identical output). The decode source is
+                // the primary/lowering view, never `self` (which may be a
+                // non-primary view in a depth-N chain).
+                let rebound_arc;
+                let level_for_target = if tidx == ctx.primary {
+                    level
+                } else {
+                    // Memoize per (target view, level address): re-encode a level
+                    // into this ledger's dict at most once per response, then reuse
+                    // the shared Arc (a refcount bump) rather than re-cloning the
+                    // sub-tree on every crossing. The key uses the level's address
+                    // — stable for the response, only ever compared.
+                    let key = (tidx, level as *const NestedSelectSpec as usize);
+                    rebound_arc = cache
+                        .rebinds
+                        .entry(key)
+                        .or_insert_with(|| {
+                            Arc::new(rebind_level_to_view(
+                                level,
+                                &ctx.views[ctx.primary].compactor,
+                                tview.db.snapshot,
+                            ))
+                        })
+                        .clone();
+                    &*rebound_arc
+                };
                 let obj = tfmt
-                    .format_subject(&tsid, Some(Arc::clone(&iri)), level, depth, visited, cache)
+                    .format_subject(
+                        &tsid,
+                        Some(Arc::clone(&iri)),
+                        level_for_target,
+                        depth,
+                        visited,
+                        cache,
+                    )
                     .await?;
                 merged = Some(match merged {
                     None => obj,
@@ -1167,7 +1286,7 @@ impl<'a> HydrationFormatter<'a> {
         level: &'b NestedSelectSpec,
         depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
-        cache: &'b mut HashMap<CacheKey, JsonValue>,
+        cache: &'b mut HydrationCaches,
     ) -> Result<JsonValue> {
         if self.dataset.is_some() {
             self.expand_ref(ref_sid, level, depth, visited, cache).await
@@ -1214,7 +1333,7 @@ impl<'a> HydrationFormatter<'a> {
         parent_level: &'b NestedSelectSpec,
         depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
-        cache: &'b mut HashMap<CacheKey, JsonValue>,
+        cache: &'b mut HydrationCaches,
     ) -> Result<Vec<JsonValue>> {
         let expanded = self.compactor.decode_sid(pred_ctx.pred)?;
         let is_rdf_type = expanded == RDF_TYPE_IRI;
@@ -1335,7 +1454,7 @@ impl<'a> HydrationFormatter<'a> {
         value: &mut JsonValue,
         depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
-        cache: &'b mut HashMap<CacheKey, JsonValue>,
+        cache: &'b mut HydrationCaches,
     ) -> Result<()> {
         let bodies = self
             .lookup_annotation_bodies(flake, depth, visited, cache)
@@ -1370,7 +1489,7 @@ impl<'a> HydrationFormatter<'a> {
         flake: &'b Flake,
         depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
-        cache: &'b mut HashMap<CacheKey, JsonValue>,
+        cache: &'b mut HydrationCaches,
     ) -> Result<Vec<JsonValue>> {
         // Zero-cost gate for non-annotation ledgers — mirrors the
         // cascade fast-path in `fluree_db_transact::stage` so a
@@ -1538,7 +1657,7 @@ impl<'a> HydrationFormatter<'a> {
         ann_sids: &[Sid],
         depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
-        cache: &'b mut HashMap<CacheKey, JsonValue>,
+        cache: &'b mut HydrationCaches,
     ) -> Result<Vec<JsonValue>> {
         let ann_level = NestedSelectSpec::Wildcard {
             refinements: HashMap::new(),
@@ -1719,7 +1838,7 @@ impl<'a> HydrationFormatter<'a> {
         parent_level: &'b NestedSelectSpec,
         depth: DepthBudget,
         visited: &'b mut HashSet<Sid>,
-        cache: &'b mut HashMap<CacheKey, JsonValue>,
+        cache: &'b mut HydrationCaches,
     ) -> Result<Vec<JsonValue>> {
         let mut values = Vec::new();
         for flake in flakes {

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -764,10 +764,8 @@ async fn run_hydration_rows(set: &FormatterSet<'_>, result: &QueryResult) -> Res
     let primary_compactor = primary.compactor;
     let typed = primary.typed;
 
-    // Shared cache across all rows and all hydration columns. The cache key
-    // includes the active ledger + a hash of the current `NestedSelectSpec`, so
-    // columns with structurally identical levels share entries while different
-    // levels (and different ledgers) stay separate.
+    // Shared per-response cache, reused across all rows and hydration columns.
+    // See `HydrationCaches` for the key shape and what each map memoizes.
     let mut cache = HydrationCaches::default();
     let mut rows: Vec<JsonValue> = Vec::new();
 

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -578,9 +578,15 @@ pub async fn format_async(
 /// Per-ledger policy is preserved: a foreign subject is read under *its own*
 /// view's policy enforcer, never the primary's.
 ///
-/// NOTE (staged): this slice routes the **root** subject. Nested cross-ledger
-/// refs still expand within the root's view (correct only when the two ledgers
-/// allocated matching namespace codes) until the union-resolution slice lands.
+/// Explicit-projection predicate `Sid`s are re-encoded into the ledger that
+/// stores each subject — both for nested refs (`expand_ref`) and for a root
+/// routed to a non-primary ledger (issue #1295) — so a cross-ledger projection
+/// returns the same predicates a single-ledger one would, regardless of how the
+/// ledgers allocated namespace codes.
+///
+/// Known gap: a root with no home-ledger provenance — bound as the *object* of a
+/// primary-ledger triple — routes to the primary view and can come back
+/// `@id`-only (a separate root-routing follow-up).
 pub async fn format_async_dataset(
     result: &QueryResult,
     dataset: &crate::view::DataSetDb,

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -87,13 +87,11 @@ type CacheKey = (usize, Sid, u64, usize, Option<Arc<str>>);
 /// - `results`: memoizes a subject's finished JSON so a subject reached many
 ///   times in one response (shared ancestors/units, multiply-referenced
 ///   entities) is hydrated once.
-/// - `reencoded_levels`: memoizes a projection level re-encoded into a target
-///   ledger's namespace dict (issue #1295), keyed by `(target view index, level
-///   address)`, so each `(level, target)` is re-encoded at most once per response
-///   and reused via a shared `Arc` instead of re-cloning the sub-tree on every
-///   cross-ledger crossing. The address key is stable for the response
-///   (originals live in the `HydrationSpec`, re-encoded copies are held here) and
-///   is only ever compared, never dereferenced.
+/// - `reencoded_levels`: memoizes a level re-encoded into a target ledger's dict
+///   (issue #1295), keyed by `(target view index, level address)` — re-encoded
+///   once per `(level, target)`, then shared via `Arc` instead of re-cloning the
+///   sub-tree per crossing. The address key is stable for the response (originals
+///   live in the `HydrationSpec`), only ever compared, never dereferenced.
 #[derive(Default)]
 struct HydrationCaches {
     results: HashMap<CacheKey, JsonValue>,
@@ -182,34 +180,20 @@ fn predicate_filter_for_level(level: &NestedSelectSpec) -> Option<Arc<[Sid]>> {
     }
 }
 
-/// Re-encode one hydration level's IMMEDIATE predicate `Sid`s from the lowering
-/// (primary) namespace dict into `target`'s dict, for cross-ledger hydration.
+/// Re-encode a hydration level's IMMEDIATE predicate `Sid`s from the lowering
+/// (primary) dict into `target`'s dict (issue #1295). The spec is lowered once
+/// against the primary dict, so its `Sid`s miss any target ledger whose codes
+/// diverge, dropping predicates in non-reserved namespaces.
 ///
-/// A dataset query is lowered once against the primary ledger's dict, so every
-/// predicate `Sid` in a [`NestedSelectSpec`] carries the *primary* ledger's
-/// namespace code. When [`HydrationFormatter::expand_ref`] crosses into another
-/// ledger, those codes no longer match the target ledger's `Sid`s, so the
-/// predicate filter (`predicate_filter_for_level`) misses the target's SPOT
-/// index and `select_predicate` fails its `Sid`-equality match — predicates in
-/// divergent namespaces are silently dropped (issue #1295). Reserved namespaces
-/// (rdf, rdfs, …) survive because their codes are stable across ledgers.
+/// **Shallow**: `sub_spec`s and reverse/refinement values stay in lowering-dict
+/// form and are re-encoded at their own crossing, so the decode source is ALWAYS
+/// the lowering view — never `self`, which may be non-primary in a depth-N chain.
+/// A predicate `target` can't encode is dropped (it can hold no such flake),
+/// mirroring the subject-side `encode_iri_strict` in `expand_ref`.
 ///
-/// This re-encodes the immediate forward/reverse (and wildcard-refinement) keys
-/// by `lowering.decode_sid` → IRI → `target.encode_iri_strict`. It is **shallow**:
-/// `sub_spec`s (and refinement/reverse values) are left in lowering-dict form —
-/// each is re-encoded at *its own* crossing, so the decode source is ALWAYS the
-/// lowering (primary) view, never `self`, even in depth-N chains where `self`
-/// is a non-primary view. A predicate the target can't encode is dropped: the
-/// target ledger has no code for that namespace, so it can hold no such flake —
-/// mirroring the subject-side `encode_iri_strict … else continue` in `expand_ref`.
-///
-/// This is the hydration-side analogue of the WHERE-scan's per-graph re-encode
-/// (`fluree_db_query::binary_scan::build_match_val_for_snapshot`'s `reencode_sid`):
-/// both decode a primary-lowered `Sid` and re-encode it into the ledger they're
-/// about to touch. They differ, deliberately, in the miss policy — the scan
-/// *preserves* the raw `Sid` (still matchable by raw bytes), hydration *drops* the
-/// predicate (an absent projection key, not a mis-scan). Keep the vocabulary in
-/// sync with that function.
+/// Mirror of the WHERE-scan's per-graph re-encode (`fluree_db_query::binary_scan`'s
+/// `reencode_sid`); that one preserves an unencodable `Sid`, this one drops it —
+/// keep the vocabulary in sync.
 fn reencode_level_for_view(
     level: &NestedSelectSpec,
     lowering: &IriCompactor,
@@ -501,17 +485,11 @@ async fn format_hydration_column(
 
     let formatter = set.pick(root.ledger_alias.as_ref());
 
-    // Re-encode the projection level's predicate Sids into the routed view's
-    // namespace dict when the root subject lives in a non-primary ledger
-    // (issue #1295, root path). The level is lowered once against the primary
-    // dict, so predicate Sids carry the primary ledger's namespace codes; a
-    // root routed to a non-primary view would otherwise miss that ledger's
-    // index for any divergent-code predicate (reserved-namespace predicates
-    // survive only because their codes are stable). A root that stays on the
-    // primary view needs no re-encode — keep the original level (no allocation,
-    // byte-identical output). This mirrors the nested `expand_ref` re-encode and
-    // shares its memo (per target view + level address). The lowering/decode
-    // source is the primary view's compactor, never the routed view's.
+    // Root path for #1295: when `pick` routes a root to a non-primary ledger,
+    // re-encode the level into that view's dict (as the nested `expand_ref` path
+    // does, sharing the memo). A primary-view root needs none — keep the original
+    // level (no allocation, byte-identical). Decode source is the primary
+    // compactor, never the routed view's.
     let reencoded_arc;
     let level = if formatter.active_idx == set.primary {
         &spec.level
@@ -1259,22 +1237,17 @@ impl<'a> HydrationFormatter<'a> {
                     continue;
                 };
                 let tfmt = ctx.formatter_for(tidx);
-                // Re-encode the projection's predicate Sids into this target
-                // ledger's namespace dict (issue #1295). The level is lowered
-                // once against the primary dict, so a same-ledger ref
-                // (`tidx == primary`) needs no re-encode — keep the original level
-                // (no allocation, byte-identical output). The decode source is
-                // the primary/lowering view, never `self` (which may be a
-                // non-primary view in a depth-N chain).
+                // Re-encode the level into this target ledger's dict (#1295). A
+                // same-ledger ref (`tidx == primary`) needs none — keep the
+                // original (no allocation, byte-identical). Decode source is the
+                // primary/lowering view, never `self` (may be non-primary in a
+                // depth-N chain).
                 let reencoded_arc;
                 let level_for_target = if tidx == ctx.primary {
                     level
                 } else {
-                    // Memoize per (target view, level address): re-encode a level
-                    // into this ledger's dict at most once per response, then reuse
-                    // the shared Arc (a refcount bump) rather than re-cloning the
-                    // sub-tree on every crossing. The key uses the level's address
-                    // — stable for the response, only ever compared.
+                    // Memoized per (target view, level address); see
+                    // `HydrationCaches::reencoded_levels`.
                     let key = (tidx, level as *const NestedSelectSpec as usize);
                     reencoded_arc = cache
                         .reencoded_levels

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -87,17 +87,17 @@ type CacheKey = (usize, Sid, u64, usize, Option<Arc<str>>);
 /// - `results`: memoizes a subject's finished JSON so a subject reached many
 ///   times in one response (shared ancestors/units, multiply-referenced
 ///   entities) is hydrated once.
-/// - `rebinds`: memoizes a projection level re-encoded into a target ledger's
-///   namespace dict (issue #1295), keyed by `(target view index, level
-///   address)`, so each `(level, target)` is rebound at most once per response
+/// - `reencoded_levels`: memoizes a projection level re-encoded into a target
+///   ledger's namespace dict (issue #1295), keyed by `(target view index, level
+///   address)`, so each `(level, target)` is re-encoded at most once per response
 ///   and reused via a shared `Arc` instead of re-cloning the sub-tree on every
 ///   cross-ledger crossing. The address key is stable for the response
-///   (originals live in the `HydrationSpec`, rebounds are held here) and is only
-///   ever compared, never dereferenced.
+///   (originals live in the `HydrationSpec`, re-encoded copies are held here) and
+///   is only ever compared, never dereferenced.
 #[derive(Default)]
 struct HydrationCaches {
     results: HashMap<CacheKey, JsonValue>,
-    rebinds: HashMap<(usize, usize), Arc<NestedSelectSpec>>,
+    reencoded_levels: HashMap<(usize, usize), Arc<NestedSelectSpec>>,
 }
 
 /// Depth bookkeeping for one hydration call.
@@ -194,26 +194,34 @@ fn predicate_filter_for_level(level: &NestedSelectSpec) -> Option<Arc<[Sid]>> {
 /// divergent namespaces are silently dropped (issue #1295). Reserved namespaces
 /// (rdf, rdfs, …) survive because their codes are stable across ledgers.
 ///
-/// This rebinds the immediate forward/reverse (and wildcard-refinement) keys by
-/// `lowering.decode_sid` → IRI → `target.encode_iri_strict`. It is **shallow**:
+/// This re-encodes the immediate forward/reverse (and wildcard-refinement) keys
+/// by `lowering.decode_sid` → IRI → `target.encode_iri_strict`. It is **shallow**:
 /// `sub_spec`s (and refinement/reverse values) are left in lowering-dict form —
-/// each is rebound at *its own* crossing, so the decode source is ALWAYS the
+/// each is re-encoded at *its own* crossing, so the decode source is ALWAYS the
 /// lowering (primary) view, never `self`, even in depth-N chains where `self`
 /// is a non-primary view. A predicate the target can't encode is dropped: the
 /// target ledger has no code for that namespace, so it can hold no such flake —
 /// mirroring the subject-side `encode_iri_strict … else continue` in `expand_ref`.
-fn rebind_level_to_view(
+///
+/// This is the hydration-side analogue of the WHERE-scan's per-graph re-encode
+/// (`fluree_db_query::binary_scan::build_match_val_for_snapshot`'s `reencode_sid`):
+/// both decode a primary-lowered `Sid` and re-encode it into the ledger they're
+/// about to touch. They differ, deliberately, in the miss policy — the scan
+/// *preserves* the raw `Sid` (still matchable by raw bytes), hydration *drops* the
+/// predicate (an absent projection key, not a mis-scan). Keep the vocabulary in
+/// sync with that function.
+fn reencode_level_for_view(
     level: &NestedSelectSpec,
     lowering: &IriCompactor,
     target: &LedgerSnapshot,
 ) -> NestedSelectSpec {
-    let rebind = |sid: &Sid| -> Option<Sid> {
+    let reencode = |sid: &Sid| -> Option<Sid> {
         let iri = lowering.decode_sid(sid).ok()?;
         target.encode_iri_strict(&iri)
     };
-    let rebind_map = |m: &std::collections::HashMap<Sid, Option<Box<NestedSelectSpec>>>| {
+    let reencode_map = |m: &std::collections::HashMap<Sid, Option<Box<NestedSelectSpec>>>| {
         m.iter()
-            .filter_map(|(k, v)| Some((rebind(k)?, v.clone())))
+            .filter_map(|(k, v)| Some((reencode(k)?, v.clone())))
             .collect()
     };
     match level {
@@ -226,12 +234,12 @@ fn rebind_level_to_view(
                         predicate,
                         sub_spec,
                     } => Some(ForwardItem::Property {
-                        predicate: rebind(predicate)?,
+                        predicate: reencode(predicate)?,
                         sub_spec: sub_spec.clone(),
                     }),
                 })
                 .collect(),
-            reverse: rebind_map(reverse),
+            reverse: reencode_map(reverse),
         },
         NestedSelectSpec::Wildcard {
             refinements,
@@ -239,9 +247,9 @@ fn rebind_level_to_view(
         } => NestedSelectSpec::Wildcard {
             refinements: refinements
                 .iter()
-                .filter_map(|(k, v)| Some((rebind(k)?, v.clone())))
+                .filter_map(|(k, v)| Some((reencode(k)?, v.clone())))
                 .collect(),
-            reverse: rebind_map(reverse),
+            reverse: reencode_map(reverse),
         },
     }
 }
@@ -500,11 +508,11 @@ async fn format_hydration_column(
     // root routed to a non-primary view would otherwise miss that ledger's
     // index for any divergent-code predicate (reserved-namespace predicates
     // survive only because their codes are stable). A root that stays on the
-    // primary view needs no rebind — keep the original level (no allocation,
-    // byte-identical output). This mirrors the nested `expand_ref` rebind and
+    // primary view needs no re-encode — keep the original level (no allocation,
+    // byte-identical output). This mirrors the nested `expand_ref` re-encode and
     // shares its memo (per target view + level address). The lowering/decode
     // source is the primary view's compactor, never the routed view's.
-    let rebound_arc;
+    let reencoded_arc;
     let level = if formatter.active_idx == set.primary {
         &spec.level
     } else {
@@ -512,18 +520,18 @@ async fn format_hydration_column(
             formatter.active_idx,
             &spec.level as *const NestedSelectSpec as usize,
         );
-        rebound_arc = cache
-            .rebinds
+        reencoded_arc = cache
+            .reencoded_levels
             .entry(key)
             .or_insert_with(|| {
-                Arc::new(rebind_level_to_view(
+                Arc::new(reencode_level_for_view(
                     &spec.level,
                     set.primary().compactor,
                     formatter.db.snapshot,
                 ))
             })
             .clone();
-        &*rebound_arc
+        &*reencoded_arc
     };
 
     let mut visited = HashSet::new();
@@ -1254,11 +1262,11 @@ impl<'a> HydrationFormatter<'a> {
                 // Re-encode the projection's predicate Sids into this target
                 // ledger's namespace dict (issue #1295). The level is lowered
                 // once against the primary dict, so a same-ledger ref
-                // (`tidx == primary`) needs no rebind — keep the original level
+                // (`tidx == primary`) needs no re-encode — keep the original level
                 // (no allocation, byte-identical output). The decode source is
                 // the primary/lowering view, never `self` (which may be a
                 // non-primary view in a depth-N chain).
-                let rebound_arc;
+                let reencoded_arc;
                 let level_for_target = if tidx == ctx.primary {
                     level
                 } else {
@@ -1268,18 +1276,18 @@ impl<'a> HydrationFormatter<'a> {
                     // sub-tree on every crossing. The key uses the level's address
                     // — stable for the response, only ever compared.
                     let key = (tidx, level as *const NestedSelectSpec as usize);
-                    rebound_arc = cache
-                        .rebinds
+                    reencoded_arc = cache
+                        .reencoded_levels
                         .entry(key)
                         .or_insert_with(|| {
-                            Arc::new(rebind_level_to_view(
+                            Arc::new(reencode_level_for_view(
                                 level,
                                 &ctx.views[ctx.primary].compactor,
                                 tview.db.snapshot,
                             ))
                         })
                         .clone();
-                    &*rebound_arc
+                    &*reencoded_arc
                 };
                 let obj = tfmt
                     .format_subject(

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -760,3 +760,65 @@ async fn cross_graph_wildcard_refinement_divergent_ns() {
         "wildcard refinement on a divergent-namespace ref did not apply cross-ledger: {value:#}"
     );
 }
+
+/// BUG (#1295 root path) — a hydration ROOT whose subject lives in a non-primary
+/// ledger, bound by a home-graph WHERE pattern (so it routes to the home ledger
+/// correctly — reserved/shared-code predicates hydrate), STILL drops a
+/// divergent-namespace predicate from its EXPLICIT projection.
+///
+/// This is the same per-predicate-Sid drop as the nested #1295 mechanism, one
+/// level up: the projection level is lowered once against the primary (catalog)
+/// dict, so every predicate Sid carries catalog's namespace codes. When the root
+/// (`p:ada`) is hydrated against the people view, `p:fullName`'s Sid carries the
+/// wrong code and misses the people index — while `schema:name` (shared code)
+/// survives, masking the loss. The nested fix lives in `expand_ref`; this root
+/// path routes through `format_hydration_column`, which now rebinds the level
+/// into the routed view's dict when the root is non-primary.
+///
+/// Distinct from `cross_graph_root_bound_as_object_hydrates_in_home_ledger`
+/// (Finding B): there the whole subject comes back `@id`-only because routing
+/// itself fails; here routing succeeds (`schema:name` is present) and only the
+/// divergent-namespace predicate is dropped.
+#[tokio::test]
+async fn cross_graph_root_projection_divergent_predicate() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_divergent_predicate_ref_ledgers(&fluree).await;
+
+    let q = json!({
+        "@context": {
+            "schema": "http://schema.org/",
+            "cat": "http://catalog.example/",
+            "p": "http://people.example/",
+            "id": "@id", "type": "@type",
+        },
+        "from": ["test/catalog:main", "test/people:main"],
+        // Root ?person is bound in its HOME (people) graph, but the projection is
+        // lowered against the primary (catalog) dict.
+        "select": { "?person": ["@id", "schema:name", "p:fullName"] },
+        "where": { "@id": "?person", "type": "schema:Person" }
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted should not error");
+
+    let person = value
+        .as_array()
+        .and_then(|a| a.first())
+        .expect("one person");
+    assert_eq!(person.get("@id").and_then(|v| v.as_str()), Some("p:ada"));
+    // Shared-code predicate survives even pre-fix (routing succeeds):
+    assert_eq!(
+        person.get("schema:name").and_then(|v| v.as_str()),
+        Some("Ada Lovelace"),
+    );
+    // THE REGRESSION: divergent-namespace predicate on the ROOT must be present.
+    assert_eq!(
+        person.get("p:fullName").and_then(|v| v.as_str()),
+        Some("Augusta Ada King"),
+        "cross-ledger root projection dropped a non-primary-namespace predicate: {value:#}"
+    );
+}

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -491,3 +491,272 @@ async fn dataset_nested_projection_cross_graph_iri_resolution_via_connection() {
         "the mis-decoded (catalog-namespace) @id must not appear: {s}"
     );
 }
+
+/// Seed a primary `catalog` ledger whose product REFERENCES a person in a
+/// separate `people` ledger, where the person carries a predicate (`p:fullName`)
+/// in a namespace that is allocated a DIFFERENT code in each ledger:
+///   - catalog: people.example registered last (via the `schema:author` ref) → high code
+///   - people:  people.example registered first (the subject `p:ada`)        → low code
+///
+/// This is the cross-ledger explicit-projection drop condition.
+async fn seed_divergent_predicate_ref_ledgers(fluree: &MemoryFluree) {
+    fluree
+        .insert(
+            genesis_ledger(fluree, "test/catalog:main"),
+            &json!({
+                "@context": {
+                    "schema": "http://schema.org/",
+                    "cat": "http://catalog.example/",
+                    "p": "http://people.example/",
+                    "id": "@id", "type": "@type",
+                },
+                "@graph": [
+                    {"@id": "cat:item1", "@type": "schema:Product",
+                     "schema:author": {"@id": "p:ada"}}
+                ]
+            }),
+        )
+        .await
+        .expect("insert catalog");
+
+    fluree
+        .insert(
+            genesis_ledger(fluree, "test/people:main"),
+            &json!({
+                "@context": {
+                    "schema": "http://schema.org/",
+                    "p": "http://people.example/",
+                    "id": "@id", "type": "@type",
+                },
+                "@graph": [
+                    {"@id": "p:ada", "@type": "schema:Person",
+                     "schema:name": "Ada Lovelace", "p:fullName": "Augusta Ada King"}
+                ]
+            }),
+        )
+        .await
+        .expect("insert people");
+}
+
+/// Cross-ledger NESTED EXPLICIT projection must return ALL projected predicates
+/// of the foreign subject — not just `@id` and reserved-namespace ones.
+///
+/// Pre-fix: `p:fullName` is lowered against the primary (catalog) dict and its
+/// Sid is filtered against the people view, where the same IRI has a different
+/// namespace code → silently dropped. `@id` and `schema:name` (schema.org shares
+/// a code here) survive, masking the loss. With the cross-ledger predicate-Sid
+/// rebind the predicate is re-encoded into the people dict and resolves to
+/// "Augusta Ada King".
+#[tokio::test]
+async fn cross_graph_nested_explicit_projection_divergent_predicate() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_divergent_predicate_ref_ledgers(&fluree).await;
+
+    let q = json!({
+        "@context": {
+            "schema": "http://schema.org/",
+            "cat": "http://catalog.example/",
+            "p": "http://people.example/",
+            "id": "@id", "type": "@type",
+        },
+        "from": ["test/catalog:main", "test/people:main"],
+        // EXPLICIT projection (not ["*"]) crossing catalog -> people:
+        "select": { "?item": ["@id",
+            { "schema:author": ["@id", "schema:name", "p:fullName"] }
+        ]},
+        "where": { "@id": "?item", "type": "schema:Product" }
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted should not error");
+
+    let item = value.as_array().and_then(|a| a.first()).expect("one item");
+    let author = item.get("schema:author").expect("author present");
+
+    assert_eq!(author.get("@id").and_then(|v| v.as_str()), Some("p:ada"));
+    // Reserved/shared-code predicate survives even pre-fix:
+    assert_eq!(
+        author.get("schema:name").and_then(|v| v.as_str()),
+        Some("Ada Lovelace"),
+    );
+    // THE REGRESSION: divergent-namespace predicate must be present, not dropped.
+    assert_eq!(
+        author.get("p:fullName").and_then(|v| v.as_str()),
+        Some("Augusta Ada King"),
+        "cross-ledger explicit projection dropped a non-primary-namespace predicate: {value:#}"
+    );
+}
+
+// =============================================================================
+// Issue #1295 — "non-primary hydration root" extension (predicted by the
+// issue's Direction section). A *second, distinct mechanism* from the
+// per-predicate-Sid drop: a hydration root whose subject lives in a non-primary
+// ledger is hydrated against the PRIMARY view, so the whole subject comes back
+// `@id`-only — even reserved-namespace predicates are dropped.
+//
+// These two tests share the `schema.org` namespace, which is allocated the SAME
+// code across all three `seed_divergent_ledgers` ledgers. So a per-predicate Sid
+// mismatch (the original #1295 mechanism) CANNOT explain `schema:name` dropping
+// — that isolates the root-view-routing mechanism cleanly.
+// =============================================================================
+
+/// CONTROL — when the root variable is bound by a pattern in the subject's HOME
+/// graph, the binding carries home-ledger provenance, so it hydrates correctly.
+#[tokio::test]
+async fn cross_graph_root_bound_in_home_graph_hydrates() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_divergent_ledgers(&fluree).await;
+
+    // ?b is matched by its own type/predicate in the books ledger.
+    let q = json!({
+        "@context": {
+            "book": "http://book.example/",
+            "schema": "http://schema.org/",
+            "id": "@id", "type": "@type",
+        },
+        "from": ["test/movies:main", "test/books:main"],
+        "select": { "?b": ["@id", "schema:name", "schema:isbn"] },
+        "where": { "@id": "?b", "type": "schema:Book" }
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted should not error");
+
+    let b = value.as_array().and_then(|a| a.first()).expect("one book");
+    assert_eq!(b.get("@id").and_then(|v| v.as_str()), Some("book:b1"));
+    assert_eq!(
+        b.get("schema:name").and_then(|v| v.as_str()),
+        Some("Gone with the Wind"),
+        "home-graph-bound root should hydrate its properties: {value:#}"
+    );
+}
+
+/// BUG (#1295 root extension) — when the SAME root subject is bound as the
+/// OBJECT of a primary-ledger triple (`movie:m1 schema:isBasedOn ?b`, matched in
+/// the movies ledger) but the subject (`book:b1`) lives in the books ledger, the
+/// bare object SID carries no home-ledger provenance, so the formatter routes
+/// hydration to the primary (movies) view — where `book:b1` has no triples — and
+/// returns it `@id`-only. `schema:name` (aligned namespace) is dropped, proving
+/// this is the root-view-routing mechanism, not the per-predicate-Sid mismatch.
+///
+/// Out of scope for the #1295 core fix (the rebind lives in `expand_ref`; this
+/// root path goes through `format_hydration_column`/`FormatterSet::pick`).
+/// Kept as a documented, ignored repro pending the root-routing follow-up.
+#[ignore = "pending #1295 non-primary-root routing follow-up"]
+#[tokio::test]
+async fn cross_graph_root_bound_as_object_hydrates_in_home_ledger() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_divergent_ledgers(&fluree).await;
+
+    let q = json!({
+        "@context": {
+            "movie": "http://movie.example/",
+            "book": "http://book.example/",
+            "schema": "http://schema.org/",
+            "id": "@id", "type": "@type",
+        },
+        "from": ["test/movies:main", "test/books:main"],
+        "select": { "?b": ["@id", "schema:name", "schema:isbn"] },
+        "where": { "@id": "?m", "schema:isBasedOn": "?b" }
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted should not error");
+
+    let b = value.as_array().and_then(|a| a.first()).expect("one book");
+    assert_eq!(b.get("@id").and_then(|v| v.as_str()), Some("book:b1"));
+    assert_eq!(
+        b.get("schema:name").and_then(|v| v.as_str()),
+        Some("Gone with the Wind"),
+        "root bound as object of a primary-ledger triple came back @id-only \
+         (hydrated against the wrong view): {value:#}"
+    );
+}
+
+/// Cross-ledger WILDCARD projection with a divergent-namespace **refinement**.
+/// The refinement key (`s:parent`, in `http://sys.example/`) is lowered against
+/// the primary (app) dict; hydration of `s:cat` happens in the sys ledger, where
+/// `sys.example` has a different namespace code. Without rebinding the refinement
+/// key, `select_predicate` misses it and the refined ref renders as a bare `@id`
+/// instead of expanding. Locks in the `refinements`-key rebind (issue #1295),
+/// which had no prior coverage.
+#[tokio::test]
+async fn cross_graph_wildcard_refinement_divergent_ns() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    // Primary (app): item → category in the sys ledger. `app.example` registers
+    // first; `sys.example` only via the cross-ledger ref → a higher code here.
+    fluree
+        .insert(
+            genesis_ledger(&fluree, "test/wr-app:main"),
+            &json!({
+                "@context": {"app": "http://app.example/", "s": "http://sys.example/",
+                             "id": "@id", "type": "@type"},
+                "@graph": [
+                    {"@id": "app:item", "@type": "app:Item", "app:cat": {"@id": "s:cat"}}
+                ]
+            }),
+        )
+        .await
+        .expect("insert app");
+    // sys: category with a divergent-namespace ref predicate `s:parent` → root.
+    // `sys.example` registers first here → a lower code (divergent from app's).
+    fluree
+        .insert(
+            genesis_ledger(&fluree, "test/wr-sys:main"),
+            &json!({
+                "@context": {"s": "http://sys.example/", "id": "@id"},
+                "@graph": [
+                    {"@id": "s:cat", "s:label": "Category", "s:parent": {"@id": "s:root"}},
+                    {"@id": "s:root", "s:label": "Root"}
+                ]
+            }),
+        )
+        .await
+        .expect("insert sys");
+
+    let q = json!({
+        "@context": {"app": "http://app.example/", "s": "http://sys.example/",
+                     "id": "@id", "type": "@type"},
+        "from": ["test/wr-app:main", "test/wr-sys:main"],
+        // ?i's app:cat crosses into sys; s:cat is hydrated with a WILDCARD that
+        // refines the divergent-namespace ref `s:parent` to expand it.
+        "select": {"?i": ["@id", {"app:cat": ["*", {"s:parent": ["@id", "s:label"]}]}]},
+        "where": {"@id": "?i", "type": "app:Item"}
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted should not error");
+
+    let item = value.as_array().and_then(|a| a.first()).expect("one item");
+    let cat = item.get("app:cat").expect("app:cat present");
+    // Wildcard includes the category's own s:label:
+    assert_eq!(
+        cat.get("s:label").and_then(|v| v.as_str()),
+        Some("Category"),
+        "wildcard cross-ledger hydration dropped s:label: {value:#}"
+    );
+    // The REFINEMENT on the divergent-namespace ref must apply cross-ledger →
+    // s:parent expands to include s:label, not render as a bare @id.
+    let parent = cat.get("s:parent").expect("s:parent present");
+    assert_eq!(
+        parent.get("s:label").and_then(|v| v.as_str()),
+        Some("Root"),
+        "wildcard refinement on a divergent-namespace ref did not apply cross-ledger: {value:#}"
+    );
+}

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -822,3 +822,154 @@ async fn cross_graph_root_projection_divergent_predicate() {
         "cross-ledger root projection dropped a non-primary-namespace predicate: {value:#}"
     );
 }
+
+// =============================================================================
+// Split subject across the default-graph union. A subject IRI is described in
+// BOTH default-graph ledgers, with the SAME multi-cardinality predicate
+// (`skos:altLabel`) carrying DIFFERENT values in each. Under default-graph RDF
+// merge semantics (`from: [A, B]`), the subject's rendering should be the union
+// of both ledgers' values. `expand_ref` does this (it loops `default_indices`
+// and `merge_subject_objects`); the root path (`format_hydration_column` /
+// `FormatterSet::pick`) routes to a single home ledger and does not — a third
+// root-path limitation alongside Finding B.
+//
+// Named-graph queries are intentionally excluded: a named graph is addressed
+// individually, so no cross-graph merge is expected (or wanted) there.
+// =============================================================================
+
+/// `ex:widget` carries a plain literal predicate (`ex:kind`) + `skos:altLabel
+/// "WA"` in ledger A; the SAME subject has only `skos:altLabel "WB"` in ledger B.
+/// `ex:parent` (in A) refs it for the nested-path test. `skos`/`ex` are
+/// non-reserved, so their codes may diverge — but the re-encode fix handles that;
+/// what's under test here is the UNION.
+///
+/// The root is bound via `ex:kind` rather than `@type` deliberately: it keeps the
+/// binding off the `@type`/`rdf:type` projection path so this exercises only the
+/// root-hydration routing, not any type-value handling.
+async fn seed_split_subject_ledgers(fluree: &MemoryFluree) {
+    fluree
+        .insert(
+            genesis_ledger(fluree, "test/split-a:main"),
+            &json!({
+                "@context": {
+                    "skos": "http://www.w3.org/2004/02/skos/core#",
+                    "ex": "http://example.org/",
+                    "id": "@id", "type": "@type",
+                },
+                "@graph": [
+                    {"@id": "ex:widget", "ex:kind": "gadget", "skos:altLabel": "WA"},
+                    {"@id": "ex:parent", "ex:kind": "container",
+                     "ex:related": {"@id": "ex:widget"}}
+                ]
+            }),
+        )
+        .await
+        .expect("insert split-a");
+
+    fluree
+        .insert(
+            genesis_ledger(fluree, "test/split-b:main"),
+            &json!({
+                "@context": {
+                    "skos": "http://www.w3.org/2004/02/skos/core#",
+                    "ex": "http://example.org/",
+                    "id": "@id", "type": "@type",
+                },
+                // Same subject IRI, additional altLabel, no other facts here.
+                "@graph": [
+                    {"@id": "ex:widget", "skos:altLabel": "WB"}
+                ]
+            }),
+        )
+        .await
+        .expect("insert split-b");
+}
+
+/// Collect a JSON-LD value's string members whether it rendered as a scalar or
+/// an array (single-valued predicates may compact to a bare string).
+fn collect_strs(v: Option<&serde_json::Value>) -> std::collections::BTreeSet<String> {
+    match v {
+        Some(serde_json::Value::Array(a)) => {
+            a.iter().filter_map(|x| x.as_str().map(String::from)).collect()
+        }
+        Some(serde_json::Value::String(s)) => [s.clone()].into_iter().collect(),
+        _ => std::collections::BTreeSet::new(),
+    }
+}
+
+/// CONTROL — the NESTED path unions the split subject across the default-graph
+/// union. `ex:parent`'s `ex:related` ref crosses into both ledgers; `expand_ref`
+/// merges A's and B's `skos:altLabel` values. Expected to pass.
+#[tokio::test]
+async fn cross_graph_nested_ref_unions_split_subject_altlabels() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_split_subject_ledgers(&fluree).await;
+
+    let q = json!({
+        "@context": {
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "ex": "http://example.org/",
+            "id": "@id", "type": "@type",
+        },
+        "from": ["test/split-a:main", "test/split-b:main"],
+        "select": {"?p": ["@id", {"ex:related": ["@id", "skos:altLabel"]}]},
+        "where": {"@id": "?p", "ex:kind": "container"}
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted should not error");
+
+    let parent = value.as_array().and_then(|a| a.first()).expect("one parent");
+    let widget = parent.get("ex:related").expect("ex:related present");
+    let labels = collect_strs(widget.get("skos:altLabel"));
+    assert_eq!(
+        labels,
+        ["WA".to_string(), "WB".to_string()].into_iter().collect(),
+        "nested ref should union skos:altLabel across the default-graph union: {value:#}"
+    );
+}
+
+/// BUG (root-path union gap) — the SAME split subject, bound at the ROOT, is
+/// hydrated against only its provenance ledger (A), so B's `skos:altLabel "WB"`
+/// is dropped. Under default-graph merge the root should union both, exactly as
+/// the nested control above does.
+///
+/// Companion to Finding B: both are root-path limitations
+/// (`format_hydration_column` / `FormatterSet::pick`) where the root does not
+/// behave like `expand_ref`. Ignored pending the root-path union follow-up.
+#[ignore = "pending root-path default-graph union follow-up (companion to Finding B)"]
+#[tokio::test]
+async fn cross_graph_root_unions_split_subject_altlabels() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed_split_subject_ledgers(&fluree).await;
+
+    let q = json!({
+        "@context": {
+            "skos": "http://www.w3.org/2004/02/skos/core#",
+            "ex": "http://example.org/",
+            "id": "@id", "type": "@type",
+        },
+        "from": ["test/split-a:main", "test/split-b:main"],
+        "select": {"?s": ["@id", "skos:altLabel"]},
+        "where": {"@id": "?s", "ex:kind": "gadget"}
+    });
+
+    let value = fluree
+        .query_from()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("execute_formatted should not error");
+
+    let widget = value.as_array().and_then(|a| a.first()).expect("one subject");
+    let labels = collect_strs(widget.get("skos:altLabel"));
+    assert_eq!(
+        labels,
+        ["WA".to_string(), "WB".to_string()].into_iter().collect(),
+        "root subject should union skos:altLabel across the default-graph union: {value:#}"
+    );
+}

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -889,9 +889,10 @@ async fn seed_split_subject_ledgers(fluree: &MemoryFluree) {
 /// an array (single-valued predicates may compact to a bare string).
 fn collect_strs(v: Option<&serde_json::Value>) -> std::collections::BTreeSet<String> {
     match v {
-        Some(serde_json::Value::Array(a)) => {
-            a.iter().filter_map(|x| x.as_str().map(String::from)).collect()
-        }
+        Some(serde_json::Value::Array(a)) => a
+            .iter()
+            .filter_map(|x| x.as_str().map(String::from))
+            .collect(),
         Some(serde_json::Value::String(s)) => [s.clone()].into_iter().collect(),
         _ => std::collections::BTreeSet::new(),
     }
@@ -923,7 +924,10 @@ async fn cross_graph_nested_ref_unions_split_subject_altlabels() {
         .await
         .expect("execute_formatted should not error");
 
-    let parent = value.as_array().and_then(|a| a.first()).expect("one parent");
+    let parent = value
+        .as_array()
+        .and_then(|a| a.first())
+        .expect("one parent");
     let widget = parent.get("ex:related").expect("ex:related present");
     let labels = collect_strs(widget.get("skos:altLabel"));
     assert_eq!(
@@ -965,7 +969,10 @@ async fn cross_graph_root_unions_split_subject_altlabels() {
         .await
         .expect("execute_formatted should not error");
 
-    let widget = value.as_array().and_then(|a| a.first()).expect("one subject");
+    let widget = value
+        .as_array()
+        .and_then(|a| a.first())
+        .expect("one subject");
     let labels = collect_strs(widget.get("skos:altLabel"));
     assert_eq!(
         labels,

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1618,6 +1618,13 @@ fn build_match_val_for_snapshot(
         // Decode to canonical IRI and re-encode into the target snapshot.
         // Use `original_snapshot` (the primary) rather than `snapshot`
         // (which may be a per-graph snapshot with different namespace codes).
+        //
+        // Hydration performs the same primary→target re-encode when it renders a
+        // foreign subject (`fluree_db_api::format::hydration::reencode_level_for_view`).
+        // The miss policy differs on purpose: here we *preserve* the raw SID (see
+        // the fallback below) so a range scan can still match by raw bytes;
+        // hydration *drops* the predicate (a projection key that can't exist in
+        // the target ledger). Keep the vocabulary in sync with that function.
         if let Some(iri) = ctx.original_snapshot.decode_sid(sid) {
             if let Some(store) = ctx.binary_store.as_deref() {
                 if let Ok(Some(persisted_sid)) = store.find_subject_sid(&iri) {

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1618,10 +1618,6 @@ fn build_match_val_for_snapshot(
         // Decode to canonical IRI and re-encode into the target snapshot.
         // Use `original_snapshot` (the primary) rather than `snapshot`
         // (which may be a per-graph snapshot with different namespace codes).
-        //
-        // Same primary→target re-encode as hydration's `reencode_level_for_view`
-        // (fluree-db-api); that one drops an unencodable Sid, this one preserves
-        // it (raw-byte match, below). Keep the vocabulary in sync.
         if let Some(iri) = ctx.original_snapshot.decode_sid(sid) {
             if let Some(store) = ctx.binary_store.as_deref() {
                 if let Ok(Some(persisted_sid)) = store.find_subject_sid(&iri) {

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1619,12 +1619,9 @@ fn build_match_val_for_snapshot(
         // Use `original_snapshot` (the primary) rather than `snapshot`
         // (which may be a per-graph snapshot with different namespace codes).
         //
-        // Hydration performs the same primary→target re-encode when it renders a
-        // foreign subject (`fluree_db_api::format::hydration::reencode_level_for_view`).
-        // The miss policy differs on purpose: here we *preserve* the raw SID (see
-        // the fallback below) so a range scan can still match by raw bytes;
-        // hydration *drops* the predicate (a projection key that can't exist in
-        // the target ledger). Keep the vocabulary in sync with that function.
+        // Same primary→target re-encode as hydration's `reencode_level_for_view`
+        // (fluree-db-api); that one drops an unencodable Sid, this one preserves
+        // it (raw-byte match, below). Keep the vocabulary in sync.
         if let Some(iri) = ctx.original_snapshot.decode_sid(sid) {
             if let Some(store) = ctx.binary_store.as_deref() {
                 if let Ok(Some(persisted_sid)) = store.find_subject_sid(&iri) {


### PR DESCRIPTION
Closes #1295.

## Problem
A cross-ledger JSON-LD **explicit** projection over a multi-ledger `from` silently drops any predicate whose namespace code differs between the primary ledger and the ledger that actually stores the subject. Reserved-namespace predicates (`rdfs`, `rdf`) survive because their codes are stable across ledgers; user-namespace predicates (e.g. `abbrevName`) are silently elided. This happens both for **nested** refs and for a top-level **root** whose subject lives in a non-primary ledger.

## Root cause
A dataset query is parsed/lowered **once** against the primary ledger's namespace dictionary, so every predicate `Sid` in the projection spec carries the *primary* ledger's namespace code. When hydration renders a subject in another ledger, it re-encodes the *subject* IRI for the target view but passes the projection `level` through unchanged. Those primary-dict predicate `Sid`s then miss the target ledger's index in the predicate filter and fail `select_predicate`'s `Sid`-equality match — both silently.

## Fix
`rebind_level_to_view` re-encodes the immediate projection level's predicate `Sid`s into the target ledger's namespace dictionary, so both the predicate filter and `select_predicate` match the `Sid`s as the target ledger actually stores them. It is applied at the two points a subject can be rendered against a non-primary view:

- **Nested refs** (`expand_ref`) — rebind at each cross-ledger crossing.
- **Root subjects** (`format_hydration_column`) — when `FormatterSet::pick` routes a root to its home (non-primary) ledger, rebind the level into that view's dict.

Single-ledger and same-ledger (primary) subjects are untouched and byte-identical (no allocation). The re-encoding is memoized per `(view, level)` for the response (`HydrationCaches`).

## Tests
- `cross_graph_nested_explicit_projection_divergent_predicate` — the nested repro, now passing.
- `cross_graph_root_projection_divergent_predicate` — the root repro (red→green): a home-graph-bound root hydrates `schema:name` (shared code) but dropped `p:fullName` pre-fix.
- `cross_graph_wildcard_refinement_divergent_ns` — covers the wildcard-refinement re-encode (previously uncovered).
- Existing cross-ledger guards stay green: cross-graph IRI decode, depth-3 wildcard expansion, home-ledger property decode, and named-graph scoped projection.

## Out of scope (follow-up)
The **non-primary hydration root routing** case — a top-level result variable bound as the *object* of a primary-ledger triple, whose subject lives in another ledger — comes back `@id`-only because routing itself fails to reach the home view (so even shared-code predicates are dropped). That's a distinct routing defect (`FormatterSet::pick` has no home-ledger provenance for a bare object SID), left as an `#[ignore]`d repro (`cross_graph_root_bound_as_object_hydrates_in_home_ledger`) pending a separate fix. See the note on #1295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
