### PR TITLE
fix: attribute ref-class stats when an endpoint gains its first type

### DIFF
--- a/fluree-db-api/tests/it_indexing_stats.rs
+++ b/fluree-db-api/tests/it_indexing_stats.rs
@@ -808,6 +808,302 @@ async fn ref_class_reattributed_after_both_endpoints_retype() {
         .await;
 }
 
+/// Untyped→typed (Case B variant): an OBJECT that had NO rdf:type when its
+/// inbound refs were indexed gains its FIRST type in a later batch. The edges
+/// must attribute to the new object class — a first-time-typed subject has no
+/// `base_subject_classes` entry, so this exercises the net-map branch of the
+/// endpoint resolver (a plain re-type does not).
+#[tokio::test]
+async fn ref_class_attributed_when_object_typed_later() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let mut fluree = FlureeBuilder::file(path)
+        .build()
+        .expect("build file fluree");
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/ref-object-typed-later:main";
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let storage = fluree
+                .backend()
+                .admin_storage_cloned()
+                .expect("test uses managed backend");
+
+            // org1 is a bare reference target: no rdf:type yet.
+            let txn1 = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","@type":"ex:Employee","ex:worksFor":{"@id":"ex:org1"}},
+                    {"@id":"ex:bob","@type":"ex:Employee","ex:worksFor":{"@id":"ex:org1"}}
+                ]
+            });
+            let r1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &txn1,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert txn1");
+            let o1 =
+                trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o1 else {
+                unreachable!("helper only returns Completed")
+            };
+            let loaded1 = load_ledger_snapshot(&storage, &root_id.expect("root1"), ledger_id)
+                .await
+                .expect("load snapshot 1");
+            assert_eq!(
+                ref_class_total(
+                    &loaded1,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
+                None,
+                "first index: org1 untyped, so no object-class bucket yet"
+            );
+
+            // org1 gains its FIRST type; the worksFor edges are untouched.
+            let type_later = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:org1","@type":"ex:Organization"}
+                ]
+            });
+            let r2 = fluree
+                .insert_with_opts(
+                    r1.ledger,
+                    &type_later,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("type org1");
+            let o2 =
+                trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
+                unreachable!("helper only returns Completed")
+            };
+            let loaded2 = load_ledger_snapshot(&storage, &root_id.expect("root2"), ledger_id)
+                .await
+                .expect("load snapshot 2");
+            assert_eq!(
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
+                Some(2),
+                "both pre-existing edges attribute once org1 is typed"
+            );
+        })
+        .await;
+}
+
+/// Untyped→typed (Case A variant): a SUBJECT with existing outgoing refs gains
+/// its FIRST type in a later batch. Its edges must appear under the new
+/// subject-class bucket.
+#[tokio::test]
+async fn ref_class_attributed_when_subject_typed_later() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let mut fluree = FlureeBuilder::file(path)
+        .build()
+        .expect("build file fluree");
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/ref-subject-typed-later:main";
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let storage = fluree
+                .backend()
+                .admin_storage_cloned()
+                .expect("test uses managed backend");
+
+            // alice has an edge but no rdf:type yet; org1 is typed.
+            let txn1 = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","ex:worksFor":{"@id":"ex:org1"}},
+                    {"@id":"ex:org1","@type":"ex:Organization"}
+                ]
+            });
+            let r1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &txn1,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert txn1");
+            let _ =
+                trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+
+            // alice gains her FIRST type; worksFor untouched.
+            let type_later = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","@type":"ex:Employee"}
+                ]
+            });
+            let r2 = fluree
+                .insert_with_opts(
+                    r1.ledger,
+                    &type_later,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("type alice");
+            let o2 =
+                trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
+                unreachable!("helper only returns Completed")
+            };
+            let loaded2 = load_ledger_snapshot(&storage, &root_id.expect("root2"), ledger_id)
+                .await
+                .expect("load snapshot 2");
+            assert_eq!(
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
+                Some(1),
+                "pre-existing edge attributes once alice is typed"
+            );
+        })
+        .await;
+}
+
+/// Untyped→typed, both endpoints: subject AND object of an existing edge gain
+/// their FIRST types in the same later batch. The edge must land in the new
+/// (subject_class, p, object_class) bucket exactly once.
+#[tokio::test]
+async fn ref_class_attributed_when_both_endpoints_typed_later() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let mut fluree = FlureeBuilder::file(path)
+        .build()
+        .expect("build file fluree");
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/ref-both-typed-later:main";
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let storage = fluree
+                .backend()
+                .admin_storage_cloned()
+                .expect("test uses managed backend");
+
+            // Neither endpoint has a type yet.
+            let txn1 = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","ex:worksFor":{"@id":"ex:org1"}}
+                ]
+            });
+            let r1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &txn1,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert txn1");
+            let _ =
+                trigger_index_and_wait_outcome(&handle, r1.ledger.ledger_id(), r1.receipt.t).await;
+
+            let type_later = json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    {"@id":"ex:alice","@type":"ex:Employee"},
+                    {"@id":"ex:org1","@type":"ex:Organization"}
+                ]
+            });
+            let r2 = fluree
+                .insert_with_opts(
+                    r1.ledger,
+                    &type_later,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("type both");
+            let o2 =
+                trigger_index_and_wait_outcome(&handle, r2.ledger.ledger_id(), r2.receipt.t).await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = o2 else {
+                unreachable!("helper only returns Completed")
+            };
+            let loaded2 = load_ledger_snapshot(&storage, &root_id.expect("root2"), ledger_id)
+                .await
+                .expect("load snapshot 2");
+            assert_eq!(
+                ref_class_total(
+                    &loaded2,
+                    "http://example.org/Employee",
+                    "http://example.org/worksFor",
+                    "http://example.org/Organization"
+                ),
+                Some(1),
+                "edge attributes exactly once when both endpoints gain first types"
+            );
+        })
+        .await;
+}
+
 /// #1266 — rebuild gate: a re-type batch above the threshold aborts incremental
 /// and the caller falls back to a full rebuild, which recomputes class/ref stats
 /// from scratch (so the result is still current-state-correct).

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2767,13 +2767,20 @@ pub async fn incremental_index(
                             }
                             // Resolve classes for endpoints not already known from this batch
                             // (stable base entities) via one batched rdf:type lookup; endpoints
-                            // in base_subject_classes (re-typed / novelty) use those maps.
+                            // in either batch map (re-typed / novelty) use those maps. A subject
+                            // typed for the FIRST time this batch has no base entry — only a net
+                            // one — so both maps must be checked or it would be mistaken for a
+                            // stable (still class-less) base entity.
                             let mut external_sids: Vec<u64> = Vec::new();
                             for &(s, _p, o) in &edges {
-                                if !base_subject_classes.contains_key(&(g_id, s)) {
+                                if !base_subject_classes.contains_key(&(g_id, s))
+                                    && !subject_classes.contains_key(&(g_id, s))
+                                {
                                     external_sids.push(s);
                                 }
-                                if !base_subject_classes.contains_key(&(g_id, o)) {
+                                if !base_subject_classes.contains_key(&(g_id, o))
+                                    && !subject_classes.contains_key(&(g_id, o))
+                                {
                                     external_sids.push(o);
                                 }
                             }
@@ -2805,11 +2812,21 @@ pub async fn incremental_index(
                             };
                             // (base_classes, net_classes) for an endpoint. A stable base
                             // entity has base == net (its type did not change this batch).
+                            // Batch-local membership is keyed on EITHER map: a first-time-typed
+                            // subject is absent from base but present in net; keying on base
+                            // alone would resolve it externally as class-less and drop the +1
+                            // side of its edge moves.
                             let resolve = |sid: u64| -> (Vec<u64>, Vec<u64>) {
-                                if let Some(b) = base_subject_classes.get(&(g_id, sid)) {
-                                    let base: Vec<u64> = b.iter().copied().collect();
+                                let key = (g_id, sid);
+                                if base_subject_classes.contains_key(&key)
+                                    || subject_classes.contains_key(&key)
+                                {
+                                    let base: Vec<u64> = base_subject_classes
+                                        .get(&key)
+                                        .map(|b| b.iter().copied().collect())
+                                        .unwrap_or_default();
                                     let net: Vec<u64> = subject_classes
-                                        .get(&(g_id, sid))
+                                        .get(&key)
                                         .map(|s| s.iter().copied().collect())
                                         .unwrap_or_default();
                                     (base, net)


### PR DESCRIPTION
## Problem

Ref-class stats (the `ref-classes` / attributed-refs maps behind `/v1/{ledger}/data-model`) attribute a ref triple's target class when the ref is indexed and never revisit it across incremental index batches. If subject `S` gains its **first** `rdf:type` in a later transaction, all previously-indexed refs pointing at (or out of) `S` stay unattributed forever — the stats disagree with what a query returns, and data-model consumers draw an incomplete class graph. Observed in the field as e.g. `Paragraph -> sourceDocument: 3,065 id-refs, 0 attributed` after ~19K documents were typed retroactively; only a full reindex or a delete/re-assert "touch" of the refs recovered.

Reproduced locally on file storage — the storage backend is irrelevant.

## Root cause

The incremental Phase 3b ref-edge re-attribution (#1266) keys batch-local class membership on `base_subject_classes` alone. A subject typed for the first time in a batch has no base entry (no `rdf:type` hits in the base PSOT lookup), so the endpoint `resolve` closure routes it to the "stable external entity" branch, which resolves both base and net classes from the base index — where it has none. The net class set comes back empty and the `+1` side of the edge move is dropped. Both Case A (outgoing edges of newly-typed subjects) and Case B (inbound edges of newly-typed objects) are affected.

Class-to-class **re-types** were unaffected (the subject has a base entry), which is why the existing #1266 tests passed. The datatype/lang re-attribution stage was also unaffected (it reads both maps with `unwrap_or_default`), producing the telltale "N id-refs, 0 attributed" signature.

Edges typed in the *same* batch as the ref always worked (the forward `subject_ref_history` pass uses net classes) — matching the observed straggler batch that did attribute.

## Fix

Treat an endpoint as batch-local when it appears in **either** `base_subject_classes` or the net `subject_classes` map. First-time-typed endpoints now resolve base = {} and net = their new classes from the in-batch membership, so the edge lands in the new bucket. They also no longer get pushed into the external base-index `rdf:type` lookup, which could only ever come back empty for them — strictly fewer base-index probes.

No new scans: the base subject-property scan and reverse-OPST inbound scan already ran for these subjects (untyped-to-typed already lands in `changed_membership`); their results were just discarded at the last step.

## Tests

Adds first-type-arrives-later variants alongside the existing #1266 re-type tests in `it_indexing_stats.rs`:
- `ref_class_attributed_when_object_typed_later` — the field repro shape (2 inbound refs, then the target gets typed)
- `ref_class_attributed_when_subject_typed_later` — outgoing direction
- `ref_class_attributed_when_both_endpoints_typed_later` — attributes exactly once (Case A/Case B dedup)

Also verified end-to-end with the CLI: refs at t=1 -> index -> type at t=2 -> incremental index -> `fluree info --graph default` now shows the refs attributed where it previously showed `ref-classes: {}`.