### PR TITLE
perf(r2rml): push numeric (double/decimal) FILTER predicates to Iceberg pruning (PR-7, H4)

### DIFF
--- a/docs/audit/2026-07-virtual-dataset-perf/04-findings-register.md
+++ b/docs/audit/2026-07-virtual-dataset-perf/04-findings-register.md
@@ -191,6 +191,18 @@ Four smoke queries **did not finish** on virtual (capped at their `timeout_s`) w
 
 ---
 
+## F15 — Latent NaN over-prune in the Float bounds compare *(latent — unreachable pre-PR-7; armed AND fixed in-PR)*
+
+**Discovery.** While widening pruning to double/decimal (PR-7, H4), the recon found that `bounds_can_contain` reasons via `TypedValue::lt`/`le` (NOT `partial_cmp`), and the `Float32`/`Float64` arms used a raw `<`/`<=`. A NaN operand therefore yielded `Some(false)`, which in `bounds_can_contain` can PRUNE: e.g. `column >= v` against a row group whose upper bound is NaN evaluates `lit.le(NaN) = Some(false)` → `false` → prune, even though NaN rows exist. That is an **over-prune** — a strict-superset violation (the pushdown may only ever over-KEEP; the in-engine FILTER is the sole authority).
+
+**Why it was unreachable pre-PR-7.** No float/double predicate ever reached the Iceberg reader: `to_scan_value` returned `None` for `Double`/`Decimal`, so `build_iceberg_filter` never emitted a `LiteralValue::Float64`, so `stat_bounds` never produced a `Float*` bound and the raw-`<` arms were never exercised. PR-7's `ScanValue::Double` push is exactly what ARMS the hazard — so its fix must ship in the same PR (the F12 pattern: a latent hazard gets a register entry, not just a silent fix).
+
+**Fix (in-PR).** The `Float32`/`Float64` arms of `lt`/`le` now return `None` when either operand is NaN (`(!a.is_nan() && !b.is_nan()).then(|| a < b)`), so `bounds_can_contain`'s `unwrap_or(true)` KEEPS the group. `±0.0` collapses to one bound (`-0.0 == +0.0`, neither `<` the other) with no ordering hazard. Guarded by `bounds_can_contain_keeps_on_nan_bound` (pruning.rs) + `nan_float_compare_is_incomparable` (value_codec.rs).
+
+**Hypothesis linkage.** H4 (numeric pruning). Same "latent hazard armed by the widening → register entry + in-PR fix" shape as F12.
+
+---
+
 ## Summary & routing
 
 | Finding | Class | Query | Root | Fix owner |
@@ -209,5 +221,6 @@ Four smoke queries **did not finish** on virtual (capped at their `timeout_s`) w
 | **F12** | correctness-latent (unreachable today) | q022 | single-table fused agg mishandles an un-annotated string GROUP BY key + a constant-object `star_constraint`; masked by the `group_kind(None)` decline. **Must fix before extending the string default to single-table** | engine (deferred — not PR-6) |
 | **F13** | harness-note / baseline-drift | q034, q050 (q009/q010 class) | native micro-query blessed baselines drift with machine state → recurring false `SLOW` alarms. PR-8b: q034 1.84×/q050 2.98× confirmed at 5 reps, then a base A/B (`c4a9b799e`, no PR-8b) reproduced 1.83×/2.93× — i.e. the ratio pre-dates the change. Chronic (twice now). **Re-bless these micro-query baselines on a quiet machine before the next gating cycle.** | harness (baseline re-bless) |
 | **F14** | perf-residual (post-PR-4b/4c) | q050, q016 | the batched R2RML OPTIONAL hash-left-join drives the seed in WINDOWS and **re-scans the main (inner) table per window** — it was never scan-once. Attributed on q016 (PR-4c): 182 `scan_table` = 180 FACT_SHIPMENT (inner, per-window) + 2 FACT_ORDER (outer, collapsed); q050 (PR-4b, shipped): 92 scans. So it flips DNF→ok (q016 39s hot, q050 9.3s) but not to seconds. Fix class: **consume the WHOLE seed in one inner scan + in-memory hash-join** (IN-set/probe extension — the real successor to `07` open-Q2); prize q016 ~39s→seconds, q050 ~9.3s→~1s. **PR-4d candidate — not a blocker** (uniform with shipped PR-4b). | engine (batched-OPTIONAL seed-windowing) |
+| **F15** | correctness-latent (armed + fixed in-PR by PR-7) | (synthetic — NaN float bounds) | `TypedValue::lt`/`le` `Float` arms used a raw `<`, so a NaN bound returns `Some(false)` → `bounds_can_contain` could over-prune a row group holding NaN rows (strict-superset violation). **Unreachable until PR-7's `ScanValue::Double` push produces a float bound.** Fixed in-PR: NaN operand → `None` → keep; guarded by two unit tests. | engine (fixed in PR-7) |
 
 **The two correctness bugs (F1/F2) share one root** and are the highest priority — they deliver wrong answers as silent successes. **F3 is a second, independent correctness gap** (root-caused) on the most common inspector shape — small fix surface, high user-visible impact (missing `@type` in the solo subject inspector). **F5-q050** is the sharpest perf signal (dims-only, 377 scans). **F4 is corpus hygiene, not an engine bug** — but it must be fixed (the determinism amendment) so nondeterministic-selection queries stop masking real divergences. F1/F2/F3/F5 feed the WP7 diagnosis and WP8 roadmap; F4 feeds the corpus determinism amendment; F7 feeds back into WP6 harness tuning.

--- a/docs/audit/2026-07-virtual-dataset-perf/14-pr7-numeric-stats.md
+++ b/docs/audit/2026-07-virtual-dataset-perf/14-pr7-numeric-stats.md
@@ -1,0 +1,64 @@
+# PR-7 — widen file / row-group pruning to double + decimal (H4) — DESIGN SKETCH
+
+**Branch:** `perf/r2rml-pr7-numeric-stats` (off `perf/r2rml-pr4c-optional-star` HEAD `b1cb988c2`)
+**Status:** APPROVED + IMPLEMENTED (unit-green). Awaiting the H4 A/B/C live gate before commit/PR.
+**Substrate:** ROADMAP PR-7, `05-diagnosis.md` H4 (F6: q011 date pruned 98.8% — the path works; decimal/double blind), `00-brief` (decimal never pushes down; int pushes down but doesn't prune).
+
+## Where the blind spot actually is (two layers)
+
+**Primary — the QUERY side never pushes a numeric predicate.** `ScanValue` (`provider.rs:43`) has only `Bool | Int | Date | Str | TemplateKey`; its own doc says *"Decimal / float predicates are left to the in-engine FILTER."* So `to_scan_value` (rewrite.rs) can't carry a double/decimal, `build_iceberg_filter` (r2rml.rs) never emits one, and the iceberg reader never even sees a numeric-column predicate to prune on. This is the real reason q019 shows `files_pruned = 0`.
+
+**Secondary — the ICEBERG side would decline it anyway.** `LiteralValue` and `TypedValue` ALREADY carry `Float32/Float64/Decimal{unscaled,precision,scale}` (`value_codec.rs`, `predicate.rs`), and `TypedValue::partial_cmp` already scale-normalizes decimals (`decimal_cmp`). But: (i) `stat_bounds` (`pruning.rs:289`) has no `Statistics::Double/Float`/FLBA arm → `(None,None)`; (ii) `prunable_stats` (`:272`) returns `None` for ANY decimal column (a defensive guard); (iii) `TypedValue::lt/le` — which `bounds_can_contain` uses (NOT `partial_cmp`) — have Float arms but **no Decimal arm**, and the Float arms use raw `<` (a NaN hazard, §c).
+
+## (a) `stat_bounds`: Double (clean) + Decimal (FLBA only)
+
+- **Double/Float — add directly.** `(Statistics::Double(s), TypedValue::Float64(_))` and `(Statistics::Float(s), TypedValue::Float32(_))` arms. The bound is the raw f64/f32 min/max; `bounds_can_contain` compares via `lt/le` (Float arms exist, made NaN-safe in §c).
+- **Decimal — support FLBA, DECLINE int32/int64-backed.** Parquet decimal physical encodings by precision: `int32` (≤9 digits), `int64` (≤18), `fixed_len_byte_array` (any) — all holding a **big-endian two's-complement UNSCALED integer**. The Iceberg spec mandates **FLBA** for decimals, so that is the only encoding a conformant table produces. PR-7 supports FLBA: relax `prunable_stats` to allow FLBA-decimal columns, decode the FLBA bytes → `i128` unscaled and read `precision/scale` from the column's `Decimal` logical type → `TypedValue::Decimal{unscaled, precision, scale}`. It **declines** int32/int64-backed decimals (return `None`, unchanged): their stats are unscaled ints indistinguishable from a real int column without threading the logical type, they are off-spec, and the whole point of the `07`/#1406 guard was to not compare an unscaled bound to a scaled literal. The scale is now carried IN the `TypedValue` and normalized by `decimal_cmp`, so the unscaled-vs-scaled bug that motivated the guard cannot recur on the FLBA path.
+
+## (b) `ScanValue`/`TypedValue` + the query→iceberg bridge
+
+- `TypedValue`: **add `Decimal` arms to `lt`/`le`** (delegate to `decimal_cmp`, as `partial_cmp` already does) — without them a pushed decimal predicate silently never prunes (`lt/le → None → keep`). Float arms already exist (fixed for NaN in §c).
+- `ScanValue`: **add `Double(f64)` and `Decimal { unscaled: i128, precision: u8, scale: i8 }`** (mirroring `LiteralValue::Decimal`). Touch points, all small: `to_scan_value` (`rewrite.rs`) — emit them from an `xsd:double`/`xsd:decimal` FILTER operand; `build_iceberg_filter` (`r2rml.rs`) — bridge `ScanValue::Double/Decimal` → `LiteralValue::Float64/Decimal` (`to_typed_value` already handles the rest); `row_group_can_contain` / the file-level `decode_by_type_string` path already flow through `TypedValue`. The PR-1-era note stands: `ScanValue` variant additions are localized to those two functions plus the pattern match in the operator's filter builder.
+
+## (c) NaN / ±0 and the strict-SUPERSET invariant
+
+**Invariant (restated):** the pushdown is a conservative SUPER-filter — it may **over-keep** (a row group kept that the in-engine FILTER then rejects) but must **NEVER over-prune** (drop a row group holding a matching row). The in-engine SPARQL FILTER (post-decode) is the sole authority for the answer; pushdown only removes provably-empty files/row-groups.
+
+**NaN.** Current `Float32/Float64` `lt/le` use raw `<`/`<=`, so any NaN operand yields `Some(false)` — which in `bounds_can_contain` can PRUNE (e.g. `col <= v` with a NaN upper bound → `lit.le(NaN)=Some(false)` → prune) even though NaN rows exist. That is an over-prune. **Fix:** make the Float `lt/le` arms NaN-conservative — if either operand is NaN, return `None` (→ `bounds_can_contain`'s `unwrap_or(true)` keeps the group). Parquet may also record a `nan_count`/absent-max; a column whose stats can't bound NaNs simply isn't pruned. **±0:** `-0.0 == +0.0` and neither `<` the other in IEEE — they collapse to one bound value, no ordering hazard. SPARQL FILTER numeric semantics (the authority) are unaffected; pushdown just declines to prune around NaN.
+
+## (d) Gates
+
+- **H4 A/B/C on the GL fact (the files_pruned counter now exists — F7 closed by PR-8's spans):**
+  - **q019** (decimal FILTER): expect `files_pruned > 0` for the FIRST time — the headline H4 win. Honest caveat: the magnitude depends on whether the money column is CLUSTERED (like q011's date → 98.8%); an unclustered money column may prune little even with correct stats (data-layout, not code).
+  - **q020** (date control): still prunes — a regression check that the existing int32/date path is untouched.
+  - **q021** (int): already pushes down (`ScanValue::Int` + `stat_bounds` Int32/Int64) but prunes ~0 — DIAGNOSE and set expectations: per `00-brief`, the int column's values span every file's min/max (unsorted/unclustered), so no file is provably empty. **PR-7 does not fix this** — it is a data-distribution/layout property, not a stats gap; the fix would be clustering the data on the filtered column. State it plainly.
+- **cold q019** (38.8 s cold, pruning-shaped prize): if the decimal column clusters, pruned files cut the cold data-fetch proportionally; if not, cold stays fetch-bound (the residual PR-5/PR-7-data lever). Report the actual files_pruned and the cold delta.
+- **Parity everywhere** — the pushdown is a strict superset, so every result is byte-identical (the in-engine FILTER is authority); native 0-mismatch + q019/q020/q021 rows-parity.
+- **Switch (my call): a dedicated `FLUREE_ICEBERG_NUMERIC_STATS`** (default on) gating ONLY the double+decimal widening, so it reverts independently of the shipped int/date/string pushdown (mirrors the PR-4c sub-switch discipline); off ⇒ `stat_bounds`/`ScanValue` behave exactly as today (numeric predicates → in-engine FILTER only).
+
+## Change surface (on nod)
+
+query: `ScanValue`(+Double,+Decimal) · `to_scan_value` · `build_iceberg_filter`. iceberg: `stat_bounds`(+Double,+FLBA-decimal) · `prunable_stats`(FLBA relax) · `TypedValue::lt/le`(+Decimal arm, NaN-safe Float). Tests: a hermetic pruning unit (double bounds prune/keep incl. NaN-keep; FLBA-decimal scale-aware prune/keep; int32/int64-decimal declines) + the H4 live A/B/C + parity. **PR-5's pruning leg builds on this** (numeric stats first, per the tail ordering).
+
+## Implemented (approved with four riders)
+
+Lead approved the two-layer reframe, the FLBA-only boundary, and the decimal_cmp-retires-the-skip line. Four riders, all landed:
+
+1. **NaN over-prune fix ships in-PR + F15 register entry** (latent, unreachable pre-PR-7, armed by the `Double` push). `TypedValue::lt`/`le` `Float` arms now NaN→`None`→keep. See F15 in `04-findings-register.md`.
+2. **Non-FLBA decimal decline is observable** — `prunable_stats` emits `tracing::debug!("decimal stats declined: non-FLBA physical encoding")` for INT32/INT64-backed decimals.
+3. **Hermetic unit covers the cross-scale round-trip** — `9.99` (scale 2) vs a scale-3 column (`9.990`), prune + keep + boundary; plus a positive assert-it-prunes decimal case (guards the `lt/le` Decimal-arm gap) and the INT-decimal decline. Query decompose proven scale-insensitive.
+4. **Live gate proves Snowflake decimals are FLBA** via q019 `files_pruned > 0`; if 0, check physical encoding before the code.
+
+`!=` stays never-pruned; `eq`-on-double keeps `[min,max]` as a superset.
+
+## The q019 integer-vs-decimal seam — Option A (lead ruling)
+
+STOP-and-report finding: q019 (`FILTER(?deb > 1000000)`) compares an **integer** literal (SPARQL lexes `1000000` as `xsd:integer` → `FlakeValue::Long`) against the `xsd:decimal` `DEBIT_AMOUNT` column. The approved surface handled explicit decimal/double literals but NOT this integer-vs-decimal-column form, so q019 would still show `files_pruned=0`. Lead ruled **Option A**: in `build_iceberg_filter`, push `ScanValue::Int` against a `decimal(p,s)` column as an EXACT scale-0 decimal (`LiteralValue::Decimal{ unscaled: n as i128, scale: 0 }`) instead of `Int64` — `decimal_cmp` normalizes the scale gap, so the superset invariant holds by construction (int is exact as a scale-0 decimal; `rescale`'s `checked_mul→None→keep` covers the overflow edge). Gated by an **api-side** `iceberg_numeric_stats_enabled()` OnceLock reading `FLUREE_ICEBERG_NUMERIC_STATS` (the disk_catalog_cache precedent; the query-crate `pub(crate)` fn is NOT promoted). Off ⇒ integer stays `Int64` → decimal bound compare declines → no prune (full revert). Localized in `int_pushdown_literal`.
+
+**Two documented residuals (decline-observably, not implemented).** (i) A DOUBLE literal vs a decimal column is NOT pushed — a binary-float→decimal coercion is inexact in general, so keep is correct; routed through a `debug!` breadcrumb. (ii) A DECIMAL literal vs an integer column is NOT pushed — no exact cross-type bound compare — likewise keep + breadcrumb. Both are conservative residuals (never wrong), not gaps; a future PR could add exact handling if a workload needs it.
+
+**Change surface as shipped.** query: `ScanValue`(+`Double`,+`Decimal`) · `to_scan_value`(+gated arms, `scan_value_from_bigdecimal`) · `iceberg_numeric_stats_enabled()` (`FLUREE_ICEBERG_NUMERIC_STATS`, mod.rs) · `object_term_matches` exhaustiveness arms · `build_iceberg_filter`(`Double`→`Float64` on double cols, `Decimal`→`Decimal` on decimal cols, `Int`→scale-0 `Decimal` on decimal cols via `int_pushdown_literal`, + the two decline breadcrumbs). api: `iceberg_numeric_stats_enabled()` OnceLock + `int_pushdown_literal`. iceberg: `stat_bounds`(+`Double`/`Float`/FLBA-decimal, +`col_decimal` param) · `prunable_stats`(FLBA relax + decline log) · `column_decimal` helper · `TypedValue::lt`/`le`(+Decimal arm, NaN-safe Float). The numeric widening is gated at BOTH push sites (query `to_scan_value` for explicit decimal/double, api `int_pushdown_literal` for the int-coercion); the iceberg-side widening is inert without a numeric `LiteralValue`.
+
+**Tests (unit-green, 11 new).** iceberg `pruning.rs`: `row_group_pruning_uses_double_stats`, `row_group_pruning_uses_flba_decimal_stats`, `row_group_pruning_int_coerced_scale0_decimal` (positive prune / in-bounds keep / rescale-overflow keep / Int64 revert), `row_group_pruning_declines_int_backed_decimal`, `bounds_can_contain_keeps_on_nan_bound`. iceberg `value_codec.rs`: `nan_float_compare_is_incomparable`, `decimal_lt_le_cross_scale`. query `rewrite.rs`: `bigdecimal_decomposes_scale_insensitively`. api `r2rml.rs`: `int_literal_coerces_to_scale0_decimal_only_when_numeric_stats_on`, `int_scalar_against_decimal_column_pushes_scale0_decimal`, `double_pushed_only_against_double_column`, `decimal_pushed_only_against_decimal_column_preserving_literal_scale`.
+
+**Next:** H4 A/B/C live (q019 `files_pruned>0` — NOW the coercion makes this reachable; q020 date control; q021 int diagnose) + cold q019 + parity, then commit + PR. PR-5's pruning leg builds on this.

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -86,6 +86,51 @@ pub(crate) fn rest_client_cache_key(graph_source_id: &str, config: &str) -> Stri
     format!("{graph_source_id}\u{1f}{:016x}", config_fingerprint(config))
 }
 
+/// Whether numeric (double / decimal) FILTER pushdown — including the integer →
+/// scale-0-decimal coercion against a decimal column — is enabled (PR-7). Mirrors
+/// the query-crate `FLUREE_ICEBERG_NUMERIC_STATS` switch (the two crates can't
+/// share the `pub(crate)` symbol); read once, cached for the process. Off restores
+/// the pre-PR-7 behavior: an integer literal against a decimal column pushes as
+/// `Int64`, which the decimal bound compare declines → no prune (full revert).
+pub(crate) fn iceberg_numeric_stats_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var("FLUREE_ICEBERG_NUMERIC_STATS") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        Err(_) => true,
+    })
+}
+
+/// The Iceberg pushdown literal for an integer scan value against a column of
+/// `type_str`. Against a `decimal(p,s)` column with `numeric_stats` on, the
+/// integer is pushed as an EXACT scale-0 decimal (comparable to the column's
+/// decimal bounds — `decimal_cmp` normalizes the scale gap); with it off it stays
+/// `Int64` (which the decimal bound compare declines → no prune), preserving the
+/// switch's revert guarantee. This is what lets an integer FILTER (`?deb >
+/// 1000000`) prune an `xsd:decimal` column (q019 / H4). An `int`-typed column
+/// narrows to `Int32`, skipping (`None`) an out-of-range literal rather than
+/// wrapping. `None` = skip the push (the operator still enforces).
+fn int_pushdown_literal(
+    n: i64,
+    type_str: Option<&str>,
+    numeric_stats: bool,
+) -> Option<LiteralValue> {
+    match type_str {
+        Some("int") => i32::try_from(n).ok().map(LiteralValue::Int32),
+        Some(t) if t.starts_with("decimal") && numeric_stats => Some(LiteralValue::Decimal {
+            unscaled: i128::from(n),
+            // precision is cosmetic for pruning (`decimal_cmp` ignores it); an i64
+            // is ≤19 digits, so the decimal128 max always covers it.
+            precision: 38,
+            scale: 0,
+        }),
+        _ => Some(LiteralValue::Int64(n)),
+    }
+}
+
 /// Translate resolved scan filters into an Iceberg pushdown `Expression` for
 /// file pruning. Filters on unknown columns are skipped; an empty result is
 /// `None`. Conservative — pruning never drops matching rows because the
@@ -119,18 +164,64 @@ fn build_iceberg_filter(
                 Some("date") => LiteralValue::Date(*d),
                 _ => continue,
             },
-            // Iceberg `int` is 32-bit, `long` 64-bit. For an `int` column a
-            // literal outside i32 range must NOT be truncated with `as` (it would
-            // wrap and could prune files the residual filter keeps); skip the
-            // pushdown for that predicate instead.
-            ScanValue::Int(n) => match field.type_string() {
-                Some("int") => match i32::try_from(*n) {
-                    Ok(v) => LiteralValue::Int32(v),
-                    Err(_) => continue,
-                },
-                _ => LiteralValue::Int64(*n),
-            },
+            // Iceberg `int` is 32-bit, `long` 64-bit; against a `decimal` column an
+            // integer pushes as an EXACT scale-0 decimal when numeric pushdown is
+            // on (else stays `Int64` → no prune). An out-of-i32-range literal on an
+            // `int` column is skipped rather than wrapped. See `int_pushdown_literal`.
+            ScanValue::Int(n) => {
+                match int_pushdown_literal(*n, field.type_string(), iceberg_numeric_stats_enabled())
+                {
+                    Some(v) => v,
+                    None => continue,
+                }
+            }
             ScanValue::Str(s) => LiteralValue::String(s.clone()),
+            // xsd:double / xsd:float FILTER value. Push only against a physically
+            // `double` column (exact f64 bounds); a `float` column would need an
+            // f64→f32 narrowing that can round the literal and over-prune a range,
+            // so skip it — the in-engine FILTER still applies.
+            ScanValue::Double(d) => match field.type_string() {
+                Some("double") => LiteralValue::Float64(*d),
+                // A binary float → decimal coercion is not exact in general, so a
+                // double literal is NOT pushed against a decimal column (keep is
+                // correct; the in-engine FILTER enforces). Breadcrumb per the
+                // decline-observably ruling.
+                Some(t) if t.starts_with("decimal") => {
+                    debug!(
+                        column = %f.column,
+                        "double literal vs decimal column: pushdown declined (inexact float→decimal); in-engine FILTER enforces"
+                    );
+                    continue;
+                }
+                _ => continue,
+            },
+            // xsd:decimal FILTER value. Push only against a `decimal(...)` column;
+            // the literal keeps its own scale and the bound compare normalizes it
+            // against the column's scale. Row-group stats prune only when the
+            // column is FLBA-encoded (see `prunable_stats`); file-level manifest
+            // bounds prune regardless.
+            ScanValue::Decimal {
+                unscaled,
+                precision,
+                scale,
+            } => match field.type_string() {
+                Some(t) if t.starts_with("decimal") => LiteralValue::Decimal {
+                    unscaled: *unscaled,
+                    precision: *precision,
+                    scale: *scale,
+                },
+                // A decimal literal against an integer column has no exact
+                // cross-type bound compare, so it is NOT pushed (keep is correct).
+                // Breadcrumb per the decline-observably ruling.
+                Some("int" | "long") => {
+                    debug!(
+                        column = %f.column,
+                        "decimal literal vs integer column: pushdown declined (no exact cross-type bound compare); in-engine FILTER enforces"
+                    );
+                    continue;
+                }
+                _ => continue,
+            },
             // A reversed subject-template key: coerce the raw string to the
             // column's physical type. A key that parses as an integer pushes as an
             // integer literal against an `int`/`long`/`decimal` column — including
@@ -1648,6 +1739,8 @@ mod tests {
                 field(3, "dec_key", json!("decimal(38,0)")),
                 field(4, "str_key", json!("string")),
                 field(5, "date_key", json!("date")),
+                field(6, "double_key", json!("double")),
+                field(7, "float_key", json!("float")),
             ],
         }
     }
@@ -1709,6 +1802,108 @@ mod tests {
         // Utf8 `"2024-01-15"`) would drop — pushing here would remove an
         // operator-kept row.
         assert!(build_iceberg_filter(&[date_filter("str_key")], &s).is_none());
+    }
+
+    #[test]
+    fn double_pushed_only_against_double_column() {
+        let s = key_schema();
+        let dbl = |col: &str| ScanFilter {
+            column: col.to_string(),
+            op: ScanCmpOp::Lt,
+            value: ScanValue::Double(9.99),
+        };
+        // Physically-`double`: pushes as an exact f64 bound.
+        assert!(matches!(
+            only_literal(&[dbl("double_key")], &s),
+            Some(LiteralValue::Float64(v)) if v == 9.99
+        ));
+        // Physically-`float`: skipped (an f64→f32 narrowing could round the
+        // literal and over-prune a range).
+        assert!(build_iceberg_filter(&[dbl("float_key")], &s).is_none());
+        // Non-numeric column: skipped.
+        assert!(build_iceberg_filter(&[dbl("str_key")], &s).is_none());
+    }
+
+    #[test]
+    fn int_literal_coerces_to_scale0_decimal_only_when_numeric_stats_on() {
+        // On: an integer against a decimal column → EXACT scale-0 decimal (prunable).
+        assert!(matches!(
+            int_pushdown_literal(1_000_000, Some("decimal(38,2)"), true),
+            Some(LiteralValue::Decimal {
+                unscaled: 1_000_000,
+                scale: 0,
+                ..
+            })
+        ));
+        // Off (revert guarantee): stays Int64 → the decimal bound compare declines
+        // → no prune, exactly the pre-PR-7 behavior.
+        assert!(matches!(
+            int_pushdown_literal(1_000_000, Some("decimal(38,2)"), false),
+            Some(LiteralValue::Int64(1_000_000))
+        ));
+        // An `int` column narrows to Int32; an out-of-range literal skips (no wrap).
+        assert!(matches!(
+            int_pushdown_literal(5, Some("int"), true),
+            Some(LiteralValue::Int32(5))
+        ));
+        assert!(int_pushdown_literal(i64::from(i32::MAX) + 1, Some("int"), true).is_none());
+        // `long` / other columns: Int64 unchanged, on or off.
+        assert!(matches!(
+            int_pushdown_literal(5, Some("long"), true),
+            Some(LiteralValue::Int64(5))
+        ));
+        assert!(matches!(
+            int_pushdown_literal(5, Some("long"), false),
+            Some(LiteralValue::Int64(5))
+        ));
+    }
+
+    #[test]
+    fn int_scalar_against_decimal_column_pushes_scale0_decimal() {
+        // End-to-end through build_iceberg_filter with the default (on) switch: an
+        // integer FILTER literal on a decimal column becomes a scale-0 decimal.
+        let s = key_schema();
+        let f = ScanFilter {
+            column: "dec_key".to_string(),
+            op: ScanCmpOp::Gt,
+            value: ScanValue::Int(1_000_000),
+        };
+        assert!(matches!(
+            only_literal(&[f], &s),
+            Some(LiteralValue::Decimal {
+                unscaled: 1_000_000,
+                scale: 0,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn decimal_pushed_only_against_decimal_column_preserving_literal_scale() {
+        let s = key_schema();
+        // The `ScanValue::Decimal` carries the LITERAL's scale (9.99 → scale 2);
+        // the column is decimal(38,0). The bridge preserves the literal scale —
+        // the bound compare normalizes across the column/literal scale gap.
+        let dec = |col: &str| ScanFilter {
+            column: col.to_string(),
+            op: ScanCmpOp::Lt,
+            value: ScanValue::Decimal {
+                unscaled: 999,
+                precision: 3,
+                scale: 2,
+            },
+        };
+        assert!(matches!(
+            only_literal(&[dec("dec_key")], &s),
+            Some(LiteralValue::Decimal {
+                unscaled: 999,
+                scale: 2,
+                ..
+            })
+        ));
+        // Non-decimal columns: skipped (no cross-type bound compare exists).
+        assert!(build_iceberg_filter(&[dec("long_key")], &s).is_none());
+        assert!(build_iceberg_filter(&[dec("str_key")], &s).is_none());
     }
 
     #[test]

--- a/fluree-db-iceberg/src/manifest/value_codec.rs
+++ b/fluree-db-iceberg/src/manifest/value_codec.rs
@@ -47,13 +47,37 @@ impl TypedValue {
             (TypedValue::Boolean(a), TypedValue::Boolean(b)) => Some(!a && *b),
             (TypedValue::Int32(a), TypedValue::Int32(b)) => Some(a < b),
             (TypedValue::Int64(a), TypedValue::Int64(b)) => Some(a < b),
-            (TypedValue::Float32(a), TypedValue::Float32(b)) => Some(a < b),
-            (TypedValue::Float64(a), TypedValue::Float64(b)) => Some(a < b),
+            // NaN is unordered: a NaN operand yields None (incomparable), so
+            // `bounds_can_contain`'s `unwrap_or(true)` KEEPS the row group. Raw
+            // `<` would return `Some(false)` and could prune a group holding NaN
+            // rows — a strict-superset violation. (Reachable only once a float
+            // predicate is pushed to the reader; see F15.)
+            (TypedValue::Float32(a), TypedValue::Float32(b)) => {
+                (!a.is_nan() && !b.is_nan()).then(|| a < b)
+            }
+            (TypedValue::Float64(a), TypedValue::Float64(b)) => {
+                (!a.is_nan() && !b.is_nan()).then(|| a < b)
+            }
             (TypedValue::Date(a), TypedValue::Date(b)) => Some(a < b),
             (TypedValue::Timestamp(a), TypedValue::Timestamp(b)) => Some(a < b),
             (TypedValue::TimestampTz(a), TypedValue::TimestampTz(b)) => Some(a < b),
             (TypedValue::String(a), TypedValue::String(b)) => Some(a < b),
             (TypedValue::Bytes(a), TypedValue::Bytes(b)) => Some(a < b),
+            // Decimals compare by real value across differing scales (see
+            // `decimal_cmp`). Without this arm a pushed decimal predicate compares
+            // None → the row group is always kept (never pruned).
+            (
+                TypedValue::Decimal {
+                    unscaled: a,
+                    scale: sa,
+                    ..
+                },
+                TypedValue::Decimal {
+                    unscaled: b,
+                    scale: sb,
+                    ..
+                },
+            ) => decimal_cmp(*a, *sa, *b, *sb).map(std::cmp::Ordering::is_lt),
             _ => None,
         }
     }
@@ -64,13 +88,30 @@ impl TypedValue {
             (TypedValue::Boolean(a), TypedValue::Boolean(b)) => Some(a <= b),
             (TypedValue::Int32(a), TypedValue::Int32(b)) => Some(a <= b),
             (TypedValue::Int64(a), TypedValue::Int64(b)) => Some(a <= b),
-            (TypedValue::Float32(a), TypedValue::Float32(b)) => Some(a <= b),
-            (TypedValue::Float64(a), TypedValue::Float64(b)) => Some(a <= b),
+            // NaN → None → keep the row group (see `lt` and F15).
+            (TypedValue::Float32(a), TypedValue::Float32(b)) => {
+                (!a.is_nan() && !b.is_nan()).then(|| a <= b)
+            }
+            (TypedValue::Float64(a), TypedValue::Float64(b)) => {
+                (!a.is_nan() && !b.is_nan()).then(|| a <= b)
+            }
             (TypedValue::Date(a), TypedValue::Date(b)) => Some(a <= b),
             (TypedValue::Timestamp(a), TypedValue::Timestamp(b)) => Some(a <= b),
             (TypedValue::TimestampTz(a), TypedValue::TimestampTz(b)) => Some(a <= b),
             (TypedValue::String(a), TypedValue::String(b)) => Some(a <= b),
             (TypedValue::Bytes(a), TypedValue::Bytes(b)) => Some(a <= b),
+            (
+                TypedValue::Decimal {
+                    unscaled: a,
+                    scale: sa,
+                    ..
+                },
+                TypedValue::Decimal {
+                    unscaled: b,
+                    scale: sb,
+                    ..
+                },
+            ) => decimal_cmp(*a, *sa, *b, *sb).map(std::cmp::Ordering::is_le),
             _ => None,
         }
     }
@@ -633,5 +674,45 @@ mod tests {
     #[test]
     fn test_error_on_unsupported_type() {
         assert!(decode_by_type_string(&[1, 2, 3, 4], Some("unknown_type")).is_err());
+    }
+
+    #[test]
+    fn nan_float_compare_is_incomparable() {
+        // A NaN operand must yield None (incomparable) so pruning keeps the group,
+        // never `Some(false)` (which would let `bounds_can_contain` over-prune a
+        // row group holding NaN rows — the F15 hazard).
+        let nan = TypedValue::Float64(f64::NAN);
+        let five = TypedValue::Float64(5.0);
+        assert_eq!(nan.lt(&five), None);
+        assert_eq!(nan.le(&five), None);
+        assert_eq!(nan.gt(&five), None);
+        assert_eq!(nan.ge(&five), None);
+        assert_eq!(five.lt(&nan), None);
+        assert_eq!(five.le(&nan), None);
+        // Finite floats still compare normally.
+        assert_eq!(five.lt(&TypedValue::Float64(6.0)), Some(true));
+        // Same for f32.
+        let nan32 = TypedValue::Float32(f32::NAN);
+        assert_eq!(nan32.lt(&TypedValue::Float32(1.0)), None);
+        assert_eq!(TypedValue::Float32(1.0).le(&nan32), None);
+    }
+
+    #[test]
+    fn decimal_lt_le_cross_scale() {
+        let d = |unscaled, scale| TypedValue::Decimal {
+            unscaled,
+            precision: 38,
+            scale,
+        };
+        // 9.99 (scale 2) vs 9.990 (scale 3) are the SAME value.
+        assert_eq!(d(999, 2).lt(&d(9990, 3)), Some(false));
+        assert_eq!(d(999, 2).le(&d(9990, 3)), Some(true));
+        assert_eq!(d(9990, 3).le(&d(999, 2)), Some(true));
+        // 9.99 < 20.000.
+        assert_eq!(d(999, 2).lt(&d(20000, 3)), Some(true));
+        assert_eq!(d(20000, 3).lt(&d(999, 2)), Some(false));
+        // gt/ge delegate through le/lt.
+        assert_eq!(d(20000, 3).gt(&d(999, 2)), Some(true));
+        assert_eq!(d(999, 2).ge(&d(9990, 3)), Some(true));
     }
 }

--- a/fluree-db-iceberg/src/manifest/value_codec.rs
+++ b/fluree-db-iceberg/src/manifest/value_codec.rs
@@ -714,5 +714,13 @@ mod tests {
         // gt/ge delegate through le/lt.
         assert_eq!(d(20000, 3).gt(&d(999, 2)), Some(true));
         assert_eq!(d(999, 2).ge(&d(9990, 3)), Some(true));
+        // Negative scale: a round literal normalized via `normalized()` becomes
+        // (unscaled 1, scale -6) = 1_000_000. decimal_cmp rescales to the max scale
+        // keeping exponents >= 0, so a negative-scale operand still compares exactly
+        // against a positive-scale one (#1494 review — the last untested arm).
+        assert_eq!(d(1, -6).lt(&d(999_999_999, 3)), Some(false)); // 1_000_000 !< 999_999.999
+        assert_eq!(d(999_999_999, 3).lt(&d(1, -6)), Some(true)); // 999_999.999 < 1_000_000
+        assert_eq!(d(1, -6).le(&d(1_000_000_000, 3)), Some(true)); // 1_000_000 == 1_000_000.000
+        assert_eq!(d(1, -6).ge(&d(1_000_000_000, 3)), Some(true));
     }
 }

--- a/fluree-db-iceberg/src/scan/pruning.rs
+++ b/fluree-db-iceberg/src/scan/pruning.rs
@@ -231,11 +231,12 @@ pub fn row_group_can_contain(
             let Some(&col_idx) = field_id_to_leaf.get(field_id) else {
                 return true;
             };
-            let Some(stats) = prunable_stats(row_group.column(col_idx)) else {
+            let col = row_group.column(col_idx);
+            let Some(stats) = prunable_stats(col) else {
                 return true;
             };
             let lit = value.to_typed_value();
-            let (lower, upper) = stat_bounds(stats, &lit);
+            let (lower, upper) = stat_bounds(stats, &lit, column_decimal(col));
             bounds_can_contain(*op, &lit, lower, upper)
         }
         Expression::In {
@@ -244,12 +245,14 @@ pub fn row_group_can_contain(
             let Some(&col_idx) = field_id_to_leaf.get(field_id) else {
                 return true;
             };
-            let Some(stats) = prunable_stats(row_group.column(col_idx)) else {
+            let col = row_group.column(col_idx);
+            let Some(stats) = prunable_stats(col) else {
                 return true;
             };
+            let decimal = column_decimal(col);
             values.iter().any(|v| {
                 let lit = v.to_typed_value();
-                let (lower, upper) = stat_bounds(stats, &lit);
+                let (lower, upper) = stat_bounds(stats, &lit, decimal);
                 bounds_can_contain(ComparisonOp::Eq, &lit, lower, upper)
             })
         }
@@ -259,16 +262,18 @@ pub fn row_group_can_contain(
 }
 
 /// Statistics usable for row-group pruning, or `None` (→ keep the row group
-/// conservatively) when the column has no statistics or is a Decimal type.
+/// conservatively) when the column has no statistics or is a decimal in a
+/// non-prunable physical encoding.
 ///
-/// [`stat_bounds`] keys purely on the Parquet *physical* variant. A decimal
-/// stored as INT32/INT64 holds unscaled integers, so comparing a scaled query
+/// [`stat_bounds`] reads decimal bounds from `FIXED_LEN_BYTE_ARRAY` statistics
+/// (big-endian two's-complement unscaled bytes) using the column's scale, which
+/// is the encoding the Iceberg spec mandates. A decimal stored as INT32/INT64
+/// holds unscaled integers whose stats are indistinguishable from a real int
+/// column without threading the logical scale, so comparing a scaled query
 /// literal (`5`) against unscaled bounds (`[500, 504]` for `Decimal(_, 2)`) could
-/// prune a row group that actually matches. The Iceberg spec currently mandates
-/// `fixed_len_byte_array` for decimals — whose statistics already fall through to
-/// the conservative `(None, None)` — so this guard is defensive rather than a live
-/// bug, keeping correctness off the implicit encoding assumption (fluree/db#1406
-/// review).
+/// prune a row group that actually matches — so those are DECLINED (fluree/db
+/// #1406), with a debug breadcrumb for anyone investigating why an off-spec
+/// writer's decimal filters don't prune.
 fn prunable_stats(col: &ColumnChunkMetaData) -> Option<&Statistics> {
     let info = col.column_descr().self_type().get_basic_info();
     let is_decimal = info.converted_type() == parquet::basic::ConvertedType::DECIMAL
@@ -276,17 +281,44 @@ fn prunable_stats(col: &ColumnChunkMetaData) -> Option<&Statistics> {
             info.logical_type(),
             Some(parquet::basic::LogicalType::Decimal { .. })
         );
-    if is_decimal {
+    if is_decimal
+        && col.column_descr().physical_type() != parquet::basic::Type::FIXED_LEN_BYTE_ARRAY
+    {
+        tracing::debug!(
+            column = col.column_descr().name(),
+            "decimal stats declined: non-FLBA physical encoding"
+        );
         return None;
     }
     col.statistics()
 }
 
+/// The `(precision, scale)` of a decimal column, from its Parquet primitive type
+/// descriptor. Reached only via the FLBA-decimal arm of [`stat_bounds`] (entered
+/// only for a decimal literal against FLBA statistics), so it is called only on
+/// real decimal columns; `None` if the descriptor's precision/scale don't fit.
+fn column_decimal(col: &ColumnChunkMetaData) -> Option<(u8, i8)> {
+    let d = col.column_descr();
+    let precision = u8::try_from(d.type_precision()).ok()?;
+    let scale = i8::try_from(d.type_scale()).ok()?;
+    Some((precision, scale))
+}
+
 /// Extract a Parquet row-group column's min/max as `TypedValue`s coerced to the
 /// same variant as `like` (the predicate literal). Only the pushdown-supported
-/// physical types are read (bool / int32 / int64, including int32-backed dates);
-/// anything else yields `(None, None)` so pruning stays conservative.
-fn stat_bounds(stats: &Statistics, like: &TypedValue) -> (Option<TypedValue>, Option<TypedValue>) {
+/// physical types are read (bool / int32 / int64, including int32-backed dates;
+/// float / double; and FLBA-backed decimal); anything else yields `(None, None)`
+/// so pruning stays conservative.
+///
+/// `col_decimal` is the column's `(precision, scale)`, needed to decode FLBA
+/// decimal bounds at the COLUMN's scale (not the literal's). Float min/max are
+/// read raw; a NaN bound is neutralized downstream by the NaN-safe
+/// [`TypedValue::lt`]/[`TypedValue::le`], keeping pruning a strict superset.
+fn stat_bounds(
+    stats: &Statistics,
+    like: &TypedValue,
+    col_decimal: Option<(u8, i8)>,
+) -> (Option<TypedValue>, Option<TypedValue>) {
     match (stats, like) {
         (Statistics::Boolean(s), TypedValue::Boolean(_)) => (
             s.min_opt().map(|&v| TypedValue::Boolean(v)),
@@ -305,6 +337,29 @@ fn stat_bounds(stats: &Statistics, like: &TypedValue) -> (Option<TypedValue>, Op
             s.min_opt().map(|&v| TypedValue::Int64(v)),
             s.max_opt().map(|&v| TypedValue::Int64(v)),
         ),
+        // Float / double min/max read raw; NaN bounds are handled by the
+        // NaN-safe compare (a NaN operand → incomparable → keep).
+        (Statistics::Double(s), TypedValue::Float64(_)) => (
+            s.min_opt().map(|&v| TypedValue::Float64(v)),
+            s.max_opt().map(|&v| TypedValue::Float64(v)),
+        ),
+        (Statistics::Float(s), TypedValue::Float32(_)) => (
+            s.min_opt().map(|&v| TypedValue::Float32(v)),
+            s.max_opt().map(|&v| TypedValue::Float32(v)),
+        ),
+        // FLBA-backed decimal: min/max are big-endian two's-complement unscaled
+        // bytes carrying the COLUMN's scale (`col_decimal`), which the query
+        // literal's scale may differ from — `decimal_cmp` normalizes them.
+        (Statistics::FixedLenByteArray(s), TypedValue::Decimal { .. }) => {
+            let Some((precision, scale)) = col_decimal else {
+                return (None, None);
+            };
+            let type_str = format!("decimal({precision}, {scale})");
+            let decode = |b: &parquet::data_type::FixedLenByteArray| {
+                decode_by_type_string(b.data(), Some(type_str.as_str())).ok()
+            };
+            (s.min_opt().and_then(&decode), s.max_opt().and_then(&decode))
+        }
         // UTF-8 string min/max. Parquet stats are valid bounds even when the
         // writer truncates them (min truncated down, max up), so lexicographic
         // pruning stays conservative. Non-UTF-8 bytes fall through to no bound.
@@ -839,6 +894,392 @@ mod tests {
             &lt_m,
             meta.row_group(1),
             &field_to_col
+        ));
+    }
+
+    /// Two DOUBLE row groups with disjoint ranges: rg0 = [1.0, 3.0], rg1 = [100.0, 102.0].
+    fn two_row_group_double_parquet() -> bytes::Bytes {
+        use parquet::data_type::DoubleType;
+        use parquet::file::properties::WriterProperties;
+        use parquet::file::writer::SerializedFileWriter;
+        use parquet::schema::parser::parse_message_type;
+
+        let schema = Arc::new(parse_message_type("message s { REQUIRED DOUBLE v; }").unwrap());
+        let props = Arc::new(WriterProperties::builder().build());
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut writer = SerializedFileWriter::new(&mut buf, schema, props).unwrap();
+            for vals in [[1.0f64, 2.0, 3.0], [100.0, 101.0, 102.0]] {
+                let mut rg = writer.next_row_group().unwrap();
+                let mut col = rg.next_column().unwrap().unwrap();
+                col.typed::<DoubleType>()
+                    .write_batch(&vals, None, None)
+                    .unwrap();
+                col.close().unwrap();
+                rg.close().unwrap();
+            }
+            writer.close().unwrap();
+        }
+        bytes::Bytes::from(buf)
+    }
+
+    #[test]
+    fn row_group_pruning_uses_double_stats() {
+        use parquet::file::reader::{FileReader, SerializedFileReader};
+
+        let reader = SerializedFileReader::new(two_row_group_double_parquet()).unwrap();
+        let meta = reader.metadata();
+        let field_to_col = HashMap::from([(1i32, 0usize)]);
+        let cmp = |op, v: f64| Expression::Comparison {
+            field_id: 1,
+            column: "v".to_string(),
+            op,
+            value: LiteralValue::Float64(v),
+        };
+
+        // v >= 50.0: rg0 (max 3.0) pruned, rg1 kept.
+        let ge = cmp(ComparisonOp::GtEq, 50.0);
+        assert!(!row_group_can_contain(
+            &ge,
+            meta.row_group(0),
+            &field_to_col
+        ));
+        assert!(row_group_can_contain(&ge, meta.row_group(1), &field_to_col));
+
+        // v < 50.0: rg0 kept, rg1 pruned.
+        let lt = cmp(ComparisonOp::Lt, 50.0);
+        assert!(row_group_can_contain(&lt, meta.row_group(0), &field_to_col));
+        assert!(!row_group_can_contain(
+            &lt,
+            meta.row_group(1),
+            &field_to_col
+        ));
+
+        // v == 2.0: only rg0 can contain it.
+        let eq = cmp(ComparisonOp::Eq, 2.0);
+        assert!(row_group_can_contain(&eq, meta.row_group(0), &field_to_col));
+        assert!(!row_group_can_contain(
+            &eq,
+            meta.row_group(1),
+            &field_to_col
+        ));
+    }
+
+    /// Two FLBA(16) DECIMAL(38,3) row groups (unscaled big-endian): rg0 =
+    /// [1.000, 9.990], rg1 = [20.000, 30.000]. The column scale is 3; the query
+    /// literals below carry scale 2 to exercise the cross-scale compare.
+    fn flba_decimal_parquet() -> bytes::Bytes {
+        use parquet::basic::{LogicalType, Repetition, Type as PhysicalType};
+        use parquet::data_type::{FixedLenByteArray, FixedLenByteArrayType};
+        use parquet::file::properties::WriterProperties;
+        use parquet::file::writer::SerializedFileWriter;
+        use parquet::schema::types::Type;
+
+        let col_type = Type::primitive_type_builder("v", PhysicalType::FIXED_LEN_BYTE_ARRAY)
+            .with_repetition(Repetition::REQUIRED)
+            .with_length(16)
+            .with_logical_type(Some(LogicalType::Decimal {
+                scale: 3,
+                precision: 38,
+            }))
+            .with_precision(38)
+            .with_scale(3)
+            .build()
+            .unwrap();
+        let schema = Arc::new(
+            Type::group_type_builder("s")
+                .with_fields(vec![Arc::new(col_type)])
+                .build()
+                .unwrap(),
+        );
+        let props = Arc::new(WriterProperties::builder().build());
+        let flba = |unscaled: i128| FixedLenByteArray::from(unscaled.to_be_bytes().to_vec());
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut writer = SerializedFileWriter::new(&mut buf, schema, props).unwrap();
+            for vals in [[1000i128, 5000, 9990], [20000, 25000, 30000]] {
+                let arr: Vec<FixedLenByteArray> = vals.iter().map(|&u| flba(u)).collect();
+                let mut rg = writer.next_row_group().unwrap();
+                let mut col = rg.next_column().unwrap().unwrap();
+                col.typed::<FixedLenByteArrayType>()
+                    .write_batch(&arr, None, None)
+                    .unwrap();
+                col.close().unwrap();
+                rg.close().unwrap();
+            }
+            writer.close().unwrap();
+        }
+        bytes::Bytes::from(buf)
+    }
+
+    #[test]
+    fn row_group_pruning_uses_flba_decimal_stats() {
+        use parquet::file::reader::{FileReader, SerializedFileReader};
+
+        let reader = SerializedFileReader::new(flba_decimal_parquet()).unwrap();
+        let meta = reader.metadata();
+        assert_eq!(meta.num_row_groups(), 2);
+        // The FLBA-decimal column is now admitted for pruning (was declined).
+        assert!(prunable_stats(meta.row_group(0).column(0)).is_some());
+        let field_to_col = HashMap::from([(1i32, 0usize)]);
+        let cmp = |op, unscaled: i128, scale: i8| Expression::Comparison {
+            field_id: 1,
+            column: "v".to_string(),
+            op,
+            value: LiteralValue::Decimal {
+                unscaled,
+                precision: 38,
+                scale,
+            },
+        };
+
+        // v = 9.99 (scale 2) == 9.990 (rg0 max, scale 3): rg0 boundary-equal kept;
+        // rg1 (min 20.000) pruned. Cross-scale equality keep.
+        let eq = cmp(ComparisonOp::Eq, 999, 2);
+        assert!(row_group_can_contain(&eq, meta.row_group(0), &field_to_col));
+        assert!(!row_group_can_contain(
+            &eq,
+            meta.row_group(1),
+            &field_to_col
+        ));
+
+        // v = 15.00 (scale 2) falls in the gap between the groups: BOTH pruned —
+        // the positive "it actually prunes" decimal case (would silently no-prune
+        // without the `TypedValue::lt/le` Decimal arm).
+        let eq_gap = cmp(ComparisonOp::Eq, 1500, 2);
+        assert!(!row_group_can_contain(
+            &eq_gap,
+            meta.row_group(0),
+            &field_to_col
+        ));
+        assert!(!row_group_can_contain(
+            &eq_gap,
+            meta.row_group(1),
+            &field_to_col
+        ));
+
+        // v >= 25.00 (scale 2): rg0 (max 9.990) pruned, rg1 (max 30.000) kept.
+        let ge = cmp(ComparisonOp::GtEq, 2500, 2);
+        assert!(!row_group_can_contain(
+            &ge,
+            meta.row_group(0),
+            &field_to_col
+        ));
+        assert!(row_group_can_contain(&ge, meta.row_group(1), &field_to_col));
+
+        // v < 15.00 (scale 2): rg0 kept, rg1 (min 20.000) pruned.
+        let lt = cmp(ComparisonOp::Lt, 1500, 2);
+        assert!(row_group_can_contain(&lt, meta.row_group(0), &field_to_col));
+        assert!(!row_group_can_contain(
+            &lt,
+            meta.row_group(1),
+            &field_to_col
+        ));
+
+        // v > 9.99 (strict, scale 2): rg0 upper 9.990 == 9.99 → not strictly
+        // greater → rg0 pruned. Boundary-strict prune.
+        let gt = cmp(ComparisonOp::Gt, 999, 2);
+        assert!(!row_group_can_contain(
+            &gt,
+            meta.row_group(0),
+            &field_to_col
+        ));
+
+        // Same-scale (scale 3) literal also prunes: v = 5.000 → only rg0.
+        let eq3 = cmp(ComparisonOp::Eq, 5000, 3);
+        assert!(row_group_can_contain(
+            &eq3,
+            meta.row_group(0),
+            &field_to_col
+        ));
+        assert!(!row_group_can_contain(
+            &eq3,
+            meta.row_group(1),
+            &field_to_col
+        ));
+    }
+
+    #[test]
+    fn row_group_pruning_int_coerced_scale0_decimal() {
+        use parquet::file::reader::{FileReader, SerializedFileReader};
+
+        // Mirrors PR-7's integer→decimal coercion: an integer FILTER literal
+        // pushed against a decimal column as an EXACT scale-0 decimal (q019 shape:
+        // `?deb > 1000000` on the scale-3 money column, decimal_cmp normalizing).
+        let reader = SerializedFileReader::new(flba_decimal_parquet()).unwrap();
+        let meta = reader.metadata();
+        let field_to_col = HashMap::from([(1i32, 0usize)]);
+        // rg0 = [1.000, 9.990], rg1 = [20.000, 30.000].
+        let dec0 = |op, unscaled: i128| Expression::Comparison {
+            field_id: 1,
+            column: "v".to_string(),
+            op,
+            value: LiteralValue::Decimal {
+                unscaled,
+                precision: 38,
+                scale: 0,
+            },
+        };
+
+        // Positive prune: v = 15 (15.000) falls in the gap → BOTH groups pruned.
+        let eq15 = dec0(ComparisonOp::Eq, 15);
+        assert!(!row_group_can_contain(
+            &eq15,
+            meta.row_group(0),
+            &field_to_col
+        ));
+        assert!(!row_group_can_contain(
+            &eq15,
+            meta.row_group(1),
+            &field_to_col
+        ));
+
+        // In-bounds keep: v = 5 (5.000) is within rg0's [1.000, 9.990] → kept.
+        let eq5 = dec0(ComparisonOp::Eq, 5);
+        assert!(row_group_can_contain(
+            &eq5,
+            meta.row_group(0),
+            &field_to_col
+        ));
+
+        // Range (q019 shape): v > 15 → rg0 (max 9.990) pruned, rg1 (max 30) kept.
+        let gt15 = dec0(ComparisonOp::Gt, 15);
+        assert!(!row_group_can_contain(
+            &gt15,
+            meta.row_group(0),
+            &field_to_col
+        ));
+        assert!(row_group_can_contain(
+            &gt15,
+            meta.row_group(1),
+            &field_to_col
+        ));
+
+        // Rescale-overflow → keep: a scale-0 literal so large that normalizing to
+        // the column's scale 3 overflows i128 → decimal_cmp None → conservative keep.
+        let huge = dec0(ComparisonOp::Eq, i128::MAX);
+        assert!(row_group_can_contain(
+            &huge,
+            meta.row_group(0),
+            &field_to_col
+        ));
+        assert!(row_group_can_contain(
+            &huge,
+            meta.row_group(1),
+            &field_to_col
+        ));
+
+        // Switch-off revert form (pre-PR-7): an Int64 literal against a decimal
+        // column is NOT pruned — stat_bounds has no Int64-vs-FLBA arm → keep.
+        let int_lit = Expression::Comparison {
+            field_id: 1,
+            column: "v".to_string(),
+            op: ComparisonOp::Gt,
+            value: LiteralValue::Int64(15),
+        };
+        assert!(row_group_can_contain(
+            &int_lit,
+            meta.row_group(0),
+            &field_to_col
+        ));
+        assert!(row_group_can_contain(
+            &int_lit,
+            meta.row_group(1),
+            &field_to_col
+        ));
+    }
+
+    /// One INT32-backed DECIMAL(9,2) row group holding 5.00..5.04 (unscaled
+    /// [500, 502, 504]). INT32/INT64-backed decimals are off-spec and DECLINED.
+    fn int32_decimal_parquet() -> bytes::Bytes {
+        use parquet::basic::{LogicalType, Repetition, Type as PhysicalType};
+        use parquet::data_type::Int32Type;
+        use parquet::file::properties::WriterProperties;
+        use parquet::file::writer::SerializedFileWriter;
+        use parquet::schema::types::Type;
+
+        let col_type = Type::primitive_type_builder("v", PhysicalType::INT32)
+            .with_repetition(Repetition::REQUIRED)
+            .with_logical_type(Some(LogicalType::Decimal {
+                scale: 2,
+                precision: 9,
+            }))
+            .with_precision(9)
+            .with_scale(2)
+            .build()
+            .unwrap();
+        let schema = Arc::new(
+            Type::group_type_builder("s")
+                .with_fields(vec![Arc::new(col_type)])
+                .build()
+                .unwrap(),
+        );
+        let props = Arc::new(WriterProperties::builder().build());
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut writer = SerializedFileWriter::new(&mut buf, schema, props).unwrap();
+            let mut rg = writer.next_row_group().unwrap();
+            let mut col = rg.next_column().unwrap().unwrap();
+            col.typed::<Int32Type>()
+                .write_batch(&[500, 502, 504], None, None)
+                .unwrap();
+            col.close().unwrap();
+            rg.close().unwrap();
+            writer.close().unwrap();
+        }
+        bytes::Bytes::from(buf)
+    }
+
+    #[test]
+    fn row_group_pruning_declines_int_backed_decimal() {
+        use parquet::file::reader::{FileReader, SerializedFileReader};
+
+        let reader = SerializedFileReader::new(int32_decimal_parquet()).unwrap();
+        let meta = reader.metadata();
+        // The INT32-backed decimal is declined: no prunable stats.
+        assert!(prunable_stats(meta.row_group(0).column(0)).is_none());
+
+        let field_to_col = HashMap::from([(1i32, 0usize)]);
+        // v = 100.00: the column holds only 5.00..5.04, so a scale-aware compare
+        // WOULD prune — but the decline keeps the row group conservatively.
+        let eq = Expression::Comparison {
+            field_id: 1,
+            column: "v".to_string(),
+            op: ComparisonOp::Eq,
+            value: LiteralValue::Decimal {
+                unscaled: 10000,
+                precision: 9,
+                scale: 2,
+            },
+        };
+        assert!(row_group_can_contain(&eq, meta.row_group(0), &field_to_col));
+    }
+
+    #[test]
+    fn bounds_can_contain_keeps_on_nan_bound() {
+        // A NaN bound must never prune (the F15 strict-superset invariant): a NaN
+        // operand makes the compare incomparable → `unwrap_or(true)` keeps.
+        let lit = TypedValue::Float64(5.0);
+        // column >= 5.0 with a NaN upper bound.
+        assert!(bounds_can_contain(
+            ComparisonOp::GtEq,
+            &lit,
+            Some(TypedValue::Float64(1.0)),
+            Some(TypedValue::Float64(f64::NAN)),
+        ));
+        // column <= 5.0 with a NaN lower bound.
+        assert!(bounds_can_contain(
+            ComparisonOp::LtEq,
+            &lit,
+            Some(TypedValue::Float64(f64::NAN)),
+            Some(TypedValue::Float64(10.0)),
+        ));
+        // Equality with a NaN bound also keeps.
+        assert!(bounds_can_contain(
+            ComparisonOp::Eq,
+            &lit,
+            Some(TypedValue::Float64(f64::NAN)),
+            Some(TypedValue::Float64(f64::NAN)),
         ));
     }
 }

--- a/fluree-db-query/src/r2rml/mod.rs
+++ b/fluree-db-query/src/r2rml/mod.rs
@@ -64,3 +64,16 @@ pub(crate) fn parallel_catalog_resolution_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| env_switch_enabled("FLUREE_R2RML_PARALLEL_CATALOG"))
 }
+
+/// Whether numeric (double / decimal) FILTER predicates may be pushed to the
+/// Iceberg scan for file / row-group pruning (PR-7). Default on;
+/// `FLUREE_ICEBERG_NUMERIC_STATS=0|false|off|no` reverts to leaving them with the
+/// in-engine FILTER only, independently of the shipped int/date/string pushdown.
+/// Gating at the single push site (`to_scan_value`) keeps the iceberg-side
+/// widening inert when off — no numeric `LiteralValue` is ever produced, so the
+/// new `stat_bounds` arms and FLBA-decimal relax are never exercised. Cached in a
+/// `OnceLock` — set at process startup, not per query.
+pub(crate) fn iceberg_numeric_stats_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| env_switch_enabled("FLUREE_ICEBERG_NUMERIC_STATS"))
+}

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -1743,6 +1743,21 @@ fn rdf_term_eq_object_constant_cached(
                 ScanValue::Date(days) => {
                     fluree_db_core::Date::parse(v).is_ok_and(|d| d.days_since_epoch() == *days)
                 }
+                // Double / Decimal `ScanValue`s only ever reach the scan as
+                // FILTER pushdowns, never wrapped in a `Scalar` object constant
+                // (a numeric object routes to `ObjectConstant::Double`/`Decimal`
+                // above). These arms exist for match exhaustiveness; should one be
+                // reached, match loosely by value so it can never be WRONG.
+                ScanValue::Double(f) => v.parse::<f64>().is_ok_and(|x| x == *f),
+                ScanValue::Decimal {
+                    unscaled, scale, ..
+                } => {
+                    let d = bigdecimal::BigDecimal::new(
+                        num_bigint::BigInt::from(*unscaled),
+                        i64::from(*scale),
+                    );
+                    v.parse::<bigdecimal::BigDecimal>().is_ok_and(|x| x == d)
+                }
                 // A TemplateKey is only ever a reversed subject-key filter, never
                 // an object constant, so it never matches an object term.
                 ScanValue::TemplateKey(_) => false,

--- a/fluree-db-query/src/r2rml/provider.rs
+++ b/fluree-db-query/src/r2rml/provider.rs
@@ -36,9 +36,11 @@ pub enum ScanCmpOp {
 /// A literal value for a pushed-down scan filter.
 ///
 /// Limited to types that prune safely against Iceberg column min/max bounds and
-/// that the Arrow row filter can evaluate: date/int/bool, plus strings
-/// (lexicographic, e.g. equality on a name/code column). Decimal / float
-/// predicates are left to the in-engine FILTER.
+/// that the Arrow row filter can evaluate: date/int/bool, strings (lexicographic,
+/// e.g. equality on a name/code column), plus double and decimal — the last two
+/// gated by `FLUREE_ICEBERG_NUMERIC_STATS` and only ever produced from a numeric
+/// FILTER predicate (see `to_scan_value`). A missed push is never wrong: the
+/// in-engine FILTER remains the authority.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ScanValue {
     Bool(bool),
@@ -47,6 +49,18 @@ pub enum ScanValue {
     Date(i32),
     /// UTF-8 string (byte-lexicographic order matches Parquet stats + xsd:string).
     Str(String),
+    /// An `xsd:double`/`xsd:float` value — pushed against a physically-`double`
+    /// column only (see `build_iceberg_filter`). NaN bounds never over-prune (the
+    /// Iceberg compare treats a NaN operand as incomparable → keep).
+    Double(f64),
+    /// A decimal value as its unscaled i128 + precision/scale (mirrors
+    /// `LiteralValue::Decimal`). Carries the LITERAL's scale; the column's scale
+    /// may differ and is normalized during comparison.
+    Decimal {
+        unscaled: i128,
+        precision: u8,
+        scale: i8,
+    },
     /// A raw column value recovered by reversing a subject template (bound-subject
     /// pushdown). The physical type is unknown here — it is resolved against the
     /// Iceberg field type when the pushdown predicate is built, and the pushdown is

--- a/fluree-db-query/src/r2rml/rewrite.rs
+++ b/fluree-db-query/src/r2rml/rewrite.rs
@@ -574,14 +574,51 @@ fn const_object(value: &FlakeValue) -> Option<ObjectConstant> {
     }
 }
 
+/// Convert a FILTER comparison's constant literal to a prunable `ScanValue`.
+/// Integer / boolean / date / string always push. Double and decimal push only
+/// when `FLUREE_ICEBERG_NUMERIC_STATS` is on (PR-7) — this is the single gate for
+/// numeric pushdown, so with it off no numeric `LiteralValue` reaches the reader
+/// and the iceberg-side numeric widening stays inert. Anything else (refs,
+/// big-integers beyond i128, temporal beyond date, …) stays with the in-engine
+/// FILTER.
 fn to_scan_value(value: &FlakeValue) -> Option<ScanValue> {
     match value {
         FlakeValue::Long(n) => Some(ScanValue::Int(*n)),
         FlakeValue::Boolean(b) => Some(ScanValue::Bool(*b)),
         FlakeValue::Date(d) => Some(ScanValue::Date(d.days_since_epoch())),
         FlakeValue::String(s) => Some(ScanValue::Str(s.clone())),
+        FlakeValue::Double(f) if crate::r2rml::iceberg_numeric_stats_enabled() => {
+            Some(ScanValue::Double(*f))
+        }
+        FlakeValue::Decimal(d) if crate::r2rml::iceberg_numeric_stats_enabled() => {
+            scan_value_from_bigdecimal(d)
+        }
         _ => None,
     }
+}
+
+/// Decompose a `BigDecimal` into `ScanValue::Decimal { unscaled, precision, scale }`.
+/// Normalizes first (so `9.99` and `9.990` decompose identically), then reads the
+/// unscaled mantissa and base-10 exponent. Returns `None` if the unscaled value
+/// exceeds i128 or the scale exceeds i8 — those stay with the in-engine FILTER.
+fn scan_value_from_bigdecimal(bd: &bigdecimal::BigDecimal) -> Option<ScanValue> {
+    use num_traits::ToPrimitive;
+    // value = unscaled * 10^-scale. Normalize so scale-equivalent forms (9.99 vs
+    // 9.990) decompose identically.
+    let (unscaled_bi, scale) = bd.normalized().as_bigint_and_exponent();
+    let scale = i8::try_from(scale).ok()?;
+    let unscaled = unscaled_bi.to_i128()?;
+    // precision is cosmetic for pruning (`decimal_cmp` ignores it); derive it from
+    // the unscaled magnitude so it is self-consistent across scale-equivalent
+    // forms, clamped to the decimal128 max.
+    let precision = u8::try_from(unscaled.unsigned_abs().checked_ilog10().unwrap_or(0) + 1)
+        .unwrap_or(38)
+        .clamp(1, 38);
+    Some(ScanValue::Decimal {
+        unscaled,
+        precision,
+        scale,
+    })
 }
 
 /// The subject var of a regular-predicate R2RML pattern that can join a
@@ -1867,5 +1904,34 @@ mod tests {
             "first-seen order must be preserved: {msg}"
         );
         assert!(msg.contains("gs:main"), "names the graph source: {msg}");
+    }
+
+    #[test]
+    fn bigdecimal_decomposes_scale_insensitively() {
+        use std::str::FromStr;
+        let bd = |s: &str| bigdecimal::BigDecimal::from_str(s).unwrap();
+        // 9.99 and 9.990 are the SAME value → identical decomposition (the exact
+        // cross-scale shape the pruning layer must then compare correctly).
+        let want = Some(ScanValue::Decimal {
+            unscaled: 999,
+            precision: 3,
+            scale: 2,
+        });
+        assert_eq!(scan_value_from_bigdecimal(&bd("9.99")), want);
+        assert_eq!(scan_value_from_bigdecimal(&bd("9.990")), want);
+        // Trailing-zero integer forms also normalize to one representation.
+        assert_eq!(
+            scan_value_from_bigdecimal(&bd("100")),
+            scan_value_from_bigdecimal(&bd("100.00"))
+        );
+        // Negative value.
+        assert_eq!(
+            scan_value_from_bigdecimal(&bd("-0.05")),
+            Some(ScanValue::Decimal {
+                unscaled: -5,
+                precision: 1,
+                scale: 2,
+            })
+        );
     }
 }


### PR DESCRIPTION
## What

PR-7 (H4): push numeric (double / decimal) FILTER predicates down to Iceberg file / row-group pruning, so a numeric range/equality filter skips data files instead of decoding all of them. Previously only int / date / string predicates pruned; a decimal or double FILTER decoded every file.

## The two-layer blind spot

- **Query side (primary):** `ScanValue` carried no numeric type, so `to_scan_value` never produced a numeric predicate, `build_iceberg_filter` never emitted one, and the reader never saw it — the real reason q019 showed `files_pruned = 0`.
- **Iceberg side:** `stat_bounds` had no Double / FLBA-decimal arm, `prunable_stats` declined all decimals, and `TypedValue::lt/le` had no Decimal arm (a pushed decimal would silently never prune).

Both are closed here, gated by `FLUREE_ICEBERG_NUMERIC_STATS` (default on).

## Change surface

**Query:** `ScanValue` +`Double`/`Decimal`; `to_scan_value` gated arms + scale-normalizing BigDecimal decompose; `build_iceberg_filter` Double→Float64 (double cols), Decimal→Decimal (decimal cols). An **integer** literal against a decimal column (q019 `?deb > 1000000` on the `xsd:decimal` money column) coerces to an EXACT scale-0 decimal via `int_pushdown_literal` — `decimal_cmp` normalizes the scale gap. Gated api-side (`FLUREE_ICEBERG_NUMERIC_STATS` OnceLock, disk-catalog-cache precedent); switch-off keeps the pre-PR-7 `Int64` no-prune form (full revert).

**Iceberg:** `stat_bounds` +Double/Float/FLBA-decimal (decodes the *column's* scale, not the literal's); `prunable_stats` admits FLBA-encoded decimals (the encoding the Iceberg spec mandates), declines INT32/INT64-backed decimals with a debug breadcrumb; `TypedValue::lt/le` +Decimal arm + NaN-safe Float.

## Correctness

The pushdown is a strict **superset** — it may over-keep, never over-prune; the in-engine FILTER is the sole authority. A latent **NaN over-prune** (F15; unreachable pre-PR-7, armed by the Double push) is fixed in-PR: a NaN operand in Float `lt/le` returns `None` → keep. Two conservative residuals decline **observably** (double-vs-decimal, decimal-vs-int; inexact / no exact cross-type compare → keep + debug breadcrumb).

## H4 live gate (DW_SF01, ~7670 files per fact table)

| query | files_pruned / selected | wall (hot) | note |
|---|---|---|---|
| q019 | 7670 / 0 | 800ms | integer > money threshold; **cold 38.8s → 4.0s (~10×)** |
| q020 | 7579 / 91 | 635ms | date range — representative partial prune |
| q021 | 7670 / 0 | 636ms | int account-code band |
| q019 switch-off | 0 / 7670 | 916ms | byte-identical → perfect revert |

Native 54/54 parity: 0 hash mismatch. Snowflake decimals ARE FLBA in practice (the prune worked end to end).

**Caveat:** q019/q021 select zero rows on this dataset, so their total prune is the predicate-selects-nothing case (the strongest but easiest prune); a partially-selective filter prunes proportional to data layout (q020's 91-file partial is the representative middle). This is a different case from the 05-diagnosis "int pushes but nothing prunes" note, which measured an in-range predicate over the column's value spread — q021 here is an out-of-range band — so it is not a regression of that finding.

## Tests

11 new hermetic unit tests over real Parquet fixtures: double prune/keep, FLBA-decimal cross-scale (9.99↔9.990) prune/keep/boundary, int→scale-0-decimal coercion (positive prune / in-bounds keep / rescale-overflow keep / switch-off revert), INT-decimal decline, NaN-keep, and the BigDecimal decompose. iceberg lib 172, query r2rml 59, api r2rml 14 — all green; clippy + fmt clean.

Stacked on `perf/r2rml-pr4c-optional-star`. PR-5 (scan-side top-k), whose pruning leg these numeric stats unblock, is the next and final roadmap item.
