### PR TITLE
feat(iceberg): add AWS Glue Data Catalog + S3 Tables catalog modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -171,7 +171,7 @@ checksum = "36fa98bc79671c7981272d91a8753a928ff6a1cd8e4f20a44c45bd5d313840bf"
 dependencies = [
  "bigdecimal 0.4.10",
  "bon",
- "digest",
+ "digest 0.10.7",
  "log",
  "miniz_oxide",
  "num-bigint",
@@ -212,6 +212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -564,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.2"
+version = "1.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -615,6 +624,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-glue"
+version = "1.153.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b33661f9c0b02b6c23d42646f43ea9eab6db37fdcbd80f85fabe72a70b9d8e"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,16 +671,41 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 1.0.1",
  "lru 0.16.3",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "aws-sdk-s3tables"
+version = "1.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf4f0e9ec9c0cd8f978b0672086924c1b6c4c19776773bf1a6f0020d24c954d"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -724,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -734,16 +793,15 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "p256",
  "percent-encoding",
- "ring",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
@@ -778,15 +836,15 @@ dependencies = [
  "md-5",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.20"
+version = "0.60.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -847,10 +905,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -875,15 +935,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -900,11 +961,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -916,10 +978,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -952,13 +1036,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -1039,9 +1124,9 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base256emoji"
@@ -1144,6 +1229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1426,7 +1520,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1487,6 +1581,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -1581,6 +1681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1748,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,7 +1778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rustversion",
  "spin 0.10.0",
 ]
@@ -1786,24 +1901,14 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1815,6 +1920,15 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1848,15 +1962,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -2031,21 +2154,12 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2109,9 +2223,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2211,14 +2338,16 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.6.1",
+ "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature 1.6.4",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -2227,8 +2356,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -2240,7 +2369,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2253,18 +2382,18 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest",
+ "crypto-bigint",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "pkcs8 0.9.0",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -2345,9 +2474,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -2534,7 +2663,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -2589,7 +2718,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "shellexpand",
  "tempfile",
  "tokio",
@@ -2647,7 +2776,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2682,7 +2811,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 1.0.69",
  "tokio",
@@ -2702,7 +2831,7 @@ dependencies = [
  "jsonwebtoken",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -2717,7 +2846,7 @@ dependencies = [
  "fluree-db-nameservice",
  "hex",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "zeroize",
@@ -2759,7 +2888,9 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-credential-types",
+ "aws-sdk-glue",
  "aws-sdk-s3",
+ "aws-sdk-s3tables",
  "aws-smithy-http-client",
  "bytes",
  "chrono",
@@ -2808,7 +2939,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.69",
@@ -2862,7 +2993,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -2948,7 +3079,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -3010,7 +3141,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -3104,7 +3235,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2",
+ "sha2 0.10.9",
  "shellexpand",
  "tempfile",
  "thiserror 1.0.69",
@@ -3178,7 +3309,7 @@ dependencies = [
  "s2",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",
@@ -3202,7 +3333,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -3220,7 +3351,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -3264,7 +3395,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -3534,6 +3665,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3650,9 +3782,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -3812,7 +3944,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3890,6 +4031,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -4632,7 +4782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5050,13 +5200,14 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5166,6 +5317,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5205,22 +5365,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
-]
-
-[[package]]
-name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -5264,7 +5414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5360,6 +5510,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.115",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -5793,13 +5952,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -5934,7 +6092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "globset",
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -6206,14 +6364,14 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.6.1",
+ "der",
  "generic-array",
- "pkcs8 0.9.0",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -6412,8 +6570,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6423,8 +6581,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6463,20 +6632,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6577,22 +6737,12 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -7339,9 +7489,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ulid"
@@ -7389,7 +7539,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,8 @@ aws-config = "1.8.15"
 aws-sdk-s3 = "1.124.0"
 aws-sdk-dynamodb = "1.109.0"
 aws-sdk-sts = "1.101.0"
+aws-sdk-glue = "1.153.0"
+aws-sdk-s3tables = "1.59.0"
 aws-credential-types = "1.2"
 aws-smithy-types = "1.4.7"
 # HTTP/1.1-pinned transport for the S3 SDK. GCS's S3-interop endpoint negotiates

--- a/docs/cli/iceberg.md
+++ b/docs/cli/iceberg.md
@@ -33,7 +33,7 @@ fluree iceberg map <NAME> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--mode <MODE>` | Catalog mode: `rest` (default) or `direct` |
+| `--mode <MODE>` | Catalog mode: `rest` (default), `direct`, `glue` (AWS Glue Data Catalog), or `s3tables` (AWS S3 Tables) |
 
 **REST catalog mode options:**
 
@@ -49,6 +49,15 @@ fluree iceberg map <NAME> [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `--table-location <URI>` | S3 table location (required for direct mode, e.g., `s3://bucket/warehouse/ns/table`) |
+
+**AWS Glue / S3 Tables mode options** (native AWS SDK; reads S3 with the ambient AWS credential chain — no vended credentials):
+
+| Option | Description |
+|--------|-------------|
+| `--table <ID>` | Table identifier `namespace.table` (required). For `glue`, `namespace` is the Glue database. |
+| `--region <REGION>` | AWS region (falls back to the SDK default chain if omitted) |
+| `--catalog-id <ID>` | Glue catalog id for cross-account access (`glue` mode; defaults to the caller's account) |
+| `--table-bucket-arn <ARN>` | S3 Tables table-bucket ARN (required for `s3tables` mode) |
 
 **R2RML mapping:**
 

--- a/docs/graph-sources/iceberg.md
+++ b/docs/graph-sources/iceberg.md
@@ -17,10 +17,14 @@ Apache Iceberg is an open table format for huge analytical datasets. It provides
 
 ### Catalog Modes
 
-Fluree supports two ways to discover Iceberg metadata:
+Fluree supports four ways to discover Iceberg metadata:
 
-- **REST catalog**: discover table metadata via an Iceberg REST catalog API (e.g., Polaris).
+- **REST catalog**: discover table metadata via an Iceberg REST catalog API (e.g., Polaris, Snowflake Horizon).
 - **Direct S3 (no catalog server)**: bypass REST discovery and read `version-hint.text` from the table’s `metadata/` directory to resolve the current metadata file.
+- **AWS Glue Data Catalog** (`--mode glue`): resolve the table's `metadata_location` through the native AWS SDK (`aws-sdk-glue`), then read metadata and data from S3 with the ambient AWS credential chain. No REST catalog and no request signing — the SDK signs its own calls. The Glue *database* is the table identifier's namespace (`<database>.<table>`).
+- **AWS S3 Tables** (`--mode s3tables`): the same native-SDK approach via `aws-sdk-s3tables` against an S3 Tables table bucket (`--table-bucket-arn`).
+
+Glue and S3 Tables use the **ambient** AWS credential chain (env vars, `~/.aws/credentials`, IAM role / SSO) — the same as Direct mode; they do not use vended credentials. Vended-credential catalogs (Snowflake Horizon / Polaris, or Lake-Formation-governed Glue) go through REST mode.
 
 ### CLI
 
@@ -38,6 +42,21 @@ fluree iceberg map execution-log \
   --mode direct \
   --table-location s3://bucket/warehouse/logs/execution_log \
   --r2rml mappings/execution_log.ttl
+
+# AWS Glue Data Catalog (native SDK, ambient AWS credentials)
+fluree iceberg map warehouse-orders \
+  --mode glue \
+  --table sales.orders \
+  --region us-east-1 \
+  --r2rml mappings/orders.ttl
+
+# AWS S3 Tables (native SDK, ambient AWS credentials)
+fluree iceberg map warehouse-orders \
+  --mode s3tables \
+  --table analytics_ns.orders \
+  --table-bucket-arn arn:aws:s3tables:us-east-1:123456789012:bucket/analytics \
+  --region us-east-1 \
+  --r2rml mappings/orders.ttl
 
 # Google Cloud Storage — see "Google Cloud Storage (GCS)" below
 fluree iceberg map orders \

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -241,6 +241,10 @@ required-features = ["vector"]
 name = "it_select_star_deep_crawl_stack"
 path = "tests/it_select_star_deep_crawl_stack.rs"
 
+[[example]]
+name = "glue_onboarding"
+required-features = ["iceberg"]
+
 [[bench]]
 name = "vector_query"
 harness = false

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -213,6 +213,11 @@ path = "tests/it_graph_source_r2rml.rs"
 required-features = ["iceberg"]
 
 [[test]]
+name = "it_glue_live"
+path = "tests/it_glue_live.rs"
+required-features = ["iceberg"]
+
+[[test]]
 name = "it_iceberg_direct"
 path = "tests/it_iceberg_direct.rs"
 required-features = ["iceberg", "aws-testcontainers"]

--- a/fluree-db-api/examples/glue_onboarding.rs
+++ b/fluree-db-api/examples/glue_onboarding.rs
@@ -1,0 +1,38 @@
+//! Live check: the AWS Glue onboarding/introspection surface (catalog browse +
+//! table preview) via the public API — the paths that used to hard-reject Glue.
+//!
+//! Run:
+//! ```
+//! AWS_PROFILE=aj-sandbox AWS_REGION=us-east-1 \
+//!   cargo run --example glue_onboarding -p fluree-db-api --features iceberg
+//! ```
+
+use fluree_db_api::{
+    browse_iceberg_catalog, preview_iceberg_table, BrowseDepth, IcebergConnectionConfig, StatsTier,
+    TableIdentifier,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let region = std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".into());
+    let conn = IcebergConnectionConfig::glue(Some(region), None);
+
+    println!("=== browse_iceberg_catalog (Glue, depth=Tables) ===");
+    let browse = browse_iceberg_catalog(conn.clone(), BrowseDepth::Tables).await?;
+    println!("namespaces: {:?}", browse.namespaces);
+    println!("tables ({}):", browse.tables.len());
+    for t in browse.tables.iter().take(12) {
+        println!("  {}.{}", t.namespace, t.name);
+    }
+
+    println!("\n=== preview_iceberg_table (Glue) enterprise_dw.dim_store ===");
+    let table = TableIdentifier {
+        namespace: "enterprise_dw".into(),
+        name: "dim_store".into(),
+    };
+    let preview = preview_iceberg_table(conn, table, StatsTier::Schema).await?;
+    println!("{preview:#?}");
+
+    println!("\nONBOARDING OK");
+    Ok(())
+}

--- a/fluree-db-api/src/graph_source/config.rs
+++ b/fluree-db-api/src/graph_source/config.rs
@@ -437,6 +437,27 @@ pub enum CatalogMode {
         /// Example: "s3://bucket/warehouse/my_namespace/my_table"
         table_location: String,
     },
+    /// Resolve tables via the AWS Glue Data Catalog using the native AWS SDK.
+    ///
+    /// The Glue *database* is the table identifier's namespace. Credentials come
+    /// from the ambient AWS credential chain — no REST/SigV4 or vended
+    /// credentials are involved.
+    Glue {
+        /// AWS region. Falls back to the SDK default chain / `io.s3_region` if `None`.
+        region: Option<String>,
+        /// Glue catalog id for cross-account access (`None` = the caller's account).
+        catalog_id: Option<String>,
+    },
+    /// Resolve tables via AWS S3 Tables using the native AWS SDK.
+    ///
+    /// Credentials come from the ambient AWS credential chain.
+    S3Tables {
+        /// AWS region. Falls back to the SDK default chain / `io.s3_region` if `None`.
+        region: Option<String>,
+        /// The S3 Tables table-bucket ARN
+        /// (`arn:aws:s3tables:<region>:<account>:bucket/<name>`).
+        table_bucket_arn: String,
+    },
 }
 
 /// REST catalog mode configuration.
@@ -476,6 +497,35 @@ impl IcebergConnectionConfig {
         Self {
             catalog_mode: CatalogMode::Direct {
                 table_location: table_location.into(),
+            },
+            io: fluree_db_iceberg::config::IoConfig {
+                vended_credentials: false,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Create an AWS Glue Data Catalog connection (native AWS SDK). Vended
+    /// credentials are forced off — the SDK reads S3 with the ambient/IAM
+    /// credential chain.
+    pub fn glue(region: Option<String>, catalog_id: Option<String>) -> Self {
+        Self {
+            catalog_mode: CatalogMode::Glue { region, catalog_id },
+            io: fluree_db_iceberg::config::IoConfig {
+                vended_credentials: false,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Create an AWS S3 Tables connection (native AWS SDK) from a table-bucket
+    /// ARN. Vended credentials are forced off — the SDK reads the managed table
+    /// bucket with the ambient/IAM credential chain.
+    pub fn s3_tables(region: Option<String>, table_bucket_arn: impl Into<String>) -> Self {
+        Self {
+            catalog_mode: CatalogMode::S3Tables {
+                region,
+                table_bucket_arn: table_bucket_arn.into(),
             },
             io: fluree_db_iceberg::config::IoConfig {
                 vended_credentials: false,
@@ -543,6 +593,9 @@ impl IcebergConnectionConfig {
             CatalogMode::Direct { .. } => {
                 tracing::warn!("with_oauth2_scope has no effect in Direct catalog mode");
             }
+            CatalogMode::Glue { .. } | CatalogMode::S3Tables { .. } => {
+                tracing::warn!("with_oauth2_scope has no effect in Glue/S3Tables catalog mode");
+            }
         }
         self
     }
@@ -569,6 +622,9 @@ impl IcebergConnectionConfig {
             }
             CatalogMode::Direct { .. } => {
                 tracing::warn!("with_oauth2_audience has no effect in Direct catalog mode");
+            }
+            CatalogMode::Glue { .. } | CatalogMode::S3Tables { .. } => {
+                tracing::warn!("with_oauth2_audience has no effect in Glue/S3Tables catalog mode");
             }
         }
         self
@@ -617,6 +673,10 @@ impl IcebergConnectionConfig {
         match &self.catalog_mode {
             CatalogMode::Rest(rest) => &rest.catalog_uri,
             CatalogMode::Direct { table_location } => table_location,
+            CatalogMode::Glue { catalog_id, .. } => catalog_id.as_deref().unwrap_or("aws-glue"),
+            CatalogMode::S3Tables {
+                table_bucket_arn, ..
+            } => table_bucket_arn,
         }
     }
 
@@ -628,6 +688,16 @@ impl IcebergConnectionConfig {
     /// Returns `true` if this connection uses direct S3 catalog mode.
     pub fn is_direct(&self) -> bool {
         matches!(self.catalog_mode, CatalogMode::Direct { .. })
+    }
+
+    /// Returns `true` if this connection uses AWS Glue catalog mode.
+    pub fn is_glue(&self) -> bool {
+        matches!(self.catalog_mode, CatalogMode::Glue { .. })
+    }
+
+    /// Returns `true` if this connection uses AWS S3 Tables catalog mode.
+    pub fn is_s3tables(&self) -> bool {
+        matches!(self.catalog_mode, CatalogMode::S3Tables { .. })
     }
 }
 
@@ -748,7 +818,10 @@ impl IcebergCreateConfig {
     /// Get the table identifier string (for REST mode), or derive from location (for direct mode).
     pub fn table_identifier_display(&self) -> String {
         match &self.connection.catalog_mode {
-            CatalogMode::Rest(_) => self.table_identifier.clone(),
+            // REST / Glue / S3Tables all carry an explicit `namespace.table`.
+            CatalogMode::Rest(_) | CatalogMode::Glue { .. } | CatalogMode::S3Tables { .. } => {
+                self.table_identifier.clone()
+            }
             CatalogMode::Direct { table_location } => {
                 let path = table_location
                     .trim_start_matches("s3://")
@@ -794,6 +867,37 @@ impl IcebergCreateConfig {
                     mapping: None,
                 }
             }
+            CatalogMode::Glue { region, catalog_id } => {
+                // AWS SDK reads S3 with the ambient credential chain — never vended.
+                let mut io = self.connection.io.clone();
+                io.vended_credentials = false;
+                IcebergGsConfig {
+                    catalog: CatalogConfig::Glue {
+                        region: region.clone(),
+                        catalog_id: catalog_id.clone(),
+                    },
+                    table: TableConfig::Identifier(self.table_identifier.clone()),
+                    io,
+                    mapping: None,
+                }
+            }
+            CatalogMode::S3Tables {
+                region,
+                table_bucket_arn,
+            } => {
+                // AWS SDK reads the managed table bucket with the ambient chain.
+                let mut io = self.connection.io.clone();
+                io.vended_credentials = false;
+                IcebergGsConfig {
+                    catalog: CatalogConfig::S3Tables {
+                        region: region.clone(),
+                        table_bucket_arn: table_bucket_arn.clone(),
+                    },
+                    table: TableConfig::Identifier(self.table_identifier.clone()),
+                    io,
+                    mapping: None,
+                }
+            }
         }
     }
 
@@ -834,6 +938,35 @@ impl IcebergCreateConfig {
                     )));
                 }
             }
+            CatalogMode::Glue { .. } => {
+                if self.table_identifier.trim().is_empty() {
+                    return Err(crate::ApiError::config(
+                        "Table identifier cannot be empty for Glue catalog mode (use namespace.table)",
+                    ));
+                }
+                use fluree_db_iceberg::catalog::parse_table_identifier;
+                parse_table_identifier(&self.table_identifier).map_err(|e| {
+                    crate::ApiError::config(format!("Invalid table identifier: {e}"))
+                })?;
+            }
+            CatalogMode::S3Tables {
+                table_bucket_arn, ..
+            } => {
+                if !table_bucket_arn.starts_with("arn:aws:s3tables:") {
+                    return Err(crate::ApiError::config(format!(
+                        "S3Tables table_bucket_arn must be an S3 Tables bucket ARN (arn:aws:s3tables:...), got: {table_bucket_arn}"
+                    )));
+                }
+                if self.table_identifier.trim().is_empty() {
+                    return Err(crate::ApiError::config(
+                        "Table identifier cannot be empty for S3Tables catalog mode (use namespace.table)",
+                    ));
+                }
+                use fluree_db_iceberg::catalog::parse_table_identifier;
+                parse_table_identifier(&self.table_identifier).map_err(|e| {
+                    crate::ApiError::config(format!("Invalid table identifier: {e}"))
+                })?;
+            }
         }
 
         Ok(())
@@ -847,6 +980,16 @@ impl IcebergCreateConfig {
     /// Returns `true` if this config uses direct S3 catalog mode.
     pub fn is_direct(&self) -> bool {
         self.connection.is_direct()
+    }
+
+    /// Returns `true` if this config uses AWS Glue catalog mode.
+    pub fn is_glue(&self) -> bool {
+        self.connection.is_glue()
+    }
+
+    /// Returns `true` if this config uses AWS S3 Tables catalog mode.
+    pub fn is_s3tables(&self) -> bool {
+        self.connection.is_s3tables()
     }
 }
 
@@ -1181,7 +1324,9 @@ mod tests {
     fn oauth2_auth(config: &IcebergCreateConfig) -> &fluree_db_iceberg::auth::AuthConfig {
         match &config.connection.catalog_mode {
             CatalogMode::Rest(rest) => &rest.auth,
-            CatalogMode::Direct { .. } => panic!("expected REST catalog mode"),
+            CatalogMode::Direct { .. }
+            | CatalogMode::Glue { .. }
+            | CatalogMode::S3Tables { .. } => panic!("expected REST catalog mode"),
         }
     }
 

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -18,7 +18,10 @@ use serde::{Deserialize, Serialize};
 use crate::graph_source::config::{CatalogMode, IcebergConnectionConfig};
 use crate::Result;
 
-use fluree_db_iceberg::catalog::{RestCatalogClient, RestCatalogConfig, SendCatalogClient};
+use fluree_db_iceberg::catalog::{
+    GlueSdkCatalogClient, RestCatalogClient, RestCatalogConfig, S3TablesSdkCatalogClient,
+    SendCatalogClient,
+};
 use fluree_db_iceberg::io::batch::IcebergFieldTypeExt;
 use fluree_db_iceberg::io::S3IcebergStorage;
 use fluree_db_iceberg::metadata::{
@@ -132,65 +135,101 @@ pub struct CatalogBrowse {
     pub tables: Vec<TableRef>,
 }
 
-/// Build a REST catalog client from a connection, or a clear typed error for
-/// Direct mode (which has no catalog to browse/list).
-fn rest_catalog_client(
+/// Build a catalog client from a connection, or a clear typed error for Direct
+/// mode (which has no catalog to browse/list).
+///
+/// Returns a boxed [`SendCatalogClient`] (REST, AWS Glue, or S3 Tables — all
+/// three implement the trait), a display label (the catalog URI for REST, the
+/// Glue catalog id / S3 Tables bucket ARN otherwise), and the warehouse (REST
+/// only). Async because the AWS SDK catalog clients build from the ambient
+/// credential chain (`GlueSdkCatalogClient::new` / `S3TablesSdkCatalogClient::new`
+/// are async), mirroring the scan path's catalog dispatch.
+async fn catalog_client(
     conn: &IcebergConnectionConfig,
     op: &str,
-) -> Result<(RestCatalogClient, String, Option<String>)> {
-    let rest = match &conn.catalog_mode {
-        CatalogMode::Rest(rest) => rest,
-        CatalogMode::Direct { .. } => {
-            return Err(crate::ApiError::config(format!(
-                "Direct catalog mode cannot be used for {op}: there is no REST catalog to query. \
-                 Provide a REST connection (catalog_uri + auth)."
-            )));
+) -> Result<(Box<dyn SendCatalogClient>, String, Option<String>)> {
+    match &conn.catalog_mode {
+        CatalogMode::Rest(rest) => {
+            let auth = rest.auth.create_provider_arc().map_err(|e| {
+                crate::ApiError::config(format!("Failed to create auth provider: {e}"))
+            })?;
+
+            let catalog_config = RestCatalogConfig {
+                uri: rest.catalog_uri.clone(),
+                warehouse: rest.warehouse.clone(),
+                ..Default::default()
+            };
+
+            let catalog = RestCatalogClient::new(catalog_config, auth).map_err(|e| {
+                crate::ApiError::config(format!("Failed to create catalog client: {e}"))
+            })?;
+
+            Ok((
+                Box::new(catalog),
+                rest.catalog_uri.clone(),
+                rest.warehouse.clone(),
+            ))
         }
-        CatalogMode::Glue { .. } | CatalogMode::S3Tables { .. } => {
-            return Err(crate::ApiError::config(format!(
-                "catalog browse is not supported for Glue/S3Tables mode yet ({op}). \
-                 Map a specific table with `fluree iceberg map --mode glue|s3tables --table ns.table`."
-            )));
+        CatalogMode::Glue { region, catalog_id } => {
+            // Region precedence mirrors the scan path: the Glue mode's `region`,
+            // then `io.s3_region`, else the SDK default chain.
+            let catalog = GlueSdkCatalogClient::new(
+                region.as_deref().or(conn.io.s3_region.as_deref()),
+                catalog_id.clone(),
+            )
+            .await
+            .map_err(|e| {
+                crate::ApiError::config(format!("Failed to create Glue catalog client: {e}"))
+            })?;
+
+            Ok((
+                Box::new(catalog),
+                conn.catalog_uri_or_location().to_string(),
+                None,
+            ))
         }
-    };
+        CatalogMode::S3Tables {
+            region,
+            table_bucket_arn,
+        } => {
+            let catalog = S3TablesSdkCatalogClient::new(
+                region.as_deref().or(conn.io.s3_region.as_deref()),
+                table_bucket_arn.clone(),
+            )
+            .await
+            .map_err(|e| {
+                crate::ApiError::config(format!("Failed to create S3 Tables catalog client: {e}"))
+            })?;
 
-    let auth = rest
-        .auth
-        .create_provider_arc()
-        .map_err(|e| crate::ApiError::config(format!("Failed to create auth provider: {e}")))?;
-
-    let catalog_config = RestCatalogConfig {
-        uri: rest.catalog_uri.clone(),
-        warehouse: rest.warehouse.clone(),
-        ..Default::default()
-    };
-
-    let catalog = RestCatalogClient::new(catalog_config, auth)
-        .map_err(|e| crate::ApiError::config(format!("Failed to create catalog client: {e}")))?;
-
-    Ok((catalog, rest.catalog_uri.clone(), rest.warehouse.clone()))
+            Ok((Box::new(catalog), table_bucket_arn.clone(), None))
+        }
+        CatalogMode::Direct { .. } => Err(crate::ApiError::config(format!(
+            "Direct catalog mode cannot be used for {op}: there is no catalog to query. \
+             Provide a REST connection (catalog_uri + auth) or an AWS Glue / S3 Tables catalog."
+        ))),
+    }
 }
 
-/// Browse an Iceberg REST catalog: list namespaces and, at `depth = Tables`,
-/// the tables in each namespace.
+/// Browse an Iceberg catalog (REST, AWS Glue, or S3 Tables): list namespaces
+/// and, at `depth = Tables`, the tables in each namespace.
 ///
-/// **Metadata-only** and stateless — it needs no `Fluree` instance and touches
-/// no S3. Direct catalog mode returns a clear [`crate::ApiError::Config`] (there
-/// is nothing to browse).
+/// **Metadata-only** and stateless — it needs no `Fluree` instance and reads no
+/// S3 objects (Glue / S3 Tables list via their native SDK APIs). Direct catalog
+/// mode returns a clear [`crate::ApiError::Config`] (there is nothing to browse).
 pub async fn browse_iceberg_catalog(
     conn: IcebergConnectionConfig,
     depth: BrowseDepth,
 ) -> Result<CatalogBrowse> {
-    let (catalog, catalog_uri, warehouse) = rest_catalog_client(&conn, "catalog browse")?;
+    let (catalog, catalog_uri, warehouse) = catalog_client(&conn, "catalog browse").await?;
 
-    let namespaces = SendCatalogClient::list_namespaces(&catalog)
+    let namespaces = SendCatalogClient::list_namespaces(&*catalog)
         .await
         .map_err(|e| crate::ApiError::config(format!("Failed to list namespaces: {e}")))?;
 
     let mut tables = Vec::new();
     if depth == BrowseDepth::Tables {
         for ns in &namespaces {
-            let ns_tables = SendCatalogClient::list_tables(&catalog, ns)
+            let ns_tables = SendCatalogClient::list_tables(&*catalog, ns)
                 .await
                 .map_err(|e| {
                     crate::ApiError::config(format!("Failed to list tables in namespace {ns}: {e}"))
@@ -590,33 +629,35 @@ pub(crate) fn table_schema_from_metadata(
 /// Preview an Iceberg table's schema (Tier-A) and, at `tier = Stats`, its
 /// per-column statistics (Tier-B).
 ///
-/// **Metadata-only**: Tier-A reads the inline REST `loadTable` metadata (no S3);
-/// Tier-B additionally reads the snapshot's manifest-list + manifest Avro files
-/// (never a Parquet/data file). Direct catalog mode and a catalog that omits the
-/// inline metadata both return a clear typed error.
+/// **Metadata-only**: Tier-A reads the table metadata JSON — inline from the
+/// REST `loadTable` response, or (for the AWS SDK catalogs, which return only a
+/// `metadata_location`) fetched + parsed from S3 — never a Parquet/data file.
+/// Tier-B additionally reads the snapshot's manifest-list + manifest Avro files.
+/// Direct catalog mode returns a clear typed error (there is no catalog to load).
 pub async fn preview_iceberg_table(
     conn: IcebergConnectionConfig,
     table: TableIdentifier,
     tier: StatsTier,
 ) -> Result<TablePreview> {
-    let (catalog, _uri, _wh) = rest_catalog_client(&conn, "table preview")?;
+    let (catalog, _uri, _wh) = catalog_client(&conn, "table preview").await?;
     let table_id = table.to_catalog();
 
-    let load = SendCatalogClient::load_table(&catalog, &table_id, conn.io.vended_credentials)
+    let mut load = SendCatalogClient::load_table(&*catalog, &table_id, conn.io.vended_credentials)
         .await
         .map_err(|e| {
             crate::ApiError::config(format!("Failed to load table {}: {e}", table.qualified()))
         })?;
 
-    let metadata = load.metadata.as_ref().ok_or_else(|| {
-        crate::ApiError::config(format!(
-            "Catalog did not return inline table metadata for {} — metadata preview requires a \
-             REST catalog whose loadTable response includes the `metadata` object.",
-            table.qualified()
-        ))
-    })?;
+    // REST `loadTable` carries the metadata inline; the AWS SDK catalogs
+    // (Glue / S3 Tables) return only a `metadata_location`, so fetch + parse the
+    // metadata JSON from S3 (the same read the scan path performs) when the
+    // inline object is absent.
+    let metadata = match load.metadata.take() {
+        Some(m) => m,
+        None => fetch_metadata_from_s3(&conn, &load.metadata_location).await?,
+    };
 
-    let mut schema = table_schema_from_metadata(&table, metadata)?;
+    let mut schema = table_schema_from_metadata(&table, &metadata)?;
 
     match tier {
         StatsTier::Schema => Ok(TablePreview {
@@ -708,6 +749,29 @@ pub async fn preview_iceberg_table(
             })
         }
     }
+}
+
+/// Fetch + parse the table metadata JSON from S3 via its `metadata_location`.
+///
+/// REST `loadTable` carries the metadata inline, but the AWS SDK catalogs
+/// (Glue / S3 Tables) return only a `metadata_location`, so the preview lane
+/// reads + parses it from S3 with the ambient AWS credential chain — the same
+/// fetch the scan path performs (`read` → [`TableMetadata::from_json`]). Those
+/// catalogs never vend credentials, so ambient (`credentials = None`) is the
+/// correct policy here.
+async fn fetch_metadata_from_s3(
+    conn: &IcebergConnectionConfig,
+    metadata_location: &str,
+) -> Result<TableMetadata> {
+    use fluree_db_iceberg::io::SendIcebergStorage;
+
+    let storage = build_preview_storage(conn, None).await?;
+    let bytes = storage
+        .read(metadata_location)
+        .await
+        .map_err(|e| crate::ApiError::config(format!("Failed to read table metadata: {e}")))?;
+    TableMetadata::from_json(&bytes)
+        .map_err(|e| crate::ApiError::config(format!("Failed to parse table metadata: {e}")))
 }
 
 /// Build S3 storage for reading manifests during a Tier-B preview, mirroring the

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -146,6 +146,12 @@ fn rest_catalog_client(
                  Provide a REST connection (catalog_uri + auth)."
             )));
         }
+        CatalogMode::Glue { .. } | CatalogMode::S3Tables { .. } => {
+            return Err(crate::ApiError::config(format!(
+                "catalog browse is not supported for Glue/S3Tables mode yet ({op}). \
+                 Map a specific table with `fluree iceberg map --mode glue|s3tables --table ns.table`."
+            )));
+        }
     };
 
     let auth = rest

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -142,6 +142,116 @@ fn build_iceberg_filter(
     }
 }
 
+/// Which AWS-SDK catalog to build on a `loadTable` cache miss.
+enum SdkCatalog {
+    Glue {
+        region: Option<String>,
+        catalog_id: Option<String>,
+    },
+    S3Tables {
+        region: Option<String>,
+        table_bucket_arn: String,
+    },
+}
+
+impl SdkCatalog {
+    fn label(&self) -> &'static str {
+        match self {
+            SdkCatalog::Glue { .. } => "AWS Glue Data Catalog",
+            SdkCatalog::S3Tables { .. } => "AWS S3 Tables",
+        }
+    }
+
+    async fn build(&self) -> QueryResult<Box<dyn SendCatalogClient>> {
+        Ok(match self {
+            SdkCatalog::Glue { region, catalog_id } => Box::new(
+                fluree_db_iceberg::catalog::GlueSdkCatalogClient::new(
+                    region.as_deref(),
+                    catalog_id.clone(),
+                )
+                .await
+                .map_err(|e| {
+                    QueryError::Internal(format!("Failed to create Glue catalog client: {e}"))
+                })?,
+            ),
+            SdkCatalog::S3Tables {
+                region,
+                table_bucket_arn,
+            } => Box::new(
+                fluree_db_iceberg::catalog::S3TablesSdkCatalogClient::new(
+                    region.as_deref(),
+                    table_bucket_arn.clone(),
+                )
+                .await
+                .map_err(|e| {
+                    QueryError::Internal(format!("Failed to create S3 Tables catalog client: {e}"))
+                })?,
+            ),
+        })
+    }
+}
+
+/// Resolve an AWS-SDK catalog's `loadTable` with the same per-query snapshot pin
+/// (one Iceberg snapshot for the whole query — a correctness guarantee the raw
+/// per-scan SDK path lacked) and cross-query `loadTable` cache the REST path uses.
+/// Glue/S3Tables return `credentials: None`, so the credential-expiry gating is a
+/// no-op. The SDK client is built only on a genuine miss, so warm scans skip the
+/// per-scan credential-chain resolution + `GetTable`/`GetTableMetadataLocation`.
+async fn sdk_resolve_load_table(
+    session: &super::catalog_session::IcebergCatalogSession,
+    cache: &R2rmlCache,
+    graph_source_id: &str,
+    table_id: &fluree_db_iceberg::catalog::TableIdentifier,
+    kind: &SdkCatalog,
+) -> QueryResult<fluree_db_iceberg::catalog::LoadTableResponse> {
+    use super::catalog_session::{CachedLoadTable, IcebergCatalogSession};
+    let lt_key = IcebergCatalogSession::load_table_key(
+        graph_source_id,
+        &table_id.namespace,
+        &table_id.table,
+    );
+
+    if let Some(cached) = session.cached_load_table(&lt_key) {
+        debug!(namespace = %table_id.namespace, table = %table_id.table,
+            "loadTable pin hit (query-scoped)");
+        return Ok(cached);
+    }
+    let pinned = session.pinned_metadata_location(&lt_key);
+    let cross_query = if pinned.is_none() {
+        cache.get_rest_load_table(&lt_key)
+    } else {
+        None
+    };
+    let mut resp = if let Some(cq) = cross_query {
+        debug!(namespace = %table_id.namespace, table = %table_id.table,
+            "loadTable cache hit (cross-query)");
+        cq.to_response()
+    } else {
+        info!(namespace = %table_id.namespace, table = %table_id.table,
+            catalog = kind.label(), "Loading table via AWS SDK catalog");
+        let catalog = kind.build().await?;
+        let actual = catalog.load_table(table_id, false).await.map_err(|e| {
+            QueryError::Internal(format!("Failed to load table from {}: {e}", kind.label()))
+        })?;
+        cache.put_rest_load_table(
+            lt_key.clone(),
+            std::sync::Arc::new(CachedLoadTable::from_response(&actual)),
+        );
+        actual
+    };
+    // Keep the query on its pinned snapshot even if the table committed since.
+    if let Some(ref pinned_loc) = pinned {
+        if *pinned_loc != resp.metadata_location {
+            resp.metadata_location = pinned_loc.clone();
+        }
+    }
+    session.store_load_table(lt_key.clone(), &resp);
+    if let Some(pinned_loc) = session.pinned_metadata_location(&lt_key) {
+        resp.metadata_location = pinned_loc;
+    }
+    Ok(resp)
+}
+
 // =============================================================================
 // Iceberg/R2RML Graph Source Creation
 // =============================================================================
@@ -942,14 +1052,22 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                 (load_response, storage)
             }
             CatalogConfig::Glue { region, catalog_id } => {
-                info!(
-                    ?region,
-                    ?catalog_id,
-                    "Loading table via AWS Glue Data Catalog (SDK)"
-                );
+                // Resolve metadata_location through the shared per-query snapshot
+                // pin + cross-query cache (builds the SDK client only on a miss),
+                // then read S3 with the ambient chain — Glue in IAM mode does not
+                // vend credentials, so this is the same reader as Direct mode.
+                let load_response = sdk_resolve_load_table(
+                    &self.session,
+                    self.fluree.r2rml_cache(),
+                    graph_source_id,
+                    &table_id,
+                    &SdkCatalog::Glue {
+                        region: region.clone(),
+                        catalog_id: catalog_id.clone(),
+                    },
+                )
+                .await?;
 
-                // Ambient AWS credential chain reads S3 (Glue in IAM mode does not
-                // vend credentials); same reader as Direct mode.
                 let storage: Arc<S3IcebergStorage> = Arc::new(
                     S3IcebergStorage::from_default_chain(
                         region.as_deref().or(iceberg_config.io.s3_region.as_deref()),
@@ -960,24 +1078,6 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                     .map_err(|e| {
                         QueryError::Internal(format!("Failed to create S3 storage: {e}"))
                     })?,
-                );
-
-                let catalog = fluree_db_iceberg::catalog::GlueSdkCatalogClient::new(
-                    region.as_deref(),
-                    catalog_id.clone(),
-                )
-                .await
-                .map_err(|e| {
-                    QueryError::Internal(format!("Failed to create Glue catalog client: {e}"))
-                })?;
-
-                let load_response = catalog.load_table(&table_id, false).await.map_err(|e| {
-                    QueryError::Internal(format!("Failed to load table from AWS Glue: {e}"))
-                })?;
-
-                info!(
-                    metadata_location = %load_response.metadata_location,
-                    "Resolved table metadata via AWS Glue Data Catalog"
                 );
 
                 (load_response, storage)
@@ -986,8 +1086,17 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                 region,
                 table_bucket_arn,
             } => {
-                info!(?region, table_bucket_arn = %table_bucket_arn,
-                    "Loading table via AWS S3 Tables (SDK)");
+                let load_response = sdk_resolve_load_table(
+                    &self.session,
+                    self.fluree.r2rml_cache(),
+                    graph_source_id,
+                    &table_id,
+                    &SdkCatalog::S3Tables {
+                        region: region.clone(),
+                        table_bucket_arn: table_bucket_arn.clone(),
+                    },
+                )
+                .await?;
 
                 let storage: Arc<S3IcebergStorage> = Arc::new(
                     S3IcebergStorage::from_default_chain(
@@ -999,24 +1108,6 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                     .map_err(|e| {
                         QueryError::Internal(format!("Failed to create S3 storage: {e}"))
                     })?,
-                );
-
-                let catalog = fluree_db_iceberg::catalog::S3TablesSdkCatalogClient::new(
-                    region.as_deref(),
-                    table_bucket_arn.clone(),
-                )
-                .await
-                .map_err(|e| {
-                    QueryError::Internal(format!("Failed to create S3 Tables catalog client: {e}"))
-                })?;
-
-                let load_response = catalog.load_table(&table_id, false).await.map_err(|e| {
-                    QueryError::Internal(format!("Failed to load table from AWS S3 Tables: {e}"))
-                })?;
-
-                info!(
-                    metadata_location = %load_response.metadata_location,
-                    "Resolved table metadata via AWS S3 Tables"
                 );
 
                 (load_response, storage)

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -321,6 +321,12 @@ impl crate::Fluree {
                     "Connection test is not supported for Direct catalog mode".to_string(),
                 ));
             }
+            CatalogMode::Glue { .. } | CatalogMode::S3Tables { .. } => {
+                // Glue / S3Tables validate at query time via the ambient AWS
+                // credential chain; a pre-flight check would require live AWS
+                // calls, so treat the connection as OK here.
+                return Ok(());
+            }
         };
 
         // Create auth provider
@@ -931,6 +937,86 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
                 info!(
                     metadata_location = %load_response.metadata_location,
                     "Resolved table metadata via version-hint.text"
+                );
+
+                (load_response, storage)
+            }
+            CatalogConfig::Glue { region, catalog_id } => {
+                info!(
+                    ?region,
+                    ?catalog_id,
+                    "Loading table via AWS Glue Data Catalog (SDK)"
+                );
+
+                // Ambient AWS credential chain reads S3 (Glue in IAM mode does not
+                // vend credentials); same reader as Direct mode.
+                let storage: Arc<S3IcebergStorage> = Arc::new(
+                    S3IcebergStorage::from_default_chain(
+                        region.as_deref().or(iceberg_config.io.s3_region.as_deref()),
+                        iceberg_config.io.s3_endpoint.as_deref(),
+                        iceberg_config.io.s3_path_style,
+                    )
+                    .await
+                    .map_err(|e| {
+                        QueryError::Internal(format!("Failed to create S3 storage: {e}"))
+                    })?,
+                );
+
+                let catalog = fluree_db_iceberg::catalog::GlueSdkCatalogClient::new(
+                    region.as_deref(),
+                    catalog_id.clone(),
+                )
+                .await
+                .map_err(|e| {
+                    QueryError::Internal(format!("Failed to create Glue catalog client: {e}"))
+                })?;
+
+                let load_response = catalog.load_table(&table_id, false).await.map_err(|e| {
+                    QueryError::Internal(format!("Failed to load table from AWS Glue: {e}"))
+                })?;
+
+                info!(
+                    metadata_location = %load_response.metadata_location,
+                    "Resolved table metadata via AWS Glue Data Catalog"
+                );
+
+                (load_response, storage)
+            }
+            CatalogConfig::S3Tables {
+                region,
+                table_bucket_arn,
+            } => {
+                info!(?region, table_bucket_arn = %table_bucket_arn,
+                    "Loading table via AWS S3 Tables (SDK)");
+
+                let storage: Arc<S3IcebergStorage> = Arc::new(
+                    S3IcebergStorage::from_default_chain(
+                        region.as_deref().or(iceberg_config.io.s3_region.as_deref()),
+                        iceberg_config.io.s3_endpoint.as_deref(),
+                        iceberg_config.io.s3_path_style,
+                    )
+                    .await
+                    .map_err(|e| {
+                        QueryError::Internal(format!("Failed to create S3 storage: {e}"))
+                    })?,
+                );
+
+                let catalog = fluree_db_iceberg::catalog::S3TablesSdkCatalogClient::new(
+                    region.as_deref(),
+                    table_bucket_arn.clone(),
+                )
+                .await
+                .map_err(|e| {
+                    QueryError::Internal(format!("Failed to create S3 Tables catalog client: {e}"))
+                })?;
+
+                let load_response = catalog.load_table(&table_id, false).await.map_err(|e| {
+                    QueryError::Internal(format!("Failed to load table from AWS S3 Tables: {e}"))
+                })?;
+
+                info!(
+                    metadata_location = %load_response.metadata_location,
+                    "Resolved table metadata via AWS S3 Tables"
                 );
 
                 (load_response, storage)

--- a/fluree-db-api/tests/it_glue_live.rs
+++ b/fluree-db-api/tests/it_glue_live.rs
@@ -1,0 +1,82 @@
+//! Env-gated live integration tests: the AWS Glue onboarding/introspection
+//! surface (catalog browse + table preview) via the public API — the paths that
+//! used to hard-reject Glue. SKIP unless `FLUREE_GLUE_IT_DATABASE` is set (no
+//! live dependency in CI). Requires ambient AWS credentials.
+//!
+//! Run (matches the sandbox harness):
+//! ```
+//! AWS_PROFILE=aj-sandbox AWS_REGION=us-east-1 \
+//!   FLUREE_GLUE_IT_DATABASE=enterprise_dw FLUREE_GLUE_IT_TABLE=dim_store \
+//!   cargo test -p fluree-db-api --features iceberg --test it_glue_live -- --nocapture
+//! ```
+#![cfg(feature = "iceberg")]
+
+use fluree_db_api::{
+    browse_iceberg_catalog, preview_iceberg_table, BrowseDepth, IcebergConnectionConfig, StatsTier,
+    TableIdentifier,
+};
+
+fn env(k: &str) -> Option<String> {
+    std::env::var(k).ok().filter(|s| !s.is_empty())
+}
+fn region() -> Option<String> {
+    env("FLUREE_GLUE_IT_REGION").or_else(|| env("AWS_REGION"))
+}
+fn conn() -> IcebergConnectionConfig {
+    IcebergConnectionConfig::glue(region(), env("FLUREE_GLUE_IT_CATALOG_ID"))
+}
+
+#[tokio::test]
+async fn glue_browse_lists_database_and_tables() {
+    let Some(db) = env("FLUREE_GLUE_IT_DATABASE") else {
+        eprintln!("skip glue_browse: set FLUREE_GLUE_IT_DATABASE");
+        return;
+    };
+    let browse = browse_iceberg_catalog(conn(), BrowseDepth::Tables)
+        .await
+        .expect("browse should succeed for a Glue catalog");
+    assert!(
+        browse.namespaces.iter().any(|n| n == &db),
+        "namespaces {:?} should include {db}",
+        browse.namespaces
+    );
+    assert!(
+        browse.tables.iter().any(|t| t.namespace == db),
+        "expected at least one table in namespace {db}"
+    );
+    eprintln!(
+        "glue browse OK: {} namespaces, {} tables",
+        browse.namespaces.len(),
+        browse.tables.len()
+    );
+}
+
+#[tokio::test]
+async fn glue_preview_returns_schema() {
+    let Some(namespace) = env("FLUREE_GLUE_IT_DATABASE") else {
+        eprintln!("skip glue_preview: set FLUREE_GLUE_IT_DATABASE + FLUREE_GLUE_IT_TABLE");
+        return;
+    };
+    let name =
+        env("FLUREE_GLUE_IT_TABLE").expect("FLUREE_GLUE_IT_TABLE required when DATABASE set");
+    let preview = preview_iceberg_table(
+        conn(),
+        TableIdentifier { namespace, name },
+        StatsTier::Schema,
+    )
+    .await
+    .expect("preview should succeed for a Glue table (via the S3 metadata fallback)");
+    assert!(
+        !preview.schema.columns.is_empty(),
+        "preview schema should list columns"
+    );
+    assert!(
+        preview.schema.format_version >= 1,
+        "expected an Iceberg format version"
+    );
+    eprintln!(
+        "glue preview OK: {} columns, format v{}",
+        preview.schema.columns.len(),
+        preview.schema.format_version
+    );
+}

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -2172,6 +2172,8 @@ pub enum IcebergAction {
     ///   fluree iceberg map my-gs --catalog-uri https://polaris.example.com --table openflights.airlines
     ///   fluree iceberg map my-gs --catalog-uri https://... --r2rml mappings/airlines.ttl
     ///   fluree iceberg map my-gs --mode direct --table-location s3://bucket/warehouse/ns/table
+    ///   fluree iceberg map my-gs --mode glue --table enterprise_dw.dim_geography --region us-east-1 --r2rml mapping.ttl
+    ///   fluree iceberg map my-gs --mode s3tables --table enterprise_dw.dim_geography --table-bucket-arn arn:aws:s3tables:us-east-1:123456789012:bucket/demo --region us-east-1
     Map(Box<IcebergMapArgs>),
 
     /// List Iceberg-family graph sources (Iceberg and R2RML mappings)
@@ -2216,7 +2218,7 @@ pub struct IcebergMapArgs {
     #[arg(long)]
     pub remote: Option<String>,
 
-    /// Catalog mode: "rest" (default) or "direct"
+    /// Catalog mode: "rest" (default), "direct", "glue", or "s3tables"
     #[arg(long, default_value = "rest")]
     pub mode: String,
 
@@ -2233,6 +2235,21 @@ pub struct IcebergMapArgs {
     /// S3 table location for direct mode (e.g., "s3://bucket/warehouse/ns/table")
     #[arg(long)]
     pub table_location: Option<String>,
+
+    /// AWS region for glue / s3tables mode (falls back to the AWS SDK default
+    /// credential-chain region if omitted)
+    #[arg(long)]
+    pub region: Option<String>,
+
+    /// AWS Glue catalog id for cross-account access (glue mode; defaults to the
+    /// caller's account)
+    #[arg(long)]
+    pub catalog_id: Option<String>,
+
+    /// AWS S3 Tables table-bucket ARN (required for s3tables mode),
+    /// e.g. "arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket"
+    #[arg(long)]
+    pub table_bucket_arn: Option<String>,
 
     /// R2RML mapping file (Turtle format). Defines how Iceberg table rows
     /// are mapped to RDF triples. When provided, table references come from

--- a/fluree-db-cli/src/commands/iceberg.rs
+++ b/fluree-db-cli/src/commands/iceberg.rs
@@ -370,6 +370,15 @@ fn args_to_json(args: &IcebergMapArgs) -> CliResult<serde_json::Value> {
     if let Some(ref v) = args.table_location {
         obj.insert("table_location".into(), v.clone().into());
     }
+    if let Some(ref v) = args.region {
+        obj.insert("region".into(), v.clone().into());
+    }
+    if let Some(ref v) = args.catalog_id {
+        obj.insert("catalog_id".into(), v.clone().into());
+    }
+    if let Some(ref v) = args.table_bucket_arn {
+        obj.insert("table_bucket_arn".into(), v.clone().into());
+    }
     if let Some(ref v) = args.r2rml {
         // Read file content and send it (not the path)
         let content = std::fs::read_to_string(v).map_err(|e| {
@@ -730,9 +739,47 @@ fn build_iceberg_config(args: &IcebergMapArgs) -> CliResult<fluree_db_api::Icebe
             })?;
             fluree_db_api::IcebergCreateConfig::new_direct(&args.name, location)
         }
+        "glue" => {
+            let table = args.table.as_deref().unwrap_or_default();
+            if table.is_empty() {
+                return Err(CliError::Usage(
+                    "--table is required for glue mode (namespace.table, e.g. enterprise_dw.dim_geography)"
+                        .into(),
+                ));
+            }
+            let connection = fluree_db_api::IcebergConnectionConfig::glue(
+                args.region.clone(),
+                args.catalog_id.clone(),
+            );
+            fluree_db_api::IcebergCreateConfig {
+                name: args.name.clone(),
+                branch: None,
+                connection,
+                table_identifier: table.to_string(),
+            }
+        }
+        "s3tables" => {
+            let arn = args.table_bucket_arn.as_ref().ok_or_else(|| {
+                CliError::Usage("--table-bucket-arn is required for s3tables mode".into())
+            })?;
+            let table = args.table.as_deref().unwrap_or_default();
+            if table.is_empty() {
+                return Err(CliError::Usage(
+                    "--table is required for s3tables mode (namespace.table)".into(),
+                ));
+            }
+            let connection =
+                fluree_db_api::IcebergConnectionConfig::s3_tables(args.region.clone(), arn);
+            fluree_db_api::IcebergCreateConfig {
+                name: args.name.clone(),
+                branch: None,
+                connection,
+                table_identifier: table.to_string(),
+            }
+        }
         other => {
             return Err(CliError::Usage(format!(
-                "unknown catalog mode '{other}'. Use 'rest' or 'direct'."
+                "unknown catalog mode '{other}'. Use 'rest', 'direct', 'glue', or 's3tables'."
             )));
         }
     };
@@ -821,6 +868,9 @@ mod tests {
             catalog_uri: Some("https://catalog.example.com".to_string()),
             table: Some("ns.tbl".to_string()),
             table_location: None,
+            region: None,
+            catalog_id: None,
+            table_bucket_arn: None,
             r2rml: None,
             r2rml_type: None,
             branch: None,

--- a/fluree-db-iceberg/Cargo.toml
+++ b/fluree-db-iceberg/Cargo.toml
@@ -15,6 +15,8 @@ default = []
 aws = [
     "dep:aws-credential-types",
     "dep:aws-sdk-s3",
+    "dep:aws-sdk-glue",
+    "dep:aws-sdk-s3tables",
     "dep:aws-config",
     "dep:aws-smithy-http-client",
     "dep:hyper-rustls",
@@ -79,6 +81,8 @@ dashmap.workspace = true
 # Optional: AWS SDK (credential provider + S3 storage)
 aws-credential-types = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true, optional = true }
+aws-sdk-glue = { workspace = true, optional = true }
+aws-sdk-s3tables = { workspace = true, optional = true }
 aws-config = { workspace = true, optional = true }
 # HTTP/1.1-pinned transport for the S3 SDK when reading GCS-backed tables (avoids
 # the smithy-rs HTTP/2 range-read bug against the GCS S3-interop endpoint). The
@@ -101,6 +105,10 @@ required-features = ["aws"]
 
 [[example]]
 name = "read_local_iceberg"
+required-features = ["aws"]
+
+[[example]]
+name = "read_glue"
 required-features = ["aws"]
 
 [lints]

--- a/fluree-db-iceberg/examples/read_glue.rs
+++ b/fluree-db-iceberg/examples/read_glue.rs
@@ -1,0 +1,96 @@
+//! Example: read an Iceberg table from AWS Glue Data Catalog or AWS S3 Tables via
+//! the native AWS SDK (no REST catalog, no SigV4 signing code — the SDK signs).
+//!
+//! Exercises `GlueSdkCatalogClient` / `S3TablesSdkCatalogClient` end-to-end:
+//! catalog `load_table` -> metadata_location -> ambient S3 read -> scan plan ->
+//! Parquet decode.
+//!
+//! Glue:
+//! ```
+//! MODE=glue GLUE_DB=enterprise_dw GLUE_TABLE=dim_geography \
+//!   AWS_PROFILE=aj-sandbox AWS_REGION=us-east-1 \
+//!   cargo run --example read_glue -p fluree-db-iceberg --features aws
+//! ```
+//! S3 Tables:
+//! ```
+//! MODE=s3tables S3TABLES_ARN=arn:aws:s3tables:us-east-1:ACCT:bucket/NAME \
+//!   NS=enterprise_dw TABLE=dim_geography \
+//!   AWS_PROFILE=aj-sandbox AWS_REGION=us-east-1 \
+//!   cargo run --example read_glue -p fluree-db-iceberg --features aws
+//! ```
+
+use fluree_db_iceberg::catalog::{
+    GlueSdkCatalogClient, S3TablesSdkCatalogClient, SendCatalogClient, TableIdentifier,
+};
+use fluree_db_iceberg::io::send_parquet::SendParquetReader;
+use fluree_db_iceberg::io::{S3IcebergStorage, SendIcebergStorage};
+use fluree_db_iceberg::metadata::TableMetadata;
+use fluree_db_iceberg::scan::{ScanConfig, SendScanPlanner};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mode = std::env::var("MODE").unwrap_or_else(|_| "glue".into());
+    let region = std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".into());
+
+    let (catalog, table_id): (Box<dyn SendCatalogClient>, TableIdentifier) = if mode == "s3tables" {
+        let arn = std::env::var("S3TABLES_ARN").expect("S3TABLES_ARN required for MODE=s3tables");
+        let namespace = std::env::var("NS").unwrap_or_else(|_| "enterprise_dw".into());
+        let table = std::env::var("TABLE").unwrap_or_else(|_| "dim_geography".into());
+        println!("=== AWS S3 Tables: {namespace}.{table}\n    bucket: {arn}");
+        (
+            Box::new(S3TablesSdkCatalogClient::new(Some(&region), arn).await?),
+            TableIdentifier { namespace, table },
+        )
+    } else {
+        let namespace = std::env::var("GLUE_DB").unwrap_or_else(|_| "enterprise_dw".into());
+        let table = std::env::var("GLUE_TABLE").unwrap_or_else(|_| "dim_geography".into());
+        println!("=== AWS Glue Data Catalog: {namespace}.{table}");
+        (
+            Box::new(GlueSdkCatalogClient::new(Some(&region), None).await?),
+            TableIdentifier { namespace, table },
+        )
+    };
+
+    // 1. Resolve the metadata location via the SDK catalog client.
+    let load = catalog.load_table(&table_id, false).await?;
+    println!("metadata_location : {}", load.metadata_location);
+    println!("vended credentials: {}", load.credentials.is_some());
+
+    // 2. Read metadata from S3 with the ambient credential chain.
+    let storage = S3IcebergStorage::from_default_chain(Some(&region), None, false).await?;
+    let metadata_bytes = storage.read(&load.metadata_location).await?;
+    let metadata = TableMetadata::from_json(&metadata_bytes)?;
+    println!("format-version    : {}", metadata.format_version);
+    if let Some(schema) = metadata.current_schema() {
+        println!(
+            "schema fields     : {} ({})",
+            schema.fields.len(),
+            schema
+                .fields
+                .iter()
+                .map(|f| f.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    // 3. Plan the scan.
+    let planner = SendScanPlanner::new(&storage, &metadata, ScanConfig::new());
+    let plan = planner.plan_scan().await?;
+    println!(
+        "files selected    : {} (pruned {}), est. rows {}",
+        plan.files_selected, plan.files_pruned, plan.estimated_row_count
+    );
+
+    // 4. Read the data files.
+    let reader = SendParquetReader::new(&storage);
+    let mut total_rows = 0;
+    for task in &plan.tasks {
+        for batch in &reader.read_task(task).await? {
+            total_rows += batch.num_rows;
+        }
+    }
+    println!("TOTAL ROWS READ   : {total_rows}");
+    println!("OK");
+    Ok(())
+}

--- a/fluree-db-iceberg/src/catalog/aws_sdk.rs
+++ b/fluree-db-iceberg/src/catalog/aws_sdk.rs
@@ -30,6 +30,25 @@ async fn sdk_config(region: Option<&str>) -> aws_config::SdkConfig {
     loader.load().await
 }
 
+/// Extract the Iceberg `metadata_location` from a Glue table's `Parameters`.
+/// Factored out so the (SDK-free) extraction — the one bit of the Glue path with
+/// no other automated coverage — is unit-testable without live AWS.
+fn glue_metadata_location(
+    parameters: Option<&HashMap<String, String>>,
+    namespace: &str,
+    table: &str,
+) -> Result<String> {
+    parameters
+        .and_then(|p| p.get("metadata_location"))
+        .cloned()
+        .ok_or_else(|| {
+            IcebergError::Metadata(format!(
+                "Glue table {namespace}.{table} has no `metadata_location` parameter \
+                 (not an Iceberg table?)"
+            ))
+        })
+}
+
 // ---------------------------------------------------------------------------
 // AWS Glue Data Catalog
 // ---------------------------------------------------------------------------
@@ -125,16 +144,8 @@ impl SendCatalogClient for GlueSdkCatalogClient {
         })?;
 
         // Iceberg tables registered in Glue carry `metadata_location` in Parameters.
-        let metadata_location = table
-            .parameters()
-            .and_then(|p| p.get("metadata_location"))
-            .cloned()
-            .ok_or_else(|| {
-                IcebergError::Metadata(format!(
-                    "Glue table {}.{} has no `metadata_location` parameter (not an Iceberg table?)",
-                    table_id.namespace, table_id.table
-                ))
-            })?;
+        let metadata_location =
+            glue_metadata_location(table.parameters(), &table_id.namespace, &table_id.table)?;
 
         Ok(LoadTableResponse {
             metadata_location,
@@ -243,5 +254,37 @@ impl SendCatalogClient for S3TablesSdkCatalogClient {
             credentials: None,
             metadata: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glue_metadata_location_extracted_from_parameters() {
+        let mut params = HashMap::new();
+        params.insert("table_type".to_string(), "ICEBERG".to_string());
+        params.insert(
+            "metadata_location".to_string(),
+            "s3://bucket/dim_store/metadata/00001-abc.metadata.json".to_string(),
+        );
+        assert_eq!(
+            glue_metadata_location(Some(&params), "enterprise_dw", "dim_store").unwrap(),
+            "s3://bucket/dim_store/metadata/00001-abc.metadata.json"
+        );
+    }
+
+    #[test]
+    fn glue_metadata_location_missing_is_a_clear_error() {
+        // A non-Iceberg Glue table (e.g. the Hive/Parquet `fuel_events` table) has
+        // no `metadata_location` — must be a clear error, not a panic.
+        let params = HashMap::from([("classification".to_string(), "parquet".to_string())]);
+        let err = glue_metadata_location(Some(&params), "db", "t")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("metadata_location"), "unhelpful error: {err}");
+        assert!(err.contains("db.t"), "error should name the table: {err}");
+        assert!(glue_metadata_location(None, "db", "t").is_err());
     }
 }

--- a/fluree-db-iceberg/src/catalog/aws_sdk.rs
+++ b/fluree-db-iceberg/src/catalog/aws_sdk.rs
@@ -1,0 +1,247 @@
+//! AWS-SDK-backed Iceberg catalog clients: AWS Glue Data Catalog + S3 Tables.
+//!
+//! Unlike the REST catalog client (`rest.rs`), these reach the catalog through
+//! the native AWS SDK (`aws-sdk-glue` / `aws-sdk-s3tables`): the SDK performs
+//! SigV4 signing, credential resolution, refresh, and retries — no request
+//! signing, REST prefixing, or credential vending lives here. Each client only
+//! resolves a table's current metadata-JSON *location*; the metadata, manifests
+//! and data files are then read from S3 by the shared scan path using the ambient
+//! AWS credential chain (`S3IcebergStorage::from_default_chain`) — the exact same
+//! reader the Direct catalog uses.
+//!
+//! This is the empirically-chosen path for AWS catalogs: for a normally
+//! S3-authorized principal, neither Glue Data Catalog (IAM mode) nor S3 Tables
+//! vends credentials, so ambient reads suffice. Lake-Formation-governed catalogs
+//! that require *vended* credentials remain the REST client's domain.
+//!
+//! Gated behind the `aws` feature.
+
+use crate::catalog::{LoadTableResponse, SendCatalogClient, TableIdentifier};
+use crate::error::{IcebergError, Result};
+use async_trait::async_trait;
+use std::collections::HashMap;
+
+/// Build an `SdkConfig` from the ambient credential chain, optionally pinning a region.
+async fn sdk_config(region: Option<&str>) -> aws_config::SdkConfig {
+    let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest());
+    if let Some(r) = region {
+        loader = loader.region(aws_config::Region::new(r.to_string()));
+    }
+    loader.load().await
+}
+
+// ---------------------------------------------------------------------------
+// AWS Glue Data Catalog
+// ---------------------------------------------------------------------------
+
+/// Catalog client backed by the AWS Glue Data Catalog via `aws-sdk-glue`.
+///
+/// `load_table` resolves the Iceberg `metadata_location` from Glue `GetTable`
+/// (stored in the table's `Parameters`). The namespace/table come from the
+/// graph source's `TableConfig`; the Glue *database* is the namespace.
+pub struct GlueSdkCatalogClient {
+    client: aws_sdk_glue::Client,
+    /// Glue catalog id for cross-account access (`None` = the caller's account).
+    catalog_id: Option<String>,
+}
+
+impl std::fmt::Debug for GlueSdkCatalogClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GlueSdkCatalogClient")
+            .field("catalog_id", &self.catalog_id)
+            .finish()
+    }
+}
+
+impl GlueSdkCatalogClient {
+    /// Build a Glue catalog client from the ambient AWS credential chain.
+    pub async fn new(region: Option<&str>, catalog_id: Option<String>) -> Result<Self> {
+        let cfg = sdk_config(region).await;
+        Ok(Self {
+            client: aws_sdk_glue::Client::new(&cfg),
+            catalog_id,
+        })
+    }
+}
+
+#[async_trait]
+impl SendCatalogClient for GlueSdkCatalogClient {
+    async fn list_namespaces(&self) -> Result<Vec<String>> {
+        let out = self
+            .client
+            .get_databases()
+            .set_catalog_id(self.catalog_id.clone())
+            .send()
+            .await
+            .map_err(|e| IcebergError::Catalog(format!("Glue GetDatabases failed: {e}")))?;
+        Ok(out
+            .database_list()
+            .iter()
+            .map(|d| d.name().to_string())
+            .collect())
+    }
+
+    async fn list_tables(&self, namespace: &str) -> Result<Vec<String>> {
+        let out = self
+            .client
+            .get_tables()
+            .set_catalog_id(self.catalog_id.clone())
+            .database_name(namespace)
+            .send()
+            .await
+            .map_err(|e| IcebergError::Catalog(format!("Glue GetTables failed: {e}")))?;
+        Ok(out
+            .table_list()
+            .iter()
+            .map(|t| t.name().to_string())
+            .collect())
+    }
+
+    async fn load_table(
+        &self,
+        table_id: &TableIdentifier,
+        _request_credentials: bool,
+    ) -> Result<LoadTableResponse> {
+        let out = self
+            .client
+            .get_table()
+            .set_catalog_id(self.catalog_id.clone())
+            .database_name(&table_id.namespace)
+            .name(&table_id.table)
+            .send()
+            .await
+            .map_err(|e| {
+                IcebergError::Catalog(format!(
+                    "Glue GetTable {}.{} failed: {e}",
+                    table_id.namespace, table_id.table
+                ))
+            })?;
+
+        let table = out.table().ok_or_else(|| {
+            IcebergError::TableNotFound(format!(
+                "Glue table {}.{} not found",
+                table_id.namespace, table_id.table
+            ))
+        })?;
+
+        // Iceberg tables registered in Glue carry `metadata_location` in Parameters.
+        let metadata_location = table
+            .parameters()
+            .and_then(|p| p.get("metadata_location"))
+            .cloned()
+            .ok_or_else(|| {
+                IcebergError::Metadata(format!(
+                    "Glue table {}.{} has no `metadata_location` parameter (not an Iceberg table?)",
+                    table_id.namespace, table_id.table
+                ))
+            })?;
+
+        Ok(LoadTableResponse {
+            metadata_location,
+            config: HashMap::new(),
+            credentials: None, // ambient AWS credential chain reads S3
+            metadata: None,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AWS S3 Tables
+// ---------------------------------------------------------------------------
+
+/// Catalog client backed by AWS S3 Tables via `aws-sdk-s3tables`.
+///
+/// `load_table` resolves the Iceberg metadata location from
+/// `GetTableMetadataLocation`. Data files live in the S3-Tables-managed bucket
+/// and are read with the ambient credential chain.
+pub struct S3TablesSdkCatalogClient {
+    client: aws_sdk_s3tables::Client,
+    table_bucket_arn: String,
+}
+
+impl std::fmt::Debug for S3TablesSdkCatalogClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3TablesSdkCatalogClient")
+            .field("table_bucket_arn", &self.table_bucket_arn)
+            .finish()
+    }
+}
+
+impl S3TablesSdkCatalogClient {
+    /// Build an S3 Tables catalog client from the ambient AWS credential chain.
+    pub async fn new(region: Option<&str>, table_bucket_arn: String) -> Result<Self> {
+        let cfg = sdk_config(region).await;
+        Ok(Self {
+            client: aws_sdk_s3tables::Client::new(&cfg),
+            table_bucket_arn,
+        })
+    }
+}
+
+#[async_trait]
+impl SendCatalogClient for S3TablesSdkCatalogClient {
+    async fn list_namespaces(&self) -> Result<Vec<String>> {
+        let out = self
+            .client
+            .list_namespaces()
+            .table_bucket_arn(&self.table_bucket_arn)
+            .send()
+            .await
+            .map_err(|e| IcebergError::Catalog(format!("S3Tables ListNamespaces failed: {e}")))?;
+        Ok(out
+            .namespaces()
+            .iter()
+            .filter_map(|n| n.namespace().first().cloned())
+            .collect())
+    }
+
+    async fn list_tables(&self, namespace: &str) -> Result<Vec<String>> {
+        let out = self
+            .client
+            .list_tables()
+            .table_bucket_arn(&self.table_bucket_arn)
+            .namespace(namespace)
+            .send()
+            .await
+            .map_err(|e| IcebergError::Catalog(format!("S3Tables ListTables failed: {e}")))?;
+        Ok(out.tables().iter().map(|t| t.name().to_string()).collect())
+    }
+
+    async fn load_table(
+        &self,
+        table_id: &TableIdentifier,
+        _request_credentials: bool,
+    ) -> Result<LoadTableResponse> {
+        let out = self
+            .client
+            .get_table_metadata_location()
+            .table_bucket_arn(&self.table_bucket_arn)
+            .namespace(&table_id.namespace)
+            .name(&table_id.table)
+            .send()
+            .await
+            .map_err(|e| {
+                IcebergError::Catalog(format!(
+                    "S3Tables GetTableMetadataLocation {}.{} failed: {e}",
+                    table_id.namespace, table_id.table
+                ))
+            })?;
+
+        let metadata_location = out
+            .metadata_location()
+            .ok_or_else(|| {
+                IcebergError::Metadata(format!(
+                    "S3Tables table {}.{} has no metadata location",
+                    table_id.namespace, table_id.table
+                ))
+            })?
+            .to_string();
+
+        Ok(LoadTableResponse {
+            metadata_location,
+            config: HashMap::new(),
+            credentials: None,
+            metadata: None,
+        })
+    }
+}

--- a/fluree-db-iceberg/src/catalog/mod.rs
+++ b/fluree-db-iceberg/src/catalog/mod.rs
@@ -14,6 +14,11 @@ pub use table_identifier::{encode_namespace_for_rest, parse_table_identifier, Ta
 #[cfg(feature = "aws")]
 pub use direct::SendDirectCatalogClient;
 
+#[cfg(feature = "aws")]
+mod aws_sdk;
+#[cfg(feature = "aws")]
+pub use aws_sdk::{GlueSdkCatalogClient, S3TablesSdkCatalogClient};
+
 use crate::credential::VendedCredentials;
 use crate::error::Result;
 use async_trait::async_trait;

--- a/fluree-db-iceberg/src/catalog/rest.rs
+++ b/fluree-db-iceberg/src/catalog/rest.rs
@@ -233,51 +233,7 @@ impl CatalogClient for RestCatalogClient {
 
         let response = self.get(&path, &headers).await?;
 
-        let metadata_location = response
-            .get("metadata-location")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                IcebergError::Catalog("Missing metadata-location in response".to_string())
-            })?
-            .to_string();
-
-        // Extract config map
-        let config: HashMap<String, serde_json::Value> =
-            if let Some(config_obj) = response.get("config").and_then(|v| v.as_object()) {
-                config_obj
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect()
-            } else {
-                HashMap::new()
-            };
-
-        // Parse vended credentials if present
-        let credentials = VendedCredentials::from_config_map(&config)?;
-
-        // Retain the inline `metadata` object the REST loadTable response carries
-        // (Snowflake Horizon / Polaris include it). This lets metadata preview
-        // read the full schema/snapshot with no extra S3 fetch. A present-but-
-        // unparseable metadata object is logged and dropped, never fatal — the
-        // metadata_location fetch path still works.
-        let metadata = response.get("metadata").and_then(|m| {
-            match serde_json::from_value::<crate::metadata::TableMetadata>(m.clone()) {
-                Ok(md) => Some(md),
-                Err(e) => {
-                    tracing::debug!(
-                        "REST loadTable inline metadata present but failed to parse: {e}"
-                    );
-                    None
-                }
-            }
-        });
-
-        Ok(LoadTableResponse {
-            metadata_location,
-            config,
-            credentials,
-            metadata,
-        })
+        parse_load_table_response(&response)
     }
 }
 
@@ -350,45 +306,51 @@ impl super::SendCatalogClient for RestCatalogClient {
 
         let response = self.get(&path, &headers).await?;
 
-        let metadata_location = response
-            .get("metadata-location")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| {
-                IcebergError::Catalog("Missing metadata-location in response".to_string())
-            })?
-            .to_string();
-
-        let config: HashMap<String, serde_json::Value> =
-            if let Some(config_obj) = response.get("config").and_then(|v| v.as_object()) {
-                config_obj
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect()
-            } else {
-                HashMap::new()
-            };
-
-        let credentials = VendedCredentials::from_config_map(&config)?;
-
-        let metadata = response.get("metadata").and_then(|m| {
-            match serde_json::from_value::<crate::metadata::TableMetadata>(m.clone()) {
-                Ok(md) => Some(md),
-                Err(e) => {
-                    tracing::debug!(
-                        "REST loadTable inline metadata present but failed to parse: {e}"
-                    );
-                    None
-                }
-            }
-        });
-
-        Ok(LoadTableResponse {
-            metadata_location,
-            config,
-            credentials,
-            metadata,
-        })
+        parse_load_table_response(&response)
     }
+}
+
+/// Build a [`LoadTableResponse`] from a REST `loadTable` JSON response.
+///
+/// Shared by the `CatalogClient` (?Send) and `SendCatalogClient` impls — it is
+/// synchronous, so there is no `Send` friction. Resolves vended credentials via
+/// [`VendedCredentials::from_load_table_response`], which prefers the
+/// standardized top-level `storage-credentials` array over the legacy flat
+/// `config` map, and retains both the flat `config` map and the inline `metadata`
+/// object (Snowflake Horizon / Polaris include it, letting preview skip an S3
+/// fetch). A present-but-unparseable inline `metadata` is logged and dropped,
+/// never fatal — the `metadata_location` fetch path still works.
+fn parse_load_table_response(response: &serde_json::Value) -> Result<LoadTableResponse> {
+    let metadata_location = response
+        .get("metadata-location")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| IcebergError::Catalog("Missing metadata-location in response".to_string()))?
+        .to_string();
+
+    let credentials = VendedCredentials::from_load_table_response(response, &metadata_location)?;
+
+    let config: HashMap<String, serde_json::Value> = response
+        .get("config")
+        .and_then(|v| v.as_object())
+        .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        .unwrap_or_default();
+
+    let metadata = response.get("metadata").and_then(|m| {
+        match serde_json::from_value::<crate::metadata::TableMetadata>(m.clone()) {
+            Ok(md) => Some(md),
+            Err(e) => {
+                tracing::debug!("REST loadTable inline metadata present but failed to parse: {e}");
+                None
+            }
+        }
+    });
+
+    Ok(LoadTableResponse {
+        metadata_location,
+        config,
+        credentials,
+        metadata,
+    })
 }
 
 #[cfg(test)]

--- a/fluree-db-iceberg/src/config.rs
+++ b/fluree-db-iceberg/src/config.rs
@@ -132,6 +132,23 @@ impl IcebergGsConfig {
                     ));
                 }
             }
+            CatalogConfig::Glue { .. } => {
+                // Namespace + table must be explicit (cannot derive from a path).
+                // `vended_credentials` is ignored: the AWS SDK reads S3 with the
+                // ambient credential chain.
+                self.table_identifier()?;
+            }
+            CatalogConfig::S3Tables {
+                table_bucket_arn, ..
+            } => {
+                if !table_bucket_arn.starts_with("arn:aws:s3tables:") {
+                    return Err(IcebergError::Config(format!(
+                        "S3Tables catalog.table_bucket_arn must be an S3 Tables bucket ARN \
+                         (arn:aws:s3tables:...), got: {table_bucket_arn}"
+                    )));
+                }
+                self.table_identifier()?;
+            }
         }
 
         Ok(())
@@ -177,6 +194,35 @@ pub enum CatalogConfig {
         /// Example: "s3://bucket/warehouse/my_namespace/my_table"
         table_location: String,
     },
+
+    /// AWS Glue Data Catalog via the native AWS SDK (`aws-sdk-glue`).
+    ///
+    /// Resolves the table's `metadata_location` from Glue `GetTable`, then reads
+    /// metadata/manifests/data from S3 with the ambient AWS credential chain. The
+    /// Glue *database* is the table identifier's namespace. No REST/SigV4/vended
+    /// credentials are involved — the SDK signs its own calls.
+    Glue {
+        /// AWS region. Falls back to the SDK default chain / `io.s3_region` if `None`.
+        #[serde(default)]
+        region: Option<String>,
+        /// Glue catalog id for cross-account access (`None` = the caller's account).
+        #[serde(default)]
+        catalog_id: Option<String>,
+    },
+
+    /// AWS S3 Tables via the native AWS SDK (`aws-sdk-s3tables`).
+    ///
+    /// Resolves the table's metadata location from `GetTableMetadataLocation`,
+    /// then reads from the managed table bucket with the ambient AWS credential
+    /// chain.
+    S3Tables {
+        /// AWS region. Falls back to the SDK default chain / `io.s3_region` if `None`.
+        #[serde(default)]
+        region: Option<String>,
+        /// The S3 Tables table-bucket ARN
+        /// (`arn:aws:s3tables:<region>:<account>:bucket/<name>`).
+        table_bucket_arn: String,
+    },
 }
 
 impl CatalogConfig {
@@ -202,6 +248,19 @@ impl CatalogConfig {
         }
         CatalogConfig::Direct {
             table_location: loc,
+        }
+    }
+
+    /// Create an AWS Glue Data Catalog config.
+    pub fn glue(region: Option<String>, catalog_id: Option<String>) -> Self {
+        CatalogConfig::Glue { region, catalog_id }
+    }
+
+    /// Create an AWS S3 Tables catalog config from a table-bucket ARN.
+    pub fn s3_tables(region: Option<String>, table_bucket_arn: impl Into<String>) -> Self {
+        CatalogConfig::S3Tables {
+            region,
+            table_bucket_arn: table_bucket_arn.into(),
         }
     }
 }
@@ -237,6 +296,17 @@ enum TaggedCatalogConfig {
     },
     Direct {
         table_location: String,
+    },
+    Glue {
+        #[serde(default)]
+        region: Option<String>,
+        #[serde(default)]
+        catalog_id: Option<String>,
+    },
+    S3Tables {
+        #[serde(default)]
+        region: Option<String>,
+        table_bucket_arn: String,
     },
 }
 
@@ -279,6 +349,16 @@ impl From<CatalogConfigHelper> for CatalogConfig {
             CatalogConfigHelper::Tagged(TaggedCatalogConfig::Direct { table_location }) => {
                 CatalogConfig::Direct { table_location }
             }
+            CatalogConfigHelper::Tagged(TaggedCatalogConfig::Glue { region, catalog_id }) => {
+                CatalogConfig::Glue { region, catalog_id }
+            }
+            CatalogConfigHelper::Tagged(TaggedCatalogConfig::S3Tables {
+                region,
+                table_bucket_arn,
+            }) => CatalogConfig::S3Tables {
+                region,
+                table_bucket_arn,
+            },
         }
     }
 }
@@ -300,6 +380,16 @@ impl From<CatalogConfig> for CatalogConfigHelper {
             CatalogConfig::Direct { table_location } => {
                 CatalogConfigHelper::Tagged(TaggedCatalogConfig::Direct { table_location })
             }
+            CatalogConfig::Glue { region, catalog_id } => {
+                CatalogConfigHelper::Tagged(TaggedCatalogConfig::Glue { region, catalog_id })
+            }
+            CatalogConfig::S3Tables {
+                region,
+                table_bucket_arn,
+            } => CatalogConfigHelper::Tagged(TaggedCatalogConfig::S3Tables {
+                region,
+                table_bucket_arn,
+            }),
         }
     }
 }
@@ -494,6 +584,129 @@ mod tests {
         let table_id = config.table_identifier().unwrap();
         assert_eq!(table_id.namespace, "ns");
         assert_eq!(table_id.table, "table");
+    }
+
+    #[test]
+    fn test_parse_tagged_glue_config() {
+        let json = r#"{
+            "catalog": { "type": "glue", "region": "us-east-1" },
+            "table": "enterprise_dw.dim_geography",
+            "io": { "vended_credentials": false }
+        }"#;
+        let config: IcebergGsConfig = serde_json::from_str(json).unwrap();
+        match &config.catalog {
+            CatalogConfig::Glue { region, catalog_id } => {
+                assert_eq!(region, &Some("us-east-1".to_string()));
+                assert_eq!(catalog_id, &None);
+            }
+            other => panic!("Expected Glue variant, got {other:?}"),
+        }
+        let table_id = config.table_identifier().unwrap();
+        assert_eq!(table_id.namespace, "enterprise_dw");
+        assert_eq!(table_id.table, "dim_geography");
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn test_parse_tagged_s3tables_config() {
+        let json = r#"{
+            "catalog": {
+                "type": "s3tables",
+                "region": "us-east-1",
+                "table_bucket_arn": "arn:aws:s3tables:us-east-1:767398143329:bucket/demo"
+            },
+            "table": "enterprise_dw.dim_geography",
+            "io": { "vended_credentials": false }
+        }"#;
+        let config: IcebergGsConfig = serde_json::from_str(json).unwrap();
+        match &config.catalog {
+            CatalogConfig::S3Tables {
+                region,
+                table_bucket_arn,
+            } => {
+                assert_eq!(region, &Some("us-east-1".to_string()));
+                assert_eq!(
+                    table_bucket_arn,
+                    "arn:aws:s3tables:us-east-1:767398143329:bucket/demo"
+                );
+            }
+            other => panic!("Expected S3Tables variant, got {other:?}"),
+        }
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn test_glue_config_roundtrips_and_tags() {
+        // Serializes with the `glue` discriminator, and round-trips through JSON.
+        let config = IcebergGsConfig {
+            catalog: CatalogConfig::glue(Some("us-east-1".to_string()), None),
+            table: TableConfig::Identifier("enterprise_dw.dim_store".to_string()),
+            io: IoConfig {
+                vended_credentials: false,
+                ..Default::default()
+            },
+            mapping: None,
+        };
+        let json = config.to_json().unwrap();
+        assert!(
+            json.contains("\"type\":\"glue\""),
+            "expected glue tag in {json}"
+        );
+        let back = IcebergGsConfig::from_json(&json).unwrap();
+        assert!(matches!(back.catalog, CatalogConfig::Glue { .. }));
+    }
+
+    #[test]
+    fn test_s3tables_config_roundtrips_and_tags() {
+        let config = IcebergGsConfig {
+            catalog: CatalogConfig::s3_tables(
+                None,
+                "arn:aws:s3tables:us-east-1:767398143329:bucket/demo",
+            ),
+            table: TableConfig::Identifier("enterprise_dw.dim_store".to_string()),
+            io: IoConfig {
+                vended_credentials: false,
+                ..Default::default()
+            },
+            mapping: None,
+        };
+        let json = config.to_json().unwrap();
+        assert!(
+            json.contains("\"type\":\"s3tables\""),
+            "expected s3tables tag in {json}"
+        );
+        let back = IcebergGsConfig::from_json(&json).unwrap();
+        assert!(matches!(back.catalog, CatalogConfig::S3Tables { .. }));
+    }
+
+    #[test]
+    fn test_validate_glue_requires_table_identifier() {
+        let config = IcebergGsConfig {
+            catalog: CatalogConfig::glue(Some("us-east-1".to_string()), None),
+            table: TableConfig::Identifier(String::new()),
+            io: IoConfig {
+                vended_credentials: false,
+                ..Default::default()
+            },
+            mapping: None,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_s3tables_rejects_non_arn() {
+        let config = IcebergGsConfig {
+            catalog: CatalogConfig::s3_tables(None, "not-an-arn"),
+            table: TableConfig::Identifier("ns.t".to_string()),
+            io: IoConfig {
+                vended_credentials: false,
+                ..Default::default()
+            },
+            mapping: None,
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ARN"));
     }
 
     // ── Validation ──

--- a/fluree-db-iceberg/src/credential/vended.rs
+++ b/fluree-db-iceberg/src/credential/vended.rs
@@ -119,6 +119,65 @@ impl VendedCredentials {
         }))
     }
 
+    /// Parse vended credentials from a full REST `loadTable` response.
+    ///
+    /// Honors the standardized top-level `storage-credentials` array
+    /// (apache/iceberg #10722): per spec a client MUST check `storage-credentials`
+    /// **before** the legacy top-level `config` map. Among entries whose `prefix`
+    /// matches `metadata_location`, the **longest** prefix that yields usable
+    /// static creds wins — a remote-signing-only entry carries no `s3.*` keys, so
+    /// [`Self::from_config_map`] returns `None` and it is skipped. Falls back to
+    /// the flat top-level `config` map when no usable storage-credential is found
+    /// (the shape AWS Lake Formation and older catalogs still emit).
+    pub fn from_load_table_response(
+        response: &serde_json::Value,
+        metadata_location: &str,
+    ) -> Result<Option<Self>> {
+        if let Some(entries) = response
+            .get("storage-credentials")
+            .and_then(|v| v.as_array())
+        {
+            let mut best: Option<(usize, Self)> = None;
+            for entry in entries {
+                let prefix = entry.get("prefix").and_then(|p| p.as_str()).unwrap_or("");
+                // An empty/absent prefix applies to everything; a present prefix
+                // must be a prefix of this table's metadata_location.
+                if !prefix.is_empty() && !metadata_location.starts_with(prefix) {
+                    continue;
+                }
+                let Some(cfg_obj) = entry.get("config").and_then(|c| c.as_object()) else {
+                    continue;
+                };
+                let cfg: HashMap<String, serde_json::Value> = cfg_obj
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                // Skip entries with no usable static creds (e.g. remote-signing).
+                if let Some(creds) = Self::from_config_map(&cfg)? {
+                    let len = prefix.len();
+                    let better = match &best {
+                        None => true,
+                        Some((best_len, _)) => len >= *best_len,
+                    };
+                    if better {
+                        best = Some((len, creds));
+                    }
+                }
+            }
+            if let Some((_, creds)) = best {
+                return Ok(Some(creds));
+            }
+        }
+
+        // Fall back to the legacy flat top-level `config` map.
+        let config: HashMap<String, serde_json::Value> = response
+            .get("config")
+            .and_then(|v| v.as_object())
+            .map(|obj| obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default();
+        Self::from_config_map(&config)
+    }
+
     /// Check if credentials are expired or will expire within buffer.
     ///
     /// Uses a 30-second buffer to ensure we refresh before actual expiration.
@@ -508,5 +567,117 @@ mod tests {
         );
         // The access key ID (an identifier, unusable without the secret) is shown.
         assert!(dbg.contains("AKIAEXAMPLE"));
+    }
+
+    // ── from_load_table_response: standardized `storage-credentials` array
+    //    (apache/iceberg #10722), precedence + longest-usable-prefix + fallback ──
+
+    const ML: &str = "s3://bucket/db/tbl/metadata/v1.json";
+
+    fn creds_config(ak: &str) -> serde_json::Value {
+        serde_json::json!({
+            "s3.access-key-id": ak,
+            "s3.secret-access-key": "secret",
+            "s3.session-token": "token",
+            "client.region": "us-east-1",
+        })
+    }
+
+    fn load_creds(resp: &serde_json::Value) -> Option<VendedCredentials> {
+        VendedCredentials::from_load_table_response(resp, ML).unwrap()
+    }
+
+    #[test]
+    fn storage_credentials_array_is_parsed() {
+        let resp = serde_json::json!({
+            "metadata-location": ML,
+            "storage-credentials": [
+                { "prefix": "s3://bucket/db/tbl", "config": creds_config("AKIA_SC") }
+            ],
+        });
+        let c = load_creds(&resp).expect("creds");
+        assert_eq!(c.access_key_id, "AKIA_SC");
+        assert_eq!(c.region.as_deref(), Some("us-east-1"));
+    }
+
+    #[test]
+    fn storage_credentials_take_precedence_over_config() {
+        let resp = serde_json::json!({
+            "metadata-location": ML,
+            "config": creds_config("AKIA_CONFIG"),
+            "storage-credentials": [
+                { "prefix": "s3://bucket/db/tbl", "config": creds_config("AKIA_SC") }
+            ],
+        });
+        assert_eq!(load_creds(&resp).unwrap().access_key_id, "AKIA_SC");
+    }
+
+    #[test]
+    fn longest_matching_prefix_wins() {
+        let resp = serde_json::json!({
+            "metadata-location": ML,
+            "storage-credentials": [
+                { "prefix": "s3://bucket", "config": creds_config("AKIA_SHORT") },
+                { "prefix": "s3://bucket/db/tbl", "config": creds_config("AKIA_LONG") }
+            ],
+        });
+        assert_eq!(load_creds(&resp).unwrap().access_key_id, "AKIA_LONG");
+    }
+
+    #[test]
+    fn longest_prefix_without_usable_keys_is_skipped() {
+        // The longest-prefix entry is remote-signing-only (no static s3.* keys);
+        // the shorter entry that actually carries keys must be chosen.
+        let resp = serde_json::json!({
+            "metadata-location": ML,
+            "storage-credentials": [
+                { "prefix": "s3://bucket/db", "config": creds_config("AKIA_USABLE") },
+                { "prefix": "s3://bucket/db/tbl", "config": { "s3.remote-signing-enabled": "true" } }
+            ],
+        });
+        assert_eq!(load_creds(&resp).unwrap().access_key_id, "AKIA_USABLE");
+    }
+
+    #[test]
+    fn non_matching_prefix_falls_back_to_config() {
+        let resp = serde_json::json!({
+            "metadata-location": ML,
+            "storage-credentials": [
+                { "prefix": "s3://other-bucket/x", "config": creds_config("AKIA_OTHER") }
+            ],
+            "config": creds_config("AKIA_CONFIG"),
+        });
+        assert_eq!(load_creds(&resp).unwrap().access_key_id, "AKIA_CONFIG");
+    }
+
+    #[test]
+    fn falls_back_to_legacy_config_map() {
+        let resp = serde_json::json!({
+            "metadata-location": ML,
+            "config": creds_config("AKIA_CONFIG"),
+        });
+        assert_eq!(load_creds(&resp).unwrap().access_key_id, "AKIA_CONFIG");
+    }
+
+    #[test]
+    fn malformed_entries_are_skipped_gracefully() {
+        let resp = serde_json::json!({
+            "metadata-location": ML,
+            "storage-credentials": [
+                "not-an-object",
+                { "prefix": "s3://bucket/db/tbl" },            // no config
+                { "config": creds_config("AKIA_NOPREFIX") }    // no prefix -> applies to all
+            ],
+        });
+        assert_eq!(load_creds(&resp).unwrap().access_key_id, "AKIA_NOPREFIX");
+    }
+
+    #[test]
+    fn no_credentials_yields_none() {
+        let resp = serde_json::json!({
+            "metadata-location": ML,
+            "config": { "table_type": "ICEBERG" },
+        });
+        assert!(load_creds(&resp).is_none());
     }
 }

--- a/fluree-db-iceberg/tests/it_glue_sdk_reads.rs
+++ b/fluree-db-iceberg/tests/it_glue_sdk_reads.rs
@@ -1,0 +1,116 @@
+//! Env-gated live integration tests: AWS Glue Data Catalog + S3 Tables Iceberg
+//! reads via the native AWS SDK. These need a live catalog + ambient AWS
+//! credentials, so — like `it_gcs_sdk_reads.rs` — they SKIP unless the relevant
+//! env vars are set (no live dependency in CI).
+//!
+//! Glue (matches the sandbox harness):
+//! ```
+//! AWS_PROFILE=aj-sandbox AWS_REGION=us-east-1 \
+//!   FLUREE_GLUE_IT_DATABASE=enterprise_dw FLUREE_GLUE_IT_TABLE=dim_store \
+//!   FLUREE_GLUE_IT_EXPECT_ROWS=300 \
+//!   cargo test -p fluree-db-iceberg --features aws --test it_glue_sdk_reads -- --nocapture
+//! ```
+//! S3 Tables:
+//! ```
+//! FLUREE_S3TABLES_IT_ARN=arn:aws:s3tables:us-east-1:ACCT:bucket/NAME \
+//!   FLUREE_S3TABLES_IT_TABLE=dim_geography FLUREE_S3TABLES_IT_EXPECT_ROWS=200 ...
+//! ```
+#![cfg(feature = "aws")]
+
+use fluree_db_iceberg::catalog::{
+    GlueSdkCatalogClient, S3TablesSdkCatalogClient, SendCatalogClient, TableIdentifier,
+};
+use fluree_db_iceberg::io::send_parquet::SendParquetReader;
+use fluree_db_iceberg::io::{S3IcebergStorage, SendIcebergStorage};
+use fluree_db_iceberg::metadata::TableMetadata;
+use fluree_db_iceberg::scan::{ScanConfig, SendScanPlanner};
+
+fn env(k: &str) -> Option<String> {
+    std::env::var(k).ok().filter(|s| !s.is_empty())
+}
+fn region() -> Option<String> {
+    env("FLUREE_GLUE_IT_REGION").or_else(|| env("AWS_REGION"))
+}
+
+/// Resolve `metadata_location` via the SDK catalog, then read the table's rows
+/// with the ambient credential chain — the full SDK-native read path.
+async fn read_rows(catalog: Box<dyn SendCatalogClient>, table_id: TableIdentifier) -> usize {
+    let load = catalog
+        .load_table(&table_id, false)
+        .await
+        .expect("load_table");
+    assert!(
+        load.metadata_location.contains("://"),
+        "metadata_location should be a URI, got {}",
+        load.metadata_location
+    );
+    assert!(
+        load.credentials.is_none(),
+        "the AWS SDK path reads S3 with ambient creds (no vending)"
+    );
+
+    let storage = S3IcebergStorage::from_default_chain(region().as_deref(), None, false)
+        .await
+        .expect("storage");
+    let bytes = storage
+        .read(&load.metadata_location)
+        .await
+        .expect("read metadata");
+    let metadata = TableMetadata::from_json(&bytes).expect("parse metadata");
+
+    let planner = SendScanPlanner::new(&storage, &metadata, ScanConfig::new());
+    let plan = planner.plan_scan().await.expect("plan_scan");
+
+    let reader = SendParquetReader::new(&storage);
+    let mut total = 0;
+    for task in &plan.tasks {
+        for batch in &reader.read_task(task).await.expect("read_task") {
+            total += batch.num_rows;
+        }
+    }
+    total
+}
+
+#[tokio::test]
+async fn glue_catalog_reads_rows() {
+    let Some(namespace) = env("FLUREE_GLUE_IT_DATABASE") else {
+        eprintln!(
+            "skip glue_catalog_reads_rows: set FLUREE_GLUE_IT_DATABASE + FLUREE_GLUE_IT_TABLE"
+        );
+        return;
+    };
+    let table =
+        env("FLUREE_GLUE_IT_TABLE").expect("FLUREE_GLUE_IT_TABLE required when DATABASE set");
+    let catalog = Box::new(
+        GlueSdkCatalogClient::new(region().as_deref(), env("FLUREE_GLUE_IT_CATALOG_ID"))
+            .await
+            .expect("glue client"),
+    );
+    let total = read_rows(catalog, TableIdentifier { namespace, table }).await;
+    match env("FLUREE_GLUE_IT_EXPECT_ROWS").and_then(|v| v.parse::<usize>().ok()) {
+        Some(expect) => assert_eq!(total, expect, "row-count mismatch"),
+        None => assert!(total > 0, "expected a non-empty table"),
+    }
+    eprintln!("glue read {total} rows OK");
+}
+
+#[tokio::test]
+async fn s3tables_catalog_reads_rows() {
+    let Some(arn) = env("FLUREE_S3TABLES_IT_ARN") else {
+        eprintln!("skip s3tables_catalog_reads_rows: set FLUREE_S3TABLES_IT_ARN");
+        return;
+    };
+    let namespace = env("FLUREE_S3TABLES_IT_NS").unwrap_or_else(|| "enterprise_dw".into());
+    let table = env("FLUREE_S3TABLES_IT_TABLE").unwrap_or_else(|| "dim_geography".into());
+    let catalog = Box::new(
+        S3TablesSdkCatalogClient::new(region().as_deref(), arn)
+            .await
+            .expect("s3tables client"),
+    );
+    let total = read_rows(catalog, TableIdentifier { namespace, table }).await;
+    match env("FLUREE_S3TABLES_IT_EXPECT_ROWS").and_then(|v| v.parse::<usize>().ok()) {
+        Some(expect) => assert_eq!(total, expect, "row-count mismatch"),
+        None => assert!(total > 0, "expected a non-empty table"),
+    }
+    eprintln!("s3tables read {total} rows OK");
+}

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -314,13 +314,19 @@ fn build_iceberg_config(req: &IcebergMapRequest) -> Result<fluree_db_api::Iceber
 /// (a subset of [`IcebergMapRequest`], minus `name`/`table`/`r2rml`).
 #[derive(Deserialize)]
 pub struct IcebergConnectionRequest {
-    /// Catalog mode: "rest" (default) or "direct"
+    /// Catalog mode: "rest" (default), "direct", "glue", or "s3tables"
     #[serde(default = "default_mode")]
     pub mode: String,
     /// REST catalog URI
     pub catalog_uri: Option<String>,
     /// S3 table location (direct mode)
     pub table_location: Option<String>,
+    /// AWS region (glue / s3tables mode)
+    pub region: Option<String>,
+    /// AWS Glue catalog id for cross-account access (glue mode)
+    pub catalog_id: Option<String>,
+    /// AWS S3 Tables table-bucket ARN (s3tables mode)
+    pub table_bucket_arn: Option<String>,
     /// Bearer token for catalog auth
     pub auth_bearer: Option<String>,
     /// OAuth2 token URL
@@ -367,9 +373,16 @@ fn build_iceberg_connection(
             })?;
             IcebergConnectionConfig::direct(location)
         }
+        "glue" => IcebergConnectionConfig::glue(req.region.clone(), req.catalog_id.clone()),
+        "s3tables" => {
+            let arn = req.table_bucket_arn.as_ref().ok_or_else(|| {
+                ServerError::bad_request("table_bucket_arn is required for s3tables mode")
+            })?;
+            IcebergConnectionConfig::s3_tables(req.region.clone(), arn)
+        }
         other => {
             return Err(ServerError::bad_request(format!(
-                "unknown catalog mode '{other}'. Use 'rest' or 'direct'."
+                "unknown catalog mode '{other}'. Use 'rest', 'direct', 'glue', or 's3tables'."
             )));
         }
     };
@@ -862,6 +875,40 @@ mod tests {
         assert!(req.depth.is_none());
         let conn = build_iceberg_connection(&req.connection).unwrap();
         assert!(conn.is_direct());
+    }
+
+    #[test]
+    fn browse_request_glue_mode_builds_glue_connection() {
+        // The connection builder must accept the glue mode + its region/catalog_id
+        // fields (browse/preview/generate/validate parity with iceberg/map).
+        let body = serde_json::json!({
+            "mode": "glue",
+            "region": "us-east-1",
+            "catalog_id": "123456789012"
+        });
+        let req: IcebergBrowseRequest = serde_json::from_value(body).unwrap();
+        let conn = build_iceberg_connection(&req.connection).unwrap();
+        assert!(conn.is_glue());
+    }
+
+    #[test]
+    fn browse_request_s3tables_mode_builds_s3tables_connection() {
+        let body = serde_json::json!({
+            "mode": "s3tables",
+            "region": "us-east-1",
+            "table_bucket_arn": "arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket"
+        });
+        let req: IcebergBrowseRequest = serde_json::from_value(body).unwrap();
+        let conn = build_iceberg_connection(&req.connection).unwrap();
+        assert!(conn.is_s3tables());
+    }
+
+    #[test]
+    fn build_iceberg_connection_s3tables_requires_arn() {
+        // s3tables mode without an ARN is a 400, mirroring build_iceberg_config.
+        let body = serde_json::json!({ "mode": "s3tables" });
+        let req: IcebergBrowseRequest = serde_json::from_value(body).unwrap();
+        assert!(build_iceberg_connection(&req.connection).is_err());
     }
 
     #[test]

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -21,7 +21,7 @@ use super::ledger::forward_write_request;
 pub struct IcebergMapRequest {
     /// Graph source name
     pub name: String,
-    /// Catalog mode: "rest" (default) or "direct"
+    /// Catalog mode: "rest" (default), "direct", "glue", or "s3tables"
     #[serde(default = "default_mode")]
     pub mode: String,
     /// REST catalog URI
@@ -30,6 +30,12 @@ pub struct IcebergMapRequest {
     pub table: Option<String>,
     /// S3 table location (direct mode)
     pub table_location: Option<String>,
+    /// AWS region (glue / s3tables mode)
+    pub region: Option<String>,
+    /// AWS Glue catalog id for cross-account access (glue mode)
+    pub catalog_id: Option<String>,
+    /// AWS S3 Tables table-bucket ARN (s3tables mode)
+    pub table_bucket_arn: Option<String>,
     /// R2RML mapping source
     pub r2rml: Option<String>,
     /// R2RML mapping media type
@@ -216,9 +222,46 @@ fn build_iceberg_config(req: &IcebergMapRequest) -> Result<fluree_db_api::Iceber
             })?;
             fluree_db_api::IcebergCreateConfig::new_direct(&req.name, location)
         }
+        "glue" => {
+            let table = req.table.as_deref().unwrap_or_default();
+            if table.is_empty() {
+                return Err(ServerError::bad_request(
+                    "table is required for glue mode (namespace.table)",
+                ));
+            }
+            let connection = fluree_db_api::IcebergConnectionConfig::glue(
+                req.region.clone(),
+                req.catalog_id.clone(),
+            );
+            fluree_db_api::IcebergCreateConfig {
+                name: req.name.clone(),
+                branch: None,
+                connection,
+                table_identifier: table.to_string(),
+            }
+        }
+        "s3tables" => {
+            let arn = req.table_bucket_arn.as_ref().ok_or_else(|| {
+                ServerError::bad_request("table_bucket_arn is required for s3tables mode")
+            })?;
+            let table = req.table.as_deref().unwrap_or_default();
+            if table.is_empty() {
+                return Err(ServerError::bad_request(
+                    "table is required for s3tables mode (namespace.table)",
+                ));
+            }
+            let connection =
+                fluree_db_api::IcebergConnectionConfig::s3_tables(req.region.clone(), arn);
+            fluree_db_api::IcebergCreateConfig {
+                name: req.name.clone(),
+                branch: None,
+                connection,
+                table_identifier: table.to_string(),
+            }
+        }
         other => {
             return Err(ServerError::bad_request(format!(
-                "unknown catalog mode '{other}'. Use 'rest' or 'direct'."
+                "unknown catalog mode '{other}'. Use 'rest', 'direct', 'glue', or 's3tables'."
             )));
         }
     };


### PR DESCRIPTION
## Summary

Adds two **native-AWS-SDK** catalog modes to the Iceberg/R2RML graph-source path — **AWS Glue Data Catalog** (`--mode glue`) and **AWS S3 Tables** (`--mode s3tables`) — at **full parity** with the existing REST (Polaris / Snowflake Horizon) and Direct modes.

```bash
fluree iceberg map gs --mode glue     --table enterprise_dw.dim_store --region us-east-1 --r2rml m.ttl
fluree iceberg map gs --mode s3tables --table ns.tbl --table-bucket-arn arn:aws:s3tables:... --region us-east-1 --r2rml m.ttl
```

## Approach

Both modes resolve the table's `metadata_location` through the native AWS SDK (`aws-sdk-glue` `GetTable` / `aws-sdk-s3tables` `GetTableMetadataLocation`), then read metadata/manifests/data from S3 with the **ambient** credential chain — reusing the existing `direct.rs` reader and `from_default_chain`. **No `aws-sigv4`, no request signing, no REST prefix.**

**Why SDK-native rather than REST + SigV4:** empirically, for a normally S3-authorized principal, neither Glue DC (IAM mode) nor S3 Tables vends credentials, so ambient reads suffice — and staying on the AWS SDK keeps consistent signing/transport paths (prefer the SDK / override its HTTP client via `aws-smithy-http` rather than roll alternatives) instead of a hand-rolled REST+SigV4 client.

## Changes

- **Core:** `GlueSdkCatalogClient` + `S3TablesSdkCatalogClient` (`catalog/aws_sdk.rs`); `CatalogConfig::Glue`/`S3Tables` (serde `"glue"`/`"s3tables"`, variant ungated / SDK impl `aws`-gated); two `r2rml.rs` scan arms; `CatalogMode` + CLI + server `map`; `aws-sdk-glue`/`aws-sdk-s3tables` deps; `read_glue` example.
- **Full parity:** catalog browse, table preview, R2RML auto-generate, and mapping validate now work for glue/s3tables (were hard-rejected). `catalog_client()` dispatches to the SDK clients; preview fetches table metadata from S3 when the catalog returns no inline metadata; server request struct + dispatch widened. Query-time: glue/s3tables scans use the same per-query snapshot pin + cross-query `loadTable` cache as REST (`sdk_resolve_load_table`).
- **Tests:** env-gated live integration tests (`it_glue_sdk_reads.rs`, `it_glue_live.rs`) + a CI-level `metadata_location`-extraction unit test.
- **`storage-credentials` parsing fix (was a listed follow-up):** `VendedCredentials::from_load_table_response` now parses the standardized top-level `storage-credentials` array (apache/iceberg #10722) with spec-normative precedence over the legacy flat `config` map (longest-*usable*-prefix; remote-signing-only entries skipped), and the two duplicated REST `loadTable` parse sites are factored into one shared `parse_load_table_response`. This was a latent bug that would 403 any REST catalog vending via `storage-credentials`. Not hit by this PR's SDK-native path (ambient by design); benefits spec-compliant REST vending catalogs (Polaris/Unity/future Snowflake).

## Validation

- **Offline:** config + `iceberg_catalog` + server-route + api-lib (689) + iceberg (202, incl. `storage-credentials` fixtures) suites pass; `fmt`/`clippy` clean.
- **Live** (Glue + S3 Tables harness): `read_glue` exact counts (Glue 500 / 60,000, S3 Tables 200); full SPARQL e2e over Glue exact (300 stores / 60,000 order-line⋈product / 6 categories / 20,000 order⋈customer) incl. multi-table joins + a dangling-FK check; browse + preview live; the env-gated `it_glue_*` tests assert Glue 300 / S3 Tables 200 / browse / preview.

## Follow-up

- **#1456** — SDK-native Lake-Formation vended credentials for LF-governed Glue tables read by a *restricted* principal (the remaining "vended AWS" case; ambient reads 403 there). Filed as a de-risked spec — fail-closed on fine-grained LF policies, hybrid-catalog try-ambient-then-vend, `VendedS3Path` scope enforcement — produced by this PR's adversarial audit. S3 Tables LF-vending is deferred within that issue (managed storage needs the Glue federation integration).
