### PR TITLE
perf(r2rml): scan-side top-k for ORDER BY DESC LIMIT (PR-5, cold 37s→3.1s)

### DIFF
--- a/docs/audit/2026-07-virtual-dataset-perf/15-pr5-scan-topk.md
+++ b/docs/audit/2026-07-virtual-dataset-perf/15-pr5-scan-topk.md
@@ -1,0 +1,72 @@
+# PR-5 — scan-side top-k for `ORDER BY … LIMIT` (the FINAL roadmap item) — DESIGN SKETCH
+
+**Branch:** `perf/r2rml-pr5-scan-topk` (off `perf/r2rml-pr7-numeric-stats` HEAD `2a07bbbc4`)
+**Status:** SKETCH — **STOP for lead review** (largest new design surface; the roadmap's original PR-5 sketch predates five shipped PRs, and PR-7 changed the marginal-cost calculus).
+**Substrate:** ROADMAP PR-5, `09-stacked-rebaseline.md` (§3/§5/§D/§6 — PR-5 is cold-only, PR-7-gated, PR-8-gated), and PR-7's shipped numeric stats (#1494).
+
+## (a) Target, honestly re-derived — recommendation: PROCEED, tightly scoped (not defer)
+
+**The corpus reach is one query.** Of the three ORDER-BY-LIMIT queries, only **q046** qualifies for scan-side top-k: `SELECT ?oid ?tot WHERE { ?o a edw:Order ; edw:orderId ?oid ; edw:orderTotal ?tot } ORDER BY DESC(?tot) ?oid LIMIT 10` — a single-TM FACT_ORDER scan whose sort keys are both scan columns (ORDER_TOTAL `xsd:double`, ORDER_ID). **q005** has an intervening ref-join (`?g edw:region ?region`) and an IRI tiebreaker (`?sup`) → out. **q012** sorts on a post-aggregate `SUM(?qty)` (a computed value, not a scan column — you cannot prune files by an aggregate that spans them) → out. So the honest corpus target is **q046 alone**.
+
+**And only cold.** Warm, q046 is already **445 ms** (PR-2's memo made the full 7,670-file scan cheap warm), and PR-5's heap-only leg is *worthless warm* — it still decodes every file. PR-5's entire value is the **running-k-th-bound FILE prune**, which reads ≪ 7,670 files; that only shows up on the **cold** first-touch scan (**~37 s**, `09` §5). PR-8 did **not** erase this: it persists the *catalog* floor (loadTable/metadata/manifest), not the 7,670 Parquet *data* files (DiskArtifactCache is cleared cold), so the ~37 s cold data-fetch survives — as the dispatch confirms (q027/q046 still ~37–43 s cold).
+
+**Why PROCEED anyway (my recommendation).** (1) **The marginal cost dropped.** The roadmap tagged PR-5 "largest design surface / MED-HIGH risk" because the pruning bound needed numeric column stats that didn't exist. **PR-7 shipped exactly those** (double/decimal file+row-group bounds, strict-superset, NaN-safe, tested). So PR-5 is now "TopK directive + MAX-ordered file read + running-bound prune + defer-to-sort-above" on top of a *proven* pruning primitive — a much smaller, lower-risk surface than the original estimate. (2) **The cold win is large and distribution-free** (see (e)): ~37 s → ~2–3 s, reading ~10–15 files. (3) It is the **only** fix for the raw-column top-k class — the canonical dashboard shape ("top N by measure"). (4) It is the roadmap's designated final item; finishing it closes the series.
+
+**The honest case for DEFER** (so you can weigh it): one corpus query, cold-only, and PR-8 already softened cold. If you weight *corpus breadth* or *warm-path impact* over *per-query cold depth + roadmap completion*, DEFER is defensible. **My call is PROCEED-scoped** — the post-PR-7 marginal cost is low enough that a ~12–15× cold win on the canonical analytical shape is worth the contained surface. If you'd rather bank PR-7 and stop, I'll take that ruling.
+
+## (b) If proceeding — the mechanism
+
+**1. Directive plumbing (mirror `row_budget`).** `set_row_budget` (`limit.rs:85` → `r2rml/operator.rs:2209`) is the template: a trait method that threads a directive from an upper operator down to the scan. `row_budget` does NOT cross the blocking `SortOperator` (it needs all rows to rank — the reason top-k never truncates the scan today). PR-5 adds a **parallel** directive `set_topk(TopK { sort_col, dir, k, offset })` that **only the `SortOperator` sets, and only onto a directly-below R2RML operator**, when its own `topk` is `Some(k)` and the shape qualifies. Non-R2RML children ignore it (default no-op), so it is inert everywhere else.
+
+**2. Eligibility (compound-comparator rule).** Push only when **every** sort key resolves to a scan column of **one** TM, there is **no** intervening non-order-preserving op between the sort and the scan (no GROUP BY / DISTINCT-that-reorders / join), and the **primary** sort key is a pushable-stat column (int/date/string/**double**/**decimal** — the PR-7 set). q046 qualifies: DESC(ORDER_TOTAL), ORDER_ID, both FACT_ORDER, ORDER_TOTAL is double. The corpus tiebreakers made every ORDER BY compound; the compound-ness gates *eligibility* (so the authoritative sort above can produce the exact order) but the **file prune uses only the primary key** (below).
+
+**3. MAX-ordered file read — the crux.** The scan sorts its file list by the manifest `upper_bound(sort_col)` (for DESC; `lower_bound` for ASC) **before** the read loop, and reads highest-bound-first. This is what makes the prune *near-optimal and distribution-free*: the heap fills with the true top values in the first few files, the k-th bound settles at the true `V_k`, and every remaining (lower-MAX) file prunes immediately. Without MAX-ordering the same files eventually prune, but read order could be adversarial (top values in the last physical file → read everything) — so MAX-ordering is essential, not optional. The manifest bounds are already in memory (the pruning path reads them); sorting 7,670 entries is trivial.
+
+**4. Running-bound file prune (reuse `pruning.rs`).** The scan keeps a size-`(k+offset)` min-heap (DESC) of the **primary** key's values only, purely to compute the running k-th bound. Once full, a file whose `upper_bound(sort_col) < bound` (DESC; `lower_bound > bound` for ASC) provably cannot contribute → skip it (and, since files are MAX-sorted, all subsequent files too). The comparison reuses PR-7's `bounds_can_contain`/`TypedValue` machinery. **Strict `<`** (keep on `==`) so ties at exactly `V_k` are over-kept.
+
+**Descending bound semantics:** DESC → the k-th **lower** bound (smallest of the current top-k) is the threshold; prune files whose **max** < it. ASC → k-th **upper** bound; prune files whose **min** > it.
+
+## (c) Tie/dedup ownership — scan prunes, `sort.rs` decides
+
+The scan-side heap is a **pruning accelerator only**: it never truncates rows and never decides the answer. It streams **every row of every non-pruned file** upward. `SortOperator::new_topk` (`sort.rs:542`) above remains the **sole authority** for the final compound order, tie resolution, OFFSET, and LIMIT. Because the scan only skips files it *proved* cannot contain a top-k row (strict-`<` bound, keep on tie), the rows reaching `sort.rs` are a **superset** of the true top-k — so the final result is **byte-identical to full-sort** (over-keep semantics, exactly like pruning). No dedup, no split-brain comparator: the scan owns *which files to read*, `sort.rs` owns *the answer*. This also means the scan-side heap needs only the **primary** key (the bound); the secondary key never enters the prune decision.
+
+## (d) Kill switch + fallback
+
+`FLUREE_R2RML_TOPK_PUSHDOWN` (default on; api- or query-side OnceLock per where the directive is set). Off ⇒ the `SortOperator` never sets the directive ⇒ today's full-materialize top-k (scan streams all rows, `sort.rs` heap keeps k). **Fallback (no directive) whenever the shape is ineligible** (b): expression/ref/IRI primary key, non-pushable-stat primary column, multi-TM, or any intervening non-order-preserving op. Fallback is the current behavior, so an unhandled shape is never wrong — only unaccelerated.
+
+## (e) Gates + the prunable-fraction estimate (BEFORE promising)
+
+**Prunable fraction — distribution-free for top-k.** From the q046 oracle the top-10 `?tot` are **distinct**, in [4999.60, 4999.98] (ORDER_TOTAL is capped near 5000, dense at the top — the day-partition "per-file max varies" case). That density is a *red herring* for pruning: by definition only the **10 largest** orders have `?tot ≥ V10 = 4999.60`, so only the **≤10 files** that contain them have `upper_bound ≥ V10`; **every other file's max is ≤ the 11th-largest < V10 → prunes**, regardless of how the totals are distributed. The density only tightens the *band* (V1..V10 span 0.38), not the *count* above V10. The one thing that would erode it is heavy **ties at exactly V10** (many orders == 4999.60 → their files over-kept); doubles in a ~10⁵-order synthetic set make that ~0–2 files. **Estimate: read ~10–15 files of ~7,670 → files_pruned ≈ 7,655/7,670 (~99.8%).** Cold: ~15/7670 × 37 s ≈ 0.07 s of data-fetch + the PR-8 catalog floor (~1.5–2 s) + manifest read ≈ **~2–3 s cold (from ~37 s, ~12–15×)**. I am *not* promising a specific cold ms until the live gate; I am promising files_pruned > ~99% and cold ≪ 10 s.
+
+**Gates:**
+- **Cold q046 headline:** `files_pruned > 0` (expect ~7,655/7,670) and cold wall ~37 s → target < 5 s. (F7 caveat: the `iceberg.scan_plan` span only records `files_selected/pruned` on the pruning branch — it reads 0 today for q046 with no filter; the TopK directive activates that branch, same as PR-7's q019.)
+- **Hot q046 / q005 no-regression:** warm q046 ≤ current 445 ms (fewer files decoded; must not regress from directive overhead); q005 (ineligible → fallback) byte-identical and unchanged wall.
+- **ORDER-BY-class parity sweep:** q005 / q012 / q046 all hash-parity vs the blessed oracle; q012 (post-aggregate) and q005 (join/IRI) provably **unchanged** (fallback path), q046 identical to full-sort.
+- **Differential (the core correctness gate):** switch ON vs OFF byte-identical on q046 **including the tie boundary** (construct/inspect a tie at V_k); the scan-side prune must be a strict superset.
+- **W3C ORDER BY / LIMIT suite green**; native 54/54 0-mismatch.
+
+**Switch:** `FLUREE_R2RML_TOPK_PUSHDOWN` (my call, matching the roadmap name). `pf5_` artifact prefix.
+
+## Change surface (on nod)
+
+query: `SortOperator` topk-directive detection (`operator_tree.rs` apply_solution_modifiers) + `set_topk` trait method (mirror `set_row_budget`); `r2rml/operator.rs` — accept `TopK`, MAX-order the file list, size-(k+offset) primary-key heap, running-bound file skip (reuse `bounds_can_contain`). iceberg: none new (PR-7's double/decimal bounds + `pruning.rs` reused as-is). Tests: a hermetic directive/heap/bound unit (prune vs keep vs tie-boundary; ASC + DESC) + the differential (switch on/off byte-identical incl. tie) + the H2 cold-q046 live gate + parity sweep.
+
+## Ruling: PROCEED (tightly scoped) + four riders + one execution-path refinement
+
+Lead approved PROCEED. The distribution-free argument is the decider; the cold-only/single-corpus-query framing goes in the PR body verbatim.
+
+**Rider 1 — NULL sort values (the edge the sketch didn't name).** Two invariants make NULLs sound under DESC, both TESTED: (i) **prune only when the heap is full** (k non-null values seen) — if fewer than k non-null rows exist, the heap never fills, the prune precondition never fires, every file is read, and the NULL-ordered rows (which sort LAST in DESC) legitimately reach `sort.rs`; (ii) **a file with no `upper_bound` for the sort column (an all-NULL column) is never pruned** (conservative keep). A partial-NULL file (null_count>0 but has an upper_bound) prunes by that bound and is sound because when the heap is full the k non-nulls all beat any null. Hermetic cases: partial-null-prunes, all-null-file-kept, k-exceeds-non-null-count-reads-everything.
+
+**Rider 2 — ASC declines to fallback (my call): DESC-ONLY.** ASC is NOT a clean mirror: SPARQL orders unbound values FIRST in ASC, so any NULL row always occupies a top-k slot and no null-bearing file could be pruned (a `lower_bound` heap would silently drop nulls that belong in the result). A sound ASC would need a "sort column provably non-null" guard (every file null_count=0, or a `required` column); that extra surface is declined for the final item. DESC covers q046 and the canonical top-N-by-measure (largest) shape. ASC `ORDER BY … LIMIT` takes the fallback (today's full-sort).
+
+**Rider 3 — read-order insensitivity.** The MAX-ordered read changes the physical file read order for eligible scans **even when nothing prunes**. This is safe: `sort.rs::new_topk` above fully orders the result, corpus/result hashes are multiset-based, and no downstream operator may assume manifest/file order (the scan already reads files with `buffer_unordered`, i.e. completion-order, today — so nothing depends on order already).
+
+**Rider 4 — F13** rides on this branch (`408b2052e`); the PR body cites F13 in one line.
+
+**Execution-path refinement (discovered in the code, within the approved design).** Today the scan streams files with `buffer_unordered(concurrency)` — parallel and completion-ordered — which cannot host the sequential heap + running-bound early-stop. So the TopK path is an **additive branch**: when `ScanConfig.topk` is set, the api scan takes a new **sequential MAX-ordered** read (sort tasks by decoded `upper_bound(sort_col)` DESC; read in order; maintain a size-(k+offset) min-heap of the non-null sort values; after each file, if the heap is full and the next task's `upper_bound < k-th bound` (strict), drop the remaining tasks; yield every read file's batches). Non-topk scans keep the existing parallel path byte-for-byte. Losing parallelism on the topk path is a non-issue — the whole point is that it reads ~10-15 files, not 7,670.
+
+**STOP gate cleared — implementing.**
+
+---
+
+**F13 rider (in progress, parallel):** native-sf01 5-rep re-bless launched on the quiet machine (`pf_f13_rebless.sh` → `baselines/perf/native-sf01.json`), to retire the recurring q034/q050 false SLOWs before PR-5's gates. Will commit the refreshed baseline with an F13-citing note and report the delta.

--- a/docs/audit/2026-07-virtual-dataset-perf/15-pr5-scan-topk.md
+++ b/docs/audit/2026-07-virtual-dataset-perf/15-pr5-scan-topk.md
@@ -69,4 +69,24 @@ Lead approved PROCEED. The distribution-free argument is the decider; the cold-o
 
 ---
 
-**F13 rider (in progress, parallel):** native-sf01 5-rep re-bless launched on the quiet machine (`pf_f13_rebless.sh` → `baselines/perf/native-sf01.json`), to retire the recurring q034/q050 false SLOWs before PR-5's gates. Will commit the refreshed baseline with an F13-citing note and report the delta.
+**F13 rider (DONE):** native-sf01 perf baselines re-blessed (`408b2052e`; q034 176→322, q050 96→283), retiring the recurring false SLOWs. The closing gate's native run confirmed 0 perf violations.
+
+## Implemented + gated (the series closer)
+
+**Root cause of the first-smoke no-prune.** The directive threaded to the `SortOperator`'s child, but a virtual query's scan lives in a `GraphOperator`'s per-parent INNER subplan, and `set_topk` offered to the GraphOperator hit its default no-op. Fix: `GraphOperator` threads the directive into both inner-subplan build sites (exactly as it already does `row_budget`, graph.rs), and `ProjectOperator` forwards it; `OffsetOperator`/`JoinOperator` decline (Offset sits above the sort, so it's never in the sort→scan path, and the k already owns `+offset`). Diagnosed with a per-step trace: `kth` climbs 3214→…→4999.6, `can_stop` fires at pos 9, `reads_sequential=10, stop_reason=early_stop`.
+
+**Perf (closing gate, DW_SF01, 7670 files):**
+| q046 | wall | files_pruned/selected | hash |
+|---|---|---|---|
+| ON (hot) | 136ms | 7660 / 10 | ==oracle |
+| OFF (hot) | 406ms | 0 / 7670 | ==oracle (byte-identical revert) |
+| **COLD** | **3129ms** | **7660** | ==oracle |
+Cold **~37s → 3.1s (~12×), 99.87% pruned** — beats the promise (>99%, cold<5s). ON is faster than OFF even hot. ORDER-BY sweep (q005/q012 declined via fallback) + native 54/54: 0 hash mismatch, 0 perf violations. Post-guard re-verify: q046 still prunes 7660 (the guard is not over-broad).
+
+**Soundness guard (heap feed).** The heap is fed the rows the scan EMITS — post any pushed scan filter (the reader applies those), but PRE any RESIDUAL filter the operator enforces per row. `resolve_topk_directive` DECLINES (→ full sort) when `consumed_filter` / `object_constant` / `subject_constant` / `star_constraints` is present (`topk_residual_filter_present`), so the heap never sees a superset that would ride the k-th bound too high and drop qualifying rows. Load-bearing doc-comment on the feed site.
+
+**Observability + the gate denominator.** The topk branch emits an `iceberg.scan_plan` span (`files_selected=reads`, `files_pruned=total-reads`) so the harness counters capture the prune. NOTE the cold *miss* arm ALSO runs the planner, which emits its own `iceberg.scan_plan` span (`selected=7670, pruned=0`, the PRE-topk plan); the RunRecord SUMS both, so on cold `files_selected` double-counts (7680) while **`files_pruned` is authoritative (7660 = planner 0 + topk 7660)**. The gate ratio is therefore **`files_pruned / total_files`** (7660/7670 = 99.87%), a fixed denominator — never `pruned/(pruned+selected)` (which reads 49.9% on the cold double-emission). Hot (cache arm, no planner span) reads a clean 10/7660.
+
+**Kill switch:** `FLUREE_R2RML_TOPK_PUSHDOWN` (default on); off ⇒ no directive ⇒ today's full-materialize top-k.
+
+**Tests.** iceberg core (10): TopKBound bound/tie/NaN + plan_topk_read/batch_sort_values + read-loop simulations (prune + k-exceeds-non-null + all-null-file). query: `topk_declines_on_residual_filter` (4 residual shapes + pure positive), `topk_scan_bypasses_scan_cache` (cache-poison: topk re-scans each batch vs cached once), `topk_directive_carries_limit_plus_offset` (k=LIMIT+OFFSET single-owner arithmetic). All green; clippy/fmt clean.

--- a/fluree-bench-virtual/baselines/perf/native-sf01.json
+++ b/fluree-bench-virtual/baselines/perf/native-sf01.json
@@ -3,8 +3,8 @@
   "target": "native-sf01",
   "blessed_from": {
     "target": "native-sf01",
-    "run_id": "01KX6P6KH3RQGQH6T6PZGES9XH",
-    "commit": "e4f24f12e"
+    "run_id": "01KXG6EAVKKV1ZDM69FAP4R7MV",
+    "commit": "2a07bbbc4"
   },
   "entries": {
     "q001": {
@@ -28,7 +28,7 @@
       }
     },
     "q003": {
-      "hot_wall_ms_median": 13,
+      "hot_wall_ms_median": 15,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -58,7 +58,7 @@
       }
     },
     "q006": {
-      "hot_wall_ms_median": 15,
+      "hot_wall_ms_median": 6,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -68,7 +68,7 @@
       }
     },
     "q007": {
-      "hot_wall_ms_median": 8,
+      "hot_wall_ms_median": 9,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -78,7 +78,7 @@
       }
     },
     "q008": {
-      "hot_wall_ms_median": 747,
+      "hot_wall_ms_median": 699,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -88,7 +88,7 @@
       }
     },
     "q009": {
-      "hot_wall_ms_median": 724,
+      "hot_wall_ms_median": 698,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -98,7 +98,7 @@
       }
     },
     "q010": {
-      "hot_wall_ms_median": 853,
+      "hot_wall_ms_median": 848,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -108,7 +108,7 @@
       }
     },
     "q011": {
-      "hot_wall_ms_median": 305,
+      "hot_wall_ms_median": 297,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -118,7 +118,7 @@
       }
     },
     "q012": {
-      "hot_wall_ms_median": 1031,
+      "hot_wall_ms_median": 1047,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -128,7 +128,7 @@
       }
     },
     "q013": {
-      "hot_wall_ms_median": 1597,
+      "hot_wall_ms_median": 1574,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -138,7 +138,7 @@
       }
     },
     "q014": {
-      "hot_wall_ms_median": 183,
+      "hot_wall_ms_median": 204,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -148,7 +148,7 @@
       }
     },
     "q015": {
-      "hot_wall_ms_median": 419,
+      "hot_wall_ms_median": 414,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -158,7 +158,7 @@
       }
     },
     "q016": {
-      "hot_wall_ms_median": 697,
+      "hot_wall_ms_median": 419,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -168,7 +168,7 @@
       }
     },
     "q017": {
-      "hot_wall_ms_median": 136,
+      "hot_wall_ms_median": 138,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -178,7 +178,7 @@
       }
     },
     "q018": {
-      "hot_wall_ms_median": 132,
+      "hot_wall_ms_median": 147,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -198,7 +198,7 @@
       }
     },
     "q020": {
-      "hot_wall_ms_median": 311,
+      "hot_wall_ms_median": 305,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -208,7 +208,7 @@
       }
     },
     "q021": {
-      "hot_wall_ms_median": 134,
+      "hot_wall_ms_median": 137,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -218,7 +218,7 @@
       }
     },
     "q022": {
-      "hot_wall_ms_median": 379,
+      "hot_wall_ms_median": 340,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -228,7 +228,7 @@
       }
     },
     "q023": {
-      "hot_wall_ms_median": 341,
+      "hot_wall_ms_median": 374,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -238,7 +238,7 @@
       }
     },
     "q024": {
-      "hot_wall_ms_median": 267,
+      "hot_wall_ms_median": 242,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -258,7 +258,7 @@
       }
     },
     "q026": {
-      "hot_wall_ms_median": 38,
+      "hot_wall_ms_median": 37,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -268,7 +268,7 @@
       }
     },
     "q027": {
-      "hot_wall_ms_median": 1229,
+      "hot_wall_ms_median": 1274,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -288,7 +288,7 @@
       }
     },
     "q029": {
-      "hot_wall_ms_median": 177,
+      "hot_wall_ms_median": 152,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -308,7 +308,7 @@
       }
     },
     "q031": {
-      "hot_wall_ms_median": 200,
+      "hot_wall_ms_median": 196,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -318,7 +318,7 @@
       }
     },
     "q032": {
-      "hot_wall_ms_median": 253,
+      "hot_wall_ms_median": 249,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -338,7 +338,7 @@
       }
     },
     "q034": {
-      "hot_wall_ms_median": 176,
+      "hot_wall_ms_median": 322,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -348,7 +348,7 @@
       }
     },
     "q035": {
-      "hot_wall_ms_median": 1,
+      "hot_wall_ms_median": 0,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -378,7 +378,7 @@
       }
     },
     "q038": {
-      "hot_wall_ms_median": 213,
+      "hot_wall_ms_median": 198,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -398,7 +398,7 @@
       }
     },
     "q040": {
-      "hot_wall_ms_median": 366,
+      "hot_wall_ms_median": 356,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -408,7 +408,7 @@
       }
     },
     "q041": {
-      "hot_wall_ms_median": 302,
+      "hot_wall_ms_median": 294,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -428,7 +428,7 @@
       }
     },
     "q043": {
-      "hot_wall_ms_median": 168,
+      "hot_wall_ms_median": 78,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -438,7 +438,7 @@
       }
     },
     "q044": {
-      "hot_wall_ms_median": 104,
+      "hot_wall_ms_median": 53,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -448,7 +448,7 @@
       }
     },
     "q045": {
-      "hot_wall_ms_median": 149,
+      "hot_wall_ms_median": 147,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -458,7 +458,7 @@
       }
     },
     "q046": {
-      "hot_wall_ms_median": 202,
+      "hot_wall_ms_median": 193,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -468,7 +468,7 @@
       }
     },
     "q047": {
-      "hot_wall_ms_median": 154,
+      "hot_wall_ms_median": 146,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -478,7 +478,7 @@
       }
     },
     "q048": {
-      "hot_wall_ms_median": 229,
+      "hot_wall_ms_median": 217,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -488,7 +488,7 @@
       }
     },
     "q049": {
-      "hot_wall_ms_median": 62,
+      "hot_wall_ms_median": 59,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -498,7 +498,7 @@
       }
     },
     "q050": {
-      "hot_wall_ms_median": 96,
+      "hot_wall_ms_median": 283,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -508,7 +508,7 @@
       }
     },
     "q051": {
-      "hot_wall_ms_median": 475,
+      "hot_wall_ms_median": 471,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -518,7 +518,7 @@
       }
     },
     "q052": {
-      "hot_wall_ms_median": 1177,
+      "hot_wall_ms_median": 1190,
       "counters": {
         "spans": {},
         "files_selected": 0,
@@ -528,7 +528,7 @@
       }
     },
     "q053": {
-      "hot_wall_ms_median": 386,
+      "hot_wall_ms_median": 351,
       "counters": {
         "spans": {},
         "files_selected": 0,

--- a/fluree-bench-virtual/targets/virtual-sf01-stacked.json
+++ b/fluree-bench-virtual/targets/virtual-sf01-stacked.json
@@ -1,0 +1,8 @@
+{
+  "id": "virtual-sf01-stacked",
+  "kind": "virtual",
+  "fluree_home": "/Users/ajohnson/vbench/.fluree",
+  "alias": "enterprise-sf01-v",
+  "description": "Data-identical clone of virtual-sf01 (same fluree_home + alias). Exists only to bless a POST-PR-stack perf baseline (baselines/perf/virtual-sf01-stacked.json) at HEAD 36564e8e6 (PR-2/3/4/4b) WITHOUT clobbering the pre-PR reference in baselines/perf/virtual-sf01.json (blessed 7d77218e2). Expected oracles are query-keyed and target-independent, so `compare` validates a stacked run against the same native oracles. Auth: VBENCH_PAT (ICEBERG_READER, expires 2026-10-08).",
+  "status": "ready"
+}

--- a/fluree-db-api/src/graph_source/crawl.rs
+++ b/fluree-db-api/src/graph_source/crawl.rs
@@ -832,6 +832,7 @@ mod e2e {
             table: &str,
             _projection: &[String],
             _filters: &[ScanFilter],
+            _topk: Option<&fluree_db_query::r2rml::ScanTopK>,
             _as_of_t: Option<i64>,
         ) -> QueryResult<ColumnBatchStream> {
             self.scanned.lock().unwrap().push(table.to_string());

--- a/fluree-db-api/src/graph_source/ephemeral.rs
+++ b/fluree-db-api/src/graph_source/ephemeral.rs
@@ -379,6 +379,7 @@ mod tests {
             table: &str,
             _projection: &[String],
             _filters: &[ScanFilter],
+            _topk: Option<&fluree_db_query::r2rml::ScanTopK>,
             _as_of_t: Option<i64>,
         ) -> QResult<ColumnBatchStream> {
             let batches = self.tables.get(table).cloned().unwrap_or_default();

--- a/fluree-db-api/src/graph_source/ephemeral.rs
+++ b/fluree-db-api/src/graph_source/ephemeral.rs
@@ -250,6 +250,7 @@ impl R2rmlTableProvider for EphemeralR2rmlProvider {
         table_name: &str,
         projection: &[String],
         _filters: &[ScanFilter],
+        _topk: Option<&fluree_db_query::r2rml::ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> QueryResult<ColumnBatchStream> {
         self.scan_provisional_table(table_name, projection).await

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -15,19 +15,31 @@ use fluree_db_iceberg::{
     catalog::{RestCatalogClient, RestCatalogConfig, SendCatalogClient},
     io::{ColumnBatch, S3IcebergStorage, SendIcebergStorage, SendParquetReader},
     metadata::TableMetadata,
-    scan::{ComparisonOp, Expression, FileScanTask, LiteralValue, ScanConfig, SendScanPlanner},
+    scan::{
+        topk::{batch_sort_values, plan_topk_read, TopKBound},
+        ComparisonOp, Expression, FileScanTask, LiteralValue, ScanConfig, SendScanPlanner,
+    },
     stats::{aggregate_column_stats, send_read_snapshot_data_files},
     IcebergGsConfig,
 };
 use fluree_db_nameservice::GraphSourceType;
 use fluree_db_query::error::{QueryError, Result as QueryResult};
 use fluree_db_query::r2rml::{
-    ColumnBatchStream, R2rmlProvider, R2rmlTableProvider, ScanCmpOp, ScanFilter, ScanValue,
+    ColumnBatchStream, R2rmlProvider, R2rmlTableProvider, ScanCmpOp, ScanFilter, ScanTopK,
+    ScanValue,
 };
 use fluree_db_r2rml::mapping::CompiledR2rmlMapping;
 use futures::StreamExt;
 use std::sync::Arc;
 use tracing::{debug, info, warn, Instrument};
+
+/// Max files a scan-side top-k (PR-5) reads SEQUENTIALLY (bound-ordered, with
+/// early-stop) before conceding the prune is ineffective and handing the rest to
+/// the normal bounded-parallel reader. Caps the worst case (adversarial layout /
+/// all files tie at the bound / a heap that never fills) so the topk path can
+/// never be slower than the parallel path it replaces. The win case (q046) reads
+/// ~10-15 files and stops well under this.
+const TOPK_SEQUENTIAL_CAP: usize = 128;
 
 /// How many data files to read concurrently. Defaults to
 /// `min(available_parallelism, files, 32)`; override with
@@ -774,6 +786,7 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
         table_name: &str,
         projection: &[String],
         filters: &[ScanFilter],
+        topk: Option<&ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> QueryResult<ColumnBatchStream> {
         // Time the whole scan SETUP (loadTable + planning) as one span; it closes
@@ -787,9 +800,16 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
             table_name,
             projection_len = projection.len()
         );
-        self.scan_table_inner(graph_source_id, table_name, projection, filters, _as_of_t)
-            .instrument(span)
-            .await
+        self.scan_table_inner(
+            graph_source_id,
+            table_name,
+            projection,
+            filters,
+            topk,
+            _as_of_t,
+        )
+        .instrument(span)
+        .await
     }
 
     /// The table's exact live row count from the pinned Iceberg manifest — **only
@@ -1391,6 +1411,7 @@ impl FlureeR2rmlProvider<'_> {
         table_name: &str,
         projection: &[String],
         filters: &[ScanFilter],
+        topk: Option<&ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> QueryResult<ColumnBatchStream> {
         // GREP: r2rml-as-of-t — time-travel is not implemented for Iceberg scans;
@@ -1596,6 +1617,135 @@ impl FlureeR2rmlProvider<'_> {
         // resident — the consumer (R2rmlScanOperator) materializes and aggregates
         // incrementally instead of the whole table being collected here.
         let footers = cache.parquet_footers();
+
+        // PR-5 scan-side top-k. When a resolvable single-column DESC directive is
+        // present, read files in `upper_bound(sort_col)`-DESC order with a running
+        // k-th bound and stop once no unread file can beat it — streaming a strict
+        // SUPERSET of the top-k (the `SortOperator` above is authoritative). The
+        // pruned subset MUST bypass the operator's scan cache (handled by its
+        // `cacheable` guard gaining `&& topk.is_none()`); the disk *artifact* cache
+        // is keyed by file path+size with whole-file entries, so a pruned subset
+        // never poisons it. Falls through to the parallel path if the sort column
+        // is unresolvable. Sequential reads are bounded by `TOPK_SEQUENTIAL_CAP`:
+        // if the prune is ineffective (adversarial layout / all files tie at the
+        // bound / a heap that can't fill), the remaining files are handed to the
+        // normal parallel reader so the topk path can never be slower than it.
+        if let Some(tk) = topk {
+            if let Some(field) = schema.field_by_name(&tk.sort_column) {
+                let sort_field_id = field.id;
+                let sort_type = field.type_string().map(str::to_string);
+                let order = plan_topk_read(
+                    tasks.iter().map(|t| &t.data_file),
+                    sort_field_id,
+                    sort_type.as_deref(),
+                );
+
+                let mut bound = TopKBound::new(tk.k);
+                let mut collected: Vec<ColumnBatch> = Vec::new();
+                let mut tail: Vec<FileScanTask> = Vec::new();
+                for pos in 0..order.len() {
+                    if pos >= TOPK_SEQUENTIAL_CAP {
+                        // Prune ineffective after the cap — finish in parallel.
+                        tail = order[pos..]
+                            .iter()
+                            .map(|(orig, _)| tasks[*orig].clone())
+                            .collect();
+                        break;
+                    }
+                    let (orig, _) = order[pos];
+                    let read_span = tracing::debug_span!(
+                        "iceberg.parquet_read",
+                        path = %tasks[orig].data_file.file_path,
+                        file_size = tasks[orig].data_file.file_size_in_bytes,
+                    );
+                    let batches = SendParquetReader::with_caches(
+                        storage.as_ref(),
+                        footers.as_ref(),
+                        &disk_cache,
+                        &cache_dir,
+                    )
+                    .read_task(&tasks[orig])
+                    .instrument(read_span)
+                    .await
+                    .map_err(|e| {
+                        QueryError::Internal(format!(
+                            "Failed to read Parquet file '{}': {e}",
+                            tasks[orig].data_file.file_path
+                        ))
+                    })?;
+                    for b in &batches {
+                        bound.observe_all(batch_sort_values(b, sort_field_id));
+                    }
+                    collected.extend(batches);
+                    // Stop iff the heap is full and the NEXT (highest-remaining)
+                    // file's bound is strictly below the k-th (over-keep on ties;
+                    // a no-bound next → never stops). See `TopKBound::can_stop`.
+                    if let Some((_, next_upper)) = order.get(pos + 1) {
+                        if bound.can_stop(next_upper.as_ref()) {
+                            break;
+                        }
+                    }
+                }
+                debug!(
+                    files_read = order.len() - tail.len(),
+                    tail_parallel = tail.len(),
+                    total_files = order.len(),
+                    k = tk.k,
+                    "scan-side top-k read"
+                );
+                let prefix = futures::stream::iter(collected.into_iter().map(Ok));
+                if tail.is_empty() {
+                    return Ok(Box::pin(prefix));
+                }
+                // Parallel fallback tail (same bounded-parallel read as the normal
+                // path). The bound still holds; we just stop paying sequentiality.
+                let concurrency = iceberg_scan_concurrency(tail.len());
+                let tail_stream =
+                    futures::stream::iter(tail)
+                        .map(move |task| {
+                            let storage = Arc::clone(&storage);
+                            let footers = Arc::clone(&footers);
+                            let disk_cache = Arc::clone(&disk_cache);
+                            let cache_dir = cache_dir.clone();
+                            let read_span = tracing::debug_span!(
+                                "iceberg.parquet_read",
+                                path = %task.data_file.file_path,
+                                file_size = task.data_file.file_size_in_bytes,
+                            );
+                            async move {
+                                tokio::spawn(async move {
+                                    let reader = SendParquetReader::with_caches(
+                                        storage.as_ref(),
+                                        footers.as_ref(),
+                                        &disk_cache,
+                                        &cache_dir,
+                                    );
+                                    reader.read_task(&task).instrument(read_span).await.map_err(
+                                        |e| {
+                                            QueryError::Internal(format!(
+                                                "Failed to read Parquet file '{}': {e}",
+                                                task.data_file.file_path
+                                            ))
+                                        },
+                                    )
+                                })
+                                .await
+                                .map_err(|e| {
+                                    QueryError::Internal(format!("Parquet read worker failed: {e}"))
+                                })?
+                            }
+                        })
+                        .buffer_unordered(concurrency)
+                        .flat_map(|res: QueryResult<Vec<ColumnBatch>>| match res {
+                            Ok(batches) => futures::stream::iter(
+                                batches.into_iter().map(Ok).collect::<Vec<_>>(),
+                            ),
+                            Err(e) => futures::stream::iter(vec![Err(e)]),
+                        });
+                return Ok(Box::pin(prefix.chain(tail_stream)));
+            }
+        }
+
         let concurrency = iceberg_scan_concurrency(tasks.len());
         debug!(
             files = tasks.len(),

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -1643,9 +1643,11 @@ impl FlureeR2rmlProvider<'_> {
                 let mut bound = TopKBound::new(tk.k);
                 let mut collected: Vec<ColumnBatch> = Vec::new();
                 let mut tail: Vec<FileScanTask> = Vec::new();
+                let mut reads = 0usize;
                 for pos in 0..order.len() {
                     if pos >= TOPK_SEQUENTIAL_CAP {
-                        // Prune ineffective after the cap — finish in parallel.
+                        // Prune ineffective after the cap — finish in parallel so
+                        // the topk path is never slower than the full parallel scan.
                         tail = order[pos..]
                             .iter()
                             .map(|(orig, _)| tasks[*orig].clone())
@@ -1673,25 +1675,49 @@ impl FlureeR2rmlProvider<'_> {
                             tasks[orig].data_file.file_path
                         ))
                     })?;
+                    // SOUNDNESS INVARIANT: the heap is fed the sort values of the
+                    // rows this scan EMITS — which are the QUALIFYING result rows
+                    // (post any pushed row filter). The directive is declined
+                    // upstream (`resolve_topk_directive`) whenever a RESIDUAL filter
+                    // the operator enforces after this scan is present, because
+                    // feeding pre-filter values would ride the k-th bound too high
+                    // and prune files whose qualifying rows belong in the true
+                    // top-k. Never feed a superset of the qualifying rows here.
                     for b in &batches {
                         bound.observe_all(batch_sort_values(b, sort_field_id));
                     }
                     collected.extend(batches);
+                    reads += 1;
                     // Stop iff the heap is full and the NEXT (highest-remaining)
-                    // file's bound is strictly below the k-th (over-keep on ties;
-                    // a no-bound next → never stops). See `TopKBound::can_stop`.
+                    // file's upper_bound is strictly below the k-th (over-keep on
+                    // ties; a no-bound next → never stops). See `TopKBound::can_stop`.
                     if let Some((_, next_upper)) = order.get(pos + 1) {
                         if bound.can_stop(next_upper.as_ref()) {
                             break;
                         }
                     }
                 }
+
+                // Report the topk file selection through the SAME span the bench
+                // harness sums (`iceberg.scan_plan`) — the planner's span does not
+                // fire on this path, so without this the `files_selected` /
+                // `files_pruned` counters would read 0. `files_selected` is the
+                // files actually read (the sequential prefix plus any parallel
+                // tail); the rest were provably unable to beat the k-th bound.
+                let files_selected = reads + tail.len();
+                let files_pruned = order.len().saturating_sub(files_selected);
+                tracing::debug_span!(
+                    "iceberg.scan_plan",
+                    files_selected = files_selected as u64,
+                    files_pruned = files_pruned as u64,
+                )
+                .in_scope(|| {});
                 debug!(
-                    files_read = order.len() - tail.len(),
-                    tail_parallel = tail.len(),
+                    files_selected,
+                    files_pruned,
                     total_files = order.len(),
                     k = tk.k,
-                    "scan-side top-k read"
+                    "scan-side top-k prune"
                 );
                 let prefix = futures::stream::iter(collected.into_iter().map(Ok));
                 if tail.is_empty() {

--- a/fluree-db-api/tests/it_graph_source_r2rml.rs
+++ b/fluree-db-api/tests/it_graph_source_r2rml.rs
@@ -15,7 +15,7 @@ use fluree_db_iceberg::io::batch::{BatchSchema, Column, ColumnBatch, FieldInfo, 
 use fluree_db_query::error::{QueryError, Result as QueryResult};
 use fluree_db_query::r2rml::{
     convert_triple_to_r2rml, ColumnBatchStream, R2rmlProvider, R2rmlTableProvider, ScanFilter,
-    ScanValue,
+    ScanTopK, ScanValue,
 };
 use fluree_db_r2rml::loader::R2rmlLoader;
 use fluree_db_r2rml::mapping::CompiledR2rmlMapping;
@@ -94,6 +94,7 @@ impl R2rmlTableProvider for MockR2rmlProvider {
         _table_name: &str,
         _projection: &[String],
         _filters: &[ScanFilter],
+        _topk: Option<&ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> QueryResult<ColumnBatchStream> {
         Ok(vec_batch_stream(self.batches.clone()))
@@ -235,7 +236,14 @@ async fn test_mock_r2rml_provider() {
     // Test scan_table
     use futures::StreamExt;
     let batches: Vec<ColumnBatch> = provider
-        .scan_table("test-gs:main", "openflights.airlines", &[], &[], Some(0))
+        .scan_table(
+            "test-gs:main",
+            "openflights.airlines",
+            &[],
+            &[],
+            None,
+            Some(0),
+        )
         .await
         .unwrap()
         .map(|b| b.unwrap())
@@ -952,6 +960,7 @@ impl R2rmlTableProvider for IcebergDirectProvider {
         table_name: &str,
         projection: &[String],
         _filters: &[ScanFilter],
+        _topk: Option<&ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> QueryResult<ColumnBatchStream> {
         use fluree_db_iceberg::{
@@ -1514,6 +1523,7 @@ async fn engine_e2e_split_triples_map_class_and_predicate_not_fused() {
             table: &str,
             _p: &[String],
             _f: &[ScanFilter],
+            _topk: Option<&ScanTopK>,
             _t: Option<i64>,
         ) -> QueryResult<ColumnBatchStream> {
             let batches = if table == "names" {
@@ -1700,6 +1710,7 @@ async fn engine_e2e_provider_method_calls() {
             table_name: &str,
             projection: &[String],
             _filters: &[ScanFilter],
+            _topk: Option<&ScanTopK>,
             _as_of_t: Option<i64>,
         ) -> QueryResult<ColumnBatchStream> {
             eprintln!(
@@ -2452,6 +2463,7 @@ impl R2rmlTableProvider for MultiTableMockProvider {
         table_name: &str,
         _projection: &[String],
         _filters: &[ScanFilter],
+        _topk: Option<&ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> QueryResult<ColumnBatchStream> {
         eprintln!("MultiTableMockProvider.scan_table: {table_name}");
@@ -2689,6 +2701,7 @@ impl R2rmlTableProvider for RecordingTableProvider {
         table_name: &str,
         _projection: &[String],
         _filters: &[ScanFilter],
+        _topk: Option<&ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> QueryResult<ColumnBatchStream> {
         self.scanned.lock().unwrap().push(table_name.to_string());
@@ -3389,6 +3402,7 @@ impl R2rmlTableProvider for CountingProvider {
         table_name: &str,
         projection: &[String],
         _filters: &[ScanFilter],
+        _topk: Option<&ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> QueryResult<ColumnBatchStream> {
         let mut proj = projection.to_vec();
@@ -3860,6 +3874,7 @@ impl R2rmlTableProvider for LimitProbeProvider {
         _table_name: &str,
         _projection: &[String],
         _filters: &[ScanFilter],
+        _topk: Option<&ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> QueryResult<ColumnBatchStream> {
         use futures::StreamExt;
@@ -3933,6 +3948,7 @@ impl R2rmlTableProvider for FilterCapturingProvider {
         _table_name: &str,
         _projection: &[String],
         filters: &[ScanFilter],
+        _topk: Option<&ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> QueryResult<ColumnBatchStream> {
         use futures::StreamExt;

--- a/fluree-db-iceberg/src/scan/mod.rs
+++ b/fluree-db-iceberg/src/scan/mod.rs
@@ -11,9 +11,11 @@ pub mod predicate;
 pub mod pruning;
 #[cfg(feature = "aws")]
 pub mod send_planner;
+pub mod topk;
 
 pub use planner::{FileScanTask, ScanConfig, ScanPlan, ScanPlanner};
 pub use predicate::{ComparisonOp, Expression, LiteralValue};
 pub use pruning::{can_contain_file, can_contain_partition};
 #[cfg(feature = "aws")]
 pub use send_planner::SendScanPlanner;
+pub use topk::{TopKBound, TopKConfig};

--- a/fluree-db-iceberg/src/scan/topk.rs
+++ b/fluree-db-iceberg/src/scan/topk.rs
@@ -1,0 +1,449 @@
+//! Scan-side top-k bound engine (PR-5).
+//!
+//! For a single-column DESCENDING `ORDER BY … LIMIT k` pushed to the scan, the
+//! reader visits files in `upper_bound(sort_col)`-DESC order and maintains the
+//! running k-th bound (the smallest of the k largest sort values seen so far).
+//! Once the heap is full, any *unread* file whose `upper_bound` is strictly below
+//! that bound cannot contain a top-k row, so — because files are visited in
+//! bound-DESC order — the reader stops.
+//!
+//! # Soundness (strict-superset, like [`crate::scan::pruning`])
+//!
+//! - **Prune only when the heap is full** (k non-null values seen). With fewer
+//!   than k non-null rows the bound never forms, nothing stops, every file is
+//!   read, and NULL-ordered rows (which sort last under DESC) legitimately reach
+//!   the authoritative sort above.
+//! - **A file with no `upper_bound` for the sort column (an all-NULL column)
+//!   never stops the scan** (`can_stop` returns false on a `None` next bound).
+//! - **Strict `<`** at the boundary: a file whose `upper_bound` *equals* the k-th
+//!   bound is read (a tie could belong in the result; the sort above resolves the
+//!   exact order). The engine therefore over-keeps, never over-prunes.
+//!
+//! DESC only. ASC is declined upstream (SPARQL orders unbound values *first* in
+//! ASC, so a NULL-bearing file can never be pruned — not a clean mirror).
+
+use crate::io::batch::{Column, ColumnBatch};
+use crate::manifest::value_codec::TypedValue;
+use crate::manifest::{decode_by_type_string, DataFile};
+use std::cmp::{Ordering, Reverse};
+use std::collections::BinaryHeap;
+
+/// Directive handed to the scan for a single-column DESC top-k pushdown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TopKConfig {
+    /// Iceberg field id of the primary DESC sort column.
+    pub sort_field_id: i32,
+    /// How many top rows the bound must retain — the query's `LIMIT + OFFSET`.
+    pub k: usize,
+}
+
+/// Total-order wrapper over a same-typed `TypedValue` for heap ordering. In
+/// practice one column has one type; `partial_cmp` is total except for float
+/// NaN, which we fold to `Equal` (a NaN sort key only ever *weakens* pruning —
+/// the file-bound compare is NaN-safe and keeps — never breaks correctness).
+#[derive(Debug, Clone)]
+struct OrdKey(TypedValue);
+
+impl PartialEq for OrdKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+impl Eq for OrdKey {}
+impl PartialOrd for OrdKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for OrdKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.partial_cmp(&other.0).unwrap_or(Ordering::Equal)
+    }
+}
+
+/// The running k-th bound over the sort column's non-null values.
+#[derive(Debug)]
+pub struct TopKBound {
+    k: usize,
+    /// Min-heap of the k largest values seen — the root is the current k-th
+    /// (smallest retained) value once full.
+    heap: BinaryHeap<Reverse<OrdKey>>,
+}
+
+impl TopKBound {
+    pub fn new(k: usize) -> Self {
+        Self {
+            k,
+            heap: BinaryHeap::with_capacity(k.saturating_add(1)),
+        }
+    }
+
+    /// Fold one non-null sort value into the running top-k.
+    pub fn observe(&mut self, v: TypedValue) {
+        if self.k == 0 {
+            return;
+        }
+        if self.heap.len() < self.k {
+            self.heap.push(Reverse(OrdKey(v)));
+            return;
+        }
+        // Replace the current k-th (smallest retained) if v is strictly larger.
+        if let Some(Reverse(min)) = self.heap.peek() {
+            if OrdKey(v.clone()).cmp(min) == Ordering::Greater {
+                self.heap.pop();
+                self.heap.push(Reverse(OrdKey(v)));
+            }
+        }
+    }
+
+    /// Fold every non-null value of one file.
+    pub fn observe_all(&mut self, vals: impl IntoIterator<Item = TypedValue>) {
+        for v in vals {
+            self.observe(v);
+        }
+    }
+
+    /// True once k non-null values have been seen — the precondition for any prune.
+    pub fn is_full(&self) -> bool {
+        self.heap.len() >= self.k && self.k > 0
+    }
+
+    /// The k-th bound (smallest of the retained top-k), or `None` until full.
+    pub fn kth(&self) -> Option<&TypedValue> {
+        if self.is_full() {
+            self.heap.peek().map(|Reverse(OrdKey(v))| v)
+        } else {
+            None
+        }
+    }
+
+    /// Whether the scan may stop before reading the next file, whose (highest
+    /// remaining) `upper_bound` is `next_upper`. Stop iff the heap is full and
+    /// `next_upper` is strictly below the k-th bound. A `None` next bound (all-NULL
+    /// column / missing stats) never stops (must read); a tie (`==`) never stops
+    /// (over-keep); a NaN compare never stops (`lt` → None → false).
+    pub fn can_stop(&self, next_upper: Option<&TypedValue>) -> bool {
+        match (self.kth(), next_upper) {
+            (Some(kth), Some(u)) => u.lt(kth).unwrap_or(false),
+            _ => false,
+        }
+    }
+}
+
+/// Plan the DESC top-k read order over a set of data files: pairs of
+/// `(original_index, decoded upper_bound of the sort column)` sorted so the
+/// highest `upper_bound` is read first and **files with no `upper_bound` (an
+/// all-NULL column or missing stats) come LAST** — they can never stop the scan
+/// (see [`TopKBound::can_stop`]) and must be read. The read loop visits the
+/// returned order and, after each file, consults the NEXT pair's bound to decide
+/// whether to stop.
+pub fn plan_topk_read<'a>(
+    data_files: impl Iterator<Item = &'a DataFile>,
+    sort_field_id: i32,
+    sort_type: Option<&str>,
+) -> Vec<(usize, Option<TypedValue>)> {
+    let mut order: Vec<(usize, Option<TypedValue>)> = data_files
+        .enumerate()
+        .map(|(i, df)| {
+            let bound = df
+                .upper_bound(sort_field_id)
+                .and_then(|bytes| decode_by_type_string(bytes, sort_type).ok());
+            (i, bound)
+        })
+        .collect();
+    order.sort_by(|(_, a), (_, b)| match (a, b) {
+        // DESC by value; a stable sort preserves the manifest order within ties.
+        (Some(x), Some(y)) => y.partial_cmp(x).unwrap_or(Ordering::Equal),
+        (Some(_), None) => Ordering::Less, // bound-present before no-bound
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    });
+    order
+}
+
+/// The non-null values of column `field_id` in a batch, as `TypedValue`s, to fold
+/// into a [`TopKBound`]. NULLs are skipped (they never form the DESC bound; they
+/// sort last and only matter when the heap can't fill). `Bytes` is not an ordered
+/// pushable key, so it yields nothing (the bound stays loose → conservative).
+pub fn batch_sort_values(batch: &ColumnBatch, field_id: i32) -> Vec<TypedValue> {
+    let Some(col) = batch.column_by_id(field_id) else {
+        return Vec::new();
+    };
+    match col {
+        Column::Boolean(v) => v
+            .iter()
+            .flatten()
+            .map(|&x| TypedValue::Boolean(x))
+            .collect(),
+        Column::Int32(v) => v.iter().flatten().map(|&x| TypedValue::Int32(x)).collect(),
+        Column::Int64(v) => v.iter().flatten().map(|&x| TypedValue::Int64(x)).collect(),
+        Column::Float32(v) => v
+            .iter()
+            .flatten()
+            .map(|&x| TypedValue::Float32(x))
+            .collect(),
+        Column::Float64(v) => v
+            .iter()
+            .flatten()
+            .map(|&x| TypedValue::Float64(x))
+            .collect(),
+        Column::String(v) => v
+            .iter()
+            .flatten()
+            .map(|x| TypedValue::String(x.clone()))
+            .collect(),
+        Column::Date(v) => v.iter().flatten().map(|&x| TypedValue::Date(x)).collect(),
+        Column::Timestamp(v) => v
+            .iter()
+            .flatten()
+            .map(|&x| TypedValue::Timestamp(x))
+            .collect(),
+        Column::TimestampTz(v) => v
+            .iter()
+            .flatten()
+            .map(|&x| TypedValue::TimestampTz(x))
+            .collect(),
+        Column::Decimal {
+            values,
+            precision,
+            scale,
+        } => values
+            .iter()
+            .flatten()
+            .map(|&unscaled| TypedValue::Decimal {
+                unscaled,
+                precision: *precision,
+                scale: *scale,
+            })
+            .collect(),
+        Column::Bytes(_) => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn f(v: f64) -> TypedValue {
+        TypedValue::Float64(v)
+    }
+
+    #[test]
+    fn bound_forms_only_when_full() {
+        let mut b = TopKBound::new(3);
+        assert!(!b.is_full());
+        assert_eq!(b.kth(), None);
+        b.observe(f(10.0));
+        b.observe(f(20.0));
+        assert!(!b.is_full(), "2 < k=3");
+        assert_eq!(
+            b.kth(),
+            None,
+            "no bound until full → can't prune (k>non-null)"
+        );
+        b.observe(f(30.0));
+        assert!(b.is_full());
+        assert_eq!(b.kth(), Some(&f(10.0)), "k-th = smallest of the top-3");
+    }
+
+    #[test]
+    fn larger_values_evict_the_kth() {
+        let mut b = TopKBound::new(3);
+        b.observe_all([f(10.0), f(20.0), f(30.0)]);
+        assert_eq!(b.kth(), Some(&f(10.0)));
+        b.observe(f(25.0)); // evicts 10 → top-3 {20,25,30}, k-th = 20
+        assert_eq!(b.kth(), Some(&f(20.0)));
+        b.observe(f(5.0)); // below k-th → ignored
+        assert_eq!(b.kth(), Some(&f(20.0)));
+        b.observe(f(100.0)); // evicts 20 → {25,30,100}, k-th = 25
+        assert_eq!(b.kth(), Some(&f(25.0)));
+    }
+
+    #[test]
+    fn can_stop_semantics() {
+        let mut b = TopKBound::new(3);
+        // Not full → never stop, whatever the next bound.
+        assert!(!b.can_stop(Some(&f(1.0))));
+        b.observe_all([f(10.0), f(20.0), f(30.0)]); // k-th = 10
+                                                    // next strictly below k-th → STOP.
+        assert!(b.can_stop(Some(&f(9.999))));
+        // next equal to k-th → do NOT stop (tie over-keep).
+        assert!(!b.can_stop(Some(&f(10.0))));
+        // next above k-th → do NOT stop.
+        assert!(!b.can_stop(Some(&f(11.0))));
+        // no bound (all-null column) → never stop (must read).
+        assert!(!b.can_stop(None));
+    }
+
+    #[test]
+    fn k_zero_is_inert() {
+        let mut b = TopKBound::new(0);
+        b.observe(f(10.0));
+        assert!(!b.is_full());
+        assert_eq!(b.kth(), None);
+        assert!(!b.can_stop(Some(&f(1.0))));
+    }
+
+    #[test]
+    fn nan_never_over_prunes() {
+        // A NaN sort value folded in must not produce a bound that prunes a file
+        // holding real values (the file-bound compare stays NaN-safe → keep).
+        let mut b = TopKBound::new(2);
+        b.observe(f(f64::NAN));
+        b.observe(f(5.0));
+        // Full (2 values), but the k-th may be NaN; a NaN k-th makes `u.lt(NaN)`
+        // return None → unwrap_or(false) → never stop. Conservative.
+        assert!(!b.can_stop(Some(&f(1.0))) || b.kth() == Some(&f(5.0)));
+    }
+
+    fn df_with_upper(field_id: i32, upper: Option<f64>, null_count: i64) -> DataFile {
+        use std::collections::HashMap;
+        let upper_bounds = upper.map(|u| {
+            let mut m = HashMap::new();
+            m.insert(field_id, u.to_le_bytes().to_vec());
+            m
+        });
+        let null_value_counts = {
+            let mut m = HashMap::new();
+            m.insert(field_id, null_count);
+            Some(m)
+        };
+        DataFile {
+            file_path: "t.parquet".to_string(),
+            file_format: crate::manifest::FileFormat::Parquet,
+            record_count: 10,
+            file_size_in_bytes: 1,
+            partition: crate::manifest::PartitionData::default(),
+            column_sizes: None,
+            value_counts: None,
+            null_value_counts,
+            nan_value_counts: None,
+            lower_bounds: None,
+            upper_bounds,
+            split_offsets: None,
+            sort_order_id: None,
+        }
+    }
+
+    #[test]
+    fn plan_orders_desc_with_no_bound_last() {
+        let dfs = vec![
+            df_with_upper(1, Some(10.0), 0), // 0
+            df_with_upper(1, Some(30.0), 0), // 1
+            df_with_upper(1, None, 5),       // 2 — all-null column, no upper_bound
+            df_with_upper(1, Some(20.0), 0), // 3
+        ];
+        let order = plan_topk_read(dfs.iter(), 1, Some("double"));
+        let idxs: Vec<usize> = order.iter().map(|(i, _)| *i).collect();
+        // DESC by upper_bound: 30(1), 20(3), 10(0); the no-bound file (2) LAST.
+        assert_eq!(idxs, vec![1, 3, 0, 2]);
+        assert_eq!(order.last().unwrap().1, None, "all-null file has no bound");
+    }
+
+    #[test]
+    fn extract_skips_nulls() {
+        use crate::io::batch::{BatchSchema, FieldInfo, FieldType};
+        use std::sync::Arc;
+        let schema = Arc::new(BatchSchema::new(vec![FieldInfo {
+            name: "tot".to_string(),
+            field_type: FieldType::Float64,
+            nullable: true,
+            field_id: 7,
+        }]));
+        let col = Column::Float64(vec![Some(4999.9), None, Some(4999.6), None]);
+        let batch = ColumnBatch::new(schema, vec![col]).unwrap();
+        assert_eq!(batch_sort_values(&batch, 7), vec![f(4999.9), f(4999.6)]);
+        assert!(
+            batch_sort_values(&batch, 99).is_empty(),
+            "unknown field → empty (conservative)"
+        );
+    }
+
+    /// End-to-end pure simulation of the read loop: prune the low files after the
+    /// heap fills with the top-k. Proves the early-stop reads only the files
+    /// holding the top-k.
+    #[test]
+    fn read_loop_prunes_after_heap_fills() {
+        let vals = vec![
+            vec![Some(4999.98), Some(100.0)], // 0: holds the max
+            vec![Some(4999.60), Some(50.0)],  // 1: holds the 2nd
+            vec![Some(3000.0), Some(10.0)],   // 2: below the top-2 once full
+            vec![None, None],                 // 3: all-null
+        ];
+        let dfs = vec![
+            df_with_upper(1, Some(4999.98), 0),
+            df_with_upper(1, Some(4999.60), 0),
+            df_with_upper(1, Some(3000.0), 0),
+            df_with_upper(1, None, 2),
+        ];
+        let order = plan_topk_read(dfs.iter(), 1, Some("double"));
+        let mut bound = TopKBound::new(2);
+        let mut read = 0usize;
+        for pos in 0..order.len() {
+            let (orig, _) = order[pos];
+            read += 1;
+            bound.observe_all(vals[orig].iter().flatten().map(|&x| f(x)));
+            if let Some((_, next_upper)) = order.get(pos + 1) {
+                if bound.can_stop(next_upper.as_ref()) {
+                    break;
+                }
+            }
+        }
+        assert_eq!(
+            read, 2,
+            "read only the 2 files holding the top-2; pruned the rest"
+        );
+        assert_eq!(bound.kth(), Some(&f(4999.60)));
+    }
+
+    /// k exceeds the non-null count → the heap never fills → nothing prunes → every
+    /// file is read, including the all-null file (NULL-ordered rows must reach the
+    /// authoritative sort). Rider 1.
+    #[test]
+    fn read_loop_reads_all_when_k_exceeds_nonnull() {
+        let vals = vec![vec![Some(5.0)], vec![Some(3.0)], vec![None]];
+        let dfs = vec![
+            df_with_upper(1, Some(5.0), 0),
+            df_with_upper(1, Some(3.0), 0),
+            df_with_upper(1, None, 1), // all-null
+        ];
+        let order = plan_topk_read(dfs.iter(), 1, Some("double"));
+        let mut bound = TopKBound::new(5); // k=5 > 2 non-null values
+        let mut read = 0usize;
+        for pos in 0..order.len() {
+            let (orig, _) = order[pos];
+            read += 1;
+            bound.observe_all(vals[orig].iter().flatten().map(|&x| f(x)));
+            if let Some((_, next_upper)) = order.get(pos + 1) {
+                if bound.can_stop(next_upper.as_ref()) {
+                    break;
+                }
+            }
+        }
+        assert_eq!(read, 3, "no prune when heap can't fill → all files read");
+        assert!(!bound.is_full());
+    }
+
+    #[test]
+    fn works_for_int_and_string_keys() {
+        let mut bi = TopKBound::new(2);
+        bi.observe_all([
+            TypedValue::Int64(3),
+            TypedValue::Int64(9),
+            TypedValue::Int64(5),
+        ]);
+        assert_eq!(bi.kth(), Some(&TypedValue::Int64(5)));
+        assert!(bi.can_stop(Some(&TypedValue::Int64(4))));
+        assert!(!bi.can_stop(Some(&TypedValue::Int64(5))));
+
+        let mut bs = TopKBound::new(2);
+        bs.observe_all([
+            TypedValue::String("apple".into()),
+            TypedValue::String("mango".into()),
+            TypedValue::String("cherry".into()),
+        ]);
+        // top-2 by value: mango, cherry; k-th = cherry.
+        assert_eq!(bs.kth(), Some(&TypedValue::String("cherry".into())));
+        assert!(bs.can_stop(Some(&TypedValue::String("banana".into()))));
+    }
+}

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -3380,6 +3380,21 @@ pub(crate) fn apply_solution_modifiers(
                 (Some(limit), None) => limit,
                 _ => 0,
             };
+            // PR-5: offer the primary DESC sort key + k to the row-preserving scan
+            // below, so a single-column `ORDER BY DESC(<scan col>) LIMIT k` over an
+            // R2RML scan can read only the files that can hold the top-k. Offered
+            // only for a DESCENDING primary key (ASC declines — SPARQL orders
+            // unbound first, so a null-bearing file can't be pruned); the scan
+            // honors it ONLY if the key resolves to a single scalar scan column,
+            // else no-op. Pure optimization — this `SortOperator` remains the
+            // authority for the exact (compound) order + LIMIT.
+            if can_topk {
+                if let Some(primary) = ordering.first() {
+                    if primary.direction == crate::sort::SortDirection::Descending {
+                        operator.set_topk(primary.var, k);
+                    }
+                }
+            }
             let mut sort_op = if can_topk {
                 SortOperator::new_topk(operator, ordering.to_vec(), k)
             } else {

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -3447,6 +3447,70 @@ mod tests {
     use fluree_db_core::Sid;
     use fluree_graph_json_ld::ParsedContext;
 
+    /// PR-5: the scan-side top-k directive offered to the child must carry
+    /// `k = LIMIT + OFFSET`, not `LIMIT` — the scan has to retain enough rows for
+    /// the OFFSET the sort above then skips, or `ORDER BY DESC … LIMIT k OFFSET m`
+    /// would silently drop the rows at positions `k+1..=k+m`. This locks the
+    /// single-owner `+offset` arithmetic against a future edit that moves or
+    /// duplicates it. (A pure `ORDER BY DESC LIMIT` with no residual filter still
+    /// pushes topk, so this arithmetic is live even though q046 has offset 0.)
+    #[test]
+    fn topk_directive_carries_limit_plus_offset() {
+        use crate::binding::Batch;
+        use crate::context::ExecutionContext;
+        use crate::error::Result as QResult;
+        use crate::operator::{BoxedOperator, Operator};
+        use std::sync::{Arc, Mutex};
+
+        struct RecordingTopkOp {
+            schema: Vec<VarId>,
+            recorded: Arc<Mutex<Option<(VarId, usize)>>>,
+        }
+        #[async_trait::async_trait]
+        impl Operator for RecordingTopkOp {
+            fn schema(&self) -> &[VarId] {
+                &self.schema
+            }
+            async fn open(&mut self, _ctx: &ExecutionContext<'_>) -> QResult<()> {
+                Ok(())
+            }
+            async fn next_batch(&mut self, _ctx: &ExecutionContext<'_>) -> QResult<Option<Batch>> {
+                Ok(None)
+            }
+            fn close(&mut self) {}
+            fn set_topk(&mut self, sort_var: VarId, k: usize) {
+                *self.recorded.lock().unwrap() = Some((sort_var, k));
+            }
+        }
+
+        let recorded = Arc::new(Mutex::new(None));
+        let op: BoxedOperator = Box::new(RecordingTopkOp {
+            schema: vec![VarId(0), VarId(1)],
+            recorded: Arc::clone(&recorded),
+        });
+        let planning = crate::temporal_mode::PlanningContext::current();
+        // ORDER BY DESC(?1) LIMIT 10 OFFSET 5.
+        let _tree = apply_solution_modifiers(
+            op,
+            None,
+            &[],
+            &[SortSpec::desc(VarId(1))],
+            None,
+            false,
+            Some(5),
+            Some(10),
+            false,
+            None,
+            &planning,
+        )
+        .expect("apply_solution_modifiers");
+        assert_eq!(
+            *recorded.lock().unwrap(),
+            Some((VarId(1), 15)),
+            "k must be LIMIT(10) + OFFSET(5) = 15, so the scan retains the offset rows the sort then skips"
+        );
+    }
+
     fn make_pattern(s_var: VarId, p_name: &str, o_var: VarId) -> TriplePattern {
         TriplePattern::new(
             Ref::Var(s_var),

--- a/fluree-db-query/src/graph.rs
+++ b/fluree-db-query/src/graph.rs
@@ -102,6 +102,14 @@ pub struct GraphOperator {
     /// under a GRAPH wrapper (notably an R2RML graph source) can early-terminate
     /// instead of draining the whole table into `result_buffer`.
     row_budget: Option<usize>,
+    /// Scan-side top-k directive (PR-5): `(primary DESC sort var, LIMIT+OFFSET)`,
+    /// threaded into the per-parent inner subplan exactly like `row_budget` so a
+    /// `ORDER BY DESC(<scan col>) LIMIT k` above a GRAPH wrapper (an R2RML graph
+    /// source) reaches the inner scan. Per-partition top-k is sound: any global
+    /// top-k row from partition p is among p's k largest, so the global top-k is a
+    /// subset of the union of the per-partition results (the authoritative sort
+    /// above re-selects the exact k).
+    topk: Option<(VarId, usize)>,
     /// Plan-time decision: seed the enumerated graph variable into the inner
     /// subplan. True only when the inner patterns bind the graph var in EVERY
     /// solution (required top-level triple / property path / slice-free
@@ -170,6 +178,7 @@ impl GraphOperator {
             buffer_pos: 0,
             planning,
             row_budget: None,
+            topk: None,
             seed_graph_var,
         }
     }
@@ -347,6 +356,9 @@ impl GraphOperator {
         if let Some(budget) = self.row_budget {
             inner.set_row_budget(budget);
         }
+        if let Some((sort_var, k)) = self.topk {
+            inner.set_topk(sort_var, k);
+        }
         inner.open(&graph_ctx).await?;
 
         // NumBig arena handles are scoped per (graph, predicate). When this
@@ -523,6 +535,9 @@ impl GraphOperator {
         if let Some(budget) = self.row_budget {
             inner.set_row_budget(budget);
         }
+        if let Some((sort_var, k)) = self.topk {
+            inner.set_topk(sort_var, k);
+        }
         inner.open(&graph_ctx).await?;
 
         let numbig_exit_gv = if graph_ctx.binary_g_id != ctx.binary_g_id {
@@ -627,6 +642,13 @@ impl Operator for GraphOperator {
         // produces parent rows that seed the correlated inner execution, which is
         // not row-preserving, so it must still yield every row the inner needs.
         self.row_budget = Some(budget);
+    }
+
+    fn set_topk(&mut self, sort_var: VarId, k: usize) {
+        // Record the top-k directive; threaded into the per-parent inner subplan
+        // (like `row_budget`). NOT forwarded to `self.child` (the parent seed is
+        // not the scan). Per-partition top-k is sound (see the field doc).
+        self.topk = Some((sort_var, k));
     }
 
     async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {

--- a/fluree-db-query/src/operator.rs
+++ b/fluree-db-query/src/operator.rs
@@ -97,6 +97,16 @@ pub trait Operator: Send + Sync {
     /// never inside fused per-row/per-group loops (hot-loop purity).
     fn set_row_budget(&mut self, _budget: usize) {}
 
+    /// Offer a scan-side top-k directive (PR-5): a single-column DESC `ORDER BY
+    /// <sort_var> LIMIT k` sits directly above a row-preserving operator chain
+    /// down to a single R2RML scan. Default no-op; only the R2RML scan honors it
+    /// (and only when `sort_var` resolves to a scalar scan column). Order-
+    /// preserving pass-through operators forward it to their child so it reaches
+    /// the scan. It is a pure optimization — a scan may then read only the files
+    /// that can hold the top-k — and never changes results (the `Sort` above is
+    /// authoritative). Set **before** `open()`.
+    fn set_topk(&mut self, _sort_var: VarId, _k: usize) {}
+
     // ------------------------------------------------------------------
     // EXPLAIN introspection (never called on the hot path)
     // ------------------------------------------------------------------

--- a/fluree-db-query/src/optional.rs
+++ b/fluree-db-query/src/optional.rs
@@ -2491,6 +2491,7 @@ mod tests {
                 table: &str,
                 _proj: &[String],
                 _filters: &[ScanFilter],
+                _topk: Option<&crate::r2rml::ScanTopK>,
                 _t: Option<i64>,
             ) -> Result<ColumnBatchStream> {
                 // products: PID 1 (FK 10 -> exists) and PID 2 (FK 99 -> DANGLING).
@@ -2706,6 +2707,7 @@ mod tests {
                 table: &str,
                 _proj: &[String],
                 _filters: &[ScanFilter],
+                _topk: Option<&crate::r2rml::ScanTopK>,
                 _t: Option<i64>,
             ) -> Result<ColumnBatchStream> {
                 // shipments: SH 100/101 → order 1 (TWO → cartesian); 102 → order 3

--- a/fluree-db-query/src/project.rs
+++ b/fluree-db-query/src/project.rs
@@ -59,6 +59,12 @@ impl Operator for ProjectOperator {
         self.child.set_row_budget(budget);
     }
 
+    fn set_topk(&mut self, sort_var: crate::var_registry::VarId, k: usize) {
+        // Projection is row- and order-preserving, so a top-k directive passes
+        // straight through to the scan below (mirrors `set_row_budget`).
+        self.child.set_topk(sort_var, k);
+    }
+
     async fn next_batch(&mut self, ctx: &ExecutionContext<'_>) -> Result<Option<Batch>> {
         if !self.state.can_next() {
             if self.state == OperatorState::Created {

--- a/fluree-db-query/src/r2rml/fused_aggregate.rs
+++ b/fluree-db-query/src/r2rml/fused_aggregate.rs
@@ -1029,6 +1029,7 @@ impl Operator for FusedR2rmlAggregateOperator {
                 &resolved.table_name,
                 &resolved.projection,
                 &[],
+                None,
                 as_of_t,
             )
             .await?;
@@ -1768,7 +1769,7 @@ impl FusedR2rmlAggregateOperator {
             std::collections::HashMap::new();
         {
             let mut s = table_provider
-                .scan_table(gs, &terminal_table, &terminal_proj, &[], as_of_t)
+                .scan_table(gs, &terminal_table, &terminal_proj, &[], None, as_of_t)
                 .await?;
             while let Some(batch) = s.next().await {
                 let batch = batch?;
@@ -1819,7 +1820,7 @@ impl FusedR2rmlAggregateOperator {
             let mut next_map: std::collections::HashMap<Vec<String>, Vec<GKey>> =
                 std::collections::HashMap::new();
             let mut s = table_provider
-                .scan_table(gs, &inter_table, &proj, &[], as_of_t)
+                .scan_table(gs, &inter_table, &proj, &[], None, as_of_t)
                 .await?;
             while let Some(batch) = s.next().await {
                 let batch = batch?;

--- a/fluree-db-query/src/r2rml/mod.rs
+++ b/fluree-db-query/src/r2rml/mod.rs
@@ -30,7 +30,7 @@ pub use fused_aggregate::{detect_fused_r2rml_aggregate, FusedR2rmlAggregateOpera
 pub use operator::{R2rmlParentMemo, R2rmlScanOperator};
 pub use provider::{
     ColumnBatchStream, NoOpR2rmlProvider, ObjectConstant, R2rmlProvider, R2rmlTableProvider,
-    ScanCmpOp, ScanFilter, ScanValue,
+    ScanCmpOp, ScanFilter, ScanTopK, ScanValue,
 };
 pub use rewrite::{
     convert_triple_to_r2rml, rewrite_patterns_for_r2rml, unsupported_subscope_error,

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -556,6 +556,11 @@ impl R2rmlScanOperator {
     /// LIMIT, so a `None` here is only a missed optimization, never wrong.
     fn resolve_topk_directive(&self, triples_map: &TriplesMap) -> Option<crate::r2rml::ScanTopK> {
         let (sort_var, k) = self.topk?;
+        // SOUNDNESS (heap feed): decline when a residual filter the operator
+        // enforces after the scan is present — the heap would see pre-filter rows.
+        if topk_residual_filter_present(&self.pattern) {
+            return None;
+        }
         let pred_iri = if Some(sort_var) == self.pattern.object_var {
             self.pattern.predicate_filter.as_deref()
         } else {
@@ -969,6 +974,15 @@ impl R2rmlScanOperator {
             // the directive — replaying that subset for a later FULL scan of the
             // same table+projection would silently drop rows (the exact silent-
             // wrong class the differential's second-scan case guards).
+            //
+            // The bypass keys on the STORED directive (`self.topk`), NOT the
+            // resolved one: when `resolve_topk_directive` DECLINES (a residual
+            // filter, below), `self.topk` is still `Some` so `cacheable` is false,
+            // but `main_scan_topk` is `None` so the scan runs FULL. That full scan
+            // then merely skips the cache — a missed optimization, never wrong. The
+            // load-bearing invariant is one-directional: NO path that could return
+            // a pruned subset (`self.topk.is_some()`) is ever cacheable, so a
+            // pruned result can never poison the `(table, projection)` cache.
             let main_scan_topk = self.resolve_topk_directive(triples_map);
             let cacheable = scan_cache_enabled()
                 && scan_filters.is_empty()
@@ -1659,6 +1673,21 @@ fn value_pushdown_column(om: &ObjectMap) -> Option<&str> {
         ObjectMap::Column { column, .. } => Some(column.as_str()),
         _ => None,
     }
+}
+
+/// Whether a pattern carries a RESIDUAL filter — one the operator enforces per
+/// row AFTER the scan emits (a folded `consumed_filter`, a constant object or
+/// subject, or a same-subject star existence constraint). The scan-side top-k
+/// heap is fed the scan's EMITTED rows; a residual filter means those include
+/// rows that don't survive to the result, so the k-th bound would ride too high
+/// and prune files whose qualifying rows belong in the true top-k. When true, the
+/// top-k pushdown MUST be declined (→ full sort). Pushed `scan_filters` are NOT
+/// residual — the reader applies them, so the emitted batch is already filtered.
+fn topk_residual_filter_present(pattern: &R2rmlPattern) -> bool {
+    pattern.consumed_filter.is_some()
+        || pattern.object_constant.is_some()
+        || pattern.subject_constant.is_some()
+        || !pattern.star_constraints.is_empty()
 }
 
 /// Datatype IRI declared by an ObjectMap, if any (column/template/constant).
@@ -2448,6 +2477,41 @@ mod tests {
     use crate::r2rml::{ObjectConstant, ScanValue};
     use fluree_db_r2rml::mapping::{ObjectMap, PredicateMap, PredicateObjectMap};
     use fluree_db_r2rml::materialize::RdfTerm;
+
+    /// PR-5 soundness: the top-k pushdown must be declined whenever the scan
+    /// carries a residual filter the operator enforces after emitting rows —
+    /// otherwise the heap is fed pre-filter values and could prune files whose
+    /// qualifying rows belong in the true top-k (silently dropping rows). A pure
+    /// value scan (q046 shape) is eligible; a folded FILTER, a constant
+    /// object/subject, or a same-subject star existence constraint declines.
+    #[test]
+    fn topk_declines_on_residual_filter() {
+        let base = R2rmlPattern::new("gs:main", VarId(1), Some(VarId(2)))
+            .with_predicate("http://ex/orderTotal");
+        assert!(
+            !topk_residual_filter_present(&base),
+            "pure value scan is eligible"
+        );
+
+        let mut folded_filter = base.clone();
+        folded_filter.consumed_filter = Some(crate::ir::Expression::Var(VarId(7)));
+        assert!(topk_residual_filter_present(&folded_filter));
+
+        let mut const_object = base.clone();
+        const_object.object_constant = Some(ObjectConstant::Iri("http://ex/x".to_string()));
+        assert!(topk_residual_filter_present(&const_object));
+
+        let mut bound_subject = base.clone();
+        bound_subject.subject_constant = Some("http://ex/o/1".to_string());
+        assert!(topk_residual_filter_present(&bound_subject));
+
+        let mut star_constraint = base.clone();
+        star_constraint.star_constraints = vec![(
+            "http://ex/isCurrent".to_string(),
+            ObjectConstant::Scalar(ScanValue::Bool(true)),
+        )];
+        assert!(topk_residual_filter_present(&star_constraint));
+    }
 
     fn pom(pred: &str, col: &str) -> PredicateObjectMap {
         PredicateObjectMap {
@@ -3321,6 +3385,64 @@ mod tests {
                 provider.scans.lock().unwrap().get("customers").copied().unwrap_or(0),
                 2,
                 "two graph sources ⇒ two parent scans (graph_source_id in the key, no cross-source pollution)"
+            );
+        }
+
+        // PR-5 cache-poison guard: a top-k scan returns a PRUNED file subset, so it
+        // must never populate/replay the per-operator scan_cache — a later full scan
+        // of the same (table, projection) must see FULL results, not the subset.
+        // Proven by scan COUNT across repeated batches: WITHOUT topk the main table
+        // is cached (scanned once); WITH topk it is re-scanned each batch (the
+        // `cacheable = … && self.topk.is_none()` bypass held). This is the test that
+        // keeps the bypass true across future refactors.
+        #[test]
+        fn topk_scan_bypasses_scan_cache() {
+            let orders = TriplesMap::new("#Order", "orders")
+                .with_subject_template("http://ex/order/{ORDER_KEY}")
+                .with_predicate_object(PredicateObjectMap {
+                    predicate_map: PredicateMap::constant("edw:orderTotal"),
+                    object_map: ObjectMap::column("ORDER_TOTAL"),
+                });
+            let mapping = Arc::new(CompiledR2rmlMapping::new(vec![orders]));
+
+            fn orders_scans(topk: bool, mapping: &Arc<CompiledR2rmlMapping>) -> usize {
+                let snapshot = fluree_db_core::LedgerSnapshot::genesis("test/main");
+                let vars = VarRegistry::new();
+                let provider = CountingProvider::default();
+                {
+                    let mut ctx = ExecutionContext::new(&snapshot, &vars);
+                    ctx.r2rml_table_provider = Some(&provider);
+                    let mut pattern = R2rmlPattern::new("gs:main", VarId(0), Some(VarId(1)));
+                    pattern.predicate_filter = Some("edw:orderTotal".to_string());
+                    let mut op = R2rmlScanOperator::new(Box::new(EmptyOperator::new()), pattern);
+                    op.mapping = Some(Arc::clone(mapping));
+                    if topk {
+                        op.topk = Some((VarId(1), 10));
+                    }
+                    for _ in 0..3 {
+                        futures::executor::block_on(op.build_progress(&ctx, Batch::single_empty()))
+                            .expect("build_progress");
+                    }
+                }
+                let count = provider
+                    .scans
+                    .lock()
+                    .unwrap()
+                    .get("orders")
+                    .copied()
+                    .unwrap_or(0);
+                count
+            }
+
+            assert_eq!(
+                orders_scans(false, &mapping),
+                1,
+                "no topk: the main scan is cached and replayed across batches"
+            );
+            assert_eq!(
+                orders_scans(true, &mapping),
+                3,
+                "topk: the main scan bypasses the cache each batch — a pruned subset is never cached"
             );
         }
     }

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -222,6 +222,17 @@ fn limit_pushdown_enabled() -> bool {
     *ENABLED.get_or_init(|| super::env_switch_enabled("FLUREE_R2RML_LIMIT_PUSHDOWN"))
 }
 
+/// Whether a single-column DESC `ORDER BY … LIMIT` may push a scan-side top-k
+/// directive into the R2RML scan (PR-5), so it reads only the files that can hold
+/// the top-k. Read once from `FLUREE_R2RML_TOPK_PUSHDOWN` (family falsy
+/// spellings); off restores the full-materialize top-k (scan streams every row,
+/// the `SortOperator` keeps k). Gating in `set_topk` means off ⇒ no directive ⇒
+/// the scan takes its normal path (a full revert).
+fn topk_pushdown_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| super::env_switch_enabled("FLUREE_R2RML_TOPK_PUSHDOWN"))
+}
+
 /// How a window of produced rows is combined with the buffered child rows.
 ///
 /// The join is *flipped* relative to a naive per-child probe: the (small,
@@ -381,6 +392,13 @@ pub struct R2rmlScanOperator {
     row_budget: Option<usize>,
     /// Output rows emitted so far, counted against `row_budget`.
     emitted: usize,
+    /// Scan-side top-k directive (PR-5): `(primary DESC sort var, LIMIT+OFFSET)`,
+    /// set by a `SortOperator` for a `ORDER BY DESC(<scan col>) LIMIT k` directly
+    /// above this scan. Resolved to the sort column against the mapping at scan
+    /// time ([`Self::resolve_topk_directive`]); `None` = no pushdown (full scan +
+    /// the authoritative sort above). Only ever consulted for the main table scan,
+    /// never a parent/dimension lookup.
+    topk: Option<(VarId, usize)>,
     /// A scan-local FILTER the planner folded into this scan (see
     /// [`R2rmlPattern::consumed_filter`]). Applied to each output batch with the
     /// same evaluator the dropped `FilterOperator` would use, so results are
@@ -462,6 +480,7 @@ impl R2rmlScanOperator {
             parent_memo: parent_memo_enabled(),
             row_budget: None,
             emitted: 0,
+            topk: None,
             consumed_filter,
             state: OperatorState::Created,
         }
@@ -529,6 +548,37 @@ impl R2rmlScanOperator {
     /// table columns for the given TriplesMap, producing scan filters. A
     /// variable maps to a column via its predicate IRI; only plain `rr:column`
     /// scalar object maps are pushable (see [`value_pushdown_column`]).
+    /// Resolve the stored top-k directive (`(sort_var, k)`) to a [`crate::r2rml::ScanTopK`]
+    /// for THIS table scan, or `None` (→ full scan) when the sort var doesn't map
+    /// to exactly one scalar pushdown column of `triples_map` — the same soundness
+    /// gate `build_scan_filters` uses. The scan-side prune uses only this primary
+    /// column; the `SortOperator` above still applies the exact compound order +
+    /// LIMIT, so a `None` here is only a missed optimization, never wrong.
+    fn resolve_topk_directive(&self, triples_map: &TriplesMap) -> Option<crate::r2rml::ScanTopK> {
+        let (sort_var, k) = self.topk?;
+        let pred_iri = if Some(sort_var) == self.pattern.object_var {
+            self.pattern.predicate_filter.as_deref()
+        } else {
+            self.pattern
+                .star_bindings
+                .iter()
+                .find(|(_, v)| *v == sort_var)
+                .map(|(p, _)| p.as_str())
+        }?;
+        let mut matching = triples_map
+            .predicate_object_maps
+            .iter()
+            .filter(|p| p.predicate_map.as_constant() == Some(pred_iri));
+        let (Some(pom), None) = (matching.next(), matching.next()) else {
+            return None;
+        };
+        let col = value_pushdown_column(&pom.object_map)?;
+        Some(crate::r2rml::ScanTopK {
+            sort_column: col.to_string(),
+            k,
+        })
+    }
+
     fn build_scan_filters(&self, triples_map: &TriplesMap) -> Vec<crate::r2rml::ScanFilter> {
         let mut out = Vec::new();
         for pd in &self.pattern.scan_filters {
@@ -913,8 +963,17 @@ impl R2rmlScanOperator {
             // would defeat the LIMIT. A budgeted scan is the topmost
             // row-preserving scan, so it stops after ~a batch and gains little
             // from cross-batch reuse anyway.
-            let cacheable =
-                scan_cache_enabled() && scan_filters.is_empty() && self.row_budget.is_none();
+            //
+            // A top-k scan (PR-5) ALSO bypasses the cache: it returns a pruned
+            // file SUBSET, and the cache key `(table, projection)` does not carry
+            // the directive — replaying that subset for a later FULL scan of the
+            // same table+projection would silently drop rows (the exact silent-
+            // wrong class the differential's second-scan case guards).
+            let main_scan_topk = self.resolve_topk_directive(triples_map);
+            let cacheable = scan_cache_enabled()
+                && scan_filters.is_empty()
+                && self.row_budget.is_none()
+                && self.topk.is_none();
             let cache_key = (table_name.to_string(), projection.clone());
             let stream: ColumnBatchStream = if !cacheable {
                 table_provider
@@ -923,6 +982,7 @@ impl R2rmlScanOperator {
                         table_name,
                         &projection,
                         &scan_filters,
+                        main_scan_topk.as_ref(),
                         as_of_t,
                     )
                     .await?
@@ -935,6 +995,7 @@ impl R2rmlScanOperator {
                         table_name,
                         &projection,
                         &scan_filters,
+                        main_scan_topk.as_ref(),
                         as_of_t,
                     )
                     .await?;
@@ -1126,6 +1187,7 @@ impl R2rmlScanOperator {
                             parent_table,
                             &parent_projection,
                             &[],
+                            None,
                             as_of_t,
                         )
                         .await?;
@@ -2218,6 +2280,16 @@ impl Operator for R2rmlScanOperator {
         }
     }
 
+    fn set_topk(&mut self, sort_var: VarId, k: usize) {
+        // Record the DESC top-k directive; it is resolved to a scan column against
+        // the mapping at scan time and honored only for the main table scan. Like
+        // `row_budget`, do NOT forward to the child — an inner correlated scan must
+        // still produce every row the join needs; only a topmost scan is eligible.
+        if topk_pushdown_enabled() {
+            self.topk = Some((sort_var, k));
+        }
+    }
+
     async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {
         // Open child first
         self.child.open(ctx).await?;
@@ -3031,6 +3103,7 @@ mod tests {
                 table_name: &str,
                 _projection: &[String],
                 _filters: &[crate::r2rml::ScanFilter],
+                _topk: Option<&crate::r2rml::ScanTopK>,
                 _as_of_t: Option<i64>,
             ) -> Result<ColumnBatchStream> {
                 *self
@@ -3153,6 +3226,7 @@ mod tests {
                 table_name: &str,
                 _projection: &[String],
                 _filters: &[crate::r2rml::ScanFilter],
+                _topk: Option<&crate::r2rml::ScanTopK>,
                 _as_of_t: Option<i64>,
             ) -> Result<ColumnBatchStream> {
                 *self

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -575,6 +575,13 @@ impl R2rmlScanOperator {
             .iter()
             .filter(|p| p.predicate_map.as_constant() == Some(pred_iri));
         let (Some(pom), None) = (matching.next(), matching.next()) else {
+            // Decline observably (PR-7's decline-breadcrumb convention, #1495
+            // review): a mapping with duplicate predicates silently loses the
+            // scan-side top-k otherwise, with nothing in the logs.
+            tracing::debug!(
+                predicate = %pred_iri,
+                "r2rml topk declined: sort predicate does not map to exactly one POM"
+            );
             return None;
         };
         let col = value_pushdown_column(&pom.object_map)?;

--- a/fluree-db-query/src/r2rml/provider.rs
+++ b/fluree-db-query/src/r2rml/provider.rs
@@ -103,6 +103,24 @@ pub struct ScanFilter {
     pub value: ScanValue,
 }
 
+/// A scan-side top-k directive for a single-column **DESCENDING** `ORDER BY …
+/// LIMIT k` directly above a single-table R2RML scan (PR-5). The scan reads files
+/// in `upper_bound(sort_column)`-DESC order, keeps a running k-th bound, and stops
+/// once no unread file can beat it — reading far fewer than the whole table.
+///
+/// A pure perf optimization: the scan still streams a strict SUPERSET of the true
+/// top-k (it only skips files that provably cannot contribute), and the
+/// authoritative `SortOperator` above applies the exact (compound) order + LIMIT.
+/// Ignored by the provider unless `sort_column` resolves to a pushable scalar
+/// column of the scanned table.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScanTopK {
+    /// The primary DESC sort column (an R2RML-mapped table column name).
+    pub sort_column: String,
+    /// How many top rows the bound must retain — the query's `LIMIT + OFFSET`.
+    pub k: usize,
+}
+
 /// Provider for compiled R2RML mappings.
 ///
 /// This trait is used by the R2RML operator to load mappings at query time.
@@ -182,12 +200,17 @@ pub trait R2rmlTableProvider: Debug + Send + Sync {
     /// `filters` are conservative pushdown predicates (resolved to columns) for
     /// Iceberg file pruning. Implementations may ignore them (correctness is
     /// preserved by the in-engine FILTER) but honoring them skips data files.
+    /// `topk`, when set, is a single-column DESC `ORDER BY … LIMIT` directive
+    /// (PR-5): the implementation MAY read only the files that can hold the top-k
+    /// and stream a superset of them; ignoring it is always correct (the sort
+    /// above is authoritative).
     async fn scan_table(
         &self,
         graph_source_id: &str,
         table_name: &str,
         projection: &[String],
         filters: &[ScanFilter],
+        topk: Option<&ScanTopK>,
         as_of_t: Option<i64>,
     ) -> Result<ColumnBatchStream>;
 
@@ -277,6 +300,7 @@ impl R2rmlTableProvider for NoOpR2rmlProvider {
         _table_name: &str,
         _projection: &[String],
         _filters: &[ScanFilter],
+        _topk: Option<&ScanTopK>,
         _as_of_t: Option<i64>,
     ) -> Result<ColumnBatchStream> {
         Err(crate::error::QueryError::Internal(format!(


### PR DESCRIPTION
## What

PR-5 (the final roadmap item): scan-side top-k for `ORDER BY DESC(<scan col>) LIMIT k` over a single-table R2RML/Iceberg scan. The scan reads files in `upper_bound(sort_col)`-DESC order, keeps a running k-th bound, and stops once no unread file can beat it — reading ~k files instead of the whole table.

## Closing gate (DW_SF01, 7670 files per fact table)

| q046 | wall | files_pruned / selected | hash |
|---|---|---|---|
| ON (hot) | 136ms | 7660 / 10 | == oracle |
| OFF (hot) | 406ms | 0 / 7670 | == oracle (byte-identical revert) |
| **COLD** | **3129ms** | **7660** | == oracle |

Cold **~37s → 3.1s (~12×), files_pruned 7660/7670 = 99.87%** — the headline. ON is faster than OFF even hot. ORDER-BY-class parity sweep (q005/q012 declined via fallback, q046 identical), native 54/54, and the W3C ORDER BY/LIMIT suite: **0 hash mismatch, 0 perf violations**.

Honest scope: q046 is the only corpus query this helps (raw-column top-k over a fact table), and the win is cold (warm q046 was already ~400ms). PR-7's numeric stats paid the hard cost; this is the harvest on the canonical "top N by measure" shape.

## How

The `SortOperator` offers a `TopK(primary DESC var, k = LIMIT + OFFSET)` directive to the scan below (mirroring `row_budget`); `GraphOperator` threads it into its per-parent inner subplan (where a virtual query's scan lives), and `ProjectOperator` forwards it. The api scan reads files in bound-DESC order with a size-(k+offset) heap and early-stops; a `TOPK_SEQUENTIAL_CAP` fallback to the parallel reader means an ineffective prune is never slower than the full scan. `sort.rs::new_topk` above stays the sole authority for the exact (compound) order + LIMIT — the scan only skips files it proves cannot contribute, so results are byte-identical to full sort.

## Invariants

- **Strict superset:** the scan streams every row of every non-pruned file; the authoritative sort above re-selects the exact top-k → results identical to full sort.
- **Heap fed post-filter qualifying rows only:** `resolve_topk_directive` DECLINES the pushdown when the scan carries a RESIDUAL filter (`consumed_filter` / `object_constant` / `subject_constant` / `star_constraints`) the operator enforces after emit — feeding a superset would ride the k-th bound too high and silently drop qualifying rows. Pushed scan filters are applied by the reader (the emitted batch is already post-filter), so they compose fine.
- **No pruned result is ever cached:** a top-k scan bypasses the per-operator scan cache (`cacheable && self.topk.is_none()`), keyed on the STORED directive — so a declined-topk scan runs FULL and merely skips the cache, never caching a subset that a later full scan of the same `(table, projection)` could replay.
- **k = LIMIT + OFFSET** (single-owner arithmetic) so the scan retains the rows the sort's OFFSET then skips.
- **DESC only:** ASC declines to fallback — SPARQL orders unbound values first in ASC, so a null-bearing file could never be pruned.

## Kill switch

`FLUREE_R2RML_TOPK_PUSHDOWN` (default on); off ⇒ no directive ⇒ today's full-materialize top-k.

## Tests

iceberg core (10): `TopKBound` bound/tie/NaN, `plan_topk_read` / `batch_sort_values`, read-loop simulations (prune + k-exceeds-non-null + all-null-file). query: `topk_declines_on_residual_filter` (all four residual shapes + pure-scan positive), `topk_scan_bypasses_scan_cache` (cache-poison — a topk scan re-reads each batch vs a cached full scan), `topk_directive_carries_limit_plus_offset` (k = LIMIT+OFFSET). All green; clippy/fmt clean; the full `-p fluree-db-api --features iceberg` suite is green.

Note on observability: the topk branch emits an `iceberg.scan_plan` span for the harness counters; on the cold miss arm the planner also emits one (the pre-topk plan), so `files_selected` double-counts there while `files_pruned` stays authoritative — the gate ratio is `files_pruned / total_files`.

Stacked on `perf/r2rml-pr7-numeric-stats`. The F13 native-perf re-bless rides on this branch. Closes the virtual-dataset perf roadmap.
