### PR TITLE
fix(query): resolve hydration roots across the default-graph union

### DIFF
--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -484,45 +484,44 @@ async fn format_hydration_column(
     };
 
     let formatter = set.pick(root.ledger_alias.as_ref());
-
-    // Root path for #1295: when `pick` routes a root to a non-primary ledger,
-    // re-encode the level into that view's dict (as the nested `expand_ref` path
-    // does, sharing the memo). A primary-view root needs none — keep the original
-    // level (no allocation, byte-identical). Decode source is the primary
-    // compactor, never the routed view's.
-    let reencoded_arc;
-    let level = if formatter.active_idx == set.primary {
-        &spec.level
-    } else {
-        let key = (
-            formatter.active_idx,
-            &spec.level as *const NestedSelectSpec as usize,
-        );
-        reencoded_arc = cache
-            .reencoded_levels
-            .entry(key)
-            .or_insert_with(|| {
-                Arc::new(reencode_level_for_view(
-                    &spec.level,
-                    set.primary().compactor,
-                    formatter.db.snapshot,
-                ))
-            })
-            .clone();
-        &*reencoded_arc
-    };
-
     let mut visited = HashSet::new();
-    formatter
-        .format_subject(
-            &root.sid,
-            root.iri,
-            level,
-            DepthBudget::root(spec.depth),
-            &mut visited,
-            cache,
-        )
-        .await
+
+    // Multi-ledger: resolve the root across the default-graph union (same
+    // machinery as nested `expand_ref`), so a subject described in several
+    // default ledgers merges (RDF merge) and a root with no home-ledger
+    // provenance — e.g. one bound as the object of a primary-ledger triple —
+    // is still found in its home ledger rather than coming back `@id`-only.
+    // The level is re-encoded per contributing view inside the resolver (#1295).
+    // Single-ledger: format directly in the one view (byte-identical).
+    if formatter.dataset.is_some() {
+        // Canonical IRI: an `IriMatch` root carries it; a bare-`Sid` root's SID
+        // is primary-dict-encoded, so decode it against the picked (primary)
+        // view to recover it.
+        let iri: Arc<str> = match &root.iri {
+            Some(iri) => Arc::clone(iri),
+            None => Arc::from(formatter.compactor.decode_sid(&root.sid)?.as_str()),
+        };
+        formatter
+            .resolve_iri_across_union(
+                iri,
+                &spec.level,
+                DepthBudget::root(spec.depth),
+                &mut visited,
+                cache,
+            )
+            .await
+    } else {
+        formatter
+            .format_subject(
+                &root.sid,
+                root.iri,
+                &spec.level,
+                DepthBudget::root(spec.depth),
+                &mut visited,
+                cache,
+            )
+            .await
+    }
 }
 
 /// Async hydration formatter entry point.
@@ -1213,82 +1212,109 @@ impl<'a> HydrationFormatter<'a> {
         cache: &'b mut HydrationCaches,
     ) -> BoxFuture<'b, Result<JsonValue>> {
         async move {
-            let Some(ctx) = self.dataset else {
+            if self.dataset.is_none() {
                 // Single-ledger: stay in the current view.
                 return self
                     .format_subject(ref_sid, None, level, depth, visited, cache)
                     .await;
-            };
+            }
 
             // Decode against the CURRENT view (where the flake lives) to recover
-            // the canonical IRI, then resolve it in the target ledger(s).
+            // the canonical IRI, then resolve it across the scope.
             let iri: Arc<str> = Arc::from(self.compactor.decode_sid(ref_sid)?.as_str());
-
-            // Scope: default-graph refs resolve across the default-graph union;
-            // a named-graph ref stays within its graph.
-            let targets: Vec<usize> = if ctx.default_indices.contains(&self.active_idx) {
-                ctx.default_indices.clone()
-            } else {
-                vec![self.active_idx]
-            };
-
-            let mut merged: Option<JsonValue> = None;
-            for tidx in targets {
-                let tview = &ctx.views[tidx];
-                // Only a view whose namespace dict can encode the IRI can hold
-                // the subject — skip the rest (no scan, no error).
-                let Some(tsid) = tview.db.snapshot.encode_iri_strict(&iri) else {
-                    continue;
-                };
-                let tfmt = ctx.formatter_for(tidx);
-                // Re-encode the level into this target ledger's dict (#1295). A
-                // same-ledger ref (`tidx == primary`) needs none — keep the
-                // original (no allocation, byte-identical). Decode source is the
-                // primary/lowering view, never `self` (may be non-primary in a
-                // depth-N chain).
-                let reencoded_arc;
-                let level_for_target = if tidx == ctx.primary {
-                    level
-                } else {
-                    // Memoized per (target view, level address); see
-                    // `HydrationCaches::reencoded_levels`.
-                    let key = (tidx, level as *const NestedSelectSpec as usize);
-                    reencoded_arc = cache
-                        .reencoded_levels
-                        .entry(key)
-                        .or_insert_with(|| {
-                            Arc::new(reencode_level_for_view(
-                                level,
-                                &ctx.views[ctx.primary].compactor,
-                                tview.db.snapshot,
-                            ))
-                        })
-                        .clone();
-                    &*reencoded_arc
-                };
-                let obj = tfmt
-                    .format_subject(
-                        &tsid,
-                        Some(Arc::clone(&iri)),
-                        level_for_target,
-                        depth,
-                        visited,
-                        cache,
-                    )
-                    .await?;
-                merged = Some(match merged {
-                    None => obj,
-                    Some(acc) => merge_subject_objects(acc, obj),
-                });
-            }
-
-            // No view could resolve the subject → bare canonical @id.
-            match merged {
-                Some(v) => Ok(v),
-                None => Ok(json!({ "@id": self.compactor.compact_id_iri(&iri) })),
-            }
+            self.resolve_iri_across_union(iri, level, depth, visited, cache)
+                .await
         }
         .boxed()
+    }
+
+    /// Hydrate a canonical IRI across the current scope, RDF-merging each
+    /// contributing ledger's view of the subject.
+    ///
+    /// A subject reached from a default-graph view resolves across the **whole
+    /// default-graph union** (so a subject described in several default ledgers
+    /// merges — same predicate included); a subject in a named graph stays in
+    /// that graph. Each contributing view re-encodes the projection level into
+    /// its own dict (#1295) and reads under its own policy. Returns a bare
+    /// `{"@id": …}` when no view can resolve the subject.
+    ///
+    /// Shared by nested-ref expansion (`expand_ref`) and root hydration
+    /// (`format_hydration_column`) so both honor the same default-graph merge.
+    /// Requires a dataset context; single-ledger callers format directly.
+    async fn resolve_iri_across_union(
+        &self,
+        iri: Arc<str>,
+        level: &NestedSelectSpec,
+        depth: DepthBudget,
+        visited: &mut HashSet<Sid>,
+        cache: &mut HydrationCaches,
+    ) -> Result<JsonValue> {
+        let ctx = self
+            .dataset
+            .expect("resolve_iri_across_union requires a dataset context");
+
+        // Scope: default-graph subjects resolve across the default-graph union;
+        // a named-graph subject stays within its graph.
+        let targets: Vec<usize> = if ctx.default_indices.contains(&self.active_idx) {
+            ctx.default_indices.clone()
+        } else {
+            vec![self.active_idx]
+        };
+
+        let mut merged: Option<JsonValue> = None;
+        for tidx in targets {
+            let tview = &ctx.views[tidx];
+            // Only a view whose namespace dict can encode the IRI can hold the
+            // subject — skip the rest (no scan, no error).
+            let Some(tsid) = tview.db.snapshot.encode_iri_strict(&iri) else {
+                continue;
+            };
+            let tfmt = ctx.formatter_for(tidx);
+            // Re-encode the level into this target ledger's dict (#1295). The
+            // primary view (`tidx == primary`) needs none — keep the original
+            // (no allocation, byte-identical). Decode source is the
+            // primary/lowering view, never `self` (may be non-primary here).
+            let reencoded_arc;
+            let level_for_target = if tidx == ctx.primary {
+                level
+            } else {
+                // Memoized per (target view, level address); see
+                // `HydrationCaches::reencoded_levels`.
+                let key = (tidx, level as *const NestedSelectSpec as usize);
+                reencoded_arc = cache
+                    .reencoded_levels
+                    .entry(key)
+                    .or_insert_with(|| {
+                        Arc::new(reencode_level_for_view(
+                            level,
+                            &ctx.views[ctx.primary].compactor,
+                            tview.db.snapshot,
+                        ))
+                    })
+                    .clone();
+                &*reencoded_arc
+            };
+            let obj = tfmt
+                .format_subject(
+                    &tsid,
+                    Some(Arc::clone(&iri)),
+                    level_for_target,
+                    depth,
+                    visited,
+                    cache,
+                )
+                .await?;
+            merged = Some(match merged {
+                None => obj,
+                Some(acc) => merge_subject_objects(acc, obj),
+            });
+        }
+
+        // No view could resolve the subject → bare canonical @id.
+        match merged {
+            Some(v) => Ok(v),
+            None => Ok(json!({ "@id": self.compactor.compact_id_iri(&iri) })),
+        }
     }
 
     /// Hydrate a referenced subject, dispatching cross-ledger only when needed.

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -647,10 +647,11 @@ async fn cross_graph_root_bound_in_home_graph_hydrates() {
 /// returns it `@id`-only. `schema:name` (aligned namespace) is dropped, proving
 /// this is the root-view-routing mechanism, not the per-predicate-Sid mismatch.
 ///
-/// Out of scope for the #1295 core fix (the rebind lives in `expand_ref`; this
-/// root path goes through `format_hydration_column`/`FormatterSet::pick`).
-/// Kept as a documented, ignored repro pending the root-routing follow-up.
-#[ignore = "pending #1295 non-primary-root routing follow-up"]
+/// FIXED by the root-path union resolution: `format_hydration_column` now
+/// resolves a multi-ledger root across the default-graph union (like nested
+/// `expand_ref`), decoding the bare object SID against the primary view to
+/// recover its IRI and finding the subject in its home ledger — no home-ledger
+/// provenance required.
 #[tokio::test]
 async fn cross_graph_root_bound_as_object_hydrates_in_home_ledger() {
     let fluree = FlureeBuilder::memory().build_memory();
@@ -937,15 +938,10 @@ async fn cross_graph_nested_ref_unions_split_subject_altlabels() {
     );
 }
 
-/// BUG (root-path union gap) — the SAME split subject, bound at the ROOT, is
-/// hydrated against only its provenance ledger (A), so B's `skos:altLabel "WB"`
-/// is dropped. Under default-graph merge the root should union both, exactly as
-/// the nested control above does.
-///
-/// Companion to Finding B: both are root-path limitations
-/// (`format_hydration_column` / `FormatterSet::pick`) where the root does not
-/// behave like `expand_ref`. Ignored pending the root-path union follow-up.
-#[ignore = "pending root-path default-graph union follow-up (companion to Finding B)"]
+/// FIXED — the SAME split subject, bound at the ROOT, now unions both ledgers'
+/// `skos:altLabel` values under default-graph merge, exactly as the nested
+/// control above does. `format_hydration_column` routes the root through the
+/// same union resolver as `expand_ref` instead of picking a single ledger.
 #[tokio::test]
 async fn cross_graph_root_unions_split_subject_altlabels() {
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/tests/it_multi_ledger_formatting.rs
+++ b/fluree-db-api/tests/it_multi_ledger_formatting.rs
@@ -969,6 +969,13 @@ async fn cross_graph_root_unions_split_subject_altlabels() {
         .as_array()
         .and_then(|a| a.first())
         .expect("one subject");
+    // @id must stay a single scalar: both default ledgers encode the subject, so
+    // the merge sees `@id` twice — `merge_values` must dedup it, not array it.
+    assert_eq!(
+        widget.get("@id").and_then(|v| v.as_str()),
+        Some("ex:widget"),
+        "merged root @id should be a single scalar, not duplicated/arrayed: {value:#}"
+    );
     let labels = collect_strs(widget.get("skos:altLabel"));
     assert_eq!(
         labels,


### PR DESCRIPTION
Stacked on #1417 (base is that PR's branch; will retarget to `main` once it merges).

## Problem
A multi-ledger hydration **root** was routed to a single home ledger (`FormatterSet::pick`) and formatted there, while nested refs (`expand_ref`) resolve across the whole default-graph union and RDF-merge. Two consequences under a `from: [A, B]` default-graph union:

- A subject described in **several** default-graph ledgers — same multi-cardinality predicate, e.g. `skos:altLabel` with different values in each — rendered only its provenance ledger's values at the root. No union.
- A root with **no home-ledger provenance** (bound as the object of a primary-ledger triple) fell back to the primary view and came back `@id`-only (previously tracked as "Finding B").

Both are correct for named-graph queries (a named graph is addressed individually — no merge) and never affected single-ledger queries.

## Fix
Extract `expand_ref`'s union+merge body into a shared `resolve_iri_across_union`, and route the multi-ledger root through it:

- Recover the root's canonical IRI — from the `IriMatch` binding, or by decoding the bare primary-dict `Sid` against the primary view.
- Resolve it across the default-graph union, re-encoding the projection level per contributing view (#1295) and merging (`merge_subject_objects`).

Scope correctness falls out of `pick` + `active_idx`: an IriMatch root on a default ledger unions across defaults; a named-graph root stays single; a provenance-less root starts at primary (a default) and finds its subject in the union. Single-ledger (`dataset == None`) formats directly — byte-identical. `expand_ref` folds in the extracted `async fn` with no extra boxing, so nested-ref behavior/allocation is unchanged.

## Tests
- `cross_graph_root_bound_as_object_hydrates_in_home_ledger` (Finding B) — un-ignored, now passes.
- `cross_graph_root_unions_split_subject_altlabels` — un-ignored, now passes; asserts the union of `skos:altLabel` across both ledgers **and** that the merged `@id` stays a single scalar (merge dedup).
- `cross_graph_nested_ref_unions_split_subject_altlabels` — the passing nested control on the same split subject.
- Full multi-ledger module green (0 ignored); `grp_query` / `grp_query_sparql` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
