### PR TITLE
feat(iceberg): BYO-IAM on operator-owned S3 — inline metadata, fail-closed credentials, SecretRef rotation fix, typed storage errors, verify probe (#1500, #1497, #1498)

### DIFF
--- a/fluree-bench-virtual/src/exec.rs
+++ b/fluree-bench-virtual/src/exec.rs
@@ -179,6 +179,9 @@ impl Engine {
     /// clearing happens in the caller (`cmd_exec_one`) *before* `open`, since the
     /// cache is read at open time. Pacing is the parent's job (2 s between cold
     /// children), so a single exec-one does not sleep.
+    // Bench-harness plumbing: the params mirror the exec-one CLI surface 1:1;
+    // bundling them into a struct would just move the argument list.
+    #[allow(clippy::too_many_arguments)]
     pub fn exec_one(
         &self,
         fluree: &Fluree,

--- a/fluree-db-api/src/error.rs
+++ b/fluree-db-api/src/error.rs
@@ -240,6 +240,45 @@ pub enum ApiError {
     #[error("Internal error: {0}")]
     Internal(String),
 
+    /// Object storage denied a read of an external table's data (S3 403 /
+    /// `AccessDenied`), on the preview/browse path.
+    ///
+    /// Surfaced as HTTP 403 (not the generic 400/500) so the caller can tell a
+    /// permission problem from a bad query. Because S3 also returns
+    /// `AccessDenied` for a missing object without `s3:ListBucket`, this means
+    /// the credentials lack access **or** the object was moved/removed. The scan
+    /// path produces the equivalent [`fluree_db_query::QueryError::StorageAccessDenied`]
+    /// (wrapped here via [`ApiError::Query`]); both map to the same server code.
+    #[error(
+        "Storage access denied for s3://{bucket}/{key}{region_suffix}: {message}",
+        region_suffix = .region.as_deref().map(|r| format!(" (region {r})")).unwrap_or_default()
+    )]
+    StorageAccessDenied {
+        /// Bucket parsed from the object path.
+        bucket: String,
+        /// Object key parsed from the object path.
+        key: String,
+        /// Configured/resolved region, if known.
+        region: Option<String>,
+        /// The underlying storage error detail.
+        message: String,
+    },
+
+    /// The catalog authorized the table but vended no storage credentials while
+    /// the source requires them (`vended_credentials = true`).
+    ///
+    /// Fail-closed on the preview/browse path: refused rather than silently
+    /// downgrading to ambient (process-default) AWS credentials.
+    #[error(
+        "Catalog {catalog_uri} authorized the table but vended no storage credentials; \
+         either fix the catalog's credential vending or set vended_credentials=false on \
+         the source to explicitly use ambient AWS credentials"
+    )]
+    CatalogCredentialsNotVended {
+        /// The REST catalog URI that authorized the table.
+        catalog_uri: String,
+    },
+
     /// HTTP error with explicit status code
     ///
     /// Used when the error source already has a known HTTP status (e.g., TrackedErrorResponse
@@ -418,6 +457,16 @@ impl ApiError {
             // Builder validation errors
             ApiError::Builder(_) => 400,
             ApiError::Query(fluree_db_query::QueryError::Cancelled { .. }) => 408,
+            // Storage-permission / fail-closed errors are 403 (Forbidden),
+            // whether raised directly (preview path) or wrapped from the query
+            // engine (scan path). These arms MUST precede the generic
+            // `ApiError::Query(_) => 400` below.
+            ApiError::StorageAccessDenied { .. }
+            | ApiError::CatalogCredentialsNotVended { .. }
+            | ApiError::Query(
+                fluree_db_query::QueryError::StorageAccessDenied { .. }
+                | fluree_db_query::QueryError::CatalogCredentialsNotVended { .. },
+            ) => 403,
             // Most errors are client errors (bad input)
             ApiError::Parse(_)
             | ApiError::Query(_)
@@ -463,3 +512,59 @@ impl ApiError {
 
 /// Result type alias for API operations
 pub type Result<T> = std::result::Result<T, ApiError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_permission_errors_are_403() {
+        // Direct (preview path) and query-wrapped (scan path) both → 403, and
+        // the query-wrapped ones must NOT fall through to the generic
+        // `ApiError::Query(_) => 400`.
+        assert_eq!(
+            ApiError::StorageAccessDenied {
+                bucket: "b".into(),
+                key: "k".into(),
+                region: None,
+                message: "m".into(),
+            }
+            .status_code(),
+            403
+        );
+        assert_eq!(
+            ApiError::CatalogCredentialsNotVended {
+                catalog_uri: "https://c/v1".into(),
+            }
+            .status_code(),
+            403
+        );
+        assert_eq!(
+            ApiError::Query(fluree_db_query::QueryError::StorageAccessDenied {
+                bucket: "b".into(),
+                key: "k".into(),
+                region: Some("us-east-2".into()),
+                message: "m".into(),
+            })
+            .status_code(),
+            403
+        );
+        assert_eq!(
+            ApiError::Query(fluree_db_query::QueryError::CatalogCredentialsNotVended {
+                catalog_uri: "https://c/v1".into(),
+            })
+            .status_code(),
+            403
+        );
+    }
+
+    #[test]
+    fn generic_query_error_still_400() {
+        // Guard against the new 403 arms accidentally swallowing other query
+        // errors.
+        assert_eq!(
+            ApiError::Query(fluree_db_query::QueryError::InvalidQuery("bad".into())).status_code(),
+            400
+        );
+    }
+}

--- a/fluree-db-api/src/graph_source/catalog_session.rs
+++ b/fluree-db-api/src/graph_source/catalog_session.rs
@@ -420,6 +420,33 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn cached_storage_persists_without_a_fresh_load_table() {
+        // fluree/db#1498: Direct mode caches its S3 client here but NEVER calls
+        // `store_load_table` (it has no vended credentials to rotate), so the only
+        // thing that would invalidate the client never happens — the client stays
+        // cached for the whole query and every repeated scan of the table reuses
+        // it. This is the session-layer invariant the direct-branch reuse relies
+        // on; the r2rml helper test drives the same contract end-to-end.
+        let s = IcebergCatalogSession::default();
+        let key = IcebergCatalogSession::load_table_key("gs:main", "DW", "DIM_STORE");
+        let storage = Arc::new(
+            S3IcebergStorage::from_default_chain(Some("us-east-2"), None, false)
+                .await
+                .expect("offline SDK client construction"),
+        );
+        s.store_storage(key.clone(), Arc::clone(&storage));
+        // No `store_load_table` in between (Direct mode's flow) — the client must
+        // still be served, and it must be the very same Arc.
+        let hit = s
+            .cached_storage(&key)
+            .expect("storage stays cached with no reload");
+        assert!(
+            Arc::ptr_eq(&hit, &storage),
+            "the cached Direct-mode client must be the same Arc across resolutions"
+        );
+    }
+
     #[test]
     fn keys_isolate_by_source_and_table() {
         let s = IcebergCatalogSession::default();

--- a/fluree-db-api/src/graph_source/config.rs
+++ b/fluree-db-api/src/graph_source/config.rs
@@ -496,6 +496,26 @@ impl IcebergConnectionConfig {
         self
     }
 
+    /// Set bearer token authentication from a secret REFERENCE (REST mode only).
+    ///
+    /// `token_ref` is an opaque reference resolved at use time by the injected
+    /// [`SecretResolver`](fluree_db_iceberg::SecretResolver) (see
+    /// [`Fluree::with_secret_resolver`](crate::Fluree::with_secret_resolver)); the
+    /// token value never appears in the stored config. Mirrors
+    /// [`Self::with_auth_bearer`].
+    pub fn with_auth_bearer_token_ref(mut self, token_ref: impl Into<String>) -> Self {
+        if let CatalogMode::Rest(ref mut rest) = self.catalog_mode {
+            rest.auth = fluree_db_iceberg::auth::AuthConfig::Bearer {
+                token: fluree_db_iceberg::ConfigValue::SecretRef {
+                    secret_ref: token_ref.into(),
+                },
+            };
+        } else {
+            tracing::warn!("with_auth_bearer_token_ref has no effect in Direct catalog mode");
+        }
+        self
+    }
+
     /// Set OAuth2 client credentials authentication (REST mode only).
     pub fn with_auth_oauth2(
         mut self,
@@ -513,6 +533,39 @@ impl IcebergConnectionConfig {
             };
         } else {
             tracing::warn!("with_auth_oauth2 has no effect in Direct catalog mode");
+        }
+        self
+    }
+
+    /// Set OAuth2 client-credentials auth with the client secret supplied as a
+    /// secret REFERENCE (REST mode only).
+    ///
+    /// `client_secret_ref` is an opaque reference resolved at use time by the
+    /// injected [`SecretResolver`](fluree_db_iceberg::SecretResolver); the secret
+    /// value never appears in the stored config. `token_url` and `client_id` are
+    /// non-secret and stored literally. Scope/audience are set separately via
+    /// [`Self::with_oauth2_scope`] / [`Self::with_oauth2_audience`] (call them
+    /// AFTER this). Mirrors [`Self::with_auth_oauth2`].
+    pub fn with_auth_oauth2_client_secret_ref(
+        mut self,
+        token_url: impl Into<String>,
+        client_id: impl Into<String>,
+        client_secret_ref: impl Into<String>,
+    ) -> Self {
+        if let CatalogMode::Rest(ref mut rest) = self.catalog_mode {
+            rest.auth = fluree_db_iceberg::auth::AuthConfig::OAuth2ClientCredentials {
+                token_url: token_url.into(),
+                client_id: fluree_db_iceberg::ConfigValue::literal(client_id.into()),
+                client_secret: fluree_db_iceberg::ConfigValue::SecretRef {
+                    secret_ref: client_secret_ref.into(),
+                },
+                scope: None,
+                audience: None,
+            };
+        } else {
+            tracing::warn!(
+                "with_auth_oauth2_client_secret_ref has no effect in Direct catalog mode"
+            );
         }
         self
     }
@@ -679,6 +732,30 @@ impl IcebergCreateConfig {
         self.connection = self
             .connection
             .with_auth_oauth2(token_url, client_id, client_secret);
+        self
+    }
+
+    /// Set bearer authentication from a secret *reference* (REST mode only).
+    /// See [`IcebergConnectionConfig::with_auth_bearer_token_ref`].
+    pub fn with_auth_bearer_token_ref(mut self, token_ref: impl Into<String>) -> Self {
+        self.connection = self.connection.with_auth_bearer_token_ref(token_ref);
+        self
+    }
+
+    /// Set OAuth2 client-credentials authentication with the client secret as a
+    /// secret *reference* (REST mode only). See
+    /// [`IcebergConnectionConfig::with_auth_oauth2_client_secret_ref`].
+    pub fn with_auth_oauth2_client_secret_ref(
+        mut self,
+        token_url: impl Into<String>,
+        client_id: impl Into<String>,
+        client_secret_ref: impl Into<String>,
+    ) -> Self {
+        self.connection = self.connection.with_auth_oauth2_client_secret_ref(
+            token_url,
+            client_id,
+            client_secret_ref,
+        );
         self
     }
 
@@ -954,6 +1031,30 @@ impl R2rmlCreateConfig {
         self
     }
 
+    /// Set bearer authentication from a secret *reference*.
+    /// See [`IcebergConnectionConfig::with_auth_bearer_token_ref`].
+    pub fn with_auth_bearer_token_ref(mut self, token_ref: impl Into<String>) -> Self {
+        self.iceberg = self.iceberg.with_auth_bearer_token_ref(token_ref);
+        self
+    }
+
+    /// Set OAuth2 client-credentials authentication with the client secret as a
+    /// secret *reference*. See
+    /// [`IcebergConnectionConfig::with_auth_oauth2_client_secret_ref`].
+    pub fn with_auth_oauth2_client_secret_ref(
+        mut self,
+        token_url: impl Into<String>,
+        client_id: impl Into<String>,
+        client_secret_ref: impl Into<String>,
+    ) -> Self {
+        self.iceberg = self.iceberg.with_auth_oauth2_client_secret_ref(
+            token_url,
+            client_id,
+            client_secret_ref,
+        );
+        self
+    }
+
     /// Set the OAuth2 `scope` (delegates to the underlying Iceberg config).
     ///
     /// Call after [`Self::with_auth_oauth2`]. See
@@ -1201,6 +1302,59 @@ mod tests {
             } => {
                 assert_eq!(scope.as_deref(), Some("session:role:ICEBERG_READER"));
                 assert_eq!(audience.as_deref(), Some("polaris"));
+            }
+            other => panic!("expected OAuth2 auth, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "iceberg")]
+    fn conn_auth(conn: &IcebergConnectionConfig) -> &fluree_db_iceberg::auth::AuthConfig {
+        match &conn.catalog_mode {
+            CatalogMode::Rest(rest) => &rest.auth,
+            CatalogMode::Direct { .. } => panic!("expected REST catalog mode"),
+        }
+    }
+
+    #[cfg(feature = "iceberg")]
+    #[test]
+    fn bearer_token_ref_builder_stores_secret_ref() {
+        let conn = IcebergConnectionConfig::rest("https://catalog.example.com")
+            .with_auth_bearer_token_ref("vault://team/bearer");
+        match conn_auth(&conn) {
+            fluree_db_iceberg::auth::AuthConfig::Bearer { token } => assert_eq!(
+                *token,
+                fluree_db_iceberg::ConfigValue::SecretRef {
+                    secret_ref: "vault://team/bearer".to_string()
+                }
+            ),
+            other => panic!("expected Bearer auth, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "iceberg")]
+    #[test]
+    fn oauth2_client_secret_ref_builder_stores_secret_ref_and_literal_id() {
+        let conn = IcebergConnectionConfig::rest("https://catalog.example.com")
+            .with_auth_oauth2_client_secret_ref(
+                "https://catalog.example.com/v1/oauth/tokens",
+                "svc-client",
+                "vault://team/client-secret",
+            );
+        match conn_auth(&conn) {
+            fluree_db_iceberg::auth::AuthConfig::OAuth2ClientCredentials {
+                client_id,
+                client_secret,
+                ..
+            } => {
+                // client_id is non-secret and stored as a plain literal.
+                assert_eq!(client_id.resolve().unwrap(), "svc-client");
+                // client_secret is stored as an opaque SecretRef, never a literal.
+                assert_eq!(
+                    *client_secret,
+                    fluree_db_iceberg::ConfigValue::SecretRef {
+                        secret_ref: "vault://team/client-secret".to_string()
+                    }
+                );
             }
             other => panic!("expected OAuth2 auth, got {other:?}"),
         }

--- a/fluree-db-api/src/graph_source/disk_catalog_cache.rs
+++ b/fluree-db-api/src/graph_source/disk_catalog_cache.rs
@@ -15,7 +15,6 @@
 //! benchmark protocol can clear the data artifact cache while KEEPING catalog
 //! persistence — that "cold-data / warm-catalog" state is slice 2's DoD gate.
 
-use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -201,7 +200,17 @@ fn pointer_is_usable(
 /// field added to [`DataFile`] (or these persisted structs) could silently
 /// misread an old entry (a defaulted field) instead of refetching. **BUMP THIS
 /// whenever any persisted payload type changes** — an entry whose stored version
-/// differs is dropped and refetched.
+/// differs is dropped and refetched (see [`DiskCatalogCache::read`]).
+///
+/// **v2** = the payload change that added the verified [`Envelope::key`] field.
+/// The filename RE-KEY that landed alongside it (a spec-defined [`stable_key_hash`]
+/// replacing `std`'s `DefaultHasher`, plus a [`CACHE_SCOPE`] segment) is ORTHOGONAL
+/// to this version and deliberately did NOT bump it: it changes file NAMES, not the
+/// stored layout, so a re-keyed process simply never opens a pre-existing file. Old
+/// entries are harmless ORPHANS, evicted oldest-first by the [`MAX_CACHE_BYTES`]
+/// mtime prune, exactly as a superseded `metadata_location`'s entries already are (a
+/// table commit orphans its old key the same way — no new leak class). Bump this
+/// only for a PAYLOAD change; a re-key needs no bump.
 const CACHE_FORMAT_VERSION: u32 = 2;
 
 /// Versioned on-disk envelope. The version is checked before the payload is
@@ -210,11 +219,15 @@ const CACHE_FORMAT_VERSION: u32 = 2;
 struct Envelope<T> {
     format_version: u32,
     /// The FULL cache key (an `s3://…` metadata_location, or an `lt_key`). The
-    /// filename stem is only a 64-bit `DefaultHasher` of the key, so two distinct
-    /// keys can collide onto one path; verifying the stored key on read turns a
-    /// collision into a clean miss instead of silently serving another entry's
-    /// payload — a wrong *table*'s metadata for the pointer entry (#1491/#1503
-    /// review). Hash quality is then irrelevant to correctness.
+    /// filename stem is only a 64-bit hash of the key (see [`stable_key_hash`]), so
+    /// two distinct keys can collide onto one path; verifying the stored key on read
+    /// turns a collision into a clean miss instead of silently serving another
+    /// entry's payload — a wrong *table*'s metadata for the pointer entry
+    /// (#1491/#1503 review). Hash quality is then irrelevant to CORRECTNESS — which
+    /// is why [`stable_key_hash`] exists for a different reason (cross-toolchain
+    /// filename STABILITY, which this check cannot provide: a hash whose algorithm
+    /// changed re-names every file, so nothing is ever misread — it is silently all
+    /// missed).
     key: String,
     payload: T,
 }
@@ -224,6 +237,53 @@ struct Envelope<T> {
 /// `~/.fluree` would eventually be a support ticket. Pruned oldest-first at
 /// process startup (see [`DiskCatalogCache::for_dir`]).
 const MAX_CACHE_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Stable 64-bit hash of a cache key, used to build the on-disk filename stem.
+///
+/// **Cross-toolchain stability is load-bearing.** The returned value IS the
+/// filename, so the same input must hash to the same value on every platform and
+/// every Rust release, forever. `std`'s `DefaultHasher` does NOT guarantee this —
+/// its algorithm may change between compiler releases — so keying on it means a
+/// routine toolchain bump would silently re-name (and thus re-key) the ENTIRE
+/// cache dir: a one-time full miss that [`CACHE_FORMAT_VERSION`] cannot detect
+/// (nothing is misread; the new names simply never collide with the old files).
+/// xxHash-64 is a published, spec-defined algorithm with fixed output, already a
+/// dependency of this crate (`xxhash-rust`, `xxh64` feature enabled at the
+/// workspace root). The `stable_key_hash_is_pinned` golden test pins a known
+/// input→output pair so any accidental algorithm/seed drift fails loudly in CI.
+fn stable_key_hash(key: &str) -> u64 {
+    // Seed 0 is part of the on-disk contract; changing it re-keys every entry.
+    xxhash_rust::xxh64::xxh64(key.as_bytes(), 0)
+}
+
+/// Cache-scope discriminant embedded in every entry filename (see
+/// [`DiskCatalogCache::path`]). CONSTANT today: every graph source in a process
+/// currently reads S3 under the SAME identity, so a single shared scope is
+/// correct by construction and a shared key is safe.
+///
+/// **Load-bearing design rule for mechanism B (per-graph-source
+/// `sts:AssumeRole`).** When per-graph-source role assumption lands, this
+/// constant MUST be replaced by a per-entry scope value that is a STABLE
+/// FINGERPRINT of the graph source's catalog-auth scope — the same identity
+/// `rest_clients` is keyed on. It MUST NEVER be the vended credential itself:
+/// vended credentials rotate on every `loadTable`, so keying on the credential
+/// would yield a 0% hit rate under the default configuration. Keeping the scope a
+/// constant embedded in the existing filename slot makes that future change a
+/// localized edit (thread a `scope: &str` into [`DiskCatalogCache::path`]) rather
+/// than a format migration.
+///
+/// **Per-layer verdict** (decide this deliberately when B lands — do not inherit it
+/// by accident):
+/// - `scanfiles` / `countstats` — **storage-gated**: their column bounds and
+///   per-file record counts come from manifests, i.e. S3 objects behind the storage
+///   gate. These are the layers a per-source identity must discriminate.
+/// - `metadata` — **catalog-gated**: a successful `loadTable` discloses the schema
+///   by protocol (and now hands it to us inline), so it crosses no storage gate.
+/// - `pointer` — **catalog-gated AND already per-graph-source**: its key is an
+///   `lt_key` (`graph_source_id` + namespace + table), so two graph sources can never
+///   share an entry, and the value is a non-secret `s3://` path the catalog itself
+///   returned. It needs no scope.
+const CACHE_SCOPE: &str = "shared";
 
 /// Content-addressed on-disk catalog cache. A pure optimization: any I/O, parse,
 /// or version failure degrades to a miss (the caller reads from S3), never an
@@ -252,12 +312,21 @@ impl DiskCatalogCache {
         }
     }
 
-    /// File path for `metadata_location`'s `suffix` entry. The location is an
-    /// `s3://…` path; hash it to a filesystem-safe, fixed-length stem.
-    fn path(&self, metadata_location: &str, suffix: &str) -> PathBuf {
-        let mut h = std::collections::hash_map::DefaultHasher::new();
-        metadata_location.hash(&mut h);
-        self.dir.join(format!("{:016x}.{suffix}.json", h.finish()))
+    /// File path for `key`'s `suffix` entry, under [`CACHE_SCOPE`].
+    ///
+    /// `key` spans TWO DISJOINT key spaces, separated only by `suffix`: an `s3://…`
+    /// `metadata_location` (the `metadata` / `scanfiles` / `countstats` layers) or an
+    /// `lt_key` (the `pointer` layer). Hash it — STABLY, see [`stable_key_hash`] — to
+    /// a filesystem-safe, fixed-length stem; [`Envelope::key`] stores the full key so
+    /// a stem collision (within or across those spaces) is a clean miss rather than a
+    /// wrong-payload read. The middle `scope` segment is a discriminant for future
+    /// per-graph-source identity (see [`CACHE_SCOPE`]); it is a constant today, so
+    /// this shape already leaves room to make the scope a per-call argument without
+    /// changing the filename layout. Shape: `{hash:016x}.{scope}.{suffix}.json`.
+    fn path(&self, key: &str, suffix: &str) -> PathBuf {
+        let hash = stable_key_hash(key);
+        self.dir
+            .join(format!("{hash:016x}.{CACHE_SCOPE}.{suffix}.json"))
     }
 
     /// Read + version-check an entry. A deserialize failure (corrupt, truncated by
@@ -658,5 +727,69 @@ mod tests {
         let cache = DiskCatalogCache::for_dir(&file.join("child"));
         cache.put_count_stats("s3://b/m.json", &[data_file("s3://b/f.parquet", 1)], false);
         assert!(cache.get_count_stats("s3://b/m.json").is_none());
+    }
+
+    /// GOLDEN: pins the stable key hash so cross-toolchain stability is enforced,
+    /// not merely intended. If this fails after a toolchain / `xxhash-rust` bump,
+    /// the on-disk cache would silently re-key (a one-time full miss) — treat a
+    /// change here as a format break (bump `CACHE_FORMAT_VERSION`), never a
+    /// rubber-stamp constant update. The input is a fixed, arbitrary test vector.
+    #[test]
+    fn stable_key_hash_is_pinned() {
+        assert_eq!(
+            stable_key_hash("s3://fluree-golden/warehouse/t/metadata/00001.metadata.json"),
+            0xa577_4957_4046_c156,
+            "stable_key_hash(xxh64, seed 0) must be deterministic across toolchains"
+        );
+        // A different input yields a different value (sanity, not a golden).
+        assert_ne!(
+            stable_key_hash("s3://fluree-golden/warehouse/t/metadata/00002.metadata.json"),
+            stable_key_hash("s3://fluree-golden/warehouse/t/metadata/00001.metadata.json"),
+        );
+    }
+
+    /// The on-disk filename carries the `{hash}.{scope}.{suffix}.json` shape, so
+    /// the scope discriminant slot exists today (constant) for mechanism B later.
+    #[test]
+    fn path_includes_scope_segment() {
+        let cache = DiskCatalogCache::for_dir(&tmp_dir("scope"));
+        let p = cache.path("s3://b/m.json", "metadata");
+        let name = p.file_name().and_then(|n| n.to_str()).unwrap();
+        assert!(
+            name.ends_with(&format!(".{CACHE_SCOPE}.metadata.json")),
+            "filename must carry the scope discriminant + suffix: {name}"
+        );
+        let stem = name.split('.').next().unwrap();
+        assert_eq!(stem.len(), 16, "hash stem is a fixed 16 hex chars: {name}");
+        assert!(
+            stem.chars().all(|c| c.is_ascii_hexdigit()),
+            "hash stem is lowercase hex: {name}"
+        );
+    }
+
+    /// A v1 payload sharing a v2 filename is a miss AND is deleted, so it stops
+    /// occupying the size cap. (Real v1 orphans keep their old names and are never
+    /// opened; they are pruned oldest-first by the mtime cap instead — see the
+    /// `CACHE_FORMAT_VERSION` doc.)
+    #[test]
+    fn v1_entry_is_a_miss_and_deleted() {
+        let dir = tmp_dir("v1drop");
+        let cache = DiskCatalogCache::for_dir(&dir);
+        let loc = "s3://b/m.json";
+        cache.put_count_stats(loc, &[data_file("s3://b/f.parquet", 1)], false);
+        let path = only_entry(&dir);
+        // Downgrade the envelope version in place, payload untouched.
+        let mut v: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        v["format_version"] = serde_json::json!(1u32);
+        std::fs::write(&path, serde_json::to_vec(&v).unwrap()).unwrap();
+        assert!(
+            cache.get_count_stats(loc).is_none(),
+            "a v1-versioned entry is a miss under CACHE_FORMAT_VERSION = 2"
+        );
+        assert!(
+            !path.exists(),
+            "a version-mismatched entry is deleted so it stops occupying the cap"
+        );
     }
 }

--- a/fluree-db-api/src/graph_source/ephemeral.rs
+++ b/fluree-db-api/src/graph_source/ephemeral.rs
@@ -283,6 +283,10 @@ impl crate::Fluree {
         mapping_ttl: String,
         sparql: String,
     ) -> Result<crate::QueryResult> {
+        // Resolve any SecretRef auth up front (fail closed if a ref has no
+        // resolver) so the sync catalog-client build below sees literal creds.
+        let conn = self.hydrate_conn(conn).await?;
+
         // Compile the candidate mapping inline (same loader the validate/persist
         // paths use). A compile failure is the agent's first signal.
         let compiled = R2rmlLoader::from_turtle(&mapping_ttl)

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -20,7 +20,8 @@ use crate::Result;
 
 use fluree_db_iceberg::catalog::{RestCatalogClient, RestCatalogConfig, SendCatalogClient};
 use fluree_db_iceberg::io::batch::IcebergFieldTypeExt;
-use fluree_db_iceberg::io::S3IcebergStorage;
+use fluree_db_iceberg::io::{S3IcebergStorage, SendIcebergStorage};
+use fluree_db_iceberg::manifest::DataFile;
 use fluree_db_iceberg::metadata::{
     PartitionField, Schema, SchemaField, Snapshot, SortField, TableMetadata,
 };
@@ -918,6 +919,246 @@ impl crate::Fluree {
     }
 }
 
+// =============================================================================
+// (c) Storage-access verification (§6)
+//
+// A config-time probe that goes through the ENGINE'S OWN credential decision
+// ([`decide_credential_source`], §2 fail-closed included) and storage
+// construction, then proves BOTH S3 prefixes a query needs — the `metadata/`
+// prefix (manifest-list + manifests) and the `data/` prefix (a `HeadObject` on
+// the first data file). It never reads a Parquet/data file's bytes. A green
+// report proves a query will not fail on storage permissions, so solo's
+// onboarding "Test" button validates on the same path queries use.
+// =============================================================================
+
+/// The result of a storage-access verification probe.
+///
+/// This shape goes over HTTP verbatim (solo's onboarding wizard renders it), so
+/// the field names are pinned.
+#[derive(Debug, Serialize)]
+pub struct StorageAccessReport {
+    /// Which credential source the probe used: `"vended"` (catalog-delegated) or
+    /// `"ambient"` (the process AWS credential chain). This is the SAME decision
+    /// the scan/preview paths make (see [`decide_credential_source`]), so a green
+    /// probe proves a query authenticates to storage the same way.
+    pub credential_source: &'static str,
+    /// The table's current metadata-JSON location
+    /// (`…/metadata/*.metadata.json`), from the catalog `loadTable` response.
+    pub metadata_location: String,
+    /// Number of data files listed in the current snapshot's manifests. Listing
+    /// them proves the `metadata/` prefix (manifest-list + manifests) is readable.
+    pub data_files_listed: usize,
+    /// The single data file the probe stat-checked (`HeadObject`) to prove the
+    /// `data/` prefix is readable; `None` when the data probe was skipped.
+    pub probed_data_file: Option<String>,
+    /// The stat-checked data file's size in bytes; `None` when skipped.
+    pub probed_data_file_bytes: Option<u64>,
+    /// `true` when the `data/` prefix probe was skipped because the table has no
+    /// data file to stat (an empty table, or a snapshotless table). The
+    /// `metadata/` prefix was still proven for an empty table; for a snapshotless
+    /// table there were no manifests to read either — see `skip_reason`.
+    pub data_probe_skipped: bool,
+    /// Human-readable reason the data probe was skipped; `None` when it ran.
+    pub skip_reason: Option<String>,
+}
+
+/// The `data/`-prefix half of the probe, factored out so it is unit-testable over
+/// a stub storage (no Avro manifest fixtures needed): given the already-listed
+/// data files, `HeadObject` the first one to prove the `data/` prefix is
+/// readable, or record a skip when the table lists no data files.
+#[derive(Debug)]
+struct DataFileProbe {
+    probed_data_file: Option<String>,
+    probed_data_file_bytes: Option<u64>,
+    data_probe_skipped: bool,
+    skip_reason: Option<String>,
+}
+
+async fn probe_data_files<S: SendIcebergStorage + ?Sized>(
+    storage: &S,
+    data_files: &[DataFile],
+    table_qualified: &str,
+) -> Result<DataFileProbe> {
+    match data_files.first() {
+        Some(first) => {
+            // `HeadObject` (not a byte read): proves the `data/` prefix is
+            // readable under the same credentials without downloading the file.
+            let bytes = storage.file_size(&first.file_path).await.map_err(|e| {
+                storage_api_error(
+                    &format!(
+                        "Failed to stat data file {} for {table_qualified}",
+                        first.file_path
+                    ),
+                    e,
+                )
+            })?;
+            Ok(DataFileProbe {
+                probed_data_file: Some(first.file_path.clone()),
+                probed_data_file_bytes: Some(bytes),
+                data_probe_skipped: false,
+                skip_reason: None,
+            })
+        }
+        None => Ok(DataFileProbe {
+            probed_data_file: None,
+            probed_data_file_bytes: None,
+            data_probe_skipped: true,
+            skip_reason: Some(
+                "table snapshot lists no data files (empty table); the data/ prefix \
+                 was not probed"
+                    .to_string(),
+            ),
+        }),
+    }
+}
+
+/// Read the snapshot's manifests (proving the `metadata/` prefix) and stat the
+/// first data file (proving the `data/` prefix), assembling a
+/// [`StorageAccessReport`]. Factored to be generic over the storage trait so the
+/// metadata- and data-prefix denial paths are unit-testable without S3 (mirrors
+/// §1's `resolve_table_metadata`).
+async fn probe_storage_access<S: SendIcebergStorage + ?Sized>(
+    storage: &S,
+    snapshot: &Snapshot,
+    credential_source: &'static str,
+    metadata_location: String,
+    table_qualified: &str,
+) -> Result<StorageAccessReport> {
+    // `metadata/` prefix proof: read the manifest-list + manifests (never a data
+    // file). Reuses the same reader the Tier-B preview / scan planner use.
+    let (data_files, _manifests_read, _has_deletes) =
+        send_read_snapshot_data_files(storage, snapshot)
+            .await
+            .map_err(|e| {
+                storage_api_error(
+                    &format!("Failed to read manifests for {table_qualified}"),
+                    e,
+                )
+            })?;
+
+    let data_files_listed = data_files.len();
+    let probe = probe_data_files(storage, &data_files, table_qualified).await?;
+
+    Ok(StorageAccessReport {
+        credential_source,
+        metadata_location,
+        data_files_listed,
+        probed_data_file: probe.probed_data_file,
+        probed_data_file_bytes: probe.probed_data_file_bytes,
+        data_probe_skipped: probe.data_probe_skipped,
+        skip_reason: probe.skip_reason,
+    })
+}
+
+/// Split a `"NAMESPACE.NAME"` table string into a catalog [`TableIdentifier`].
+/// Namespaces may themselves contain dots, so the LAST dot separates namespace
+/// from name (mirrors [`split_qualified_table`] / the validate path). A name with
+/// no dot yields an empty-namespace identifier, which the catalog rejects as
+/// not-found.
+fn parse_qualified_table(table: &str) -> TableIdentifier {
+    match table.rsplit_once('.') {
+        Some((namespace, name)) => TableIdentifier::new(namespace, name),
+        None => TableIdentifier::new("", table),
+    }
+}
+
+/// Verify that this connection's resolved credentials can actually READ a table's
+/// storage — the config-time probe behind solo's onboarding "Test" button.
+///
+/// It goes through the ENGINE'S OWN credential decision
+/// ([`decide_credential_source`], including §2 fail-closed) and storage
+/// construction, then proves both S3 prefixes a query needs: the `metadata/`
+/// prefix (manifest-list + manifests) and the `data/` prefix (a `HeadObject` on
+/// the first data file — never a byte read). A green report therefore proves a
+/// query will not fail on storage permissions, on the same credential path
+/// queries use.
+///
+/// REST catalogs only: Direct mode returns the same clear typed error as
+/// [`preview_iceberg_table`] (there is no catalog to authorize the read).
+pub async fn verify_storage_access(
+    conn: IcebergConnectionConfig,
+    table: &str,
+) -> Result<StorageAccessReport> {
+    let (catalog, _uri, _wh) = rest_catalog_client(&conn, "storage access verification")?;
+    let table_id = parse_qualified_table(table);
+    let catalog_table = table_id.to_catalog();
+
+    let load = SendCatalogClient::load_table(&catalog, &catalog_table, conn.io.vended_credentials)
+        .await
+        .map_err(|e| {
+            crate::ApiError::config(format!(
+                "Failed to load table {}: {e}",
+                table_id.qualified()
+            ))
+        })?;
+
+    // Build storage through the SAME credential decision the scan path uses. §2
+    // fail-closed fires HERE: a REST source that requires vended credentials but
+    // whose catalog vended none is refused (ApiError::CatalogCredentialsNotVended)
+    // rather than silently probing with ambient credentials — which is exactly the
+    // "validated on a different credential path than queries use" bug this guards.
+    let storage = build_preview_storage(&conn, load.credentials.as_ref()).await?;
+    let credential_source = if load.credentials.is_some() {
+        "vended"
+    } else {
+        "ambient"
+    };
+
+    let metadata = load.metadata.as_ref().ok_or_else(|| {
+        crate::ApiError::config(format!(
+            "Catalog did not return inline table metadata for {} — storage verification \
+             resolves the current snapshot from the loadTable `metadata` object.",
+            table_id.qualified()
+        ))
+    })?;
+
+    // Mirror the Tier-B preview: resolve the CURRENT snapshot from the inline
+    // metadata. A snapshotless table has no manifests or data files to read, so
+    // there is nothing to probe — report a skip rather than erroring (the catalog
+    // authorization and the credential decision were still exercised above).
+    match metadata.current_snapshot() {
+        Some(snapshot) => {
+            probe_storage_access(
+                &storage,
+                snapshot,
+                credential_source,
+                load.metadata_location,
+                &table_id.qualified(),
+            )
+            .await
+        }
+        None => Ok(StorageAccessReport {
+            credential_source,
+            metadata_location: load.metadata_location,
+            data_files_listed: 0,
+            probed_data_file: None,
+            probed_data_file_bytes: None,
+            data_probe_skipped: true,
+            skip_reason: Some(
+                "table has no current snapshot; there are no manifests or data files to \
+                 probe (catalog authorization and credential resolution still succeeded)"
+                    .to_string(),
+            ),
+        }),
+    }
+}
+
+impl crate::Fluree {
+    /// Verify that a connection's resolved credentials can read an Iceberg table's
+    /// storage (the onboarding "Test" probe). Resolver-aware wrapper over
+    /// [`verify_storage_access`]: hydrates any `SecretRef` catalog auth via this
+    /// instance's secret resolver FIRST (mirroring the browse/preview wrappers),
+    /// then runs the probe through the engine's own credential + storage path.
+    pub async fn verify_iceberg_storage_access(
+        &self,
+        conn: IcebergConnectionConfig,
+        table: &str,
+    ) -> Result<StorageAccessReport> {
+        let conn = self.hydrate_conn(conn).await?;
+        verify_storage_access(conn, table).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1266,5 +1507,253 @@ mod tests {
         let conn = IcebergConnectionConfig::rest("https://c.example.com")
             .with_auth_bearer("literal-token");
         assert!(fluree.hydrate_conn(conn).await.is_ok());
+    }
+
+    // ── §6 storage-access verification ──
+
+    use fluree_db_iceberg::error::Result as IcebergResult;
+    use fluree_db_iceberg::manifest::{FileFormat, PartitionData};
+
+    /// A structured 403 as the S3 storage layer produces it, so the probe's
+    /// error-lift is exercised end to end (StorageAccessDenied → 403).
+    fn denied(path: &str) -> fluree_db_iceberg::IcebergError {
+        fluree_db_iceberg::IcebergError::StorageAccessDenied {
+            bucket: "bucket".to_string(),
+            key: path.to_string(),
+            region: Some("us-east-1".to_string()),
+            message: "service error: AccessDenied".to_string(),
+        }
+    }
+
+    /// Storage stub whose every access denies with a structured 403.
+    #[derive(Debug)]
+    struct DeniedStorage;
+
+    #[async_trait::async_trait]
+    impl SendIcebergStorage for DeniedStorage {
+        async fn read(&self, path: &str) -> IcebergResult<bytes::Bytes> {
+            Err(denied(path))
+        }
+        async fn read_range(
+            &self,
+            path: &str,
+            _range: std::ops::Range<u64>,
+        ) -> IcebergResult<bytes::Bytes> {
+            Err(denied(path))
+        }
+        async fn file_size(&self, path: &str) -> IcebergResult<u64> {
+            Err(denied(path))
+        }
+    }
+
+    /// Storage stub that panics on ANY access: the empty-table data probe must not
+    /// touch storage, so a panic here fails the test loudly.
+    #[derive(Debug)]
+    struct PanicStorage;
+
+    #[async_trait::async_trait]
+    impl SendIcebergStorage for PanicStorage {
+        async fn read(&self, path: &str) -> IcebergResult<bytes::Bytes> {
+            panic!("storage.read must not be called on the empty-table probe (path={path})");
+        }
+        async fn read_range(
+            &self,
+            _path: &str,
+            _range: std::ops::Range<u64>,
+        ) -> IcebergResult<bytes::Bytes> {
+            panic!("storage.read_range must not be called on the empty-table probe");
+        }
+        async fn file_size(&self, path: &str) -> IcebergResult<u64> {
+            panic!("storage.file_size must not be called on the empty-table probe (path={path})");
+        }
+    }
+
+    /// Storage stub that answers `file_size` (`HeadObject`) with a fixed size and
+    /// panics on any byte read: the data-prefix probe must stat, never download.
+    #[derive(Debug)]
+    struct HeadOnlyStorage {
+        size: u64,
+    }
+
+    #[async_trait::async_trait]
+    impl SendIcebergStorage for HeadOnlyStorage {
+        async fn read(&self, path: &str) -> IcebergResult<bytes::Bytes> {
+            panic!("storage.read must not be called on the data-prefix probe (path={path})");
+        }
+        async fn read_range(
+            &self,
+            _path: &str,
+            _range: std::ops::Range<u64>,
+        ) -> IcebergResult<bytes::Bytes> {
+            panic!("storage.read_range must not be called on the data-prefix probe");
+        }
+        async fn file_size(&self, _path: &str) -> IcebergResult<u64> {
+            Ok(self.size)
+        }
+    }
+
+    fn sample_data_file(path: &str) -> DataFile {
+        DataFile {
+            file_path: path.to_string(),
+            file_format: FileFormat::Parquet,
+            record_count: 10,
+            file_size_in_bytes: 100,
+            partition: PartitionData::default(),
+            column_sizes: None,
+            value_counts: None,
+            null_value_counts: None,
+            nan_value_counts: None,
+            lower_bounds: None,
+            upper_bounds: None,
+            split_offsets: None,
+            sort_order_id: None,
+        }
+    }
+
+    fn snapshot_with_manifest_list(path: &str) -> Snapshot {
+        Snapshot {
+            snapshot_id: 1,
+            parent_snapshot_id: None,
+            sequence_number: 0,
+            timestamp_ms: 1_700_000_000_000,
+            manifest_list: Some(path.to_string()),
+            manifests: None,
+            summary: HashMap::new(),
+            schema_id: Some(0),
+        }
+    }
+
+    #[test]
+    fn storage_access_report_serde_shape() {
+        // The solo wizard reads these exact keys — pin the field set + names.
+        let report = StorageAccessReport {
+            credential_source: "vended",
+            metadata_location: "s3://bucket/warehouse/t/metadata/v3.metadata.json".to_string(),
+            data_files_listed: 4,
+            probed_data_file: Some("s3://bucket/warehouse/t/data/part-0.parquet".to_string()),
+            probed_data_file_bytes: Some(2048),
+            data_probe_skipped: false,
+            skip_reason: None,
+        };
+        let v = serde_json::to_value(&report).unwrap();
+        assert_eq!(v["credential_source"], "vended");
+        assert_eq!(
+            v["metadata_location"],
+            "s3://bucket/warehouse/t/metadata/v3.metadata.json"
+        );
+        assert_eq!(v["data_files_listed"], 4);
+        assert_eq!(
+            v["probed_data_file"],
+            "s3://bucket/warehouse/t/data/part-0.parquet"
+        );
+        assert_eq!(v["probed_data_file_bytes"], 2048);
+        assert_eq!(v["data_probe_skipped"], false);
+        assert!(v["skip_reason"].is_null());
+        assert_eq!(
+            v.as_object().unwrap().len(),
+            7,
+            "report field set is pinned: {v}"
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_skips_data_prefix_for_empty_table() {
+        // No data files ⇒ the data/ prefix probe is skipped WITHOUT any storage
+        // read (PanicStorage would panic on a touch).
+        let probe = probe_data_files(&PanicStorage, &[], "DW.EMPTY")
+            .await
+            .expect("empty-table probe must succeed without any storage read");
+        assert!(probe.data_probe_skipped);
+        assert!(probe.probed_data_file.is_none());
+        assert!(probe.probed_data_file_bytes.is_none());
+        assert!(probe.skip_reason.is_some());
+    }
+
+    #[tokio::test]
+    async fn probe_stats_first_data_file_when_present() {
+        // A non-empty table stats (HeadObject) the first data file — never reads it.
+        let df = sample_data_file("s3://bucket/warehouse/t/data/part-0.parquet");
+        let probe = probe_data_files(
+            &HeadOnlyStorage { size: 99 },
+            std::slice::from_ref(&df),
+            "DW.T",
+        )
+        .await
+        .expect("a readable data file resolves via HeadObject");
+        assert!(!probe.data_probe_skipped);
+        assert_eq!(
+            probe.probed_data_file.as_deref(),
+            Some("s3://bucket/warehouse/t/data/part-0.parquet")
+        );
+        assert_eq!(probe.probed_data_file_bytes, Some(99));
+        assert!(probe.skip_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn probe_data_prefix_denied_surfaces_storage_access_denied() {
+        // A denied HeadObject on the data/ prefix must surface as the typed
+        // access-denied variant (→ HTTP 403), not a generic config error.
+        let df = sample_data_file("s3://bucket/warehouse/t/data/part-0.parquet");
+        let err = probe_data_files(&DeniedStorage, std::slice::from_ref(&df), "DW.T")
+            .await
+            .expect_err("a denied HeadObject must propagate");
+        assert!(
+            matches!(err, crate::ApiError::StorageAccessDenied { .. }),
+            "expected StorageAccessDenied, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_metadata_prefix_denied_surfaces_storage_access_denied() {
+        // A denied read of the manifest list (metadata/ prefix) must likewise
+        // surface as the typed access-denied variant.
+        let snapshot = snapshot_with_manifest_list(
+            "s3://bucket/warehouse/t/metadata/snap-1-manifest-list.avro",
+        );
+        let err = probe_storage_access(
+            &DeniedStorage,
+            &snapshot,
+            "vended",
+            "s3://bucket/warehouse/t/metadata/v3.metadata.json".to_string(),
+            "DW.T",
+        )
+        .await
+        .expect_err("a denied manifest-list read must propagate");
+        assert!(
+            matches!(err, crate::ApiError::StorageAccessDenied { .. }),
+            "expected StorageAccessDenied, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_qualified_table_splits_on_last_dot() {
+        assert_eq!(
+            parse_qualified_table("DW.DIM_STORE"),
+            TableIdentifier::new("DW", "DIM_STORE")
+        );
+        // Dotted namespace: the LAST dot separates namespace from name.
+        assert_eq!(
+            parse_qualified_table("db.schema.events"),
+            TableIdentifier::new("db.schema", "events")
+        );
+        // No dot ⇒ empty namespace (catalog rejects as not-found).
+        assert_eq!(
+            parse_qualified_table("bare"),
+            TableIdentifier::new("", "bare")
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_direct_mode_errors() {
+        // Direct mode has no catalog to authorize the read — mirror preview and
+        // reject with a clear typed error, without any network access.
+        let conn = IcebergConnectionConfig::direct("s3://bucket/warehouse/ns/table");
+        let err = verify_storage_access(conn, "ns.table")
+            .await
+            .expect_err("Direct mode must not be verifiable");
+        assert!(
+            err.to_string().contains("Direct catalog mode"),
+            "error should explain Direct mode is unsupported, got: {err}"
+        );
     }
 }

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -651,10 +651,10 @@ pub async fn preview_iceberg_table(
                         send_read_snapshot_data_files(&storage, snapshot)
                             .await
                             .map_err(|e| {
-                                crate::ApiError::config(format!(
-                                    "Failed to read manifests for {}: {e}",
-                                    table.qualified()
-                                ))
+                                storage_api_error(
+                                    &format!("Failed to read manifests for {}", table.qualified()),
+                                    e,
+                                )
                             })?;
 
                     let agg = aggregate_column_stats(&data_files, iceberg_schema);
@@ -710,30 +710,152 @@ pub async fn preview_iceberg_table(
     }
 }
 
+/// Lift an [`IcebergError`](fluree_db_iceberg::IcebergError) raised at a
+/// **storage-read** site into a [`QueryError`](fluree_db_query::QueryError),
+/// preserving the typed access-denied case.
+///
+/// [`StorageAccessDenied`](fluree_db_iceberg::IcebergError::StorageAccessDenied)
+/// becomes `QueryError::StorageAccessDenied` (→ HTTP 403); every other variant
+/// becomes `QueryError::Internal("{context}: {err}")`, byte-for-byte the
+/// pre-existing wrapping. Use ONLY at storage-read sites (metadata / manifest /
+/// Parquet / resolve-from-table-location) — client-construction failures stay
+/// `Internal`.
+pub(crate) fn storage_query_error(
+    context: &str,
+    err: fluree_db_iceberg::IcebergError,
+) -> fluree_db_query::QueryError {
+    match err {
+        fluree_db_iceberg::IcebergError::StorageAccessDenied {
+            bucket,
+            key,
+            region,
+            message,
+        } => fluree_db_query::QueryError::StorageAccessDenied {
+            bucket,
+            key,
+            region,
+            message,
+        },
+        other => fluree_db_query::QueryError::Internal(format!("{context}: {other}")),
+    }
+}
+
+/// Preview/browse-path analogue of [`storage_query_error`]: lift a
+/// storage-read [`IcebergError`](fluree_db_iceberg::IcebergError) into an
+/// [`ApiError`](crate::ApiError). The access-denied case becomes
+/// `ApiError::StorageAccessDenied` (→ HTTP 403); everything else becomes
+/// `ApiError::config("{context}: {err}")`, matching the pre-existing preview
+/// wrapping.
+pub(crate) fn storage_api_error(
+    context: &str,
+    err: fluree_db_iceberg::IcebergError,
+) -> crate::ApiError {
+    match err {
+        fluree_db_iceberg::IcebergError::StorageAccessDenied {
+            bucket,
+            key,
+            region,
+            message,
+        } => crate::ApiError::StorageAccessDenied {
+            bucket,
+            key,
+            region,
+            message,
+        },
+        other => crate::ApiError::config(format!("{context}: {other}")),
+    }
+}
+
+/// Which credential source a scan/preview should use, given the source's
+/// `vended_credentials` flag, whether the catalog actually vended credentials,
+/// and whether this is a REST catalog. See [`decide_credential_source`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CredentialSource {
+    /// Use the catalog-vended credentials (they are present).
+    Vended,
+    /// Use the ambient AWS credential chain (explicit `vended_credentials =
+    /// false` opt-in, or Direct mode which never vends).
+    Ambient,
+    /// Refuse: the REST source requires vending but the catalog vended none.
+    FailClosed,
+}
+
+/// §2 credential-source decision — the single source of truth for the scan and
+/// preview paths, factored out so the full matrix is unit-testable.
+///
+/// | `vended_credentials` | vended creds present | REST | decision |
+/// |----------------------|----------------------|------|----------|
+/// | any                  | yes                  | any  | `Vended` (response-driven) |
+/// | true                 | no                   | yes  | `FailClosed` |
+/// | true                 | no                   | no (Direct) | `Ambient` (Direct never vends) |
+/// | false                | no                   | any  | `Ambient` (explicit opt-in) |
+///
+/// The `(false, present)` case stays `Vended` to preserve today's
+/// response-driven behavior: `vended_credentials = false` suppresses the
+/// delegation request, so credentials should not arrive — but if a catalog vends
+/// them anyway, using them (rather than ignoring them) matches prior behavior.
+pub(crate) fn decide_credential_source(
+    vended_credentials_cfg: bool,
+    has_vended_creds: bool,
+    is_rest_catalog: bool,
+) -> CredentialSource {
+    if has_vended_creds {
+        CredentialSource::Vended
+    } else if vended_credentials_cfg && is_rest_catalog {
+        CredentialSource::FailClosed
+    } else {
+        CredentialSource::Ambient
+    }
+}
+
 /// Build S3 storage for reading manifests during a Tier-B preview, mirroring the
-/// scan path's policy: vended credentials when the catalog delegated them,
-/// otherwise the ambient AWS credential chain.
+/// scan path's policy via [`decide_credential_source`]: vended credentials when
+/// the catalog delegated them, otherwise — for `vended_credentials = false` or
+/// Direct mode — the ambient AWS credential chain.
+///
+/// §2 fail-closed: a REST source configured to require vended credentials
+/// (`io.vended_credentials = true`, the default) must NOT silently downgrade to
+/// ambient credentials when the catalog vended none — that would read from
+/// whatever ambient identity the process happens to have. Direct mode never
+/// vends (it sends no delegation request), so it is exempt.
 pub(crate) async fn build_preview_storage(
     conn: &IcebergConnectionConfig,
     credentials: Option<&fluree_db_iceberg::credential::VendedCredentials>,
 ) -> Result<S3IcebergStorage> {
     let io = &conn.io;
-    let storage = if let Some(creds) = credentials {
-        S3IcebergStorage::from_vended_credentials(
-            creds,
-            io.s3_region.as_deref(),
-            io.s3_endpoint.as_deref(),
-            io.s3_path_style,
-        )
-        .await
-    } else {
-        S3IcebergStorage::from_default_chain(
-            io.s3_region.as_deref(),
-            io.s3_endpoint.as_deref(),
-            io.s3_path_style,
-        )
-        .await
-    };
+    let is_rest = matches!(conn.catalog_mode, CatalogMode::Rest(_));
+    let storage =
+        match decide_credential_source(io.vended_credentials, credentials.is_some(), is_rest) {
+            CredentialSource::Vended => {
+                let creds = credentials.expect("Vended decision implies credentials are present");
+                S3IcebergStorage::from_vended_credentials(
+                    creds,
+                    io.s3_region.as_deref(),
+                    io.s3_endpoint.as_deref(),
+                    io.s3_path_style,
+                )
+                .await
+            }
+            CredentialSource::Ambient => {
+                S3IcebergStorage::from_default_chain(
+                    io.s3_region.as_deref(),
+                    io.s3_endpoint.as_deref(),
+                    io.s3_path_style,
+                )
+                .await
+            }
+            CredentialSource::FailClosed => {
+                // FailClosed only arises for a REST catalog (see the decision table),
+                // so this destructure always matches.
+                let catalog_uri = match &conn.catalog_mode {
+                    CatalogMode::Rest(rest) => rest.catalog_uri.clone(),
+                    CatalogMode::Direct { .. } => {
+                        unreachable!("FailClosed is only produced for REST catalogs")
+                    }
+                };
+                return Err(crate::ApiError::CatalogCredentialsNotVended { catalog_uri });
+            }
+        };
     storage.map_err(|e| crate::ApiError::config(format!("Failed to create S3 storage: {e}")))
 }
 
@@ -769,6 +891,55 @@ impl crate::Fluree {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── §2 credential-source decision (pure; the full matrix) ──
+
+    #[test]
+    fn creds_present_always_vended() {
+        // Response-driven: if the catalog vended credentials, use them —
+        // regardless of the flag or catalog kind.
+        for &cfg in &[true, false] {
+            for &rest in &[true, false] {
+                assert_eq!(
+                    decide_credential_source(cfg, true, rest),
+                    CredentialSource::Vended,
+                    "cfg={cfg} rest={rest}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rest_requires_vending_fails_closed_when_none() {
+        // vended_credentials = true (default) + REST + no creds → refuse.
+        assert_eq!(
+            decide_credential_source(true, false, true),
+            CredentialSource::FailClosed
+        );
+    }
+
+    #[test]
+    fn direct_mode_never_fails_closed() {
+        // Direct never vends; vended_credentials = true must NOT start failing —
+        // it uses the ambient chain (item 8).
+        assert_eq!(
+            decide_credential_source(true, false, false),
+            CredentialSource::Ambient
+        );
+    }
+
+    #[test]
+    fn explicit_opt_in_uses_ambient() {
+        // vended_credentials = false + no creds → ambient (both catalog kinds).
+        assert_eq!(
+            decide_credential_source(false, false, true),
+            CredentialSource::Ambient
+        );
+        assert_eq!(
+            decide_credential_source(false, false, false),
+            CredentialSource::Ambient
+        );
+    }
 
     #[tokio::test]
     async fn browse_direct_mode_errors() {

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -218,6 +218,34 @@ fn split_qualified_table(queried_ns: &str, qualified: &str) -> TableRef {
 }
 
 impl crate::Fluree {
+    /// Resolve any `ConfigValue::SecretRef` auth references in a REST connection
+    /// via this instance's injected secret resolver, returning a connection whose
+    /// auth is resolver-free (literal / env-var / none) and therefore safe to
+    /// hand to the SYNCHRONOUS [`rest_catalog_client`].
+    ///
+    /// Pass-through for Direct mode (no catalog auth) and for connections with no
+    /// secret reference. Fails closed with an actionable error when a `SecretRef`
+    /// is present but no resolver was injected (the OSS/CLI path). This is the
+    /// single hydration hop the impl-`Fluree` catalog wrappers call at their top,
+    /// keeping `rest_catalog_client` and the free functions unchanged for
+    /// external literal/env-var users.
+    pub(crate) async fn hydrate_conn(
+        &self,
+        mut conn: IcebergConnectionConfig,
+    ) -> Result<IcebergConnectionConfig> {
+        if let CatalogMode::Rest(ref mut rest) = conn.catalog_mode {
+            let hydrated = rest
+                .auth
+                .hydrate(self.secret_resolver())
+                .await
+                .map_err(|e| {
+                    crate::ApiError::config(format!("Failed to resolve catalog auth secret: {e}"))
+                })?;
+            rest.auth = hydrated;
+        }
+        Ok(conn)
+    }
+
     /// Browse an Iceberg REST catalog (namespaces, and tables at
     /// `depth = Tables`). Convenience wrapper over the stateless
     /// [`browse_iceberg_catalog`] free function — browse needs no engine state.
@@ -226,6 +254,7 @@ impl crate::Fluree {
         conn: IcebergConnectionConfig,
         depth: BrowseDepth,
     ) -> Result<CatalogBrowse> {
+        let conn = self.hydrate_conn(conn).await?;
         browse_iceberg_catalog(conn, depth).await
     }
 }
@@ -884,6 +913,7 @@ impl crate::Fluree {
         table: TableIdentifier,
         tier: StatsTier,
     ) -> Result<TablePreview> {
+        let conn = self.hydrate_conn(conn).await?;
         preview_iceberg_table(conn, table, tier).await
     }
 }
@@ -1183,5 +1213,58 @@ mod tests {
             ),
             Some("xsd:decimal")
         );
+    }
+
+    // ── secret-resolver injection + fail-closed hydration gate ──
+
+    #[derive(Debug)]
+    struct StubResolver;
+
+    #[async_trait::async_trait]
+    impl fluree_db_iceberg::SecretResolver for StubResolver {
+        async fn resolve_secret(
+            &self,
+            secret_ref: &str,
+        ) -> std::result::Result<String, fluree_db_iceberg::SecretResolveError> {
+            Ok(format!("resolved:{secret_ref}"))
+        }
+    }
+
+    #[tokio::test]
+    async fn with_secret_resolver_clones_and_leaves_original_untouched() {
+        let fluree = crate::FlureeBuilder::memory().build_memory();
+        assert!(fluree.secret_resolver().is_none());
+
+        let resolver: std::sync::Arc<dyn fluree_db_iceberg::SecretResolver> =
+            std::sync::Arc::new(StubResolver);
+        let derived = fluree.with_secret_resolver(resolver);
+
+        // The derived clone carries the resolver; the original is untouched.
+        assert!(derived.secret_resolver().is_some());
+        assert!(fluree.secret_resolver().is_none());
+    }
+
+    #[tokio::test]
+    async fn hydrate_conn_fails_closed_before_network_when_ref_has_no_resolver() {
+        // No resolver injected + SecretRef auth ⇒ hydrate_conn errors with an
+        // actionable message BEFORE any catalog client is built or network I/O
+        // happens (the same gate the connection test relies on).
+        let fluree = crate::FlureeBuilder::memory().build_memory();
+        let conn = IcebergConnectionConfig::rest("https://unreachable.invalid")
+            .with_auth_bearer_token_ref("vault://team/bearer");
+        let err = fluree.hydrate_conn(conn).await.unwrap_err().to_string();
+        assert!(
+            err.contains("secret resolver"),
+            "actionable message expected: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn hydrate_conn_passes_through_literal_auth() {
+        // A literal-auth connection with no resolver hydrates to itself (no error).
+        let fluree = crate::FlureeBuilder::memory().build_memory();
+        let conn = IcebergConnectionConfig::rest("https://c.example.com")
+            .with_auth_bearer("literal-token");
+        assert!(fluree.hydrate_conn(conn).await.is_ok());
     }
 }

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -766,6 +766,13 @@ pub(crate) fn storage_query_error(
             region,
             message,
         },
+        // §2's fail-closed error, raised inside a deferred `LazyS3Storage` build and
+        // ferried out through the builder's `IcebergError` channel. Lift it back so
+        // the 403 + `err:catalog/CredentialsNotVended` wire code survives the lazy
+        // path exactly as it does the eager one.
+        fluree_db_iceberg::IcebergError::CatalogCredentialsNotVended { catalog_uri } => {
+            fluree_db_query::QueryError::CatalogCredentialsNotVended { catalog_uri }
+        }
         other => fluree_db_query::QueryError::Internal(format!("{context}: {other}")),
     }
 }

--- a/fluree-db-api/src/graph_source/iceberg_generate.rs
+++ b/fluree-db-api/src/graph_source/iceberg_generate.rs
@@ -337,6 +337,11 @@ impl crate::Fluree {
             ));
         }
 
+        // Resolve any SecretRef auth once (fail closed if a ref has no resolver);
+        // the per-table previews below each clone this hydrated, literal-auth
+        // connection so no per-table resolver calls happen.
+        let connection = self.hydrate_conn(req.connection.clone()).await?;
+
         // Fetch each requested table's Tier-A+B preview (metadata-only) with
         // BOUNDED CONCURRENCY. Each preview is an independent chain of network
         // round trips (OAuth token exchange + REST `loadTable` + manifest-list /
@@ -357,7 +362,7 @@ impl crate::Fluree {
         let previews: Vec<(TableIdentifier, TablePreview)> =
             futures::stream::iter(req.tables.iter().cloned())
                 .map(|table| {
-                    let connection = req.connection.clone();
+                    let connection = connection.clone();
                     async move {
                         let preview =
                             preview_iceberg_table(connection, table.clone(), StatsTier::Stats)

--- a/fluree-db-api/src/graph_source/iceberg_sample.rs
+++ b/fluree-db-api/src/graph_source/iceberg_sample.rs
@@ -275,6 +275,7 @@ impl crate::Fluree {
         projection: Option<Vec<String>>,
         n: usize,
     ) -> Result<Vec<Value>> {
+        let conn = self.hydrate_conn(conn).await?;
         sample_iceberg_rows(conn, table, projection, n).await
     }
 
@@ -288,6 +289,7 @@ impl crate::Fluree {
         column: String,
         n: usize,
     ) -> Result<Vec<Value>> {
+        let conn = self.hydrate_conn(conn).await?;
         sample_column_values(conn, table, column, n).await
     }
 }

--- a/fluree-db-api/src/graph_source/iceberg_validate.rs
+++ b/fluree-db-api/src/graph_source/iceberg_validate.rs
@@ -373,6 +373,11 @@ impl crate::Fluree {
         turtle: String,
         snapshot: Option<i64>,
     ) -> Result<ValidateR2rmlResponse> {
+        // Resolve any SecretRef auth up front. A missing resolver is a host
+        // wiring fault (not a mapping problem), so it fails closed here rather
+        // than degrading to a per-table TableNotFound diagnostic.
+        let conn = self.hydrate_conn(conn).await?;
+
         let compiled = match compile_for_validate(&turtle) {
             Ok(compiled) => compiled,
             Err(response) => return Ok(response),

--- a/fluree-db-api/src/graph_source/mod.rs
+++ b/fluree-db-api/src/graph_source/mod.rs
@@ -152,9 +152,10 @@ pub use config::{CatalogMode, IcebergConnectionConfig, IcebergCreateConfig, Rest
 
 #[cfg(feature = "iceberg")]
 pub use iceberg_catalog::{
-    browse_iceberg_catalog, guard_iceberg_connection_urls, preview_iceberg_table, BrowseDepth,
-    CatalogBrowse, ColumnInfo, ColumnStats, PartitionFieldInfo, SnapshotRef, SortFieldInfo,
-    StatsCompleteness, StatsTier, TableIdentifier, TablePreview, TableRef, TableSchema,
+    browse_iceberg_catalog, guard_iceberg_connection_urls, preview_iceberg_table,
+    verify_storage_access, BrowseDepth, CatalogBrowse, ColumnInfo, ColumnStats, PartitionFieldInfo,
+    SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier, StorageAccessReport, TableIdentifier,
+    TablePreview, TableRef, TableSchema,
 };
 
 #[cfg(feature = "iceberg")]

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -1561,24 +1561,26 @@ impl FlureeR2rmlProvider<'_> {
                     "Loading table via direct S3 access"
                 );
 
-                // Direct mode: create storage once, share via Arc. gs://-backed
-                // tables (GCS S3-interop endpoint) are read through the same S3
-                // SDK path; the client is pinned to HTTP/1.1 to avoid the AWS-SDK
-                // HTTP/2 range-read bug against that endpoint.
-                let storage: Arc<S3IcebergStorage> = Arc::new(
-                    S3IcebergStorage::from_default_chain(
-                        iceberg_config.io.s3_region.as_deref(),
-                        iceberg_config.io.s3_endpoint.as_deref(),
-                        iceberg_config.io.s3_path_style,
-                    )
-                    .await
-                    .map_err(|e| {
-                        QueryError::Internal(format!("Failed to create S3 storage: {e}"))
-                    })?,
+                // Session cache key for this table's storage client — the same
+                // key the REST branch uses (source id + fully-qualified table),
+                // so repeated scans of one Direct table in a query reuse a single
+                // S3 client instead of rebuilding it (credential-chain resolution
+                // + a fresh connection pool) per scan (fluree/db#1498).
+                let lt_key = super::catalog_session::IcebergCatalogSession::load_table_key(
+                    graph_source_id,
+                    &table_id.namespace,
+                    &table_id.table,
                 );
 
                 let cache = self.fluree.r2rml_cache();
-                let load_response = if let Some(metadata_location) =
+                // Storage construction sits BELOW the metadata-location check so a
+                // hit resolves through `direct_session_storage`, which serves the
+                // session-cached client when this table was already resolved this
+                // query and skips `from_default_chain` entirely. Both arms still
+                // need storage (the scan reads data files; the miss arm also reads
+                // version-hint/metadata via the direct catalog), so this is a
+                // reordering — the session cache covers it, not an elision.
+                let (load_response, storage) = if let Some(metadata_location) =
                     cache.get_direct_metadata_location(table_location).await
                 {
                     debug!(
@@ -1586,14 +1588,34 @@ impl FlureeR2rmlProvider<'_> {
                         metadata_location = %metadata_location,
                         "Direct metadata-location cache hit"
                     );
-                    fluree_db_iceberg::catalog::LoadTableResponse {
+                    let storage = direct_session_storage(
+                        &self.session,
+                        &lt_key,
+                        iceberg_config.io.s3_region.as_deref(),
+                        iceberg_config.io.s3_endpoint.as_deref(),
+                        iceberg_config.io.s3_path_style,
+                    )
+                    .await?;
+                    let load_response = fluree_db_iceberg::catalog::LoadTableResponse {
                         metadata_location,
                         config: std::collections::HashMap::default(),
                         credentials: None,
                         metadata: None,
-                    }
+                    };
+                    (load_response, storage)
                 } else {
                     debug!(table_location = %table_location, "Direct metadata-location cache miss");
+
+                    // The direct catalog reads version-hint.text + metadata from
+                    // S3, so it needs the storage client up front.
+                    let storage = direct_session_storage(
+                        &self.session,
+                        &lt_key,
+                        iceberg_config.io.s3_region.as_deref(),
+                        iceberg_config.io.s3_endpoint.as_deref(),
+                        iceberg_config.io.s3_path_style,
+                    )
+                    .await?;
 
                     let direct_catalog =
                         SendDirectCatalogClient::new(table_location.clone(), Arc::clone(&storage));
@@ -1616,7 +1638,7 @@ impl FlureeR2rmlProvider<'_> {
                             load_response.metadata_location.clone(),
                         )
                         .await;
-                    load_response
+                    (load_response, storage)
                 };
 
                 info!(
@@ -2268,6 +2290,43 @@ async fn resolve_table_metadata<S: SendIcebergStorage>(
     Ok(metadata)
 }
 
+/// Acquire the S3 storage client for a Direct-mode table, reusing the query
+/// session's cached client when one is present.
+///
+/// Direct mode builds from the ambient AWS credential chain
+/// (`from_default_chain`: env → `~/.aws` → IMDS/ECS network round-trips) and
+/// stands up a fresh connection pool — not free, and repeated for every scan of
+/// a table that a correlated join (or the slice-1 prefetch→scan) re-resolves.
+/// This mirrors the REST branch's `cached_storage`/`store_storage` reuse
+/// (fluree/db#1498). Unlike REST, Direct never calls `store_load_table` (it has
+/// no vended credentials to rotate), so the cached client is never invalidated
+/// mid-query: the first build is stored and every later resolution of the same
+/// table returns that Arc. `cached_storage`/`store_storage` are gated on
+/// `cache_enabled()`, so with caching disabled this still builds per call
+/// (matching REST and the pre-#1498 behavior).
+async fn direct_session_storage(
+    session: &super::catalog_session::IcebergCatalogSession,
+    lt_key: &str,
+    region: Option<&str>,
+    endpoint: Option<&str>,
+    path_style: bool,
+) -> QueryResult<Arc<S3IcebergStorage>> {
+    if let Some(cached) = session.cached_storage(lt_key) {
+        debug!("S3 storage client reused (query-scoped, direct)");
+        return Ok(cached);
+    }
+    // gs://-backed tables (GCS S3-interop endpoint) are read through this same S3
+    // SDK path; the client is pinned to HTTP/1.1 to avoid the AWS-SDK HTTP/2
+    // range-read bug against that endpoint.
+    let built = Arc::new(
+        S3IcebergStorage::from_default_chain(region, endpoint, path_style)
+            .await
+            .map_err(|e| QueryError::Internal(format!("Failed to create S3 storage: {e}")))?,
+    );
+    session.store_storage(lt_key.to_string(), Arc::clone(&built));
+    Ok(built)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2857,6 +2916,45 @@ mod tests {
         assert_ne!(
             key_raw, key_h1,
             "the raw ref-bearing key must differ from the hydrated key"
+        );
+    }
+
+    /// fluree/db#1498: Direct mode resolves its S3 client through the query
+    /// session cache, so two resolutions of the same table in one query share ONE
+    /// client instead of rebuilding it (credential-chain resolution + a fresh
+    /// connection pool) per scan. Direct mode never calls `store_load_table`, so
+    /// nothing invalidates the cached client mid-query — the second acquisition
+    /// must return the first Arc. `from_default_chain(Some(region), ..)` builds an
+    /// SDK client offline (region set, ambient creds resolved lazily, no request),
+    /// so this runs in CI without AWS credentials. This is the strongest seam that
+    /// exercises the actual fix without a live catalog: it drives the exact helper
+    /// the Direct branch now calls in both metadata-location arms.
+    #[tokio::test]
+    async fn direct_session_storage_reuses_arc_across_calls() {
+        use crate::graph_source::catalog_session::IcebergCatalogSession;
+        let session = IcebergCatalogSession::default();
+        let key = IcebergCatalogSession::load_table_key("gs:main", "DW", "DIM_STORE");
+
+        let first = direct_session_storage(&session, &key, Some("us-east-2"), None, false)
+            .await
+            .expect("offline SDK client construction");
+        let second = direct_session_storage(&session, &key, Some("us-east-2"), None, false)
+            .await
+            .expect("offline SDK client construction");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "the second Direct-mode acquisition must reuse the session-cached S3 client"
+        );
+
+        // A different table (different key) is a distinct client — the cache keys
+        // per (source, table), so unrelated tables never alias one client.
+        let other_key = IcebergCatalogSession::load_table_key("gs:main", "DW", "DIM_GEOGRAPHY");
+        let other = direct_session_storage(&session, &other_key, Some("us-east-2"), None, false)
+            .await
+            .expect("offline SDK client construction");
+        assert!(
+            !Arc::ptr_eq(&first, &other),
+            "a different table must not reuse another table's cached client"
         );
     }
 }

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -8,6 +8,9 @@
 use super::lazy_storage::LazyS3Storage;
 use crate::graph_source::cache::{CachedScanFiles, R2rmlCache};
 use crate::graph_source::config::{CatalogMode, IcebergCreateConfig, R2rmlCreateConfig};
+use crate::graph_source::iceberg_catalog::{
+    decide_credential_source, storage_query_error, CredentialSource,
+};
 use crate::graph_source::result::{IcebergCreateResult, R2rmlCreateResult};
 use crate::Result;
 use async_trait::async_trait;
@@ -1074,9 +1077,10 @@ impl FlureeR2rmlProvider<'_> {
                     ))
                     .await
                     .map_err(|e| {
-                        QueryError::Internal(format!(
-                            "Failed to read manifests for row count of '{table_name}': {e}"
-                        ))
+                        storage_query_error(
+                            &format!("Failed to read manifests for row count of '{table_name}'"),
+                            e,
+                        )
                     })?;
             catalog_cache.put_count_stats(&metadata_location, &data_files, has_delete_manifests);
             (data_files, has_delete_manifests)
@@ -1442,6 +1446,32 @@ impl FlureeR2rmlProvider<'_> {
                     resp
                 };
 
+                // §2 fail-closed: the source is configured to require
+                // catalog-vended storage credentials (io.vended_credentials =
+                // true, the default), but the loadTable response carried none. Do
+                // NOT silently downgrade to ambient AWS credentials — a BYO-IAM
+                // misconfiguration (or a catalog that stopped vending) must
+                // surface as an actionable error, not read from whatever ambient
+                // identity the process happens to have. `vended_credentials =
+                // false` is the explicit opt-in to ambient (the else-branch
+                // below), and Direct mode never reaches here (`is_rest = true`).
+                // This holds on cache hits too: the loadTable caches preserve
+                // `credentials` verbatim and only ever MISS-and-reload on expiry,
+                // so a resolved `credentials == None` always means the catalog
+                // genuinely vended nothing (never a dropped-credential
+                // reconstruction). The Vended/Ambient split is left to the
+                // `if let Some(..)` construction below.
+                if decide_credential_source(
+                    iceberg_config.io.vended_credentials,
+                    load_response.credentials.is_some(),
+                    true,
+                ) == CredentialSource::FailClosed
+                {
+                    return Err(QueryError::CatalogCredentialsNotVended {
+                        catalog_uri: uri.clone(),
+                    });
+                }
+
                 // GCS-backed tables (S3-interop endpoint) are read through this
                 // same S3 SDK path; the SDK client is pinned to HTTP/1.1 so the
                 // GCS HTTP/2 range-read bug cannot occur.
@@ -1548,9 +1578,12 @@ impl FlureeR2rmlProvider<'_> {
                             .load_table(&table_id, false)
                             .await
                             .map_err(|e| {
-                                QueryError::Internal(format!(
-                                    "Failed to resolve table metadata from {table_location}: {e}"
-                                ))
+                                storage_query_error(
+                                    &format!(
+                                        "Failed to resolve table metadata from {table_location}"
+                                    ),
+                                    e,
+                                )
                             })?;
                     cache
                         .put_direct_metadata_location(
@@ -1706,7 +1739,7 @@ impl FlureeR2rmlProvider<'_> {
             let plan = planner
                 .plan_scan()
                 .await
-                .map_err(|e| QueryError::Internal(format!("Failed to plan scan: {e}")))?;
+                .map_err(|e| storage_query_error("Failed to plan scan", e))?;
             (
                 plan.tasks,
                 plan.files_selected,
@@ -1782,7 +1815,7 @@ impl FlureeR2rmlProvider<'_> {
             let plan = planner
                 .plan_scan()
                 .await
-                .map_err(|e| QueryError::Internal(format!("Failed to plan scan: {e}")))?;
+                .map_err(|e| storage_query_error("Failed to plan scan", e))?;
 
             let cached = Arc::new(CachedScanFiles {
                 data_files: Arc::new(
@@ -1881,10 +1914,13 @@ impl FlureeR2rmlProvider<'_> {
                     .instrument(read_span)
                     .await
                     .map_err(|e| {
-                        QueryError::Internal(format!(
-                            "Failed to read Parquet file '{}': {e}",
-                            tasks[orig].data_file.file_path
-                        ))
+                        storage_query_error(
+                            &format!(
+                                "Failed to read Parquet file '{}'",
+                                tasks[orig].data_file.file_path
+                            ),
+                            e,
+                        )
                     })?;
                     // SOUNDNESS INVARIANT: the heap is fed the sort values of the
                     // rows this scan EMITS — which are the QUALIFYING result rows
@@ -1959,10 +1995,13 @@ impl FlureeR2rmlProvider<'_> {
                                     );
                                     reader.read_task(&task).instrument(read_span).await.map_err(
                                         |e| {
-                                            QueryError::Internal(format!(
-                                                "Failed to read Parquet file '{}': {e}",
-                                                task.data_file.file_path
-                                            ))
+                                            storage_query_error(
+                                                &format!(
+                                                    "Failed to read Parquet file '{}'",
+                                                    task.data_file.file_path
+                                                ),
+                                                e,
+                                            )
                                         },
                                     )
                                 })
@@ -2020,10 +2059,13 @@ impl FlureeR2rmlProvider<'_> {
                             .instrument(read_span)
                             .await
                             .map_err(|e| {
-                                QueryError::Internal(format!(
-                                    "Failed to read Parquet file '{}': {e}",
-                                    task.data_file.file_path
-                                ))
+                                storage_query_error(
+                                    &format!(
+                                        "Failed to read Parquet file '{}'",
+                                        task.data_file.file_path
+                                    ),
+                                    e,
+                                )
                             })
                     })
                     .await
@@ -2174,7 +2216,7 @@ async fn resolve_table_metadata<S: SendIcebergStorage>(
             let metadata_bytes = storage
                 .read(metadata_location)
                 .await
-                .map_err(|e| QueryError::Internal(format!("Failed to read table metadata: {e}")))?;
+                .map_err(|e| storage_query_error("Failed to read table metadata", e))?;
             let parsed = TableMetadata::from_json(&metadata_bytes).map_err(|e| {
                 QueryError::Internal(format!("Failed to parse table metadata: {e}"))
             })?;

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -927,6 +927,125 @@ impl R2rmlTableProvider for FlureeR2rmlProvider<'_> {
     }
 }
 
+/// Build the catalog auth provider for a REST client, hydrating any
+/// `ConfigValue::SecretRef` first (§3 of fluree/db#1500).
+///
+/// **Every query-path provider build goes through this**, never through a bare
+/// `create_provider_arc`: that resolves `ConfigValue`s SYNCHRONOUSLY, so a `SecretRef`
+/// reaching it un-hydrated hard-errors via `resolve()`'s fail-closed arm. Pairing the
+/// two here means a NEW client-construction site cannot silently ship without
+/// hydration — which is exactly how the pointer rung's copy arrived. (The one
+/// deliberate exception is `test_iceberg_connection`, which is `ApiError`-typed and
+/// hydrates inline so a missing/denied resolver surfaces as an actionable *config*
+/// error at the connection-test gate rather than a query error.)
+///
+/// ⚠️ ORDERING: the caller MUST already have computed its `rest_client_cache_key`
+/// fingerprint over the RAW, reference-bearing config BEFORE calling this. Hydrating
+/// before the fingerprint re-keys the client cache on every secret rotation, turning
+/// one resolver call + OAuth exchange per client lifetime into one PER QUERY. Pinned
+/// by `secret_ref_fingerprint_is_rotation_stable`.
+async fn hydrated_auth_provider(
+    auth: &fluree_db_iceberg::auth::AuthConfig,
+    resolver: Option<&Arc<dyn fluree_db_iceberg::SecretResolver>>,
+) -> QueryResult<Arc<dyn fluree_db_iceberg::auth::SendCatalogAuth>> {
+    let hydrated = auth
+        .hydrate(resolver)
+        .await
+        .map_err(|e| QueryError::Internal(format!("Failed to resolve catalog auth secret: {e}")))?;
+    hydrated
+        .create_provider_arc()
+        .map_err(|e| QueryError::Internal(format!("Failed to create auth provider: {e}")))
+}
+
+/// Resolve the S3 storage client for a REST table: the §2 credential decision, the
+/// query-session reuse (#1498), and the vended/ambient construction — in ONE place.
+///
+/// **Both** the eager `load_table_context` arm and the deferred [`LazyS3Storage`]
+/// builder (via [`resolve_rest_load_and_storage`]) construct storage for the same
+/// table under the same config, so they MUST make the same credential decision. They
+/// were two independent copies; the copy the deferred builder used silently omitted
+/// §2's fail-closed check, which reopened the ambient downgrade on any lazy-forced
+/// build. Keep them behind this one helper — a second copy is a fail-open waiting to
+/// happen.
+///
+/// §2: a source configured for vended credentials (`io.vended_credentials = true`,
+/// the default) whose catalog vended none ERRORS — it must never silently fall back
+/// to the process's ambient AWS identity. Ambient is reachable only via an explicit
+/// `vended_credentials = false`. REST only: Direct never requests vending and has its
+/// own [`direct_session_storage`].
+async fn rest_session_storage(
+    session: &super::catalog_session::IcebergCatalogSession,
+    lt_key: &str,
+    io: &IoConfig,
+    load_response: &LoadTableResponse,
+    catalog_uri: &str,
+) -> QueryResult<Arc<S3IcebergStorage>> {
+    // The loadTable caches preserve `credentials` verbatim and only ever
+    // MISS-and-reload on expiry, so a resolved `credentials == None` always means
+    // the catalog genuinely vended nothing — never a dropped-credential
+    // reconstruction. Safe to fail closed on.
+    if decide_credential_source(
+        io.vended_credentials,
+        load_response.credentials.is_some(),
+        true,
+    ) == CredentialSource::FailClosed
+    {
+        return Err(QueryError::CatalogCredentialsNotVended {
+            catalog_uri: catalog_uri.to_string(),
+        });
+    }
+
+    // Reuse the query session's cached S3 client for this table when one is present:
+    // constructing it (`aws_config` load + S3 client + HTTP client) is not free, and a
+    // correlated join — or the slice-1 prefetch→scan — resolves the same table
+    // repeatedly. Any fresh loadTable dropped the entry via `store_load_table`, so a
+    // hit here always corresponds to the current pinned credentials.
+    if let Some(cached) = session.cached_storage(lt_key) {
+        debug!("S3 storage client reused (query-scoped)");
+        return Ok(cached);
+    }
+
+    // GCS-backed tables (S3-interop endpoint) are read through this same S3 SDK path;
+    // the SDK client is pinned to HTTP/1.1 so the GCS HTTP/2 range-read bug cannot
+    // occur.
+    let built = if let Some(ref credentials) = load_response.credentials {
+        info!(
+            region = ?io.s3_region,
+            endpoint = ?io.s3_endpoint,
+            "Using vended credentials from catalog"
+        );
+        // Thread the io overrides so a catalog that omits the region (or where we want
+        // an operator-configured endpoint/path-style) still resolves correctly.
+        // Precedence inside the call: vended > these overrides > SDK.
+        S3IcebergStorage::from_vended_credentials(
+            credentials,
+            io.s3_region.as_deref(),
+            io.s3_endpoint.as_deref(),
+            io.s3_path_style,
+        )
+        .await
+        .map_err(|e| QueryError::Internal(format!("Failed to create S3 storage: {e}")))?
+    } else {
+        // Reachable only under an explicit `vended_credentials = false` (§2 returned
+        // above otherwise).
+        info!(
+            region = ?io.s3_region,
+            endpoint = ?io.s3_endpoint,
+            "Using ambient AWS credentials"
+        );
+        S3IcebergStorage::from_default_chain(
+            io.s3_region.as_deref(),
+            io.s3_endpoint.as_deref(),
+            io.s3_path_style,
+        )
+        .await
+        .map_err(|e| QueryError::Internal(format!("Failed to create S3 storage: {e}")))?
+    };
+    let built = Arc::new(built);
+    session.store_storage(lt_key.to_string(), Arc::clone(&built));
+    Ok(built)
+}
+
 /// Resolve `loadTable` (the REST catalog GET, honoring the query pin + the
 /// cross-query cache) and build the vended-credential S3 storage — the SAME
 /// session-pin path the eager scan used before the lazy split (PR-8 loadTable-
@@ -950,6 +1069,7 @@ async fn resolve_rest_load_and_storage(
     table_id: TableIdentifier,
     io: IoConfig,
     lt_key: String,
+    catalog_uri: String,
 ) -> QueryResult<(Arc<S3IcebergStorage>, LoadTableResponse)> {
     // (1) Resolve the loadTable response, cheapest first: the per-query pin, then
     // the cross-query cache (skips the ~1–3s GET), then a real REST load.
@@ -999,32 +1119,10 @@ async fn resolve_rest_load_and_storage(
         resp
     };
 
-    // (2) Build (or reuse the query session's) S3 storage from the vended creds.
-    let storage = if let Some(cached) = session.cached_storage(&lt_key) {
-        cached
-    } else {
-        let built = if let Some(ref credentials) = load_response.credentials {
-            S3IcebergStorage::from_vended_credentials(
-                credentials,
-                io.s3_region.as_deref(),
-                io.s3_endpoint.as_deref(),
-                io.s3_path_style,
-            )
-            .await
-            .map_err(|e| QueryError::Internal(format!("Failed to create S3 storage: {e}")))?
-        } else {
-            S3IcebergStorage::from_default_chain(
-                io.s3_region.as_deref(),
-                io.s3_endpoint.as_deref(),
-                io.s3_path_style,
-            )
-            .await
-            .map_err(|e| QueryError::Internal(format!("Failed to create S3 storage: {e}")))?
-        };
-        let built = Arc::new(built);
-        session.store_storage(lt_key.clone(), Arc::clone(&built));
-        built
-    };
+    // (2) Build (or reuse the query session's) S3 storage — §2 fail-closed decision
+    // and session reuse included, shared verbatim with the eager arm.
+    let storage =
+        rest_session_storage(&session, &lt_key, &io, &load_response, &catalog_uri).await?;
 
     Ok((storage, load_response))
 }
@@ -1274,9 +1372,11 @@ impl FlureeR2rmlProvider<'_> {
                     let catalog = match cache.rest_client(&client_fp) {
                         Some(c) => c,
                         None => {
-                            let auth_provider = auth.create_provider_arc().map_err(|e| {
-                                QueryError::Internal(format!("Failed to create auth provider: {e}"))
-                            })?;
+                            // ORDERING TRAP (§3): hydration happens ONLY here, inside
+                            // the cache-miss arm, strictly AFTER `client_fp` was
+                            // computed above over the RAW, reference-bearing config.
+                            let auth_provider =
+                                hydrated_auth_provider(auth, self.fluree.secret_resolver()).await?;
                             let client = Arc::new(
                                 RestCatalogClient::new(
                                     RestCatalogConfig {
@@ -1305,6 +1405,7 @@ impl FlureeR2rmlProvider<'_> {
                     let io = iceberg_config.io.clone();
                     let table_id = table_id.clone();
                     let lt_key_b = lt_key.clone();
+                    let uri_b = uri.clone();
                     let builder: super::lazy_storage::StorageBuilder<'static, S3IcebergStorage> =
                         Arc::new(move || {
                             let catalog = Arc::clone(&catalog);
@@ -1313,13 +1414,44 @@ impl FlureeR2rmlProvider<'_> {
                             let io = io.clone();
                             let table_id = table_id.clone();
                             let lt_key = lt_key_b.clone();
+                            let catalog_uri = uri_b.clone();
                             Box::pin(async move {
                                 resolve_rest_load_and_storage(
-                                    catalog, cache, session, table_id, io, lt_key,
+                                    catalog,
+                                    cache,
+                                    session,
+                                    table_id,
+                                    io,
+                                    lt_key,
+                                    catalog_uri,
                                 )
                                 .await
                                 .map(|(storage, _)| storage)
-                                .map_err(|e| IcebergError::Catalog(e.to_string()))
+                                // Preserve the TYPED errors across the builder's
+                                // `IcebergError` channel: `storage_query_error` lifts
+                                // these two straight back to their `QueryError`
+                                // counterparts, so a lazy-forced build reports the same
+                                // 403 + wire code (`err:storage/AccessDenied` /
+                                // `err:catalog/CredentialsNotVended`) as the eager path.
+                                // A blanket `to_string()` here would flatten them into
+                                // an opaque string and put hosts back to regex-guessing.
+                                .map_err(|e| match e {
+                                    QueryError::StorageAccessDenied {
+                                        bucket,
+                                        key,
+                                        region,
+                                        message,
+                                    } => IcebergError::StorageAccessDenied {
+                                        bucket,
+                                        key,
+                                        region,
+                                        message,
+                                    },
+                                    QueryError::CatalogCredentialsNotVended { catalog_uri } => {
+                                        IcebergError::CatalogCredentialsNotVended { catalog_uri }
+                                    }
+                                    other => IcebergError::Catalog(other.to_string()),
+                                })
                             })
                         });
                     return Ok((Arc::new(LazyS3Storage::deferred(builder)), md, loc));
@@ -1349,24 +1481,12 @@ impl FlureeR2rmlProvider<'_> {
                 let catalog = match cache.rest_client(&client_fp) {
                     Some(c) => c,
                     None => {
-                        // ORDERING TRAP — hydrate ONLY here, inside the cache-miss
-                        // arm, strictly AFTER `client_fp` was computed (above) over
-                        // the RAW, reference-bearing config. Hydrating before the
-                        // fingerprint would re-key the client cache on every secret
-                        // rotation → a resolver call + full OAuth token exchange PER
-                        // QUERY instead of once per ~900s client lifetime. The
-                        // fingerprint-stability test in this module guards this.
-                        let hydrated_auth = auth
-                            .hydrate(self.fluree.secret_resolver())
-                            .await
-                            .map_err(|e| {
-                                QueryError::Internal(format!(
-                                    "Failed to resolve catalog auth secret: {e}"
-                                ))
-                            })?;
-                        let auth_provider = hydrated_auth.create_provider_arc().map_err(|e| {
-                            QueryError::Internal(format!("Failed to create auth provider: {e}"))
-                        })?;
+                        // ORDERING TRAP (§3): hydration happens ONLY here, inside the
+                        // cache-miss arm, strictly AFTER `client_fp` was computed above
+                        // over the RAW, reference-bearing config. The fingerprint-
+                        // stability test pins this.
+                        let auth_provider =
+                            hydrated_auth_provider(auth, self.fluree.secret_resolver()).await?;
                         let catalog_config = RestCatalogConfig {
                             uri: uri.clone(),
                             warehouse: warehouse.clone(),
@@ -1471,87 +1591,18 @@ impl FlureeR2rmlProvider<'_> {
                     resp
                 };
 
-                // §2 fail-closed: the source is configured to require
-                // catalog-vended storage credentials (io.vended_credentials =
-                // true, the default), but the loadTable response carried none. Do
-                // NOT silently downgrade to ambient AWS credentials — a BYO-IAM
-                // misconfiguration (or a catalog that stopped vending) must
-                // surface as an actionable error, not read from whatever ambient
-                // identity the process happens to have. `vended_credentials =
-                // false` is the explicit opt-in to ambient (the else-branch
-                // below), and Direct mode never reaches here (`is_rest = true`).
-                // This holds on cache hits too: the loadTable caches preserve
-                // `credentials` verbatim and only ever MISS-and-reload on expiry,
-                // so a resolved `credentials == None` always means the catalog
-                // genuinely vended nothing (never a dropped-credential
-                // reconstruction). The Vended/Ambient split is left to the
-                // `if let Some(..)` construction below.
-                if decide_credential_source(
-                    iceberg_config.io.vended_credentials,
-                    load_response.credentials.is_some(),
-                    true,
-                ) == CredentialSource::FailClosed
-                {
-                    return Err(QueryError::CatalogCredentialsNotVended {
-                        catalog_uri: uri.clone(),
-                    });
-                }
-
-                // GCS-backed tables (S3-interop endpoint) are read through this
-                // same S3 SDK path; the SDK client is pinned to HTTP/1.1 so the
-                // GCS HTTP/2 range-read bug cannot occur.
-                //
-                // Reuse the query session's cached S3 client for this table when
-                // one is present: constructing it (`aws_config` load + S3 client +
-                // HTTP client) is not free, and a correlated join — or the slice-1
-                // prefetch→scan — resolves the same table repeatedly. Any fresh
-                // loadTable above dropped the entry via `store_load_table`, so a hit
-                // here always corresponds to the current pinned credentials.
-                let storage = if let Some(cached) = self.session.cached_storage(&lt_key) {
-                    debug!(namespace = %table_id.namespace, table = %table_id.table,
-                        "S3 storage client reused (query-scoped)");
-                    cached
-                } else {
-                    let built = if let Some(ref credentials) = load_response.credentials {
-                        info!(
-                            region = ?iceberg_config.io.s3_region,
-                            endpoint = ?iceberg_config.io.s3_endpoint,
-                            "Using vended credentials from catalog"
-                        );
-                        // Thread the io overrides so a catalog that omits the region (or where
-                        // we want an operator-configured endpoint/path-style) still resolves
-                        // correctly. Precedence inside the call: vended > these overrides > SDK.
-                        S3IcebergStorage::from_vended_credentials(
-                            credentials,
-                            iceberg_config.io.s3_region.as_deref(),
-                            iceberg_config.io.s3_endpoint.as_deref(),
-                            iceberg_config.io.s3_path_style,
-                        )
-                        .await
-                        .map_err(|e| {
-                            QueryError::Internal(format!("Failed to create S3 storage: {e}"))
-                        })?
-                    } else {
-                        info!(
-                            region = ?iceberg_config.io.s3_region,
-                            endpoint = ?iceberg_config.io.s3_endpoint,
-                            "Using ambient AWS credentials"
-                        );
-                        S3IcebergStorage::from_default_chain(
-                            iceberg_config.io.s3_region.as_deref(),
-                            iceberg_config.io.s3_endpoint.as_deref(),
-                            iceberg_config.io.s3_path_style,
-                        )
-                        .await
-                        .map_err(|e| {
-                            QueryError::Internal(format!("Failed to create S3 storage: {e}"))
-                        })?
-                    };
-                    let built = Arc::new(built);
-                    self.session
-                        .store_storage(lt_key.clone(), Arc::clone(&built));
-                    built
-                };
+                // §2 fail-closed + query-session reuse + vended/ambient construction,
+                // shared verbatim with the deferred `LazyS3Storage` builder's path so
+                // the two can never make different credential decisions for the same
+                // table (see `rest_session_storage`).
+                let storage = rest_session_storage(
+                    &self.session,
+                    &lt_key,
+                    &iceberg_config.io,
+                    &load_response,
+                    uri,
+                )
+                .await?;
 
                 (load_response, storage)
             }
@@ -2797,6 +2848,137 @@ mod tests {
             );
         }
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ---- Composition guards (restack onto the loadTable-METADATA cache chain) ----
+    //
+    // These cover the seams where OUR credential handling meets the chain's
+    // pointer-rung / `LazyS3Storage` architecture. Neither suite could see them
+    // before: ours predates the rung, theirs predates SecretRef / fail-closed /
+    // typed errors. Each one FAILS if the corresponding guard is dropped in a
+    // future merge.
+
+    fn vended_response(loc: &str, with_creds: bool) -> LoadTableResponse {
+        LoadTableResponse {
+            metadata_location: loc.to_string(),
+            config: std::collections::HashMap::default(),
+            credentials: with_creds.then(|| fluree_db_iceberg::credential::VendedCredentials {
+                access_key_id: "AKIAEXAMPLE".to_string(),
+                secret_access_key: "secret".to_string(),
+                session_token: None,
+                expires_at: None,
+                endpoint: None,
+                region: Some("us-east-2".to_string()),
+                path_style: false,
+            }),
+            metadata: None,
+        }
+    }
+
+    /// §2 on the LAZY path: a REST source configured to require vended credentials
+    /// whose catalog vends none must FAIL CLOSED — never silently read under the
+    /// process's ambient AWS identity. `rest_session_storage` is the one decision
+    /// point the eager arm AND the deferred `LazyS3Storage` builder share, so this
+    /// covers both; a second, unguarded copy is exactly the fail-open this pins.
+    #[tokio::test]
+    async fn rest_storage_fails_closed_when_catalog_vends_nothing() {
+        let session = super::super::catalog_session::IcebergCatalogSession::default();
+        let lt_key = super::super::catalog_session::IcebergCatalogSession::load_table_key(
+            "gs:main",
+            "DW",
+            "DIM_STORE",
+        );
+        let io = IoConfig {
+            vended_credentials: true, // the default
+            ..Default::default()
+        };
+        let resp = vended_response("s3://b/t/metadata/v1.metadata.json", false);
+
+        let err = rest_session_storage(&session, &lt_key, &io, &resp, "https://cat.example/v1")
+            .await
+            .expect_err("vended-configured source with no vended creds must fail closed");
+        match err {
+            QueryError::CatalogCredentialsNotVended { catalog_uri } => {
+                assert_eq!(catalog_uri, "https://cat.example/v1");
+            }
+            other => panic!("expected CatalogCredentialsNotVended, got: {other:?}"),
+        }
+        // ...and it must NOT have cached an ambient client under this key.
+        assert!(
+            session.cached_storage(&lt_key).is_none(),
+            "fail-closed must not leave a storage client in the session"
+        );
+    }
+
+    /// The explicit ambient opt-in (`vended_credentials = false`) still resolves —
+    /// fail-closed must not turn BYO-IAM into an error.
+    #[tokio::test]
+    async fn rest_storage_allows_explicit_ambient_opt_in() {
+        let session = super::super::catalog_session::IcebergCatalogSession::default();
+        let lt_key = super::super::catalog_session::IcebergCatalogSession::load_table_key(
+            "gs:main",
+            "DW",
+            "DIM_AMBIENT",
+        );
+        let io = IoConfig {
+            vended_credentials: false, // explicit BYO-IAM
+            s3_region: Some("us-east-2".to_string()),
+            ..Default::default()
+        };
+        let resp = vended_response("s3://b/t/metadata/v1.metadata.json", false);
+        rest_session_storage(&session, &lt_key, &io, &resp, "https://cat.example/v1")
+            .await
+            .expect("explicit vended_credentials=false must use the ambient chain");
+    }
+
+    /// §5 across the deferred builder's `IcebergError` channel: the typed errors must
+    /// round-trip back to their `QueryError` counterparts (and thus their 403 wire
+    /// codes) instead of being flattened to an opaque string by a blanket
+    /// `to_string()`. Mirrors the `map_err` the `LazyS3Storage` builder applies.
+    #[test]
+    fn typed_storage_errors_survive_the_lazy_builder_channel() {
+        let denied = QueryError::StorageAccessDenied {
+            bucket: "b".to_string(),
+            key: "k".to_string(),
+            region: Some("us-east-2".to_string()),
+            message: "AccessDenied ... no identity-based policy allows".to_string(),
+        };
+        let ferried = match denied {
+            QueryError::StorageAccessDenied {
+                bucket,
+                key,
+                region,
+                message,
+            } => IcebergError::StorageAccessDenied {
+                bucket,
+                key,
+                region,
+                message,
+            },
+            other => IcebergError::Catalog(other.to_string()),
+        };
+        match super::super::iceberg_catalog::storage_query_error("ctx", ferried) {
+            QueryError::StorageAccessDenied { bucket, key, .. } => {
+                assert_eq!((bucket.as_str(), key.as_str()), ("b", "k"));
+            }
+            other => panic!("StorageAccessDenied must survive the builder: {other:?}"),
+        }
+
+        let not_vended = QueryError::CatalogCredentialsNotVended {
+            catalog_uri: "https://cat.example/v1".to_string(),
+        };
+        let ferried = match not_vended {
+            QueryError::CatalogCredentialsNotVended { catalog_uri } => {
+                IcebergError::CatalogCredentialsNotVended { catalog_uri }
+            }
+            other => IcebergError::Catalog(other.to_string()),
+        };
+        match super::super::iceberg_catalog::storage_query_error("ctx", ferried) {
+            QueryError::CatalogCredentialsNotVended { catalog_uri } => {
+                assert_eq!(catalog_uri, "https://cat.example/v1");
+            }
+            other => panic!("CatalogCredentialsNotVended must survive the builder: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -459,9 +459,19 @@ impl crate::Fluree {
             }
         };
 
-        // Create auth provider
-        let auth = rest
+        // Hydrate any SecretRef auth BEFORE building the provider — this is the
+        // connection-test gate, so a secret reference with no resolver (or a
+        // Denied resolution) must error HERE, actionably, before any network call.
+        let hydrated_auth = rest
             .auth
+            .hydrate(self.secret_resolver())
+            .await
+            .map_err(|e| {
+                crate::ApiError::Config(format!("Failed to resolve catalog auth secret: {e}"))
+            })?;
+
+        // Create auth provider
+        let auth = hydrated_auth
             .create_provider_arc()
             .map_err(|e| crate::ApiError::Config(format!("Failed to create auth provider: {e}")))?;
 
@@ -1339,7 +1349,22 @@ impl FlureeR2rmlProvider<'_> {
                 let catalog = match cache.rest_client(&client_fp) {
                     Some(c) => c,
                     None => {
-                        let auth_provider = auth.create_provider_arc().map_err(|e| {
+                        // ORDERING TRAP — hydrate ONLY here, inside the cache-miss
+                        // arm, strictly AFTER `client_fp` was computed (above) over
+                        // the RAW, reference-bearing config. Hydrating before the
+                        // fingerprint would re-key the client cache on every secret
+                        // rotation → a resolver call + full OAuth token exchange PER
+                        // QUERY instead of once per ~900s client lifetime. The
+                        // fingerprint-stability test in this module guards this.
+                        let hydrated_auth = auth
+                            .hydrate(self.fluree.secret_resolver())
+                            .await
+                            .map_err(|e| {
+                                QueryError::Internal(format!(
+                                    "Failed to resolve catalog auth secret: {e}"
+                                ))
+                            })?;
+                        let auth_provider = hydrated_auth.create_provider_arc().map_err(|e| {
                             QueryError::Internal(format!("Failed to create auth provider: {e}"))
                         })?;
                         let catalog_config = RestCatalogConfig {
@@ -2740,5 +2765,98 @@ mod tests {
             "fallback path must perform exactly one storage read"
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── ORDERING-TRAP GUARD: rest_client_cache_key must fingerprint the RAW,
+    //    reference-bearing config, NOT a hydrated one. ──
+
+    #[derive(Debug)]
+    struct FixedResolver(&'static str);
+
+    #[async_trait]
+    impl fluree_db_iceberg::SecretResolver for FixedResolver {
+        async fn resolve_secret(
+            &self,
+            _secret_ref: &str,
+        ) -> std::result::Result<String, fluree_db_iceberg::SecretResolveError> {
+            Ok(self.0.to_string())
+        }
+    }
+
+    fn oauth2_auth(
+        client_secret: fluree_db_iceberg::ConfigValue,
+    ) -> fluree_db_iceberg::auth::AuthConfig {
+        fluree_db_iceberg::auth::AuthConfig::OAuth2ClientCredentials {
+            token_url: "https://c.example.com/token".to_string(),
+            client_id: fluree_db_iceberg::ConfigValue::literal("svc"),
+            client_secret,
+            scope: None,
+            audience: None,
+        }
+    }
+
+    fn gs_config_json(auth: fluree_db_iceberg::auth::AuthConfig) -> String {
+        use fluree_db_iceberg::config::{CatalogConfig, IoConfig, TableConfig};
+        fluree_db_iceberg::IcebergGsConfig {
+            catalog: CatalogConfig::Rest {
+                catalog_type: "rest".to_string(),
+                uri: "https://c.example.com".to_string(),
+                auth,
+                warehouse: None,
+            },
+            table: TableConfig::Identifier("ns.t".to_string()),
+            io: IoConfig::default(),
+            mapping: None,
+        }
+        .to_json()
+        .unwrap()
+    }
+
+    /// The fingerprint keys the process-wide REST client cache. It MUST be stable
+    /// across secret rotations (so a warm server does one OAuth exchange per client
+    /// lifetime, not one per query) — which holds ONLY because it is computed over
+    /// the raw, reference-bearing config, BEFORE hydration. This test proves that
+    /// discipline: fingerprinting the ref-bearing config is rotation-stable, while
+    /// fingerprinting a hydrated config would re-key on every rotation.
+    #[tokio::test]
+    async fn secret_ref_fingerprint_is_rotation_stable() {
+        use std::sync::Arc;
+        let gsid = "gs-1";
+
+        // Raw stored config carries the REFERENCE (this is `record.config` at the
+        // scan site). Recomputing over it is identical even though the secret
+        // behind the ref may have rotated between queries: the cache is NOT re-keyed.
+        let raw = gs_config_json(oauth2_auth(fluree_db_iceberg::ConfigValue::SecretRef {
+            secret_ref: "vault://cs".to_string(),
+        }));
+        let key_raw = rest_client_cache_key(gsid, &raw);
+        assert_eq!(
+            rest_client_cache_key(gsid, &raw),
+            key_raw,
+            "the ref-bearing fingerprint must be stable across rotations"
+        );
+
+        // Hydrate the SAME auth with two different resolver outputs (a rotation),
+        // serialize the hydrated configs, and fingerprint those. They differ —
+        // which is EXACTLY why hydration must run AFTER the fingerprint, never
+        // before (hydrating first would re-key the client cache every rotation).
+        let auth = oauth2_auth(fluree_db_iceberg::ConfigValue::SecretRef {
+            secret_ref: "vault://cs".to_string(),
+        });
+        let r1: Arc<dyn fluree_db_iceberg::SecretResolver> = Arc::new(FixedResolver("secret-v1"));
+        let r2: Arc<dyn fluree_db_iceberg::SecretResolver> = Arc::new(FixedResolver("secret-v2"));
+        let hydrated_v1 = gs_config_json(auth.hydrate(Some(&r1)).await.unwrap());
+        let hydrated_v2 = gs_config_json(auth.hydrate(Some(&r2)).await.unwrap());
+        let key_h1 = rest_client_cache_key(gsid, &hydrated_v1);
+        let key_h2 = rest_client_cache_key(gsid, &hydrated_v2);
+        assert_ne!(
+            key_h1, key_h2,
+            "hydrated configs with rotated secrets differ → hydrating before the \
+             fingerprint would re-key the client cache every rotation"
+        );
+        assert_ne!(
+            key_raw, key_h1,
+            "the raw ref-bearing key must differ from the hydrated key"
+        );
     }
 }

--- a/fluree-db-api/src/graph_source/r2rml.rs
+++ b/fluree-db-api/src/graph_source/r2rml.rs
@@ -1313,8 +1313,10 @@ impl FlureeR2rmlProvider<'_> {
             }
         }
 
-        // Resolve metadata location and create storage based on catalog mode
-        let (load_response, storage) = match &iceberg_config.catalog {
+        // Resolve metadata location and create storage based on catalog mode.
+        // `mut` so we can move the REST catalog's inline metadata out of the
+        // response below (see the metadata resolution) without cloning it.
+        let (mut load_response, storage) = match &iceberg_config.catalog {
             CatalogConfig::Rest {
                 uri,
                 warehouse,
@@ -1568,65 +1570,26 @@ impl FlureeR2rmlProvider<'_> {
             }
         };
 
-        // Check cache for table metadata
-        let cache = self.fluree.r2rml_cache();
-        let metadata_location = &load_response.metadata_location;
-
-        let metadata = if let Some(cached) = cache.get_metadata(metadata_location).await {
-            debug!(metadata_location = %metadata_location, "Table metadata cache hit");
-            cached
-        } else {
-            debug!(metadata_location = %metadata_location, "Table metadata cache miss");
-
-            // PR-8 slice 2: on the in-memory miss, try the persistent disk catalog
-            // cache before hitting S3. `metadata_location` is content-addressed, so
-            // a hit is always current for that snapshot. A cold process with a warm
-            // catalog dir serves the parsed metadata from local disk (no S3 GET,
-            // no `r2rml.read_metadata` span).
-            let catalog_cache = self.catalog_disk_cache();
-            let metadata = if let Some(disk) = catalog_cache.get_metadata(metadata_location) {
-                debug!(metadata_location = %metadata_location, "Table metadata disk-cache hit");
-                disk
-            } else {
-                // Measurement sub-span (PR-8 cold decomposition): isolate the
-                // metadata-JSON S3 GET + parse — the `load_table_context` component
-                // between the loadTable REST GET (`r2rml.load_table`) and the
-                // manifest read (`iceberg.scan_plan` / `r2rml.count_manifest_read`).
-                // Allowlisted in `fluree-bench-virtual::spans`.
-                let metadata = async {
-                    let metadata_bytes =
-                        storage
-                            .as_ref()
-                            .read(metadata_location)
-                            .await
-                            .map_err(|e| {
-                                QueryError::Internal(format!("Failed to read table metadata: {e}"))
-                            })?;
-                    let parsed = TableMetadata::from_json(&metadata_bytes).map_err(|e| {
-                        QueryError::Internal(format!("Failed to parse table metadata: {e}"))
-                    })?;
-                    Ok::<_, QueryError>(Arc::new(parsed))
-                }
-                .instrument(tracing::debug_span!(
-                    "r2rml.read_metadata",
-                    metadata_location = %metadata_location,
-                ))
-                .await?;
-                catalog_cache.put_metadata(metadata_location, metadata.as_ref());
-                metadata
-            };
-            cache
-                .put_metadata(metadata_location.clone(), Arc::clone(&metadata))
-                .await;
-
-            info!(
-                metadata_location = %metadata_location,
-                format_version = metadata.format_version,
-                "Loaded and cached table metadata"
-            );
-
-            metadata
-        };
+        // Resolve the table metadata from the cheapest available source: the
+        // in-memory cache, the REST catalog's inline `metadata`, the disk catalog
+        // cache, then a fresh S3 GET. Extracted into `resolve_table_metadata` so the
+        // resolution order — in particular that an inline `loadTable` copy
+        // short-circuits the disk/S3 fetch and its `r2rml.read_metadata` span — is
+        // unit-testable against a storage stub. The inline metadata is moved out of
+        // `load_response` (never cloned — it replaces an S3 GET) and is `None` for
+        // Direct mode and cache-reconstructed responses (per-query pin / cross-query
+        // cache), which is precisely why the disk/S3 fallback in the helper must stay
+        // intact. It seeds BOTH cache layers — the disk write is what lets the pointer
+        // rung above serve the NEXT process with zero REST (see the fn doc).
+        let inline_metadata = load_response.metadata.take();
+        let metadata = resolve_table_metadata(
+            self.fluree.r2rml_cache(),
+            storage.as_ref(),
+            &load_response.metadata_location,
+            inline_metadata,
+            &disk,
+        )
+        .await?;
         // Persist the credential-free pointer so the NEXT process resolves this
         // table's `metadata_location` without a loadTable GET. `snapshot_ms` feeds
         // the as_of_t rider (grep r2rml-as-of-t). The eager `storage` is already
@@ -2136,6 +2099,108 @@ fn sound_manifest_row_count(
     Some(total)
 }
 
+/// Resolve a table's [`TableMetadata`] from the cheapest available source.
+///
+/// Order, cheapest first:
+/// 1. the in-memory moka cache (`cache`);
+/// 2. `inline_metadata` — the parsed `metadata` a real REST `loadTable` already
+///    handed us in `LoadTableResponse` (populated in `catalog/rest.rs`). It is
+///    `None` for Direct mode and for cache-reconstructed responses (per-query pin
+///    / cross-query cache), which carry only a metadata location;
+/// 3. the persistent disk catalog cache (`disk`);
+/// 4. a fresh S3 GET of the metadata JSON, timed under the `r2rml.read_metadata`
+///    span.
+///
+/// The inline short-circuit is §1 of fluree/db#1500: a REST catalog that vends
+/// metadata inline never re-fetches it from S3, and emits NO `r2rml.read_metadata`
+/// span (that span must fire only on a real S3 read; the live gate asserts n=0 for
+/// inline-vending REST catalogs).
+///
+/// The inline result seeds BOTH cache layers, and the disk write is LOAD-BEARING —
+/// not bookkeeping. The pointer rung in `load_table_context` serves a cross-process
+/// zero-REST resolve only when it finds BOTH a persisted `metadata_location` pointer
+/// AND the metadata itself via `metadata_from_caches`, which reads the in-memory
+/// cache then **this disk layer**. A fresh process has an empty in-memory cache, so
+/// skipping the disk write here would starve the pointer rung for exactly the
+/// catalogs that vend inline metadata (Snowflake Horizon / Polaris) — silently
+/// converting their zero-REST first-ask back into a ~1–3 s `loadTable` GET, with the
+/// regression visible only in the cache gate's `load_table.n` counter. Seeding from
+/// the free inline copy is strictly better than the pre-§1 behaviour, where this
+/// layer could only be populated by first paying an S3 GET.
+async fn resolve_table_metadata<S: SendIcebergStorage>(
+    cache: &R2rmlCache,
+    storage: &S,
+    metadata_location: &str,
+    inline_metadata: Option<TableMetadata>,
+    disk: &super::disk_catalog_cache::DiskCatalogCache,
+) -> QueryResult<Arc<TableMetadata>> {
+    if let Some(cached) = cache.get_metadata(metadata_location).await {
+        debug!(metadata_location = %metadata_location, "Table metadata cache hit");
+        return Ok(cached);
+    }
+
+    if let Some(inline) = inline_metadata {
+        debug!(
+            metadata_location = %metadata_location,
+            "Table metadata used inline from loadTable response (no S3 fetch)"
+        );
+        let metadata = Arc::new(inline);
+        // Seed the disk layer too: this is what the next process's pointer rung
+        // reads (see the fn doc). Content-addressed by `metadata_location`, so the
+        // entry is immutable and always current for that snapshot.
+        disk.put_metadata(metadata_location, metadata.as_ref());
+        cache
+            .put_metadata(metadata_location.to_string(), Arc::clone(&metadata))
+            .await;
+        return Ok(metadata);
+    }
+
+    debug!(metadata_location = %metadata_location, "Table metadata cache miss");
+
+    // PR-8 slice 2: on the in-memory miss, try the persistent disk catalog cache
+    // before hitting S3. `metadata_location` is content-addressed, so a hit is
+    // always current for that snapshot. A cold process with a warm catalog dir
+    // serves the parsed metadata from local disk (no S3 GET, no
+    // `r2rml.read_metadata` span).
+    let metadata = if let Some(cached) = disk.get_metadata(metadata_location) {
+        debug!(metadata_location = %metadata_location, "Table metadata disk-cache hit");
+        cached
+    } else {
+        // Measurement sub-span (PR-8 cold decomposition): isolate the metadata-JSON
+        // S3 GET + parse — the `load_table_context` component between the loadTable
+        // REST GET (`r2rml.load_table`) and the manifest read (`iceberg.scan_plan` /
+        // `r2rml.count_manifest_read`). Allowlisted in `fluree-bench-virtual::spans`.
+        let metadata = async {
+            let metadata_bytes = storage
+                .read(metadata_location)
+                .await
+                .map_err(|e| QueryError::Internal(format!("Failed to read table metadata: {e}")))?;
+            let parsed = TableMetadata::from_json(&metadata_bytes).map_err(|e| {
+                QueryError::Internal(format!("Failed to parse table metadata: {e}"))
+            })?;
+            Ok::<_, QueryError>(Arc::new(parsed))
+        }
+        .instrument(tracing::debug_span!(
+            "r2rml.read_metadata",
+            metadata_location = %metadata_location,
+        ))
+        .await?;
+        disk.put_metadata(metadata_location, metadata.as_ref());
+        metadata
+    };
+    cache
+        .put_metadata(metadata_location.to_string(), Arc::clone(&metadata))
+        .await;
+
+    info!(
+        metadata_location = %metadata_location,
+        format_version = metadata.format_version,
+        "Loaded and cached table metadata"
+    );
+
+    Ok(metadata)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2489,5 +2554,149 @@ mod tests {
             sound_manifest_row_count(&schema, &files, false, &["NOPE".to_string()]),
             None
         );
+    }
+
+    // ---- §1 (fluree/db#1500): inline loadTable metadata short-circuits S3 ----
+
+    use crate::graph_source::disk_catalog_cache::DiskCatalogCache;
+    use fluree_db_iceberg::error::Result as IcebergResult;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Minimal valid Iceberg table metadata JSON (only the non-defaulted fields),
+    /// so tests build `TableMetadata` through the real `from_json` path.
+    fn sample_metadata_json(location: &str) -> String {
+        serde_json::json!({
+            "format-version": 2,
+            "location": location,
+            "last-updated-ms": 0,
+            "last-column-id": 0,
+        })
+        .to_string()
+    }
+
+    fn sample_metadata(location: &str) -> TableMetadata {
+        TableMetadata::from_json(sample_metadata_json(location).as_bytes())
+            .expect("sample metadata JSON parses")
+    }
+
+    /// Storage stub that panics on any access: the inline-metadata path must never
+    /// touch storage, so any read here fails the test loudly.
+    #[derive(Debug)]
+    struct NeverReadStorage;
+
+    #[async_trait::async_trait]
+    impl SendIcebergStorage for NeverReadStorage {
+        async fn read(&self, path: &str) -> IcebergResult<bytes::Bytes> {
+            panic!("storage.read must not be called on the inline-metadata path (path={path})");
+        }
+        async fn read_range(
+            &self,
+            _path: &str,
+            _range: std::ops::Range<u64>,
+        ) -> IcebergResult<bytes::Bytes> {
+            panic!("storage.read_range must not be called on the inline-metadata path");
+        }
+        async fn file_size(&self, _path: &str) -> IcebergResult<u64> {
+            panic!("storage.file_size must not be called on the inline-metadata path");
+        }
+    }
+
+    /// Storage stub that serves a fixed metadata JSON and counts reads, for the
+    /// fallback-intact test (no inline metadata => a real object read must happen).
+    #[derive(Debug)]
+    struct CountingStorage {
+        body: bytes::Bytes,
+        reads: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl SendIcebergStorage for CountingStorage {
+        async fn read(&self, _path: &str) -> IcebergResult<bytes::Bytes> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            Ok(self.body.clone())
+        }
+        async fn read_range(
+            &self,
+            _path: &str,
+            _range: std::ops::Range<u64>,
+        ) -> IcebergResult<bytes::Bytes> {
+            unreachable!("resolve_table_metadata reads whole objects, not ranges")
+        }
+        async fn file_size(&self, _path: &str) -> IcebergResult<u64> {
+            unreachable!("resolve_table_metadata does not stat")
+        }
+    }
+
+    /// A disk cache rooted at a unique temp dir (a guaranteed miss on first read).
+    fn tmp_disk_cache(tag: &str) -> (DiskCatalogCache, std::path::PathBuf) {
+        let dir =
+            std::env::temp_dir().join(format!("fluree-r2rml-md-test-{}-{tag}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        (DiskCatalogCache::for_dir(&dir), dir)
+    }
+
+    #[tokio::test]
+    async fn inline_metadata_short_circuits_s3_and_seeds_both_caches() {
+        let cache = R2rmlCache::new(4, 4);
+        let loc = "s3://bucket/warehouse/t/metadata/v3.metadata.json";
+        let inline = sample_metadata("s3://bucket/warehouse/t");
+        let (disk, dir) = tmp_disk_cache("inline");
+
+        // In-memory cache empty (miss); inline metadata present. `NeverReadStorage`
+        // panics on any access, so a green result proves S3 was never touched —
+        // without §1's inline branch this would fall through to the disk miss and
+        // then a storage read, which panics here.
+        let out = resolve_table_metadata(&cache, &NeverReadStorage, loc, Some(inline), &disk)
+            .await
+            .expect("inline metadata resolves without any storage read");
+        assert_eq!(out.location, "s3://bucket/warehouse/t");
+
+        // The inline result seeds the in-memory cache so a later cache-reconstructed
+        // load (which carries `metadata: None`) hits it instead of re-fetching.
+        assert!(
+            cache.get_metadata(loc).await.is_some(),
+            "inline metadata must be cached in-memory for later loads"
+        );
+
+        // ...and seeds the DISK layer, which is what the NEXT PROCESS's pointer rung
+        // reads via `metadata_from_caches` (its in-memory cache is empty). Skipping
+        // this write would silently starve the zero-REST first-ask for exactly the
+        // catalogs that vend inline metadata — the regression would show up only as
+        // the cache gate's `load_table.n` going non-zero. Asserted only when disk
+        // caching is enabled; `put_metadata` is a no-op when the env switch is off.
+        if crate::graph_source::disk_catalog_cache::disk_catalog_cache_enabled() {
+            assert!(
+                disk.get_metadata(loc).is_some(),
+                "inline metadata must seed the disk layer for the pointer rung"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn no_inline_metadata_falls_back_to_storage_read() {
+        let cache = R2rmlCache::new(4, 4);
+        let loc = "s3://bucket/warehouse/u/metadata/v1.metadata.json";
+        let reads = Arc::new(AtomicUsize::new(0));
+        let storage = CountingStorage {
+            body: bytes::Bytes::from(sample_metadata_json("s3://bucket/warehouse/u")),
+            reads: Arc::clone(&reads),
+        };
+
+        // No inline metadata and an empty in-memory cache: resolution must reach
+        // storage. A unique temp dir keeps the disk cache a guaranteed miss (or a
+        // no-op when disk caching is disabled), so the resolution proceeds to the
+        // object read regardless of the ambient disk-cache setting.
+        let (disk, dir) = tmp_disk_cache("fallback");
+        let out = resolve_table_metadata(&cache, &storage, loc, None, &disk)
+            .await
+            .expect("fallback resolves via the storage read");
+        assert_eq!(out.location, "s3://bucket/warehouse/u");
+        assert_eq!(
+            reads.load(Ordering::SeqCst),
+            1,
+            "fallback path must perform exactly one storage read"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/fluree-db-api/src/ledger_info.rs
+++ b/fluree-db-api/src/ledger_info.rs
@@ -995,6 +995,19 @@ fn is_secret_config_key(key: &str) -> bool {
     SECRET_CONFIG_KEYS.iter().any(|s| *s == lower)
 }
 
+/// True iff `v` is EXACTLY `{"secret_ref": "<string>"}` — the wire shape of
+/// `ConfigValue::SecretRef`. Strict (a single key named `secret_ref` with a
+/// string value) so that any OTHER object shape under a secret key falls through
+/// to normal, fail-closed redaction rather than being blanket-preserved.
+fn is_secret_ref_object(v: &JsonValue) -> bool {
+    match v {
+        JsonValue::Object(m) => {
+            m.len() == 1 && matches!(m.get("secret_ref"), Some(JsonValue::String(_)))
+        }
+        _ => false,
+    }
+}
+
 /// Recursively replace secret-bearing scalar values with `"[redacted]"`.
 ///
 /// A secret held as an env-var reference object (`{"env_var": "...",
@@ -1006,9 +1019,24 @@ fn redact_json_secrets(value: &mut JsonValue) -> bool {
     match value {
         JsonValue::Object(map) => {
             for (k, v) in map.iter_mut() {
-                if is_secret_config_key(k) && !v.is_object() && !v.is_array() && !v.is_null() {
-                    *v = JsonValue::String("[redacted]".to_string());
-                    redacted = true;
+                if is_secret_config_key(k) {
+                    if is_secret_ref_object(v) {
+                        // A secret *reference* is not a secret (same policy as
+                        // env-var names, which the redactor deliberately keeps):
+                        // the opaque ref stays visible for display and solo
+                        // consumes it. Leave it intact and do NOT recurse — its
+                        // lone `secret_ref` key is not on the allowlist anyway.
+                    } else if !v.is_object() && !v.is_array() && !v.is_null() {
+                        // Scalar under a secret key → redact.
+                        *v = JsonValue::String("[redacted]".to_string());
+                        redacted = true;
+                    } else if redact_json_secrets(v) {
+                        // Object/array under a secret key that is NOT a clean
+                        // secret_ref (e.g. an env-var `Dynamic`): recurse so inner
+                        // secret leaves (`default_val`) are redacted while
+                        // non-secret keys (`env_var`) stay visible.
+                        redacted = true;
+                    }
                 } else if redact_json_secrets(v) {
                     redacted = true;
                 }
@@ -1533,7 +1561,18 @@ async fn fetch_virtual_table_row_counts(
     let catalog: Arc<RestCatalogClient> = match cache.rest_client(&client_fp) {
         Some(c) => c,
         None => {
-            let auth_provider = match auth.create_provider_arc() {
+            // Hydrate any SecretRef auth INSIDE the miss arm — after `client_fp`
+            // was computed over the raw config (same ordering discipline as the
+            // scan path). Best-effort: a resolver failure just omits counts, like
+            // every other failure in this display-only path.
+            let hydrated_auth = match auth.hydrate(fluree.secret_resolver()).await {
+                Ok(a) => a,
+                Err(e) => {
+                    tracing::debug!(error = %e, "virtual ledger-info: auth secret resolution failed; counts omitted");
+                    return (HashMap::new(), None);
+                }
+            };
+            let auth_provider = match hydrated_auth.create_provider_arc() {
                 Ok(p) => p,
                 Err(e) => {
                     tracing::debug!(error = %e, "virtual ledger-info: auth provider build failed; counts omitted");
@@ -2801,6 +2840,10 @@ mod tests {
 
         const SENTINEL_A: &str = "sentinel-secret-value-AAAA";
         const SENTINEL_B: &str = "sentinel-secret-value-BBBB";
+        // A secret REFERENCE is not a secret; it must stay visible after redaction
+        // (same policy as env-var names). Chosen so it shares no substring with the
+        // sentinels above.
+        const VISIBLE_REF: &str = "vault://team/ref-ID-VISIBLE";
 
         let auths: Vec<AuthConfig> = vec![
             AuthConfig::None,
@@ -2823,6 +2866,17 @@ mod tests {
                     default_val: Some(SENTINEL_A.to_string()),
                 },
                 scope: Some("PRINCIPAL_ROLE:ALL".to_string()),
+                audience: None,
+            },
+            // SecretRef under the `client_secret` secret key: the opaque ref must
+            // survive redaction (a reference is not a secret).
+            AuthConfig::OAuth2ClientCredentials {
+                token_url: "https://c.example.com/tokens".to_string(),
+                client_id: ConfigValue::literal("svc-client"),
+                client_secret: ConfigValue::SecretRef {
+                    secret_ref: VISIBLE_REF.to_string(),
+                },
+                scope: None,
                 audience: None,
             },
         ];
@@ -2867,6 +2921,13 @@ mod tests {
                 assert!(
                     redacted.contains("MY_SECRET"),
                     "env var name lost: {redacted}"
+                );
+            }
+            // A SecretRef's opaque reference survives (it is not a secret).
+            if stored.contains(VISIBLE_REF) {
+                assert!(
+                    redacted.contains(VISIBLE_REF),
+                    "secret ref must stay visible on redaction: {redacted}"
                 );
             }
         }

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -199,13 +199,13 @@ pub use view::{
 #[cfg(feature = "iceberg")]
 pub use graph_source::{
     browse_iceberg_catalog, guard_iceberg_connection_urls, preview_iceberg_table,
-    sample_column_values, sample_iceberg_rows, BrowseDepth, CatalogBrowse, CatalogMode, ColumnInfo,
-    ColumnStats, Diagnostic, FlureeR2rmlProvider, GenerateOptions, GenerateR2rmlRequest,
-    GenerateR2rmlResponse, IcebergConnectionConfig, IcebergCreateConfig, IcebergCreateResult,
-    PartitionFieldInfo, R2rmlCreateConfig, R2rmlCreateResult, R2rmlMappingInput, RestCatalogMode,
-    SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier, StructuredR2rmlMapping,
-    SubjectStrategy, TableIdentifier, TableOverride, TablePreview, TableRef, TableSchema,
-    ValidateR2rmlResponse,
+    sample_column_values, sample_iceberg_rows, verify_storage_access, BrowseDepth, CatalogBrowse,
+    CatalogMode, ColumnInfo, ColumnStats, Diagnostic, FlureeR2rmlProvider, GenerateOptions,
+    GenerateR2rmlRequest, GenerateR2rmlResponse, IcebergConnectionConfig, IcebergCreateConfig,
+    IcebergCreateResult, PartitionFieldInfo, R2rmlCreateConfig, R2rmlCreateResult,
+    R2rmlMappingInput, RestCatalogMode, SnapshotRef, SortFieldInfo, StatsCompleteness, StatsTier,
+    StorageAccessReport, StructuredR2rmlMapping, SubjectStrategy, TableIdentifier, TableOverride,
+    TablePreview, TableRef, TableSchema, ValidateR2rmlResponse,
 };
 
 /// Secret-resolution injection point for `ConfigValue::SecretRef` in Iceberg

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -154,7 +154,7 @@ pub use import::{
     EffectiveImportSettings, ImportBuilder, ImportConfig, ImportError, ImportPhase, ImportResult,
     ImportSummary, RemoteSource,
 };
-pub use ledger_info::LedgerInfoBuilder;
+pub use ledger_info::{redact_graph_source_config, LedgerInfoBuilder};
 pub use ledger_manager::GuardedStagedCommit;
 pub use ledger_manager::{
     FreshnessCheck, FreshnessSource, LedgerHandle, LedgerManager, LedgerManagerConfig,

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -208,6 +208,13 @@ pub use graph_source::{
     ValidateR2rmlResponse,
 };
 
+/// Secret-resolution injection point for `ConfigValue::SecretRef` in Iceberg
+/// graph-source auth. The host constructs a [`SecretResolver`] with the tenant
+/// captured and injects it via [`Fluree::with_secret_resolver`]; db stays
+/// tenant-agnostic and fails closed when a secret reference has no resolver.
+#[cfg(feature = "iceberg")]
+pub use fluree_db_iceberg::{SecretResolveError, SecretResolver};
+
 pub use bm25_worker::{
     Bm25MaintenanceWorker, Bm25WorkerConfig, Bm25WorkerHandle, Bm25WorkerState, Bm25WorkerStats,
 };
@@ -1257,6 +1264,10 @@ pub struct FlureeBuilder {
     event_bus: Option<Arc<fluree_db_nameservice::LedgerEventBus>>,
     /// Read-only remote mounts applied at build time (alias-prefixed).
     remote_mounts: Vec<RemoteMountSpec>,
+    /// Optional secret resolver forwarded to the built `Fluree` for
+    /// `ConfigValue::SecretRef` hydration. See [`FlureeBuilder::with_secret_resolver`].
+    #[cfg(feature = "iceberg")]
+    secret_resolver: Option<Arc<dyn fluree_db_iceberg::SecretResolver>>,
 }
 
 /// Configuration for background indexing in `FlureeBuilder`.
@@ -1473,6 +1484,8 @@ impl FlureeBuilder {
             remote_connections: remote_service::RemoteConnectionRegistry::new(),
             event_bus: None,
             remote_mounts: Vec::new(),
+            #[cfg(feature = "iceberg")]
+            secret_resolver: None,
         }
     }
 
@@ -1489,6 +1502,8 @@ impl FlureeBuilder {
             remote_connections: remote_service::RemoteConnectionRegistry::new(),
             event_bus: None,
             remote_mounts: Vec::new(),
+            #[cfg(feature = "iceberg")]
+            secret_resolver: None,
         }
     }
 
@@ -1557,6 +1572,8 @@ impl FlureeBuilder {
             remote_connections: remote_service::RemoteConnectionRegistry::new(),
             event_bus: None,
             remote_mounts: Vec::new(),
+            #[cfg(feature = "iceberg")]
+            secret_resolver: None,
         }
     }
 
@@ -1751,6 +1768,8 @@ impl FlureeBuilder {
             remote_connections: remote_service::RemoteConnectionRegistry::new(),
             event_bus: None,
             remote_mounts: Vec::new(),
+            #[cfg(feature = "iceberg")]
+            secret_resolver: None,
         })
     }
 
@@ -1949,6 +1968,19 @@ impl FlureeBuilder {
     /// spawned on the tokio runtime, so `build()` must be called within a
     /// tokio context.
     #[cfg(feature = "native")]
+    /// Inject a secret resolver used to hydrate `ConfigValue::SecretRef` auth
+    /// references in Iceberg graph sources built by this builder. It is forwarded
+    /// to the finalized `Fluree`. Most hosts inject per-request via
+    /// [`Fluree::with_secret_resolver`] instead; use this for a build-time default.
+    #[cfg(feature = "iceberg")]
+    pub fn with_secret_resolver(
+        mut self,
+        resolver: Arc<dyn fluree_db_iceberg::SecretResolver>,
+    ) -> Self {
+        self.secret_resolver = Some(resolver);
+        self
+    }
+
     pub fn build(mut self) -> Result<Fluree> {
         let path = self
             .storage_path
@@ -1979,6 +2011,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         ))
     }
 
@@ -2009,6 +2043,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         )
     }
 
@@ -2116,6 +2152,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         ))
     }
 
@@ -2153,6 +2191,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         )
     }
 
@@ -2187,6 +2227,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         )
     }
 
@@ -2241,6 +2283,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         )
     }
 
@@ -2319,6 +2363,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         ))
     }
 
@@ -2421,6 +2467,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         ))
     }
 
@@ -2507,6 +2555,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         ))
     }
 
@@ -2640,6 +2690,12 @@ impl FlureeBuilder {
         parts: RuntimeParts,
         remote_connections: remote_service::RemoteConnectionRegistry,
         remote_mounts: Vec<RemoteMountSpec>,
+        // The single assembly point forwards the builder's secret resolver so
+        // every `build*` path carries it uniformly. Gated: the trait lives in the
+        // optional `fluree-db-iceberg` dep.
+        #[cfg(feature = "iceberg")] secret_resolver: Option<
+            Arc<dyn fluree_db_iceberg::SecretResolver>,
+        >,
     ) -> Fluree {
         let RuntimeParts {
             backend,
@@ -2693,6 +2749,8 @@ impl FlureeBuilder {
             event_bus,
             ledger_manager,
             remote_service: build_remote_service(remote_connections),
+            #[cfg(feature = "iceberg")]
+            secret_resolver,
         }
     }
 
@@ -2800,6 +2858,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         ))
     }
 
@@ -2871,6 +2931,8 @@ impl FlureeBuilder {
                 },
                 self.remote_connections,
                 self.remote_mounts,
+                #[cfg(feature = "iceberg")]
+                self.secret_resolver,
             ))
         }
     }
@@ -2932,6 +2994,8 @@ impl FlureeBuilder {
             },
             self.remote_connections,
             self.remote_mounts,
+            #[cfg(feature = "iceberg")]
+            self.secret_resolver,
         ))
     }
 
@@ -2982,6 +3046,12 @@ impl FlureeBuilder {
 ///
 /// Combines connection management, nameservice, and query execution
 /// into a unified interface.
+///
+/// `Clone` is cheap: every field is either config data or `Arc`-backed shared
+/// state (caches, event bus, ledger manager). This lets a host derive a
+/// per-tenant instance via [`Fluree::with_secret_resolver`] per request without
+/// re-opening storage.
+#[derive(Clone)]
 pub struct Fluree {
     /// Connection configuration
     config: ConnectionConfig,
@@ -3020,6 +3090,13 @@ pub struct Fluree {
     /// the executor is passed to `ContextConfig` and made available to
     /// `ServiceOperator` during query execution.
     remote_service: Option<Arc<dyn fluree_db_query::remote_service::RemoteServiceExecutor>>,
+    /// Injected resolver for `ConfigValue::SecretRef` secret references in
+    /// Iceberg graph-source auth. `None` in OSS/CLI (secret references then fail
+    /// closed); a host (e.g. solo) injects a tenant-scoped resolver via
+    /// [`Fluree::with_secret_resolver`]. db never sees tenant identity — the
+    /// resolver authorizes itself.
+    #[cfg(feature = "iceberg")]
+    secret_resolver: Option<Arc<dyn fluree_db_iceberg::SecretResolver>>,
 }
 
 impl Fluree {
@@ -3057,6 +3134,8 @@ impl Fluree {
             event_bus: Arc::new(fluree_db_nameservice::LedgerEventBus::new(1024)),
             ledger_manager: None,
             remote_service: None,
+            #[cfg(feature = "iceberg")]
+            secret_resolver: None,
         }
     }
 
@@ -3080,12 +3159,38 @@ impl Fluree {
             event_bus: Arc::new(fluree_db_nameservice::LedgerEventBus::new(1024)),
             ledger_manager: None,
             remote_service: None,
+            #[cfg(feature = "iceberg")]
+            secret_resolver: None,
         }
     }
 
     /// Set the indexing mode
     pub fn set_indexing_mode(&mut self, mode: tx::IndexingMode) {
         self.indexing_mode = mode;
+    }
+
+    /// Return a clone of this `Fluree` carrying `resolver`, used to hydrate
+    /// `ConfigValue::SecretRef` auth references in Iceberg graph sources.
+    ///
+    /// The clone is cheap (config + `Arc`-backed shared state) and the original
+    /// is left untouched, so a host can derive a per-tenant instance per request.
+    /// db performs no authorization itself — the resolver captures the tenant and
+    /// authorizes each `secret_ref` resolution.
+    #[cfg(feature = "iceberg")]
+    pub fn with_secret_resolver(
+        &self,
+        resolver: Arc<dyn fluree_db_iceberg::SecretResolver>,
+    ) -> Fluree {
+        let mut cloned = self.clone();
+        cloned.secret_resolver = Some(resolver);
+        cloned
+    }
+
+    /// The injected secret resolver, if any. Used by the Iceberg auth-hydration
+    /// path; `None` means `ConfigValue::SecretRef` references fail closed.
+    #[cfg(feature = "iceberg")]
+    pub(crate) fn secret_resolver(&self) -> Option<&Arc<dyn fluree_db_iceberg::SecretResolver>> {
+        self.secret_resolver.as_ref()
     }
 
     /// Get the remote SERVICE executor, if configured.

--- a/fluree-db-cli/src/commands/iceberg.rs
+++ b/fluree-db-cli/src/commands/iceberg.rs
@@ -612,9 +612,11 @@ fn print_graph_source_info(gs: &fluree_db_nameservice::GraphSourceRecord) {
 /// it for display, or `None` when there is nothing worth showing (empty / `{}` /
 /// not JSON — the last preserving the prior "skip unparseable config" behavior).
 ///
-/// Routes through [`fluree_db_api::redact_graph_source_config`]: allowlist
-/// redaction that FAILS CLOSED (non-JSON input becomes a placeholder, never the
-/// raw bytes). This is the single guard that keeps a stored `client_secret`/PAT
+/// Routes through [`fluree_db_api::redact_graph_source_config`]: redacts values
+/// under a fixed set of KNOWN secret key names (`SECRET_CONFIG_KEYS` — a
+/// denylist: fields not on it print verbatim, so new secret-bearing config
+/// fields MUST be added there). Unparseable input fails closed to a
+/// placeholder. This is the guard that keeps a stored `client_secret`/PAT
 /// off the terminal for both local records and remote responses (issue #1497).
 /// Redaction is idempotent, so a server response that was already redacted
 /// server-side is displayed unchanged. See the canary test

--- a/fluree-db-cli/src/commands/iceberg.rs
+++ b/fluree-db-cli/src/commands/iceberg.rs
@@ -566,13 +566,15 @@ fn print_remote_graph_source_info(info: &serde_json::Value) {
             println!("Dependencies:   {}", dep_strs.join(", "));
         }
     }
+    // Defense-in-depth: the server already redacts this config field, but an
+    // older server (version skew) may not — redaction is idempotent, so passing
+    // an already-redacted config through again is a no-op (issue #1497).
     if let Some(config) = info.get("config") {
-        println!();
-        println!("Configuration:");
-        println!(
-            "{}",
-            serde_json::to_string_pretty(config).unwrap_or_default()
-        );
+        if let Some(config_block) = redact_config_pretty(&config.to_string()) {
+            println!();
+            println!("Configuration:");
+            println!("{config_block}");
+        }
     }
 }
 
@@ -596,16 +598,36 @@ fn print_graph_source_info(gs: &fluree_db_nameservice::GraphSourceRecord) {
         println!("Dependencies:   {}", gs.dependencies.join(", "));
     }
 
-    if !gs.config.is_empty() && gs.config != "{}" {
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&gs.config) {
-            println!();
-            println!("Configuration:");
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&parsed).unwrap_or_else(|_| gs.config.clone())
-            );
-        }
+    // The stored config holds live catalog credentials (e.g. a Snowflake PAT
+    // under `catalog.auth.client_secret`); LOCAL mode reads it verbatim, so it
+    // MUST be redacted before display — issue #1497.
+    if let Some(config_block) = redact_config_pretty(&gs.config) {
+        println!();
+        println!("Configuration:");
+        println!("{config_block}");
     }
+}
+
+/// Redact secret leaves from a graph-source config JSON string and pretty-print
+/// it for display, or `None` when there is nothing worth showing (empty / `{}` /
+/// not JSON — the last preserving the prior "skip unparseable config" behavior).
+///
+/// Routes through [`fluree_db_api::redact_graph_source_config`]: allowlist
+/// redaction that FAILS CLOSED (non-JSON input becomes a placeholder, never the
+/// raw bytes). This is the single guard that keeps a stored `client_secret`/PAT
+/// off the terminal for both local records and remote responses (issue #1497).
+/// Redaction is idempotent, so a server response that was already redacted
+/// server-side is displayed unchanged. See the canary test
+/// `test_redact_graph_source_config_fails_closed_on_non_json` in `fluree-db-api`.
+fn redact_config_pretty(config: &str) -> Option<String> {
+    if config.is_empty() || config == "{}" {
+        return None;
+    }
+    // Preserve the prior gate: only render configs that parse as JSON.
+    serde_json::from_str::<serde_json::Value>(config).ok()?;
+    let redacted = fluree_db_api::redact_graph_source_config(config);
+    let parsed = serde_json::from_str::<serde_json::Value>(&redacted).ok()?;
+    Some(serde_json::to_string_pretty(&parsed).unwrap_or(redacted))
 }
 
 // =============================================================================
@@ -948,5 +970,47 @@ mod tests {
         args.r2rml_type = Some("application/ld+json".to_string());
         let body = args_to_json(&args).unwrap();
         assert_eq!(body["r2rml_type"], "application/ld+json");
+    }
+
+    // A stored Iceberg config carrying a live PAT under
+    // `catalog.auth.client_secret`, mirroring the local record shape that
+    // `fluree iceberg info` reads verbatim.
+    const CONFIG_WITH_SECRET: &str = r#"{"catalog":{"type":"rest","uri":"https://polaris.example.com","auth":{"type":"oauth2_client_credentials","client_id":"svc-client","client_secret":"SUPER-SECRET-PAT","scope":"PRINCIPAL_ROLE:ALL"}}}"#;
+
+    #[test]
+    fn redact_config_pretty_masks_secret_keeps_identifiers() {
+        let out = redact_config_pretty(CONFIG_WITH_SECRET).expect("config should render");
+        // The live secret must NOT reach the terminal (issue #1497)...
+        assert!(!out.contains("SUPER-SECRET-PAT"), "secret leaked: {out}");
+        assert!(out.contains("[redacted]"), "expected placeholder: {out}");
+        // ...while non-secret identifiers are preserved for debugging.
+        assert!(out.contains("svc-client"), "client_id dropped: {out}");
+        assert!(
+            out.contains("https://polaris.example.com"),
+            "catalog uri dropped: {out}"
+        );
+        // Output stays pretty-printed (multi-line), matching prior formatting.
+        assert!(out.contains('\n'), "expected pretty JSON: {out}");
+    }
+
+    #[test]
+    fn redact_config_pretty_skips_empty_and_non_json() {
+        assert!(redact_config_pretty("").is_none());
+        assert!(redact_config_pretty("{}").is_none());
+        // Non-JSON is gated out (skip), preserving prior CLI behavior.
+        assert!(redact_config_pretty("client_secret=not-json").is_none());
+    }
+
+    #[test]
+    fn redact_config_pretty_is_idempotent() {
+        let once = redact_config_pretty(CONFIG_WITH_SECRET).expect("first pass");
+        // Feed a compact re-serialization of the redacted output back through.
+        let compact =
+            serde_json::to_string(&serde_json::from_str::<serde_json::Value>(&once).unwrap())
+                .unwrap();
+        let twice = redact_config_pretty(&compact).expect("second pass");
+        assert!(!twice.contains("SUPER-SECRET-PAT"));
+        assert!(twice.contains("svc-client"));
+        assert_eq!(once, twice, "redaction must be idempotent");
     }
 }

--- a/fluree-db-cli/src/commands/info.rs
+++ b/fluree-db-cli/src/commands/info.rs
@@ -195,13 +195,15 @@ fn print_remote_graph_source_info(info: &serde_json::Value) {
             println!("Dependencies:   {}", dep_strs.join(", "));
         }
     }
+    // Defense-in-depth: the server already redacts this config field, but an
+    // older server (version skew) may not — redaction is idempotent, so passing
+    // an already-redacted config through again is a no-op (issue #1497).
     if let Some(config) = info.get("config") {
-        println!();
-        println!("Configuration:");
-        println!(
-            "{}",
-            serde_json::to_string_pretty(config).unwrap_or_default()
-        );
+        if let Some(config_block) = redact_config_pretty(&config.to_string()) {
+            println!();
+            println!("Configuration:");
+            println!("{config_block}");
+        }
     }
 }
 
@@ -225,17 +227,37 @@ fn print_graph_source_info(gs: &fluree_db_nameservice::GraphSourceRecord) {
         println!("Dependencies:   {}", gs.dependencies.join(", "));
     }
 
-    // Print config JSON (pretty)
-    if !gs.config.is_empty() && gs.config != "{}" {
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&gs.config) {
-            println!();
-            println!("Configuration:");
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&parsed).unwrap_or_else(|_| gs.config.clone())
-            );
-        }
+    // Print config JSON (pretty), with auth leaves redacted. The stored config
+    // is a live credential store (e.g. a Snowflake PAT under
+    // `catalog.auth.client_secret`); LOCAL mode reads it verbatim, so it MUST be
+    // routed through the redactor before display — issue #1497.
+    if let Some(config_block) = redact_config_pretty(&gs.config) {
+        println!();
+        println!("Configuration:");
+        println!("{config_block}");
     }
+}
+
+/// Redact secret leaves from a graph-source config JSON string and pretty-print
+/// it for display, or `None` when there is nothing worth showing (empty / `{}` /
+/// not JSON — the last preserving the prior "skip unparseable config" behavior).
+///
+/// Routes through [`fluree_db_api::redact_graph_source_config`]: allowlist
+/// redaction that FAILS CLOSED (non-JSON input becomes a placeholder, never the
+/// raw bytes). This is the single guard that keeps a stored `client_secret`/PAT
+/// off the terminal for both local records and remote responses (issue #1497).
+/// Redaction is idempotent, so a server response that was already redacted
+/// server-side is displayed unchanged. See the canary test
+/// `test_redact_graph_source_config_fails_closed_on_non_json` in `fluree-db-api`.
+fn redact_config_pretty(config: &str) -> Option<String> {
+    if config.is_empty() || config == "{}" {
+        return None;
+    }
+    // Preserve the prior gate: only render configs that parse as JSON.
+    serde_json::from_str::<serde_json::Value>(config).ok()?;
+    let redacted = fluree_db_api::redact_graph_source_config(config);
+    let parsed = serde_json::from_str::<serde_json::Value>(&redacted).ok()?;
+    Some(serde_json::to_string_pretty(&parsed).unwrap_or(redacted))
 }
 
 fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) -> String {
@@ -246,5 +268,52 @@ fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) -> String {
         fluree_db_nameservice::GraphSourceType::R2rml => "R2RML".to_string(),
         fluree_db_nameservice::GraphSourceType::Iceberg => "Iceberg".to_string(),
         fluree_db_nameservice::GraphSourceType::Unknown(s) => format!("Unknown({s})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A stored graph-source config carrying a live PAT under
+    // `catalog.auth.client_secret`, mirroring the local record shape that
+    // `fluree info <gs>` reads verbatim.
+    const CONFIG_WITH_SECRET: &str = r#"{"catalog":{"type":"rest","uri":"https://polaris.example.com","auth":{"type":"oauth2_client_credentials","client_id":"svc-client","client_secret":"SUPER-SECRET-PAT","scope":"PRINCIPAL_ROLE:ALL"}}}"#;
+
+    #[test]
+    fn redact_config_pretty_masks_secret_keeps_identifiers() {
+        let out = redact_config_pretty(CONFIG_WITH_SECRET).expect("config should render");
+        // The live secret must NOT reach the terminal (issue #1497)...
+        assert!(!out.contains("SUPER-SECRET-PAT"), "secret leaked: {out}");
+        assert!(out.contains("[redacted]"), "expected placeholder: {out}");
+        // ...while non-secret identifiers are preserved for debugging.
+        assert!(out.contains("svc-client"), "client_id dropped: {out}");
+        assert!(
+            out.contains("https://polaris.example.com"),
+            "catalog uri dropped: {out}"
+        );
+        // Output stays pretty-printed (multi-line), matching prior formatting.
+        assert!(out.contains('\n'), "expected pretty JSON: {out}");
+    }
+
+    #[test]
+    fn redact_config_pretty_skips_empty_and_non_json() {
+        assert!(redact_config_pretty("").is_none());
+        assert!(redact_config_pretty("{}").is_none());
+        // Non-JSON is gated out (skip), preserving prior CLI behavior.
+        assert!(redact_config_pretty("client_secret=not-json").is_none());
+    }
+
+    #[test]
+    fn redact_config_pretty_is_idempotent() {
+        let once = redact_config_pretty(CONFIG_WITH_SECRET).expect("first pass");
+        // Feed a compact re-serialization of the redacted output back through.
+        let compact =
+            serde_json::to_string(&serde_json::from_str::<serde_json::Value>(&once).unwrap())
+                .unwrap();
+        let twice = redact_config_pretty(&compact).expect("second pass");
+        assert!(!twice.contains("SUPER-SECRET-PAT"));
+        assert!(twice.contains("svc-client"));
+        assert_eq!(once, twice, "redaction must be idempotent");
     }
 }

--- a/fluree-db-cli/src/commands/info.rs
+++ b/fluree-db-cli/src/commands/info.rs
@@ -242,9 +242,11 @@ fn print_graph_source_info(gs: &fluree_db_nameservice::GraphSourceRecord) {
 /// it for display, or `None` when there is nothing worth showing (empty / `{}` /
 /// not JSON — the last preserving the prior "skip unparseable config" behavior).
 ///
-/// Routes through [`fluree_db_api::redact_graph_source_config`]: allowlist
-/// redaction that FAILS CLOSED (non-JSON input becomes a placeholder, never the
-/// raw bytes). This is the single guard that keeps a stored `client_secret`/PAT
+/// Routes through [`fluree_db_api::redact_graph_source_config`]: redacts values
+/// under a fixed set of KNOWN secret key names (`SECRET_CONFIG_KEYS` — a
+/// denylist: fields not on it print verbatim, so new secret-bearing config
+/// fields MUST be added there). Unparseable input fails closed to a
+/// placeholder. This is the guard that keeps a stored `client_secret`/PAT
 /// off the terminal for both local records and remote responses (issue #1497).
 /// Redaction is idempotent, so a server response that was already redacted
 /// server-side is displayed unchanged. See the canary test

--- a/fluree-db-iceberg/src/auth/mod.rs
+++ b/fluree-db-iceberg/src/auth/mod.rs
@@ -15,11 +15,12 @@ mod oauth2;
 pub use bearer::BearerTokenAuth;
 pub use oauth2::{OAuth2ClientCredentials, OAuth2Config};
 
-use crate::config_value::ConfigValue;
+use crate::config_value::{ConfigValue, SecretResolver};
 use crate::error::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use std::sync::Arc;
 
 /// Authentication provider for REST catalog requests.
 ///
@@ -141,6 +142,38 @@ impl AuthConfig {
             }
         }
     }
+
+    /// Resolve every [`ConfigValue::SecretRef`] auth field via `resolver`,
+    /// returning a config whose secret-bearing values are all literal (or
+    /// env-var / `None`) and therefore safe to hand to the SYNCHRONOUS
+    /// [`create_provider`](Self::create_provider) /
+    /// [`create_provider_arc`](Self::create_provider_arc).
+    ///
+    /// This is the single async step in the auth pipeline; call it once (with the
+    /// host's injected resolver) before building a provider. Fields carrying no
+    /// secret reference clone through untouched, and a `None` resolver only
+    /// errors when a `SecretRef` is actually present (fail closed).
+    pub async fn hydrate(&self, resolver: Option<&Arc<dyn SecretResolver>>) -> Result<AuthConfig> {
+        match self {
+            AuthConfig::None => Ok(AuthConfig::None),
+            AuthConfig::Bearer { token } => Ok(AuthConfig::Bearer {
+                token: token.hydrate(resolver).await?,
+            }),
+            AuthConfig::OAuth2ClientCredentials {
+                token_url,
+                client_id,
+                client_secret,
+                scope,
+                audience,
+            } => Ok(AuthConfig::OAuth2ClientCredentials {
+                token_url: token_url.clone(),
+                client_id: client_id.hydrate(resolver).await?,
+                client_secret: client_secret.hydrate(resolver).await?,
+                scope: scope.clone(),
+                audience: audience.clone(),
+            }),
+        }
+    }
 }
 
 /// No-op authentication (for testing or public catalogs).
@@ -217,5 +250,57 @@ mod tests {
             }
             _ => panic!("Expected OAuth2 auth"),
         }
+    }
+
+    #[derive(Debug)]
+    struct StubResolver;
+
+    #[async_trait]
+    impl SecretResolver for StubResolver {
+        async fn resolve_secret(
+            &self,
+            secret_ref: &str,
+        ) -> std::result::Result<String, crate::config_value::SecretResolveError> {
+            Ok(format!("resolved:{secret_ref}"))
+        }
+    }
+
+    #[tokio::test]
+    async fn hydrate_oauth2_resolves_secret_ref_client_secret() {
+        let resolver: Arc<dyn SecretResolver> = Arc::new(StubResolver);
+        let auth = AuthConfig::OAuth2ClientCredentials {
+            token_url: "https://c.example.com/token".to_string(),
+            client_id: ConfigValue::literal("svc-client"),
+            client_secret: ConfigValue::SecretRef {
+                secret_ref: "vault://cs".to_string(),
+            },
+            scope: Some("session:role:ANALYST".to_string()),
+            audience: None,
+        };
+        let hydrated = auth.hydrate(Some(&resolver)).await.unwrap();
+        match hydrated {
+            AuthConfig::OAuth2ClientCredentials {
+                client_id,
+                client_secret,
+                scope,
+                ..
+            } => {
+                // client_id (no ref) untouched; client_secret ref resolved.
+                assert_eq!(client_id.resolve().unwrap(), "svc-client");
+                assert_eq!(client_secret.resolve().unwrap(), "resolved:vault://cs");
+                assert_eq!(scope, Some("session:role:ANALYST".to_string()));
+            }
+            _ => panic!("expected OAuth2 auth"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hydrate_bearer_secret_ref_without_resolver_fails_closed() {
+        let auth = AuthConfig::Bearer {
+            token: ConfigValue::SecretRef {
+                secret_ref: "vault://tok".to_string(),
+            },
+        };
+        assert!(auth.hydrate(None).await.is_err());
     }
 }

--- a/fluree-db-iceberg/src/catalog/rest.rs
+++ b/fluree-db-iceberg/src/catalog/rest.rs
@@ -152,14 +152,6 @@ impl RestCatalogClient {
         })
     }
 
-    /// Override the catalog-request semaphore (tests only), so a bounded-pool test
-    /// isn't at the mercy of the process-wide `OnceLock`'s first-caller init.
-    #[cfg(test)]
-    pub(crate) fn with_catalog_semaphore(mut self, sem: Arc<tokio::sync::Semaphore>) -> Self {
-        self.catalog_semaphore = sem;
-        self
-    }
-
     /// Make a GET request to the catalog API.
     ///
     /// Handles authentication headers and 401 retry with token refresh.

--- a/fluree-db-iceberg/src/config_value.rs
+++ b/fluree-db-iceberg/src/config_value.rs
@@ -5,7 +5,9 @@
 //! environment variables with optional defaults.
 
 use crate::error::{IcebergError, Result};
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 /// A configuration value that can be either a literal string or resolved
 /// dynamically from environment variables.
@@ -47,6 +49,22 @@ use serde::{Deserialize, Serialize};
 pub enum ConfigValue {
     /// Literal string value
     Literal(String),
+    /// Opaque reference to a secret held outside the config, resolved at use
+    /// time by an injected [`SecretResolver`]. Wire shape: `{"secret_ref":
+    /// "<opaque>"}`. The reference is passed to the resolver verbatim — this
+    /// crate never parses or interprets it.
+    ///
+    /// **Variant ORDER is load-bearing.** `serde(untagged)` tries variants in
+    /// declaration order, and `Dynamic`'s fields are all `#[serde(default)]`, so
+    /// `Dynamic` matches *any* JSON object (it would silently swallow
+    /// `{"secret_ref": ...}`). `SecretRef` MUST therefore be declared BEFORE
+    /// `Dynamic`. The `secret_ref` field is REQUIRED (no serde default) so that
+    /// `{"env_var": ...}` fails to match `SecretRef` and correctly falls through
+    /// to `Dynamic`.
+    SecretRef {
+        /// Opaque secret reference, passed to the resolver as-is.
+        secret_ref: String,
+    },
     /// Dynamic value from environment or properties
     Dynamic {
         /// Environment variable name to resolve
@@ -69,6 +87,12 @@ impl std::fmt::Debug for ConfigValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConfigValue::Literal(_) => f.write_str("Literal(\"***\")"),
+            // A secret *reference* is not itself a secret (same policy as an
+            // env-var name), so the ref is shown to aid debugging.
+            ConfigValue::SecretRef { secret_ref } => f
+                .debug_struct("SecretRef")
+                .field("secret_ref", secret_ref)
+                .finish(),
             ConfigValue::Dynamic {
                 env_var,
                 java_property,
@@ -120,6 +144,14 @@ impl ConfigValue {
     pub fn resolve(&self) -> Result<String> {
         match self {
             ConfigValue::Literal(value) => Ok(value.clone()),
+            // A `SecretRef` cannot be resolved synchronously from config alone —
+            // it needs the injected async resolver (see [`ConfigValue::hydrate`]).
+            // Fail closed so every path that never threaded a resolver (OSS/CLI)
+            // errors actionably instead of silently using an empty/wrong value.
+            ConfigValue::SecretRef { .. } => Err(IcebergError::credential(
+                "secret reference requires an injected secret resolver; \
+                 OSS/CLI contexts must use literals or env vars",
+            )),
             ConfigValue::Dynamic {
                 env_var,
                 java_property: _,
@@ -150,6 +182,72 @@ impl ConfigValue {
     pub fn is_literal(&self) -> bool {
         matches!(self, ConfigValue::Literal(_))
     }
+
+    /// Resolve a [`ConfigValue::SecretRef`] to a [`ConfigValue::Literal`] using
+    /// the injected `resolver`, cloning every other variant through untouched.
+    ///
+    /// Async because resolution may hit a remote secret backend. This is the
+    /// bridge that lets the rest of the auth stack (`create_provider*`) stay
+    /// synchronous: hydrate once (async), then resolve/build synchronously.
+    ///
+    /// # Errors
+    ///
+    /// - `SecretRef` with `Some` resolver: any [`SecretResolveError`] is mapped
+    ///   to [`IcebergError::Credential`], preserving the Denied/NotFound/
+    ///   Unavailable kind in the message.
+    /// - `SecretRef` with `None` resolver: fails closed with the same actionable
+    ///   message as [`ConfigValue::resolve`].
+    pub async fn hydrate(&self, resolver: Option<&Arc<dyn SecretResolver>>) -> Result<ConfigValue> {
+        match self {
+            ConfigValue::SecretRef { secret_ref } => match resolver {
+                Some(resolver) => {
+                    let value = resolver.resolve_secret(secret_ref).await.map_err(|e| {
+                        IcebergError::credential(format!("failed to resolve secret reference: {e}"))
+                    })?;
+                    Ok(ConfigValue::Literal(value))
+                }
+                None => Err(IcebergError::credential(
+                    "secret reference requires an injected secret resolver; \
+                     OSS/CLI contexts must use literals or env vars",
+                )),
+            },
+            other => Ok(other.clone()),
+        }
+    }
+}
+
+/// Error returned by a [`SecretResolver`] when a secret reference cannot be
+/// turned into a value. The kind is preserved so callers (and their surfaced
+/// errors) can distinguish an authorization failure from a genuinely missing
+/// secret or a transient backend outage.
+#[derive(Debug, thiserror::Error)]
+pub enum SecretResolveError {
+    /// The caller was authenticated but is not authorized for this secret.
+    #[error("secret reference denied: {0}")]
+    Denied(String),
+    /// No secret exists for the given reference.
+    #[error("secret reference not found: {0}")]
+    NotFound(String),
+    /// The secret backend was unreachable or otherwise failed transiently.
+    #[error("secret resolver unavailable: {0}")]
+    Unavailable(String),
+}
+
+/// Resolves opaque secret references ([`ConfigValue::SecretRef`]) to their
+/// secret values.
+///
+/// The implementation performs its **own authorization** — the host constructs
+/// it with the tenant/principal captured — so this crate (and db) never sees
+/// tenant identity and stays tenant-agnostic. The `secret_ref` string is passed
+/// through verbatim; db never parses or interprets it.
+#[async_trait]
+pub trait SecretResolver: Send + Sync + std::fmt::Debug {
+    /// Resolve `secret_ref` to its secret value, or a typed error describing why
+    /// not. Implementations authorize the (captured) caller before returning.
+    async fn resolve_secret(
+        &self,
+        secret_ref: &str,
+    ) -> std::result::Result<String, SecretResolveError>;
 }
 
 impl From<String> for ConfigValue {
@@ -265,5 +363,135 @@ mod tests {
             !dbg.contains("fallback-secret"),
             "Debug must not leak the default secret, got: {dbg}"
         );
+    }
+
+    // ── SecretRef: ordering canary + resolve + hydrate ──
+
+    /// A resolver stub whose behavior is selected by the ref value, so a single
+    /// impl exercises success and every error kind.
+    #[derive(Debug)]
+    struct StubResolver;
+
+    #[async_trait]
+    impl SecretResolver for StubResolver {
+        async fn resolve_secret(
+            &self,
+            secret_ref: &str,
+        ) -> std::result::Result<String, SecretResolveError> {
+            match secret_ref {
+                "deny" => Err(SecretResolveError::Denied("no access to secret".into())),
+                "missing" => Err(SecretResolveError::NotFound("unknown ref".into())),
+                "down" => Err(SecretResolveError::Unavailable("backend down".into())),
+                other => Ok(format!("resolved:{other}")),
+            }
+        }
+    }
+
+    #[test]
+    fn secret_ref_parses_and_is_not_dynamic() {
+        // ORDERING CANARY: {"secret_ref": ...} MUST deserialize to SecretRef, not
+        // be silently swallowed by Dynamic (whose all-default fields match any
+        // object). If SecretRef is ever moved after Dynamic, this fails.
+        let value: ConfigValue = serde_json::from_str(r#"{"secret_ref": "vault://abc"}"#).unwrap();
+        match value {
+            ConfigValue::SecretRef { ref secret_ref } => assert_eq!(secret_ref, "vault://abc"),
+            other => panic!("expected SecretRef, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn env_var_object_still_parses_as_dynamic() {
+        // The complement of the ordering canary: a required `secret_ref` field
+        // means {"env_var": ...} does NOT match SecretRef and falls to Dynamic.
+        let value: ConfigValue = serde_json::from_str(r#"{"env_var": "E"}"#).unwrap();
+        assert!(
+            matches!(value, ConfigValue::Dynamic { .. }),
+            "got {value:?}"
+        );
+    }
+
+    #[test]
+    fn bare_string_still_parses_as_literal() {
+        let value: ConfigValue = serde_json::from_str(r#""just-a-string""#).unwrap();
+        assert!(matches!(value, ConfigValue::Literal(_)), "got {value:?}");
+    }
+
+    #[test]
+    fn secret_ref_round_trips_losslessly() {
+        let value = ConfigValue::SecretRef {
+            secret_ref: "vault://team/secret".to_string(),
+        };
+        let json = serde_json::to_string(&value).unwrap();
+        assert_eq!(json, r#"{"secret_ref":"vault://team/secret"}"#);
+        let back: ConfigValue = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, value);
+    }
+
+    #[test]
+    fn secret_ref_debug_shows_ref() {
+        // A reference is not a secret; it stays visible (aids debugging).
+        let value = ConfigValue::SecretRef {
+            secret_ref: "vault://visible-ref".to_string(),
+        };
+        let dbg = format!("{value:?}");
+        assert!(dbg.contains("vault://visible-ref"), "got: {dbg}");
+    }
+
+    #[test]
+    fn resolve_on_secret_ref_errors_actionably() {
+        let value = ConfigValue::SecretRef {
+            secret_ref: "vault://abc".to_string(),
+        };
+        let err = value.resolve().unwrap_err().to_string();
+        assert!(err.contains("secret resolver"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn hydrate_secret_ref_with_resolver_becomes_literal() {
+        let resolver: Arc<dyn SecretResolver> = Arc::new(StubResolver);
+        let value = ConfigValue::SecretRef {
+            secret_ref: "abc".to_string(),
+        };
+        let hydrated = value.hydrate(Some(&resolver)).await.unwrap();
+        assert_eq!(hydrated, ConfigValue::Literal("resolved:abc".to_string()));
+    }
+
+    #[tokio::test]
+    async fn hydrate_secret_ref_without_resolver_fails_closed() {
+        let value = ConfigValue::SecretRef {
+            secret_ref: "abc".to_string(),
+        };
+        let err = value.hydrate(None).await.unwrap_err().to_string();
+        assert!(err.contains("secret resolver"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn hydrate_passes_literal_and_dynamic_through() {
+        let resolver: Arc<dyn SecretResolver> = Arc::new(StubResolver);
+        let literal = ConfigValue::literal("plain");
+        assert_eq!(
+            literal.hydrate(Some(&resolver)).await.unwrap(),
+            ConfigValue::literal("plain")
+        );
+        let dynamic = ConfigValue::from_env("SOME_VAR");
+        assert_eq!(
+            dynamic.hydrate(Some(&resolver)).await.unwrap(),
+            ConfigValue::from_env("SOME_VAR")
+        );
+    }
+
+    #[tokio::test]
+    async fn hydrate_preserves_denied_kind_in_message() {
+        let resolver: Arc<dyn SecretResolver> = Arc::new(StubResolver);
+        let value = ConfigValue::SecretRef {
+            secret_ref: "deny".to_string(),
+        };
+        let err = value
+            .hydrate(Some(&resolver))
+            .await
+            .unwrap_err()
+            .to_string();
+        // The Denied kind (via SecretResolveError's Display) survives the mapping.
+        assert!(err.contains("denied"), "kind lost in mapping: {err}");
     }
 }

--- a/fluree-db-iceberg/src/error.rs
+++ b/fluree-db-iceberg/src/error.rs
@@ -29,6 +29,30 @@ pub enum IcebergError {
     #[error("Storage error: {0}")]
     Storage(String),
 
+    /// Object storage denied a read (S3 403 / `AccessDenied`).
+    ///
+    /// Structured so callers can surface a 403 (rather than a generic 400/500)
+    /// and name the exact object. AWS returns `AccessDenied` both for a genuine
+    /// permission failure and — when the caller lacks `s3:ListBucket` — for a
+    /// missing object (S3 cannot reveal 404 vs 403 without list permission), so
+    /// this means the credentials lack access **or** the object was moved/removed.
+    #[error(
+        "S3 access denied reading s3://{bucket}/{key}{region_suffix}: {message}. \
+         The credentials lack permission for this object, or — without s3:ListBucket — \
+         the object no longer exists (a missing object also surfaces as AccessDenied).",
+        region_suffix = .region.as_deref().map(|r| format!(" (region {r})")).unwrap_or_default()
+    )]
+    StorageAccessDenied {
+        /// Bucket parsed from the `s3://`/`gs://` path.
+        bucket: String,
+        /// Object key parsed from the path.
+        key: String,
+        /// Configured/resolved region, if known.
+        region: Option<String>,
+        /// The underlying SDK error chain (status, request id, etc.).
+        message: String,
+    },
+
     /// Snapshot not found
     #[error("Snapshot not found: {0}")]
     SnapshotNotFound(String),
@@ -101,6 +125,11 @@ impl From<IcebergError> for fluree_db_core::error::Error {
         match &err {
             IcebergError::TableNotFound(msg) => fluree_db_core::error::Error::not_found(msg),
             IcebergError::Storage(msg) => fluree_db_core::error::Error::storage(msg),
+            // Access-denied is still a storage-read failure at the core layer
+            // (core has no unauthorized variant); the full message is preserved.
+            IcebergError::StorageAccessDenied { .. } => {
+                fluree_db_core::error::Error::storage(err.to_string())
+            }
             // Auth and other errors map to generic "other" since core doesn't have unauthorized
             _ => fluree_db_core::error::Error::other(err.to_string()),
         }

--- a/fluree-db-iceberg/src/error.rs
+++ b/fluree-db-iceberg/src/error.rs
@@ -53,6 +53,25 @@ pub enum IcebergError {
         message: String,
     },
 
+    /// The source is configured to require catalog-vended storage credentials
+    /// (`io.vended_credentials = true`) but the catalog's `loadTable` returned none.
+    ///
+    /// Carried as an `IcebergError` ONLY so the typed error survives the deferred
+    /// `LazyS3Storage` builder's `Result` channel (which is `IcebergError`-typed);
+    /// `storage_query_error` lifts it straight back to
+    /// `QueryError::CatalogCredentialsNotVended` and its `err:catalog/CredentialsNotVended`
+    /// wire code, so the lazy path reports identically to the eager one. Never
+    /// construct it for a Direct-mode source — Direct never requests vending.
+    #[error(
+        "Catalog {catalog_uri} authorized the table but vended no storage credentials; \
+         either fix the catalog's credential vending or set vended_credentials=false \
+         on the source to explicitly use ambient AWS credentials"
+    )]
+    CatalogCredentialsNotVended {
+        /// The REST catalog URI that authorized the table but vended nothing.
+        catalog_uri: String,
+    },
+
     /// Snapshot not found
     #[error("Snapshot not found: {0}")]
     SnapshotNotFound(String),
@@ -129,6 +148,9 @@ impl From<IcebergError> for fluree_db_core::error::Error {
             // (core has no unauthorized variant); the full message is preserved.
             IcebergError::StorageAccessDenied { .. } => {
                 fluree_db_core::error::Error::storage(err.to_string())
+            }
+            IcebergError::CatalogCredentialsNotVended { .. } => {
+                fluree_db_core::error::Error::other(err.to_string())
             }
             // Auth and other errors map to generic "other" since core doesn't have unauthorized
             _ => fluree_db_core::error::Error::other(err.to_string()),

--- a/fluree-db-iceberg/src/io/storage.rs
+++ b/fluree-db-iceberg/src/io/storage.rs
@@ -135,6 +135,49 @@ fn error_chain(err: &dyn std::error::Error) -> String {
     msg
 }
 
+/// Classify whether an S3 read failure denotes access-denied.
+///
+/// Pure decision split out from the SDK call sites so it is unit-testable
+/// without constructing `SdkError` values. S3 signals denial either through the
+/// modeled service error code `AccessDenied` or a raw HTTP 403; either counts.
+/// A missing object *without* `s3:ListBucket` also arrives as `AccessDenied`
+/// (S3 will not reveal 404 vs 403 without list permission), so a denied result
+/// does not distinguish "no permission" from "object moved/removed".
+#[cfg(any(feature = "aws", test))]
+fn is_s3_access_denied(error_code: Option<&str>, http_status: Option<u16>) -> bool {
+    matches!(error_code, Some(code) if code.eq_ignore_ascii_case("AccessDenied"))
+        || http_status == Some(403)
+}
+
+/// Build an [`IcebergError`] from a failed S3 read.
+///
+/// Returns the structured [`IcebergError::StorageAccessDenied`] (which the API/
+/// server layers surface as HTTP 403) when [`is_s3_access_denied`] fires, and
+/// otherwise the pre-existing stringly [`IcebergError::Storage`] with the exact
+/// `"S3 {op} failed: …"` message — so every non-denial failure is byte-for-byte
+/// unchanged from before.
+#[cfg(any(feature = "aws", test))]
+fn s3_read_error(
+    op: &str,
+    bucket: &str,
+    key: &str,
+    region: Option<String>,
+    error_code: Option<&str>,
+    http_status: Option<u16>,
+    chained_message: String,
+) -> IcebergError {
+    if is_s3_access_denied(error_code, http_status) {
+        IcebergError::StorageAccessDenied {
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            region,
+            message: chained_message,
+        }
+    } else {
+        IcebergError::storage(format!("S3 {op} failed: {chained_message}"))
+    }
+}
+
 #[cfg(feature = "aws")]
 impl S3IcebergStorage {
     /// Resolve effective region/endpoint/path-style from vended credentials plus
@@ -329,6 +372,15 @@ impl S3IcebergStorage {
         }
     }
 
+    /// The region resolved onto the S3 client, if any (used to annotate
+    /// access-denied errors). `None` when the SDK default chain applies.
+    fn configured_region(&self) -> Option<String> {
+        self.client
+            .config()
+            .region()
+            .map(|r| r.as_ref().to_string())
+    }
+
     /// Parse an object-store URI into (bucket, key).
     ///
     /// Supports formats:
@@ -375,7 +427,16 @@ impl S3IcebergStorage {
             .send()
             .await
             .map_err(|e| {
-                IcebergError::storage(format!("S3 GetObject failed: {}", error_chain(&e)))
+                use aws_sdk_s3::error::ProvideErrorMetadata;
+                s3_read_error(
+                    "GetObject",
+                    bucket,
+                    key,
+                    self.configured_region(),
+                    e.code(),
+                    e.raw_response().map(|r| r.status().as_u16()),
+                    error_chain(&e),
+                )
             })?;
 
         let body = response.body.collect().await.map_err(|e| {
@@ -429,7 +490,16 @@ impl IcebergStorage for S3IcebergStorage {
             .send()
             .await
             .map_err(|e| {
-                IcebergError::storage(format!("S3 GetObject failed: {}", error_chain(&e)))
+                use aws_sdk_s3::error::ProvideErrorMetadata;
+                s3_read_error(
+                    "GetObject",
+                    bucket,
+                    key,
+                    self.configured_region(),
+                    e.code(),
+                    e.raw_response().map(|r| r.status().as_u16()),
+                    error_chain(&e),
+                )
             })?;
 
         let body = response.body.collect().await.map_err(|e| {
@@ -455,7 +525,16 @@ impl IcebergStorage for S3IcebergStorage {
             .send()
             .await
             .map_err(|e| {
-                IcebergError::storage(format!("S3 HeadObject failed: {}", error_chain(&e)))
+                use aws_sdk_s3::error::ProvideErrorMetadata;
+                s3_read_error(
+                    "HeadObject",
+                    bucket,
+                    key,
+                    self.configured_region(),
+                    e.code(),
+                    e.raw_response().map(|r| r.status().as_u16()),
+                    error_chain(&e),
+                )
             })?;
 
         response
@@ -479,7 +558,16 @@ impl SendIcebergStorage for S3IcebergStorage {
             .send()
             .await
             .map_err(|e| {
-                IcebergError::storage(format!("S3 GetObject failed: {}", error_chain(&e)))
+                use aws_sdk_s3::error::ProvideErrorMetadata;
+                s3_read_error(
+                    "GetObject",
+                    bucket,
+                    key,
+                    self.configured_region(),
+                    e.code(),
+                    e.raw_response().map(|r| r.status().as_u16()),
+                    error_chain(&e),
+                )
             })?;
 
         let body = response.body.collect().await.map_err(|e| {
@@ -505,7 +593,16 @@ impl SendIcebergStorage for S3IcebergStorage {
             .send()
             .await
             .map_err(|e| {
-                IcebergError::storage(format!("S3 HeadObject failed: {}", error_chain(&e)))
+                use aws_sdk_s3::error::ProvideErrorMetadata;
+                s3_read_error(
+                    "HeadObject",
+                    bucket,
+                    key,
+                    self.configured_region(),
+                    e.code(),
+                    e.raw_response().map(|r| r.status().as_u16()),
+                    error_chain(&e),
+                )
             })?;
 
         response
@@ -811,5 +908,88 @@ mod tests {
         // Start beyond end - should return empty
         let empty = storage.read_range("test.txt", 100..200).await.unwrap();
         assert!(empty.is_empty());
+    }
+
+    // ── Access-denied classification (feature-independent; no SDK types) ──
+
+    #[test]
+    fn access_denied_by_service_code() {
+        assert!(is_s3_access_denied(Some("AccessDenied"), None));
+        // Case-insensitive so an SDK code-casing change does not silently
+        // reclassify a 403 as a generic storage error.
+        assert!(is_s3_access_denied(Some("accessdenied"), Some(200)));
+    }
+
+    #[test]
+    fn access_denied_by_http_403() {
+        assert!(is_s3_access_denied(None, Some(403)));
+        // A 403 is denied even when the modeled code is something else.
+        assert!(is_s3_access_denied(Some("Forbidden"), Some(403)));
+    }
+
+    #[test]
+    fn not_access_denied_for_other_errors() {
+        assert!(!is_s3_access_denied(Some("NoSuchKey"), Some(404)));
+        assert!(!is_s3_access_denied(Some("SlowDown"), Some(503)));
+        assert!(!is_s3_access_denied(None, Some(500)));
+        assert!(!is_s3_access_denied(None, None));
+    }
+
+    #[test]
+    fn s3_read_error_maps_denied_to_structured_variant() {
+        let err = s3_read_error(
+            "GetObject",
+            "my-bucket",
+            "path/to/data.parquet",
+            Some("us-east-2".to_string()),
+            Some("AccessDenied"),
+            Some(403),
+            "service error: AccessDenied".to_string(),
+        );
+        match err {
+            IcebergError::StorageAccessDenied {
+                bucket,
+                key,
+                region,
+                message,
+            } => {
+                assert_eq!(bucket, "my-bucket");
+                assert_eq!(key, "path/to/data.parquet");
+                assert_eq!(region.as_deref(), Some("us-east-2"));
+                assert!(message.contains("AccessDenied"));
+            }
+            other => panic!("expected StorageAccessDenied, got {other:?}"),
+        }
+
+        // Display is actionable: names the object, the region, and the
+        // ListBucket caveat (no-permission OR object-moved).
+        let shown = IcebergError::StorageAccessDenied {
+            bucket: "b".into(),
+            key: "k".into(),
+            region: Some("us-west-1".into()),
+            message: "svc".into(),
+        }
+        .to_string();
+        assert!(shown.contains("s3://b/k"), "shown: {shown}");
+        assert!(shown.contains("region us-west-1"), "shown: {shown}");
+        assert!(shown.contains("s3:ListBucket"), "shown: {shown}");
+    }
+
+    #[test]
+    fn s3_read_error_preserves_legacy_message_for_non_denied() {
+        let err = s3_read_error(
+            "HeadObject",
+            "b",
+            "k",
+            None,
+            Some("NoSuchKey"),
+            Some(404),
+            "chain".to_string(),
+        );
+        // Byte-for-byte identical to the pre-typed-error stringly message.
+        assert_eq!(
+            err.to_string(),
+            "Storage error: S3 HeadObject failed: chain"
+        );
     }
 }

--- a/fluree-db-iceberg/src/lib.rs
+++ b/fluree-db-iceberg/src/lib.rs
@@ -66,7 +66,7 @@ pub mod stats;
 
 // Re-export commonly used types
 pub use config::{CatalogConfig, IcebergGsConfig, IoConfig, MappingSource, TableConfig};
-pub use config_value::ConfigValue;
+pub use config_value::{ConfigValue, SecretResolveError, SecretResolver};
 pub use error::{IcebergError, Result};
 
 // Re-export Phase 2 types for convenience

--- a/fluree-db-iceberg/src/scan/topk.rs
+++ b/fluree-db-iceberg/src/scan/topk.rs
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn plan_orders_desc_with_no_bound_last() {
-        let dfs = vec![
+        let dfs = [
             df_with_upper(1, Some(10.0), 0), // 0
             df_with_upper(1, Some(30.0), 0), // 1
             df_with_upper(1, None, 5),       // 2 — all-null column, no upper_bound
@@ -364,13 +364,13 @@ mod tests {
     /// holding the top-k.
     #[test]
     fn read_loop_prunes_after_heap_fills() {
-        let vals = vec![
+        let vals = [
             vec![Some(4999.98), Some(100.0)], // 0: holds the max
             vec![Some(4999.60), Some(50.0)],  // 1: holds the 2nd
             vec![Some(3000.0), Some(10.0)],   // 2: below the top-2 once full
             vec![None, None],                 // 3: all-null
         ];
-        let dfs = vec![
+        let dfs = [
             df_with_upper(1, Some(4999.98), 0),
             df_with_upper(1, Some(4999.60), 0),
             df_with_upper(1, Some(3000.0), 0),
@@ -401,8 +401,8 @@ mod tests {
     /// authoritative sort). Rider 1.
     #[test]
     fn read_loop_reads_all_when_k_exceeds_nonnull() {
-        let vals = vec![vec![Some(5.0)], vec![Some(3.0)], vec![None]];
-        let dfs = vec![
+        let vals = [vec![Some(5.0)], vec![Some(3.0)], vec![None]];
+        let dfs = [
             df_with_upper(1, Some(5.0), 0),
             df_with_upper(1, Some(3.0), 0),
             df_with_upper(1, None, 1), // all-null

--- a/fluree-db-query/src/error.rs
+++ b/fluree-db-query/src/error.rs
@@ -69,6 +69,44 @@ pub enum QueryError {
         reason: fluree_db_core::QueryCancellationReason,
     },
 
+    /// Object storage denied a read of an external table's data (S3 403 /
+    /// `AccessDenied`).
+    ///
+    /// Kept iceberg-agnostic (plain fields, no crate dependency): the API layer
+    /// lifts `IcebergError::StorageAccessDenied` into this so the server can
+    /// surface HTTP 403 instead of a generic 400/500. Because S3 also returns
+    /// `AccessDenied` for a missing object without `s3:ListBucket`, this means
+    /// the credentials lack access **or** the object was moved/removed.
+    #[error(
+        "Storage access denied for s3://{bucket}/{key}{region_suffix}: {message}",
+        region_suffix = .region.as_deref().map(|r| format!(" (region {r})")).unwrap_or_default()
+    )]
+    StorageAccessDenied {
+        /// Bucket parsed from the object path.
+        bucket: String,
+        /// Object key parsed from the object path.
+        key: String,
+        /// Configured/resolved region, if known.
+        region: Option<String>,
+        /// The underlying storage error detail.
+        message: String,
+    },
+
+    /// The catalog authorized the table but vended no storage credentials while
+    /// the source requires them (`vended_credentials = true`).
+    ///
+    /// Fail-closed: the scan is refused rather than silently downgrading to
+    /// ambient (process-default) AWS credentials.
+    #[error(
+        "Catalog {catalog_uri} authorized the table but vended no storage credentials; \
+         either fix the catalog's credential vending or set vended_credentials=false on \
+         the source to explicitly use ambient AWS credentials"
+    )]
+    CatalogCredentialsNotVended {
+        /// The REST catalog URI that authorized the table.
+        catalog_uri: String,
+    },
+
     /// Internal error (should not happen in normal operation)
     #[error("Internal error: {0}")]
     Internal(String),
@@ -191,5 +229,43 @@ mod tests {
             !QueryError::dictionary_lookup("missing string id".to_string())
                 .demotes_to_unbound_in_extend()
         );
+    }
+
+    #[test]
+    fn storage_access_denied_display_names_object_and_region() {
+        let e = QueryError::StorageAccessDenied {
+            bucket: "b".to_string(),
+            key: "warehouse/t/data/f.parquet".to_string(),
+            region: Some("us-east-2".to_string()),
+            message: "service error: AccessDenied".to_string(),
+        };
+        let shown = e.to_string();
+        assert!(
+            shown.contains("s3://b/warehouse/t/data/f.parquet"),
+            "{shown}"
+        );
+        assert!(shown.contains("region us-east-2"), "{shown}");
+
+        // Region is omitted cleanly when unknown.
+        let no_region = QueryError::StorageAccessDenied {
+            bucket: "b".to_string(),
+            key: "k".to_string(),
+            region: None,
+            message: "m".to_string(),
+        };
+        assert_eq!(
+            no_region.to_string(),
+            "Storage access denied for s3://b/k: m"
+        );
+    }
+
+    #[test]
+    fn catalog_credentials_not_vended_display_is_actionable() {
+        let e = QueryError::CatalogCredentialsNotVended {
+            catalog_uri: "https://catalog.example/v1".to_string(),
+        };
+        let shown = e.to_string();
+        assert!(shown.contains("https://catalog.example/v1"), "{shown}");
+        assert!(shown.contains("vended_credentials=false"), "{shown}");
     }
 }

--- a/fluree-db-server/src/error.rs
+++ b/fluree-db-server/src/error.rs
@@ -103,6 +103,22 @@ impl ServerError {
             ServerError::Api(ApiError::Query(fluree_db_query::QueryError::Cancelled {
                 ..
             })) => errors::QUERY_CANCELLED,
+
+            // Storage-permission / fail-closed errors (403). Raised directly on
+            // the preview path or wrapped from the query engine on the scan
+            // path; both surface the same distinct `@type` so clients can branch.
+            // These MUST precede the generic `ApiError::Query(_)` arm below.
+            ServerError::Api(
+                ApiError::StorageAccessDenied { .. }
+                | ApiError::Query(fluree_db_query::QueryError::StorageAccessDenied { .. }),
+            ) => errors::STORAGE_ACCESS_DENIED,
+            ServerError::Api(
+                ApiError::CatalogCredentialsNotVended { .. }
+                | ApiError::Query(fluree_db_query::QueryError::CatalogCredentialsNotVended {
+                    ..
+                }),
+            ) => errors::CATALOG_CREDENTIALS_NOT_VENDED,
+
             ServerError::Api(ApiError::Query(_)) => errors::INVALID_QUERY,
             ServerError::Api(ApiError::Batch(_)) => errors::INVALID_QUERY,
             // Optimistic-concurrency conflicts: a distinct, retryable class so
@@ -176,6 +192,18 @@ impl ServerError {
                 | fluree_db_api::TransactError::PublishLostRace { .. }
                 | fluree_db_api::TransactError::NamespaceConflict(_),
             )) => StatusCode::CONFLICT,
+
+            // 403 - Forbidden (storage-permission / fail-closed). Raised
+            // directly (preview path) or wrapped from the query engine (scan
+            // path). MUST precede the generic `ApiError::Query(_)` arm below.
+            ServerError::Api(
+                ApiError::StorageAccessDenied { .. }
+                | ApiError::CatalogCredentialsNotVended { .. }
+                | ApiError::Query(
+                    fluree_db_query::QueryError::StorageAccessDenied { .. }
+                    | fluree_db_query::QueryError::CatalogCredentialsNotVended { .. },
+                ),
+            ) => StatusCode::FORBIDDEN,
 
             // 400 - Bad Request (client errors)
             ServerError::Api(ApiError::Parse(_)) => StatusCode::BAD_REQUEST,
@@ -389,3 +417,98 @@ fn extract_cause(error: &ServerError) -> Option<Box<ErrorResponse>> {
 
 /// Result type alias for server operations
 pub type Result<T> = std::result::Result<T, ServerError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_vocab::errors;
+
+    fn storage_denied_direct() -> ApiError {
+        ApiError::StorageAccessDenied {
+            bucket: "b".into(),
+            key: "warehouse/t/data/f.parquet".into(),
+            region: Some("us-east-2".into()),
+            message: "service error: AccessDenied".into(),
+        }
+    }
+
+    fn storage_denied_via_query() -> ApiError {
+        ApiError::Query(fluree_db_query::QueryError::StorageAccessDenied {
+            bucket: "b".into(),
+            key: "warehouse/t/data/f.parquet".into(),
+            region: Some("us-east-2".into()),
+            message: "service error: AccessDenied".into(),
+        })
+    }
+
+    fn not_vended_direct() -> ApiError {
+        ApiError::CatalogCredentialsNotVended {
+            catalog_uri: "https://catalog.example/v1".into(),
+        }
+    }
+
+    fn not_vended_via_query() -> ApiError {
+        ApiError::Query(fluree_db_query::QueryError::CatalogCredentialsNotVended {
+            catalog_uri: "https://catalog.example/v1".into(),
+        })
+    }
+
+    #[test]
+    fn storage_access_denied_is_403_both_paths() {
+        // Preview path (direct ApiError) and scan path (wrapped via Query) both
+        // surface HTTP 403 + the distinct STORAGE_ACCESS_DENIED @type.
+        for api in [storage_denied_direct(), storage_denied_via_query()] {
+            let se = ServerError::Api(api);
+            assert_eq!(se.status_code(), StatusCode::FORBIDDEN);
+            assert_eq!(se.error_type(), errors::STORAGE_ACCESS_DENIED);
+        }
+    }
+
+    #[test]
+    fn credentials_not_vended_is_403_both_paths() {
+        for api in [not_vended_direct(), not_vended_via_query()] {
+            let se = ServerError::Api(api);
+            assert_eq!(se.status_code(), StatusCode::FORBIDDEN);
+            assert_eq!(se.error_type(), errors::CATALOG_CREDENTIALS_NOT_VENDED);
+        }
+    }
+
+    #[test]
+    fn error_body_json_shape_for_storage_access_denied() {
+        // Exact body the solo code-first dispatch consumes: `@type` is the
+        // stable dispatch key; `status` is 403; the structured fields
+        // (bucket/key/region) are carried in the human-readable `error` string.
+        let se = ServerError::Api(storage_denied_via_query());
+        let body = ErrorResponse {
+            error: se.to_string(),
+            status: se.status_code().as_u16(),
+            error_type: se.error_type().to_string(),
+            cause: extract_cause(&se),
+        };
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["status"], 403);
+        assert_eq!(json["@type"], errors::STORAGE_ACCESS_DENIED);
+        let msg = json["error"].as_str().unwrap();
+        assert!(msg.contains("s3://b/warehouse/t/data/f.parquet"), "{msg}");
+        assert!(msg.contains("region us-east-2"), "{msg}");
+        // No cause chain for these leaf errors.
+        assert!(json.get("cause").is_none());
+    }
+
+    #[test]
+    fn error_body_json_shape_for_credentials_not_vended() {
+        let se = ServerError::Api(not_vended_direct());
+        let body = ErrorResponse {
+            error: se.to_string(),
+            status: se.status_code().as_u16(),
+            error_type: se.error_type().to_string(),
+            cause: extract_cause(&se),
+        };
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["status"], 403);
+        assert_eq!(json["@type"], errors::CATALOG_CREDENTIALS_NOT_VENDED);
+        let msg = json["error"].as_str().unwrap();
+        assert!(msg.contains("https://catalog.example/v1"), "{msg}");
+        assert!(msg.contains("vended_credentials=false"), "{msg}");
+    }
+}

--- a/fluree-db-server/src/routes/iceberg.rs
+++ b/fluree-db-server/src/routes/iceberg.rs
@@ -529,6 +529,75 @@ async fn iceberg_catalog_preview_local(
     .await
 }
 
+/// Request body for `POST /v1/fluree/iceberg/catalog/verify`
+#[derive(Deserialize)]
+pub struct IcebergVerifyRequest {
+    #[serde(flatten)]
+    pub connection: IcebergConnectionRequest,
+    /// Table identifier (`"NAMESPACE.NAME"`, byte-for-byte catalog casing).
+    pub table: String,
+}
+
+/// Verify that the connection's resolved credentials can READ a table's storage
+/// (the onboarding "Test" probe). Read-only: creates no graph source, writes
+/// nothing; it goes through the engine's own credential + storage path and proves
+/// both the `metadata/` and `data/` S3 prefixes are readable.
+///
+/// POST /v1/fluree/iceberg/catalog/verify
+pub async fn iceberg_catalog_verify(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Response {
+    iceberg_catalog_verify_local(state, request)
+        .await
+        .into_response()
+}
+
+async fn iceberg_catalog_verify_local(
+    state: Arc<AppState>,
+    request: Request,
+) -> Result<impl IntoResponse> {
+    let headers = FlureeHeaders::from_headers(request.headers())?;
+    let request_id = extract_request_id(&headers.raw, &state.telemetry_config);
+    let trace_id = extract_trace_id(&headers.raw);
+    let req: IcebergVerifyRequest = parse_iceberg_body(request).await?;
+
+    let span = create_request_span(
+        "iceberg:catalog:verify",
+        request_id.as_deref(),
+        trace_id.as_deref(),
+        Some(&req.table),
+        None,
+        None,
+    );
+    async move {
+        guard_connection_urls(
+            req.connection.catalog_uri.as_deref(),
+            req.connection.oauth2_token_url.as_deref(),
+            req.connection.s3_endpoint.as_deref(),
+        )?;
+        let conn = build_iceberg_connection(&req.connection)?;
+
+        let report = state
+            .fluree
+            .verify_iceberg_storage_access(conn, &req.table)
+            .await
+            .map_err(ServerError::Api)?;
+
+        tracing::info!(
+            status = "success",
+            table = %req.table,
+            credential_source = report.credential_source,
+            data_files_listed = report.data_files_listed,
+            data_probe_skipped = report.data_probe_skipped,
+            "iceberg storage access verified"
+        );
+        Ok((StatusCode::OK, Json(report)))
+    }
+    .instrument(span)
+    .await
+}
+
 // =============================================================================
 // Deterministic R2RML generation (metadata-only; creates no graph source).
 // =============================================================================
@@ -881,6 +950,40 @@ mod tests {
         // The flattened connection builds a REST connection carrying the scope.
         let conn = build_iceberg_connection(&req.connection).unwrap();
         assert!(conn.is_rest());
+    }
+
+    #[test]
+    fn verify_request_flattens_connection_and_table() {
+        // The flattened connection fields must deserialize alongside `table`, and
+        // build a REST connection carrying the OAuth2 scope.
+        let body = serde_json::json!({
+            "mode": "rest",
+            "catalog_uri": "https://catalog.example.com",
+            "warehouse": "wh1",
+            "oauth2_token_url": "https://catalog.example.com/v1/oauth/tokens",
+            "oauth2_client_secret": "pat",
+            "oauth2_scope": "session:role:ICEBERG_READER",
+            "table": "DW.DIM_STORE"
+        });
+        let req: IcebergVerifyRequest = serde_json::from_value(body).unwrap();
+        assert_eq!(req.table, "DW.DIM_STORE");
+        assert_eq!(req.connection.warehouse.as_deref(), Some("wh1"));
+
+        let conn = build_iceberg_connection(&req.connection).unwrap();
+        assert!(conn.is_rest());
+    }
+
+    #[test]
+    fn verify_request_direct_mode_builds_direct_connection() {
+        let body = serde_json::json!({
+            "mode": "direct",
+            "table_location": "s3://bucket/warehouse/ns/table",
+            "table": "ns.table"
+        });
+        let req: IcebergVerifyRequest = serde_json::from_value(body).unwrap();
+        assert_eq!(req.table, "ns.table");
+        let conn = build_iceberg_connection(&req.connection).unwrap();
+        assert!(conn.is_direct());
     }
 
     #[test]

--- a/fluree-db-server/src/routes/mod.rs
+++ b/fluree-db-server/src/routes/mod.rs
@@ -151,6 +151,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             post(iceberg::iceberg_catalog_preview),
         )
         .route(
+            "/iceberg/catalog/verify",
+            post(iceberg::iceberg_catalog_verify),
+        )
+        .route(
             "/iceberg/r2rml/generate",
             post(iceberg::iceberg_r2rml_generate),
         )

--- a/fluree-vocab/src/errors.rs
+++ b/fluree-vocab/src/errors.rs
@@ -136,6 +136,22 @@ pub const STORAGE_READ: &str = "err:storage/ReadFailure";
 /// Storage write failure
 pub const STORAGE_WRITE: &str = "err:storage/WriteFailure";
 
+/// Object storage denied a read (S3 403 / `AccessDenied`).
+///
+/// Distinct from the policy-layer [`ACCESS_DENIED`]: this is the external
+/// object store (S3/GCS) refusing a read of an Iceberg data/metadata/manifest
+/// file, not a Fluree policy decision. Because S3 also returns `AccessDenied`
+/// for a missing object when the caller lacks `s3:ListBucket`, this means the
+/// credentials lack access **or** the object was moved/removed.
+pub const STORAGE_ACCESS_DENIED: &str = "err:storage/AccessDenied";
+
+/// The catalog authorized the table but vended no storage credentials while the
+/// source is configured to require them (`vended_credentials = true`).
+///
+/// Fail-closed signal: the query/preview is refused rather than silently
+/// downgrading to ambient (process-default) AWS credentials.
+pub const CATALOG_CREDENTIALS_NOT_VENDED: &str = "err:catalog/CredentialsNotVended";
+
 /// Connection error
 pub const CONNECTION: &str = "err:storage/ConnectionError";
 


### PR DESCRIPTION
Iceberg on operator-owned S3 (BYO-IAM): inline metadata, fail-closed credential handling, SecretRef rotation fix, typed storage errors, verify probe. Closes #1500, #1497, #1498.

## What this is

The db-side engine work for the cross-repo BYO-IAM effort (fluree/solo#782 credential rotation + fluree/solo#783 configure-time BYO-IAM wizard): a Snowflake operator whose Iceberg data files live in an S3 bucket **they** own configures it on a **live** Solo stack — no CloudFormation update per bucket. Driven by a real client configuration, live-verified against a standing Snowflake + AWS rig throughout.

**Stacked on the head of the perf chain** — base `perf/r2rml-f17-union-budget` (#1507), i.e. `#1502 → #1503 (loadTable-METADATA cache) → #1506 (corpus) → #1507 (F17)`. That is deliberate: the binding constraint was **performance must not degrade under any credential configuration**, so this had to be built and measured on top of the virtual-dataset perf work rather than reconciled at merge time.

### ⚠️ The restack found four semantic breaks — this is the part to review

Rebasing onto the chain applied **textually clean for 8 of 10 commits**, and that was the trap. #1503 did not *replace* the two sites this branch hardens — it **cloned** them into a deferred (`LazyS3Storage`) copy that none of the guards reached. Every break below is invisible to *both* test suites (ours predates the pointer rung; #1503's predates SecretRef / fail-closed / typed errors), and a plain merge ships all four silently:

| # | What a clean merge would have shipped |
|---|---|
| 1 | **§1 starves #1503's zero-REST win — on Snowflake specifically.** The rung serves zero-REST only if `metadata_from_caches` hits, and its cross-process source is the disk `metadata` layer — whose only writer was the S3 read §1 removes. Fresh process ⇒ rung misses ⇒ the ~1–3 s `loadTable` GET returns, visible **only** in the `load_table.n` counter (§1 still books its own win, so nothing looks wrong). |
| 2 | **SecretRef hard-errors whenever the disk cache is warm.** #1503's rung added a *second* `create_provider_arc` that §3's hydrate never reached ⇒ `resolve()`'s fail-closed arm ⇒ fluree/solo#782's rotation breaks on the fast path. |
| 3 | **The silent vended→ambient downgrade returns.** #1503's copy of the storage build has no §2 guard, so any lazy-forced build reads under the process's ambient identity — the exact fail-open §2 exists to close. |
| 4 | **Typed 403s are flattened.** The deferred builder's `map_err(|e| IcebergError::Catalog(e.to_string()))` destroys `err:storage/AccessDenied` / `err:catalog/CredentialsNotVended`, putting hosts back to regex-guessing. |

Fixed by **unifying, not by patching duplicates** (commit `fix(iceberg): reconcile BYO-IAM credential handling with the loadTable-METADATA cache`):
- **`rest_session_storage()`** — one §2 decision + #1498 session reuse + vended/ambient construction, shared by the eager arm *and* the deferred builder. There is now exactly **one** `decide_credential_source` call site on the scan path, so the two arms cannot diverge again.
- **`hydrated_auth_provider()`** — pairs hydration with provider construction so a new client-construction site cannot ship un-hydrated. Hydration still runs strictly **after** `rest_client_cache_key` in both arms (pinned by `secret_ref_fingerprint_is_rotation_stable`).
- **`IcebergError::CatalogCredentialsNotVended`** + a `storage_query_error` lift — typed errors round-trip the builder's `IcebergError` channel, so the lazy path reports identically to the eager one.
- **§1 seeds the disk metadata layer** from the free inline copy — which arms #1503's rung *one touch earlier* than #1503 alone (previously that layer could only be filled by first paying an S3 GET).
- **§4** reconciled with the review wave's own `CACHE_FORMAT_VERSION` bump: their `2` is a *payload* change (`Envelope.key` + verification); our filename re-key is orthogonal and correctly needs **no** bump. `path()`'s key param generalized for the new `lt_key` space; the `pointer` layer given an explicit scope verdict (catalog-gated **and** already per-graph-source ⇒ needs no scope).

## Commits (one per spec section)

| Commit | Spec | What |
|---|---|---|
| `654677b23` | #1497 | Local CLI `info`/`iceberg info` route config display through the existing fail-closed redactor (re-exported as `fluree_db_api::redact_graph_source_config`) |
| `dcf692484` | #1500 §1 | Use the REST catalog's inline `loadTable` metadata — no S3 GET for bytes we were handed; `r2rml.read_metadata` fires only on real reads. **Seeds both cache layers**, which is what keeps #1503's zero-REST rung armed (see above) |
| `6967946be` | #1500 §4 | Disk catalog cache: stable xxh64 key hash (golden-pinned) + scope segment; reconciled with the wave's `Envelope.key` bump |
| `2a9d35206` | #1500 §5+§2 | Typed `StorageAccessDenied` (bucket/key/region → 403 `err:storage/AccessDenied`) + fail-closed vended→ambient downgrade (`err:catalog/CredentialsNotVended`); one shared `decide_credential_source` matrix for scan AND preview |
| `f305df480` | #1500 §3 | `ConfigValue::SecretRef` + async `hydrate()` + injected `SecretResolver` (tenant-agnostic); `Fluree::with_secret_resolver` cheap-clone injection; `_ref` builders at all three config levels |
| `16e5ed489` | #1498 | Direct mode reuses the session-cached S3 client (was: full credential-chain + connection pool per call, even on cache hits) |
| `291f00749` | #1500 §6 | `verify_storage_access` + `POST /v1/fluree/iceberg/catalog/verify`: config-time probe through the engine's own credential path (manifest read = metadata/ prefix, HeadObject = data/ prefix) |
| **`210cf4833`** | **#1500 × #1503** | **The restack reconciliation** — `rest_session_storage()`, `hydrated_auth_provider()`, typed round-trip, §1 disk seeding, §4 version reconcile (see the section above; this is the review-critical commit) |
| `1b25366e2`, `42761a386`, `7b9f32d74` | — | pre-existing clippy lints blocking the `-D warnings` gate + a bench `allow` + redactor doc accuracy |

*(The pre-restack rustfmt-drift commit dropped as **empty** — the review wave applied the identical fmt fixes upstream, which is where they belong.)*

## Decisions & corrections to the issues (recorded on the issues as comments)

- **#1497's preferred fix (redacting `Serialize`) is refuted**: a CI-locked contract requires lossless config persistence (`ledger_info.rs` "storage serialization must be lossless"); a lossy `Serialize` would persist `[redacted]` and break query-time auth. The display-layer denylist redactor is the correct seam; §3's SecretRef-at-rest is the disease-level fix (no secret in storage at all). Hardening follow-up: #1504.
- **§1 is bypass-when-inline, not full disk-layer retirement**: inline metadata exists only on a *real* REST loadTable (session/60s-cache reconstructions and Direct mode carry `None`), so full removal would regress Direct-mode cross-process cold starts. Live outcome identical (Snowflake vends inline ⇒ zero metadata GETs).
- **§2 is an intended behavior change**: a REST source with `vended_credentials=true` (default) whose catalog vends nothing now 403s instead of silently reading with the process's ambient AWS identity. Explicit `vended_credentials=false` is the ambient opt-in. (Solo runbook copy notified.)
- **The ordering trap held**: `hydrate()` runs strictly after `rest_client_cache_key` fingerprints the *raw, reference-bearing* config, inside the client-cache miss arm — pinned by `secret_ref_fingerprint_is_rotation_stable` (rotation does not re-key; hydrate-before-fingerprint would have).
- **`SecretRef` sits between `Literal` and `Dynamic`**: untagged serde tries variants in order and `Dynamic` (all-default fields) matches any object — declared later, the ref would be silently swallowed. Ordering canary test pins it. (Both sessions found this hazard independently.)

## Verification

**Adversarial review** (independent agent over the full diff): **SHIP, zero blockers.** Independently recomputed the §4 golden hash, byte-diffed legacy error strings, verified resolved secrets are never persisted/fingerprinted/logged (create/map persists the original ref-bearing config), and confirmed 401→refresh untouched. Its one SHOULD-FIX (redactor doc claimed allowlist semantics) landed as 462c61c73 + #1504.

**Machine gates** (local — CI does not fire on stacked bases): `cargo +1.96.1 fmt --all --check` CLEAN; `cargo +1.96.1 clippy --locked --workspace --all-features --all-targets -- -D warnings` CLEAN (this branch also clears four pre-existing perf-line lints to get there); workspace test suite (`--all-features --no-fail-fast`): **174/176 targets pass**; both failures are outside this branch's code — a pre-existing `fluree-bench-virtual` corpus-drift test (`error_boundary_queries_match_observed_behavior`, q013 error-boundary declaration vs observed engine behavior; the crate is untouched here beyond a lint `#[allow]` and the test pre-dates the fork) and a testcontainers flake (`fluree-db-connection` `publish_index_without_preexisting_index_item` — passes on immediate re-run; crate untouched).

**Live rig** (standing Snowflake ABACYOU-PP85756 + AWS sandbox, all under fresh isolated caches):
- Vended path E2E: rows, cold-verified. BYO-IAM path E2E under a **zero-identity-permission role with bucket-policy-only access**: rows, cold-verified.
- §1: `Table metadata used inline from loadTable response` fired exactly once; `r2rml.read_metadata` **n=0**.
- #1497: local `fluree info` shows `"client_secret": "[redacted]"`, zero PAT occurrences.
- §5 message fidelity: both AWS AccessDenied variants survive **verbatim** to the CLI error and the server 403 JSON — `no identity-based policy allows` (no-perm role) and `no permissions boundary allows` (boundary-limited role). This is the distinction solo's runbook dispatch branches on (a boundary'd admin must not be told to re-apply a bucket policy).
- §6 route, all three shapes: 200 `credential_source:"vended"`; 200 `credential_source:"ambient"` under the bucket-policy-only role (HeadObject needs no ListBucket — Lambda shape confirmed); 403 `@type: err:storage/AccessDenied` under the no-perm role. The probe reads S3 directly (never cache-served), so it cannot be masked by a warm artifact cache.

**Composition proven live** (Snowflake `virtual-sf01`, restacked binary) — two consecutive `exec-one` processes, warm disk between them:

| process | wall | `r2rml.load_table.n` | `iceberg.oauth_token.n` | `r2rml.read_metadata.n` |
|---|---|---|---|---|
| prime (cold) | 3227 ms | 1 | 1 | **0** |
| gate (fresh proc, warm disk) | **4 ms** | **0** | **0** | **0** |

The counters self-discriminate, so this is a proof rather than a correlation: the prime did a **real** loadTable (`n=1`) ⇒ the rung missed ⇒ the disk `metadata` layer was empty; and `read_metadata.n=0` ⇒ §1 served that metadata **inline**, with no S3 read. So the only possible writer of the entry the gate then hit is §1's seeding — and #1503's DoD gate (`load_table.n=0` **and** `oauth_token.n=0`) holds *because of it*. Pre-fix this reads `load_table.n=1` at ~3 s with nothing else looking wrong.

**Live rig re-verified at the restacked head** (standing Snowflake + AWS sandbox; every credential-discriminating case under a fresh per-process cache): vended E2E ✅ (3 rows, 4.82 s) · BYO-IAM E2E under a **bucket-policy-only role with zero identity-based S3 permissions** ✅ (3 rows, 3.47 s) · both AWS AccessDenied strings survive verbatim to the CLI (`no identity-based policy allows` present, `no permissions boundary allows` correctly absent for the identity variant) ✅ · `fluree info` redaction, zero PAT occurrences ✅ · **zero-REST rung × BYO-IAM** ✅ (second process resolves with no catalog REST at all) · on-disk proof of §1 seeding (`*.shared.metadata.json` present after a run that logged "used inline … (no S3 fetch)") ✅ · no cache file ever contains the PAT ✅.
§2's guard is **live-proven on the lazy arm**: the deferred path emits `Using ambient AWS credentials`, a log line that lives *inside* `rest_session_storage` **after** the §2 check — so the shared guard demonstrably executes there.

**Benchmark corpus**: `vbench compare --gate` is running post-push against the new base (the chain adds q055–q059, so the pre-restack baseline is not comparable). Prior to the restack this branch gated clean (0 hash mismatches, 0 perf violations across 108 records; native median Δ +0 ms, virtual −37 s). Result will be posted here; note the chain's own baseline carries 5 known network-attributed violations (their F21).

## Notes for reviewers

- `fluree-db-query` stays iceberg-agnostic (generic storage-denied variant; mapping helper lives in fluree-db-api). The 401→refresh-retry path is status-based on the catalog call and untouched.
- `Fluree` is now `Clone` (all fields Arc-backed or already-Clone); `with_secret_resolver` is the per-request-or-process-wide injection point. Non-iceberg builds unaffected (feature-gated).
- Known boundary (matches preview): `verify_storage_access` requires the catalog to vend inline metadata — same as the existing preview path; Snowflake Horizon/Polaris do.
- **Follow-up filed: #1510** — a *pre-existing* typed-error gap (present on `main`, not introduced here): a storage denial on the **disk-cache-fill Parquet route** surfaces as 500 `Internal` instead of 403 + `err:storage/AccessDenied`, because `send_parquet.rs`'s `coalesced_fetch` flattens the typed error through an `io::Error` two layers below our lift. #1503 makes that route more reachable (warm catalog + cold artifact cache ⇒ the first S3 read is a data file). §5 is a strict improvement everywhere it lands; the raw AWS chain still survives so host regex dispatch still fires. Not fixed here deliberately — it touches the Parquet reader's hot path and deserves its own review + bench.
- Observed while verifying, not addressed here: the RUST_LOG policy comment in `fluree-db-cli/src/main.rs:22` contradicts the code (honored only *with* `--verbose`); machine-global artifact cache means previously-fetched table data remains locally readable after upstream access revocation (inherent to content-addressed caching; the §6 probe is immune by construction).
