### PR TITLE
fix(policy): honor policy-class when identity is also present (same-ledger)

### DIFF
--- a/fluree-db-api/src/policy_builder.rs
+++ b/fluree-db-api/src/policy_builder.rs
@@ -99,7 +99,8 @@ pub fn resolve_policy_source_g_ids(
 /// 2. **policy_class**: Query for policies of the given class types
 /// 3. **policy**: Parse inline policy JSON-LD
 ///
-/// Priority: identity > policy_class > policy
+/// Priority: (identity + policy_class: classes select, identity binds) >
+/// identity > policy_class > policy
 ///
 /// # Arguments
 ///
@@ -257,7 +258,8 @@ async fn build_policy_context_from_opts_inner(
     // when we have a concrete SID), not for gating access — `opts.default_allow`
     // governs in all three cases.
     //
-    // Priority: cross-ledger restrictions > identity > policy_class > policy >
+    // Priority: cross-ledger restrictions > (identity + policy_class: classes
+    // select, identity binds) > identity > policy_class > policy >
     // policy_values["?$identity"]
     let (identity_sid, restrictions) = if let Some(mut merged) = cross_ledger_restrictions {
         // Cross-ledger short-circuit: the resolver already materialized

--- a/fluree-db-api/src/policy_builder.rs
+++ b/fluree-db-api/src/policy_builder.rs
@@ -303,6 +303,37 @@ async fn build_policy_context_from_opts_inner(
             merged.extend(parse_inline_policy(snapshot, policy_json)?);
         }
         (identity_sid, merged)
+    } else if let (Some(identity_iri), Some(classes)) = (
+        &opts.identity,
+        opts.policy_class.as_ref().filter(|c| !c.is_empty()),
+    ) {
+        // Same-ledger identity + explicit `policy-class`: the request's
+        // classes select the policy set; the identity is BIND-ONLY — it
+        // resolves to populate `?$identity` for f:query rules and never
+        // drives rule selection. This mirrors the cross-ledger identity
+        // contract above.
+        //
+        // Without this arm, a request carrying both fields silently ignored
+        // `policy-class` and fell through to identity-mode selection below —
+        // which yields an empty policy set (deny-all under default-deny)
+        // whenever the identity has no `f:policyClass` triples in the
+        // ledger, and can never work for identities that are not resolvable
+        // IRIs (bare emails / UUID subjects minted by application auth
+        // systems). Gateways that resolve grant-derived classes per request
+        // and forward them alongside the authenticated identity depend on
+        // the classes being honored.
+        let identity_sid =
+            resolve_identity_binding_sid(snapshot, overlay, to_t, identity_iri, policy_graphs)
+                .await?;
+        if let Some(sid) = &identity_sid {
+            policy_values.insert("?$identity".to_string(), sid.clone());
+        }
+        let mut restrictions =
+            load_policies_by_class(snapshot, overlay, to_t, classes, policy_graphs).await?;
+        if let Some(policy_json) = &opts.policy {
+            restrictions.extend(parse_inline_policy(snapshot, policy_json)?);
+        }
+        (identity_sid, restrictions)
     } else if let Some(identity_iri) = &opts.identity {
         match load_policies_by_identity(snapshot, overlay, to_t, identity_iri, policy_graphs)
             .await?

--- a/fluree-db-api/tests/it_policy_tx.rs
+++ b/fluree-db-api/tests/it_policy_tx.rs
@@ -694,3 +694,174 @@ async fn turtle_insert_enforces_modify_policy() {
         ok.err()
     );
 }
+
+/// Test: `identity` + `policy-class` together — classes select, identity is
+/// bind-only.
+///
+/// A request carrying BOTH an identity and an explicit policy-class must have
+/// its policy set selected by the class (stored policies typed with it), with
+/// the identity only binding `?$identity`. This is the shape gateways send
+/// when they resolve grant-derived classes per request and forward them with
+/// the authenticated identity — including identities that are not resolvable
+/// IRIs (bare emails / UUID subjects), which must not poison the context.
+#[tokio::test]
+async fn identity_with_policy_class_selects_class_policies() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "identity_with_policy_class");
+
+    // Store class-typed policies IN the ledger (class selection, not inline):
+    // a view policy on ex:Lead and a modify property-whitelist.
+    let policies = json!({
+        "@context": {
+            "f": "https://ns.flur.ee/db#",
+            "ex": "http://example.org/ns/",
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:leadView",
+                "@type": ["f:AccessPolicy", "ex:LeadAppAccess"],
+                "f:action": {"@id": "f:view"},
+                "f:allow": true,
+                "f:onClass": {"@id": "ex:Lead"}
+            },
+            {
+                "@id": "ex:leadModify",
+                "@type": ["f:AccessPolicy", "ex:LeadAppAccess"],
+                "f:action": {"@id": "f:modify"},
+                "f:allow": true,
+                "f:onProperty": [
+                    {"@id": "rdf:type"},
+                    {"@id": "ex:name"},
+                    {"@id": "ex:campaign"}
+                ]
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &policies).await.unwrap().ledger;
+
+    let insert_lead = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@id": "ex:lead-1",
+        "@type": "ex:Lead",
+        "ex:name": "Maya",
+        "ex:campaign": "trailhead"
+    });
+    let index_config = IndexConfig {
+        reindex_min_bytes: 100_000,
+        reindex_max_bytes: 1_000_000_000,
+    };
+
+    // ── identity + policy-class: classes select; insert is allowed ──
+    // The identity is deliberately NOT a resolvable IRI: it must be treated
+    // as bind-only (unbound `?$identity`), not poison rule selection.
+    let qc_opts = GovernanceOptions {
+        identity: Some("admin@fluree.local".to_string()),
+        policy_class: Some(vec!["http://example.org/ns/LeadAppAccess".to_string()]),
+        default_allow: false,
+        ..Default::default()
+    };
+    let policy_ctx = policy_builder::build_policy_context_from_opts(
+        &ledger.snapshot,
+        ledger.novelty.as_ref(),
+        Some(ledger.novelty.as_ref()),
+        ledger.t(),
+        &qc_opts,
+        &[0],
+    )
+    .await
+    .expect("build policy context");
+
+    let input = TrackedTransactionInput::new(
+        TxnType::Insert,
+        &insert_lead,
+        TxnOpts::default(),
+        &policy_ctx,
+    );
+    // Transacting consumes the LedgerState; the denial sections below each
+    // work on their own clone of the post-policies state.
+    let ledger_for_identity_only = ledger.clone();
+    let ledger_for_sneaky = ledger.clone();
+    let result = fluree
+        .transact_tracked_with_policy(ledger, input, CommitOpts::default(), &index_config)
+        .await;
+    assert!(
+        result.is_ok(),
+        "class-selected whitelist must allow the lead insert: {:?}",
+        result.err()
+    );
+
+    // ── same identity WITHOUT policy-class: identity-mode → deny ──
+    // Pins that the allow above came from the class arm, not a loosening of
+    // identity-mode.
+    let identity_only = GovernanceOptions {
+        identity: Some("admin@fluree.local".to_string()),
+        default_allow: false,
+        ..Default::default()
+    };
+    let ledger = ledger_for_identity_only;
+    let policy_ctx = policy_builder::build_policy_context_from_opts(
+        &ledger.snapshot,
+        ledger.novelty.as_ref(),
+        Some(ledger.novelty.as_ref()),
+        ledger.t(),
+        &identity_only,
+        &[0],
+    )
+    .await
+    .expect("build policy context");
+    let insert_lead2 = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@id": "ex:lead-2",
+        "@type": "ex:Lead",
+        "ex:name": "Denied"
+    });
+    let input = TrackedTransactionInput::new(
+        TxnType::Insert,
+        &insert_lead2,
+        TxnOpts::default(),
+        &policy_ctx,
+    );
+    let result = fluree
+        .transact_tracked_with_policy(ledger, input, CommitOpts::default(), &index_config)
+        .await;
+    assert!(
+        result.is_err(),
+        "identity-mode without classes must stay default-deny"
+    );
+    let ledger = ledger_for_sneaky;
+
+    // ── class-selected but non-whitelisted property: still denied ──
+    let qc_opts = GovernanceOptions {
+        identity: Some("admin@fluree.local".to_string()),
+        policy_class: Some(vec!["http://example.org/ns/LeadAppAccess".to_string()]),
+        default_allow: false,
+        ..Default::default()
+    };
+    let policy_ctx = policy_builder::build_policy_context_from_opts(
+        &ledger.snapshot,
+        ledger.novelty.as_ref(),
+        Some(ledger.novelty.as_ref()),
+        ledger.t(),
+        &qc_opts,
+        &[0],
+    )
+    .await
+    .expect("build policy context");
+    let sneaky = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@id": "ex:secret-1",
+        "@type": "ex:Secret",
+        "ex:val": "x"
+    });
+    let input =
+        TrackedTransactionInput::new(TxnType::Insert, &sneaky, TxnOpts::default(), &policy_ctx);
+    let result = fluree
+        .transact_tracked_with_policy(ledger, input, CommitOpts::default(), &index_config)
+        .await;
+    assert!(
+        result.is_err(),
+        "non-whitelisted property must be denied even with the class selected"
+    );
+}


### PR DESCRIPTION
## Problem

A request carrying **both** `identity` and `policy-class` silently ignored the classes. In `build_policy_context_from_opts`, the same-ledger identity arm wins the priority chain and selects rules only from the identity node's own `f:policyClass` triples in the ledger. Two failure modes fall out:

- An identity with no subject node in the ledger (`IdentityLookupResult::NotFound`) yields an **empty policy set** — deny-all under default-deny.
- An identity that is not a resolvable IRI at all (bare emails, UUID subjects minted by application auth systems) can **never** carry `f:policyClass` triples, so the combination can never work for those callers.

Gateways that resolve grant-derived policy classes per request and forward them alongside the authenticated identity (the documented `fluree-identity` + `fluree-policy-class` header pair) depend on the classes being honored. Today that combination enforces nothing — it denies everything.

## Fix

New arm in the priority chain: when both fields are present, the **classes select the policy set** and the **identity is bind-only** — it resolves to populate `?$identity` for `f:query` rules and never drives rule selection. This mirrors the documented cross-ledger identity contract ("identities are bind-only under cross-ledger"). An unresolvable identity simply leaves `?$identity` unbound. Inline `opts.policy` still merges on top.

Identity-only and class-only behavior are unchanged.

## Tests

New integration test (`it_policy_tx::identity_with_policy_class_selects_class_policies`) covering three contracts:

1. Stored class-typed policies + a non-IRI identity + `policy-class` → insert allowed via the class-selected property whitelist
2. Same identity **without** `policy-class` → identity-mode stays default-deny (pins that the allow comes from the new arm, not a loosening of identity-mode)
3. Non-whitelisted property with the class selected → still denied

Full policy group: 60/60 passing.