### PR TITLE
[FIX] SPARQL Parsing of sub-`SELECT` as a Set-Operation Operand

### DIFF
--- a/fluree-db-api/tests/grp_query_sparql.rs
+++ b/fluree-db-api/tests/grp_query_sparql.rs
@@ -13,6 +13,8 @@ mod it_query_negation;
 mod it_query_sparql;
 #[path = "it_query_sparql_annotations.rs"]
 mod it_query_sparql_annotations;
+#[path = "it_query_sparql_setop_subselect.rs"]
+mod it_query_sparql_setop_subselect;
 #[path = "it_query_subquery.rs"]
 mod it_query_subquery;
 #[path = "it_query_unwind.rs"]

--- a/fluree-db-api/tests/it_query_sparql_setop_subselect.rs
+++ b/fluree-db-api/tests/it_query_sparql_setop_subselect.rs
@@ -1,0 +1,242 @@
+//! Regression tests: SPARQL sub-SELECT as an operand of a set operation.
+//!
+//! Fixes azure-chat #42 (sub-SELECT in UNION) and #43 (sub-SELECT in MINUS),
+//! plus the broader family (OPTIONAL, mixed arms) sharing the same parser root
+//! cause: `parse_group_graph_pattern` only recognised a `{ SELECT ... }`
+//! sub-SELECT inside its own nested-`{` branch, so a sub-SELECT used as a set-op
+//! operand was mis-parsed — UNION dropped the operator, MINUS/OPTIONAL dropped
+//! the `(expr AS ?v)` projection. See `fluree-db-sparql` parser tests for the
+//! AST-level guards; these assert the end-to-end query results.
+//!
+//! All inserts and queries are explicit with `@context` / `PREFIX`.
+
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+
+/// 3 Person, 2 Company, 5 Country, 2 Maker (France + Japan have a maker).
+/// This is the exact dataset from the azure-chat repro.
+async fn seed_setop(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    let insert = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice",  "@type": "ex:Person",  "ex:name": "Alice"},
+            {"@id": "ex:bob",    "@type": "ex:Person",  "ex:name": "Bob"},
+            {"@id": "ex:carol",  "@type": "ex:Person",  "ex:name": "Carol"},
+            {"@id": "ex:acme",   "@type": "ex:Company", "ex:name": "Acme"},
+            {"@id": "ex:globex", "@type": "ex:Company", "ex:name": "Globex"},
+            {"@id": "ex:france",  "@type": "ex:Country", "ex:cname": "France"},
+            {"@id": "ex:germany", "@type": "ex:Country", "ex:cname": "Germany"},
+            {"@id": "ex:japan",   "@type": "ex:Country", "ex:cname": "Japan"},
+            {"@id": "ex:brazil",  "@type": "ex:Country", "ex:cname": "Brazil"},
+            {"@id": "ex:canada",  "@type": "ex:Country", "ex:cname": "Canada"},
+            {"@id": "ex:maker1", "@type": "ex:Maker", "ex:inCountry": {"@id": "ex:france"}},
+            {"@id": "ex:maker2", "@type": "ex:Maker", "ex:inCountry": {"@id": "ex:japan"}}
+        ]
+    });
+    fluree.insert(ledger0, &insert).await.unwrap().ledger
+}
+
+async fn sparql_rows(fluree: &MemoryFluree, ledger: &MemoryLedger, q: &str) -> serde_json::Value {
+    support::query_sparql(fluree, ledger, q)
+        .await
+        .expect("sparql query should succeed")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld")
+}
+
+/// azure-chat #42, verbatim: `{ SELECT (?pn AS ?n) } UNION { SELECT (?cn AS ?n) }`
+/// must return the union of both arms, not just one.
+#[tokio::test]
+async fn sparql_subselect_union_returns_all_arms() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_setop(&fluree, "setop:union").await;
+
+    let q = r"
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?n WHERE {
+          { SELECT (?pn AS ?n) WHERE { ?p a ex:Person ; ex:name ?pn } }
+          UNION
+          { SELECT (?cn AS ?n) WHERE { ?c a ex:Company ; ex:name ?cn } }
+        }
+    ";
+
+    let rows = sparql_rows(&fluree, &ledger, q).await;
+    assert_eq!(
+        normalize_rows(&rows),
+        normalize_rows(&json!([
+            ["Alice"],
+            ["Bob"],
+            ["Carol"],
+            ["Acme"],
+            ["Globex"]
+        ])),
+        "sub-SELECT UNION must return both arms, got {rows}"
+    );
+}
+
+/// The surviving arm was cardinality-dependent (smaller arm won), so swapping
+/// the arms must not change the result.
+#[tokio::test]
+async fn sparql_subselect_union_is_order_independent() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_setop(&fluree, "setop:union-swap").await;
+
+    let q = r"
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?n WHERE {
+          { SELECT (?cn AS ?n) WHERE { ?c a ex:Company ; ex:name ?cn } }
+          UNION
+          { SELECT (?pn AS ?n) WHERE { ?p a ex:Person ; ex:name ?pn } }
+        }
+    ";
+
+    let rows = sparql_rows(&fluree, &ledger, q).await;
+    assert_eq!(
+        normalize_rows(&rows),
+        normalize_rows(&json!([
+            ["Alice"],
+            ["Bob"],
+            ["Carol"],
+            ["Acme"],
+            ["Globex"]
+        ]))
+    );
+}
+
+/// The sub-SELECT-wrapped UNION must agree with the semantically identical flat
+/// UNION on the same data (the flat form was always correct).
+#[tokio::test]
+async fn sparql_subselect_union_matches_flat_union() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_setop(&fluree, "setop:union-vs-flat").await;
+
+    let subselect = r"
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?n WHERE {
+          { SELECT (?pn AS ?n) WHERE { ?p a ex:Person ; ex:name ?pn } }
+          UNION
+          { SELECT (?cn AS ?n) WHERE { ?c a ex:Company ; ex:name ?cn } }
+        }
+    ";
+    let flat = r"
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?n WHERE {
+          { ?p a ex:Person ; ex:name ?n }
+          UNION
+          { ?c a ex:Company ; ex:name ?n }
+        }
+    ";
+
+    let sub_rows = sparql_rows(&fluree, &ledger, subselect).await;
+    let flat_rows = sparql_rows(&fluree, &ledger, flat).await;
+    assert_eq!(normalize_rows(&sub_rows), normalize_rows(&flat_rows));
+}
+
+/// Either arm may be a sub-SELECT: a plain-group left arm with a sub-SELECT
+/// right arm must still union both (the right arm previously produced a stray
+/// unbound row instead of the company names).
+#[tokio::test]
+async fn sparql_subselect_union_mixed_arms() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_setop(&fluree, "setop:union-mixed").await;
+
+    let q = r"
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?n WHERE {
+          { ?p a ex:Person ; ex:name ?n }
+          UNION
+          { SELECT (?cn AS ?n) WHERE { ?c a ex:Company ; ex:name ?cn } }
+        }
+    ";
+
+    let rows = sparql_rows(&fluree, &ledger, q).await;
+    assert_eq!(
+        normalize_rows(&rows),
+        normalize_rows(&json!([
+            ["Alice"],
+            ["Bob"],
+            ["Carol"],
+            ["Acme"],
+            ["Globex"]
+        ]))
+    );
+}
+
+/// azure-chat #43, verbatim: `{ SELECT (?cn AS ?n) } MINUS { SELECT (?mn AS ?n) }`
+/// must subtract the right arm (countries with a maker) from the left.
+#[tokio::test]
+async fn sparql_subselect_minus_subtracts() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_setop(&fluree, "setop:minus").await;
+
+    let q = r"
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?n WHERE {
+          { SELECT (?cn AS ?n) WHERE { ?c a ex:Country ; ex:cname ?cn } }
+          MINUS
+          { SELECT (?mn AS ?n) WHERE { ?c2 a ex:Country ; ex:cname ?mn . ?m a ex:Maker ; ex:inCountry ?c2 } }
+        }
+    ";
+
+    let rows = sparql_rows(&fluree, &ledger, q).await;
+    assert_eq!(
+        normalize_rows(&rows),
+        normalize_rows(&json!([["Brazil"], ["Canada"], ["Germany"]])),
+        "sub-SELECT MINUS must subtract France + Japan, got {rows}"
+    );
+}
+
+/// The sub-SELECT MINUS must agree with the semantically identical
+/// FILTER NOT EXISTS form (which was always correct).
+#[tokio::test]
+async fn sparql_subselect_minus_matches_filter_not_exists() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_setop(&fluree, "setop:minus-vs-fne").await;
+
+    let minus = r"
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?n WHERE {
+          { SELECT (?cn AS ?n) WHERE { ?c a ex:Country ; ex:cname ?cn } }
+          MINUS
+          { SELECT (?mn AS ?n) WHERE { ?c2 a ex:Country ; ex:cname ?mn . ?m a ex:Maker ; ex:inCountry ?c2 } }
+        }
+    ";
+    let fne = r"
+        PREFIX ex: <http://example.org/>
+        SELECT DISTINCT ?n WHERE {
+          ?c a ex:Country ; ex:cname ?n .
+          FILTER NOT EXISTS { ?m a ex:Maker ; ex:inCountry ?c }
+        }
+    ";
+
+    let minus_rows = sparql_rows(&fluree, &ledger, minus).await;
+    let fne_rows = sparql_rows(&fluree, &ledger, fne).await;
+    assert_eq!(normalize_rows(&minus_rows), normalize_rows(&fne_rows));
+}
+
+/// A sub-SELECT inside OPTIONAL must keep its `(expr AS ?v)` projection so the
+/// aggregate value binds. Previously `?cnt` was dropped and rows duplicated.
+#[tokio::test]
+async fn sparql_subselect_in_optional_binds_projection() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_setop(&fluree, "setop:optional").await;
+
+    // Uncorrelated COUNT of companies (=2), broadcast to each of the 3 people.
+    let q = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?n ?cnt WHERE {
+          ?p a ex:Person ; ex:name ?n .
+          OPTIONAL { SELECT (COUNT(?c) AS ?cnt) WHERE { ?c a ex:Company } }
+        }
+    ";
+
+    let rows = sparql_rows(&fluree, &ledger, q).await;
+    assert_eq!(
+        normalize_rows(&rows),
+        normalize_rows(&json!([["Alice", 2], ["Bob", 2], ["Carol", 2]])),
+        "OPTIONAL sub-SELECT must bind ?cnt=2 for each person, got {rows}"
+    );
+}

--- a/fluree-db-api/tests/it_query_sparql_setop_subselect.rs
+++ b/fluree-db-api/tests/it_query_sparql_setop_subselect.rs
@@ -224,7 +224,11 @@ async fn sparql_subselect_in_optional_binds_projection() {
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger = seed_setop(&fluree, "setop:optional").await;
 
-    // Uncorrelated COUNT of companies (=2), broadcast to each of the 3 people.
+    // The sub-SELECT shares no variable with the outer query, so it is an
+    // UNCORRELATED aggregate: it evaluates once (COUNT of companies = 2) and that
+    // single row broadcasts to each of the 3 people. This is correct SPARQL
+    // semantics and the point of the test — do not "fix" it into a per-person
+    // correlated count.
     let q = r"
         PREFIX ex: <http://example.org/>
         SELECT ?n ?cnt WHERE {

--- a/fluree-db-sparql/src/parse/query/pattern.rs
+++ b/fluree-db-sparql/src/parse/query/pattern.rs
@@ -39,6 +39,31 @@ impl super::Parser<'_> {
     pub(super) fn parse_group_graph_pattern(&mut self) -> Option<GraphPattern> {
         let start = self.stream.previous_span(); // The opening brace
 
+        // SPARQL grammar: GroupGraphPattern ::= '{' ( SubSelect | GroupGraphPatternSub ) '}'
+        //
+        // The opening '{' has already been consumed by the caller, so a leading
+        // SELECT means this brace encloses a *sub-SELECT*, not a basic graph
+        // pattern. Detecting it here — rather than only in the nested-'{' branch
+        // of the loop below — is what makes a sub-SELECT a legal operand in EVERY
+        // position that admits a group: OPTIONAL, GRAPH, SERVICE, the right arm of
+        // MINUS, and every arm of UNION (and, via the free `parse_group_graph_pattern`
+        // wrapper, EXISTS / NOT EXISTS). Previously those positions consumed the
+        // '{' and called straight into the loop, which only recognises a
+        // sub-SELECT after itself consuming a nested '{'; the leading SELECT was
+        // therefore treated as an unexpected token and the projection was dropped.
+        // `parse_subquery` consumes through the matching closing '}'.
+        if self.stream.check_keyword(TokenKind::KwSelect) {
+            return self.parse_subquery(start).or_else(|| {
+                // Malformed sub-SELECT: skip to the matching '}' so its tokens
+                // don't leak into the enclosing scope. The opening brace was
+                // already consumed by the caller, so `skip_balanced` starts at
+                // depth 1 (mirrors the recovery the '{' branch performed before).
+                self.stream
+                    .skip_balanced(&TokenKind::LBrace, &TokenKind::RBrace);
+                None
+            });
+        }
+
         let mut patterns: Vec<GraphPattern> = Vec::new();
         let mut current_triples: Vec<crate::ast::TriplePattern> = Vec::new();
 
@@ -113,24 +138,20 @@ impl super::Parser<'_> {
                     patterns.push(values);
                 }
             } else if self.stream.check(&TokenKind::LBrace) {
-                // Nested group or subquery
+                // Nested group or sub-SELECT.
                 super::flush_current_triples(&mut current_triples, &mut patterns);
 
-                let brace_span = self.stream.current_span();
                 self.stream.advance(); // consume {
 
-                // Check if this is a subquery: { SELECT ... }
-                if self.stream.check_keyword(TokenKind::KwSelect) {
-                    if let Some(subquery) = self.parse_subquery(brace_span) {
-                        patterns.push(subquery);
-                    } else {
-                        // Subquery parse failed — skip to matching } to prevent
-                        // the unparsed tokens from leaking into the outer scope.
-                        self.stream
-                            .skip_balanced(&TokenKind::LBrace, &TokenKind::RBrace);
-                    }
-                } else if let Some(inner) = self.parse_group_graph_pattern() {
-                    // Check for UNION after the group
+                // `parse_group_graph_pattern` handles BOTH a basic group and a
+                // `{ SELECT ... }` sub-SELECT (see the SubSelect check at its
+                // top). Either is a valid left operand of a UNION, so the
+                // trailing-UNION check below must run for both. Previously the
+                // sub-SELECT case pushed the subquery and skipped this check, so
+                // `{ SELECT ... } UNION { ... }` silently dropped the UNION (the
+                // `UNION` token then hit "UNION must follow a pattern" and was
+                // discarded, leaving two independent patterns).
+                if let Some(inner) = self.parse_group_graph_pattern() {
                     if self.stream.check_keyword(TokenKind::KwUnion) {
                         if let Some(union) = self.parse_union_continuation(inner) {
                             patterns.push(union);

--- a/fluree-db-sparql/src/parse/query/pattern.rs
+++ b/fluree-db-sparql/src/parse/query/pattern.rs
@@ -52,6 +52,12 @@ impl super::Parser<'_> {
         // sub-SELECT after itself consuming a nested '{'; the leading SELECT was
         // therefore treated as an unexpected token and the projection was dropped.
         // `parse_subquery` consumes through the matching closing '}'.
+        //
+        // Do NOT re-add a per-caller `KwSelect` check that bypasses this: any new
+        // group-opening construct inherits sub-SELECT support for free by calling
+        // this function after consuming its own `{`. A local check at a call site
+        // would silently reintroduce the dropped-UNION / dropped-projection bug
+        // (#1435 / azure-chat #42, #43).
         if self.stream.check_keyword(TokenKind::KwSelect) {
             return self.parse_subquery(start).or_else(|| {
                 // Malformed sub-SELECT: skip to the matching '}' so its tokens

--- a/fluree-db-sparql/src/parse/query/tests.rs
+++ b/fluree-db-sparql/src/parse/query/tests.rs
@@ -232,6 +232,117 @@ fn test_minus_requires_left_pattern() {
 }
 
 #[test]
+fn test_union_of_subselects_preserves_both_arms() {
+    // Regression (azure-chat #42): `{ SELECT ... } UNION { SELECT ... }` used to
+    // drop the UNION entirely — the left sub-SELECT was pushed, then the UNION
+    // token hit "UNION must follow a pattern" and was discarded, collapsing the
+    // query into two independent subqueries. `assert_parses` also guards that no
+    // error diagnostic is emitted. Both arms must survive as a Union of SubSelects.
+    let ast = assert_parses(
+        "PREFIX ex: <http://example.org/> \
+         SELECT ?n WHERE { \
+           { SELECT (?x AS ?n) WHERE { ?s ex:name ?x } } UNION \
+           { SELECT (?y AS ?n) WHERE { ?t ex:label ?y } } }",
+    );
+    if let QueryBody::Select(q) = &ast.body {
+        if let GraphPattern::Union { left, right, .. } = &q.where_clause.pattern {
+            assert!(
+                matches!(left.as_ref(), GraphPattern::SubSelect { .. }),
+                "left arm should be a sub-SELECT, got {left:?}"
+            );
+            assert!(
+                matches!(right.as_ref(), GraphPattern::SubSelect { .. }),
+                "right arm should be a sub-SELECT, got {right:?}"
+            );
+        } else {
+            panic!(
+                "Expected Union of sub-SELECTs, got {:?}",
+                q.where_clause.pattern
+            );
+        }
+    }
+}
+
+#[test]
+fn test_union_mixed_group_and_subselect_arms() {
+    // Either arm may be a sub-SELECT; a plain-group left arm must not swallow
+    // the union or drop the sub-SELECT right arm.
+    let ast = assert_parses(
+        "PREFIX ex: <http://example.org/> \
+         SELECT ?n WHERE { \
+           { ?s ex:name ?n } UNION \
+           { SELECT (?y AS ?n) WHERE { ?t ex:label ?y } } }",
+    );
+    if let QueryBody::Select(q) = &ast.body {
+        if let GraphPattern::Union { left, right, .. } = &q.where_clause.pattern {
+            assert!(
+                !matches!(left.as_ref(), GraphPattern::SubSelect { .. }),
+                "left arm should be a plain group, got {left:?}"
+            );
+            assert!(
+                matches!(right.as_ref(), GraphPattern::SubSelect { .. }),
+                "right arm should be a sub-SELECT, got {right:?}"
+            );
+        } else {
+            panic!("Expected Union, got {:?}", q.where_clause.pattern);
+        }
+    }
+}
+
+#[test]
+fn test_minus_right_side_subselect_preserved() {
+    // Regression (azure-chat #43): the right arm of MINUS being a sub-SELECT was
+    // parsed as a bare BGP with the `(expr AS ?v)` projection dropped, so MINUS
+    // shared no bound variable with the left and subtracted nothing. The right
+    // arm must remain a sub-SELECT.
+    let ast = assert_parses(
+        "PREFIX ex: <http://example.org/> \
+         SELECT ?n WHERE { \
+           ?s ex:name ?n MINUS \
+           { SELECT (?y AS ?n) WHERE { ?t ex:hidden ?y } } }",
+    );
+    if let QueryBody::Select(q) = &ast.body {
+        if let GraphPattern::Minus { right, .. } = &q.where_clause.pattern {
+            assert!(
+                matches!(right.as_ref(), GraphPattern::SubSelect { .. }),
+                "MINUS right arm should be a sub-SELECT, got {right:?}"
+            );
+        } else {
+            panic!("Expected Minus, got {:?}", q.where_clause.pattern);
+        }
+    }
+}
+
+#[test]
+fn test_optional_subselect_preserved() {
+    // A sub-SELECT is a valid OPTIONAL body (grammar admits a group here, and a
+    // group may be a SubSelect). It must not be flattened to a bare BGP.
+    let ast = assert_parses(
+        "PREFIX ex: <http://example.org/> \
+         SELECT ?n WHERE { \
+           ?s ex:name ?n OPTIONAL \
+           { SELECT (COUNT(?t) AS ?c) WHERE { ?t a ex:Thing } } }",
+    );
+    if let QueryBody::Select(q) = &ast.body {
+        if let GraphPattern::Group { patterns, .. } = &q.where_clause.pattern {
+            let opt = patterns
+                .iter()
+                .find_map(|p| match p {
+                    GraphPattern::Optional { pattern, .. } => Some(pattern),
+                    _ => None,
+                })
+                .expect("expected an OPTIONAL pattern");
+            assert!(
+                matches!(opt.as_ref(), GraphPattern::SubSelect { .. }),
+                "OPTIONAL body should be a sub-SELECT, got {opt:?}"
+            );
+        } else {
+            panic!("Expected Group, got {:?}", q.where_clause.pattern);
+        }
+    }
+}
+
+#[test]
 fn test_values_single_var() {
     let ast = assert_parses(r"SELECT * WHERE { VALUES ?x { 1 2 3 } }");
     if let QueryBody::Select(q) = &ast.body {


### PR DESCRIPTION
Fixes #1435. Repairs the root cause behind **fluree/azure-chat#42** (sub-SELECT in `UNION`) and **fluree/azure-chat#43** (sub-SELECT in `MINUS`).

## The bug

A SPARQL sub-SELECT (`{ SELECT ... }`) used as an operand of a set/graph operation was mis-parsed, silently returning wrong results:

| Query shape | Expected | Before |
|---|---|---|
| `{ SELECT (…AS ?n) } UNION { SELECT (…AS ?n) }` | both arms | one arm only (or 0 rows) |
| `{ SELECT (…AS ?n) } MINUS { SELECT (…AS ?n) }` | difference | full left set (no subtraction) |
| `{ plain } UNION { SELECT (…AS ?n) }` | both arms | sub-SELECT arm dropped |
| `OPTIONAL { SELECT (COUNT(…) AS ?c) … }` | `?c` bound | `?c` lost, rows duplicated |

Silent (HTTP 200, no error), which is worse than a hard failure — NL→SPARQL / SQL→SPARQL generators emit `{ SELECT } UNION { SELECT }` and `{ SELECT } MINUS { SELECT }` routinely for "either/or" and "without" questions.

## Root cause

`Parser::parse_group_graph_pattern` (`fluree-db-sparql/src/parse/query/pattern.rs`) only recognised a `{ SELECT ... }` sub-SELECT **inside its own nested-`{` branch**. Every other position that opens a group — `OPTIONAL`, `GRAPH`, `SERVICE`, the right arm of `MINUS`, each arm of `UNION` (`parse_union_continuation`), `EXISTS`/`NOT EXISTS` (the free `parse_group_graph_pattern`), and a bare `WHERE { SELECT … }` — consumes the `{` itself and then calls `parse_group_graph_pattern` positioned at the `SELECT`, where the leading `SELECT` was treated as an unexpected token.

- **UNION**: the left sub-SELECT was pushed with no trailing-`UNION` check (the plain-group branch had one), so `UNION` hit `"UNION must follow a pattern"` and was discarded — the query collapsed into two independent subqueries lowered as a **conjunction**. At execution that becomes a correlated join on the shared projected variable; the arms' values are disjoint, so one arm survives (the smaller-cardinality one; ties → left) or 0 rows. (So it is *not* "only the last arm," as azure-chat#42 guessed.)
- **MINUS / OPTIONAL / GRAPH / SERVICE**: the sub-SELECT was parsed as a bare BGP with the `(expr AS ?v)` projection **dropped**. MINUS then shares no bound variable with the left → subtracts nothing; OPTIONAL loses the projected/aggregate variable.

Lowered IR confirms it — before: `{SELECT} UNION {SELECT}` → `[Subquery, Subquery]` (no `Union`); `{SELECT} MINUS {SELECT}` → `[Subquery, Minus(Triple×4)]` (projection gone).

## The fix (parser-only)

`fluree-db-sparql/src/parse/query/pattern.rs`:

1. Detect the `SubSelect` alternative at the **top** of `parse_group_graph_pattern` (the opening `{` is already consumed by the caller), so every caller implements the grammar rule `GroupGraphPattern ::= '{' ( SubSelect | GroupGraphPatternSub ) '}'`. This fixes MINUS/OPTIONAL/GRAPH/SERVICE/EXISTS/UNION-right and bare `WHERE { SELECT }` in one place.
2. Route the nested-`{` branch through `parse_group_graph_pattern` (which now handles both a group and a sub-SELECT) and run the trailing-`UNION` check for a sub-SELECT left arm too.

Error recovery for a malformed sub-SELECT is preserved (skip to the matching `}`).

## Performance

No query-engine change. Fixed queries now compile to the **same** `UnionOperator` the equivalent flat `UNION` always used, and to a proper sub-SELECT `MINUS` — i.e. the already-optimised plans. The *buggy* path was actually a more expensive per-row correlated `SubqueryOperator` join chain. So this is neutral-to-positive on speed, with no memory impact.

## Testing

- **Parser AST tests** (`fluree-db-sparql`): sub-SELECT in UNION (both arms + mixed group/sub-SELECT), MINUS right arm, OPTIONAL body. `assert_parses` also guards that the spurious `"UNION must follow a pattern"` diagnostic is gone.
- **Integration tests** (`fluree-db-api/tests/it_query_sparql_setop_subselect.rs`): the verbatim azure-chat 42 & 43 queries and near-neighbors, asserting end-to-end results (UNION == flat UNION; MINUS == FILTER NOT EXISTS; OPTIONAL binds the aggregate).
- **W3C SPARQL suite** (before → after): syntax-query **81 → 83** (`syntax-SELECTscope1`, a positive `{SELECT} UNION {SELECT}` syntax test), subquery **11 → 12** (`sq12`, bare `WHERE { SELECT }` in CONSTRUCT), negation **12 → 12** (no W3C test covers sub-SELECT-as-MINUS-operand — the new integration tests fill that gap). **Zero regressions.**
- Full `grp_query_sparql` (265) and `grp_query` JSON-LD (303) integration groups pass; `cargo clippy -p fluree-db-sparql --all-features -- -D warnings` clean.
- JSON-LD query surface is unaffected (separate parser; `{query}`-in-union already worked and still passes).

## Files

- `fluree-db-sparql/src/parse/query/pattern.rs` — the fix.
- `fluree-db-sparql/src/parse/query/tests.rs` — parser AST regression tests.
- `fluree-db-api/tests/it_query_sparql_setop_subselect.rs` (+ `grp_query_sparql.rs`) — integration regression tests.
