### PR TITLE
fix: close Cypher benchgraph gaps and add benchmark-critical fast paths

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1970,6 +1970,64 @@ mem:fact-01ktys13s07fm2mphwxqnr339h a mem:Fact ;
     mem:createdAt "2026-06-12T20:40:28.192512+00:00"^^xsd:dateTime ;
     mem:rationale "46 panel-confirmed findings from a 260-agent audit; fixing engine lanes is pointless until ingestion stops corrupting values — any future decimal work should start from DECIMAL_AUDIT.md's priority list." .
 
+mem:fact-01kwstgh1vshsahk63r0dzdkdt a mem:Fact ;
+    mem:content "Cypher bound rel var `-[e]->` is now dual-mode (benchgraph D1 fix): a statement-wide scan (fluree-db-cypher lower/annotation_use.rs) classifies vars; value-only vars (no e.prop/properties/keys/map-projection anywhere) lower to plain base triple + OPTIONAL EdgeAnnotation + Bind e=coalesce(ann, MakeRel(s,p,o)) so unreified edges match while reified parallel edges keep per-annotation rows; property-reading vars keep annotation-only lowering. The OPTIONAL probe is skipped entirely when encode_iri(f:reifiesSubject) fails (no reified edge exists in the ledger). Engine prereq: Coalesce got a binding-path arm in eval/list.rs eval_list_fn_to_binding — the scalar ComparableValue path collapses Rel/List/Map to Unbound." ;
+    mem:tag "coalesce" ;
+    mem:tag "cypher" ;
+    mem:tag "edge-annotation" ;
+    mem:tag "lowering" ;
+    mem:tag "rel-var" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-cypher/src/lower/annotation_use.rs" ;
+    mem:artifactRef "fluree-db-cypher/src/lower/pattern.rs" ;
+    mem:artifactRef "fluree-db-query/src/eval/list.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-07-05T19:01:33.371634+00:00"^^xsd:dateTime .
+
+mem:fact-01kwstgvy9sfntgk0w8vydzkyf a mem:Fact ;
+    mem:content "Untyped shortestPath/allShortestPaths (benchgraph F2): ShortestPathPattern.predicate is now Option<Sid> — None = wildcard edge-set (Ref objects only, excludes rdf:type + f:reifies* via property_path::is_reserved_edge_predicate, now pub(crate)). Wildcard backward hops probe OPST (POST needs a predicate prefix). Per-hop predicates for relationships(p) are NOT threaded through BFS — build_edges resolves each found hop post-hoc via a SPOT probe (hop_predicate), trying both orientations under Either. JSON-LD lowering wraps Some(pred); the sparql firewall (lower/mod.rs) guards Some only." ;
+    mem:tag "cypher" ;
+    mem:tag "property-path" ;
+    mem:tag "query" ;
+    mem:tag "shortest-path" ;
+    mem:tag "wildcard" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-cypher/src/lower/pattern.rs" ;
+    mem:artifactRef "fluree-db-query/src/ir/path.rs" ;
+    mem:artifactRef "fluree-db-query/src/shortest_path.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-07-05T19:01:44.521231+00:00"^^xsd:dateTime .
+
+mem:fact-01kwsthd6k6xagy4tdtre2ncew a mem:Fact ;
+    mem:content "Benchgraph gap fixes round 1 (2026-07-05): B2 unary-minus folded at parse (parse_unary); B1 untyped single-hop --> gets edge-set filter (pred != rdf:type AND isIri||isBlank(o)) in push_rel_triple; F3 bare MATCH (n) opt-in via FLUREE_CYPHER_ALLOW_FULL_SCAN env → uncorrelated SELECT DISTINCT subject subquery; F4 bare CREATE () asserts hidden rdf:type db:Node marker (fluree_vocab::fluree::NODE, filtered from labels()); F5 inline UNWIND range()/[list] before writes folds to a synthetic $param (inline_constant_unwind, 10k cap)." ;
+    mem:tag "benchgraph" ;
+    mem:tag "cypher" ;
+    mem:tag "full-scan" ;
+    mem:tag "unwind" ;
+    mem:tag "write-path" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/src/query/helpers.rs" ;
+    mem:artifactRef "fluree-db-cypher/src/lower/pattern.rs" ;
+    mem:artifactRef "fluree-db-cypher/src/params.rs" ;
+    mem:artifactRef "fluree-db-transact/src/lower_cypher_update.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-07-05T19:02:02.195415+00:00"^^xsd:dateTime .
+
+mem:fact-01kwsthhc6fkb931xyd6anfjye a mem:Fact ;
+    mem:content "Cypher RETURN-on-write (benchgraph F1) is still deferred; the viable design: expose the staging skolem txn_id + WHERE solution count through CommitReceipt/TransactionReceipt (6 construction sites + Raft path), OR pre-supply txn_id via TxnOpts derived from the request tx-id. Created-node Sids are then reconstructible statelessly: Sid::new(BLANK_NODE, \"fdb-{txn_id}-{solution}-{label-sans-_:}\") — blank_node_sid needs no registry state. Server side then swaps the commit-receipt body for the cypher-json envelope (fluree-db-api/src/format/cypher.rs) when the statement had RETURN." ;
+    mem:tag "consensus" ;
+    mem:tag "cypher" ;
+    mem:tag "design" ;
+    mem:tag "return-on-write" ;
+    mem:tag "skolemization" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-consensus/src/lib.rs" ;
+    mem:artifactRef "fluree-db-server/src/routes/transact.rs" ;
+    mem:artifactRef "fluree-db-transact/src/generate/flakes.rs" ;
+    mem:artifactRef "fluree-db-transact/src/stage.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-07-05T19:02:06.470017+00:00"^^xsd:dateTime .
+
 mem:constraint-01kp8yczz09ndt54ztchbheeyb a mem:Constraint ;
     mem:content "JSON-LD transaction parsing does NOT auto-promote bare string values to IRI references. User data becomes an IRI only when wrapped in `{\"@id\": \"...\"}` or when the property has `@type: \"@id\"` in `@context`. The former `looks_like_iri` heuristic (three sites in parse/jsonld.rs) was removed — it silently promoted strings starting with `http://`/`https://`/`did:`/`fluree:`/`urn:` to IRIs, which violated the JSON-LD spec (especially for `{\"@value\": \"...\"}`, explicitly a literal)." ;
     mem:tag "iri" ;

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -94,6 +94,7 @@
   - [Cross-ledger model enforcement](design/cross-ledger-model-enforcement.md)
   - [Storage traits](design/storage-traits.md)
   - [Raft command queue and replicated state machine](design/raft-command-queue.md)
+  - [Bolt protocol adapter (proposed)](design/bolt-adapter.md)
 
 - [HTTP API (fluree-db-server)](api/README.md)
   - [Overview](api/overview.md)

--- a/docs/contributing/benches.md
+++ b/docs/contributing/benches.md
@@ -208,7 +208,7 @@ future micro-bench wants to exercise `fluree-db-indexer`,
 | `import` | bulk Turtle / N-Quads / JSON-LD ingest | `fluree-db-api/benches/import_bulk.rs` |
 | `transact` | stage + commit | `fluree-db-api/benches/transact_commit.rs` |
 | `reindex` | full reindex; incremental | `fluree-db-api/benches/reindex_full.rs`, `fluree-db-api/benches/reindex_incremental.rs` |
-| `query_hot` | BSBM-shape SPARQL on warm cache | `fluree-db-api/benches/query_hot_bsbm.rs` (Explore Q3/Q5/Q9), `fluree-db-api/benches/query_hot_bsbm_bi.rs` (BI-F2 bowtie / seed tie-break) |
+| `query_hot` | warm-cache query latency | `fluree-db-api/benches/query_hot_bsbm.rs` (BSBM Explore Q3/Q5/Q9), `fluree-db-api/benches/query_hot_bsbm_bi.rs` (BI-F2 bowtie / seed tie-break), `fluree-db-api/benches/query_hot_whole_graph_agg.rs` (Cypher metadata-lane aggregate folds vs. pipeline baseline) |
 | `query_cold` | reload + first-query latency | `fluree-db-api/benches/query_cold_reload.rs` |
 | `novelty` | replay, catch-up, bulk-apply | `fluree-db-api/benches/novelty_replay.rs` |
 | `vector_math` | SIMD vs scalar math micro-benches | `fluree-db-query/benches/vector_math.rs` |

--- a/docs/design/bolt-adapter.md
+++ b/docs/design/bolt-adapter.md
@@ -1,0 +1,243 @@
+# Bolt protocol adapter — implementation hand-off
+
+Status: proposed (not started). This document captures the design,
+code anchor points, and performance expectations worked out during the
+benchgraph/Pokec optimization effort (branch `fix/cypher-benchgraph-gaps`,
+2026-07). Read alongside [Cypher (concept)](../query/cypher.md) and the
+[openCypher support matrix](../reference/cypher-support-matrix.md).
+
+## What and why
+
+Bolt is Neo4j's versioned binary protocol (TCP handshake + PackStream
+serialization + a session message state machine). Implementing the server
+side gives Fluree two things:
+
+1. **Ecosystem access** — every official Neo4j driver (Python, Java, JS,
+   Go, .NET) and most Neo4j-compatible tooling can connect to Fluree's
+   openCypher surface unmodified.
+2. **Per-request floor parity** — published graph-database benchmarks
+   (memgraph/benchgraph and similar) measure Bolt round trips over
+   persistent sessions. Our HTTP numbers carry per-request connection and
+   envelope costs the vendors' numbers do not. A Bolt session erases that
+   gap and makes 12-worker-concurrency comparisons apples-to-apples.
+
+It does **not** speed up engine-bound queries; it removes wire and
+per-request overhead only. See [Performance expectations](#performance-expectations).
+
+## Sequencing recommendation
+
+Do these in order — the first is engine work that pays off regardless of
+protocol and is a prerequisite for Bolt hitting its floor:
+
+1. **Parsed-AST / lowered-IR cache** (no protocol work; see
+   [Plan cache](#the-plan-cache-do-this-first)).
+2. **Bolt v1**: autocommit only, versions 4.4 + 5.x, the value mappings we
+   already have. ~1–2 weeks.
+3. **Driver-matrix polish + explicit transactions**: open-ended tail;
+   schedule separately.
+
+## Scope
+
+### v1 (benchmark- and driver-smoke-grade)
+
+- Handshake: magic `0x6060B017`, 4-slot version negotiation. Offer 5.x
+  (pick one minor, e.g. 5.4) and 4.4 — that covers current official
+  drivers and most third-party clients.
+- Messages: `HELLO` (+ `LOGON` for 5.1+), `RUN`, `PULL {n}` (reactive
+  batching with `has_more`), `DISCARD`, `RESET`, `GOODBYE`. Autocommit
+  only: `BEGIN` answers a clear `FAILURE`
+  (`Neo.ClientError.Statement.TypeError`-family code with a "explicit
+  transactions not supported" message), never a silent wrong behavior —
+  same contract as the Cypher support matrix.
+- Auth: `none` scheme when the server runs open; `basic` deferred unless
+  trivially mappable to the existing credential machinery. Do not invent a
+  new identity path for v1.
+- One database per session: Bolt's `db` metadata field (in `HELLO`
+  defaults + per-`RUN` extra) maps to a ledger id (`pokec:main`). Missing
+  `db` → a configurable default ledger.
+- Result streaming: `SUCCESS {fields: [...]}` → `RECORD` per row →
+  `SUCCESS {type, t_first, t_last, db}` summary. Write queries surface the
+  commit receipt counters in the summary metadata (`stats` map).
+
+### Explicitly deferred
+
+- Explicit transactions (`BEGIN`/`COMMIT`/`ROLLBACK`). This is the
+  genuinely hard part: an interactive multi-round-trip transaction needs
+  session-pinned staged state held across messages, reconciled with the
+  consensus commit path (`resolve_cypher_under_lock` runs under the ledger
+  lock; see the commit-conflict/refresh machinery in
+  `fluree-db-api/src/lib.rs` and `fluree-db-consensus/src/local.rs`). Do
+  not attempt in v1.
+- `ROUTE` / routing tables (cluster-aware drivers fall back fine for a
+  single server; answer `ROUTE` with a single-entry table if a driver
+  insists).
+- TLS (front with a proxy if needed initially).
+
+## Where it goes
+
+```
+Layer 5   fluree-db-server ──uses──► fluree-db-bolt (new crate)
+```
+
+- **New crate `fluree-db-bolt`** (Layer 5 sibling): PackStream
+  encode/decode, message framing (chunked transport: u16-length chunks,
+  0x0000 terminator), version negotiation, and the session state machine
+  (`READY` / `STREAMING` / `FAILED` / `INTERRUPTED`). No Fluree
+  dependencies beyond `fluree-db-api` types at the edge — keep the codec
+  pure so it unit-tests against captured byte fixtures.
+  - Evaluate vendoring/depending on the `bolt-proto` crate (message +
+    value types through Bolt 4.x; used by `bb8-bolt`) and the PackStream
+    implementation inside `neo4rs`. Expect to write the 5.x deltas
+    (element ids, `LOGON` split) ourselves either way.
+- **Wiring in `fluree-db-server`**, feature-gated `bolt` (default off
+  initially):
+  - Config: `bolt_listen_addr: Option<SocketAddr>` (conventional port
+    7687) in `fluree-db-server/src/config.rs` + the config file schema +
+    `docs/operations/configuration.md`.
+  - Listener: `Server::run()` in `fluree-db-server/src/lib.rs` (~line
+    239) already binds the HTTP `TcpListener` and spawns background
+    tasks; bind the Bolt listener alongside and spawn one tokio task per
+    connection. Each connection holds an `Arc<AppState>` — the same
+    ledger-manager, consensus, and full-scan configuration the HTTP
+    routes use.
+
+### Execution glue — reuse these, do not fork them
+
+| Concern | Existing entry point |
+|---|---|
+| Read query with params | `Fluree::query_cypher_with_params` (`fluree-db-api/src/view/query.rs:161`) → `parse_cypher_to_ir` (`fluree-db-api/src/query/helpers.rs:108`) |
+| Ledger view resolution | `fluree.db(ledger_id)` (`fluree-db-api/src/view/fluree_ext.rs:525`) — cheap snapshot clone, read-scaling already handled |
+| Write (autocommit `RUN` of a write statement) | the same path `execute_cypher_transact` uses in `fluree-db-server/src/routes/transact.rs` (~line 810): `plan_write_return_source` → `TxnOpts { skolem_txn_id }` → `submit_via_consensus` → `wait_for_committed_state` → `write_return_rows` for `CREATE … RETURN` |
+| Read/write classification | same statement sniffing the HTTP route uses (write clauses present → transact path) |
+| Bare `MATCH (n)` gating | `cypher_full_scan_enabled()` (`fluree-db-api/src/query/helpers.rs`) — process-wide `FLUREE_CYPHER_ALLOW_FULL_SCAN`, read once; Bolt sessions inherit it automatically |
+| Plan inspection while developing | `fluree_db_api::explain::explain_cypher` — added during this effort precisely because Cypher had no explain surface and plan-shape defects were invisible |
+
+### Result mapping — mostly already built
+
+The cypher-json formatter (`QueryResult::to_cypher_json{,_async}` in
+`fluree-db-api/src/query/mod.rs:245,432`) already implements the
+Neo4j-compatible **semantic** mapping (native scalars, date rendering,
+list/map values, novelty-aware IRI resolution). Bolt needs the same
+mapping targeting PackStream values instead of JSON. Factor the
+per-binding conversion so both formatters share it rather than
+copy-pasting.
+
+| Fluree value | Bolt / PackStream | Notes |
+|---|---|---|
+| IRI / node (`RETURN n`) | `Node { id, element_ids, labels, properties }` | `elementId` = IRI string. `id` (int64, required pre-5.x) = encoded `s_id` (u64 → i64; document the cast). Labels via the existing `labels()` machinery — it already hides the `db:Node` marker. Properties need a per-node property fetch at format time — same cost profile as cypher-json's node rendering. |
+| Relationship value (`Binding::Rel { start, predicate, end, reifier }`) | `Relationship { id, start, end, type, properties }` | The Cypher relationship value model landed for cypher-json; `type()` / `startNode()` / `endNode()` / `properties()` already resolve. `id` = reifier's encoded s_id when reified, else synthesize (e.g. hash) — pre-5.x drivers only need it to be stable within a result. |
+| `Binding::Path { nodes, preds }` | `Path { nodes, rels, indices }` | Same source data as `nodes()` / `relationships()` / `pathPairs()`. |
+| xsd:integer/long | Integer | |
+| xsd:double/float | Float | |
+| **xsd:decimal** | Float (document the precision loss) | cypher-json renders decimals as strings for precision; PackStream has no decimal type and Neo4j returns Float. Integer division produces xsd:decimal in our engine (see `docs/query/cypher.md`), so this shows up on ordinary `a / b`. Decide once, write it in the matrix. |
+| xsd:date / dateTime | Bolt 5 `Date` / `DateTime` structures (4.4: legacy structs) | cypher-json emits ISO strings; Bolt drivers expect the structures. |
+| unbound | Null | |
+
+## The plan cache (do this first)
+
+The remaining engine-side per-request cost is parse → lower → plan,
+re-done for every request. Two facts make caching easy to get wrong today
+and easy to get right with a small change:
+
+- `parse_cypher_to_ir` substitutes `$params` **into the AST before
+  lowering** (`fluree-db-api/src/query/helpers.rs:130-136`). A cache keyed
+  on statement text must therefore cache the **pre-substitution parsed
+  AST** (text-only key, ledger-independent, immutable — clone per request,
+  then substitute). This is exactly the split Bolt's `RUN {text, params}`
+  model assumes, and our HTTP params envelope already delivers.
+- Lowering depends on the snapshot (IRI → SID encoding added in
+  `ee7285380`, vocab/context) — caching *lowered IR* needs an
+  invalidation key tied to the ledger's namespace/dict state. Measure
+  before building it: if parse dominates lowering (likely for benchmark
+  statements), the AST cache alone captures most of the win at zero
+  invalidation risk.
+
+Suggested v1: a bounded LRU (`text → Arc<CypherAst>`) in
+`fluree-db-api`, consulted by `parse_cypher_to_ir`. Benchmark the
+parse/lower/plan split first (a `pattern_short` flamegraph or coarse
+timers) so the follow-up decision is data-driven.
+
+## Performance expectations
+
+Baseline measurements from this effort (pokec small = 10k nodes/122k
+edges, single-client, per-request `curl`, warm, Apple-silicon dev box —
+the r7a.4xlarge numbers scale similarly):
+
+| Component | Evidence |
+|---|---|
+| Full HTTP round trip, `pattern_short` | ~0.87–0.92 ms |
+| Same-shape work in-process (parse+plan+exec) | ~90–300 µs |
+| ⇒ transport + curl process/connect + HTTP/JSON envelope | **~0.4–0.7 ms** |
+| Vendors' published p50 (Bolt, persistent sessions, 12 workers) | Neo4j 0.22–0.23 ms, Memgraph 0.15–0.16 ms |
+
+Expected after Bolt v1 (persistent session, PackStream, no HTTP):
+
+- **Sub-ms micro queries (12 of 35 in benchgraph): ~0.6–0.9 ms → ~0.2–0.4 ms**
+  client-observed. Floor ≈ execution (50–300 µs) + protocol (~50 µs) +
+  parse/plan (~50–100 µs, → ~10–20 µs with the AST cache).
+- **Writes: ~1.2–1.6 ms → ~1.0–1.4 ms.** Commit dominates; wire savings
+  only.
+- **Engine-bound queries (expansion_3/4, filtered scans): unchanged.**
+- **Concurrency runs become honest**: the 12-worker comparison stops
+  penalizing us for per-request connections. The engine side already
+  scales (snapshot reads are `Arc` + `RwLock`; see
+  `fluree-db-api/tests/it_scaling_bench.rs`).
+
+Cheap partial alternative: a benchmark runner holding persistent HTTP
+connections (or any keep-alive client) captures roughly the transport
+half of the win with no protocol work — worth doing for fair numbers even
+before Bolt lands.
+
+## Testing
+
+- **Codec**: byte-fixture unit tests in `fluree-db-bolt` (captured frames
+  from a real Neo4j/driver exchange are the fastest way to get these).
+- **Integration**: `neo4rs` (Rust Bolt client) as a dev-dependency
+  driving a spawned server — mirror `fluree-db-server/tests/cypher_http_integration.rs`
+  (read, write with `RETURN`, params, error surfaces, `RESET` mid-stream).
+- **Driver smoke**: a small Python script with the official `neo4j`
+  driver, run manually or behind an ignored test — official drivers are
+  the compatibility bar, and they probe things ad-hoc clients don't
+  (`server` version string in `SUCCESS` of `HELLO`, `qid` handling,
+  summary metadata shapes).
+- **Benchmark protocol** (hard-won lessons; see also
+  `docs/troubleshooting/performance-tracing.md`):
+  - Always re-import fresh and restart the server before trusting
+    numbers. Two separate investigations in this effort were poisoned by
+    a stale server process running an older binary, and one "regression"
+    (create__edge 1.2→2.4 ms) was entirely accumulated-novelty ledger
+    state, not code.
+  - The whole-graph/class aggregate folds require a clean HEAD (no
+    novelty) and — for the bare `MATCH (n)` anchor — a graph without
+    `f:reifies*` facts; benchmark write passes create both conditions'
+    violations, so aggregate timings taken mid-suite measure the
+    fallback pipeline.
+  - `FLUREE_CYPHER_ALLOW_FULL_SCAN=1` is required for the two bare
+    `MATCH (n)` aggregation queries and is read once per process.
+
+## Effort estimate
+
+| Piece | Estimate |
+|---|---|
+| AST cache + parse/lower/plan measurement | 1–2 days |
+| PackStream + framing + handshake + state machine | 3–5 days |
+| Execution glue + result mapping (sharing the cypher-json converter) | 3–4 days |
+| Integration tests + driver smoke + config/docs | 2–3 days |
+| **v1 total** | **~2 weeks** |
+| Driver-matrix polish (5 official drivers' quirks, `ROUTE`, auth schemes) | +1–2 weeks, schedule separately |
+| Explicit transactions | Design first; touches consensus locking — not a protocol task |
+
+## Open questions
+
+1. **xsd:decimal → Float**: accept Neo4j-parity precision loss on Bolt
+   while cypher-json keeps strings? (Recommended: yes, note it in the
+   support matrix.)
+2. **Node property eagerness**: Bolt `Node` carries full properties;
+   `RETURN n` over large result sets pays a per-node property fetch.
+   Mirror whatever cypher-json does today; revisit only if it shows up.
+3. **Auth**: is `none`-scheme-when-open acceptable for v1, with `basic`
+   mapped to the existing credential/OIDC machinery later?
+4. **Numeric `id` stability**: encoded s_id is stable per index build but
+   can change across reindex. Fine for driver compatibility (ids are
+   opaque handles within a session); document that `elementId` (the IRI)
+   is the durable identity.

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -154,6 +154,7 @@ A few operational knobs are environment-only (no CLI flag):
 |----------|---------|---------|
 | `FLUREE_REASONING_MAX_FACTS` | 1,000,000 | Server-wide default OWL2-RL materialization budget (max derived facts). Overridden per ledger by `f:reasoningMaxFacts` and per query by `"reasoningBudget"`; see [Reasoning](../query/reasoning.md#materialization-budget). |
 | `FLUREE_REASONING_MAX_SECONDS` | 30 | Server-wide default OWL2-RL materialization budget (wall-clock seconds). Same override chain as above. |
+| `FLUREE_CYPHER_ALLOW_FULL_SCAN` | off | Allow bare Cypher `MATCH (n)` (no label/property/relationship constraint) to run as a whole-graph distinct-subject scan. Off by default — intended for benchmarks and ad-hoc exploration, not production queries. |
 
 ### Precedence
 

--- a/docs/query/cypher.md
+++ b/docs/query/cypher.md
@@ -347,9 +347,19 @@ ORDER BY / SKIP / LIMIT
   resolution keys off the raw MATCH variables and can't honor a rename/horizon —
   `DELETE` directly off the MATCH variables). Aggregation, `DISTINCT`, and
   `ORDER BY` / `SKIP` / `LIMIT` on a write-side `WITH` are deferred.
+- **`… RETURN <created>`** — a trailing `RETURN` of *created* entities:
+  `CREATE (n:Person {name: "Alice"}) RETURN n`,
+  `MATCH (a), (b) CREATE (a)-[e:KNOWS]->(b) RETURN e` (one row per matched
+  pair). Answered as the read path's Cypher-JSON tabular envelope; each entity
+  serializes as its identifier string. v1 surface: bare variables (optionally
+  aliased) naming a fresh `CREATE` node or relationship variable. Deferred:
+  expressions, `RETURN` modifiers, `MATCH`-bound variables, and `RETURN` with
+  `MERGE` (the matched branch's node isn't a created entity).
 
 ```rust
 let committed = fluree.transact_cypher(ledger, cypher).await?;
+// or, when the statement ends in RETURN:
+let (committed, rows) = fluree.transact_cypher_returning(ledger, cypher, None).await?;
 ```
 
 Writes default to LPG mode, where every relationship reifies (carries an

--- a/docs/query/cypher.md
+++ b/docs/query/cypher.md
@@ -381,18 +381,31 @@ on its properties — which in turn decides the cardinality and whether plain
 | Pattern | Lowers to | Cardinality | Sees plain RDF? |
 |---|---|---|---|
 | `(a)-[:T]->(b)` | Plain triple `(a, <T>, b)` | Set | Yes |
-| `(a)-[r:T]->(b)` | `EdgeAnnotation { edge, annotation: ?r, body: [] }` | Bag | No — only reifier-bundled edges |
+| `(a)-[r:T]->(b)`, `r` **value-only** | Plain triple + `OPTIONAL { EdgeAnnotation }` + `r = coalesce(annotation, MakeRel(a, T, b))` | Bag over annotations; one row for an unreified edge | Yes |
+| `(a)-[r:T]->(b)`, `r` **property-read** | `EdgeAnnotation { edge, annotation: ?r, body: [] }` | Bag | No — only reifier-bundled edges |
 | `(a)-[:T {p:v}]->(b)` | `EdgeAnnotation { edge, annotation: ?#__anon, body: [(?#__anon, p, v)] }` | Bag | No |
 
-**Consequence.** If your data was loaded via JSON-LD without
-`@annotation` (or any other path that doesn't produce reifier
-bundles), `MATCH (a)-[r:T]->(b)` returns zero rows even though the
-base triples exist. Drop the `r` to get plain-RDF-visible set
-semantics:
+A bound relationship variable is **value-only** when the statement never reads
+its properties — no `r.prop`, `properties(r)`, `keys(r)`, or map projection
+`r{…}` anywhere (a statement-wide scan decides this at lowering). Value-only
+uses (`RETURN r`, `type(r)`, `startNode(r)` / `endNode(r)`, comparisons,
+`collect(r)`) are satisfied by a relationship value synthesized from the base
+triple, so plain (un-annotated) RDF edges match too; edges that *do* carry
+reifier bundles still bind one row per annotation (parallel relationships stay
+distinct).
+
+**Consequence.** Only a *property-reading* relationship variable requires
+reifier bundles. If your data was loaded via JSON-LD without `@annotation`
+(or any other path that doesn't produce reifier bundles),
+`MATCH (a)-[r:T]->(b) RETURN r.since` returns zero rows even though the base
+triples exist — there is no annotation node to read `since` from:
 
 ```cypher
--- bag semantics, requires reifier bundles
-MATCH (a:Person)-[r:WORKS_FOR]->(o:Organization) RETURN a, r, o
+-- value-only r: sees all base edges, plus per-annotation rows where reified
+MATCH (a:Person)-[r:WORKS_FOR]->(o:Organization) RETURN a, type(r), o
+
+-- property read on r: requires reifier bundles
+MATCH (a:Person)-[r:WORKS_FOR]->(o:Organization) RETURN a, r.since, o
 
 -- set semantics, sees all base edges
 MATCH (a:Person)-[:WORKS_FOR]->(o:Organization) RETURN a, o

--- a/docs/reference/cypher-support-matrix.md
+++ b/docs/reference/cypher-support-matrix.md
@@ -43,6 +43,7 @@ These shape everything below; read them first.
 | `WITH` | ◑ | Projection boundary; `WHERE`→HAVING when it references aggregates; `DISTINCT`/`ORDER BY`/`SKIP`/`LIMIT`; `collect()` carries forward as a list. Before a **write** clause only the pass-through / rename / computed-alias / filter subset is allowed (no aggregation / `DISTINCT` / `ORDER BY` / `SKIP` / `LIMIT`); `WITH` before `DELETE` deferred. |
 | `UNWIND` | ✅ | Inline lists and runtime list expressions; `$param` lists via API substitution. Before a **write** clause: `$param` lists, inline literal lists, and constant `range()` (≤ 10000 rows). |
 | `RETURN` | ✅ | `*`, aliases, `DISTINCT`, `ORDER BY`/`SKIP`/`LIMIT`. `SKIP`/`LIMIT` must be literal integers. |
+| `RETURN` on a write (`CREATE … RETURN n`) | ◑ | Bare created-entity variables (a fresh CREATE node or relationship variable), optionally aliased; one row per WHERE solution. Deferred: expressions, RETURN modifiers, MATCH-bound variables, MERGE. |
 | `UNION` / `UNION ALL` | ✅ | Column-name-match + uniform-variant rules enforced. |
 | `CALL { … }` (subquery) | ✅ | Imports `(a,b)` / `(*)`, uncorrelated broadcast, inner `UNION`, nesting, strict scope/shadowing, correlated-aggregate soundness. |
 | `CREATE` | ✅ | Nodes + relationships (relationships reify). Bare `CREATE ()` / `CREATE (n)` asserts a hidden `db:Node` existence marker (invisible to `labels()`). |

--- a/docs/reference/cypher-support-matrix.md
+++ b/docs/reference/cypher-support-matrix.md
@@ -41,11 +41,11 @@ These shape everything below; read them first.
 | `MATCH` | ✅ | Node/relationship patterns, `WHERE`. |
 | `OPTIONAL MATCH` | ✅ | Nullable bindings; poisoned-binding semantics. |
 | `WITH` | ◑ | Projection boundary; `WHERE`→HAVING when it references aggregates; `DISTINCT`/`ORDER BY`/`SKIP`/`LIMIT`; `collect()` carries forward as a list. Before a **write** clause only the pass-through / rename / computed-alias / filter subset is allowed (no aggregation / `DISTINCT` / `ORDER BY` / `SKIP` / `LIMIT`); `WITH` before `DELETE` deferred. |
-| `UNWIND` | ✅ | Inline lists and runtime list expressions; `$param` lists via API substitution. |
+| `UNWIND` | ✅ | Inline lists and runtime list expressions; `$param` lists via API substitution. Before a **write** clause: `$param` lists, inline literal lists, and constant `range()` (≤ 10000 rows). |
 | `RETURN` | ✅ | `*`, aliases, `DISTINCT`, `ORDER BY`/`SKIP`/`LIMIT`. `SKIP`/`LIMIT` must be literal integers. |
 | `UNION` / `UNION ALL` | ✅ | Column-name-match + uniform-variant rules enforced. |
 | `CALL { … }` (subquery) | ✅ | Imports `(a,b)` / `(*)`, uncorrelated broadcast, inner `UNION`, nesting, strict scope/shadowing, correlated-aggregate soundness. |
-| `CREATE` | ✅ | Nodes + relationships (relationships reify). |
+| `CREATE` | ✅ | Nodes + relationships (relationships reify). Bare `CREATE ()` / `CREATE (n)` asserts a hidden `db:Node` existence marker (invisible to `labels()`). |
 | `MERGE` (node) | ✅ | Find-or-create with `ON CREATE SET`. `ON MATCH SET` deferred (for **all** MERGE forms — node and relationship). |
 | `MERGE` (relationship) | ◑ | Standalone + bound-endpoint forms; `ON CREATE SET`. Deferred: property-bearing rel MERGE (`-[:T {p:v}]->`), multi-hop / multi-part MERGE, multiple `MERGE` clauses, and `MERGE` combined with another write clause in one statement. |
 | `SET` / `REMOVE` | ✅ | Properties, `+=` map merge, labels. |
@@ -60,17 +60,17 @@ These shape everything below; read them first.
 | Feature | Status | Notes |
 |---------|:------:|-------|
 | Node pattern (labels, inline props) | ✅ | |
-| Bare unconstrained `MATCH (n)` | ⟂ | Rejected — a node must be constrained by a label, property, or relationship (no whole-graph scan). |
+| Bare unconstrained `MATCH (n)` | ◑ | Rejected by default (a node must be constrained by a label, property, or relationship). Opt in to a whole-graph distinct-subject scan with the server flag `FLUREE_CYPHER_ALLOW_FULL_SCAN=1`. |
 | Directed typed relationship `-[:T]->`, `<-[:T]-` | ✅ | |
 | Type alternation `-[:A\|B]->` | ✅ | `Union` of concrete predicates. |
 | Undirected `-[:T]-` | ✅ | Forward ∪ reverse `Union`. |
-| Untyped relationship `-[r]->` | ✅ | Variable predicate; system facts hidden. |
+| Untyped relationship `-->` / `-[r]->` | ✅ | Follows relationships only: `rdf:type`, `f:reifies*`, and data properties (literal objects) are excluded from the hop. |
 | Bounded var-length `-[:T*m..n]->` | ✅ | **Enumerates trails** (one row per path, relationship-uniqueness). |
 | Unbounded var-length `-[:T*]->` | ⟂ | **Reachability** (one row per reachable endpoint), not path enumeration. |
 | Untyped var-length `-[*m..n]->` | ⟂ | Wildcard reachability over node→node edges; excludes `rdf:type`/`f:reifies*`. A direction is required (`-[*]-` deferred); an unbounded lower bound above 1 (`-[*2..]->`) deferred — give an upper bound or name a type. |
 | Bounded var-length **binding** `-[r:T*m..n]->` / `p = …` | ✅ | `r` = rel list, `p` = path; via per-branch construction. |
 | Unbounded var-length binding | ⏳ | Needs a path-enumeration operator. |
-| `shortestPath` / `allShortestPaths` | ✅ | Anchored, single typed predicate; `All` emits one row per minimal path. |
+| `shortestPath` / `allShortestPaths` | ✅ | Anchored; single typed predicate or the untyped wildcard form (`shortestPath((a)-[*..15]->(b))`, same edge-set as untyped var-length); `All` emits one row per minimal path. Type alternation deferred. |
 | `relationships(p)` / `nodes(p)` / `pathPairs(p)` / `length(p)` | ✅ | `relationships(p)` carries the stored edge orientation. |
 | Bounded type-alternation var-length `-[:A\|B*1..3]->` | ⏳ | Use the unbounded form. |
 | Undirected **unbounded** path `-[:T*]-` | ⏳ | |

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -306,6 +306,10 @@ harness = false
 name = "query_hot_bsbm_bi"
 harness = false
 
+[[bench]]
+name = "query_hot_whole_graph_agg"
+harness = false
+
 [lints]
 workspace = true
 

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -191,6 +191,22 @@ name = "it_cyclic_bgp_probe"
 path = "tests/it_cyclic_bgp_probe.rs"
 
 [[test]]
+name = "it_query_cypher"
+path = "tests/it_query_cypher.rs"
+
+[[test]]
+name = "it_query_cypher_fullscan"
+path = "tests/it_query_cypher_fullscan.rs"
+
+[[test]]
+name = "it_policy_cypher"
+path = "tests/it_policy_cypher.rs"
+
+[[test]]
+name = "it_csv_import"
+path = "tests/it_csv_import.rs"
+
+[[test]]
 name = "it_query_explain"
 path = "tests/it_query_explain.rs"
 
@@ -216,6 +232,11 @@ required-features = ["iceberg"]
 name = "it_iceberg_direct"
 path = "tests/it_iceberg_direct.rs"
 required-features = ["iceberg", "aws-testcontainers"]
+
+[[test]]
+name = "it_tpch_iceberg_bench"
+path = "tests/it_tpch_iceberg_bench.rs"
+required-features = ["iceberg"]
 
 [[test]]
 name = "it_storage_s3_testcontainers"

--- a/fluree-db-api/benches/query_hot_whole_graph_agg.rs
+++ b/fluree-db-api/benches/query_hot_whole_graph_agg.rs
@@ -1,0 +1,243 @@
+//! Hot-cache Cypher aggregate latency through the metadata-lane folds.
+//!
+//! Guards the fast paths from `fluree-db-query`'s `fast_whole_graph_agg`:
+//! whole-graph and class-anchored scalar aggregates, GROUP-BY histograms,
+//! and group-key-filtered histograms are answered from index directories
+//! and predicate-scoped scans instead of scanning the graph. The scenarios
+//! here should stay roughly **constant in graph size**; the
+//! `count/pipeline_baseline` scenario runs the same count through the
+//! general pipeline (`WITH n` blocks the fold) as the linear-cost
+//! reference, so a fold that silently stops firing shows up as the folded
+//! scenarios converging toward the baseline.
+//!
+//! ## Scenarios
+//!
+//! 1. **count/whole_graph** — `count(n)` / `count(n.age)` /
+//!    `count(DISTINCT n.age)`: directory-only row and lead-group counts.
+//! 2. **scalars/whole_graph** — min/max from POST boundary keys, avg/sum
+//!    from the predicate-scoped POST fold.
+//! 3. **scalars/class** — the class-anchored family (instance count from
+//!    class stats + containment proof for property folds).
+//! 4. **histogram/class** — `RETURN n.age, COUNT(*)` as a POST run-length
+//!    group count.
+//! 5. **histogram/class_filtered** — same, with a group-key range filter
+//!    evaluated once per group.
+//! 6. **count/pipeline_baseline** — fold-blocked `MATCH (n) WITH n RETURN
+//!    count(n)`: the general DISTINCT-subject scan, linear in graph size.
+//!
+//! ## Setup discipline
+//!
+//! Each scale level builds a Person/Company dataset once, populates a
+//! file-backed ledger, runs a full reindex, and reuses the resulting
+//! `GraphDb` for all `b.iter` calls — the folds require a HEAD index with
+//! no novelty. Bare `MATCH (n)` needs the whole-graph-scan opt-in, so the
+//! bench sets `FLUREE_CYPHER_ALLOW_FULL_SCAN=1` before the first query
+//! (the flag is read once per process). Only Persons carry `ex:age`, so
+//! the class-anchored containment proof holds; ages cycle through 48
+//! values, keeping histogram output bounded at every scale.
+//!
+//! ## Matrix
+//!
+//!   inputs:    BenchScale → n_nodes (Tiny=1k, Small=10k, Medium=100k,
+//!              Large=1M), inserted in 1k-node transactions
+//!   metric:    ns/query (criterion default)
+//!
+//! ## Running
+//!
+//!   cargo bench -p fluree-db-api --bench query_hot_whole_graph_agg
+//!   cargo bench -p fluree-db-api --bench query_hot_whole_graph_agg -- --test
+//!   FLUREE_BENCH_SCALE=medium cargo bench -p fluree-db-api --bench query_hot_whole_graph_agg
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use fluree_bench_support::gen::people::{generate_txn_data, TxnData};
+use fluree_bench_support::{
+    bench_runtime, current_profile, current_scale, init_tracing_for_bench, next_ledger_alias,
+};
+use fluree_db_api::admin::ReindexOptions;
+use fluree_db_api::{CommitOpts, Fluree, FlureeBuilder, GraphDb, IndexConfig, TxnOpts};
+use serde_json::{json, Value as JsonValue};
+
+const NODES_PER_TXN: usize = 1_000;
+
+/// The scenario queries. Bare identifiers resolve under the Cypher default
+/// vocab (`http://example.org/`), so the dataset is serialized with that
+/// base rather than `gen::people`'s `http://example.org/ns/` prefix.
+const COUNT_WHOLE_GRAPH: &str =
+    "MATCH (n) RETURN count(n) AS c, count(n.age) AS ca, count(DISTINCT n.age) AS cd";
+const SCALARS_WHOLE_GRAPH: &str =
+    "MATCH (n) RETURN min(n.age) AS mn, max(n.age) AS mx, avg(n.age) AS av, sum(n.age) AS s";
+const SCALARS_CLASS: &str =
+    "MATCH (n:Person) RETURN count(n) AS c, count(DISTINCT n.age) AS d, max(n.age) AS mx, avg(n.age) AS av";
+const HISTOGRAM_CLASS: &str = "MATCH (n:Person) RETURN n.age, COUNT(*)";
+const HISTOGRAM_CLASS_FILTERED: &str = "MATCH (n:Person) WHERE n.age >= 40 RETURN n.age, COUNT(*)";
+const COUNT_PIPELINE_BASELINE: &str = "MATCH (n) WITH n RETURN count(n) AS c";
+
+/// `gen::people` data under the Cypher default vocab: `ex:` maps to
+/// `http://example.org/` so `MATCH (n:Person)` / `n.age` hit the inserted
+/// IRIs without a ledger default context.
+fn txn_data_to_jsonld_bare_vocab(data: &TxnData) -> JsonValue {
+    let mut graph = Vec::with_capacity(data.persons.len() + data.companies.len());
+    for p in &data.persons {
+        graph.push(json!({
+            "@id": p.id,
+            "@type": "ex:Person",
+            "ex:name": p.name,
+            "ex:email": p.email,
+            "ex:age": {"@value": p.age, "@type": "xsd:integer"}
+        }));
+    }
+    for c in &data.companies {
+        let employees: Vec<JsonValue> =
+            c.employee_ids.iter().map(|id| json!({"@id": id})).collect();
+        let customers: Vec<JsonValue> =
+            c.customer_ids.iter().map(|id| json!({"@id": id})).collect();
+        graph.push(json!({
+            "@id": c.id,
+            "@type": "ex:Company",
+            "ex:name": c.name,
+            "ex:founded": {"@value": c.founded, "@type": "xsd:date"},
+            "ex:employees": employees,
+            "ex:customers": customers
+        }));
+    }
+    json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@graph": graph
+    })
+}
+
+/// Build a populated, indexed, novelty-free file-backed ledger and return
+/// the `GraphDb` the scenarios query. The caller keeps `(TempDir, Fluree)`
+/// alive for the duration of the bench. Also returns the total node count
+/// for the setup sanity check.
+async fn setup_indexed(n_nodes: usize) -> (tempfile::TempDir, Fluree, GraphDb, usize) {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let alias = next_ledger_alias("query-hot-wga");
+    let mut ledger = fluree.create_ledger(&alias).await.expect("create_ledger");
+
+    // High thresholds during populate so the foreground commits don't race
+    // with background indexing — we run an explicit reindex below.
+    let index_config = IndexConfig {
+        reindex_min_bytes: 5_000_000_000,
+        reindex_max_bytes: 5_000_000_000,
+    };
+
+    let n_txns = n_nodes.div_ceil(NODES_PER_TXN);
+    let mut total_nodes = 0usize;
+    for txn_idx in 0..n_txns {
+        let data = generate_txn_data(txn_idx, NODES_PER_TXN);
+        total_nodes += data.persons.len() + data.companies.len();
+        let doc = txn_data_to_jsonld_bare_vocab(&data);
+        let result = fluree
+            .insert_with_opts(
+                ledger,
+                &doc,
+                TxnOpts::default(),
+                CommitOpts::default(),
+                &index_config,
+            )
+            .await
+            .expect("populate insert");
+        ledger = result.ledger;
+    }
+
+    // Reindex publishes a HEAD index with empty novelty — the strict
+    // metadata-lane gate the folds require.
+    let _ = fluree
+        .reindex(&alias, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let db = fluree.db(&alias).await.expect("indexed GraphDb");
+
+    (db_dir, fluree, db, total_nodes)
+}
+
+/// First row of a Cypher result as JSON.
+async fn first_row(fluree: &Fluree, db: &GraphDb, cypher: &str) -> JsonValue {
+    let cj = fluree
+        .query_cypher(db, cypher)
+        .await
+        .expect("cypher execute")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cypher json");
+    cj["results"][0]["data"][0]["row"].clone()
+}
+
+/// The folds must actually answer the scenarios — a setup where they
+/// silently decline would bake scan-speed numbers into the baseline.
+/// Cross-check the folded whole-graph count against the generator's node
+/// count (correctness implies the shape lowered as expected; the timing
+/// gap vs. `count/pipeline_baseline` in the report confirms the lane).
+async fn sanity_check(fluree: &Fluree, db: &GraphDb, total_nodes: usize) {
+    let row = first_row(fluree, db, "MATCH (n) RETURN count(n) AS c").await;
+    assert_eq!(
+        row[0],
+        json!(total_nodes),
+        "whole-graph count(n) must equal the generated node count"
+    );
+    let row = first_row(fluree, db, HISTOGRAM_CLASS_FILTERED).await;
+    assert!(
+        row[0].is_number(),
+        "filtered histogram must produce group rows: {row}"
+    );
+}
+
+fn bench_query_hot_whole_graph_agg(c: &mut Criterion) {
+    // Must precede the first Cypher query: the whole-graph-scan opt-in is
+    // read once per process.
+    std::env::set_var("FLUREE_CYPHER_ALLOW_FULL_SCAN", "1");
+
+    init_tracing_for_bench();
+    let rt = bench_runtime();
+    let scale = current_scale();
+    let profile = current_profile();
+    let n_nodes = scale.elements_default() as usize;
+
+    eprintln!(
+        "  [query_hot_whole_graph_agg] scale={} n_nodes={}",
+        scale.as_str(),
+        n_nodes
+    );
+
+    let (_db_dir, fluree, db, total_nodes) = rt.block_on(setup_indexed(n_nodes));
+    rt.block_on(sanity_check(&fluree, &db, total_nodes));
+
+    let mut group = c.benchmark_group("query_hot_whole_graph_agg");
+    group.sample_size(profile.sample_size());
+    group.sampling_mode(criterion::SamplingMode::Flat);
+
+    let scenarios: &[(&str, &str)] = &[
+        ("count/whole_graph", COUNT_WHOLE_GRAPH),
+        ("scalars/whole_graph", SCALARS_WHOLE_GRAPH),
+        ("scalars/class", SCALARS_CLASS),
+        ("histogram/class", HISTOGRAM_CLASS),
+        ("histogram/class_filtered", HISTOGRAM_CLASS_FILTERED),
+        ("count/pipeline_baseline", COUNT_PIPELINE_BASELINE),
+    ];
+
+    for (name, cypher) in scenarios {
+        group.bench_with_input(BenchmarkId::new(*name, scale.as_str()), cypher, |b, q| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let result = fluree.query_cypher(&db, q).await.expect("execute");
+                    black_box(result);
+                });
+            });
+        });
+    }
+
+    group.finish();
+    drop(db);
+    drop(fluree);
+}
+
+criterion_group!(benches, bench_query_hot_whole_graph_agg);
+criterion_main!(benches);

--- a/fluree-db-api/src/cypher_write.rs
+++ b/fluree-db-api/src/cypher_write.rs
@@ -23,6 +23,7 @@ use fluree_db_cypher::ast::{
     NodePattern, Pattern, PatternPart, ProjectionItem, Query, ReadClause, ReturnClause, SetClause,
     Statement, Update, Variable, WithClause, WriteClause,
 };
+use fluree_db_ledger::LedgerState;
 use fluree_db_transact::ir::Txn;
 
 /// A lowered Cypher write: either a ready-to-stage `Txn`, or a conditional
@@ -375,4 +376,287 @@ pub(crate) fn build_create_ast(merge: &MergeClause) -> CypherAst {
         }),
         span,
     }
+}
+
+// ---- Write-statement RETURN (created entities) ------------------------------
+
+/// One column of a validated write-statement `RETURN`: the display name and
+/// the blank-node label (sans `_:`) of the created entity the variable names.
+#[derive(Debug, Clone)]
+pub struct CypherReturnColumn {
+    pub name: String,
+    /// The `{label}` component of the skolem key `fdb-{txn_id}-{solution}-{label}`.
+    pub label: String,
+}
+
+/// A validated plan for answering `CREATE … RETURN …` after the commit. The
+/// created entities' Sids are fully determined by the transaction's skolem id
+/// (supplied via `TxnOpts::skolem_txn_id`) plus the WHERE solution index, so
+/// the rows are reconstructed post-commit without threading state out of
+/// staging.
+#[derive(Debug, Clone)]
+pub struct CypherWriteReturnPlan {
+    pub columns: Vec<CypherReturnColumn>,
+    /// With no read clauses the templates fire exactly once (one solution);
+    /// otherwise the solution count is discovered by existence probes.
+    pub has_read_clauses: bool,
+}
+
+/// Upper bound on WHERE solutions a write RETURN will reconstruct. Exceeding
+/// it errors rather than silently truncating.
+const MAX_WRITE_RETURN_SOLUTIONS: u64 = 4096;
+
+/// Validate and plan a trailing `RETURN` on a Cypher write statement.
+/// `Ok(None)` when the statement is a read or has no RETURN. v1 surface: bare
+/// variables (optionally aliased) naming entities *created* by this
+/// statement — a fresh CREATE node variable or a CREATE relationship
+/// variable. Everything else gets a clear deferred error.
+pub fn plan_write_return(ast: &CypherAst) -> Result<Option<CypherWriteReturnPlan>, String> {
+    let Statement::Update(u) = &ast.statement else {
+        return Ok(None);
+    };
+    let Some(rc) = &u.return_clause else {
+        return Ok(None);
+    };
+    if rc.distinct || !rc.order_by.is_empty() || rc.skip.is_some() || rc.limit.is_some() {
+        return Err(
+            "DISTINCT / ORDER BY / SKIP / LIMIT on a write-statement RETURN are deferred"
+                .to_string(),
+        );
+    }
+    if u.write_clauses
+        .iter()
+        .any(|w| matches!(w, WriteClause::Merge(_)))
+    {
+        return Err(
+            "RETURN with MERGE is deferred — the matched branch's node is not a created \
+             entity, so it can't be reconstructed post-commit"
+                .to_string(),
+        );
+    }
+
+    // Variables bound by the read side (MATCH / WITH / UNWIND / InlineRows) —
+    // these reference existing data, not created entities.
+    let mut read_bound: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for c in &u.read_clauses {
+        match c {
+            ReadClause::Match(m) | ReadClause::OptionalMatch(m) => {
+                for part in &m.pattern.parts {
+                    collect_part_vars(part, &mut read_bound);
+                }
+            }
+            ReadClause::With(w) => {
+                for item in &w.items {
+                    if let Some(a) = &item.alias {
+                        read_bound.insert(a.name.as_str());
+                    } else if let Expr::Var(v) = &item.expr {
+                        read_bound.insert(v.name.as_str());
+                    }
+                }
+            }
+            ReadClause::Unwind(uw) => {
+                read_bound.insert(uw.alias.name.as_str());
+            }
+            ReadClause::InlineRows { vars, .. } => {
+                for v in vars {
+                    read_bound.insert(v.name.as_str());
+                }
+            }
+            ReadClause::CallSubquery(_) => {}
+        }
+    }
+
+    // Entities created by CREATE clauses.
+    let mut created_nodes: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut created_rels: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for w in &u.write_clauses {
+        let WriteClause::Create(c) = w else { continue };
+        for part in &c.pattern.parts {
+            for node in std::iter::once(&part.head).chain(part.tail.iter().map(|(_, n)| n)) {
+                if let Some(v) = &node.var {
+                    if !read_bound.contains(v.name.as_str()) {
+                        created_nodes.insert(v.name.as_str());
+                    }
+                }
+            }
+            for (rel, _) in &part.tail {
+                if let Some(v) = &rel.var {
+                    created_rels.insert(v.name.as_str());
+                }
+            }
+        }
+    }
+
+    let mut columns = Vec::with_capacity(rc.items.len());
+    for item in &rc.items {
+        let Expr::Var(v) = &item.expr else {
+            return Err(
+                "a write-statement RETURN supports bare created-entity variables in v1 \
+                 (expressions are deferred)"
+                    .to_string(),
+            );
+        };
+        let name = item
+            .alias
+            .as_ref()
+            .map_or_else(|| v.name.clone(), |a| a.name.clone());
+        let label = if created_rels.contains(v.name.as_str()) {
+            format!("cy_rel_{}", v.name)
+        } else if created_nodes.contains(v.name.as_str()) {
+            format!("cy_{}", v.name)
+        } else {
+            return Err(format!(
+                "RETURN of `{}` on a write statement is deferred — only entities created \
+                 by this statement (a fresh CREATE node or relationship variable) can be \
+                 returned in v1",
+                v.name
+            ));
+        };
+        columns.push(CypherReturnColumn { name, label });
+    }
+
+    Ok(Some(CypherWriteReturnPlan {
+        columns,
+        has_read_clauses: !u.read_clauses.is_empty(),
+    }))
+}
+
+fn collect_part_vars<'a>(part: &'a PatternPart, out: &mut std::collections::HashSet<&'a str>) {
+    for node in std::iter::once(&part.head).chain(part.tail.iter().map(|(_, n)| n)) {
+        if let Some(v) = &node.var {
+            out.insert(v.name.as_str());
+        }
+    }
+    for (rel, _) in &part.tail {
+        if let Some(v) = &rel.var {
+            out.insert(v.name.as_str());
+        }
+    }
+}
+
+/// The skolemized Sid a created entity resolves to (mirrors
+/// `FlakeGenerator::skolemize_blank_node`: key `{txn_id}-{solution}-{label}`,
+/// blank-node local `fdb-{key}`).
+fn skolem_sid(skolem_txn_id: &str, solution: u64, label: &str) -> fluree_db_core::Sid {
+    let local = format!(
+        "{}-{skolem_txn_id}-{solution}-{label}",
+        fluree_db_transact::BLANK_NODE_ID_PREFIX
+    );
+    fluree_db_core::Sid::new(fluree_vocab::namespaces::BLANK_NODE, local)
+}
+
+/// Reconstruct the rows for a write-statement RETURN against the post-commit
+/// ledger state, as a Cypher-JSON envelope
+/// (`{"results":[{"columns":[…],"data":[{"row":[…],"meta":[…]}]}]}`).
+///
+/// Solutions are contiguous indices `0..n`; with read clauses present, `n` is
+/// discovered by probing the first column's skolem Sid per solution (a
+/// one-flake SPOT range). Entities serialize as their blank-node identifier
+/// string (`_:fdb-…`), matching the minimal node serialization of the read
+/// path.
+pub async fn write_return_rows(
+    plan: &CypherWriteReturnPlan,
+    skolem_txn_id: &str,
+    ledger: &LedgerState,
+) -> Result<serde_json::Value, crate::error::ApiError> {
+    use fluree_db_core::{IndexType, RangeMatch, RangeOptions, RangeTest};
+
+    let solutions: u64 = if plan.has_read_clauses {
+        let probe_col = &plan.columns[0];
+        let overlay: &dyn fluree_db_core::OverlayProvider = ledger.novelty.as_ref();
+        let mut n = 0u64;
+        loop {
+            if n >= MAX_WRITE_RETURN_SOLUTIONS {
+                return Err(crate::error::ApiError::cypher(
+                    format!(
+                        "write RETURN is capped at {MAX_WRITE_RETURN_SOLUTIONS} rows — drop \
+                         the RETURN clause for larger batches"
+                    ),
+                    Vec::new(),
+                ));
+            }
+            let sid = skolem_sid(skolem_txn_id, n, &probe_col.label);
+            let db = fluree_db_core::GraphDbRef::new(
+                &ledger.snapshot,
+                fluree_db_core::DEFAULT_GRAPH_ID,
+                overlay,
+                ledger.t(),
+            );
+            let flakes = db
+                .range_with_opts(
+                    IndexType::Spot,
+                    RangeTest::Eq,
+                    RangeMatch::subject(sid),
+                    RangeOptions::default().with_flake_limit(1),
+                )
+                .await
+                .map_err(|e| {
+                    crate::error::ApiError::internal(format!(
+                        "write RETURN existence probe failed: {e}"
+                    ))
+                })?;
+            if flakes.is_empty() {
+                break;
+            }
+            n += 1;
+        }
+        n
+    } else {
+        // No WHERE: templates fire once against the single empty solution.
+        1
+    };
+
+    let columns: Vec<&str> = plan.columns.iter().map(|c| c.name.as_str()).collect();
+    let mut data = Vec::with_capacity(solutions as usize);
+    for s in 0..solutions {
+        let row: Vec<serde_json::Value> = plan
+            .columns
+            .iter()
+            .map(|c| {
+                serde_json::Value::String(format!(
+                    "{}{}-{skolem_txn_id}-{s}-{}",
+                    fluree_db_transact::BLANK_NODE_PREFIX,
+                    fluree_db_transact::BLANK_NODE_ID_PREFIX,
+                    c.label
+                ))
+            })
+            .collect();
+        let meta: Vec<serde_json::Value> = plan
+            .columns
+            .iter()
+            .map(|_| serde_json::Value::Null)
+            .collect();
+        data.push(serde_json::json!({"row": row, "meta": meta}));
+    }
+    Ok(serde_json::json!({
+        "results": [{"columns": columns, "data": data}]
+    }))
+}
+
+/// Parse + param-substitute Cypher source and plan its write-statement
+/// RETURN. Parse and parameter errors return `Ok(None)` — the consensus
+/// lowering path reports those with full diagnostics; only RETURN-shape
+/// validation errors surface here.
+pub fn plan_write_return_source(
+    cypher: &str,
+    params: Option<&fluree_db_cypher::ParamMap>,
+) -> Result<Option<CypherWriteReturnPlan>, crate::error::ApiError> {
+    let out = fluree_db_cypher::parse_cypher(cypher);
+    if out.has_errors() {
+        return Ok(None);
+    }
+    let Some(mut ast) = out.ast else {
+        return Ok(None);
+    };
+    let empty = fluree_db_cypher::ParamMap::new();
+    if fluree_db_cypher::substitute_params(&mut ast, params.unwrap_or(&empty)).is_err() {
+        return Ok(None);
+    }
+    plan_write_return(&ast).map_err(|e| crate::error::ApiError::cypher(e, Vec::new()))
+}
+
+/// A fresh unique skolemization id for [`TxnOpts::skolem_txn_id`]
+/// (`fluree_db_transact::ir::TxnOpts`).
+pub fn fresh_skolem_txn_id() -> String {
+    fluree_db_transact::generate_txn_id()
 }

--- a/fluree-db-api/src/explain.rs
+++ b/fluree-db-api/src/explain.rs
@@ -697,6 +697,23 @@ pub async fn explain_sparql(
     explain_from_parsed(snapshot, &vars, &parsed, json!(sparql), None)
 }
 
+/// Explain an openCypher query against a LedgerSnapshot.
+///
+/// Lowers the Cypher statement to the shared query IR (resolving bare
+/// labels/keys via `default_context`, exactly like execution) and returns the
+/// same `{ "query": ..., "plan": { ... } }` report as the SPARQL/JSON-LD
+/// explains.
+pub async fn explain_cypher(
+    snapshot: &fluree_db_core::LedgerSnapshot,
+    cypher: &str,
+    default_context: Option<&JsonValue>,
+) -> Result<JsonValue> {
+    let (vars, parsed) =
+        crate::query::helpers::parse_cypher_to_ir(cypher, snapshot, default_context, None)?;
+
+    explain_from_parsed(snapshot, &vars, &parsed, json!(cypher), None)
+}
+
 /// Explain a SPARQL query against a LedgerSnapshot, using a default JSON-LD context.
 ///
 /// The `default_context` is used for prefix expansion during parsing and for

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -3484,8 +3484,52 @@ impl Fluree {
         cypher: &str,
         params: Option<&fluree_db_cypher::ParamMap>,
     ) -> Result<TransactResult> {
+        Ok(self
+            .transact_cypher_returning(ledger, cypher, params)
+            .await?
+            .0)
+    }
+
+    /// Like [`transact_cypher_with_params`](Self::transact_cypher_with_params)
+    /// but also answers a trailing `RETURN` on the write statement: the second
+    /// tuple element is the Cypher-JSON envelope of the created entities
+    /// (`None` when the statement has no RETURN clause). See
+    /// [`crate::cypher_write::plan_write_return`] for the v1 surface.
+    pub async fn transact_cypher_returning(
+        &self,
+        ledger: LedgerState,
+        cypher: &str,
+        params: Option<&fluree_db_cypher::ParamMap>,
+    ) -> Result<(TransactResult, Option<serde_json::Value>)> {
+        // Plan the RETURN from the same parse+substitution the write plan
+        // uses; a Some plan needs a caller-known skolem id so the created
+        // Sids are reconstructible post-commit.
+        let return_plan = {
+            let out = fluree_db_cypher::parse_cypher(cypher);
+            match out.ast {
+                Some(mut ast) if !out.has_errors() => {
+                    let empty = fluree_db_cypher::ParamMap::new();
+                    fluree_db_cypher::substitute_params(&mut ast, params.unwrap_or(&empty))
+                        .map_err(|e| ApiError::cypher(e.to_string(), Vec::new()))?;
+                    crate::cypher_write::plan_write_return(&ast)
+                        .map_err(|e| ApiError::cypher(e, Vec::new()))?
+                }
+                // Parse errors surface with full diagnostics below.
+                _ => None,
+            }
+        };
+        let skolem_txn_id = return_plan
+            .as_ref()
+            .map(|_| fluree_db_transact::generate_txn_id());
+
         let plan = self
-            .cypher_write_plan(cypher, params, ledger.ledger_id(), &ledger.snapshot)
+            .cypher_write_plan_with_skolem(
+                cypher,
+                params,
+                ledger.ledger_id(),
+                &ledger.snapshot,
+                skolem_txn_id.clone(),
+            )
             .await?;
         let txn = match plan {
             crate::cypher_write::WritePlan::Single(txn) => *txn,
@@ -3496,7 +3540,15 @@ impl Fluree {
                     .await?
             }
         };
-        self.stage_owned(ledger).txn(txn).execute().await
+        let result = self.stage_owned(ledger).txn(txn).execute().await?;
+
+        let rows = match (&return_plan, &skolem_txn_id) {
+            (Some(plan), Some(id)) => {
+                Some(crate::cypher_write::write_return_rows(plan, id, &result.ledger).await?)
+            }
+            _ => None,
+        };
+        Ok((result, rows))
     }
 
     /// Parse + param-substitute a Cypher write and classify it as a single
@@ -3507,6 +3559,22 @@ impl Fluree {
         params: Option<&fluree_db_cypher::ParamMap>,
         ledger_id: &str,
         snapshot: &fluree_db_core::LedgerSnapshot,
+    ) -> Result<crate::cypher_write::WritePlan> {
+        self.cypher_write_plan_with_skolem(cypher, params, ledger_id, snapshot, None)
+            .await
+    }
+
+    /// [`cypher_write_plan`](Self::cypher_write_plan) with a caller-supplied
+    /// skolemization id (`TxnOpts::skolem_txn_id`), which makes the write's
+    /// created-entity Sids reconstructible — the mechanism behind
+    /// `CREATE … RETURN n` (see [`crate::cypher_write::write_return_rows`]).
+    pub async fn cypher_write_plan_with_skolem(
+        &self,
+        cypher: &str,
+        params: Option<&fluree_db_cypher::ParamMap>,
+        ledger_id: &str,
+        snapshot: &fluree_db_core::LedgerSnapshot,
+        skolem_txn_id: Option<String>,
     ) -> Result<crate::cypher_write::WritePlan> {
         let out = fluree_db_cypher::parse_cypher(cypher);
         if out.has_errors() {
@@ -3525,12 +3593,19 @@ impl Fluree {
         fluree_db_cypher::substitute_params(&mut ast, params.unwrap_or(&empty))
             .map_err(|e| ApiError::cypher(e.to_string(), Vec::new()))?;
 
+        // Validate a trailing RETURN up front (lowering ignores it): the v1
+        // surface is bare created-entity variables, and it never combines with
+        // the conditional (probe-based) shapes.
+        crate::cypher_write::plan_write_return(&ast)
+            .map_err(|e| ApiError::cypher(e, Vec::new()))?;
+
         if let Some(cw) = crate::cypher_write::detect_conditional(&ast) {
             return Ok(crate::cypher_write::WritePlan::Conditional(Box::new(cw)));
         }
-        let txn = self
+        let mut txn = self
             .lower_cypher_ast_to_txn(&ast, ledger_id, snapshot)
             .await?;
+        txn.opts.skolem_txn_id = skolem_txn_id;
         Ok(crate::cypher_write::WritePlan::Single(Box::new(txn)))
     }
 

--- a/fluree-db-api/src/query/helpers.rs
+++ b/fluree-db-api/src/query/helpers.rs
@@ -152,12 +152,25 @@ pub(crate) fn lower_cypher_ast_to_ir(
     let (vocab, overrides) = extract_cypher_iri_mapping(default_context);
 
     let mut vars = VarRegistry::new();
-    let mut ctx = fluree_db_cypher::LoweringContext::new(snapshot, &mut vars).with_vocab(vocab);
+    let mut ctx = fluree_db_cypher::LoweringContext::new(snapshot, &mut vars)
+        .with_vocab(vocab)
+        .with_allow_full_scan(cypher_full_scan_enabled());
     if !overrides.is_empty() {
         ctx = ctx.with_overrides(overrides);
     }
     let parsed = fluree_db_cypher::lower_cypher_with_context(ast, &mut ctx)?;
     Ok((vars, parsed))
+}
+
+/// Whether bare `MATCH (n)` whole-graph scans are opted in for Cypher
+/// (`FLUREE_CYPHER_ALLOW_FULL_SCAN=1|true`). Read once per process.
+fn cypher_full_scan_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("FLUREE_CYPHER_ALLOW_FULL_SCAN")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    })
 }
 
 /// Extract `@vocab` and bare-identifier → IRI overrides from a

--- a/fluree-db-api/tests/it_import.rs
+++ b/fluree-db-api/tests/it_import.rs
@@ -2298,3 +2298,116 @@ GRAPH <http://example.org/graphs/g1> {
         "named-graph bound-predicate must match; got {named_rows}"
     );
 }
+
+// ============================================================================
+// Incremental index over an imported (sketch-less) base preserves stats
+// ============================================================================
+
+/// Bulk import writes `sketch_ref: None`, so the first incremental index
+/// cannot merge base property stats from HLL registers. It must fall back to
+/// seeding from the base root's persisted per-graph property stats —
+/// previously it started from zero and persisted DELTA-ONLY stats (base
+/// predicates vanished; net-zero churn kept count 0), which silently broke
+/// stats-driven folds and planner selectivities on every imported ledger
+/// after its first post-import write.
+#[tokio::test]
+async fn incremental_index_over_import_preserves_property_stats() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    let ttl = r#"
+@prefix ex: <http://example.org/ns/> .
+@prefix schema: <http://schema.org/> .
+
+ex:alice a ex:User ;
+    schema:name "Alice" ;
+    schema:age 42 .
+
+ex:bob a ex:User ;
+    schema:name "Bob" ;
+    schema:age 22 .
+"#;
+    let ttl_path = write_ttl(data_dir.path(), "people.ttl", ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    let ledger_id = "test/import-incr-stats:main";
+    fluree
+        .create(ledger_id)
+        .import(&ttl_path)
+        .threads(2)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import should succeed");
+
+    // Post-import writes: net-zero churn on schema:age (retract+assert) and
+    // a brand-new predicate.
+    let ledger = fluree.ledger(ledger_id).await.expect("load after import");
+    let ctx = json!({"ex": "http://example.org/ns/", "schema": "http://schema.org/"});
+    let ledger = fluree
+        .update(
+            ledger,
+            &json!({
+                "@context": ctx,
+                "delete": [{"@id": "ex:alice", "schema:age": 42}],
+                "insert": [{"@id": "ex:alice", "schema:age": 43}]
+            }),
+        )
+        .await
+        .expect("churn age")
+        .ledger;
+    let _ledger = fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": ctx,
+                "@id": "ex:cam", "@type": "ex:User", "ex:brandnew": 7
+            }),
+        )
+        .await
+        .expect("new predicate")
+        .ledger;
+
+    // Incremental index (base exists, small gap).
+    support::build_and_publish_index(&fluree, ledger_id).await;
+    let db = fluree.db(ledger_id).await.expect("incremental view");
+
+    let stats = db.snapshot.stats.as_ref().expect("index stats");
+    let g0 = stats
+        .graphs
+        .as_ref()
+        .expect("per-graph stats")
+        .iter()
+        .find(|g| g.g_id == 0)
+        .expect("default graph stats");
+    let prop_sum: u64 = g0.properties.iter().map(|p| p.count).sum();
+    assert_eq!(
+        prop_sum,
+        g0.flakes,
+        "per-graph property counts must cover all flakes; entries: {:?}",
+        g0.properties
+            .iter()
+            .map(|p| (p.p_id, p.count))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        g0.properties.iter().all(|p| p.count > 0),
+        "net-zero churn must keep the base count: {:?}",
+        g0.properties
+            .iter()
+            .map(|p| (p.p_id, p.count))
+            .collect::<Vec<_>>()
+    );
+    // ndv floors survive even though the base had no HLL registers.
+    assert!(
+        g0.properties.iter().any(|p| p.ndv_values >= 2),
+        "base ndv estimates must not reset: {:?}",
+        g0.properties
+            .iter()
+            .map(|p| (p.p_id, p.ndv_values))
+            .collect::<Vec<_>>()
+    );
+}

--- a/fluree-db-api/tests/it_query_cypher.rs
+++ b/fluree-db-api/tests/it_query_cypher.rs
@@ -7093,3 +7093,94 @@ async fn cypher_class_anchored_filtered_histogram_matches_pipeline() {
         assert_eq!(rows_of(&cj), vec![(json!(null), json!(1))], "{cj}");
     }
 }
+
+/// A specific-value lookup (`WHERE n.id = k`, equality object bounds) must
+/// stay a point seek under live novelty on the same predicate — seeking the
+/// index AND the overlay — and must decline the narrowed seek when the
+/// predicate holds mixed numeric types (cross-type equality would miss rows).
+#[tokio::test]
+async fn cypher_equality_seek_correct_under_predicate_novelty() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/cypher:eq-seek-novelty";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    let ctx_json = json!({"ex": "http://example.org/"});
+    let ledger = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx_json,
+                "@graph": (1..=50).map(|i| json!({
+                    "@id": format!("ex:u{i}"), "@type": "ex:User", "ex:id": i
+                })).collect::<Vec<_>>()
+            }),
+        )
+        .await
+        .expect("seed")
+        .ledger;
+    rebuild_and_publish_index(&fluree, ledger_id).await;
+
+    // Live novelty on the SAME predicate: a new subject with a new id value
+    // and another with a duplicate of an existing value.
+    let ledger = fluree
+        .ledger(ledger_id)
+        .await
+        .expect("reload indexed ledger");
+    let ledger = fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": ctx_json,
+                "@graph": [
+                    {"@id": "ex:t1", "@type": "ex:UserTemp", "ex:id": 999},
+                    {"@id": "ex:t2", "@type": "ex:UserTemp", "ex:id": 7},
+                ]
+            }),
+        )
+        .await
+        .expect("novelty writes")
+        .ledger;
+    let db = graphdb_from_ledger(&ledger);
+
+    // Indexed value still found.
+    let r = fluree
+        .query_cypher(&db, "MATCH (n:User) WITH n WHERE n.id = 7 RETURN n")
+        .await
+        .expect("indexed value");
+    assert_eq!(r.row_count(), 1);
+
+    // Novelty-only value found through the narrowed seek (index ∪ overlay).
+    let r = fluree
+        .query_cypher(&db, "MATCH (n:UserTemp) WITH n WHERE n.id = 999 RETURN n")
+        .await
+        .expect("novelty value");
+    assert_eq!(r.row_count(), 1);
+
+    // The novelty duplicate of an indexed value is also visible.
+    let r = fluree
+        .query_cypher(&db, "MATCH (n:UserTemp) WHERE n.id = 7 RETURN n")
+        .await
+        .expect("novelty duplicate");
+    assert_eq!(r.row_count(), 1);
+
+    // Mixed numeric types on the predicate: cross-type equality must still
+    // match (the narrowed seek declines; the decoded filter coerces).
+    let ledger = fluree.ledger(ledger_id).await.expect("reload for mixed dt");
+    let ledger = fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": ctx_json,
+                "@id": "ex:t3", "@type": "ex:UserTemp",
+                "ex:id": {"@value": "7", "@type": "http://www.w3.org/2001/XMLSchema#double"}
+            }),
+        )
+        .await
+        .expect("double id")
+        .ledger;
+    let db = graphdb_from_ledger(&ledger);
+    let r = fluree
+        .query_cypher(&db, "MATCH (n:UserTemp) WHERE n.id = 7 RETURN n")
+        .await
+        .expect("cross-type equality");
+    assert_eq!(r.row_count(), 2, "double 7.0 must match integer equality");
+}

--- a/fluree-db-api/tests/it_query_cypher.rs
+++ b/fluree-db-api/tests/it_query_cypher.rs
@@ -6697,3 +6697,45 @@ async fn cypher_power_binds_tighter_than_unary_minus() {
         );
     }
 }
+
+#[tokio::test]
+async fn cypher_explain_reports_sid_encoded_plan() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:explain");
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx(),
+                "@id": "ex:alice",
+                "@type": "ex:Person",
+                "ex:id": 7,
+            }),
+        )
+        .await
+        .expect("seed");
+    let db = graphdb_from_ledger(&committed.ledger);
+
+    let explain = fluree_db_api::explain::explain_cypher(
+        &db.snapshot,
+        "MATCH (n:Person {id: 7}) RETURN n",
+        db.default_context.as_ref(),
+    )
+    .await
+    .expect("explain");
+
+    // The lowering must encode registered-namespace IRIs to SIDs (parity
+    // with SPARQL) — Sid-gated planner analyses and batched join lanes
+    // depend on it. The physical PropertyJoin renders Sid predicates in
+    // `ns:name` form; an unencoded pattern would render the full IRI.
+    let physical = serde_json::to_string(&explain["plan"]["physical"]).expect("physical");
+    assert!(physical.contains("PropertyJoinOperator"), "{explain}");
+    assert!(
+        physical.contains("3:type"),
+        "rdf:type not SID-encoded: {explain}"
+    );
+    assert!(
+        !physical.contains("http://example.org/id"),
+        "id not SID-encoded: {explain}"
+    );
+}

--- a/fluree-db-api/tests/it_query_cypher.rs
+++ b/fluree-db-api/tests/it_query_cypher.rs
@@ -6739,3 +6739,58 @@ async fn cypher_explain_reports_sid_encoded_plan() {
         "id not SID-encoded: {explain}"
     );
 }
+
+#[tokio::test]
+async fn cypher_with_where_property_equality_folds_to_seek() {
+    // `WITH n WHERE n.id = k` lowers the accessor to OPTIONAL + FILTER; the
+    // optional-filter fold must turn it into a required triple (seek) without
+    // changing rows — including multi-valued properties and absent properties.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:with-where-fold");
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx(),
+                "@graph": [
+                    {"@id": "ex:a", "@type": "ex:Person", "ex:id": 7, "ex:age": [25, 30]},
+                    {"@id": "ex:b", "@type": "ex:Person", "ex:id": 8},
+                    {"@id": "ex:c", "@type": "ex:Person"},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let db = graphdb_from_ledger(&committed.ledger);
+
+    let rows = |r: fluree_db_api::QueryResult| r.row_count();
+
+    let r = fluree
+        .query_cypher(&db, "MATCH (n:Person) WITH n WHERE n.id = 7 RETURN n")
+        .await
+        .expect("with-where eq");
+    assert_eq!(rows(r), 1);
+
+    // Absent property: no rows (c has no id) — the fold preserves this.
+    let r = fluree
+        .query_cypher(&db, "MATCH (n:Person) WITH n WHERE n.id = 99 RETURN n")
+        .await
+        .expect("no match");
+    assert_eq!(rows(r), 0);
+
+    // Multi-valued property through a range comparison: one row per passing
+    // value.
+    let r = fluree
+        .query_cypher(&db, "MATCH (n:Person) WHERE n.age > 26 RETURN n, n.age")
+        .await
+        .expect("range");
+    assert_eq!(rows(r), 1);
+
+    // IS NULL keeps its OPTIONAL (bound-check is not error-rejecting):
+    // only c lacks id.
+    let r = fluree
+        .query_cypher(&db, "MATCH (n:Person) WHERE n.id IS NULL RETURN n")
+        .await
+        .expect("is null");
+    assert_eq!(rows(r), 1);
+}

--- a/fluree-db-api/tests/it_query_cypher.rs
+++ b/fluree-db-api/tests/it_query_cypher.rs
@@ -6794,3 +6794,87 @@ async fn cypher_with_where_property_equality_folds_to_seek() {
         .expect("is null");
     assert_eq!(rows(r), 1);
 }
+
+#[tokio::test]
+async fn cypher_anonymous_hop_chain_fuses_to_reachability_under_distinct() {
+    // Diamond + tail: a→b1→c, a→b2→c, c→d. Two 2-hop walks reach c.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:chain-fusion");
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx(),
+                "@graph": [
+                    {"@id": "ex:a", "@type": "ex:User", "ex:id": 1,
+                     "ex:knows": [{"@id": "ex:b1"}, {"@id": "ex:b2"}]},
+                    {"@id": "ex:b1", "@type": "ex:User", "ex:knows": {"@id": "ex:c"}},
+                    {"@id": "ex:b2", "@type": "ex:User", "ex:knows": {"@id": "ex:c"}},
+                    {"@id": "ex:c", "@type": "ex:User", "ex:id": 3,
+                     "ex:knows": {"@id": "ex:d"}},
+                    {"@id": "ex:d", "@type": "ex:User", "ex:id": 4},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let db = graphdb_from_ledger(&committed.ledger);
+
+    // DISTINCT endpoints via 2 anonymous hops: just c (one row despite two
+    // walks) — the fused frontier-BFS form must agree with join semantics
+    // after dedup.
+    let r = fluree
+        .query_cypher(
+            &db,
+            "MATCH (s:User {id: 1})-->()-->(n:User) RETURN DISTINCT n.id",
+        )
+        .await
+        .expect("fused distinct");
+    assert_eq!(r.row_count(), 1);
+
+    // WITHOUT DISTINCT the chain must keep one row per walk (2 rows) — the
+    // fusion is gated off.
+    let r = fluree
+        .query_cypher(&db, "MATCH (s:User {id: 1})-->()-->(n:User) RETURN n.id")
+        .await
+        .expect("walk multiplicity");
+    assert_eq!(r.row_count(), 2, "non-DISTINCT keeps per-walk rows");
+
+    // Aggregates observe walk multiplicity: count(*) = 2 even with DISTINCT
+    // elsewhere — gated off.
+    let cj = fluree
+        .query_cypher(
+            &db,
+            "MATCH (s:User {id: 1})-->()-->(n:User) RETURN count(*) AS c",
+        )
+        .await
+        .expect("count walks")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cypher json");
+    assert_eq!(cj["results"][0]["data"][0]["row"][0], json!(2), "{cj}");
+
+    // A named intermediate node is observable — not fused; DISTINCT (m, n)
+    // pairs: (b1,c) and (b2,c).
+    let r = fluree
+        .query_cypher(
+            &db,
+            "MATCH (s:User {id: 1})-->(m)-->(n:User) RETURN DISTINCT m, n",
+        )
+        .await
+        .expect("named middle");
+    assert_eq!(r.row_count(), 2);
+
+    // 3-hop chain: only d.
+    let cj = fluree
+        .query_cypher(
+            &db,
+            "MATCH (s:User {id: 1})-->()-->()-->(n:User) RETURN DISTINCT n.id",
+        )
+        .await
+        .expect("3-hop")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cypher json");
+    assert_eq!(cj["results"][0]["data"][0]["row"][0], json!(4), "{cj}");
+}

--- a/fluree-db-api/tests/it_query_cypher.rs
+++ b/fluree-db-api/tests/it_query_cypher.rs
@@ -14,7 +14,7 @@ mod support;
 
 use fluree_db_api::FlureeBuilder;
 use serde_json::{json, Value as JsonValue};
-use support::{genesis_ledger, graphdb_from_ledger};
+use support::{genesis_ledger, graphdb_from_ledger, rebuild_and_publish_index};
 
 fn ctx() -> JsonValue {
     json!({
@@ -6877,4 +6877,131 @@ async fn cypher_anonymous_hop_chain_fuses_to_reachability_under_distinct() {
         .await
         .expect("cypher json");
     assert_eq!(cj["results"][0]["data"][0]["row"][0], json!(4), "{cj}");
+}
+
+/// Class-anchored aggregate folds (`MATCH (n:C) …`): the histogram
+/// (`RETURN n.age, COUNT(*)`) folds to a POST group count + null-group row,
+/// and the scalar family reuses the whole-graph folds under the containment
+/// proof. Indexed (fold) and novelty (pipeline) must agree.
+#[tokio::test]
+async fn cypher_class_anchored_histogram_and_scalars_match_pipeline() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/cypher:class-agg";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx(),
+                "@graph": [
+                    // alice multi-valued: contributes to two histogram groups.
+                    {"@id": "ex:alice", "@type": "ex:Person", "ex:age": [25, 30]},
+                    {"@id": "ex:bob",   "@type": "ex:Person"},
+                    {"@id": "ex:carol", "@type": "ex:Person", "ex:age": 30},
+                    {"@id": "ex:dave",  "@type": "ex:Person", "ex:age": 40},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let novelty_db = graphdb_from_ledger(&committed.ledger);
+    rebuild_and_publish_index(&fluree, ledger_id).await;
+    let indexed_db = fluree.db(ledger_id).await.expect("indexed view");
+
+    let histogram = |cj: &JsonValue| -> Vec<(JsonValue, JsonValue)> {
+        let mut rows: Vec<(JsonValue, JsonValue)> = cj["results"][0]["data"]
+            .as_array()
+            .expect("rows")
+            .iter()
+            .map(|r| (r["row"][0].clone(), r["row"][1].clone()))
+            .collect();
+        rows.sort_by_key(|(k, _)| k.to_string());
+        rows
+    };
+
+    for db in [&novelty_db, &indexed_db] {
+        let cj = fluree
+            .query_cypher(db, "MATCH (n:Person) RETURN n.age, COUNT(*)")
+            .await
+            .expect("histogram")
+            .to_cypher_json_async(db.as_graph_db_ref())
+            .await
+            .expect("cypher json");
+        // Groups: 25→1 (alice), 30→2 (alice+carol), 40→1 (dave),
+        // null→1 (bob).
+        assert_eq!(
+            histogram(&cj),
+            vec![
+                (json!(25), json!(1)),
+                (json!(30), json!(2)),
+                (json!(40), json!(1)),
+                (json!(null), json!(1)),
+            ],
+            "{cj}"
+        );
+
+        let cj = fluree
+            .query_cypher(
+                db,
+                "MATCH (n:Person) RETURN COUNT(DISTINCT n.age) AS d, count(n) AS c",
+            )
+            .await
+            .expect("scalars")
+            .to_cypher_json_async(db.as_graph_db_ref())
+            .await
+            .expect("cypher json");
+        let row = &cj["results"][0]["data"][0]["row"];
+        assert_eq!(row[0], json!(3), "distinct ages: {cj}");
+        // count(n) over the left join: alice 2 rows + bob 1 + carol 1 + dave 1.
+        assert_eq!(row[1], json!(5), "count rows: {cj}");
+    }
+}
+
+/// The containment proof must fail when a non-class subject bears the
+/// property — the fold defers and the pipeline restricts to the class.
+#[tokio::test]
+async fn cypher_class_anchored_fold_declines_without_containment() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/cypher:class-agg-decline";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx(),
+                "@graph": [
+                    {"@id": "ex:alice", "@type": "ex:Person", "ex:age": 30},
+                    // A Robot with an age: age is NOT contained in Person.
+                    {"@id": "ex:r2d2", "@type": "ex:Robot", "ex:age": 200},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let novelty_db = graphdb_from_ledger(&committed.ledger);
+    rebuild_and_publish_index(&fluree, ledger_id).await;
+    let indexed_db = fluree.db(ledger_id).await.expect("indexed view");
+
+    for db in [&novelty_db, &indexed_db] {
+        let cj = fluree
+            .query_cypher(db, "MATCH (n:Person) RETURN n.age, COUNT(*)")
+            .await
+            .expect("histogram")
+            .to_cypher_json_async(db.as_graph_db_ref())
+            .await
+            .expect("cypher json");
+        let rows = cj["results"][0]["data"].as_array().expect("rows");
+        // Only alice's age — the Robot's 200 must not leak in.
+        assert_eq!(rows.len(), 1, "{cj}");
+        assert_eq!(rows[0]["row"], json!([30, 1]), "{cj}");
+
+        let cj = fluree
+            .query_cypher(db, "MATCH (n:Person) RETURN max(n.age) AS m")
+            .await
+            .expect("max")
+            .to_cypher_json_async(db.as_graph_db_ref())
+            .await
+            .expect("cypher json");
+        assert_eq!(cj["results"][0]["data"][0]["row"][0], json!(30), "{cj}");
+    }
 }

--- a/fluree-db-api/tests/it_query_cypher.rs
+++ b/fluree-db-api/tests/it_query_cypher.rs
@@ -54,6 +54,190 @@ async fn cypher_match_labeled_node_finds_jsonld_typed_subject() {
 }
 
 #[tokio::test]
+async fn cypher_untyped_single_hop_excludes_labels_and_data_properties() {
+    // `-->` must follow only relationships: not `rdf:type` (the class node is
+    // not a neighbor) and not data properties (literals are not nodes).
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:untyped-hop-edge-set");
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx(),
+                "@graph": [
+                    {
+                        "@id": "ex:alice",
+                        "@type": "ex:Person",
+                        "ex:name": "Alice",
+                        "ex:knows": {"@id": "ex:bob"}
+                    },
+                    {"@id": "ex:bob", "@type": "ex:Person", "ex:name": "Bob"},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let db = graphdb_from_ledger(&committed.ledger);
+
+    let jsonld = fluree
+        .query_cypher(&db, r#"MATCH (n:Person {name: "Alice"})-->(m) RETURN m"#)
+        .await
+        .expect("untyped hop query")
+        .to_jsonld_async(db.as_graph_db_ref())
+        .await
+        .expect("jsonld");
+
+    let rows = jsonld.as_array().expect("rows");
+    assert_eq!(
+        rows.len(),
+        1,
+        "only the ex:knows edge is a relationship: {jsonld}"
+    );
+    assert_eq!(
+        rows[0][0].as_str(),
+        Some("http://example.org/bob"),
+        "{jsonld}"
+    );
+}
+
+#[tokio::test]
+async fn cypher_untyped_undirected_hop_excludes_labels_and_data_properties() {
+    // Same edge-set rule for the undirected `--` (forward ∪ reverse union).
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:untyped-undirected-edge-set");
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx(),
+                "@graph": [
+                    {
+                        "@id": "ex:alice",
+                        "@type": "ex:Person",
+                        "ex:name": "Alice",
+                        "ex:knows": {"@id": "ex:bob"}
+                    },
+                    {
+                        "@id": "ex:carol",
+                        "@type": "ex:Person",
+                        "ex:name": "Carol",
+                        "ex:knows": {"@id": "ex:alice"}
+                    },
+                    {"@id": "ex:bob", "@type": "ex:Person", "ex:name": "Bob"},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let db = graphdb_from_ledger(&committed.ledger);
+
+    let jsonld = fluree
+        .query_cypher(
+            &db,
+            r#"MATCH (n:Person {name: "Alice"})--(m) RETURN m ORDER BY m"#,
+        )
+        .await
+        .expect("untyped undirected hop query")
+        .to_jsonld_async(db.as_graph_db_ref())
+        .await
+        .expect("jsonld");
+
+    let rows = jsonld.as_array().expect("rows");
+    let neighbors: Vec<&str> = rows.iter().filter_map(|r| r[0].as_str()).collect();
+    assert_eq!(
+        neighbors,
+        ["http://example.org/bob", "http://example.org/carol"],
+        "both edge orientations, no class node / literals: {jsonld}"
+    );
+}
+
+#[tokio::test]
+async fn cypher_value_only_rel_var_matches_unreified_edges() {
+    // A bound relationship variable used only for its value surface
+    // (`RETURN e`, `type(e)`) must match plain-RDF edges that carry no
+    // `f:reifies*` bundle (benchgraph `match__pattern_*` on imported data).
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:value-only-rel-var");
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx(),
+                "@graph": [
+                    {
+                        "@id": "ex:alice",
+                        "@type": "ex:Person",
+                        "ex:name": "Alice",
+                        "ex:knows": {"@id": "ex:bob"}
+                    },
+                    {"@id": "ex:bob", "@type": "ex:Person", "ex:name": "Bob"},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let db = graphdb_from_ledger(&committed.ledger);
+
+    // Typed bound rel var.
+    let cj = fluree
+        .query_cypher(
+            &db,
+            r#"MATCH (a:Person {name: "Alice"})-[e:knows]->(b) RETURN type(e) AS t, b"#,
+        )
+        .await
+        .expect("typed rel var over plain triple")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cypher json");
+    let data = cj["results"][0]["data"].as_array().expect("data");
+    assert_eq!(data.len(), 1, "plain edge must match: {cj}");
+    assert_eq!(data[0]["row"][0], json!("knows"), "type(e): {cj}");
+
+    // Untyped bound rel var: same edge-set rule as `-->` (no rdf:type /
+    // data properties), and the synthesized value still answers type(e).
+    let cj = fluree
+        .query_cypher(
+            &db,
+            r#"MATCH (a:Person {name: "Alice"})-[e]->(b) RETURN type(e) AS t"#,
+        )
+        .await
+        .expect("untyped rel var over plain triple")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cypher json");
+    let data = cj["results"][0]["data"].as_array().expect("data");
+    assert_eq!(data.len(), 1, "only ex:knows is a relationship: {cj}");
+    assert_eq!(data[0]["row"][0], json!("knows"), "type(e): {cj}");
+}
+
+#[tokio::test]
+async fn cypher_value_only_rel_var_keeps_parallel_reified_edges_distinct() {
+    // Reified parallel edges (Cypher-created) share one base triple; a
+    // value-only rel var must still yield one row per relationship.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let mut l = genesis_ledger(&fluree, "it/cypher:value-only-parallel");
+    for stmt in [
+        r#"CREATE (a:Person {name: "Alice"})"#,
+        r#"CREATE (b:Person {name: "Bob"})"#,
+        r#"MATCH (a:Person {name: "Alice"}), (b:Person {name: "Bob"}) CREATE (a)-[:KNOWS {since: 2000}]->(b)"#,
+        r#"MATCH (a:Person {name: "Alice"}), (b:Person {name: "Bob"}) CREATE (a)-[:KNOWS {since: 2010}]->(b)"#,
+    ] {
+        l = fluree.transact_cypher(l, stmt).await.expect(stmt).ledger;
+    }
+    let db = graphdb_from_ledger(&l);
+
+    assert_eq!(
+        fluree
+            .query_cypher(&db, "MATCH (a)-[r:KNOWS]->(b) RETURN r")
+            .await
+            .expect("parallel edges")
+            .row_count(),
+        2,
+        "one row per reified relationship"
+    );
+}
+
+#[tokio::test]
 async fn cypher_property_accessor_in_where_filters_results() {
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/cypher:prop-accessor-where";
@@ -666,6 +850,135 @@ async fn transact_cypher_unwind_map_param_batches_node_inserts() {
             .row_count(),
         1,
         "Bob's name and age stayed on the same node"
+    );
+}
+
+#[tokio::test]
+async fn transact_cypher_unwind_inline_range_batches_node_inserts() {
+    // Inline constant UNWIND source on a write (`UNWIND range(1, 100) AS x`,
+    // benchgraph `arango__unwind_range_vertex_write`) — desugars through the
+    // same path as `UNWIND $list`.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:unwind-inline-range");
+
+    let result = fluree
+        .transact_cypher(
+            ledger0,
+            r#"UNWIND range(1, 100) AS x CREATE (n:L1:L2 {p1: true, p5: x})"#,
+        )
+        .await
+        .expect("inline range batched insert");
+
+    let db = graphdb_from_ledger(&result.ledger);
+    assert_eq!(
+        fluree
+            .query_cypher(&db, "MATCH (n:L1) RETURN n")
+            .await
+            .expect("count")
+            .row_count(),
+        100,
+        "one node per range element"
+    );
+    assert_eq!(
+        fluree
+            .query_cypher(&db, "MATCH (n:L2) WHERE n.p5 = 42 RETURN n")
+            .await
+            .expect("p5")
+            .row_count(),
+        1,
+        "each node carries its own range value"
+    );
+}
+
+#[tokio::test]
+async fn transact_cypher_unwind_inline_list_batches_node_inserts() {
+    // Inline list-literal UNWIND on a write.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:unwind-inline-list");
+
+    let result = fluree
+        .transact_cypher(
+            ledger0,
+            r#"UNWIND ["Alice", "Bob", "Carol"] AS name CREATE (n:Person {name: name})"#,
+        )
+        .await
+        .expect("inline list batched insert");
+
+    let db = graphdb_from_ledger(&result.ledger);
+    assert_eq!(
+        fluree
+            .query_cypher(&db, "MATCH (n:Person) RETURN n")
+            .await
+            .expect("count")
+            .row_count(),
+        3
+    );
+    assert_eq!(
+        fluree
+            .query_cypher(&db, r#"MATCH (n:Person {name: "Bob"}) RETURN n"#)
+            .await
+            .expect("bob")
+            .row_count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn transact_cypher_create_bare_anonymous_node() {
+    // `CREATE ()` (benchgraph `create__vertex`) — an anonymous propertyless
+    // node commits (via the hidden db:Node marker) and stays invisible to
+    // labeled matches.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:create-bare");
+    let result = fluree
+        .transact_cypher(ledger0, "CREATE ()")
+        .await
+        .expect("bare CREATE ()");
+    assert!(result.receipt.t >= 1, "committed");
+
+    // `CREATE ()-[:TempEdge]->()` (benchgraph `create__pattern`).
+    let result = fluree
+        .transact_cypher(result.ledger, "CREATE ()-[:TempEdge]->()")
+        .await
+        .expect("bare CREATE pattern");
+    let db = graphdb_from_ledger(&result.ledger);
+    assert_eq!(
+        fluree
+            .query_cypher(&db, "MATCH (a)-[:TempEdge]->(b) RETURN a, b")
+            .await
+            .expect("edge query")
+            .row_count(),
+        1,
+        "anonymous endpoints exist via the edge"
+    );
+}
+
+#[tokio::test]
+async fn transact_cypher_create_var_only_node_has_empty_labels() {
+    // `CREATE (n)` — fresh node, no labels/props; labels(n) must hide the
+    // db:Node existence marker.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:create-var-only");
+    let l = fluree
+        .transact_cypher(ledger0, "CREATE (n)")
+        .await
+        .expect("CREATE (n)")
+        .ledger;
+    let l = fluree
+        .transact_cypher(l, r#"CREATE (m:Person {name: "Alice"})"#)
+        .await
+        .expect("labeled sibling")
+        .ledger;
+    let db = graphdb_from_ledger(&l);
+
+    // The labeled match must not see the bare node.
+    assert_eq!(
+        fluree
+            .query_cypher(&db, "MATCH (n:Person) RETURN n")
+            .await
+            .expect("person")
+            .row_count(),
+        1
     );
 }
 
@@ -1533,7 +1846,10 @@ async fn transact_cypher_detach_delete_works_on_indexed_data() {
     let ledger_id = "it/cypher:detach-delete-indexed";
     let (local, handle) = support::start_background_indexer_local(
         fluree.backend().clone(),
-        std::sync::Arc::new(fluree.nameservice_mode().clone()),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
         fluree_db_indexer::IndexerConfig::small(),
     );
 
@@ -4304,6 +4620,116 @@ async fn cypher_var_length_rel_and_path_binding() {
             .await
             .is_err(),
         "unbounded var-length rel binding is deferred"
+    );
+}
+
+#[tokio::test]
+async fn cypher_shortest_path_untyped_wildcard() {
+    // Untyped shortestPath (benchgraph `arango__shortest_path`): follows any
+    // relationship type, skipping rdf:type and data properties. The chain
+    // mixes KNOWS and LIKES edges, so a single-type search can't reach Dave.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let mut l = genesis_ledger(&fluree, "it/cypher:sp-untyped");
+    for stmt in [
+        r#"CREATE (a:Person {name: "Alice"})"#,
+        r#"CREATE (b:Person {name: "Bob"})"#,
+        r#"CREATE (c:Person {name: "Carol"})"#,
+        r#"CREATE (d:Person {name: "Dave"})"#,
+        r#"MATCH (a:Person {name: "Alice"}), (b:Person {name: "Bob"}) CREATE (a)-[:KNOWS]->(b)"#,
+        r#"MATCH (b:Person {name: "Bob"}), (c:Person {name: "Carol"}) CREATE (b)-[:LIKES]->(c)"#,
+        r#"MATCH (c:Person {name: "Carol"}), (d:Person {name: "Dave"}) CREATE (c)-[:KNOWS]->(d)"#,
+    ] {
+        l = fluree.transact_cypher(l, stmt).await.expect(stmt).ledger;
+    }
+    let db = graphdb_from_ledger(&l);
+
+    let cj = fluree
+        .query_cypher(
+            &db,
+            r#"MATCH (a:Person {name: "Alice"}), (d:Person {name: "Dave"})
+               MATCH p = shortestPath((a)-[*..15]->(d))
+               RETURN length(p) AS len, [r IN relationships(p) | type(r)] AS types"#,
+        )
+        .await
+        .expect("untyped shortestPath")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cypher json");
+    let row = &cj["results"][0]["data"][0]["row"];
+    assert_eq!(row[0], json!(3), "Alice→Dave is 3 mixed hops: {cj}");
+    assert_eq!(
+        row[1],
+        json!(["KNOWS", "LIKES", "KNOWS"]),
+        "per-hop types resolved post-hoc: {cj}"
+    );
+
+    // Typed search over the same pair finds nothing (LIKES breaks the chain).
+    assert_eq!(
+        fluree
+            .query_cypher(
+                &db,
+                r#"MATCH (a:Person {name: "Alice"}), (d:Person {name: "Dave"})
+                   MATCH p = shortestPath((a)-[:KNOWS*..15]->(d))
+                   RETURN length(p)"#,
+            )
+            .await
+            .expect("typed control")
+            .row_count(),
+        0,
+        "typed-only search must not cross the LIKES hop"
+    );
+
+    // allShortestPaths untyped (benchgraph `arango__allshortest_paths`).
+    assert_eq!(
+        fluree
+            .query_cypher(
+                &db,
+                r#"MATCH (a:Person {name: "Alice"}), (d:Person {name: "Dave"})
+                   MATCH p = allShortestPaths((a)-[*..15]->(d))
+                   RETURN length(p)"#,
+            )
+            .await
+            .expect("untyped allShortestPaths")
+            .row_count(),
+        1,
+        "exactly one minimal path"
+    );
+}
+
+#[tokio::test]
+async fn cypher_shortest_path_untyped_skips_type_and_data_edges() {
+    // The wildcard edge-set must not treat rdf:type or a data property as a
+    // hop: two nodes sharing only a class have no path.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:sp-untyped-edge-set");
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx(),
+                "@graph": [
+                    {"@id": "ex:alice", "@type": "ex:Person", "ex:name": "Alice"},
+                    {"@id": "ex:bob", "@type": "ex:Person", "ex:name": "Bob"},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let db = graphdb_from_ledger(&committed.ledger);
+
+    assert_eq!(
+        fluree
+            .query_cypher(
+                &db,
+                r#"MATCH (a:Person {name: "Alice"}), (b:Person {name: "Bob"})
+                   MATCH p = shortestPath((a)-[*..15]->(b))
+                   RETURN length(p)"#,
+            )
+            .await
+            .expect("no path via class node")
+            .row_count(),
+        0,
+        "rdf:type must not connect nodes through their shared class"
     );
 }
 

--- a/fluree-db-api/tests/it_query_cypher.rs
+++ b/fluree-db-api/tests/it_query_cypher.rs
@@ -7005,3 +7005,91 @@ async fn cypher_class_anchored_fold_declines_without_containment() {
         assert_eq!(cj["results"][0]["data"][0]["row"][0], json!(30), "{cj}");
     }
 }
+
+/// Filtered histogram: the WHERE predicate references only the group key, so
+/// the fold evaluates it once per group (null group included) — identical to
+/// the pipeline's per-row filtering.
+#[tokio::test]
+async fn cypher_class_anchored_filtered_histogram_matches_pipeline() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/cypher:class-agg-filtered";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx(),
+                "@graph": [
+                    {"@id": "ex:alice", "@type": "ex:Person", "ex:age": [15, 30]},
+                    {"@id": "ex:bob",   "@type": "ex:Person"},
+                    {"@id": "ex:carol", "@type": "ex:Person", "ex:age": 30},
+                    {"@id": "ex:dave",  "@type": "ex:Person", "ex:age": 40},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let novelty_db = graphdb_from_ledger(&committed.ledger);
+    rebuild_and_publish_index(&fluree, ledger_id).await;
+    let indexed_db = fluree.db(ledger_id).await.expect("indexed view");
+
+    let rows_of = |cj: &JsonValue| -> Vec<(JsonValue, JsonValue)> {
+        let mut rows: Vec<(JsonValue, JsonValue)> = cj["results"][0]["data"]
+            .as_array()
+            .expect("rows")
+            .iter()
+            .map(|r| (r["row"][0].clone(), r["row"][1].clone()))
+            .collect();
+        rows.sort_by_key(|(k, _)| k.to_string());
+        rows
+    };
+
+    for db in [&novelty_db, &indexed_db] {
+        // Range filter: groups >= 18 only, no null group (unbound rejected).
+        let cj = fluree
+            .query_cypher(
+                db,
+                "MATCH (n:Person) WHERE n.age >= 18 RETURN n.age, COUNT(*)",
+            )
+            .await
+            .expect("filtered histogram")
+            .to_cypher_json_async(db.as_graph_db_ref())
+            .await
+            .expect("cypher json");
+        assert_eq!(
+            rows_of(&cj),
+            vec![(json!(30), json!(2)), (json!(40), json!(1))],
+            "{cj}"
+        );
+
+        // Filter that rejects every group: empty result, not an error.
+        let cj = fluree
+            .query_cypher(
+                db,
+                "MATCH (n:Person) WHERE n.age > 100 RETURN n.age, COUNT(*)",
+            )
+            .await
+            .expect("all rejected")
+            .to_cypher_json_async(db.as_graph_db_ref())
+            .await
+            .expect("cypher json");
+        assert_eq!(
+            cj["results"][0]["data"].as_array().expect("rows").len(),
+            0,
+            "{cj}"
+        );
+
+        // IS NULL keeps ONLY the null group (bound-check passes Unbound).
+        let cj = fluree
+            .query_cypher(
+                db,
+                "MATCH (n:Person) WHERE n.age IS NULL RETURN n.age, COUNT(*)",
+            )
+            .await
+            .expect("null group only")
+            .to_cypher_json_async(db.as_graph_db_ref())
+            .await
+            .expect("cypher json");
+        assert_eq!(rows_of(&cj), vec![(json!(null), json!(1))], "{cj}");
+    }
+}

--- a/fluree-db-api/tests/it_query_cypher.rs
+++ b/fluree-db-api/tests/it_query_cypher.rs
@@ -924,6 +924,104 @@ async fn transact_cypher_unwind_inline_list_batches_node_inserts() {
 }
 
 #[tokio::test]
+async fn transact_cypher_create_return_node() {
+    // `CREATE (n:UserTemp {id: 1}) RETURN n` (benchgraph
+    // `arango__single_vertex_write`) — one row carrying the created node id.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:create-return-node");
+    let (result, rows) = fluree
+        .transact_cypher_returning(ledger0, r#"CREATE (n:UserTemp {id: 1}) RETURN n"#, None)
+        .await
+        .expect("create with RETURN");
+    let rows = rows.expect("RETURN produces rows");
+    assert_eq!(rows["results"][0]["columns"], json!(["n"]), "{rows}");
+    let data = rows["results"][0]["data"].as_array().expect("data");
+    assert_eq!(data.len(), 1, "{rows}");
+    let id = data[0]["row"][0].as_str().expect("node id string");
+    assert!(id.starts_with("_:fdb-"), "skolemized node id: {rows}");
+
+    // The returned identity is the committed node: it must have the label.
+    let db = graphdb_from_ledger(&result.ledger);
+    assert_eq!(
+        fluree
+            .query_cypher(&db, "MATCH (n:UserTemp) RETURN n")
+            .await
+            .expect("verify")
+            .row_count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn transact_cypher_match_create_return_edge() {
+    // `MATCH (a),(b) CREATE (a)-[e:Temp]->(b) RETURN e` (benchgraph
+    // `arango__single_edge_write`) — one row per WHERE solution.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let mut l = genesis_ledger(&fluree, "it/cypher:create-return-edge");
+    for stmt in [
+        r#"CREATE (a:User {id: 1})"#,
+        r#"CREATE (b:User {id: 2})"#,
+        r#"CREATE (c:User {id: 3})"#,
+    ] {
+        l = fluree.transact_cypher(l, stmt).await.expect(stmt).ledger;
+    }
+
+    let (result, rows) = fluree
+        .transact_cypher_returning(
+            l,
+            r#"MATCH (a:User {id: 1}), (b:User {id: 2}) CREATE (a)-[e:Temp]->(b) RETURN e"#,
+            None,
+        )
+        .await
+        .expect("edge create with RETURN");
+    let rows = rows.expect("RETURN produces rows");
+    assert_eq!(rows["results"][0]["columns"], json!(["e"]), "{rows}");
+    let data = rows["results"][0]["data"].as_array().expect("data");
+    assert_eq!(data.len(), 1, "one solution → one created edge: {rows}");
+    assert!(
+        data[0]["row"][0]
+            .as_str()
+            .expect("edge id")
+            .contains("cy_rel_e"),
+        "{rows}"
+    );
+
+    // Multi-solution: a broader MATCH creates one edge per pair and RETURN
+    // reports each.
+    let (_, rows) = fluree
+        .transact_cypher_returning(
+            result.ledger,
+            r#"MATCH (a:User {id: 3}), (b:User) CREATE (a)-[e:Linked]->(b) RETURN e AS edge"#,
+            None,
+        )
+        .await
+        .expect("batch edge create with RETURN");
+    let rows = rows.expect("rows");
+    assert_eq!(rows["results"][0]["columns"], json!(["edge"]), "{rows}");
+    assert_eq!(
+        rows["results"][0]["data"].as_array().expect("data").len(),
+        3,
+        "three matched targets → three created edges: {rows}"
+    );
+}
+
+#[tokio::test]
+async fn transact_cypher_return_of_matched_var_is_rejected() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let l = genesis_ledger(&fluree, "it/cypher:write-return-matched");
+    let l = fluree
+        .transact_cypher(l, r#"CREATE (a:User {id: 1})"#)
+        .await
+        .expect("seed")
+        .ledger;
+    let err = fluree
+        .transact_cypher_returning(l, r#"MATCH (a:User {id: 1}) SET a.x = 1 RETURN a"#, None)
+        .await
+        .expect_err("RETURN of a MATCH-bound var must be rejected");
+    assert!(format!("{err}").contains("created"), "{err}");
+}
+
+#[tokio::test]
 async fn transact_cypher_create_bare_anonymous_node() {
     // `CREATE ()` (benchgraph `create__vertex`) — an anonymous propertyless
     // node commits (via the hidden db:Node marker) and stays invisible to

--- a/fluree-db-api/tests/it_query_cypher_fullscan.rs
+++ b/fluree-db-api/tests/it_query_cypher_fullscan.rs
@@ -1,0 +1,68 @@
+// Cypher whole-graph-scan opt-in tests. These live in their own test binary
+// because `FLUREE_CYPHER_ALLOW_FULL_SCAN` is read once per process — setting
+// it here must not leak into the main Cypher tests (which assert the
+// default rejection of bare `MATCH (n)`).
+#![allow(clippy::needless_raw_string_hashes)]
+
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+use support::{genesis_ledger, graphdb_from_ledger};
+
+#[tokio::test]
+async fn cypher_bare_match_full_scan_opt_in() {
+    std::env::set_var("FLUREE_CYPHER_ALLOW_FULL_SCAN", "1");
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "it/cypher:full-scan");
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": {"ex": "http://example.org/"},
+                "@graph": [
+                    {"@id": "ex:alice", "@type": "ex:Person", "ex:age": 25},
+                    {"@id": "ex:bob",   "@type": "ex:Person"},
+                    {"@id": "ex:acme",  "@type": "ex:Company", "ex:age": 99},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let db = graphdb_from_ledger(&committed.ledger);
+
+    // count(n) counts distinct nodes (subjects), not triples; count(n.age)
+    // counts nodes carrying the property (benchgraph `aggregation__count`).
+    let cj = fluree
+        .query_cypher(&db, "MATCH (n) RETURN count(n) AS c, count(n.age) AS ca")
+        .await
+        .expect("bare MATCH scan")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cypher json");
+    let row = &cj["results"][0]["data"][0]["row"];
+    // 3 user nodes + 2 class nodes (ex:Person / ex:Company are subjects of
+    // nothing — they appear only as objects, so they are not counted).
+    assert_eq!(row[0], json!(3), "count(n): {cj}");
+    assert_eq!(row[1], json!(2), "count(n.age): {cj}");
+
+    // min/max/avg over a property through the scan
+    // (benchgraph `aggregation__min_max_avg`).
+    let cj = fluree
+        .query_cypher(
+            &db,
+            "MATCH (n) RETURN min(n.age) AS mn, max(n.age) AS mx, avg(n.age) AS av",
+        )
+        .await
+        .expect("min/max/avg scan")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cypher json");
+    let row = &cj["results"][0]["data"][0]["row"];
+    assert_eq!(row[0], json!(25), "min: {cj}");
+    assert_eq!(row[1], json!(99), "max: {cj}");
+    // avg yields xsd:decimal, which cypher-json renders as a string to
+    // preserve precision.
+    assert_eq!(row[2], json!("62"), "avg: {cj}");
+}

--- a/fluree-db-api/tests/it_query_cypher_fullscan.rs
+++ b/fluree-db-api/tests/it_query_cypher_fullscan.rs
@@ -301,6 +301,32 @@ async fn folds_stay_correct_on_incremental_index() {
     support::build_and_publish_index(&fluree, ledger_id).await;
     let db = fluree.db(ledger_id).await.expect("incremental view");
 
+    // The incremental root must carry the BASE per-graph property stats
+    // forward, not just the novelty deltas: every property entry sums to the
+    // graph's flake total. (The regression dropped base entries and kept
+    // net-zero churn at count 0 — the sums diverged immediately.)
+    let stats = db.snapshot.stats.as_ref().expect("index stats");
+    let g0 = stats
+        .graphs
+        .as_ref()
+        .expect("per-graph stats")
+        .iter()
+        .find(|g| g.g_id == 0)
+        .expect("default graph stats");
+    let prop_sum: u64 = g0.properties.iter().map(|p| p.count).sum();
+    assert_eq!(
+        prop_sum, g0.flakes,
+        "per-graph property counts must cover all flakes (delta-only stats?)"
+    );
+    assert!(
+        g0.properties.iter().all(|p| p.count > 0),
+        "net-zero churn must keep the base count, not zero: {:?}",
+        g0.properties
+            .iter()
+            .map(|p| (p.p_id, p.count))
+            .collect::<Vec<_>>()
+    );
+
     // COUNT(DISTINCT ?p): the fold's PSOT directory walk vs the general
     // pipeline (GROUP BY blocks the distinct-count fold).
     let folded = fluree

--- a/fluree-db-api/tests/it_query_cypher_fullscan.rs
+++ b/fluree-db-api/tests/it_query_cypher_fullscan.rs
@@ -226,3 +226,140 @@ async fn cypher_indexed_whole_graph_count_declines_on_edge_annotations() {
         "annotated graph: fold must defer to the pipeline"
     );
 }
+
+/// Incrementally-built indexes currently persist delta-only per-graph
+/// property stats (base entries lost; net-zero churn kept at count 0). The
+/// folds must stay correct anyway: COUNT(DISTINCT ?p) always walks PSOT
+/// directories, and the whole-graph fold's hidden-predicate gate checks the
+/// predicate dictionary rather than the stats. This drives the corruption
+/// trigger — full index, then writes (new predicate, net-zero churn, a
+/// reified edge), then an incremental index — and pins fold == pipeline.
+#[tokio::test]
+async fn folds_stay_correct_on_incremental_index() {
+    std::env::set_var("FLUREE_CYPHER_ALLOW_FULL_SCAN", "1");
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/cypher:incremental-stats";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    let ctx = json!({"ex": "http://example.org/"});
+    let ledger1 = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": ctx,
+                "@graph": [
+                    {"@id": "ex:alice", "@type": "ex:Person", "ex:age": 30, "ex:score": 1},
+                    {"@id": "ex:bob",   "@type": "ex:Person", "ex:age": 40},
+                ]
+            }),
+        )
+        .await
+        .expect("seed")
+        .ledger;
+    rebuild_and_publish_index(&fluree, ledger_id).await;
+
+    // Post-index novelty: a brand-new predicate + class...
+    let ledger2 = fluree
+        .insert(
+            ledger1,
+            &json!({
+                "@context": ctx,
+                "@id": "ex:w1", "@type": "ex:Widget", "ex:brandnew": 7
+            }),
+        )
+        .await
+        .expect("new predicate")
+        .ledger;
+    // ...net-zero churn on ex:score (retract 1, assert 2 — count unchanged)...
+    let ledger3 = fluree
+        .update(
+            ledger2,
+            &json!({
+                "@context": ctx,
+                "delete": [{"@id": "ex:alice", "ex:score": 1}],
+                "insert": [{"@id": "ex:alice", "ex:score": 2}]
+            }),
+        )
+        .await
+        .expect("churn")
+        .ledger;
+    // ...and a reified edge (f:reifies* enters the predicate dictionary).
+    let _ledger4 = fluree
+        .insert(
+            ledger3,
+            &json!({
+                "@context": ctx,
+                "@id": "ex:alice",
+                "ex:knows": {"@id": "ex:bob", "@annotation": {"ex:since": 2020}}
+            }),
+        )
+        .await
+        .expect("annotated edge")
+        .ledger;
+
+    // Incremental index (base exists, small commit gap → incremental path).
+    support::build_and_publish_index(&fluree, ledger_id).await;
+    let db = fluree.db(ledger_id).await.expect("incremental view");
+
+    // COUNT(DISTINCT ?p): the fold's PSOT directory walk vs the general
+    // pipeline (GROUP BY blocks the distinct-count fold).
+    let folded = fluree
+        .query(
+            &db,
+            fluree_db_api::QueryInput::Sparql(
+                "SELECT (COUNT(DISTINCT ?p) AS ?c) WHERE { ?s ?p ?o }",
+            ),
+        )
+        .await
+        .expect("distinct preds")
+        .to_jsonld_async(db.as_graph_db_ref())
+        .await
+        .expect("jsonld");
+    let truth = fluree
+        .query(
+            &db,
+            fluree_db_api::QueryInput::Sparql("SELECT ?p WHERE { ?s ?p ?o } GROUP BY ?p"),
+        )
+        .await
+        .expect("preds truth")
+        .row_count();
+    assert_eq!(
+        folded[0][0].as_i64(),
+        Some(truth as i64),
+        "COUNT(DISTINCT ?p) fold vs pipeline: {folded} vs {truth}"
+    );
+
+    // Whole-graph count: reifies facts are in the dictionary, so the fold
+    // must decline (dict-based gate) — and agree with the WITH-blocked
+    // pipeline either way.
+    let count_fold = fluree
+        .query_cypher(&db, "MATCH (n) RETURN count(n) AS c")
+        .await
+        .expect("count")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cj");
+    let count_truth = fluree
+        .query_cypher(&db, "MATCH (n) WITH n RETURN count(n) AS c")
+        .await
+        .expect("count truth")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cj");
+    assert_eq!(
+        count_fold["results"][0]["data"][0]["row"], count_truth["results"][0]["data"][0]["row"],
+        "whole-graph count on incremental+reified store"
+    );
+
+    // Class-anchored histogram still folds correctly on the incremental
+    // index (class stats are maintained incrementally).
+    let hist = fluree
+        .query_cypher(&db, "MATCH (n:Person) RETURN n.age, COUNT(*)")
+        .await
+        .expect("hist")
+        .to_cypher_json_async(db.as_graph_db_ref())
+        .await
+        .expect("cj");
+    let rows = hist["results"][0]["data"].as_array().expect("rows");
+    assert_eq!(rows.len(), 2, "{hist}");
+}

--- a/fluree-db-api/tests/it_query_cypher_fullscan.rs
+++ b/fluree-db-api/tests/it_query_cypher_fullscan.rs
@@ -8,7 +8,7 @@ mod support;
 
 use fluree_db_api::FlureeBuilder;
 use serde_json::json;
-use support::{genesis_ledger, graphdb_from_ledger};
+use support::{genesis_ledger, graphdb_from_ledger, rebuild_and_publish_index};
 
 #[tokio::test]
 async fn cypher_bare_match_full_scan_opt_in() {
@@ -65,4 +65,164 @@ async fn cypher_bare_match_full_scan_opt_in() {
     // avg yields xsd:decimal, which cypher-json renders as a string to
     // preserve precision.
     assert_eq!(row[2], json!("62"), "avg: {cj}");
+}
+
+/// Run one Cypher query against both views and return the two cypher-json rows.
+async fn row_on_both(
+    fluree: &fluree_db_api::Fluree,
+    novelty_db: &fluree_db_api::GraphDb,
+    indexed_db: &fluree_db_api::GraphDb,
+    cypher: &str,
+) -> (serde_json::Value, serde_json::Value) {
+    let mut rows = Vec::new();
+    for db in [novelty_db, indexed_db] {
+        let cj = fluree
+            .query_cypher(db, cypher)
+            .await
+            .expect("query")
+            .to_cypher_json_async(db.as_graph_db_ref())
+            .await
+            .expect("cypher json");
+        rows.push(cj["results"][0]["data"][0]["row"].clone());
+    }
+    let indexed = rows.pop().unwrap();
+    let novelty = rows.pop().unwrap();
+    (novelty, indexed)
+}
+
+/// Whole-graph aggregates on an indexed ledger take the directory-fold fast
+/// path (`fast_whole_graph_agg`); the same queries on the novelty-only view
+/// run the general pipeline. Both must agree — including the row-multiplying
+/// left-join semantics of a multi-valued property.
+#[tokio::test]
+async fn cypher_indexed_whole_graph_aggregates_match_pipeline() {
+    std::env::set_var("FLUREE_CYPHER_ALLOW_FULL_SCAN", "1");
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/cypher:full-scan-indexed";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": {"ex": "http://example.org/"},
+                "@graph": [
+                    // alice has TWO ages: the accessor left-join gives her two
+                    // rows, so count(n) = 5 over 4 subjects while
+                    // count(n.age) = 4 values.
+                    {"@id": "ex:alice", "@type": "ex:Person", "ex:age": [25, 30]},
+                    {"@id": "ex:bob",   "@type": "ex:Person"},
+                    {"@id": "ex:carol", "@type": "ex:Person", "ex:age": 40},
+                    {"@id": "ex:dave",  "@type": "ex:Person", "ex:age": 40},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let novelty_db = graphdb_from_ledger(&committed.ledger);
+
+    rebuild_and_publish_index(&fluree, ledger_id).await;
+    let indexed_db = fluree.db(ledger_id).await.expect("indexed view");
+
+    // count(n) / count(n.prop) / count(DISTINCT n) — exact integer folds.
+    let (novelty, indexed) = row_on_both(
+        &fluree,
+        &novelty_db,
+        &indexed_db,
+        "MATCH (n) RETURN count(n) AS c, count(n.age) AS ca, count(DISTINCT n) AS cd",
+    )
+    .await;
+    assert_eq!(novelty, json!([5, 4, 4]), "pipeline row");
+    assert_eq!(indexed, json!([5, 4, 4]), "fold row");
+
+    // min/max fold from POST boundary keys; avg from the predicate-scoped
+    // scan. avg = (25+30+40+40)/4 = 33.75. The general pipeline renders the
+    // decimal as a string while the fold (like the existing SPARQL AVG fast
+    // path) yields a double — compare numerically.
+    let (novelty, indexed) = row_on_both(
+        &fluree,
+        &novelty_db,
+        &indexed_db,
+        "MATCH (n) RETURN min(n.age) AS mn, max(n.age) AS mx, avg(n.age) AS av",
+    )
+    .await;
+    for (label, row) in [("pipeline", &novelty), ("fold", &indexed)] {
+        assert_eq!(row[0], json!(25), "{label} min: {row}");
+        assert_eq!(row[1], json!(40), "{label} max: {row}");
+        let avg = row[2]
+            .as_f64()
+            .or_else(|| row[2].as_str().and_then(|s| s.parse().ok()))
+            .expect("numeric avg");
+        assert!((avg - 33.75).abs() < 1e-9, "{label} avg: {row}");
+    }
+
+    // sum through the same fold.
+    let (novelty, indexed) = row_on_both(
+        &fluree,
+        &novelty_db,
+        &indexed_db,
+        "MATCH (n) RETURN sum(n.age) AS s",
+    )
+    .await;
+    assert_eq!(novelty, json!([135]), "pipeline sum");
+    assert_eq!(indexed, json!([135]), "fold sum");
+
+    // count(n) with no accessor = distinct subjects.
+    let (novelty, indexed) = row_on_both(
+        &fluree,
+        &novelty_db,
+        &indexed_db,
+        "MATCH (n) RETURN count(n) AS c",
+    )
+    .await;
+    assert_eq!(novelty, json!([4]), "pipeline count");
+    assert_eq!(indexed, json!([4]), "fold count");
+}
+
+/// `f:reifies*` facts are hidden from the `?n ?p ?o` pipeline but present in
+/// the SPOT directories, so their presence must make the fold decline to the
+/// fallback — results stay identical to the novelty view either way.
+#[tokio::test]
+async fn cypher_indexed_whole_graph_count_declines_on_edge_annotations() {
+    std::env::set_var("FLUREE_CYPHER_ALLOW_FULL_SCAN", "1");
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/cypher:full-scan-annotated";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    let committed = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": {"ex": "http://example.org/"},
+                "@graph": [
+                    {
+                        "@id": "ex:alice",
+                        "@type": "ex:Person",
+                        "ex:knows": {
+                            "@id": "ex:bob",
+                            "@annotation": {"ex:since": 2020}
+                        }
+                    },
+                    {"@id": "ex:bob", "@type": "ex:Person"},
+                ]
+            }),
+        )
+        .await
+        .expect("seed");
+    let novelty_db = graphdb_from_ledger(&committed.ledger);
+
+    rebuild_and_publish_index(&fluree, ledger_id).await;
+    let indexed_db = fluree.db(ledger_id).await.expect("indexed view");
+
+    let (novelty, indexed) = row_on_both(
+        &fluree,
+        &novelty_db,
+        &indexed_db,
+        "MATCH (n) RETURN count(n) AS c",
+    )
+    .await;
+    assert_eq!(
+        novelty, indexed,
+        "annotated graph: fold must defer to the pipeline"
+    );
 }

--- a/fluree-db-consensus/src/local.rs
+++ b/fluree-db-consensus/src/local.rs
@@ -132,6 +132,7 @@ impl Committer for LocalCommitter {
                         query,
                         params.as_ref(),
                         &governance,
+                        txn_opts.skolem_txn_id.clone(),
                     )
                     .await
                     .map_err(execution_failure)?,
@@ -419,10 +420,11 @@ pub(crate) async fn resolve_cypher_under_lock(
     query: &str,
     params: Option<&serde_json::Map<String, serde_json::Value>>,
     governance: &GovernanceOptions,
+    skolem_txn_id: Option<String>,
 ) -> Result<Txn, ApiError> {
     let snap = ledger_handle.snapshot().await;
     let plan = fluree
-        .cypher_write_plan(query, params, ledger_id, &snap.snapshot)
+        .cypher_write_plan_with_skolem(query, params, ledger_id, &snap.snapshot, skolem_txn_id)
         .await?;
     match plan {
         fluree_db_api::cypher_write::WritePlan::Single(txn) => Ok(*txn),

--- a/fluree-db-consensus/src/raft/commit_worker.rs
+++ b/fluree-db-consensus/src/raft/commit_worker.rs
@@ -536,6 +536,7 @@ impl Worker {
                     query,
                     params.as_ref(),
                     &governance,
+                    txn_opts.skolem_txn_id.clone(),
                 )
                 .await
                 .map_err(|e| stage_failure(&format!("cypher lowering failed: {e}")))?,

--- a/fluree-db-cypher/src/lower/annotation_use.rs
+++ b/fluree-db-cypher/src/lower/annotation_use.rs
@@ -1,0 +1,287 @@
+//! Statement-wide scan for variables whose evaluation depends on the
+//! *annotation identity* of a relationship.
+//!
+//! A bound relationship variable is used in one of two ways:
+//!
+//! - **Value surface** — `RETURN e`, `type(e)`, `startNode(e)`, `endNode(e)`,
+//!   equality, `collect(e)`, … These read only `{start, predicate, end}` and
+//!   are satisfiable by a relationship value synthesized from the plain base
+//!   triple (`MakeRel`), so unreified (plain-RDF) edges match too.
+//! - **Annotation surface** — `e.prop`, `properties(e)`, `keys(e)`, map
+//!   projections `e{...}`. These need the `f:reifies*` annotation node, so the
+//!   variable must bind the annotation SID (`Pattern::EdgeAnnotation`).
+//!
+//! This scan over-approximates the annotation surface: any variable that
+//! *might* need annotation identity is collected, and pattern lowering only
+//! applies the plain-triple fallback to relationship variables absent from
+//! the set.
+
+use std::collections::HashSet;
+
+use crate::ast::{
+    CaseExpr, Expr, MapLit, MapProjectionSelector, NodePattern, Pattern, PatternPart, Query,
+    ReadClause, RelPattern, ReturnClause, WithClause,
+};
+
+/// Collect the names of variables used on the annotation surface anywhere in
+/// the query (including UNION tails, CALL subqueries, and nested patterns).
+pub(super) fn annotation_dependent_vars(q: &Query) -> HashSet<String> {
+    let mut out = HashSet::new();
+    scan_query(q, &mut out);
+    out
+}
+
+fn scan_query(q: &Query, out: &mut HashSet<String>) {
+    for c in &q.clauses {
+        scan_read_clause(c, out);
+    }
+    scan_return(&q.return_clause, out);
+    if let Some(t) = &q.union_tail {
+        scan_query(&t.right, out);
+    }
+}
+
+fn scan_read_clause(c: &ReadClause, out: &mut HashSet<String>) {
+    match c {
+        ReadClause::Match(m) | ReadClause::OptionalMatch(m) => {
+            scan_pattern(&m.pattern, out);
+            if let Some(w) = &m.where_clause {
+                scan_expr(w, out);
+            }
+        }
+        ReadClause::With(w) => scan_with(w, out),
+        ReadClause::Unwind(u) => scan_expr(&u.expr, out),
+        ReadClause::CallSubquery(cs) => scan_query(&cs.query, out),
+        ReadClause::InlineRows { rows, .. } => {
+            for row in rows {
+                for cell in row {
+                    scan_expr(cell, out);
+                }
+            }
+        }
+    }
+}
+
+fn scan_with(w: &WithClause, out: &mut HashSet<String>) {
+    for item in &w.items {
+        scan_expr(&item.expr, out);
+    }
+    if let Some(e) = &w.where_clause {
+        scan_expr(e, out);
+    }
+    for o in &w.order_by {
+        scan_expr(&o.expr, out);
+    }
+    for e in w.skip.iter().chain(w.limit.iter()) {
+        scan_expr(e, out);
+    }
+}
+
+fn scan_return(r: &ReturnClause, out: &mut HashSet<String>) {
+    for item in &r.items {
+        scan_expr(&item.expr, out);
+    }
+    for o in &r.order_by {
+        scan_expr(&o.expr, out);
+    }
+    for e in r.skip.iter().chain(r.limit.iter()) {
+        scan_expr(e, out);
+    }
+}
+
+fn scan_pattern(p: &Pattern, out: &mut HashSet<String>) {
+    for part in &p.parts {
+        scan_part(part, out);
+    }
+}
+
+fn scan_part(part: &PatternPart, out: &mut HashSet<String>) {
+    scan_node(&part.head, out);
+    for (rel, node) in &part.tail {
+        scan_rel(rel, out);
+        scan_node(node, out);
+    }
+}
+
+fn scan_node(n: &NodePattern, out: &mut HashSet<String>) {
+    if let Some(props) = &n.props {
+        scan_map_lit(props, out);
+    }
+}
+
+fn scan_rel(r: &RelPattern, out: &mut HashSet<String>) {
+    if let Some(props) = &r.props {
+        scan_map_lit(props, out);
+    }
+}
+
+fn scan_map_lit(m: &MapLit, out: &mut HashSet<String>) {
+    for (_, e) in &m.entries {
+        scan_expr(e, out);
+    }
+}
+
+fn scan_expr(e: &Expr, out: &mut HashSet<String>) {
+    match e {
+        Expr::Var(_) | Expr::Lit(_) | Expr::Param(_) => {}
+        Expr::Prop(target, _, _) => {
+            collect_vars(target, out);
+            scan_expr(target, out);
+        }
+        Expr::Call(c) => {
+            let name = c.name.to_ascii_lowercase();
+            if name == "properties" || name == "keys" {
+                for a in &c.args {
+                    collect_vars(a, out);
+                }
+            }
+            for a in &c.args {
+                scan_expr(a, out);
+            }
+        }
+        Expr::MapProjection(mp) => {
+            out.insert(mp.var.name.clone());
+            for sel in &mp.selectors {
+                if let MapProjectionSelector::Literal(_, e) = sel {
+                    scan_expr(e, out);
+                }
+            }
+        }
+        Expr::BinOp(_, l, r, _)
+        | Expr::In(l, r, _)
+        | Expr::StartsWith(l, r, _)
+        | Expr::EndsWith(l, r, _)
+        | Expr::Contains(l, r, _)
+        | Expr::Index(l, r, _) => {
+            scan_expr(l, out);
+            scan_expr(r, out);
+        }
+        Expr::UnaryOp(_, inner, _) | Expr::IsNull(inner, _) | Expr::IsNotNull(inner, _) => {
+            scan_expr(inner, out);
+        }
+        Expr::Case(c) => scan_case(c, out),
+        Expr::Exists(pattern, where_clause, _) => {
+            scan_pattern(pattern, out);
+            if let Some(w) = where_clause {
+                scan_expr(w, out);
+            }
+        }
+        Expr::List(items, _) => {
+            for i in items {
+                scan_expr(i, out);
+            }
+        }
+        Expr::Map(entries, _) => {
+            for (_, v) in entries {
+                scan_expr(v, out);
+            }
+        }
+        Expr::ListComprehension(lc) => {
+            scan_expr(&lc.list, out);
+            if let Some(f) = &lc.filter {
+                scan_expr(f, out);
+            }
+            if let Some(m) = &lc.map {
+                scan_expr(m, out);
+            }
+        }
+        Expr::Reduce(r) => {
+            scan_expr(&r.init, out);
+            scan_expr(&r.list, out);
+            scan_expr(&r.body, out);
+        }
+        Expr::ListPredicate(p) => {
+            scan_expr(&p.list, out);
+            scan_expr(&p.predicate, out);
+        }
+        Expr::PatternComprehension(pc) => {
+            scan_pattern(&pc.pattern, out);
+            if let Some(f) = &pc.filter {
+                scan_expr(f, out);
+            }
+            scan_expr(&pc.projection, out);
+        }
+    }
+}
+
+fn scan_case(c: &CaseExpr, out: &mut HashSet<String>) {
+    if let Some(s) = &c.subject {
+        scan_expr(s, out);
+    }
+    for (w, t) in &c.branches {
+        scan_expr(w, out);
+        scan_expr(t, out);
+    }
+    if let Some(e) = &c.else_branch {
+        scan_expr(e, out);
+    }
+}
+
+/// Every variable name occurring anywhere in `e`.
+fn collect_vars(e: &Expr, out: &mut HashSet<String>) {
+    if let Expr::Var(v) = e {
+        out.insert(v.name.clone());
+        return;
+    }
+    // Reuse the structural walk: a nested Prop/properties target inside is
+    // already collected by `scan_expr`; here we need *all* vars, so walk
+    // manually over the same shapes.
+    match e {
+        Expr::Var(_) | Expr::Lit(_) | Expr::Param(_) => {}
+        Expr::Prop(t, _, _) => collect_vars(t, out),
+        Expr::Call(c) => {
+            for a in &c.args {
+                collect_vars(a, out);
+            }
+        }
+        Expr::MapProjection(mp) => {
+            out.insert(mp.var.name.clone());
+        }
+        Expr::BinOp(_, l, r, _)
+        | Expr::In(l, r, _)
+        | Expr::StartsWith(l, r, _)
+        | Expr::EndsWith(l, r, _)
+        | Expr::Contains(l, r, _)
+        | Expr::Index(l, r, _) => {
+            collect_vars(l, out);
+            collect_vars(r, out);
+        }
+        Expr::UnaryOp(_, inner, _) | Expr::IsNull(inner, _) | Expr::IsNotNull(inner, _) => {
+            collect_vars(inner, out);
+        }
+        Expr::Case(c) => {
+            if let Some(s) = &c.subject {
+                collect_vars(s, out);
+            }
+            for (w, t) in &c.branches {
+                collect_vars(w, out);
+                collect_vars(t, out);
+            }
+            if let Some(el) = &c.else_branch {
+                collect_vars(el, out);
+            }
+        }
+        Expr::Exists(_, _, _) => {}
+        Expr::List(items, _) => {
+            for i in items {
+                collect_vars(i, out);
+            }
+        }
+        Expr::Map(entries, _) => {
+            for (_, v) in entries {
+                collect_vars(v, out);
+            }
+        }
+        Expr::ListComprehension(lc) => {
+            collect_vars(&lc.list, out);
+        }
+        Expr::Reduce(r) => {
+            collect_vars(&r.init, out);
+            collect_vars(&r.list, out);
+        }
+        Expr::ListPredicate(p) => {
+            collect_vars(&p.list, out);
+        }
+        Expr::PatternComprehension(_) => {}
+    }
+}

--- a/fluree-db-cypher/src/lower/context.rs
+++ b/fluree-db-cypher/src/lower/context.rs
@@ -34,6 +34,16 @@ pub struct LoweringContext<'a, E: IriEncoder> {
     /// query variable, and property access on it lowers to eval-time member
     /// access rather than an outer-pattern join.
     scopes: Vec<HashMap<String, VarId>>,
+    /// Variables used on the relationship *annotation* surface somewhere in
+    /// the statement (`e.prop`, `properties(e)`, …). A bound relationship
+    /// variable outside this set can bind a synthesized relationship value
+    /// from the plain base triple instead of requiring a reifier bundle.
+    annotation_dependent: std::collections::HashSet<String>,
+    /// Allow a bare `MATCH (n)` (no label, property, or relationship) to
+    /// lower to a whole-graph distinct-subject scan. Off by default — a full
+    /// scan is rarely what a production query intends; benchmarks and ad-hoc
+    /// exploration opt in (server flag `FLUREE_CYPHER_ALLOW_FULL_SCAN`).
+    pub allow_full_scan: bool,
 }
 
 impl<'a, E: IriEncoder> LoweringContext<'a, E> {
@@ -45,7 +55,27 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
             vocab: "http://example.org/".to_string(),
             overrides: HashMap::new(),
             scopes: Vec::new(),
+            annotation_dependent: std::collections::HashSet::new(),
+            allow_full_scan: false,
         }
+    }
+
+    /// Opt in to whole-graph scans for bare `MATCH (n)` patterns.
+    pub fn with_allow_full_scan(mut self, allow: bool) -> Self {
+        self.allow_full_scan = allow;
+        self
+    }
+
+    /// Record the statement-wide annotation-surface variable set (see
+    /// [`super::annotation_use`]).
+    pub(super) fn set_annotation_dependent(&mut self, vars: std::collections::HashSet<String>) {
+        self.annotation_dependent = vars;
+    }
+
+    /// Whether `name` is used on the relationship annotation surface
+    /// anywhere in the statement.
+    pub(super) fn is_annotation_dependent(&self, name: &str) -> bool {
+        self.annotation_dependent.contains(name)
     }
 
     /// Push a new loop-local scope. Pair with [`Self::exit_scope`].

--- a/fluree-db-cypher/src/lower/context.rs
+++ b/fluree-db-cypher/src/lower/context.rs
@@ -161,4 +161,24 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
     pub fn rdf_type_iri(&self) -> &'static str {
         rdf::TYPE
     }
+
+    /// Lower a resolved IRI to a pattern `Ref`, encoding to `Ref::Sid` when
+    /// the namespace is registered (parity with the SPARQL lowering — the
+    /// planner's stats lookups and the batched join lanes are Sid-gated and
+    /// silently degrade to per-row paths on `Ref::Iri`). Unregistered
+    /// namespaces stay `Ref::Iri`, which matches nothing at scan time.
+    pub fn iri_ref(&self, iri: String) -> fluree_db_query::ir::Ref {
+        match self.encoder.encode_iri_strict(&iri) {
+            Some(sid) => fluree_db_query::ir::Ref::Sid(sid),
+            None => fluree_db_query::ir::Ref::Iri(iri.into()),
+        }
+    }
+
+    /// Object-position counterpart of [`Self::iri_ref`].
+    pub fn iri_term(&self, iri: String) -> fluree_db_query::ir::Term {
+        match self.encoder.encode_iri_strict(&iri) {
+            Some(sid) => fluree_db_query::ir::Term::Sid(sid),
+            None => fluree_db_query::ir::Term::Iri(iri.into()),
+        }
+    }
 }

--- a/fluree-db-cypher/src/lower/context.rs
+++ b/fluree-db-cypher/src/lower/context.rs
@@ -44,6 +44,16 @@ pub struct LoweringContext<'a, E: IriEncoder> {
     /// scan is rarely what a production query intends; benchmarks and ad-hoc
     /// exploration opt in (server flag `FLUREE_CYPHER_ALLOW_FULL_SCAN`).
     pub allow_full_scan: bool,
+    /// Whether chains of anonymous untyped hops (`-->()-->()-->(n)`) may
+    /// lower to a single exact-depth wildcard path (frontier BFS with
+    /// per-level dedup) instead of per-hop triple joins. Join chains produce
+    /// one row per *walk*; the path operator one row per *endpoint* — the
+    /// two agree only when the statement's output is `DISTINCT`, aggregates
+    /// nothing, and never references the interior nodes. The statement
+    /// lowering sets this after checking those conditions
+    /// ([`super::stmt`]); default off (write-path MATCH lowering and CALL
+    /// bodies never enable it).
+    pub(super) fuse_reachability_chains: bool,
 }
 
 impl<'a, E: IriEncoder> LoweringContext<'a, E> {
@@ -57,6 +67,7 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
             scopes: Vec::new(),
             annotation_dependent: std::collections::HashSet::new(),
             allow_full_scan: false,
+            fuse_reachability_chains: false,
         }
     }
 

--- a/fluree-db-cypher/src/lower/expr.rs
+++ b/fluree-db-cypher/src/lower/expr.rs
@@ -501,13 +501,29 @@ pub(crate) fn resolve_property_accessor<E: IriEncoder>(
     let prop_var_name = format!("?#__prop_{}_{}", target_var.name, key);
     let prop_var = ctx.intern_var(&prop_var_name);
 
-    aux.push(Pattern::Optional(vec![Pattern::Triple(
-        TriplePattern::new(
-            Ref::Var(target_id),
-            Ref::Iri(pred_iri.into()),
-            Term::Var(prop_var),
-        ),
-    )]));
+    // Dedup within the current clause's aux list only (`min(n.age),
+    // max(n.age)` must share one accessor — a repeated Optional over the
+    // same var re-joins the property per occurrence). Cross-scope re-emits
+    // (the WITH-boundary case above) land in a fresh `aux`, so this
+    // clause-local scan never suppresses them.
+    let already_emitted = aux.iter().any(|p| match p {
+        Pattern::Optional(inner) => match inner.as_slice() {
+            [Pattern::Triple(tp)] => {
+                tp.s.as_var() == Some(target_id) && tp.o.as_var() == Some(prop_var)
+            }
+            _ => false,
+        },
+        _ => false,
+    });
+    if !already_emitted {
+        aux.push(Pattern::Optional(vec![Pattern::Triple(
+            TriplePattern::new(
+                Ref::Var(target_id),
+                Ref::Iri(pred_iri.into()),
+                Term::Var(prop_var),
+            ),
+        )]));
+    }
     Ok(prop_var)
 }
 

--- a/fluree-db-cypher/src/lower/expr.rs
+++ b/fluree-db-cypher/src/lower/expr.rs
@@ -519,7 +519,7 @@ pub(crate) fn resolve_property_accessor<E: IriEncoder>(
         aux.push(Pattern::Optional(vec![Pattern::Triple(
             TriplePattern::new(
                 Ref::Var(target_id),
-                Ref::Iri(pred_iri.into()),
+                ctx.iri_ref(pred_iri),
                 Term::Var(prop_var),
             ),
         )]));

--- a/fluree-db-cypher/src/lower/mod.rs
+++ b/fluree-db-cypher/src/lower/mod.rs
@@ -4,6 +4,7 @@
 //! `fluree-db-transact/src/lower_cypher_update.rs`. See
 //! `docs/concepts/cypher.md` for how Cypher maps onto the RDF model.
 
+mod annotation_use;
 mod context;
 mod expr;
 mod pattern;
@@ -83,7 +84,10 @@ fn lower_with_context<E: IriEncoder>(
     ctx: &mut LoweringContext<'_, E>,
 ) -> Result<Query> {
     match &ast.statement {
-        Statement::Query(q) => stmt::lower_query(ctx, q),
+        Statement::Query(q) => {
+            ctx.set_annotation_dependent(annotation_use::annotation_dependent_vars(q));
+            stmt::lower_query(ctx, q)
+        }
         Statement::Update(_) => Err(LowerError::WriteOnQueryPath),
     }
 }

--- a/fluree-db-cypher/src/lower/pattern.rs
+++ b/fluree-db-cypher/src/lower/pattern.rs
@@ -237,8 +237,8 @@ fn lower_node<E: IriEncoder>(
     // Labels — emit `s rdf:type <label-iri>` for each.
     for Label { name, .. } in &n.labels {
         let iri = ctx.resolve_iri(name);
-        let pred = Ref::Iri(ctx.rdf_type_iri().into());
-        let obj = Term::Iri(iri.into());
+        let pred = ctx.iri_ref(ctx.rdf_type_iri().to_string());
+        let obj = ctx.iri_term(iri);
         out.push(Pattern::Triple(TriplePattern::new(subj.clone(), pred, obj)));
     }
 
@@ -258,7 +258,7 @@ fn lower_inline_props<E: IriEncoder>(
 ) -> Result<()> {
     for (key, val_expr) in &props.entries {
         let pred_iri = ctx.resolve_predicate(key)?;
-        let pred = Ref::Iri(pred_iri.into());
+        let pred = ctx.iri_ref(pred_iri);
         let obj = expr_to_object_term(ctx, val_expr)?;
         out.push(Pattern::Triple(TriplePattern::new(subj.clone(), pred, obj)));
     }
@@ -338,7 +338,7 @@ fn build_rel_hop<E: IriEncoder>(
         }
         1 => {
             let iri = ctx.resolve_predicate(&rel.types[0].name)?;
-            Ref::Iri(iri.into())
+            ctx.iri_ref(iri)
         }
         _ => {
             // Alternation — a `Union` of one concrete-predicate branch per
@@ -347,12 +347,13 @@ fn build_rel_hop<E: IriEncoder>(
             let mut branches: Vec<Vec<Pattern>> = Vec::with_capacity(rel.types.len());
             for t in &rel.types {
                 let iri = ctx.resolve_predicate(&t.name)?;
+                let pred = ctx.iri_ref(iri);
                 let mut branch = Vec::new();
                 push_rel_triple(
                     ctx,
                     &rel.var,
                     &rel.props,
-                    Ref::Iri(iri.into()),
+                    pred,
                     s.clone(),
                     o.clone(),
                     &mut branch,
@@ -702,7 +703,13 @@ fn build_fixed_chain<E: IriEncoder>(
         } else {
             Ref::Var(ctx.fresh_synth())
         };
-        push_hop(&prev, &next, type_iri, direction, &mut chain);
+        push_hop(
+            &prev,
+            &next,
+            ctx.iri_ref(type_iri.to_string()),
+            direction,
+            &mut chain,
+        );
         nodes.push(next.clone());
         prev = next;
     }
@@ -852,8 +859,7 @@ fn empty_path_result(s: &Ref, o: &Ref) -> Pattern {
 
 /// Push one hop between `a` and `b`. Directed hops emit a single triple;
 /// undirected hops emit a forward∪reverse `Union`.
-fn push_hop(a: &Ref, b: &Ref, type_iri: &str, direction: Direction, out: &mut Vec<Pattern>) {
-    let pred = Ref::Iri(type_iri.into());
+fn push_hop(a: &Ref, b: &Ref, pred: Ref, direction: Direction, out: &mut Vec<Pattern>) {
     let fwd = || {
         Pattern::Triple(TriplePattern::new(
             a.clone(),
@@ -996,7 +1002,7 @@ fn build_annotation_body<E: IriEncoder>(
     if let Some(map) = props {
         for (key, val_expr) in &map.entries {
             let pred_iri = ctx.resolve_predicate(key)?;
-            let pred = Ref::Iri(pred_iri.into());
+            let pred = ctx.iri_ref(pred_iri);
             let obj = expr_to_object_term(ctx, val_expr)?;
             body.push(Pattern::Triple(TriplePattern::new(ann.clone(), pred, obj)));
         }

--- a/fluree-db-cypher/src/lower/pattern.rs
+++ b/fluree-db-cypher/src/lower/pattern.rs
@@ -75,7 +75,36 @@ fn lower_part<E: IriEncoder>(
     }
 
     let mut prev = part.head.clone();
-    for (rel, next) in &part.tail {
+    let mut i = 0;
+    while i < part.tail.len() {
+        // Reachability fusion: a run of ≥2 anonymous untyped outgoing hops
+        // (`-->()-->()-->x`) collapses to one exact-depth wildcard path —
+        // frontier BFS with per-level dedup instead of per-walk join rows.
+        // Gated statement-wide (`fuse_reachability_chains`: DISTINCT output,
+        // no aggregates, interior nodes unreferenced by construction).
+        if ctx.fuse_reachability_chains && part.path_var.is_none() {
+            let run = fusible_run_len(&part.tail[i..]);
+            if run >= 2 {
+                let end_node = &part.tail[i + run - 1].1;
+                lower_node(ctx, end_node, out)?;
+                let s_ref = lookup_node_ref(ctx, &prev);
+                let o_ref = lookup_node_ref(ctx, end_node);
+                out.push(Pattern::PropertyPath(
+                    fluree_db_query::ir::PropertyPathPattern::new_wildcard(
+                        s_ref,
+                        fluree_db_query::ir::PathModifier::OneOrMore,
+                        Some(run as u32),
+                        Some(run as u32),
+                        o_ref,
+                    ),
+                ));
+                prev = end_node.clone();
+                i += run;
+                continue;
+            }
+        }
+
+        let (rel, next) = &part.tail[i];
         lower_node(ctx, next, out)?;
         let pv = if single_var_length {
             part.path_var.as_ref()
@@ -84,8 +113,36 @@ fn lower_part<E: IriEncoder>(
         };
         lower_rel(ctx, &prev, rel, next, out, pv)?;
         prev = next.clone();
+        i += 1;
     }
     Ok(())
+}
+
+/// Length of the maximal fusible hop run at the start of `tail`: consecutive
+/// plain anonymous untyped outgoing hops (no rel var/props/types/length)
+/// whose *interior* nodes are fully anonymous (`()` — no var, label, or
+/// props). The run's final node may be anything (it is lowered normally as
+/// the path endpoint).
+fn fusible_run_len(tail: &[(RelPattern, NodePattern)]) -> usize {
+    let mut run = 0;
+    for (idx, (rel, node)) in tail.iter().enumerate() {
+        let rel_fusible = rel.length.is_none()
+            && rel.types.is_empty()
+            && rel.var.is_none()
+            && rel.props.is_none()
+            && rel.direction == Direction::Outgoing;
+        if !rel_fusible {
+            break;
+        }
+        run = idx + 1;
+        // The node just reached is interior only if another hop follows; an
+        // interior node must be fully anonymous to stay unobservable.
+        let is_anonymous = node.var.is_none() && node.labels.is_empty() && node.props.is_none();
+        if !is_anonymous {
+            break;
+        }
+    }
+    run
 }
 
 /// Lower `p = shortestPath((a)-[:T*]-(b))` / `allShortestPaths(...)` into a

--- a/fluree-db-cypher/src/lower/pattern.rs
+++ b/fluree-db-cypher/src/lower/pattern.rs
@@ -47,8 +47,13 @@ fn lower_part<E: IriEncoder>(
 
     // Head node anchored. If tail is empty (single node) and the node
     // has no labels, no inline props, no participating relationships,
-    // reject.
+    // reject — unless whole-graph scans are opted in, in which case the
+    // node binds every distinct subject in the graph.
     if part.tail.is_empty() {
+        if part.head.labels.is_empty() && part.head.props.is_none() && ctx.allow_full_scan {
+            out.push(all_subjects_scan(ctx, &part.head));
+            return Ok(());
+        }
         require_node_anchored(&part.head)?;
         lower_node(ctx, &part.head, out)?;
         return Ok(());
@@ -117,10 +122,10 @@ fn lower_shortest_path<E: IriEncoder>(
             "property filters on a shortestPath relationship are deferred",
         ));
     }
-    if rel.types.len() != 1 {
+    if rel.types.len() > 1 {
         return Err(LowerError::unsupported(
-            "shortestPath needs exactly one relationship type (`-[:T*]-`); untyped and \
-             alternation forms are deferred",
+            "shortestPath over a type alternation (`-[:A|B*]-`) is deferred; use a single \
+             type or the untyped form",
         ));
     }
 
@@ -147,27 +152,60 @@ fn lower_shortest_path<E: IriEncoder>(
         None => (Some(1), Some(1)),
     };
 
-    let type_iri = ctx.resolve_predicate(&rel.types[0].name)?;
-    match ctx.encoder.encode_iri(&type_iri) {
-        Some(predicate) => out.push(Pattern::ShortestPath(ShortestPathPattern {
-            start: start_ref,
-            end: end_ref,
-            predicate,
-            direction,
-            mode,
-            path_var: path_var_id,
-            min_hops,
-            max_hops,
-            // Conservatively build edges: Cypher's `relationships(p)` may read
-            // them, and that usage isn't visible at pattern-lowering time.
-            needs_relationships: true,
-        })),
-        // Unknown relationship type ⇒ no edges ⇒ no path. An empty result over
-        // the endpoints yields no rows (mandatory MATCH drops; an OPTIONAL
-        // wrapper restores the row with the path var null).
-        None => out.push(empty_path_result(&start_ref, &end_ref)),
-    }
+    // Untyped (`-[*..15]->`) → wildcard edge-set; typed → the named predicate.
+    // An unknown relationship type ⇒ no edges ⇒ no path: an empty result over
+    // the endpoints yields no rows (mandatory MATCH drops; an OPTIONAL wrapper
+    // restores the row with the path var null).
+    let predicate = match rel.types.first() {
+        None => None,
+        Some(t) => {
+            let type_iri = ctx.resolve_predicate(&t.name)?;
+            match ctx.encoder.encode_iri(&type_iri) {
+                Some(sid) => Some(sid),
+                None => {
+                    out.push(empty_path_result(&start_ref, &end_ref));
+                    return Ok(());
+                }
+            }
+        }
+    };
+    out.push(Pattern::ShortestPath(ShortestPathPattern {
+        start: start_ref,
+        end: end_ref,
+        predicate,
+        direction,
+        mode,
+        path_var: path_var_id,
+        min_hops,
+        max_hops,
+        // Conservatively build edges: Cypher's `relationships(p)` may read
+        // them, and that usage isn't visible at pattern-lowering time.
+        needs_relationships: true,
+    }));
     Ok(())
+}
+
+/// Whole-graph node scan for an opted-in bare `MATCH (n)`: an uncorrelated
+/// `SELECT DISTINCT ?n { ?n ?p ?o }` subquery. Nodes are distinct subjects —
+/// an IRI referenced only as an object (never described) is not matched.
+fn all_subjects_scan<E: IriEncoder>(
+    ctx: &mut LoweringContext<'_, E>,
+    node: &NodePattern,
+) -> Pattern {
+    let subj = lookup_node_ref(ctx, node);
+    let n = match &subj {
+        Ref::Var(v) => *v,
+        // `lookup_node_ref` always yields a variable (named or anonymous).
+        _ => unreachable!("node refs are variables"),
+    };
+    let p = ctx.fresh_synth();
+    let o = ctx.fresh_synth();
+    let scan = Pattern::Triple(TriplePattern::new(subj, Ref::Var(p), Term::Var(o)));
+    Pattern::Subquery(
+        fluree_db_query::ir::SubqueryPattern::new(vec![n], vec![scan])
+            .with_distinct()
+            .with_uncorrelated(),
+    )
 }
 
 fn require_node_anchored(node: &NodePattern) -> Result<()> {
@@ -290,7 +328,12 @@ fn build_rel_hop<E: IriEncoder>(
     let pred = match rel.types.len() {
         0 => {
             // Untyped — var predicate; the executor's system-fact filter
-            // (`Query.include_system_facts = false`) hides `f:reifies*`.
+            // (`Query.include_system_facts = false`) hides `f:reifies*`, but
+            // `rdf:type` (labels) and data properties are ordinary facts and
+            // must be excluded too — Cypher `-->` follows only relationships.
+            // The edge-set filter below handles that for the plain-triple
+            // shape; annotation shapes match reified edges only, which are
+            // relationships by construction.
             Ref::Var(ctx.fresh_synth())
         }
         1 => {
@@ -323,6 +366,60 @@ fn build_rel_hop<E: IriEncoder>(
 
     push_rel_triple(ctx, &rel.var, &rel.props, pred, s, o, &mut out)?;
     Ok(out)
+}
+
+/// `MakeRel(start, pred, end)` for a value-only relationship variable, or
+/// `None` when a term isn't expressible as an expression (an IRI-anchored
+/// endpoint, or a typed predicate absent from the dictionary — which has no
+/// edges anyway); callers then keep the annotation lowering.
+fn make_rel_expr<E: IriEncoder>(
+    ctx: &LoweringContext<'_, E>,
+    pred: &Ref,
+    s: &Ref,
+    o: &Ref,
+) -> Option<Expression> {
+    let p = match pred {
+        Ref::Var(v) => Expression::Var(*v),
+        Ref::Sid(sid) => Expression::Const(FlakeValue::Ref(sid.clone())),
+        Ref::Iri(iri) => Expression::Const(FlakeValue::Ref(ctx.encoder.encode_iri(iri)?)),
+    };
+    Some(Expression::call(
+        Function::MakeRel,
+        vec![ref_to_expr(s)?, p, ref_to_expr(o)?],
+    ))
+}
+
+/// The relationship edge-set constraint for an untyped single-hop pattern
+/// (`-->`): the predicate must not be `rdf:type` (a label, not a relationship)
+/// and a variable object must be a node (data properties bind literals).
+/// Matches the edge-set the untyped var-length wildcard path traverses.
+fn untyped_edge_set_filter<E: IriEncoder>(
+    ctx: &LoweringContext<'_, E>,
+    pvar: fluree_db_query::var_registry::VarId,
+    o: &Ref,
+) -> Expression {
+    let not_type = Expression::ne(
+        Expression::Var(pvar),
+        Expression::call(
+            Function::Iri,
+            vec![Expression::Const(FlakeValue::String(
+                ctx.rdf_type_iri().to_string(),
+            ))],
+        ),
+    );
+    match o {
+        Ref::Var(ov) => Expression::binary(
+            Function::And,
+            not_type,
+            Expression::binary(
+                Function::Or,
+                Expression::call(Function::IsIri, vec![Expression::Var(*ov)]),
+                Expression::call(Function::IsBlank, vec![Expression::Var(*ov)]),
+            ),
+        ),
+        // An anchored object is a node by construction.
+        _ => not_type,
+    }
 }
 
 /// Lower a variable-length relationship `-[:T*m..n]->`. Anonymous, single-typed
@@ -810,11 +907,57 @@ fn push_rel_triple<E: IriEncoder>(
     o: Ref,
     out: &mut Vec<Pattern>,
 ) -> Result<()> {
-    let edge_o: Term = o.into();
+    let edge_o: Term = o.clone().into();
+
+    // Value-only bound relationship variable — the statement never reads the
+    // relationship's *properties*, only its value surface (`RETURN e`,
+    // `type(e)`, `startNode(e)`, …). Match the plain base triple so unreified
+    // (plain-RDF) edges count too, and bind the variable per annotation when
+    // the edge is reified (parallel edges stay distinct) or to a synthesized
+    // relationship value when it isn't. Property-reading statements keep the
+    // annotation-only lowering below.
+    if let (Some(v), None) = (rel_var, rel_props) {
+        if !ctx.is_annotation_dependent(&v.name) {
+            if let Some(rel_value) = make_rel_expr(ctx, &pred, &s, &o) {
+                let var = ctx.intern_var(&v.name);
+                out.push(Pattern::Triple(TriplePattern::new(
+                    s.clone(),
+                    pred.clone(),
+                    edge_o.clone(),
+                )));
+                if let Ref::Var(pv) = &pred {
+                    out.push(Pattern::Filter(untyped_edge_set_filter(ctx, *pv, &o)));
+                }
+                // `f:reifies*` absent from the dictionary ⇒ no edge in this
+                // ledger is reified ⇒ skip the per-edge annotation probe.
+                let expr = if ctx
+                    .encoder
+                    .encode_iri(fluree_vocab::reifies_iris::SUBJECT)
+                    .is_some()
+                {
+                    let ann = ctx.fresh_synth();
+                    out.push(Pattern::Optional(vec![Pattern::EdgeAnnotation {
+                        edge: TriplePattern::new(s, pred, edge_o),
+                        annotation: Ref::Var(ann),
+                        body: Vec::new(),
+                    }]));
+                    Expression::call(Function::Coalesce, vec![Expression::Var(ann), rel_value])
+                } else {
+                    rel_value
+                };
+                out.push(Pattern::Bind { var, expr });
+                return Ok(());
+            }
+        }
+    }
+
     match (rel_var, rel_props) {
         (None, None) => {
             // Shape 1 — plain triple, set semantics.
-            out.push(Pattern::Triple(TriplePattern::new(s, pred, edge_o)));
+            out.push(Pattern::Triple(TriplePattern::new(s, pred.clone(), edge_o)));
+            if let Ref::Var(pv) = &pred {
+                out.push(Pattern::Filter(untyped_edge_set_filter(ctx, *pv, &o)));
+            }
             Ok(())
         }
         (Some(v), props) => {

--- a/fluree-db-cypher/src/lower/stmt.rs
+++ b/fluree-db-cypher/src/lower/stmt.rs
@@ -228,6 +228,42 @@ fn lower_single_branch<E: IriEncoder>(
     q: &crate::ast::Query,
     outer_scope: &[VarId],
 ) -> Result<SingleBranch> {
+    // Anonymous-hop chains may fuse to a frontier-BFS path only when walk
+    // multiplicity is unobservable: DISTINCT output, no aggregates anywhere
+    // in the projection or ORDER BY, and no clause that could observe or
+    // aggregate per-walk rows (WITH / CALL). See
+    // `LoweringContext::fuse_reachability_chains`.
+    let saved_fusion = ctx.fuse_reachability_chains;
+    ctx.fuse_reachability_chains = q.return_clause.distinct
+        && !q
+            .return_clause
+            .items
+            .iter()
+            .any(|item| expr_has_aggregate(&item.expr))
+        && !q
+            .return_clause
+            .order_by
+            .iter()
+            .any(|o| expr_has_aggregate(&o.expr))
+        && q.clauses.iter().all(|c| {
+            matches!(
+                c,
+                ReadClause::Match(_)
+                    | ReadClause::OptionalMatch(_)
+                    | ReadClause::Unwind(_)
+                    | ReadClause::InlineRows { .. }
+            )
+        });
+    let result = lower_single_branch_inner(ctx, q, outer_scope);
+    ctx.fuse_reachability_chains = saved_fusion;
+    result
+}
+
+fn lower_single_branch_inner<E: IriEncoder>(
+    ctx: &mut LoweringContext<'_, E>,
+    q: &crate::ast::Query,
+    outer_scope: &[VarId],
+) -> Result<SingleBranch> {
     let mut patterns: Vec<Pattern> = Vec::new();
     // Variables visible from an ENCLOSING scope (a CALL body sees its imports);
     // empty at the top level. A `WITH` narrows scope to its projection, so once

--- a/fluree-db-cypher/src/params.rs
+++ b/fluree-db-cypher/src/params.rs
@@ -50,6 +50,11 @@ impl std::error::Error for ParamError {}
 /// from `params`. No-op when `params` is empty (but still errors if the query
 /// references a `$param` that isn't supplied).
 pub fn substitute_params(ast: &mut CypherAst, params: &ParamMap) -> Result<(), ParamError> {
+    // A constant inline UNWIND source on a write statement (`UNWIND
+    // range(1, 100) AS x`, `UNWIND [1, 2, 3] AS x`) folds into a synthetic
+    // list parameter so the `$param` desugars below apply unchanged.
+    let augmented = inline_constant_unwind(ast, params)?;
+    let params = augmented.as_ref().unwrap_or(params);
     // Compile-time unroll of `UNWIND $list AS row CREATE (...)` (pure node
     // batch) and the VALUES desugaring of `UNWIND $list AS row MATCH … CREATE`
     // (batched edge insert) both run first, so the generic substitution below
@@ -57,6 +62,109 @@ pub fn substitute_params(ast: &mut CypherAst, params: &ParamMap) -> Result<(), P
     expand_unwind_create(ast, params)?;
     expand_unwind_match(ast, params)?;
     subst_statement(&mut ast.statement, params)
+}
+
+/// Upper bound on rows a constant inline `UNWIND` may expand to on the write
+/// path (each row unrolls to its own CREATE / VALUES row).
+const MAX_INLINE_UNWIND_ROWS: usize = 10_000;
+
+/// Rewrite `UNWIND <constant list> AS x` on a *write* statement into
+/// `UNWIND $#__cy_inline_unwind_N AS x` with the value synthesized into a
+/// cloned params map. Supports inline list literals of scalars and `range()`
+/// with integer literal arguments. Read-path UNWIND evaluates natively and is
+/// left alone; non-constant sources fall through to the generic rejection.
+fn inline_constant_unwind(
+    ast: &mut CypherAst,
+    params: &ParamMap,
+) -> Result<Option<ParamMap>, ParamError> {
+    let Statement::Update(u) = &mut ast.statement else {
+        return Ok(None);
+    };
+    let mut augmented: Option<ParamMap> = None;
+    for (i, c) in u.read_clauses.iter_mut().enumerate() {
+        let ReadClause::Unwind(uw) = c else { continue };
+        if matches!(uw.expr, Expr::Param(_)) {
+            continue;
+        }
+        let Some(values) = const_list_value(&uw.expr)? else {
+            continue;
+        };
+        // `#` can't appear in a user Cypher identifier, so this name can't be
+        // referenced from the query text.
+        let name = format!("#__cy_inline_unwind_{i}");
+        augmented
+            .get_or_insert_with(|| params.clone())
+            .insert(name.clone(), JsonValue::Array(values));
+        uw.expr = Expr::Param(crate::ast::ParamRef {
+            name,
+            span: uw.span,
+        });
+    }
+    Ok(augmented)
+}
+
+/// Evaluate a constant list expression to JSON values: a list literal of
+/// scalar literals, or `range(start, end[, step])` over integer literals
+/// (inclusive bounds, Cypher semantics). Returns `None` for anything else.
+fn const_list_value(e: &Expr) -> Result<Option<Vec<JsonValue>>, ParamError> {
+    match e {
+        Expr::List(items, _) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                let Expr::Lit(lit) = item else {
+                    return Ok(None);
+                };
+                out.push(lit_to_json(lit));
+            }
+            Ok(Some(out))
+        }
+        Expr::Call(call) if call.name.eq_ignore_ascii_case("range") => {
+            let ints: Option<Vec<i64>> = call
+                .args
+                .iter()
+                .map(|a| match a {
+                    Expr::Lit(Literal::Integer(n, _)) => Some(*n),
+                    _ => None,
+                })
+                .collect();
+            let (start, end, step) = match ints.as_deref() {
+                Some([s, e]) => (*s, *e, 1i64),
+                Some([s, e, st]) => (*s, *e, *st),
+                _ => return Ok(None),
+            };
+            if step == 0 {
+                return Err(unsupported_param("range", "range() step must be non-zero"));
+            }
+            let mut out = Vec::new();
+            let mut v = start;
+            while (step > 0 && v <= end) || (step < 0 && v >= end) {
+                out.push(JsonValue::from(v));
+                if out.len() > MAX_INLINE_UNWIND_ROWS {
+                    return Err(unsupported_param(
+                        "range",
+                        "inline UNWIND range() on a write is capped at 10000 rows — \
+                         batch via a `$param` list instead",
+                    ));
+                }
+                let Some(next) = v.checked_add(step) else {
+                    break;
+                };
+                v = next;
+            }
+            Ok(Some(out))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn lit_to_json(lit: &Literal) -> JsonValue {
+    match lit {
+        Literal::Integer(n, _) => JsonValue::from(*n),
+        Literal::Float(f, _) => JsonValue::from(*f),
+        Literal::String(s, _) => JsonValue::from(s.as_str()),
+        Literal::Bool(b, _) => JsonValue::from(*b),
+        Literal::Null(_) => JsonValue::Null,
+    }
 }
 
 fn unsupported_param(name: &str, reason: &str) -> ParamError {

--- a/fluree-db-cypher/src/parse/expr.rs
+++ b/fluree-db-cypher/src/parse/expr.rs
@@ -185,7 +185,16 @@ fn parse_unary(s: &mut TokenStream) -> Result<Expr, Diagnostic> {
     let result = if s.eat(&TokenKind::Minus).is_some() {
         parse_unary(s).map(|e| {
             let span = start.union(e.span());
-            Expr::UnaryOp(UnaryOp::Neg, Box::new(e), span)
+            // Fold a negated numeric literal into a literal so `-1` is a
+            // plain constant wherever a literal is required (inline pattern
+            // properties, SET/CREATE values). `- -1` folds twice to `1`.
+            match e {
+                Expr::Lit(Literal::Integer(n, _)) if n.checked_neg().is_some() => {
+                    Expr::Lit(Literal::Integer(-n, span))
+                }
+                Expr::Lit(Literal::Float(f, _)) => Expr::Lit(Literal::Float(-f, span)),
+                other => Expr::UnaryOp(UnaryOp::Neg, Box::new(other), span),
+            }
         })
     } else {
         parse_power(s)

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -1912,6 +1912,52 @@ pub async fn incremental_index(
             std::collections::HashMap::new()
         };
 
+        // Base carry-forward must not depend on the sketch blob alone. When
+        // it is absent or unreadable, the hook would start from zero and the
+        // new root would persist DELTA-ONLY per-graph property stats — base
+        // predicates vanish and net-zero churn shows count 0, compounding on
+        // every subsequent incremental (observed: 4 of 8 predicates left
+        // after one incremental over a sketchless bulk import). Seed
+        // counts/datatypes/last_modified_t from the base root's persisted
+        // per-graph property stats instead. HLL registers cannot be
+        // reconstructed from the persisted ndv ESTIMATES, so remember those
+        // estimates and clamp the finalized ndv below — HLL ndv is monotone
+        // (registers only grow), so the base estimate is a valid floor. The
+        // clamp applies on every incremental (not just the fallback) so ndv
+        // survives register loss in a previously fallback-seeded sketch.
+        let mut prior_properties = prior_properties;
+        let mut base_ndv_floor: std::collections::HashMap<stats::GraphPropertyKey, (u64, u64)> =
+            std::collections::HashMap::new();
+        if let Some(graphs) = base_root.stats.as_ref().and_then(|s| s.graphs.as_ref()) {
+            let seed_from_base_stats = prior_properties.is_empty();
+            for g in graphs {
+                for prop in &g.properties {
+                    let key = stats::GraphPropertyKey {
+                        g_id: g.g_id,
+                        p_id: prop.p_id,
+                    };
+                    base_ndv_floor.insert(key.clone(), (prop.ndv_values, prop.ndv_subjects));
+                    if seed_from_base_stats {
+                        let datatypes = prop
+                            .datatypes
+                            .iter()
+                            .map(|&(tag, c)| (tag, c as i64))
+                            .collect();
+                        prior_properties.insert(
+                            key,
+                            stats::IdPropertyHll::from_sketches(
+                                prop.count as i64,
+                                crate::hll::HllSketch256::new(),
+                                crate::hll::HllSketch256::new(),
+                                prop.last_modified_t,
+                                datatypes,
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+
         // Seed hook with prior properties.
         let rdf_type_p_id = novelty
             .shared
@@ -2001,6 +2047,21 @@ pub async fn incremental_index(
             // 5. Build ClassStatEntry with datatypes, langs, ref-class edges
             // 6. Apply count deltas to base entries, add new entries
             let mut final_graphs = id_stats_result.graphs;
+
+            // ndv floor from the base root (see the seeding block above).
+            if !base_ndv_floor.is_empty() {
+                for g in &mut final_graphs {
+                    for prop in &mut g.properties {
+                        if let Some(&(nv, ns)) = base_ndv_floor.get(&stats::GraphPropertyKey {
+                            g_id: g.g_id,
+                            p_id: prop.p_id,
+                        }) {
+                            prop.ndv_values = prop.ndv_values.max(nv);
+                            prop.ndv_subjects = prop.ndv_subjects.max(ns);
+                        }
+                    }
+                }
+            }
 
             let has_class_changes =
                 !class_count_deltas.is_empty() || !novelty_subject_class_deltas.is_empty();

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -287,6 +287,65 @@ impl EncodedPreFilter {
     }
 }
 
+/// Whether every row of `p_id` in graph `g_id` — persisted and overlay —
+/// provably carries object type `ot16`.
+///
+/// Base side: every non-empty leaflet in the predicate's POST range must be
+/// `o_type_const == ot16` (directory-only reads, cached). Overlay side: when
+/// live novelty exists, every translated overlay op for the predicate must
+/// carry `ot16`; an untranslatable overlay declines. Used to prove that an
+/// equality value seek cannot miss a differently-typed representation of the
+/// same number.
+fn predicate_otype_uniform(
+    ctx: &ExecutionContext<'_>,
+    store: &BinaryIndexStore,
+    g_id: GraphId,
+    p_id: u32,
+    ot16: u16,
+) -> Result<bool> {
+    for leaf_entry in crate::fast_path_common::leaf_entries_for_predicate(
+        store,
+        g_id,
+        fluree_db_binary_index::format::run_record::RunSortOrder::Post,
+        p_id,
+    ) {
+        let dir = store
+            .open_leaf_dir(&leaf_entry.leaf_cid)
+            .map_err(|e| QueryError::Internal(format!("leaf dir open: {e}")))?;
+        for entry in &dir.entries {
+            if entry.row_count == 0 || entry.p_const != Some(p_id) {
+                continue;
+            }
+            if entry.o_type_const != Some(ot16) {
+                return Ok(false);
+            }
+        }
+    }
+    if crate::fast_path_common::overlay_has_novelty(ctx) {
+        let Some(pred_sid) = store.predicate_sid(p_id) else {
+            return Ok(false);
+        };
+        // Requires an Arc'd store for the shared ops cache.
+        let Some(store_arc) = ctx.binary_store.as_ref() else {
+            return Ok(false);
+        };
+        let Some(ops) = crate::fast_path_common::cached_overlay_ops(
+            ctx,
+            store_arc,
+            g_id,
+            fluree_db_binary_index::format::run_record::RunSortOrder::Post,
+            &pred_sid,
+        )?
+        else {
+            return Ok(false);
+        };
+        if ops.iter().any(|op| op.o_type != ot16) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 pub(crate) fn compile_encoded_pre_filters_and_prune_inline_ops(
     inline_ops: &[InlineOperator],
     pattern: &TriplePattern,
@@ -1988,6 +2047,37 @@ impl Operator for BinaryScanOperator {
                     range_o_type = Some(o_type);
                     // Also set the filter o_type so directory-level pre-skip can eliminate non-matching leaflets.
                     filter.o_type = Some(o_type);
+                }
+
+                // Integer EQUALITY bounds (`FILTER(?v = 4112)`, the id-lookup
+                // shape) narrow to a point seek. Cross-type numeric equality
+                // is the hazard (an `xsd:double 4112.0` row matches the
+                // decoded filter but lives in a different POST region), so
+                // the seek only engages when every persisted leaflet AND
+                // every overlay op for this predicate carries the candidate
+                // o_type — then no other representation can exist and the
+                // point range is exact. Mixed or unverifiable predicates keep
+                // the broad scan + decoded filter. Under live novelty this is
+                // what keeps a specific-value lookup at seek speed instead of
+                // a full predicate scan (BUG-1b).
+                if range_min_okey.is_none() && range_max_okey.is_none() {
+                    if let (Some((lo, true)), Some((hi, true))) =
+                        (bounds.lower.as_ref(), bounds.upper.as_ref())
+                    {
+                        if lo == hi && matches!(lo, FlakeValue::Long(_)) {
+                            if let (Ok((ot, key)), Some(p_id)) =
+                                (value_to_otype_okey_simple(lo, store_ref), filter.p_id)
+                            {
+                                let ot16 = ot.as_u16();
+                                if predicate_otype_uniform(ctx, store_ref, self.g_id, p_id, ot16)? {
+                                    range_o_type = Some(ot16);
+                                    range_min_okey = Some(key);
+                                    range_max_okey = Some(key);
+                                    filter.o_type = Some(ot16);
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/fluree-db-query/src/context.rs
+++ b/fluree-db-query/src/context.rs
@@ -1140,7 +1140,7 @@ impl<'a> ExecutionContext<'a> {
     ///
     /// Cost: one `TypeId` comparison. Returns `None` when no range provider is
     /// attached (e.g. genesis / metadata-only snapshot).
-    fn extract_binary_store(snapshot: &LedgerSnapshot) -> Option<Arc<BinaryIndexStore>> {
+    pub(crate) fn extract_binary_store(snapshot: &LedgerSnapshot) -> Option<Arc<BinaryIndexStore>> {
         snapshot
             .range_provider
             .as_ref()

--- a/fluree-db-query/src/eval/list.rs
+++ b/fluree-db-query/src/eval/list.rs
@@ -190,6 +190,21 @@ pub fn eval_list_fn_to_binding<R: RowAccess>(
     ctx: Option<&ExecutionContext<'_>>,
 ) -> Result<Option<Binding>> {
     match func {
+        // COALESCE in binding position must preserve structured values
+        // (List / Map / Rel / Path) — the scalar path would collapse them to
+        // Unbound. Same rule as the spec's comparable-path coalesce: first
+        // argument that evaluates without error and is bound wins.
+        Function::Coalesce => {
+            for arg in args {
+                match arg.try_eval_to_binding(row, ctx) {
+                    Ok(Binding::Unbound | Binding::Poisoned) => continue,
+                    Ok(b) => return Ok(Some(b)),
+                    Err(err) if err.can_demote_in_expression() => continue,
+                    Err(err) => return Err(err),
+                }
+            }
+            Ok(Some(Binding::Unbound))
+        }
         Function::ListIndex => Ok(Some(eval_list_index_to_binding(args, row, ctx)?)),
         Function::Labels => Ok(Some(metadata::eval_labels_to_binding(args, row, ctx)?)),
         Function::Keys => Ok(Some(metadata::eval_keys_to_binding(args, row, ctx)?)),

--- a/fluree-db-query/src/eval/metadata.rs
+++ b/fluree-db-query/src/eval/metadata.rs
@@ -376,11 +376,17 @@ fn rdf_type_sid(ctx: &ExecutionContext<'_>) -> Sid {
         .unwrap_or_else(|| Sid::new(3, "type"))
 }
 
-/// Build the `labels(node)` list binding from resolved class SIDs.
+/// Build the `labels(node)` list binding from resolved class SIDs. The
+/// `db:Node` existence marker (asserted for Cypher `CREATE ()` nodes) is a
+/// system class, not a user label, and is hidden.
 fn labels_binding(class_sids: Vec<Sid>, ctx: &ExecutionContext<'_>) -> Result<Binding> {
     let dt = xsd_string_sid(ctx);
+    let node_marker = ctx.active_snapshot.encode_iri(fluree_vocab::fluree::NODE);
     let mut labels = Vec::with_capacity(class_sids.len());
     for class_sid in class_sids {
+        if node_marker.as_ref() == Some(&class_sid) {
+            continue;
+        }
         if let Some(name) = cypher_name_from_sid(&class_sid, ctx)? {
             labels.push(string_binding(name, &dt));
         }

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -36,6 +36,9 @@ use crate::fast_string_prefix_count_all::{
 };
 use crate::fast_sum_strlen_group_concat::sum_strlen_group_concat_operator;
 use crate::fast_union_star_count_all::{UnionCountMode, UnionStarCountAllOperator};
+use crate::fast_whole_graph_agg::{
+    detect_whole_graph_scalar_aggs, whole_graph_scalar_aggs_operator,
+};
 use crate::group_aggregate::{GroupAggregateOperator, StreamingAggSpec};
 use crate::groupby::GroupByOperator;
 use crate::having::HavingOperator;
@@ -2309,6 +2312,20 @@ fn build_operator_tree_inner(
                 pred,
                 mode,
                 out_var,
+                Some(fallback),
+            )));
+        }
+    }
+
+    // Fast-path: whole-graph scalar aggregates over a distinct-subject
+    // subquery, the Cypher `MATCH (n) RETURN count(n), count(n.age), …`
+    // lowering. Multi-aggregate: each output column folds from index
+    // directories / a predicate-scoped scan. See `fast_whole_graph_agg`.
+    if enable_fused_fast_paths {
+        if let Some(plan) = detect_whole_graph_scalar_aggs(query) {
+            let fallback = build_operator_tree_inner(query, stats.clone(), false, planning)?;
+            return Ok(Box::new(whole_graph_scalar_aggs_operator(
+                plan,
                 Some(fallback),
             )));
         }

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2185,6 +2185,26 @@ pub fn build_operator_tree(
     stats: Option<Arc<StatsView>>,
     planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
+    // Convert single-triple OPTIONALs whose fresh var is error-rejected by a
+    // same-group filter into required triples (well-formed left-join
+    // simplification), so equality/range pushdown and selectivity estimation
+    // see them. Canonical source: Cypher property accessors under a WHERE
+    // (`MATCH (n:User) WITH n WHERE n.id = $id` — a label scan without this).
+    // Runs first so the later folds and the planner operate on the
+    // simplified shape.
+    if crate::optional_filter_fold::has_optional_filter_candidate(query) {
+        let mut simplified = query.clone();
+        crate::optional_filter_fold::fold_optional_filters(&mut simplified);
+        return build_operator_tree_folds(&simplified, stats, planning);
+    }
+    build_operator_tree_folds(query, stats, planning)
+}
+
+fn build_operator_tree_folds(
+    query: &Query,
+    stats: Option<Arc<StatsView>>,
+    planning: &PlanningContext,
+) -> Result<BoxedOperator> {
     // Fold `FILTER(?x = ?y)` equijoins into variable unification before planning,
     // so the rewrite feeds the stats-driven reorder, count planner, and index
     // fast paths (rather than running as a cross-product + filter). Only clone

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1945,17 +1945,45 @@ pub fn build_where_operators_seeded_with_needed(
                         let mut best_idx: Option<usize> = None;
                         let mut best_est: f64 = f64::INFINITY;
                         for (idx, tp) in triples_for_exec.iter().enumerate().skip(1) {
-                            let has_bounds =
-                                tp.o.as_var()
-                                    .is_some_and(|v| pushdown.object_bounds.contains_key(&v));
-                            if !has_bounds {
+                            let bounds = tp.o.as_var().and_then(|v| pushdown.object_bounds.get(&v));
+                            let Some(bounds) = bounds else {
                                 continue;
-                            }
-                            let est = crate::planner::estimate_triple_row_count(
-                                tp,
-                                &bound_vars,
-                                stats_ref,
-                            );
+                            };
+                            // An EQUALITY bound pins the object to one value, so
+                            // the triple's effective cardinality is the per-value
+                            // row count (count/ndv) — the same estimate a
+                            // bound-object pattern gets — not the full property
+                            // scan the bare triple estimate assumes. Without
+                            // this, a handful of novelty rows on the bounded
+                            // predicate nudge its scan estimate past the class
+                            // anchor's and flip a point lookup (`WHERE n.id =
+                            // $id`) into a full-class probe join.
+                            let equality_value = match (&bounds.lower, &bounds.upper) {
+                                (Some((lo, true)), Some((hi, true))) if lo == hi => {
+                                    Some(lo.clone())
+                                }
+                                _ => None,
+                            };
+                            let est = match equality_value {
+                                Some(v) => {
+                                    let bound_tp = TriplePattern {
+                                        s: tp.s.clone(),
+                                        p: tp.p.clone(),
+                                        o: Term::Value(v),
+                                        dtc: tp.dtc.clone(),
+                                    };
+                                    crate::planner::estimate_triple_row_count(
+                                        &bound_tp,
+                                        &bound_vars,
+                                        stats_ref,
+                                    )
+                                }
+                                None => crate::planner::estimate_triple_row_count(
+                                    tp,
+                                    &bound_vars,
+                                    stats_ref,
+                                ),
+                            };
                             if est < best_est {
                                 best_est = est;
                                 best_idx = Some(idx);

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -28,7 +28,7 @@ use fluree_db_binary_index::BinaryIndexStore;
 use fluree_db_core::o_type::OType;
 use fluree_db_core::subject_id::SubjectId;
 use fluree_db_core::value_id::{ObjKey, ValueTypeTag};
-use fluree_db_core::{FlakeValue, GraphId, OverlayProvider};
+use fluree_db_core::{FlakeValue, GraphId};
 use fluree_vocab::namespaces;
 use std::sync::Arc;
 
@@ -68,7 +68,7 @@ pub fn count_rows_operator(
 
             // Lane 1 — metadata-only predicate row count (instant) when there is
             // no novelty overlay and the target is the indexed head.
-            let overlay_free = ctx.overlay.map(OverlayProvider::epoch).unwrap_or(0) == 0;
+            let overlay_free = !crate::fast_path_common::overlay_has_novelty(ctx);
             if overlay_free && ctx.to_t == store.max_t() {
                 let count = count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)?;
                 return Ok(Some(build_count_batch(

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -6,7 +6,6 @@
 //! operator tree for correctness.
 
 use crate::binary_scan::{compile_encoded_pre_filters_and_prune_inline_ops, EncodedPreFilter};
-use crate::context::ExecutionContext;
 use crate::error::{QueryError, Result};
 use crate::fast_path_common::{
     build_count_batch, count_predicate_overlay_delta, count_rows_for_predicate_psot, count_to_i64,
@@ -1072,6 +1071,15 @@ pub fn count_distinct_position_operator(
             let Some(store) = fast_path_store(ctx) else {
                 return Ok(None);
             };
+            // The variable-predicate scan hides `f:reifies*` (and default-graph
+            // `f:`) facts, but the SPOT/PSOT/OPST directories these folds read
+            // include them — a graph with a reified edge would over-count in
+            // every position (its reifier subject, the reifies predicates, and
+            // the annotation objects are all pipeline-invisible). Decline to
+            // the general pipeline when any such predicate exists.
+            if crate::fast_whole_graph_agg::graph_has_scan_hidden_predicates(ctx, store)? {
+                return Ok(None);
+            }
             let (count, overflow_label) = match position {
                 // SPOT key layout: s_id(8) + p_id(4) + o_type(2) + o_key(8) + o_i(4).
                 // Distinct subjects = lead bytes [0..8].
@@ -1080,14 +1088,15 @@ pub fn count_distinct_position_operator(
                     "COUNT(DISTINCT) subjects",
                 ),
                 DistinctPosition::Predicates => (
-                    // Prefer the in-memory per-graph stats (number of predicates
-                    // with a positive current count) — O(#predicates), no leaf
-                    // opens. Falls back to the PSOT `p_const` scan when the graph
-                    // stats are unavailable.
-                    match distinct_predicates_from_graph_stats(ctx) {
-                        Some(c) => c,
-                        None => count_distinct_predicates_psot(store, ctx.binary_g_id)?,
-                    },
+                    // Always the PSOT `p_const` directory scan — exact from
+                    // leaflet metadata. A per-graph-stats shortcut used to
+                    // answer this in-memory, but the incremental index build
+                    // persists delta-only per-graph property stats (base
+                    // entries lost, net-zero deltas kept at count 0), which
+                    // made the shortcut return wrong counts after any
+                    // incremental index. Reinstate only after the incremental
+                    // stats merge is fixed AND covered by a regression test.
+                    count_distinct_predicates_psot(store, ctx.binary_g_id)?,
                     "COUNT(DISTINCT) predicates",
                 ),
                 // OPST key layout: o_type(2) + o_key(8) + o_i(4) + p_id(4) + s_id(8).
@@ -1103,21 +1112,6 @@ pub fn count_distinct_position_operator(
         fallback,
         label,
     )
-}
-
-/// Current-state distinct-predicate count from the per-graph index stats: the
-/// number of properties with a positive current flake count.
-///
-/// `GraphPropertyStatEntry.count` is "after dedup; retractions decrement", so a
-/// predicate has a current PSOT leaflet iff its count is `> 0` — this matches
-/// `count_distinct_predicates_psot` exactly but reads the in-memory stats instead
-/// of opening every leaf. Returns `None` when the graph stats are unavailable
-/// (older index / not computed). Only correct at HEAD with no overlay; the caller
-/// gates that via `fast_path_store`.
-fn distinct_predicates_from_graph_stats(ctx: &ExecutionContext<'_>) -> Option<u64> {
-    let graphs = ctx.active_snapshot.stats.as_ref()?.graphs.as_ref()?;
-    let g = graphs.iter().find(|g| g.g_id == ctx.binary_g_id)?;
-    Some(g.properties.iter().filter(|p| p.count > 0).count() as u64)
 }
 
 /// Per-chunk partial for the distinct-lead count: groups counted within the

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -1142,7 +1142,7 @@ struct LeadGroupPartial {
 /// `lead_len` is the number of leading key bytes that define the grouping:
 /// - SPOT distinct subjects: 8 bytes (s_id)
 /// - OPST distinct objects: 10 bytes (o_type + o_key)
-fn count_distinct_lead_groups(
+pub(crate) fn count_distinct_lead_groups(
     store: &BinaryIndexStore,
     g_id: GraphId,
     order: RunSortOrder,

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -823,7 +823,7 @@ fn offer_topk(heap: &mut BinaryHeap<GroupTopK>, limit: usize, cand: GroupTopK) {
     }
 }
 
-fn group_count_v6(
+pub(crate) fn group_count_v6(
     store: &BinaryIndexStore,
     g_id: GraphId,
     predicate: &crate::ir::triple::Ref,

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -192,12 +192,7 @@ impl Operator for PredicateGroupCountFirstsOperator {
         // Try V6 fast-path first (only when no novelty overlay — overlay delta merge not yet implemented).
         //
         // `ExecutionContext` always carries an overlay provider; `NoOverlay` has epoch=0.
-        if ctx
-            .overlay
-            .map(fluree_db_core::OverlayProvider::epoch)
-            .unwrap_or(0)
-            == 0
-        {
+        if !crate::fast_path_common::overlay_has_novelty(ctx) {
             if let Some(binary_index_store) = ctx.binary_store.as_ref() {
                 match group_count_v6(
                     binary_index_store,
@@ -438,12 +433,7 @@ impl Operator for PredicateObjectCountFirstsOperator {
         // Try V6 fast-path first (only when no novelty overlay — overlay delta merge not yet implemented).
         //
         // `ExecutionContext` always carries an overlay provider; `NoOverlay` has epoch=0.
-        if ctx
-            .overlay
-            .map(fluree_db_core::OverlayProvider::epoch)
-            .unwrap_or(0)
-            == 0
-        {
+        if !crate::fast_path_common::overlay_has_novelty(ctx) {
             if let Some(binary_index_store) = ctx.binary_store.as_ref() {
                 match count_bound_object_v6(
                     ctx.active_snapshot,

--- a/fluree-db-query/src/fast_min_max_string.rs
+++ b/fluree-db-query/src/fast_min_max_string.rs
@@ -162,7 +162,7 @@ fn encoded_lit_from_otype(
 /// candidate, so no per-region bookkeeping is needed.
 ///
 /// Returns `None` when any object is not string-dict-backed.
-fn minmax_string_dict_post(
+pub(crate) fn minmax_string_dict_post(
     store: &BinaryIndexStore,
     g_id: GraphId,
     p_id: u32,
@@ -255,7 +255,7 @@ fn consider_string_candidate(
     true
 }
 
-fn minmax_numeric_post(
+pub(crate) fn minmax_numeric_post(
     store: &BinaryIndexStore,
     g_id: GraphId,
     p_id: u32,

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -2662,7 +2662,7 @@ pub fn build_overlay_cursor_for_predicate(
     // the returned batch — the output shape the count operators see is
     // unchanged. (Production masks this via the cache's `all()` load; a
     // cache-less store would miscount. See `BinaryCursor::set_overlay_ops`.)
-    let overlay_active = ctx.overlay.is_some() && ctx.overlay().epoch() != 0;
+    let overlay_active = overlay_has_novelty(ctx);
     let projection = if overlay_active {
         let identity = ColumnSet::CORE.union(ColumnSet::single(ColumnId::OI));
         ColumnProjection {
@@ -2690,7 +2690,7 @@ pub fn build_overlay_cursor_for_predicate(
     // novelty (epoch 0): the persisted index alone is then exact. Ops come
     // from the per-execution cache, so N cursors over the same predicate
     // (flushes, partitions, cyclic edges) share one walk + translation.
-    if ctx.overlay.is_some() && ctx.overlay().epoch() != 0 {
+    if overlay_has_novelty(ctx) {
         match cached_overlay_ops(ctx, store, g_id, order, &pred_sid)? {
             Some(ops) => {
                 if !ops.is_empty() {
@@ -3456,13 +3456,25 @@ fn allow_fast_path(ctx: &ExecutionContext<'_>) -> bool {
 /// unfiltered).
 #[inline]
 fn fast_path_eligible_no_policy(ctx: &ExecutionContext<'_>) -> bool {
-    !ctx.is_multi_ledger()
-        && ctx.from_t.is_none()
-        && ctx
-            .overlay
-            .map(fluree_db_core::OverlayProvider::epoch)
-            .unwrap_or(0)
-            == 0
+    !ctx.is_multi_ledger() && ctx.from_t.is_none() && !overlay_has_novelty(ctx)
+}
+
+/// True when the overlay can still contribute flakes.
+///
+/// `epoch()` is a monotonic mutation counter that never resets, so
+/// `epoch() == 0` means "never had novelty since this overlay was created" —
+/// it stays non-zero forever on a long-lived cached ledger even after an
+/// index swap drains every segment. Gating on it alone permanently disables
+/// the metadata fast paths on any server that has processed a write
+/// (measured: whole-graph aggregates stuck at ~190ms after the background
+/// indexer caught up, until restart). `is_effectively_empty()` exists for
+/// exactly this distinction; keep `epoch()` itself for cache keys only.
+#[inline]
+pub fn overlay_has_novelty(ctx: &ExecutionContext<'_>) -> bool {
+    match &ctx.overlay {
+        Some(o) => o.epoch() != 0 && !o.is_effectively_empty(),
+        None => false,
+    }
 }
 
 /// Combined fast-path eligibility: [`allow_fast_path`] + binary store present + `to_t == max_t`.

--- a/fluree-db-query/src/fast_predicate_scalar_agg.rs
+++ b/fluree-db-query/src/fast_predicate_scalar_agg.rs
@@ -171,11 +171,7 @@ pub fn predicate_scalar_agg_operator(
             // constant-folding / directory shortcuts). An uncommitted overlay or
             // `to_t < max_t` would make that scan stale, so fold the same
             // aggregate over a POST overlay cursor instead.
-            let has_overlay = ctx
-                .overlay
-                .map(fluree_db_core::OverlayProvider::epoch)
-                .unwrap_or(0)
-                != 0;
+            let has_overlay = crate::fast_path_common::overlay_has_novelty(ctx);
             let result = if !has_overlay && ctx.to_t == store.max_t() {
                 scan_predicate_scalar_agg(store, ctx.binary_g_id, &predicate, kind)?
             } else {
@@ -492,11 +488,7 @@ fn scan_predicate_scalar_agg_overlay(
         // Predicate absent from the persisted dictionary. With novelty present it
         // may exist only in the overlay (no `p_id` to range-bound a cursor), so
         // fall back to the planned pipeline; otherwise the input is genuinely empty.
-        let overlay_has_rows = ctx
-            .overlay
-            .map(fluree_db_core::OverlayProvider::epoch)
-            .unwrap_or(0)
-            != 0;
+        let overlay_has_rows = crate::fast_path_common::overlay_has_novelty(ctx);
         return if overlay_has_rows {
             Ok(None)
         } else {

--- a/fluree-db-query/src/fast_predicate_scalar_agg.rs
+++ b/fluree-db-query/src/fast_predicate_scalar_agg.rs
@@ -192,7 +192,7 @@ pub fn predicate_scalar_agg_operator(
 }
 
 /// The folded result of a scalar aggregate, before batch construction.
-enum AggOutput {
+pub(crate) enum AggOutput {
     /// `xsd:integer` value (SUM, COUNT-DISTINCT, and the empty-group identity 0
     /// for AVG).
     Integer(i64),
@@ -201,6 +201,14 @@ enum AggOutput {
 }
 
 impl AggOutput {
+    /// The result as a bare binding (for folds that assemble multi-column rows).
+    pub(crate) fn into_binding(self) -> Binding {
+        match self {
+            AggOutput::Integer(v) => Binding::lit(FlakeValue::Long(v), Sid::xsd_integer()),
+            AggOutput::Binding(b) => b,
+        }
+    }
+
     fn into_batch(self, out_var: VarId) -> Result<Batch> {
         match self {
             AggOutput::Integer(v) => build_i64_singleton_batch(out_var, v, "scalar-agg"),
@@ -352,7 +360,7 @@ fn empty_result(kind: ScalarAggKind) -> AggOutput {
 /// Shared POST-leaflet scan driver. Returns `Ok(None)` when a variant hits a
 /// runtime-unsupported leaflet (mixed/non-matching datatypes) and the caller
 /// must fall back to the planned pipeline.
-fn scan_predicate_scalar_agg(
+pub(crate) fn scan_predicate_scalar_agg(
     store: &BinaryIndexStore,
     g_id: GraphId,
     predicate: &Ref,

--- a/fluree-db-query/src/fast_whole_graph_agg.rs
+++ b/fluree-db-query/src/fast_whole_graph_agg.rs
@@ -32,11 +32,28 @@
 //! (`#P1(n) × #P2(n)`), which changes duplicate-sensitive aggregates — the
 //! detector only admits the single-accessor shape.
 //!
+//! The class-anchored family generalizes the same folds to
+//! `MATCH (n:C) RETURN …` (anchor = `?n rdf:type <C>`): the subject universe
+//! becomes the class's instance count from the per-graph class stats, and
+//! property-derived folds additionally require the **containment proof**
+//! `class_property_flakes(C, P) == predicate_rows(P)` — equality means every
+//! `P`-bearing subject is a `C`, so predicate-scoped folds equal the
+//! class-restricted join. Both sides are current-state-exact at HEAD (class
+//! stats per issue #1266; rows from PSOT directories).
+//!
+//! Beyond the single-row scalar shape, `GROUP BY ?prop` + `COUNT(*)` (the
+//! Cypher histogram `RETURN n.age, COUNT(*)`) folds to a predicate-scoped
+//! POST run-length group count (values are physically contiguous in POST)
+//! plus one null-group row (`subjects − subj(P)` — the left join gives
+//! property-less subjects a single unbound-key row).
+//!
 //! The fold requires the strict metadata-lane gate ([`fast_path_store`]:
-//! single-ledger, root/no policy, no overlay, at HEAD) and declines when the
-//! graph carries predicates the variable-predicate scan hides (`f:reifies*`
-//! anywhere, the `f:` namespace in the default graph) — those facts are
-//! invisible to `?n ?p ?o` but not to the SPOT directories this fold reads.
+//! single-ledger, root/no policy, no overlay, at HEAD). The whole-graph
+//! anchor additionally declines when the graph carries predicates the
+//! variable-predicate scan hides (`f:reifies*` anywhere, the `f:` namespace
+//! in the default graph) — those facts are invisible to `?n ?p ?o` but not
+//! to the SPOT directories; a class anchor reads only class stats, so it is
+//! immune.
 
 use crate::binding::{Batch, Binding};
 use crate::error::{QueryError, Result};
@@ -52,6 +69,7 @@ use crate::fast_path_common::{
 use crate::fast_predicate_scalar_agg::{scan_predicate_scalar_agg, ScalarAggKind, SumExprI64};
 use crate::ir::grouping::{AggregateFn, Aggregation, Grouping, InputSemantics};
 use crate::ir::triple::{Ref, Term};
+use crate::ir::Expression;
 use crate::ir::{Pattern, Query};
 use crate::operator::BoxedOperator;
 use crate::var_registry::VarId;
@@ -83,28 +101,37 @@ impl AggTask {
     }
 }
 
-/// Detected plan: the accessor predicate (if any) and one task per projected
-/// output column, in projection order.
+/// The subject universe the aggregates range over.
+enum Anchor {
+    /// Bare `MATCH (n)`: the DISTINCT-subject subquery over `?n ?p ?o`.
+    AllSubjects,
+    /// `MATCH (n:C)`: `?n rdf:type <C>` with a concrete class SID.
+    Class(Sid),
+}
+
+/// What the fold produces.
+enum FoldKind {
+    /// One row of scalar aggregates (implicit grouping), one task per
+    /// projected column in projection order.
+    Scalars(Vec<AggTask>),
+    /// `GROUP BY ?prop` + `COUNT(*)`: one row per distinct property value
+    /// plus a null group. Column positions index into `schema`.
+    Histogram { prop_col: usize, count_col: usize },
+}
+
+/// Detected plan: anchor, accessor predicate (if any), fold kind, and the
+/// output schema in projection order.
 pub(crate) struct WholeGraphAggPlan {
+    anchor: Anchor,
     accessor: Option<Ref>,
-    tasks: Vec<AggTask>,
+    kind: FoldKind,
     schema: Vec<VarId>,
 }
 
-/// Recognize the whole-graph scalar-aggregate shape. See the module docs for
-/// the exact pattern and per-aggregate soundness arguments.
+/// Recognize the whole-graph / class-anchored aggregate shapes. See the
+/// module docs for the exact patterns and per-aggregate soundness arguments.
 pub(crate) fn detect_whole_graph_scalar_aggs(query: &Query) -> Option<WholeGraphAggPlan> {
-    // Single implicit group, aggregates only — no HAVING, post-binds,
-    // ordering, offset, DISTINCT output, or LIMIT 0.
-    let Some(Grouping::Implicit {
-        aggregation: Aggregation { aggregates, binds },
-        having: None,
-    }) = &query.grouping
-    else {
-        return None;
-    };
-    if !binds.is_empty()
-        || !query.ordering.is_empty()
+    if !query.ordering.is_empty()
         || !query.order_binds.is_empty()
         || query.offset.is_some()
         || query.output.is_distinct()
@@ -114,50 +141,114 @@ pub(crate) fn detect_whole_graph_scalar_aggs(query: &Query) -> Option<WholeGraph
         return None;
     }
 
-    // Pattern shape: the DISTINCT-subject subquery, then at most one
-    // single-triple property-accessor OPTIONAL.
+    // Anchor: DISTINCT-subject subquery, or a single class triple.
     let (first, rest) = query.patterns.split_first()?;
-    let Pattern::Subquery(sq) = first else {
-        return None;
+    let (anchor, subject_var) = match first {
+        Pattern::Subquery(sq) => (Anchor::AllSubjects, distinct_subject_scan_var(sq)?),
+        Pattern::Triple(tp) => {
+            if !tp.p.is_rdf_type() || tp.dtc.is_some() {
+                return None;
+            }
+            let sv = tp.s.as_var()?;
+            let Term::Sid(class_sid) = &tp.o else {
+                return None;
+            };
+            (Anchor::Class(class_sid.clone()), sv)
+        }
+        _ => return None,
     };
-    let subject_var = distinct_subject_scan_var(sq)?;
 
-    let accessor = match rest {
-        [] => None,
-        [Pattern::Optional(inner)] => {
-            let [Pattern::Triple(tp)] = inner.as_slice() else {
-                return None;
-            };
-            if tp.s.as_var() != Some(subject_var) || !tp.p_bound() || tp.dtc.is_some() {
+    // At most one single-triple property-accessor OPTIONAL, optionally
+    // followed by an identity Bind aliasing the accessor var into the
+    // projected column (`RETURN n.age, COUNT(*)` emits `?alias = ?prop`).
+    let parse_accessor = |inner: &[Pattern]| -> Option<(Ref, VarId)> {
+        let [Pattern::Triple(tp)] = inner else {
+            return None;
+        };
+        if tp.s.as_var() != Some(subject_var) || !tp.p_bound() || tp.dtc.is_some() {
+            return None;
+        }
+        let Term::Var(prop_var) = tp.o else {
+            return None;
+        };
+        if prop_var == subject_var {
+            return None;
+        }
+        Some((tp.p.clone(), prop_var))
+    };
+    let (accessor, prop_alias) = match rest {
+        [] => (None, None),
+        [Pattern::Optional(inner)] => (Some(parse_accessor(inner)?), None),
+        [Pattern::Optional(inner), Pattern::Bind { var, expr }] => {
+            let acc = parse_accessor(inner)?;
+            if *expr != Expression::Var(acc.1) || *var == acc.1 || *var == subject_var {
                 return None;
             }
-            let Term::Var(prop_var) = tp.o else {
-                return None;
-            };
-            if prop_var == subject_var {
-                return None;
-            }
-            Some((tp.p.clone(), prop_var))
+            (Some(acc), Some(*var))
         }
         _ => return None,
     };
     let prop_var = accessor.as_ref().map(|(_, v)| *v);
-
-    // Every aggregate must fold, and the projection must be exactly the
-    // aggregate outputs.
     let select_vars = query.output.projected_vars()?;
-    if select_vars.len() != aggregates.len() {
-        return None;
-    }
-    let mut tasks = Vec::with_capacity(select_vars.len());
-    for out in &select_vars {
-        let spec = aggregates.iter().find(|a| a.output_var == *out)?;
-        tasks.push(classify_aggregate(&spec.function, subject_var, prop_var)?);
-    }
+
+    let kind = match &query.grouping {
+        // Scalars: single implicit group, aggregates only.
+        Some(Grouping::Implicit {
+            aggregation: Aggregation { aggregates, binds },
+            having: None,
+        }) => {
+            if !binds.is_empty() || select_vars.len() != aggregates.len() {
+                return None;
+            }
+            let mut tasks = Vec::with_capacity(select_vars.len());
+            for out in &select_vars {
+                let spec = aggregates.iter().find(|a| a.output_var == *out)?;
+                tasks.push(classify_aggregate(&spec.function, subject_var, prop_var)?);
+            }
+            FoldKind::Scalars(tasks)
+        }
+        // Histogram: GROUP BY the accessor value, one COUNT(*) / COUNT(?n).
+        Some(Grouping::Explicit {
+            group_by,
+            aggregation: Some(Aggregation { aggregates, binds }),
+            having: None,
+        }) => {
+            let prop_var = prop_var?;
+            // The group key is the accessor var or its projection alias
+            // (identity bind — identical value per row).
+            let key = *group_by.first();
+            if group_by.len() != 1 || (key != prop_var && Some(key) != prop_alias) {
+                return None;
+            }
+            if aggregates.len() != 1 || !binds.is_empty() {
+                return None;
+            }
+            let agg = aggregates.first();
+            match &agg.function {
+                AggregateFn::CountAll => {}
+                AggregateFn::Count(v) if *v == subject_var => {}
+                _ => return None,
+            }
+            if select_vars.len() != 2 {
+                return None;
+            }
+            let prop_col = select_vars.iter().position(|v| *v == key)?;
+            let count_col = select_vars.iter().position(|v| *v == agg.output_var)?;
+            if prop_col == count_col {
+                return None;
+            }
+            FoldKind::Histogram {
+                prop_col,
+                count_col,
+            }
+        }
+        _ => return None,
+    };
 
     Some(WholeGraphAggPlan {
+        anchor,
         accessor: accessor.map(|(p, _)| p),
-        tasks,
+        kind,
         schema: select_vars,
     })
 }
@@ -213,6 +304,10 @@ fn classify_aggregate(
     }
 }
 
+/// Histograms above this many distinct property values decline to the
+/// general pipeline (bounds the single output batch).
+const HISTOGRAM_MAX_GROUPS: usize = 65_536;
+
 /// Create the fused operator; declines to `fallback` whenever any component
 /// cannot be answered exactly.
 pub(crate) fn whole_graph_scalar_aggs_operator(
@@ -226,16 +321,26 @@ pub(crate) fn whole_graph_scalar_aggs_operator(
             let Some(store) = fast_path_store(ctx) else {
                 return Ok(None);
             };
-            if graph_has_scan_hidden_predicates(ctx, store)? {
-                return Ok(None);
-            }
 
-            // N: distinct subjects, from SPOT leaflet lead groups
-            // (SPOT key layout: s_id(8) + …).
-            let subjects =
-                count_distinct_lead_groups(store, ctx.binary_g_id, RunSortOrder::Spot, 8)?;
+            // Subject universe.
+            let subjects = match &plan.anchor {
+                Anchor::AllSubjects => {
+                    if graph_has_scan_hidden_predicates(ctx, store)? {
+                        return Ok(None);
+                    }
+                    // Distinct subjects from SPOT leaflet lead groups
+                    // (SPOT key layout: s_id(8) + …).
+                    count_distinct_lead_groups(store, ctx.binary_g_id, RunSortOrder::Spot, 8)?
+                }
+                Anchor::Class(class_sid) => {
+                    let Some(class) = class_stats(ctx, class_sid) else {
+                        return Ok(None);
+                    };
+                    class.count
+                }
+            };
             if subjects == 0 {
-                // Empty graph: leave empty-input aggregate identities
+                // Empty universe: leave empty-input aggregate identities
                 // (COUNT 0 / unbound MIN) to the general pipeline.
                 return Ok(None);
             }
@@ -249,6 +354,25 @@ pub(crate) fn whole_graph_scalar_aggs_operator(
                         return Ok(None);
                     };
                     let rows = count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)?;
+                    // Class anchor: property-derived folds are predicate-
+                    // scoped, so every P-bearing subject must be an instance
+                    // of the class. Equality of the per-(class, property)
+                    // flake count with the predicate's total row count proves
+                    // exactly that (both current-state-exact at HEAD).
+                    if let Anchor::Class(class_sid) = &plan.anchor {
+                        let Some(class) = class_stats(ctx, class_sid) else {
+                            return Ok(None);
+                        };
+                        let class_prop_rows: u64 = class
+                            .properties
+                            .iter()
+                            .find(|p| p.property_sid == pred_sid)
+                            .map(|p| p.datatypes.iter().map(|&(_, c)| c).sum())
+                            .unwrap_or(0);
+                        if class_prop_rows != rows {
+                            return Ok(None);
+                        }
+                    }
                     let Some(with_prop) =
                         count_distinct_subjects_for_predicate(store, ctx.binary_g_id, p_id)?
                     else {
@@ -264,22 +388,142 @@ pub(crate) fn whole_graph_scalar_aggs_operator(
                 None => None,
             };
 
-            let mut row = Vec::with_capacity(plan.tasks.len());
-            for task in &plan.tasks {
-                let Some(binding) =
-                    compute_task(*task, store, ctx.binary_g_id, subjects, accessor.as_ref())?
-                else {
-                    return Ok(None);
-                };
-                row.push(binding);
-            }
-            let batch = Batch::single_row(schema.clone(), row)
-                .map_err(|e| QueryError::execution(format!("whole-graph agg batch: {e}")))?;
+            let batch = match &plan.kind {
+                FoldKind::Scalars(tasks) => {
+                    let mut row = Vec::with_capacity(tasks.len());
+                    for task in tasks {
+                        let Some(binding) = compute_task(
+                            *task,
+                            store,
+                            ctx.binary_g_id,
+                            subjects,
+                            accessor.as_ref(),
+                        )?
+                        else {
+                            return Ok(None);
+                        };
+                        row.push(binding);
+                    }
+                    Batch::single_row(schema.clone(), row)
+                        .map_err(|e| QueryError::execution(format!("whole-graph agg batch: {e}")))?
+                }
+                FoldKind::Histogram {
+                    prop_col,
+                    count_col,
+                } => {
+                    let Some(a) = accessor.as_ref() else {
+                        return Ok(None);
+                    };
+                    let Some(b) =
+                        compute_histogram(ctx, store, a, subjects, &schema, *prop_col, *count_col)?
+                    else {
+                        return Ok(None);
+                    };
+                    b
+                }
+            };
             Ok(Some(batch))
         },
         fallback,
         "whole-graph scalar aggregates",
     )
+}
+
+/// The per-graph class stats entry for `class_sid`, if present.
+fn class_stats<'a>(
+    ctx: &'a crate::context::ExecutionContext<'_>,
+    class_sid: &Sid,
+) -> Option<&'a fluree_db_core::index_stats::ClassStatEntry> {
+    ctx.active_snapshot
+        .stats
+        .as_ref()?
+        .graphs
+        .as_ref()?
+        .iter()
+        .find(|g| g.g_id == ctx.binary_g_id)?
+        .classes
+        .as_ref()?
+        .iter()
+        .find(|c| &c.class_sid == class_sid)
+}
+
+/// `GROUP BY ?prop COUNT(*)`: per-value counts from a POST run-length pass
+/// (values are contiguous in POST order) plus one null-group row for
+/// subjects without the property. Declines on very wide histograms and on
+/// stores the group-count walk cannot serve.
+fn compute_histogram(
+    ctx: &crate::context::ExecutionContext<'_>,
+    store: &Arc<BinaryIndexStore>,
+    accessor: &AccessorCounts,
+    subjects: u64,
+    schema: &Arc<[VarId]>,
+    prop_col: usize,
+    count_col: usize,
+) -> Result<Option<Batch>> {
+    // Bound the output (one batch) and guarantee the top-K walk keeps every
+    // group: the directory-level distinct-object count must fit the cap.
+    match count_distinct_objects_for_predicate(store, ctx.binary_g_id, accessor.p_id)? {
+        Some(distinct) if (distinct as usize) <= HISTOGRAM_MAX_GROUPS => {}
+        _ => return Ok(None),
+    }
+    let Ok(groups) = crate::fast_group_count_firsts::group_count_v6(
+        store,
+        ctx.binary_g_id,
+        &accessor.pred,
+        HISTOGRAM_MAX_GROUPS,
+        &ctx.cancellation,
+    ) else {
+        return Ok(None);
+    };
+
+    let view = fluree_db_binary_index::BinaryGraphView::with_novelty(
+        Arc::clone(store),
+        ctx.binary_g_id,
+        ctx.dict_novelty.clone(),
+    )
+    .with_namespace_codes_fallback(ctx.namespace_codes_fallback.clone());
+
+    let null_rows = subjects.saturating_sub(accessor.subjects_with);
+    let mut col_prop: Vec<Binding> = Vec::with_capacity(groups.len() + 1);
+    let mut col_count: Vec<Binding> = Vec::with_capacity(groups.len() + 1);
+    for (o_type, o_key, count) in groups {
+        if o_type == fluree_db_core::o_type::OType::IRI_REF.as_u16() {
+            col_prop.push(Binding::encoded_sid(o_key));
+        } else {
+            let val = view
+                .decode_value(o_type, o_key, accessor.p_id)
+                .map_err(|e| QueryError::Internal(format!("histogram decode: {e}")))?;
+            let dt = store
+                .resolve_datatype_sid_for_value(o_type, &val)
+                .unwrap_or_else(|| Sid::new(0, ""));
+            let dtc = match store.resolve_lang_tag(o_type) {
+                Some(tag) => fluree_db_core::DatatypeConstraint::LangTag(Arc::from(tag)),
+                None => fluree_db_core::DatatypeConstraint::Explicit(dt),
+            };
+            col_prop.push(Binding::Lit {
+                val,
+                dtc,
+                t: None,
+                op: None,
+                p_id: None,
+            });
+        }
+        col_count.push(Binding::lit(FlakeValue::Long(count), Sid::xsd_integer()));
+    }
+    if null_rows > 0 {
+        col_prop.push(Binding::Unbound);
+        col_count.push(Binding::lit(
+            FlakeValue::Long(count_to_i64(null_rows, "histogram null group")?),
+            Sid::xsd_integer(),
+        ));
+    }
+
+    let mut cols: Vec<Vec<Binding>> = vec![Vec::new(), Vec::new()];
+    cols[prop_col] = col_prop;
+    cols[count_col] = col_count;
+    let batch = Batch::new(schema.clone(), cols)
+        .map_err(|e| QueryError::execution(format!("histogram batch: {e}")))?;
+    Ok(Some(batch))
 }
 
 struct AccessorCounts {

--- a/fluree-db-query/src/fast_whole_graph_agg.rs
+++ b/fluree-db-query/src/fast_whole_graph_agg.rs
@@ -115,8 +115,15 @@ enum FoldKind {
     /// projected column in projection order.
     Scalars(Vec<AggTask>),
     /// `GROUP BY ?prop` + `COUNT(*)`: one row per distinct property value
-    /// plus a null group. Column positions index into `schema`.
-    Histogram { prop_col: usize, count_col: usize },
+    /// plus a null group. Column positions index into `schema`. An optional
+    /// filter over the group key drops whole groups: every row in a group
+    /// shares the key value, so per-group evaluation (including on the
+    /// null group's `Unbound`) is exactly the pipeline's per-row filter.
+    Histogram {
+        prop_col: usize,
+        count_col: usize,
+        filter: Option<Expression>,
+    },
 }
 
 /// Detected plan: anchor, accessor predicate (if any), fold kind, and the
@@ -176,19 +183,44 @@ pub(crate) fn detect_whole_graph_scalar_aggs(query: &Query) -> Option<WholeGraph
         }
         Some((tp.p.clone(), prop_var))
     };
-    let (accessor, prop_alias) = match rest {
-        [] => (None, None),
-        [Pattern::Optional(inner)] => (Some(parse_accessor(inner)?), None),
+    let parse_alias = |acc: &(Ref, VarId), var: &VarId, expr: &Expression| -> Option<VarId> {
+        if *expr != Expression::Var(acc.1) || *var == acc.1 || *var == subject_var {
+            return None;
+        }
+        Some(*var)
+    };
+    let (accessor, prop_alias, key_filter) = match rest {
+        [] => (None, None, None),
+        [Pattern::Optional(inner)] => (Some(parse_accessor(inner)?), None, None),
         [Pattern::Optional(inner), Pattern::Bind { var, expr }] => {
             let acc = parse_accessor(inner)?;
-            if *expr != Expression::Var(acc.1) || *var == acc.1 || *var == subject_var {
-                return None;
-            }
-            (Some(acc), Some(*var))
+            let alias = parse_alias(&acc, var, expr)?;
+            (Some(acc), Some(alias), None)
+        }
+        [Pattern::Optional(inner), Pattern::Filter(f)] => {
+            let acc = parse_accessor(inner)?;
+            (Some(acc), None, Some(f.clone()))
+        }
+        [Pattern::Optional(inner), Pattern::Filter(f), Pattern::Bind { var, expr }] => {
+            let acc = parse_accessor(inner)?;
+            let alias = parse_alias(&acc, var, expr)?;
+            (Some(acc), Some(alias), Some(f.clone()))
         }
         _ => return None,
     };
     let prop_var = accessor.as_ref().map(|(_, v)| *v);
+    // A filter is admitted only when it reads nothing but the accessor value
+    // (whole-group-uniform) and is synchronously evaluable.
+    if let Some(f) = &key_filter {
+        let refs = f.referenced_vars();
+        if refs.is_empty()
+            || refs.iter().any(|v| Some(*v) != prop_var)
+            || crate::filter::contains_exists(f)
+            || crate::eval::metadata_resolve::contains_metadata_read(f)
+        {
+            return None;
+        }
+    }
     let select_vars = query.output.projected_vars()?;
 
     let kind = match &query.grouping {
@@ -198,6 +230,11 @@ pub(crate) fn detect_whole_graph_scalar_aggs(query: &Query) -> Option<WholeGraph
             having: None,
         }) => {
             if !binds.is_empty() || select_vars.len() != aggregates.len() {
+                return None;
+            }
+            if key_filter.is_some() {
+                // Scalar folds read predicate totals; a value filter would
+                // change them. (Histograms filter per group instead.)
                 return None;
             }
             let mut tasks = Vec::with_capacity(select_vars.len());
@@ -237,9 +274,19 @@ pub(crate) fn detect_whole_graph_scalar_aggs(query: &Query) -> Option<WholeGraph
             if prop_col == count_col {
                 return None;
             }
+            // The batch schema carries the group-key var; rewrite the filter
+            // to reference it when the key is the projection alias (identity
+            // bind — same value).
+            let filter = key_filter.map(|mut f| {
+                if key != prop_var {
+                    f.substitute_var(prop_var, key);
+                }
+                f
+            });
             FoldKind::Histogram {
                 prop_col,
                 count_col,
+                filter,
             }
         }
         _ => return None,
@@ -410,12 +457,21 @@ pub(crate) fn whole_graph_scalar_aggs_operator(
                 FoldKind::Histogram {
                     prop_col,
                     count_col,
+                    filter,
                 } => {
                     let Some(a) = accessor.as_ref() else {
                         return Ok(None);
                     };
-                    let Some(b) =
-                        compute_histogram(ctx, store, a, subjects, &schema, *prop_col, *count_col)?
+                    let Some(b) = compute_histogram(
+                        ctx,
+                        store,
+                        a,
+                        subjects,
+                        &schema,
+                        *prop_col,
+                        *count_col,
+                        filter.as_ref(),
+                    )?
                     else {
                         return Ok(None);
                     };
@@ -451,6 +507,7 @@ fn class_stats<'a>(
 /// (values are contiguous in POST order) plus one null-group row for
 /// subjects without the property. Declines on very wide histograms and on
 /// stores the group-count walk cannot serve.
+#[allow(clippy::too_many_arguments)]
 fn compute_histogram(
     ctx: &crate::context::ExecutionContext<'_>,
     store: &Arc<BinaryIndexStore>,
@@ -459,6 +516,7 @@ fn compute_histogram(
     schema: &Arc<[VarId]>,
     prop_col: usize,
     count_col: usize,
+    filter: Option<&Expression>,
 ) -> Result<Option<Batch>> {
     // Bound the output (one batch) and guarantee the top-K walk keeps every
     // group: the directory-level distinct-object count must fit the cap.
@@ -523,7 +581,19 @@ fn compute_histogram(
     cols[count_col] = col_count;
     let batch = Batch::new(schema.clone(), cols)
         .map_err(|e| QueryError::execution(format!("histogram batch: {e}")))?;
-    Ok(Some(batch))
+
+    // A group-key filter drops whole groups; evaluating it per group row
+    // (including the null group's Unbound key) is exactly the pipeline's
+    // per-row semantics, because every row of a group carries the same key.
+    let Some(filter) = filter else {
+        return Ok(Some(batch));
+    };
+    let prepared = crate::eval::PreparedBoolExpression::new(filter.clone());
+    match crate::filter::filter_batch(&batch, &prepared, schema, ctx)? {
+        Some(filtered) => Ok(Some(filtered)),
+        // Every group rejected: a legitimately empty result, not a decline.
+        None => Ok(Some(crate::fast_path_common::empty_batch(schema.clone())?)),
+    }
 }
 
 struct AccessorCounts {

--- a/fluree-db-query/src/fast_whole_graph_agg.rs
+++ b/fluree-db-query/src/fast_whole_graph_agg.rs
@@ -1,0 +1,386 @@
+//! Fast-path: whole-graph scalar aggregates over a distinct-subject scan.
+//!
+//! Cypher `MATCH (n) RETURN count(n), count(n.age)` (and the min/max/avg/sum
+//! family) lowers to:
+//!
+//! ```text
+//! patterns: [ Subquery(SELECT DISTINCT ?n WHERE { ?n ?p ?o }),
+//!             Optional([ ?n <P> ?prop ]) ]      -- one accessor, at most
+//! grouping: Implicit, aggregates over ?n / ?prop
+//! ```
+//!
+//! Executed generally, the subquery scans every flake in the graph and dedups
+//! subjects through the DISTINCT operator before a single aggregate row comes
+//! out — linear in graph size. Every aggregate the shape admits is answerable
+//! from index directories and predicate-scoped scans instead:
+//!
+//! - `count(?n)` / `COUNT(*)`: each distinct subject contributes
+//!   `max(1, #P(n))` rows through the left join, so the row count is
+//!   `N + count(P) − subj(P)` (`N` alone with no accessor) — all three terms
+//!   are directory-only reads.
+//! - `count(?prop)` counts non-null rows = `count(P)`, the predicate's live
+//!   row count. Exact for multi-valued `P` (each value is its own row).
+//! - `count(DISTINCT ?n)` = `N`; `count(DISTINCT ?prop)` = the predicate's
+//!   distinct-object lead-group count.
+//! - `min/max(?prop)` over the left join ignore nulls and duplicates — the
+//!   POST boundary-key reduction ([`crate::fast_min_max_string`]).
+//! - `avg/sum(?prop)`: the rows carrying `?prop` are exactly one per `P`
+//!   value, so the predicate-scoped POST fold
+//!   ([`crate::fast_predicate_scalar_agg`]) matches the pipeline.
+//!
+//! With two or more accessor optionals the per-subject rows multiply
+//! (`#P1(n) × #P2(n)`), which changes duplicate-sensitive aggregates — the
+//! detector only admits the single-accessor shape.
+//!
+//! The fold requires the strict metadata-lane gate ([`fast_path_store`]:
+//! single-ledger, root/no policy, no overlay, at HEAD) and declines when the
+//! graph carries predicates the variable-predicate scan hides (`f:reifies*`
+//! anywhere, the `f:` namespace in the default graph) — those facts are
+//! invisible to `?n ?p ?o` but not to the SPOT directories this fold reads.
+
+use crate::binding::{Batch, Binding};
+use crate::error::{QueryError, Result};
+use crate::fast_count::{
+    count_distinct_lead_groups, count_distinct_objects_for_predicate,
+    count_distinct_subjects_for_predicate,
+};
+use crate::fast_min_max_string::{minmax_numeric_post, minmax_string_dict_post, MinMaxMode};
+use crate::fast_path_common::{
+    count_rows_for_predicate_psot, count_to_i64, fast_path_store, normalize_pred_sid,
+    FastPathOperator,
+};
+use crate::fast_predicate_scalar_agg::{scan_predicate_scalar_agg, ScalarAggKind, SumExprI64};
+use crate::ir::grouping::{AggregateFn, Aggregation, Grouping, InputSemantics};
+use crate::ir::triple::{Ref, Term};
+use crate::ir::{Pattern, Query};
+use crate::operator::BoxedOperator;
+use crate::var_registry::VarId;
+use fluree_db_binary_index::format::run_record::RunSortOrder;
+use fluree_db_binary_index::BinaryIndexStore;
+use fluree_db_core::{FlakeValue, GraphId, Sid};
+use std::sync::Arc;
+
+/// One aggregate of the recognized shape, mapped to its fold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AggTask {
+    /// `count(?n)` / `COUNT(*)` — total pipeline rows.
+    CountRows,
+    /// `count(DISTINCT ?n)` — distinct subjects.
+    CountSubjects,
+    /// `count(?prop)` — the accessor predicate's live row count.
+    CountProp,
+    /// `count(DISTINCT ?prop)` — the predicate's distinct objects.
+    CountDistinctProp,
+    MinProp,
+    MaxProp,
+    AvgProp,
+    SumProp,
+}
+
+impl AggTask {
+    fn needs_accessor(self) -> bool {
+        !matches!(self, AggTask::CountRows | AggTask::CountSubjects)
+    }
+}
+
+/// Detected plan: the accessor predicate (if any) and one task per projected
+/// output column, in projection order.
+pub(crate) struct WholeGraphAggPlan {
+    accessor: Option<Ref>,
+    tasks: Vec<AggTask>,
+    schema: Vec<VarId>,
+}
+
+/// Recognize the whole-graph scalar-aggregate shape. See the module docs for
+/// the exact pattern and per-aggregate soundness arguments.
+pub(crate) fn detect_whole_graph_scalar_aggs(query: &Query) -> Option<WholeGraphAggPlan> {
+    // Single implicit group, aggregates only — no HAVING, post-binds,
+    // ordering, offset, DISTINCT output, or LIMIT 0.
+    let Some(Grouping::Implicit {
+        aggregation: Aggregation { aggregates, binds },
+        having: None,
+    }) = &query.grouping
+    else {
+        return None;
+    };
+    if !binds.is_empty()
+        || !query.ordering.is_empty()
+        || !query.order_binds.is_empty()
+        || query.offset.is_some()
+        || query.output.is_distinct()
+        || query.limit == Some(0)
+        || query.post_values.is_some()
+    {
+        return None;
+    }
+
+    // Pattern shape: the DISTINCT-subject subquery, then at most one
+    // single-triple property-accessor OPTIONAL.
+    let (first, rest) = query.patterns.split_first()?;
+    let Pattern::Subquery(sq) = first else {
+        return None;
+    };
+    let subject_var = distinct_subject_scan_var(sq)?;
+
+    let accessor = match rest {
+        [] => None,
+        [Pattern::Optional(inner)] => {
+            let [Pattern::Triple(tp)] = inner.as_slice() else {
+                return None;
+            };
+            if tp.s.as_var() != Some(subject_var) || !tp.p_bound() || tp.dtc.is_some() {
+                return None;
+            }
+            let Term::Var(prop_var) = tp.o else {
+                return None;
+            };
+            if prop_var == subject_var {
+                return None;
+            }
+            Some((tp.p.clone(), prop_var))
+        }
+        _ => return None,
+    };
+    let prop_var = accessor.as_ref().map(|(_, v)| *v);
+
+    // Every aggregate must fold, and the projection must be exactly the
+    // aggregate outputs.
+    let select_vars = query.output.projected_vars()?;
+    if select_vars.len() != aggregates.len() {
+        return None;
+    }
+    let mut tasks = Vec::with_capacity(select_vars.len());
+    for out in &select_vars {
+        let spec = aggregates.iter().find(|a| a.output_var == *out)?;
+        tasks.push(classify_aggregate(&spec.function, subject_var, prop_var)?);
+    }
+
+    Some(WholeGraphAggPlan {
+        accessor: accessor.map(|(p, _)| p),
+        tasks,
+        schema: select_vars,
+    })
+}
+
+/// Match `Subquery(SELECT DISTINCT ?n WHERE { ?n ?p ?o })` (no modifiers) and
+/// return `?n`. The body's `?p`/`?o` never escape (only `?n` is selected), so
+/// correlation cannot arise regardless of the `uncorrelated` flag.
+fn distinct_subject_scan_var(sq: &crate::ir::SubqueryPattern) -> Option<VarId> {
+    if !sq.distinct
+        || sq.limit.is_some()
+        || sq.offset.is_some()
+        || !sq.ordering.is_empty()
+        || !sq.order_binds.is_empty()
+        || sq.grouping.is_some()
+    {
+        return None;
+    }
+    let [subject_var] = sq.select.as_slice() else {
+        return None;
+    };
+    let [Pattern::Triple(tp)] = sq.patterns.as_slice() else {
+        return None;
+    };
+    if tp.dtc.is_some() {
+        return None;
+    }
+    let (Ref::Var(sv), Ref::Var(pv), Term::Var(ov)) = (&tp.s, &tp.p, &tp.o) else {
+        return None;
+    };
+    if sv != subject_var || pv == sv || ov == sv || pv == ov {
+        return None;
+    }
+    Some(*subject_var)
+}
+
+fn classify_aggregate(
+    function: &AggregateFn,
+    subject_var: VarId,
+    prop_var: Option<VarId>,
+) -> Option<AggTask> {
+    let is_prop = |v: VarId| prop_var == Some(v);
+    match function {
+        AggregateFn::CountAll => Some(AggTask::CountRows),
+        AggregateFn::Count(v) if *v == subject_var => Some(AggTask::CountRows),
+        AggregateFn::Count(v) if is_prop(*v) => Some(AggTask::CountProp),
+        AggregateFn::CountDistinct(v) if *v == subject_var => Some(AggTask::CountSubjects),
+        AggregateFn::CountDistinct(v) if is_prop(*v) => Some(AggTask::CountDistinctProp),
+        AggregateFn::Min(v) if is_prop(*v) => Some(AggTask::MinProp),
+        AggregateFn::Max(v) if is_prop(*v) => Some(AggTask::MaxProp),
+        AggregateFn::Avg(v, InputSemantics::List) if is_prop(*v) => Some(AggTask::AvgProp),
+        AggregateFn::Sum(v, InputSemantics::List) if is_prop(*v) => Some(AggTask::SumProp),
+        _ => None,
+    }
+}
+
+/// Create the fused operator; declines to `fallback` whenever any component
+/// cannot be answered exactly.
+pub(crate) fn whole_graph_scalar_aggs_operator(
+    plan: WholeGraphAggPlan,
+    fallback: Option<BoxedOperator>,
+) -> FastPathOperator {
+    let schema: Arc<[VarId]> = Arc::from(plan.schema.clone().into_boxed_slice());
+    FastPathOperator::with_schema(
+        schema.clone(),
+        move |ctx| {
+            let Some(store) = fast_path_store(ctx) else {
+                return Ok(None);
+            };
+            if graph_has_scan_hidden_predicates(ctx, store)? {
+                return Ok(None);
+            }
+
+            // N: distinct subjects, from SPOT leaflet lead groups
+            // (SPOT key layout: s_id(8) + …).
+            let subjects =
+                count_distinct_lead_groups(store, ctx.binary_g_id, RunSortOrder::Spot, 8)?;
+            if subjects == 0 {
+                // Empty graph: leave empty-input aggregate identities
+                // (COUNT 0 / unbound MIN) to the general pipeline.
+                return Ok(None);
+            }
+
+            let accessor = match &plan.accessor {
+                Some(pred) => {
+                    let pred_sid = normalize_pred_sid(store, pred)?;
+                    let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+                        // Absent predicate: all-null accessor rows; the
+                        // fallback computes the null-heavy identities.
+                        return Ok(None);
+                    };
+                    let rows = count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)?;
+                    let Some(with_prop) =
+                        count_distinct_subjects_for_predicate(store, ctx.binary_g_id, p_id)?
+                    else {
+                        return Ok(None);
+                    };
+                    Some(AccessorCounts {
+                        pred: pred.clone(),
+                        p_id,
+                        rows,
+                        subjects_with: with_prop,
+                    })
+                }
+                None => None,
+            };
+
+            let mut row = Vec::with_capacity(plan.tasks.len());
+            for task in &plan.tasks {
+                let Some(binding) =
+                    compute_task(*task, store, ctx.binary_g_id, subjects, accessor.as_ref())?
+                else {
+                    return Ok(None);
+                };
+                row.push(binding);
+            }
+            let batch = Batch::single_row(schema.clone(), row)
+                .map_err(|e| QueryError::execution(format!("whole-graph agg batch: {e}")))?;
+            Ok(Some(batch))
+        },
+        fallback,
+        "whole-graph scalar aggregates",
+    )
+}
+
+struct AccessorCounts {
+    pred: Ref,
+    p_id: u32,
+    rows: u64,
+    subjects_with: u64,
+}
+
+fn compute_task(
+    task: AggTask,
+    store: &Arc<BinaryIndexStore>,
+    g_id: GraphId,
+    subjects: u64,
+    accessor: Option<&AccessorCounts>,
+) -> Result<Option<Binding>> {
+    if task.needs_accessor() && accessor.is_none() {
+        return Ok(None);
+    }
+    let int = |v: u64| -> Result<Option<Binding>> {
+        Ok(Some(Binding::lit(
+            FlakeValue::Long(count_to_i64(v, "whole-graph aggregate")?),
+            Sid::xsd_integer(),
+        )))
+    };
+    match task {
+        AggTask::CountRows => match accessor {
+            // Left join: subjects without P keep 1 row, subjects with P get
+            // one row per value.
+            Some(a) => int(subjects
+                .saturating_sub(a.subjects_with)
+                .saturating_add(a.rows)),
+            None => int(subjects),
+        },
+        AggTask::CountSubjects => int(subjects),
+        AggTask::CountProp => int(accessor.unwrap().rows),
+        AggTask::CountDistinctProp => {
+            match count_distinct_objects_for_predicate(store, g_id, accessor.unwrap().p_id)? {
+                Some(distinct) => int(distinct),
+                None => Ok(None),
+            }
+        }
+        AggTask::MinProp | AggTask::MaxProp => {
+            let mode = if task == AggTask::MinProp {
+                MinMaxMode::Min
+            } else {
+                MinMaxMode::Max
+            };
+            let p_id = accessor.unwrap().p_id;
+            if let Some(b) = minmax_numeric_post(store, g_id, p_id, mode)? {
+                return Ok(Some(b));
+            }
+            minmax_string_dict_post(store, g_id, p_id, mode)
+        }
+        AggTask::AvgProp | AggTask::SumProp => {
+            let kind = if task == AggTask::AvgProp {
+                ScalarAggKind::AvgNumeric
+            } else {
+                ScalarAggKind::Sum(SumExprI64::Identity)
+            };
+            match scan_predicate_scalar_agg(store, g_id, &accessor.unwrap().pred, kind)? {
+                Some(output) => Ok(Some(output.into_binding())),
+                None => Ok(None),
+            }
+        }
+    }
+}
+
+/// Whether the graph carries any predicate the variable-predicate scan hides —
+/// `f:reifies*` in every graph, the broader `f:` namespace in the default
+/// graph (mirrors `BinaryScanOperator::is_internal_predicate`). Such facts are
+/// invisible to the `?n ?p ?o` pipeline but present in the SPOT directories
+/// this fold reads, so their presence makes the fold inexact. Errs toward
+/// declining when the per-graph stats are unavailable.
+fn graph_has_scan_hidden_predicates(
+    ctx: &crate::context::ExecutionContext<'_>,
+    store: &BinaryIndexStore,
+) -> Result<bool> {
+    let Some(graphs) = ctx
+        .active_snapshot
+        .stats
+        .as_ref()
+        .and_then(|s| s.graphs.as_ref())
+    else {
+        return Ok(true);
+    };
+    let Some(g) = graphs.iter().find(|g| g.g_id == ctx.binary_g_id) else {
+        return Ok(true);
+    };
+    for prop in &g.properties {
+        if prop.count == 0 {
+            continue;
+        }
+        let Some(sid) = store.predicate_sid(prop.p_id) else {
+            return Ok(true);
+        };
+        if fluree_db_core::is_reserved_reifies_predicate(&sid)
+            || (ctx.binary_g_id == 0 && sid.namespace_code == fluree_vocab::namespaces::FLUREE_DB)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}

--- a/fluree-db-query/src/fast_whole_graph_agg.rs
+++ b/fluree-db-query/src/fast_whole_graph_agg.rs
@@ -662,32 +662,27 @@ fn compute_task(
     }
 }
 
-/// Whether the graph carries any predicate the variable-predicate scan hides —
-/// `f:reifies*` in every graph, the broader `f:` namespace in the default
-/// graph (mirrors `BinaryScanOperator::is_internal_predicate`). Such facts are
-/// invisible to the `?n ?p ?o` pipeline but present in the SPOT directories
-/// this fold reads, so their presence makes the fold inexact. Errs toward
-/// declining when the per-graph stats are unavailable.
-fn graph_has_scan_hidden_predicates(
+/// Whether the store's predicate dictionary contains any predicate the
+/// variable-predicate scan hides — `f:reifies*` in every graph, the broader
+/// `f:` namespace in the default graph (mirrors
+/// `BinaryScanOperator::is_internal_predicate`). Such facts are invisible to
+/// the `?n ?p ?o` pipeline but present in the SPOT directories this fold
+/// reads, so their presence makes the fold inexact.
+///
+/// Deliberately checks the **dictionary**, not the per-graph stats: the
+/// incremental index build currently persists delta-only per-graph property
+/// stats (base entries lost), so a stats-driven check can silently pass on a
+/// graph that does carry hidden facts. Dictionary membership over-declines
+/// only when every row of a hidden predicate has been retracted — the safe
+/// direction. The predicate dictionary is small (one entry per predicate
+/// ever used), so the walk is trivial.
+pub(crate) fn graph_has_scan_hidden_predicates(
     ctx: &crate::context::ExecutionContext<'_>,
     store: &BinaryIndexStore,
 ) -> Result<bool> {
-    let Some(graphs) = ctx
-        .active_snapshot
-        .stats
-        .as_ref()
-        .and_then(|s| s.graphs.as_ref())
-    else {
-        return Ok(true);
-    };
-    let Some(g) = graphs.iter().find(|g| g.g_id == ctx.binary_g_id) else {
-        return Ok(true);
-    };
-    for prop in &g.properties {
-        if prop.count == 0 {
-            continue;
-        }
-        let Some(sid) = store.predicate_sid(prop.p_id) else {
+    for p_id in 0..store.predicate_count() {
+        let Some(sid) = store.predicate_sid(p_id) else {
+            // Unresolvable dictionary entry — err toward declining.
             return Ok(true);
         };
         if fluree_db_core::is_reserved_reifies_predicate(&sid)

--- a/fluree-db-query/src/fast_whole_graph_agg.rs
+++ b/fluree-db-query/src/fast_whole_graph_agg.rs
@@ -662,20 +662,23 @@ fn compute_task(
     }
 }
 
-/// Whether the store's predicate dictionary contains any predicate the
+/// Whether the queried graph carries rows under any predicate the
 /// variable-predicate scan hides — `f:reifies*` in every graph, the broader
 /// `f:` namespace in the default graph (mirrors
 /// `BinaryScanOperator::is_internal_predicate`). Such facts are invisible to
 /// the `?n ?p ?o` pipeline but present in the SPOT directories this fold
 /// reads, so their presence makes the fold inexact.
 ///
-/// Deliberately checks the **dictionary**, not the per-graph stats: the
-/// incremental index build currently persists delta-only per-graph property
-/// stats (base entries lost), so a stats-driven check can silently pass on a
-/// graph that does carry hidden facts. Dictionary membership over-declines
-/// only when every row of a hidden predicate has been retracted — the safe
-/// direction. The predicate dictionary is small (one entry per predicate
-/// ever used), so the walk is trivial.
+/// Two deliberate choices:
+/// - Candidates come from the store's predicate **dictionary**, not the
+///   per-graph stats: the incremental index build can persist delta-only
+///   per-graph property stats (base entries lost), so a stats-driven check
+///   can silently pass on a graph that does carry hidden facts.
+/// - Each hidden candidate is confirmed by its **row count in the queried
+///   graph** (`count_rows_for_predicate_psot`, directory-only): the
+///   dictionary is global across graphs, so commit-metadata `f:` predicates
+///   from the txn-meta graph are always present in it — bare membership
+///   would permanently decline every ledger.
 pub(crate) fn graph_has_scan_hidden_predicates(
     ctx: &crate::context::ExecutionContext<'_>,
     store: &BinaryIndexStore,
@@ -685,9 +688,9 @@ pub(crate) fn graph_has_scan_hidden_predicates(
             // Unresolvable dictionary entry — err toward declining.
             return Ok(true);
         };
-        if fluree_db_core::is_reserved_reifies_predicate(&sid)
-            || (ctx.binary_g_id == 0 && sid.namespace_code == fluree_vocab::namespaces::FLUREE_DB)
-        {
+        let hidden = fluree_db_core::is_reserved_reifies_predicate(&sid)
+            || (ctx.binary_g_id == 0 && sid.namespace_code == fluree_vocab::namespaces::FLUREE_DB);
+        if hidden && count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)? > 0 {
             return Ok(true);
         }
     }

--- a/fluree-db-query/src/ir/path.rs
+++ b/fluree-db-query/src/ir/path.rs
@@ -263,8 +263,11 @@ pub struct ShortestPathPattern {
     pub start: Ref,
     /// End node ref (Var or Sid — literals not allowed).
     pub end: Ref,
-    /// Predicate to traverse (resolved to Sid).
-    pub predicate: Sid,
+    /// Predicate to traverse (resolved to Sid). `None` is the untyped
+    /// (wildcard) form: any relationship edge is followed — reference-valued
+    /// objects only, excluding `rdf:type` and the `f:reifies*` system
+    /// predicates (the same edge-set as the wildcard [`PropertyPathPattern`]).
+    pub predicate: Option<Sid>,
     /// Traversal direction.
     pub direction: PathDirection,
     /// Single vs. all-shortest-paths.
@@ -278,8 +281,10 @@ pub struct ShortestPathPattern {
     /// Whether the emitted path value's per-hop `edges` are consumed (only
     /// Cypher's `relationships(p)` reads them). When `false` the operator skips
     /// building the per-hop edge tuples — a pure allocation/clone savings on the
-    /// JSON-LD/FQL surface, which has no `relationships()` function. Edges are
-    /// derivable from `nodes` + this pattern's single `predicate`/`direction`.
+    /// JSON-LD/FQL surface, which has no `relationships()` function. For a
+    /// typed pattern edges are derivable from `nodes` + `predicate`/`direction`;
+    /// a wildcard pattern resolves each found hop's predicate with a post-hoc
+    /// probe.
     pub needs_relationships: bool,
 }
 

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -72,6 +72,7 @@ pub(crate) mod object_binding;
 pub mod offset;
 pub mod operator;
 pub mod optional;
+pub(crate) mod optional_filter_fold;
 pub mod parse;
 pub mod plan_node;
 pub mod planner;

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -334,6 +334,14 @@ pub async fn execute_where_streaming<'a>(
         });
     }
 
+    // Plan with the same cached stats view the read path uses — without it,
+    // `reorder_patterns` falls back to default selectivities, where a bound-
+    // object seek (`?a <id> 4112` → 1 row) ties with a class scan
+    // (`?a rdf:type User` → N rows) and lowering order wins, turning an
+    // update's anchored MATCH into a full label scan.
+    let binary_store = ExecutionContext::extract_binary_store(db.snapshot);
+    let stats = stats_cache::cached_stats_view_for_db(db, binary_store.as_ref(), false);
+
     let mut ctx = ExecutionContext::from_graph_db_ref(db, vars).with_strict_bind_errors();
     if let Some(ds) = dataset {
         ctx = ctx.with_dataset(ds);
@@ -341,7 +349,7 @@ pub async fn execute_where_streaming<'a>(
     let mut operator = build_where_operators_seeded(
         None,
         patterns,
-        None,
+        stats,
         None,
         &temporal_mode::PlanningContext::current(),
     )?;

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -53,6 +53,7 @@ pub(crate) mod fast_string_prefix_count_all;
 pub(crate) mod fast_sum_strlen_group_concat;
 pub(crate) mod fast_union_star_count_all;
 pub(crate) mod fast_vector_topk;
+pub(crate) mod fast_whole_graph_agg;
 pub mod filter;
 pub(crate) mod filter_fold;
 pub mod geo_rewrite;

--- a/fluree-db-query/src/optional_filter_fold.rs
+++ b/fluree-db-query/src/optional_filter_fold.rs
@@ -1,0 +1,435 @@
+//! Well-formed left-join simplification: convert a single-triple `OPTIONAL`
+//! into a required triple when a filter in the same group is
+//! **error-rejecting** on a variable only that OPTIONAL produces.
+//!
+//! Canonical source: the Cypher property accessor. `MATCH (n:User) WITH n
+//! WHERE n.id = $id RETURN n` lowers `n.id` to
+//! `OPTIONAL { ?n <id> ?v } FILTER(?v = $id)` (nullable-property
+//! semantics). Rows where the OPTIONAL didn't extend leave `?v` unbound, the
+//! comparison errors, and the filter drops the row — exactly the rows a
+//! required `?n <id> ?v` would never produce. The two forms are therefore
+//! row-for-row equivalent, but the OPTIONAL wrapper hides the pattern from
+//! equality/range pushdown and selectivity estimation, turning a ~1-row seek
+//! into a label/whole-graph scan plus post-filter. SPARQL
+//! `OPTIONAL { … } FILTER(…)` hits the same cliff.
+//!
+//! The filter is kept (only the OPTIONAL wrapper is removed): substituting
+//! the constant into the triple would switch value equality to index-term
+//! matching, which differs on cross-datatype numeric equality.
+//!
+//! Soundness gates:
+//! - The OPTIONAL body is exactly one triple.
+//! - Some variable produced **only** by that triple (nowhere else in the
+//!   whole query, so left-join compatibility semantics can't be observed) is
+//!   error-rejected by a filter in the same pattern list. If the triple
+//!   doesn't match a row, *all* its fresh variables are unbound, so the
+//!   filter rejects the row either way.
+//!
+//! Profitability gates (the rewrite is sound more broadly, but a folded
+//! REQUIRED triple participates in join reordering, and reorder has no view
+//! of the filter's selectivity):
+//! - Only **equality/IN with constants** folds — the folded triple is then a
+//!   near-unique anchor, so being ordered early is exactly right. A range or
+//!   string predicate (`?v >= 18`) would fold into a full property scan that
+//!   can hijack the anchor from a far more selective seed (measured: the
+//!   benchgraph `*_with_filter` expansions went from milliseconds to
+//!   timeouts when range filters folded).
+//! - Queries containing property-path / shortest-path patterns are skipped
+//!   entirely: paths anchor traversal order, and a folded accessor on the
+//!   path's endpoint can become the driving side, re-running the traversal
+//!   once per property row.
+
+use std::collections::HashSet;
+
+use crate::ir::{Expression, Function, Pattern, Query};
+use crate::var_registry::VarId;
+
+/// Cheap candidate test: some pattern list contains both a single-triple
+/// OPTIONAL and a filter. (The full gates run in [`fold_optional_filters`].)
+pub fn has_optional_filter_candidate(query: &Query) -> bool {
+    fn list_has(patterns: &[Pattern]) -> bool {
+        let mut has_opt = false;
+        let mut has_filter = false;
+        for p in patterns {
+            match p {
+                Pattern::Optional(inner) => {
+                    if matches!(inner.as_slice(), [Pattern::Triple(_)]) {
+                        has_opt = true;
+                    }
+                    if list_has(inner) {
+                        return true;
+                    }
+                }
+                Pattern::Filter(_) => has_filter = true,
+                _ => {
+                    if walk_inner_lists(p, &list_has) {
+                        return true;
+                    }
+                }
+            }
+        }
+        has_opt && has_filter
+    }
+    list_has(&query.patterns)
+}
+
+/// Apply the rewrite everywhere in the query (top level, subquery bodies,
+/// and nested containers).
+pub fn fold_optional_filters(query: &mut Query) {
+    // Path operators anchor traversal order; see the profitability gates in
+    // the module docs.
+    if patterns_contain_path(&query.patterns) {
+        return;
+    }
+    // Vars produced anywhere in the query, with multiplicity — the "produced
+    // only by this optional" gate needs global knowledge (a var also produced
+    // in another scope could observe left-join compatibility).
+    let mut produced: Vec<VarId> = Vec::new();
+    collect_produced(&query.patterns, &mut produced);
+    let mut counts = std::collections::HashMap::new();
+    for v in produced {
+        *counts.entry(v).or_insert(0usize) += 1;
+    }
+
+    fold_in_list(&mut query.patterns, &counts);
+}
+
+fn fold_in_list(
+    patterns: &mut [Pattern],
+    produced_counts: &std::collections::HashMap<VarId, usize>,
+) {
+    // Vars rejected by some filter in THIS list.
+    let mut rejected: HashSet<VarId> = HashSet::new();
+    for p in patterns.iter() {
+        if let Pattern::Filter(expr) = p {
+            collect_rejected_vars(expr, &mut rejected);
+        }
+    }
+
+    for p in patterns.iter_mut() {
+        // Recurse first (subquery bodies, optional bodies, unions, ...).
+        recurse_containers(p, produced_counts);
+
+        let Pattern::Optional(inner) = p else {
+            continue;
+        };
+        let [Pattern::Triple(tp)] = inner.as_slice() else {
+            continue;
+        };
+        // Some fresh var of the triple (produced exactly once in the whole
+        // query, i.e. only here) must be filter-rejected in this list.
+        let qualifies = tp
+            .produced_vars()
+            .into_iter()
+            .any(|v| rejected.contains(&v) && produced_counts.get(&v).copied() == Some(1));
+        if qualifies {
+            let tp = tp.clone();
+            *p = Pattern::Triple(tp);
+        }
+    }
+}
+
+fn recurse_containers(p: &mut Pattern, produced_counts: &std::collections::HashMap<VarId, usize>) {
+    match p {
+        Pattern::Subquery(sq) => fold_in_list(&mut sq.patterns, produced_counts),
+        Pattern::Optional(inner)
+        | Pattern::Minus(inner)
+        | Pattern::Exists(inner)
+        | Pattern::NotExists(inner) => fold_in_list(inner, produced_counts),
+        Pattern::Graph { patterns, .. } => fold_in_list(patterns, produced_counts),
+        Pattern::Service(sp) => fold_in_list(&mut sp.patterns, produced_counts),
+        Pattern::Union(branches) => {
+            for branch in branches {
+                fold_in_list(branch, produced_counts);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Collect produced vars across every nested pattern list, counting each
+/// producing *leaf* once. Container variants recurse without re-adding their
+/// inner vars (`Pattern::produced_vars` on a container already includes them,
+/// which would double-count). A subquery counts its SELECT list (the producer
+/// visible to the outer scope) *and* its body's leaves.
+fn collect_produced(patterns: &[Pattern], out: &mut Vec<VarId>) {
+    for p in patterns {
+        match p {
+            Pattern::Subquery(sq) => {
+                out.extend(sq.select.iter().copied());
+                collect_produced(&sq.patterns, out);
+            }
+            Pattern::Optional(inner)
+            | Pattern::Minus(inner)
+            | Pattern::Exists(inner)
+            | Pattern::NotExists(inner) => collect_produced(inner, out),
+            Pattern::Graph { name, patterns } => {
+                if let crate::ir::GraphName::Var(v) = name {
+                    out.push(*v);
+                }
+                collect_produced(patterns, out);
+            }
+            Pattern::Service(sp) => {
+                if let crate::ir::ServiceEndpoint::Var(v) = &sp.endpoint {
+                    out.push(*v);
+                }
+                collect_produced(&sp.patterns, out);
+            }
+            Pattern::Union(branches) => {
+                for branch in branches {
+                    collect_produced(branch, out);
+                }
+            }
+            _ => out.extend(p.produced_vars()),
+        }
+    }
+}
+
+fn walk_inner_lists(p: &Pattern, f: &impl Fn(&[Pattern]) -> bool) -> bool {
+    match p {
+        Pattern::Subquery(sq) => f(&sq.patterns),
+        Pattern::Minus(inner) | Pattern::Exists(inner) | Pattern::NotExists(inner) => f(inner),
+        Pattern::Graph { patterns, .. } => f(patterns),
+        Pattern::Service(sp) => f(&sp.patterns),
+        Pattern::Union(branches) => branches.iter().any(|b| f(b)),
+        _ => false,
+    }
+}
+
+/// Add every var `v` for which `expr`, used as a filter, is guaranteed to
+/// reject rows where `v` is unbound AND pins `v` to a constant — an
+/// equality (`?v = const`, `sameTerm`) or constant `IN` list, possibly under
+/// `AND` conjuncts. An erroring conjunct makes the whole `AND` error-or-false
+/// in filter context, so any qualifying conjunct rejects the row.
+fn collect_rejected_vars(expr: &Expression, out: &mut HashSet<VarId>) {
+    let Expression::Call { func, args } = expr else {
+        return;
+    };
+    match func {
+        Function::And => {
+            for a in args {
+                collect_rejected_vars(a, out);
+            }
+        }
+        Function::Eq | Function::SameTerm if args.len() == 2 => {
+            if let (Expression::Var(v), Expression::Const(_))
+            | (Expression::Const(_), Expression::Var(v)) = (&args[0], &args[1])
+            {
+                out.insert(*v);
+            }
+        }
+        Function::In => {
+            if let Some(Expression::Var(v)) = args.first() {
+                if args[1..].iter().all(|a| matches!(a, Expression::Const(_))) {
+                    out.insert(*v);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Whether any pattern list in the query contains a path operator.
+fn patterns_contain_path(patterns: &[Pattern]) -> bool {
+    patterns.iter().any(|p| match p {
+        Pattern::PropertyPath(_) | Pattern::ShortestPath(_) => true,
+        Pattern::Subquery(sq) => patterns_contain_path(&sq.patterns),
+        Pattern::Optional(inner)
+        | Pattern::Minus(inner)
+        | Pattern::Exists(inner)
+        | Pattern::NotExists(inner) => patterns_contain_path(inner),
+        Pattern::Graph { patterns, .. } => patterns_contain_path(patterns),
+        Pattern::Service(sp) => patterns_contain_path(&sp.patterns),
+        Pattern::Union(branches) => branches.iter().any(|b| patterns_contain_path(b)),
+        _ => false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::triple::{Ref, Term, TriplePattern};
+    use crate::ir::{QueryOutput, SubqueryPattern};
+    use fluree_db_core::{FlakeValue, Sid};
+
+    fn eq_filter(v: VarId, val: i64) -> Pattern {
+        Pattern::Filter(Expression::Call {
+            func: Function::Eq,
+            args: vec![Expression::Var(v), Expression::Const(FlakeValue::Long(val))],
+        })
+    }
+
+    fn accessor_optional(subject: VarId, prop: VarId) -> Pattern {
+        Pattern::Optional(vec![Pattern::Triple(TriplePattern::new(
+            Ref::Var(subject),
+            Ref::Sid(Sid::new(100, "id")),
+            Term::Var(prop),
+        ))])
+    }
+
+    fn query_with(patterns: Vec<Pattern>) -> Query {
+        Query {
+            context: fluree_graph_json_ld::ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::select_all(vec![VarId(0)]),
+            patterns,
+            reasoning: crate::ir::ReasoningConfig::default(),
+            include_system_facts: false,
+            grouping: None,
+            ordering: Vec::new(),
+            order_binds: Vec::new(),
+            limit: None,
+            offset: None,
+            post_values: None,
+        }
+    }
+
+    #[test]
+    fn folds_equality_rejected_accessor() {
+        let mut q = query_with(vec![
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Sid(Sid::new(3, "type")),
+                Term::Sid(Sid::new(100, "User")),
+            )),
+            accessor_optional(VarId(0), VarId(1)),
+            eq_filter(VarId(1), 4112),
+        ]);
+        fold_optional_filters(&mut q);
+        assert!(
+            matches!(&q.patterns[1], Pattern::Triple(tp) if tp.o.as_var() == Some(VarId(1))),
+            "optional should become required: {:?}",
+            q.patterns[1]
+        );
+        assert!(matches!(&q.patterns[2], Pattern::Filter(_)), "filter kept");
+    }
+
+    #[test]
+    fn folds_inside_subquery_body() {
+        let sq = SubqueryPattern::new(
+            vec![VarId(0)],
+            vec![
+                Pattern::Triple(TriplePattern::new(
+                    Ref::Var(VarId(0)),
+                    Ref::Sid(Sid::new(3, "type")),
+                    Term::Sid(Sid::new(100, "User")),
+                )),
+                accessor_optional(VarId(0), VarId(1)),
+                eq_filter(VarId(1), 7),
+            ],
+        );
+        let mut q = query_with(vec![Pattern::Subquery(sq)]);
+        fold_optional_filters(&mut q);
+        let Pattern::Subquery(sq) = &q.patterns[0] else {
+            panic!("subquery");
+        };
+        assert!(matches!(&sq.patterns[1], Pattern::Triple(_)));
+    }
+
+    #[test]
+    fn keeps_optional_for_bound_check() {
+        // `FILTER(!bound(?v))` keeps unbound rows — must NOT fold.
+        let mut q = query_with(vec![
+            accessor_optional(VarId(0), VarId(1)),
+            Pattern::Filter(Expression::Call {
+                func: Function::Not,
+                args: vec![Expression::Call {
+                    func: Function::Bound,
+                    args: vec![Expression::Var(VarId(1))],
+                }],
+            }),
+        ]);
+        fold_optional_filters(&mut q);
+        assert!(matches!(&q.patterns[0], Pattern::Optional(_)));
+    }
+
+    #[test]
+    fn keeps_optional_when_var_produced_elsewhere() {
+        // The repeated-identical-optional shape: ?v has two producers, so
+        // left-join compatibility is observable — must NOT fold.
+        let mut q = query_with(vec![
+            accessor_optional(VarId(0), VarId(1)),
+            accessor_optional(VarId(0), VarId(1)),
+            eq_filter(VarId(1), 1),
+        ]);
+        fold_optional_filters(&mut q);
+        assert!(matches!(&q.patterns[0], Pattern::Optional(_)));
+        assert!(matches!(&q.patterns[1], Pattern::Optional(_)));
+    }
+
+    #[test]
+    fn keeps_optional_for_or_with_non_rejecting_branch() {
+        // `FILTER(?v = 1 OR true)` keeps unbound rows via the OR branch.
+        let mut q = query_with(vec![
+            accessor_optional(VarId(0), VarId(1)),
+            Pattern::Filter(Expression::Call {
+                func: Function::Or,
+                args: vec![
+                    Expression::Call {
+                        func: Function::Eq,
+                        args: vec![
+                            Expression::Var(VarId(1)),
+                            Expression::Const(FlakeValue::Long(1)),
+                        ],
+                    },
+                    Expression::Const(FlakeValue::Boolean(true)),
+                ],
+            }),
+        ]);
+        fold_optional_filters(&mut q);
+        assert!(matches!(&q.patterns[0], Pattern::Optional(_)));
+    }
+
+    #[test]
+    fn keeps_optional_for_range_comparison() {
+        // A folded range predicate would become a full property scan the
+        // planner can misorder as an anchor — only equality/IN folds.
+        let mut q = query_with(vec![
+            accessor_optional(VarId(0), VarId(1)),
+            Pattern::Filter(Expression::Call {
+                func: Function::Gt,
+                args: vec![
+                    Expression::Var(VarId(1)),
+                    Expression::Const(FlakeValue::Long(30)),
+                ],
+            }),
+        ]);
+        fold_optional_filters(&mut q);
+        assert!(matches!(&q.patterns[0], Pattern::Optional(_)));
+    }
+
+    #[test]
+    fn keeps_optional_when_query_has_path_pattern() {
+        // Paths anchor traversal order; the fold skips such queries wholesale.
+        let mut q = query_with(vec![
+            Pattern::PropertyPath(crate::ir::PropertyPathPattern::new_wildcard(
+                Ref::Var(VarId(2)),
+                crate::ir::PathModifier::OneOrMore,
+                Some(1),
+                Some(2),
+                Ref::Var(VarId(0)),
+            )),
+            accessor_optional(VarId(0), VarId(1)),
+            eq_filter(VarId(1), 4112),
+        ]);
+        fold_optional_filters(&mut q);
+        assert!(matches!(&q.patterns[1], Pattern::Optional(_)));
+    }
+
+    #[test]
+    fn folds_constant_in_list() {
+        let mut q = query_with(vec![
+            accessor_optional(VarId(0), VarId(1)),
+            Pattern::Filter(Expression::Call {
+                func: Function::In,
+                args: vec![
+                    Expression::Var(VarId(1)),
+                    Expression::Const(FlakeValue::Long(1)),
+                    Expression::Const(FlakeValue::Long(2)),
+                ],
+            }),
+        ]);
+        fold_optional_filters(&mut q);
+        assert!(matches!(&q.patterns[0], Pattern::Triple(_)));
+    }
+}

--- a/fluree-db-query/src/parse/lower.rs
+++ b/fluree-db-query/src/parse/lower.rs
@@ -289,7 +289,7 @@ pub fn lower_unresolved_pattern<E: IriEncoder>(
                 Some(predicate) => Ok(vec![Pattern::ShortestPath(ShortestPathPattern {
                     start: start_ref,
                     end: end_ref,
-                    predicate,
+                    predicate: Some(predicate),
                     direction: *direction,
                     mode: *mode,
                     path_var: path_var_id,

--- a/fluree-db-query/src/property_join.rs
+++ b/fluree-db-query/src/property_join.rs
@@ -211,26 +211,40 @@ impl PropertyJoinOperator {
     /// bound value (`{id: 4112}`, ~1 row) drive ahead of its `rdf:type`
     /// class pattern (|class| rows) — while a genuinely rare class, which
     /// the planner orders first, still wins the tie.
+    ///
+    /// Under time-travel replay (`replay`) a bound `rdf:type` object is
+    /// hard-preferred instead: a predicate whose rows were all retracted
+    /// after `to_t` has no PSOT/POST partition in the current index, so a
+    /// direct scan of it silently returns nothing — its historical rows are
+    /// only reachable through the subject-keyed SPOT sidecars the batched
+    /// probes replay. Driving from the class scan keeps every non-driver
+    /// predicate on that replay-correct probe lane.
     fn driver_score(
         predicate: &PropertyJoinPredicate,
         object_bounds: &HashMap<VarId, ObjectBounds>,
+        replay: bool,
     ) -> u8 {
         match &predicate.object {
+            PropertyJoinObject::Bound(_) if replay && predicate.pred_ref.is_rdf_type() => 0,
+            PropertyJoinObject::Bound(_) if replay => 1,
             PropertyJoinObject::Bound(_) => 0,
-            PropertyJoinObject::Var(obj_var) if object_bounds.contains_key(obj_var) => 1,
-            PropertyJoinObject::Var(_) => 2,
+            PropertyJoinObject::Var(obj_var) if object_bounds.contains_key(obj_var) => 2,
+            PropertyJoinObject::Var(_) => 3,
         }
     }
 
     fn select_driver_predicate(
         predicates: &[PropertyJoinPredicate],
         object_bounds: &HashMap<VarId, ObjectBounds>,
+        replay: bool,
     ) -> Option<usize> {
         predicates
             .iter()
             .enumerate()
             .filter(|(_, predicate)| predicate.required)
-            .min_by_key(|(idx, predicate)| (Self::driver_score(predicate, object_bounds), *idx))
+            .min_by_key(|(idx, predicate)| {
+                (Self::driver_score(predicate, object_bounds, replay), *idx)
+            })
             .map(|(idx, _)| idx)
     }
 
@@ -788,9 +802,17 @@ impl Operator for PropertyJoinOperator {
                     .fold(0u64, |mask, (idx, _)| mask | (1u64 << idx))
             };
 
+            let replay = ctx
+                .binary_store
+                .as_ref()
+                .is_some_and(|store| ctx.to_t < store.max_t());
             let driver_pred_idx =
-                Self::select_driver_predicate(&self.predicates, &self.object_bounds);
-            tracing::debug!(?driver_pred_idx, "property_join: selected driver predicate");
+                Self::select_driver_predicate(&self.predicates, &self.object_bounds, replay);
+            tracing::debug!(
+                ?driver_pred_idx,
+                replay,
+                "property_join: selected driver predicate"
+            );
 
             let mut scan_order: Vec<usize> = self
                 .predicates
@@ -1311,7 +1333,7 @@ mod tests {
         let mut bounds = HashMap::new();
         bounds.insert(VarId(2), ObjectBounds::new());
 
-        let driver = PropertyJoinOperator::select_driver_predicate(&op.predicates, &bounds);
+        let driver = PropertyJoinOperator::select_driver_predicate(&op.predicates, &bounds, false);
         assert_eq!(driver, Some(0));
     }
 
@@ -1336,8 +1358,16 @@ mod tests {
         ];
         let op =
             PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
-        let driver = PropertyJoinOperator::select_driver_predicate(&op.predicates, &HashMap::new());
+        let driver =
+            PropertyJoinOperator::select_driver_predicate(&op.predicates, &HashMap::new(), false);
         assert_eq!(driver, Some(0), "specific bound value should drive");
+
+        // Under time-travel replay the class pattern must reclaim the driver:
+        // a fully-retracted value predicate has no PSOT/POST partition in the
+        // current index, so it can only be probed via SPOT sidecar replay.
+        let driver =
+            PropertyJoinOperator::select_driver_predicate(&op.predicates, &HashMap::new(), true);
+        assert_eq!(driver, Some(1), "rdf:type should drive under replay");
 
         // When the planner orders the class first (rare class more selective
         // than the bound value), the tie-break preserves that choice.
@@ -1355,7 +1385,8 @@ mod tests {
         ];
         let op =
             PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
-        let driver = PropertyJoinOperator::select_driver_predicate(&op.predicates, &HashMap::new());
+        let driver =
+            PropertyJoinOperator::select_driver_predicate(&op.predicates, &HashMap::new(), false);
         assert_eq!(driver, Some(0), "planner-first class should keep driving");
     }
 

--- a/fluree-db-query/src/property_join.rs
+++ b/fluree-db-query/src/property_join.rs
@@ -203,15 +203,22 @@ impl Hash for SubjectKey {
 }
 
 impl PropertyJoinOperator {
+    /// Rank a predicate as the leading (subject-set-seeding) scan.
+    ///
+    /// All fully-bound objects share the best score; ties resolve to the
+    /// lowest index, and predicate order follows the planner's
+    /// selectivity-reordered pattern order. This is what lets a specific
+    /// bound value (`{id: 4112}`, ~1 row) drive ahead of its `rdf:type`
+    /// class pattern (|class| rows) — while a genuinely rare class, which
+    /// the planner orders first, still wins the tie.
     fn driver_score(
         predicate: &PropertyJoinPredicate,
         object_bounds: &HashMap<VarId, ObjectBounds>,
     ) -> u8 {
         match &predicate.object {
-            PropertyJoinObject::Bound(_) if predicate.pred_ref.is_rdf_type() => 0,
-            PropertyJoinObject::Bound(_) => 1,
-            PropertyJoinObject::Var(obj_var) if object_bounds.contains_key(obj_var) => 2,
-            PropertyJoinObject::Var(_) => 3,
+            PropertyJoinObject::Bound(_) => 0,
+            PropertyJoinObject::Var(obj_var) if object_bounds.contains_key(obj_var) => 1,
+            PropertyJoinObject::Var(_) => 2,
         }
     }
 
@@ -1306,6 +1313,50 @@ mod tests {
 
         let driver = PropertyJoinOperator::select_driver_predicate(&op.predicates, &bounds);
         assert_eq!(driver, Some(0));
+    }
+
+    #[test]
+    fn test_property_join_driver_follows_planner_order_for_bound_objects() {
+        // Post-reorder pattern order is [value-bound, rdf:type]: the specific
+        // bound value must drive, not the class pattern (PERF-1: a
+        // `(:User {id: $id})` star label-scanned because rdf:type outranked
+        // the ~1-row id seek).
+        let rdf_type = || Ref::Iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".into());
+        let patterns = vec![
+            TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Sid(Sid::new(100, "id")),
+                Term::Value(fluree_db_core::value::FlakeValue::Long(4112)),
+            ),
+            TriplePattern::new(
+                Ref::Var(VarId(0)),
+                rdf_type(),
+                Term::Sid(Sid::new(100, "User")),
+            ),
+        ];
+        let op =
+            PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
+        let driver = PropertyJoinOperator::select_driver_predicate(&op.predicates, &HashMap::new());
+        assert_eq!(driver, Some(0), "specific bound value should drive");
+
+        // When the planner orders the class first (rare class more selective
+        // than the bound value), the tie-break preserves that choice.
+        let patterns = vec![
+            TriplePattern::new(
+                Ref::Var(VarId(0)),
+                rdf_type(),
+                Term::Sid(Sid::new(100, "RareClass")),
+            ),
+            TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Sid(Sid::new(100, "status")),
+                Term::Value(fluree_db_core::value::FlakeValue::String("active".into())),
+            ),
+        ];
+        let op =
+            PropertyJoinOperator::new(&patterns, HashMap::new(), TemporalMode::Current).unwrap();
+        let driver = PropertyJoinOperator::select_driver_predicate(&op.predicates, &HashMap::new());
+        assert_eq!(driver, Some(0), "planner-first class should keep driving");
     }
 
     #[test]

--- a/fluree-db-query/src/property_path.rs
+++ b/fluree-db-query/src/property_path.rs
@@ -53,7 +53,7 @@ pub const DEFAULT_MAX_VISITED: usize = 10_000;
 /// edge-annotation sidecar, hidden from variable-predicate reads). Data
 /// properties are already excluded by the `Ref`-object filter in the scan.
 #[inline]
-fn is_reserved_edge_predicate(p: &Sid) -> bool {
+pub(crate) fn is_reserved_edge_predicate(p: &Sid) -> bool {
     fluree_db_core::is_rdf_type(p) || fluree_db_core::is_reserved_reifies_predicate(p)
 }
 

--- a/fluree-db-query/src/shortest_path.rs
+++ b/fluree-db-query/src/shortest_path.rs
@@ -163,10 +163,13 @@ impl ShortestPathOperator {
         let mut out = Vec::new();
 
         if use_spot {
-            // Spot: (subject=node, predicate) → ref objects.
-            let range_match = RangeMatch::new()
-                .with_subject(node.clone())
-                .with_predicate(self.pattern.predicate.clone());
+            // Spot: (subject=node[, predicate]) → ref objects. Wildcard scans
+            // all of the node's out-edges and drops reserved predicates
+            // (`rdf:type`, `f:reifies*`), matching the wildcard property path.
+            let mut range_match = RangeMatch::new().with_subject(node.clone());
+            if let Some(pred) = &self.pattern.predicate {
+                range_match = range_match.with_predicate(pred.clone());
+            }
             let flakes = range_with_overlay(
                 db,
                 ctx.binary_g_id,
@@ -178,6 +181,11 @@ impl ShortestPathOperator {
             )
             .await?;
             for flake in flakes {
+                if self.pattern.predicate.is_none()
+                    && crate::property_path::is_reserved_edge_predicate(&flake.p)
+                {
+                    continue;
+                }
                 if let FlakeValue::Ref(obj) = flake.o {
                     out.push(obj);
                 }
@@ -185,26 +193,114 @@ impl ShortestPathOperator {
         }
 
         if use_post {
-            // Post: (predicate, object=node) → subjects.
-            let range_match = RangeMatch::new()
-                .with_predicate(self.pattern.predicate.clone())
-                .with_object(FlakeValue::Ref(node.clone()));
+            // Typed: Post (predicate, object=node) → subjects. Wildcard has no
+            // predicate prefix, so it probes Opst (object=node) instead.
+            let (index, range_match) = match &self.pattern.predicate {
+                Some(pred) => (
+                    IndexType::Post,
+                    RangeMatch::new()
+                        .with_predicate(pred.clone())
+                        .with_object(FlakeValue::Ref(node.clone())),
+                ),
+                None => (
+                    IndexType::Opst,
+                    RangeMatch::new().with_object(FlakeValue::Ref(node.clone())),
+                ),
+            };
             let flakes = range_with_overlay(
                 db,
                 ctx.binary_g_id,
                 overlay,
-                IndexType::Post,
+                index,
                 RangeTest::Eq,
                 range_match,
                 RangeOptions::new().with_to_t(to_t),
             )
             .await?;
             for flake in flakes {
+                if self.pattern.predicate.is_none()
+                    && crate::property_path::is_reserved_edge_predicate(&flake.p)
+                {
+                    continue;
+                }
                 out.push(flake.s);
             }
         }
 
         Ok(out)
+    }
+
+    /// Post-hoc predicate lookup for one hop of a *wildcard* path: the first
+    /// non-reserved reference edge stored as `a → b`. Runs only on found
+    /// paths (≤ hop-count probes each), not during the search.
+    async fn hop_predicate(
+        &self,
+        ctx: &ExecutionContext<'_>,
+        a: &Sid,
+        b: &Sid,
+    ) -> Result<Option<Sid>> {
+        let (db, overlay, to_t) = ctx.require_single_graph()?;
+        let flakes = range_with_overlay(
+            db,
+            ctx.binary_g_id,
+            overlay,
+            IndexType::Spot,
+            RangeTest::Eq,
+            RangeMatch::new().with_subject(a.clone()),
+            RangeOptions::new().with_to_t(to_t),
+        )
+        .await?;
+        for flake in flakes {
+            if crate::property_path::is_reserved_edge_predicate(&flake.p) {
+                continue;
+            }
+            if matches!(&flake.o, FlakeValue::Ref(o) if o == b) {
+                return Ok(Some(flake.p));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Build the per-hop `(start, predicate, end)` edge tuples for a found
+    /// path. Typed patterns stamp the single predicate; wildcard patterns
+    /// resolve each hop's stored edge with [`Self::hop_predicate`] (trying
+    /// both orientations under `Either`; a hop whose predicate can't be
+    /// resolved is skipped defensively).
+    async fn build_edges(
+        &self,
+        ctx: &ExecutionContext<'_>,
+        path: &[Sid],
+    ) -> Result<Vec<(Sid, Sid, Sid)>> {
+        let incoming = matches!(self.pattern.direction, PathDirection::Incoming);
+        if let Some(pred) = &self.pattern.predicate {
+            return Ok(path
+                .windows(2)
+                .map(|w| {
+                    if incoming {
+                        (w[1].clone(), pred.clone(), w[0].clone())
+                    } else {
+                        (w[0].clone(), pred.clone(), w[1].clone())
+                    }
+                })
+                .collect());
+        }
+        let either = matches!(self.pattern.direction, PathDirection::Either);
+        let mut edges = Vec::with_capacity(path.len().saturating_sub(1));
+        for w in path.windows(2) {
+            let (s, o) = if incoming {
+                (&w[1], &w[0])
+            } else {
+                (&w[0], &w[1])
+            };
+            if let Some(p) = self.hop_predicate(ctx, s, o).await? {
+                edges.push((s.clone(), p, o.clone()));
+            } else if either {
+                if let Some(p) = self.hop_predicate(ctx, o, s).await? {
+                    edges.push((o.clone(), p, s.clone()));
+                }
+            }
+        }
+        Ok(edges)
     }
 
     /// Bidirectional BFS for a single shortest path. Returns the node sequence
@@ -588,36 +684,26 @@ impl ShortestPathOperator {
 
         let mut rows = Vec::with_capacity(paths.len());
         for path in paths {
+            // Orient each hop's edge by the traversal direction: outgoing keeps
+            // node[i]→node[i+1]; incoming flips to the stored edge. For an
+            // undirected (`Either`) search the per-hop orientation isn't
+            // recorded, so this falls back to traversal order (best effort;
+            // wildcard hops probe both orientations).
+            //
+            // Only Cypher's `relationships(p)` reads `edges`; skip the per-hop
+            // work entirely on surfaces that don't (JSON-LD/FQL), where
+            // `needs_relationships` is false.
+            let edges: Vec<(Sid, Sid, Sid)> = if self.pattern.needs_relationships {
+                self.build_edges(ctx, &path).await?
+            } else {
+                Vec::new()
+            };
             let mut row: Vec<Binding> = Vec::with_capacity(self.in_schema.len());
             for var in self.in_schema.iter() {
                 if *var == self.pattern.path_var {
-                    // Single-typed path. Orient each hop's edge by the traversal
-                    // direction: outgoing keeps node[i]→node[i+1]; incoming flips
-                    // to the stored edge node[i+1]→node[i]. For an undirected
-                    // (`Either`) search the per-hop orientation isn't recorded, so
-                    // we fall back to traversal order (best effort).
-                    //
-                    // Only Cypher's `relationships(p)` reads `edges`; skip the
-                    // per-hop allocation/clone entirely on surfaces that don't
-                    // (JSON-LD/FQL), where `needs_relationships` is false.
-                    let edges: Vec<(Sid, Sid, Sid)> = if self.pattern.needs_relationships {
-                        let pred = self.pattern.predicate.clone();
-                        let incoming = matches!(self.pattern.direction, PathDirection::Incoming);
-                        path.windows(2)
-                            .map(|w| {
-                                if incoming {
-                                    (w[1].clone(), pred.clone(), w[0].clone())
-                                } else {
-                                    (w[0].clone(), pred.clone(), w[1].clone())
-                                }
-                            })
-                            .collect()
-                    } else {
-                        Vec::new()
-                    };
                     row.push(Binding::Path {
                         nodes: path.clone(),
-                        edges,
+                        edges: edges.clone(),
                     });
                 } else if let Some(col) = child_batch.column(*var) {
                     row.push(col[row_idx].clone());

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -294,6 +294,26 @@ async fn transact_via_consensus(
     tx_id: String,
     headers: &HeaderMap,
 ) -> Result<Response> {
+    let receipt = submit_via_consensus(state, request, headers).await?;
+    let response_json = Json(transact_response(
+        ledger_id.to_string(),
+        receipt.commit.t,
+        tx_id,
+        receipt.commit.commit_id.to_string(),
+        receipt.tally.as_ref(),
+    ));
+    Ok(build_consensus_response(response_json, &receipt))
+}
+
+/// Submit a transaction through consensus and return the receipt, recording
+/// the tracking tally on the current span. Shared by the commit-receipt
+/// response path ([`transact_via_consensus`]) and the Cypher write-RETURN
+/// path, which shapes its own response body from the receipt.
+async fn submit_via_consensus(
+    state: &AppState,
+    request: TransactionRequest,
+    headers: &HeaderMap,
+) -> Result<fluree_db_consensus::TransactionReceipt> {
     let correlation = IndexRequestCorrelation::new(
         extract_request_id(headers, &state.telemetry_config),
         extract_trace_id(headers),
@@ -322,14 +342,7 @@ async fn transact_via_consensus(
     if let Some(tally) = &receipt.tally {
         record_tracking_on_span(&tracing::Span::current(), tally);
     }
-    let response_json = Json(transact_response(
-        ledger_id.to_string(),
-        receipt.commit.t,
-        tx_id,
-        receipt.commit.commit_id.to_string(),
-        receipt.tally.as_ref(),
-    ));
-    Ok(build_consensus_response(response_json, &receipt))
+    Ok(receipt)
 }
 
 /// If the request was signed (credentialed), return the *original* signed envelope
@@ -1843,6 +1856,26 @@ async fn execute_cypher_transact(
         &handle,
     );
     let tracking = tracking_from_headers(headers);
+
+    // A trailing RETURN on the write ships a skolemization id with the
+    // request so the created-entity rows are reconstructible post-commit
+    // (see `fluree_db_api::cypher_write`). Validation errors surface here,
+    // pre-submission; parse errors fall through to the consensus path's
+    // full-diagnostic error.
+    let return_plan =
+        fluree_db_api::cypher_write::plan_write_return_source(&cypher, params.as_ref())
+            .map_err(ServerError::Api)
+            .inspect_err(|_| {
+                set_span_error_code(span, "error:BadRequest");
+            })?;
+    let skolem_txn_id = return_plan
+        .as_ref()
+        .map(|_| fluree_db_api::cypher_write::fresh_skolem_txn_id());
+    let txn_opts = TxnOpts {
+        skolem_txn_id: skolem_txn_id.clone(),
+        ..TxnOpts::default()
+    };
+
     let request = TransactionRequest {
         idempotency_key: extract_idempotency_key(&credential.headers)?,
         ledger_id: ledger_id.to_string(),
@@ -1850,12 +1883,69 @@ async fn execute_cypher_transact(
             query: cypher,
             params,
         },
-        txn_opts: TxnOpts::default(),
+        txn_opts,
         commit_opts,
         tracking,
         governance: qc_opts,
     };
-    transact_via_consensus(state, ledger_id, request, tx_id, &credential.headers).await
+
+    let (Some(plan), Some(skolem_id)) = (return_plan, skolem_txn_id) else {
+        return transact_via_consensus(state, ledger_id, request, tx_id, &credential.headers).await;
+    };
+
+    // Write with RETURN: commit, then answer the RETURN as a Cypher-JSON
+    // envelope (matching the read path's tabular format).
+    let receipt = submit_via_consensus(state, request, &credential.headers).await?;
+    let ledger_state =
+        wait_for_committed_state(state, ledger_id, receipt.commit.t, &receipt).await?;
+    let envelope = fluree_db_api::cypher_write::write_return_rows(&plan, &skolem_id, &ledger_state)
+        .await
+        .map_err(ServerError::Api)?;
+
+    let mut response_headers = HeaderMap::new();
+    if let Some(key) = &receipt.idempotency_key {
+        if let Ok(value) = HeaderValue::from_str(key.as_str()) {
+            response_headers.insert("Idempotency-Key", value);
+        }
+    }
+    if let Some(tally) = &receipt.tally {
+        response_headers.extend(tracking_headers(tally));
+    }
+    response_headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        HeaderValue::from_static("application/vnd.fluree.cypher+json; charset=utf-8"),
+    );
+    Ok((response_headers, envelope.to_string()).into_response())
+}
+
+/// Wait (briefly) until the cached ledger state includes commit `t`. Local
+/// consensus updates the cache before the receipt returns, so this passes
+/// immediately; a Raft follower may lag until the commit event applies.
+async fn wait_for_committed_state(
+    state: &AppState,
+    ledger_id: &str,
+    commit_t: i64,
+    receipt: &fluree_db_consensus::TransactionReceipt,
+) -> Result<fluree_db_api::LedgerState> {
+    for _ in 0..40 {
+        let handle = state
+            .fluree
+            .ledger_cached(ledger_id)
+            .await
+            .map_err(ServerError::Api)?;
+        let view = handle.snapshot().await;
+        if view.t >= commit_t {
+            return Ok(view.to_ledger_state());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    Err(ServerError::Api(fluree_db_api::ApiError::internal(
+        format!(
+            "commit {} (t={commit_t}) is not yet visible in the local ledger state; \
+         the write succeeded but its RETURN rows could not be produced",
+            receipt.commit.commit_id
+        ),
+    )))
 }
 
 /// Execute a SPARQL UPDATE request

--- a/fluree-db-server/tests/cypher_http_integration.rs
+++ b/fluree-db-server/tests/cypher_http_integration.rs
@@ -362,3 +362,68 @@ async fn connection_scoped_cypher_is_rejected() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
+
+/// A trailing RETURN on a write answers with the created entities as a
+/// Cypher-JSON envelope (benchgraph `arango__single_vertex_write` /
+/// `arango__single_edge_write` round trips).
+#[tokio::test]
+async fn cypher_http_write_with_return() {
+    let (_tmp, state) = server_state().await;
+    create_ledger(&state, "cypherwriteret").await;
+
+    // Node create with RETURN.
+    let (status, body) = post_cypher(
+        &state,
+        "/v1/fluree/update/cypherwriteret",
+        "CREATE (n:UserTemp {id: 4112}) RETURN n",
+    )
+    .await;
+    assert!(status.is_success(), "status={status}; body={body}");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("cypher-json envelope");
+    assert_eq!(json["results"][0]["columns"], json!(["n"]), "{body}");
+    let data = json["results"][0]["data"].as_array().expect("data");
+    assert_eq!(data.len(), 1, "{body}");
+    assert!(
+        data[0]["row"][0]
+            .as_str()
+            .is_some_and(|s| s.starts_with("_:fdb-")),
+        "{body}"
+    );
+
+    // Edge create with RETURN (anchored MATCH).
+    let (status, _b) = post_cypher(
+        &state,
+        "/v1/fluree/update/cypherwriteret",
+        "CREATE (n:UserTemp {id: 5721})",
+    )
+    .await;
+    assert!(status.is_success());
+    let (status, body) = post_cypher(
+        &state,
+        "/v1/fluree/update/cypherwriteret",
+        "MATCH (a:UserTemp {id: 4112}), (b:UserTemp {id: 5721})
+           CREATE (a)-[e:Temp]->(b) RETURN e",
+    )
+    .await;
+    assert!(status.is_success(), "status={status}; body={body}");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("cypher-json envelope");
+    assert_eq!(json["results"][0]["columns"], json!(["e"]), "{body}");
+    let data = json["results"][0]["data"].as_array().expect("data");
+    assert_eq!(data.len(), 1, "{body}");
+    assert!(
+        data[0]["row"][0]
+            .as_str()
+            .is_some_and(|s| s.contains("cy_rel_e")),
+        "{body}"
+    );
+
+    // A no-RETURN write still answers with the commit receipt.
+    let (status, body) = post_cypher(
+        &state,
+        "/v1/fluree/update/cypherwriteret",
+        "CREATE (n:UserTemp {id: 9})",
+    )
+    .await;
+    assert!(status.is_success());
+    assert!(body.contains("commit"), "receipt shape unchanged: {body}");
+}

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -227,9 +227,13 @@ fn reject_direct_reifies_in_patterns(patterns: &[Pattern]) -> Result<()> {
                 }
                 // ShortestPath also carries a predicate Sid; apply the same
                 // firewall (no SPARQL surface produces it today, but stay safe).
+                // The wildcard form (`predicate: None`) excludes `f:reifies*`
+                // in the operator's edge-set.
                 Pattern::ShortestPath(sp) => {
-                    if fluree_db_core::is_reserved_reifies_predicate(&sp.predicate) {
-                        return Err(reject_predicate_string(format!("{}", sp.predicate)));
+                    if let Some(pred) = &sp.predicate {
+                        if fluree_db_core::is_reserved_reifies_predicate(pred) {
+                            return Err(reject_predicate_string(format!("{pred}")));
+                        }
                     }
                 }
                 Pattern::Optional(inner)

--- a/fluree-db-transact/src/ir.rs
+++ b/fluree-db-transact/src/ir.rs
@@ -478,6 +478,17 @@ pub struct TxnOpts {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lpg_edge_lifecycle: Option<bool>,
 
+    /// Skolemization id override for blank-node minting in this transaction.
+    ///
+    /// When set, staging uses this id instead of a generated timestamp in the
+    /// `fdb-{txn_id}-{solution}-{label}` skolem key, making created-entity
+    /// Sids reconstructible by the caller (Cypher `CREATE … RETURN n`
+    /// resolves the created node from the id it supplied). Must be unique per
+    /// committed transaction — reuse would collide freshly minted subjects
+    /// with an earlier commit's.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skolem_txn_id: Option<String>,
+
     /// Inline SHACL shape definitions for *this transaction only*.
     ///
     /// JSON-LD document carrying SHACL shapes (sh:NodeShape /

--- a/fluree-db-transact/src/lib.rs
+++ b/fluree-db-transact/src/lib.rs
@@ -67,7 +67,7 @@ pub use ir::{InlineValues, TemplateTerm, TripleTemplate, Txn, TxnOpts, TxnType};
 pub use lower_sparql_update::{lower_sparql_update, lower_sparql_update_ast, LowerError};
 pub use namespace::{
     stable_blank_node_sid, stable_blank_node_sid_from_label, NamespaceRegistry,
-    SharedNamespaceAllocator, BLANK_NODE_PREFIX,
+    SharedNamespaceAllocator, BLANK_NODE_ID_PREFIX, BLANK_NODE_PREFIX,
 };
 pub use parse::{
     parse_transaction, parse_trig_phase1, resolve_trig_meta, NamedGraphBlock, RawObject, RawTerm,

--- a/fluree-db-transact/src/lower_cypher_update.rs
+++ b/fluree-db-transact/src/lower_cypher_update.rs
@@ -1482,15 +1482,19 @@ impl<'a> CypherLowering<'a> {
     }
 
     fn lower_create_part(&mut self, part: &PatternPart) -> Result<(), LowerCypherError> {
-        require_node_anchored(&part.head)?;
         let head_subj = self.node_subject(&part.head);
         self.lower_node_create(&part.head, head_subj.clone())?;
+        // An isolated fresh node with no labels and no properties (`CREATE ()`
+        // / `CREATE (n)`) still needs a triple to exist as an RDF subject —
+        // mark it with the system node class (hidden from `labels()`).
+        // Relationship endpoints are anchored by the edge and need no marker.
+        if part.tail.is_empty() && self.is_fresh_bare_node(&part.head) {
+            self.push_node_marker(head_subj.clone());
+        }
 
         let mut prev_subj = head_subj;
         let mut prev_node = &part.head;
         for (rel, next) in &part.tail {
-            // Both nodes must be anchored if they appear in CREATE.
-            require_node_anchored(next)?;
             let next_subj = self.node_subject(next);
             self.lower_node_create(next, next_subj.clone())?;
             self.lower_rel_create(prev_node, &prev_subj, rel, next, &next_subj)?;
@@ -1665,6 +1669,27 @@ impl<'a> CypherLowering<'a> {
         Ok(terms)
     }
 
+    /// Whether a CREATE node is freshly minted (not a MATCH-bound reference)
+    /// and carries no labels or inline properties.
+    fn is_fresh_bare_node(&self, n: &NodePattern) -> bool {
+        let bound = n
+            .var
+            .as_ref()
+            .is_some_and(|v| self.bound_vars.contains(&v.name));
+        !bound && n.labels.is_empty() && n.props.is_none()
+    }
+
+    /// Assert the `db:Node` existence marker for a bare created node.
+    fn push_node_marker(&mut self, subj: TemplateTerm) {
+        let rdf_type_sid = self.ns.sid_for_iri(rdf::TYPE);
+        let node_sid = self.ns.sid_for_iri(fluree_vocab::fluree::NODE);
+        self.insert_templates.push(TripleTemplate::new(
+            subj,
+            TemplateTerm::Sid(rdf_type_sid),
+            TemplateTerm::Sid(node_sid),
+        ));
+    }
+
     fn node_subject(&mut self, n: &NodePattern) -> TemplateTerm {
         if let Some(var) = &n.var {
             // A var bound by a preceding MATCH references the existing
@@ -1726,15 +1751,6 @@ fn set_item_target(item: &SetItem) -> &Variable {
         | SetItem::MapReplace { target, .. }
         | SetItem::Labels { target, .. } => target,
     }
-}
-
-fn require_node_anchored(node: &NodePattern) -> Result<(), LowerCypherError> {
-    if node.labels.is_empty() && node.props.is_none() && node.var.is_none() {
-        return Err(LowerCypherError::rejected(
-            "bare `()` node in CREATE — every node needs a variable, a label, or a property",
-        ));
-    }
-    Ok(())
 }
 
 /// A standalone node in a write-statement MATCH must carry a label or a

--- a/fluree-db-transact/src/lower_cypher_update.rs
+++ b/fluree-db-transact/src/lower_cypher_update.rs
@@ -139,6 +139,10 @@ struct CypherLowering<'a> {
     /// `DELETE r` retract the base edge (the `f:reifies*` cascade then removes
     /// the bundle).
     rel_var_edges: std::collections::HashMap<String, (String, Sid, String)>,
+    /// Relationship variables already used for a CREATE relationship — each
+    /// names one created edge's annotation (label `_:cy_rel_{name}`), so a
+    /// reuse would silently merge two edges' annotations.
+    created_rel_vars: std::collections::HashSet<String>,
     /// Stable per-pattern-occurrence node labels, keyed by node span.
     /// Used so two appearances of the same node pattern in `CREATE
     /// (a)-[]->(b), (a)-[]->(c)` resolve to the same SID at staging
@@ -166,6 +170,7 @@ impl<'a> CypherLowering<'a> {
             synth_counter: 0,
             bound_vars: std::collections::HashSet::new(),
             rel_var_edges: std::collections::HashMap::new(),
+            created_rel_vars: std::collections::HashSet::new(),
             node_subject_cache: std::collections::HashMap::new(),
         }
     }
@@ -189,11 +194,10 @@ impl<'a> CypherLowering<'a> {
     }
 
     fn lower_update(&mut self, update: &Update) -> Result<(), LowerCypherError> {
-        if update.return_clause.is_some() {
-            return Err(LowerCypherError::unsupported(
-                "RETURN on a write statement is deferred in v1",
-            ));
-        }
+        // A trailing RETURN is not part of the Txn: the API layer validates it
+        // (created-entity variables only in v1), supplies a skolem txn id via
+        // `TxnOpts::skolem_txn_id`, and reconstructs the returned rows after
+        // the commit (see `fluree-db-api::cypher_write`). Lowering ignores it.
 
         // A MERGE must be the only write. Each MERGE appends a top-level NOT
         // EXISTS guard evaluated against the pre-transaction snapshot, so
@@ -1573,7 +1577,24 @@ impl<'a> CypherLowering<'a> {
         // freshened per WHERE solution (SPARQL §3.1.3), so batched edge inserts
         // mint a distinct annotation per row. The base triple above also makes
         // the edge visible to anonymous (plain-RDF) reads.
-        let ann = self.fresh_bnode();
+        //
+        // A named relationship (`CREATE (a)-[e:T]->(b)`) uses a label derived
+        // from the variable so a trailing `RETURN e` can reconstruct the
+        // created annotation's Sid (the `cy_rel_` prefix keeps it disjoint
+        // from node-variable labels `cy_{name}`).
+        let ann = match &rel.var {
+            Some(v) => {
+                if !self.created_rel_vars.insert(v.name.clone()) {
+                    return Err(LowerCypherError::rejected(format!(
+                        "relationship variable `{}` is bound more than once in CREATE; \
+                         use a distinct name for each relationship",
+                        v.name
+                    )));
+                }
+                TemplateTerm::BlankNode(format!("_:cy_rel_{}", v.name))
+            }
+            None => self.fresh_bnode(),
+        };
         self.emit_reifier_bundle(&ann, &s, &type_sid, &o)?;
         if let Some(props) = &rel.props {
             self.emit_property_triples(&ann, props)?;

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -645,8 +645,14 @@ pub async fn stage(
             ])
         };
 
-        // Generate transaction ID for blank node skolemization
-        let txn_id = generate_txn_id();
+        // Transaction ID for blank node skolemization — caller-supplied when
+        // created-entity Sids must be reconstructible (Cypher write RETURN),
+        // otherwise generated.
+        let txn_id = txn
+            .opts
+            .skolem_txn_id
+            .clone()
+            .unwrap_or_else(generate_txn_id);
 
         // Convert graph_delta (g_id -> IRI) to graph_sids (g_id -> Sid) for named graph support
         let graph_sids: HashMap<GraphId, Sid> = txn

--- a/fluree-db-transact/tests/it_lower_cypher.rs
+++ b/fluree-db-transact/tests/it_lower_cypher.rs
@@ -151,23 +151,33 @@ fn create_undirected_relationship_is_rejected() {
 }
 
 #[test]
-fn create_bare_node_is_rejected() {
-    let out = parse_cypher("CREATE ()");
-    // Empty parens may parse, but parsing a node with no var/label/props
-    // depends on the parser shape. Try both — if parse fails, that's
-    // an acceptable rejection point too.
-    if out.has_errors() {
-        return;
-    }
-    let ast = out.ast.unwrap();
-    let mut ns = NamespaceRegistry::new();
-    let r = lower_cypher_update(
-        &ast,
-        &mut ns,
-        TxnOpts::default(),
-        CypherLowerOpts::default(),
+fn create_bare_node_asserts_existence_marker() {
+    // `CREATE ()` — an anonymous propertyless node still needs one triple to
+    // exist as an RDF subject; it gets the hidden `db:Node` marker class.
+    let txn = lower("CREATE ()");
+    assert_eq!(
+        txn.insert_templates.len(),
+        1,
+        "templates: {:?}",
+        txn.insert_templates
     );
-    assert!(r.is_err(), "expected rejection of bare CREATE ()");
+    assert!(matches!(
+        txn.insert_templates[0].subject,
+        TemplateTerm::BlankNode(_)
+    ));
+}
+
+#[test]
+fn create_bare_pattern_needs_no_marker() {
+    // `CREATE ()-[:TempEdge]->()` — the edge anchors both endpoints:
+    // 1 base edge + 3 reifier bundle triples, no markers.
+    let txn = lower("CREATE ()-[:TempEdge]->()");
+    assert_eq!(
+        txn.insert_templates.len(),
+        4,
+        "templates: {:?}",
+        txn.insert_templates
+    );
 }
 
 #[test]
@@ -267,6 +277,36 @@ fn match_set_property_emits_update_with_optional_old_value() {
         txn.insert_templates[0].object,
         TemplateTerm::Value(_)
     ));
+}
+
+#[test]
+fn match_set_property_to_negative_literal() {
+    // `-1` is unary minus over a literal; the parser folds it so write
+    // lowering sees a plain literal (benchgraph `update__vertex_on_property`).
+    let txn = lower(r#"MATCH (n:Person {name: "Alice"}) SET n.property = -1"#);
+    assert_eq!(txn.insert_templates.len(), 1);
+    match &txn.insert_templates[0].object {
+        TemplateTerm::Value(fluree_db_core::FlakeValue::Long(v)) => assert_eq!(*v, -1),
+        other => panic!("expected Long(-1), got {other:?}"),
+    }
+}
+
+#[test]
+fn create_node_with_negative_property_values() {
+    let txn = lower(r#"CREATE (n:Point {x: -1, y: -2.5, z: - -3})"#);
+    // 1 label + 3 properties.
+    assert_eq!(txn.insert_templates.len(), 4);
+    let values: Vec<_> = txn
+        .insert_templates
+        .iter()
+        .filter_map(|t| match &t.object {
+            TemplateTerm::Value(v) => Some(v.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(values.contains(&fluree_db_core::FlakeValue::Long(-1)));
+    assert!(values.contains(&fluree_db_core::FlakeValue::Double(-2.5)));
+    assert!(values.contains(&fluree_db_core::FlakeValue::Long(3)));
 }
 
 #[test]

--- a/fluree-vocab/src/lib.rs
+++ b/fluree-vocab/src/lib.rs
@@ -1568,6 +1568,12 @@ pub mod fluree {
 
     /// "This commit" placeholder IRI (scheme form, used without prefix definition)
     pub const COMMIT_THIS_SCHEME: &str = "fluree:commit:this";
+
+    /// db:Node — existence marker class for LPG nodes created with no labels
+    /// and no properties (Cypher `CREATE ()`). An RDF subject needs at least
+    /// one triple to exist; this class provides it. Hidden from Cypher
+    /// `labels()`.
+    pub const NODE: &str = "https://ns.flur.ee/db#Node";
 }
 
 /// Namespace codes for IRI encoding

--- a/regression-budget.json
+++ b/regression-budget.json
@@ -63,6 +63,11 @@
         "tiny": 10.0,
         "small": 5.0,
         "medium": 3.0
+      },
+      "query_hot_whole_graph_agg": {
+        "tiny": 10.0,
+        "small": 5.0,
+        "medium": 3.0
       }
     },
     "fluree-db-query": {


### PR DESCRIPTION
## Summary

Takes the Pokec benchmark to 35/35 supported queries and brings the hot benchmark shapes to seek/count-store parity. Three groups of changes:

### Cypher surface gaps
- Untyped single-hop patterns (`-->` / `-[e]->`) now follow relationships only (rdf:type and data properties excluded), matching the untyped var-length wildcard.
- Value-only bound relationship variables lower to base triple + optional annotation probe + coalesce, so plain-RDF edges match while reified parallel edges keep one row per annotation. COALESCE gained a binding-path arm so structured values survive BIND.
- Untyped `shortestPath` / `allShortestPaths` (`ShortestPathPattern.predicate` is now `Option<Sid>`), with per-hop predicates resolved post-hoc for `relationships(p)`.
- Unary minus folds at parse time (`SET n.p = -1`, negative inline properties).
- Bare `CREATE ()` / `CREATE (n)` asserts a hidden `db:Node` existence marker; `UNWIND range(...)` before a write clause reuses the `$param` batch desugar.
- **RETURN on write statements**: created-entity Sids are deterministic given a caller-supplied skolem txn id (`TxnOpts::skolem_txn_id`), so rows are reconstructed post-commit — on the HTTP route and the new `Fluree::transact_cypher_returning` API.
- Bare `MATCH (n)` whole-graph scans available behind `FLUREE_CYPHER_ALLOW_FULL_SCAN=1` (off by default).

### Performance
- **Stats-driven write WHERE planning**: `execute_where_streaming` previously planned with no statistics, so anchored MATCHes label-scanned. Now builds the same cached novelty-merged stats view as the read path (10k-user A/B: 82.7s → 25ms). Applies to every WHERE-driven write surface, not just Cypher.
- Property-join stars driven from the most selective bound object instead of hard-preferring rdf:type (labeled point lookup 4ms → 0.65ms; cost now constant in label size).
- New metadata-lane folds: whole-graph scalar aggregates from index directories (`count(n)` 27ms → 0.5ms), class-anchored aggregates and GROUP-BY histograms, group-key-filtered histograms.
- Equality-filtered OPTIONALs fold into required triples; anonymous hop chains fuse into frontier-BFS reachability; Cypher pattern IRIs encode to SIDs at lowering.

### Correctness hardening for the fast paths
- Fast paths gate on live novelty rather than the monotonic overlay epoch.
- Base per-graph property stats carry through incremental indexing.
- Distinct-count/aggregate folds decline on partial stats and scan-hidden predicates (`f:reifies*`).
- Specific-value lookups stay at seek speed under predicate novelty.

### Test wiring
Re-wires four `fluree-db-api` test files that were orphaned from CI (`autotests = false` with no `[[test]]` target): `it_query_cypher` (156 tests), `it_policy_cypher`, `it_csv_import`, `it_tpch_iceberg_bench`. Also updates the Cypher docs (support matrix, relationship-lowering semantics, configuration) and includes the Bolt protocol adapter design doc.

## Test plan
- [x] `cargo nextest run --workspace --all-features` (including the newly re-wired test targets)
- [x] Benchgraph Pokec suite: 35/35 supported, results verified against the general pipeline (including multi-valued property row semantics)
- [x] Write-path A/B on 10k-user in-memory and indexed pokec ledgers