### PR TITLE
Fix duplicate triples from re-asserted facts in the V6 incremental indexer

### DIFF
--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -390,6 +390,20 @@ struct Phase2Task {
     kind: Phase2TaskKind,
 }
 
+/// Graph-scoped V2 fact identity: `(g_id, s_id, p_id, o_type, o_key, o_i)`.
+type FactIdentityKey = (u16, u64, u32, u16, u64, u32);
+
+fn fact_identity_key(rec: &RunRecordV2) -> FactIdentityKey {
+    (
+        rec.g_id,
+        rec.s_id.as_u64(),
+        rec.p_id,
+        rec.o_type,
+        rec.o_key,
+        rec.o_i,
+    )
+}
+
 enum Phase2TaskUpdate {
     Default { leaf_entries: Vec<LeafEntry> },
     Named { branch_cid: ContentId },
@@ -404,6 +418,9 @@ struct Phase2TaskOutput {
     replaced_sidecar_cids: Vec<ContentId>,
     new_leaf_count: usize,
     fetch_stats: Phase2FetchStatsSnapshot,
+    /// Novelty ops whose identity matched an existing base row (SPOT task
+    /// only; fresh-graph tasks have no base rows to match).
+    matched: Vec<RunRecordV2>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -434,6 +451,9 @@ async fn execute_phase2_task(
             .leaflet_rows
             .max(1)
             .saturating_mul(config.leaflets_per_leaf.max(1)),
+        // Fact identity is order-independent; collect base-row matches from
+        // the SPOT task only (they feed the Phase 3b stats deltas).
+        collect_matched: order == RunSortOrder::Spot,
     };
 
     let started = Instant::now();
@@ -472,6 +492,7 @@ async fn execute_phase2_task(
                 replaced_sidecar_cids: meta.replaced_sidecar_cids,
                 new_leaf_count: meta.new_leaf_count,
                 fetch_stats,
+                matched: meta.matched,
             }
         }
         Phase2TaskKind::DefaultFresh => {
@@ -499,6 +520,7 @@ async fn execute_phase2_task(
                 replaced_sidecar_cids: Vec::new(),
                 new_leaf_count,
                 fetch_stats: Phase2FetchStatsSnapshot::default(),
+                matched: Vec::new(),
             }
         }
         Phase2TaskKind::NamedExisting { branch_cid } => {
@@ -537,6 +559,7 @@ async fn execute_phase2_task(
                 replaced_sidecar_cids: meta.replaced_sidecar_cids,
                 new_leaf_count: meta.new_leaf_count,
                 fetch_stats,
+                matched: meta.matched,
             }
         }
         Phase2TaskKind::NamedFresh => {
@@ -573,6 +596,7 @@ async fn execute_phase2_task(
                 replaced_sidecar_cids,
                 new_leaf_count,
                 fetch_stats: Phase2FetchStatsSnapshot::default(),
+                matched: Vec::new(),
             }
         }
     };
@@ -788,9 +812,16 @@ pub async fn incremental_index(
         phase2_results.into_iter().collect::<Result<Vec<_>>>()?;
     phase2_outputs.sort_unstable_by_key(|output| output.seq);
 
+    // Fact identities the SPOT merges matched against existing base rows.
+    // Phase 3b derives materialized-state stat deltas from this: an assert of
+    // a base-present fact and a retract of a base-absent fact change no rows.
+    let mut base_matched: std::collections::HashSet<FactIdentityKey> =
+        std::collections::HashSet::new();
+
     let mut phase2_fetch_totals = Phase2FetchStatsSnapshot::default();
     for output in phase2_outputs {
         total_new_leaves += output.new_leaf_count;
+        base_matched.extend(output.matched.iter().map(fact_identity_key));
         phase2_fetch_totals.leaf_fetches += output.fetch_stats.leaf_fetches;
         phase2_fetch_totals.leaf_cache_hits += output.fetch_stats.leaf_cache_hits;
         phase2_fetch_totals.leaf_cache_misses += output.fetch_stats.leaf_cache_misses;
@@ -1977,11 +2008,16 @@ pub async fn incremental_index(
             }
         }
 
-        // Feed all novelty records.
+        // Feed all novelty records. Counts are base-seeded, so each record's
+        // signed delta reflects its materialized state transition (derived
+        // from the SPOT merge's base-row matches), not its raw op: a
+        // re-assert of a base-present fact and a retract of a base-absent
+        // fact change no rows and contribute 0.
         for (i, rec) in novelty.records.iter().enumerate() {
             let op = novelty.ops[i];
             let sr = stats::stats_record_from_v2(rec, op);
-            stats_hook.on_record(&sr);
+            let base_present = base_matched.contains(&fact_identity_key(rec));
+            stats_hook.on_record_with_base_presence(&sr, base_present);
         }
 
         // Upload HLL sketches (before finalize consumes the hook).
@@ -4049,6 +4085,7 @@ fn build_fresh_default_graph_v3(
         replaced_sidecar_cids: Vec::new(),
         branch_bytes,
         branch_cid,
+        matched: Vec::new(),
     })
 }
 

--- a/fluree-db-indexer/src/run_index/build/incremental_branch.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_branch.rs
@@ -49,6 +49,10 @@ pub struct BranchUpdateConfig {
     pub leaflet_target_rows: usize,
     /// Target rows per leaf.
     pub leaf_target_rows: usize,
+    /// Collect novelty ops that matched an existing base row into
+    /// [`BranchUpdateMeta::matched`]. Fact identity is order-independent, so
+    /// callers running all four sort orders enable this for one order only.
+    pub collect_matched: bool,
 }
 
 /// Result of a branch update.
@@ -65,6 +69,9 @@ pub struct BranchUpdateResult {
     pub branch_bytes: Vec<u8>,
     /// CID of the new branch manifest.
     pub branch_cid: ContentId,
+    /// Novelty ops whose identity matched an existing base row (empty unless
+    /// [`BranchUpdateConfig::collect_matched`] is set).
+    pub matched: Vec<RunRecordV2>,
 }
 
 /// Branch-assembly metadata from a streaming update — everything the caller
@@ -84,6 +91,9 @@ pub struct BranchUpdateMeta {
     pub branch_cid: ContentId,
     /// Number of new leaf blobs emitted to the sink.
     pub new_leaf_count: usize,
+    /// Novelty ops whose identity matched an existing base row (empty unless
+    /// [`BranchUpdateConfig::collect_matched`] is set).
+    pub matched: Vec<RunRecordV2>,
 }
 
 // ============================================================================
@@ -133,6 +143,7 @@ where
         replaced_sidecar_cids: meta.replaced_sidecar_cids,
         branch_bytes: meta.branch_bytes,
         branch_cid: meta.branch_cid,
+        matched: meta.matched,
     })
 }
 
@@ -228,7 +239,7 @@ where
     G: Fn(&ContentId) -> io::Result<Option<Vec<u8>>>,
     S: FnMut(NewLeafBlob) -> io::Result<()>,
 {
-    let mut acc = BranchAcc::with_capacity(manifest.leaves.len() + 4);
+    let mut acc = BranchAcc::with_capacity(manifest.leaves.len() + 4, config.collect_matched);
 
     match mode {
         DrainMode::Serial => update_branch_serial(
@@ -257,6 +268,8 @@ where
         replaced_leaf_cids,
         replaced_sidecar_cids,
         new_leaf_count,
+        collect_matched: _,
+        matched,
     } = acc;
 
     let branch_bytes = build_branch_bytes(config.order, config.g_id, &leaf_entries);
@@ -269,6 +282,7 @@ where
         branch_bytes,
         branch_cid,
         new_leaf_count,
+        matched,
     })
 }
 
@@ -284,15 +298,21 @@ struct BranchAcc {
     replaced_leaf_cids: Vec<ContentId>,
     replaced_sidecar_cids: Vec<ContentId>,
     new_leaf_count: usize,
+    /// When set, matched novelty ops from each touched leaf accumulate into
+    /// `matched`; otherwise they are dropped at drain time.
+    collect_matched: bool,
+    matched: Vec<RunRecordV2>,
 }
 
 impl BranchAcc {
-    fn with_capacity(leaves: usize) -> Self {
+    fn with_capacity(leaves: usize, collect_matched: bool) -> Self {
         Self {
             leaf_entries: Vec::with_capacity(leaves),
             replaced_leaf_cids: Vec::new(),
             replaced_sidecar_cids: Vec::new(),
             new_leaf_count: 0,
+            collect_matched,
+            matched: Vec::new(),
         }
     }
 }
@@ -368,6 +388,9 @@ where
     acc.replaced_leaf_cids.push(existing.leaf_cid.clone());
     if let Some(sc_cid) = &existing.sidecar_cid {
         acc.replaced_sidecar_cids.push(sc_cid.clone());
+    }
+    if acc.collect_matched {
+        acc.matched.extend(output.matched);
     }
 
     for new_leaf in output.leaves {
@@ -742,6 +765,7 @@ mod parity_tests {
             zstd_level: 1,
             leaflet_target_rows: 50,
             leaf_target_rows: 200,
+            collect_matched: false,
         };
 
         let (serial_meta, serial_blobs) = run_mode(
@@ -841,6 +865,7 @@ mod parity_tests {
             zstd_level: 1,
             leaflet_target_rows: 50,
             leaf_target_rows: 200,
+            collect_matched: false,
         };
 
         let serial = run_mode(

--- a/fluree-db-indexer/src/run_index/build/incremental_leaf.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_leaf.rs
@@ -72,6 +72,9 @@ pub struct NewLeafBlob {
 pub struct LeafUpdateOutput {
     /// New leaf blobs (1 in common case; 2+ if splits occurred).
     pub leaves: Vec<NewLeafBlob>,
+    /// Novelty ops whose identity matched an existing base row, aggregated
+    /// across this leaf's merged leaflets (see [`MergeOutput::matched`]).
+    pub matched: Vec<RunRecordV2>,
 }
 
 // ============================================================================
@@ -126,6 +129,7 @@ pub fn update_leaf(input: &LeafUpdateInput<'_>) -> io::Result<LeafUpdateOutput> 
     let mut processed: Vec<ProcessedLeafletV3> = Vec::with_capacity(
         header.leaflet_count as usize + input.novelty.len() / input.leaflet_target_rows,
     );
+    let mut matched: Vec<RunRecordV2> = Vec::new();
 
     for (i, (nov_slice, ops_slice)) in novelty_slices.iter().enumerate() {
         let entry = &dir.entries[i];
@@ -140,14 +144,22 @@ pub fn update_leaf(input: &LeafUpdateInput<'_>) -> io::Result<LeafUpdateOutput> 
             )?);
         } else {
             // Decode, merge, re-encode.
-            let mut merged =
-                merge_and_encode_leaflet(input, entry, dir.payload_base, nov_slice, ops_slice)?;
+            let mut merged = merge_and_encode_leaflet(
+                input,
+                entry,
+                dir.payload_base,
+                nov_slice,
+                ops_slice,
+                &mut matched,
+            )?;
             processed.append(&mut merged);
         }
     }
 
     // Assemble processed leaflets into leaf blob(s).
-    assemble_output_leaves(processed, input)
+    let mut output = assemble_output_leaves(processed, input)?;
+    output.matched = matched;
+    Ok(output)
 }
 
 // ============================================================================
@@ -249,6 +261,7 @@ fn passthrough_entire_leaf(input: &LeafUpdateInput<'_>) -> io::Result<LeafUpdate
                 re_encoded_leaflet_count: 0,
             },
         }],
+        matched: Vec::new(),
     })
 }
 
@@ -290,6 +303,7 @@ fn merge_and_encode_leaflet(
     payload_base: usize,
     novelty: &[RunRecordV2],
     novelty_ops: &[u8],
+    matched: &mut Vec<RunRecordV2>,
 ) -> io::Result<Vec<ProcessedLeafletV3>> {
     // 1. Load existing leaflet columns.
     let projection = ColumnProjection::all();
@@ -319,7 +333,9 @@ fn merge_and_encode_leaflet(
     let MergeOutput {
         records: merged,
         history,
+        matched: leaflet_matched,
     } = merge_novelty(&merge_input);
+    matched.extend(leaflet_matched);
 
     // 4. Handle empty-after-retract: valid in V3 (history preserved in sidecar).
     //    Preserve the original leaflet's key range and constants so branch
@@ -475,7 +491,10 @@ fn assemble_output_leaves(
     use fluree_db_binary_index::format::leaflet::EncodedLeaflet;
 
     if processed.is_empty() {
-        return Ok(LeafUpdateOutput { leaves: vec![] });
+        return Ok(LeafUpdateOutput {
+            leaves: vec![],
+            matched: Vec::new(),
+        });
     }
 
     // Convert ProcessedLeafletV3 into (EncodedLeaflet, Vec<HistEntryV2>, was_re_encoded)
@@ -521,7 +540,10 @@ fn assemble_output_leaves(
         output.push(NewLeafBlob { info: leaf_info });
     }
 
-    Ok(LeafUpdateOutput { leaves: output })
+    Ok(LeafUpdateOutput {
+        leaves: output,
+        matched: Vec::new(),
+    })
 }
 
 /// Build a single leaf blob from a group of (EncodedLeaflet, history, was_re_encoded) triples.

--- a/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
@@ -775,6 +775,9 @@ type ResolvedIdentity = (u16, u32);
 /// distinct language tags and list positions stay distinct.
 ///
 /// Input must be sorted by `(g_id, SPOT)`; output preserves that order.
+/// Compacts in place behind a write cursor — winners are always a subset of
+/// already-read input, so the stream-dominant case (every group a single
+/// event) copies nothing and allocates nothing.
 ///
 /// Dropped intermediate transitions do not reach the history sidecars, so
 /// index-served time travel cannot see a state a fact held only *within*
@@ -782,81 +785,94 @@ type ResolvedIdentity = (u16, u32);
 /// has no lived interval in the index; `merge_novelty` records no history
 /// for its final retract). The live novelty view retains those intermediate
 /// ops until the window is indexed.
-fn dedup_fact_lifecycles(records: Vec<RunRecord>, o_types: &OTypeRegistry) -> Vec<RunRecord> {
-    let mut out: Vec<RunRecord> = Vec::with_capacity(records.len());
-    // Raw records of the current sort-prefix group (all dt/lang/list
-    // variants of one value); identities resolve at flush time.
-    let mut group: Vec<RunRecord> = Vec::new();
+fn dedup_fact_lifecycles(mut records: Vec<RunRecord>, o_types: &OTypeRegistry) -> Vec<RunRecord> {
+    let len = records.len();
+    let mut write = 0;
+    let mut start = 0;
+    // Scratch for multi-record groups, reused across groups.
+    let mut keyed: Vec<(ResolvedIdentity, RunRecord)> = Vec::new();
 
-    for rec in records {
-        if group.last().is_some_and(|g| !same_sort_prefix(g, &rec)) {
-            flush_deduped_group(&mut group, o_types, &mut out);
+    while start < len {
+        let mut end = start + 1;
+        while end < len && same_sort_prefix(&records[start], &records[end]) {
+            end += 1;
         }
-        group.push(rec);
+
+        if end - start == 1 {
+            // Overwhelmingly common: a single event needs no identity
+            // resolution and, absent earlier compaction, no copy.
+            if write != start {
+                records[write] = records[start];
+            }
+            write += 1;
+        } else {
+            dedup_group(&records[start..end], o_types, &mut keyed);
+            for &(_, winner) in &keyed {
+                records[write] = winner;
+                write += 1;
+            }
+        }
+        start = end;
     }
-    flush_deduped_group(&mut group, o_types, &mut out);
-    out
+
+    records.truncate(write);
+    records
 }
 
-/// Dedup one sort-prefix group to its per-identity winners and emit them in
-/// comparator order (`dt`, `t`, `op`), clearing the group.
+/// Dedup one multi-record sort-prefix group, leaving the per-identity winners
+/// in `keyed` in comparator order (`dt`, `t`, `op`).
 ///
-/// The group is keyed by resolved V2 identity and re-sorted by
+/// The group is keyed by resolved V2 identity and sorted by
 /// `(identity, t, op)` first: the incoming `(g_id, SPOT)` order interleaves
 /// `dt` before `t`, so events of one identity spread across `dt` variants
 /// would otherwise arrive out of chronological order.
-fn flush_deduped_group(
-    group: &mut Vec<RunRecord>,
+fn dedup_group(
+    group: &[RunRecord],
     o_types: &OTypeRegistry,
-    out: &mut Vec<RunRecord>,
+    keyed: &mut Vec<(ResolvedIdentity, RunRecord)>,
 ) {
-    if group.len() == 1 {
-        // Overwhelmingly common: a single event needs no identity resolution.
-        out.append(group);
-        return;
-    }
-    if group.is_empty() {
-        return;
-    }
-
-    let mut keyed: Vec<(ResolvedIdentity, RunRecord)> = group
-        .drain(..)
-        .map(|rec| {
-            let o_type = o_types
-                .resolve(
-                    rec.obj_kind(),
-                    DatatypeDictId::from_u16(rec.dt),
-                    rec.lang_id,
-                )
-                .as_u16();
-            ((o_type, rec.i), rec)
-        })
-        .collect();
+    keyed.clear();
+    keyed.extend(group.iter().map(|&rec| {
+        let o_type = o_types
+            .resolve(
+                rec.obj_kind(),
+                DatatypeDictId::from_u16(rec.dt),
+                rec.lang_id,
+            )
+            .as_u16();
+        ((o_type, rec.i), rec)
+    }));
     keyed.sort_unstable_by(|a, b| {
         a.0.cmp(&b.0)
             .then(a.1.t.cmp(&b.1.t))
             .then(a.1.op.cmp(&b.1.op))
     });
 
-    let mut winners: Vec<RunRecord> = Vec::new();
-    let mut current: Option<ResolvedIdentity> = None;
-    for (key, rec) in keyed {
-        if current != Some(key) {
+    // Compact each identity run to its winner, in place.
+    let mut w = 0;
+    for r in 1..keyed.len() {
+        if keyed[r].0 != keyed[w].0 {
             // First event of a new identity always counts.
-            winners.push(rec);
-            current = Some(key);
+            w += 1;
+            keyed[w] = keyed[r];
             continue;
         }
-        let winner = winners.last_mut().expect("identity run has a winner");
+        let rec = keyed[r].1;
+        let winner = &mut keyed[w].1;
         let noop_reassert = rec.op == 1 && winner.op == 1;
         let same_t_retract_wins = rec.op == 1 && winner.op == 0 && rec.t == winner.t;
         if !noop_reassert && !same_t_retract_wins {
             *winner = rec;
         }
     }
+    keyed.truncate(w + 1);
 
-    winners.sort_unstable_by(|a, b| a.dt.cmp(&b.dt).then(a.t.cmp(&b.t)).then(a.op.cmp(&b.op)));
-    out.append(&mut winners);
+    keyed.sort_unstable_by(|a, b| {
+        a.1.dt
+            .cmp(&b.1.dt)
+            .then(a.1.t.cmp(&b.1.t))
+            .then(a.1.op.cmp(&b.1.op))
+    });
 }
 
 // ============================================================================
@@ -1736,6 +1752,27 @@ mod tests {
             keys(&out),
             keys(&[stray]),
             "first assert wins; lang ignored"
+        );
+    }
+
+    /// In-place compaction: records after a collapsed group shift backward
+    /// behind the write cursor without loss or reordering.
+    #[test]
+    fn records_after_a_collapsed_group_shift_back_intact() {
+        let records = vec![
+            bool_rec(1, 1, 10, 5, 5, OP_ASSERT),
+            bool_rec(1, 1, 10, 9, 6, OP_ASSERT), // collapses into the above
+            rec(2, 1, 20, 7, OP_ASSERT),
+            rec(3, 1, 30, 8, OP_RETRACT),
+        ];
+        let out = dedup(records);
+        assert_eq!(
+            keys(&out),
+            keys(&[
+                bool_rec(1, 1, 10, 5, 5, OP_ASSERT),
+                rec(2, 1, 20, 7, OP_ASSERT),
+                rec(3, 1, 30, 8, OP_RETRACT),
+            ])
         );
     }
 

--- a/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
@@ -672,7 +672,7 @@ pub async fn resolve_incremental_commits_v6(
     //      is resolved to its final state here.
     let t0 = Instant::now();
     let event_count = v1_records.len();
-    let v1_records = dedup_fact_lifecycles(v1_records);
+    let v1_records = dedup_fact_lifecycles(v1_records, &o_type_registry);
     let t_dedup_ms = t0.elapsed().as_millis() as u64;
     let deduped_count = event_count - v1_records.len();
     if deduped_count > 0 {
@@ -739,17 +739,21 @@ pub async fn resolve_incremental_commits_v6(
 // ============================================================================
 
 /// True when two records agree on every field the `(g_id, SPOT)` comparator
-/// orders by, other than `t` and `op`. Records with the same prefix are
-/// adjacent in a sorted stream; full fact identity additionally distinguishes
-/// `i` and `lang_id`, which the comparator does not order by.
+/// orders by, other than `dt`, `t`, and `op`. Records with the same prefix
+/// are adjacent in a sorted stream (`dt` sorts immediately after the prefix,
+/// so all `dt` variants of one value are contiguous). Fact identity is
+/// resolved within the group; see [`dedup_fact_lifecycles`].
 fn same_sort_prefix(a: &RunRecord, b: &RunRecord) -> bool {
     a.g_id == b.g_id
         && a.s_id == b.s_id
         && a.p_id == b.p_id
         && a.o_kind == b.o_kind
         && a.o_key == b.o_key
-        && a.dt == b.dt
 }
+
+/// Resolved V2 fact identity within a sort-prefix group: `(o_type, o_i)` —
+/// the identity `merge_novelty`, replay, and the query overlay compare by.
+type ResolvedIdentity = (u16, u32);
 
 /// Resolve each fact's event sequence within the commit window to a single
 /// final op, so the updated index materializes the same state the in-memory
@@ -762,10 +766,15 @@ fn same_sort_prefix(a: &RunRecord, b: &RunRecord) -> bool {
 /// - An assert at the same `t` as a winning retract loses (same-`t` ties
 ///   resolve retract-wins), matching `resolve_overlay_ops`.
 ///
+/// Fact identity is the resolved V2 identity `(o_type, o_i)` within the
+/// sort-prefix group — the identity `merge_novelty`, replay, and the query
+/// overlay all compare by. `OTypeRegistry::resolve` collapses `dt` for 1:1
+/// object kinds (a boolean is `xsd:boolean` whatever datatype IRI the commit
+/// carried) and consults `lang_id` only for `rdf:langString` (folded into
+/// `o_type`), so `dt`/`lang` variants of one fact dedup together while
+/// distinct language tags and list positions stay distinct.
+///
 /// Input must be sorted by `(g_id, SPOT)`; output preserves that order.
-/// Within a sort-prefix group, records for one full identity arrive in
-/// `(t, op)` order even when several identities interleave, so a linear walk
-/// per identity sees its events chronologically.
 ///
 /// Dropped intermediate transitions do not reach the history sidecars, so
 /// index-served time travel cannot see a state a fact held only *within*
@@ -773,40 +782,81 @@ fn same_sort_prefix(a: &RunRecord, b: &RunRecord) -> bool {
 /// has no lived interval in the index; `merge_novelty` records no history
 /// for its final retract). The live novelty view retains those intermediate
 /// ops until the window is indexed.
-fn dedup_fact_lifecycles(records: Vec<RunRecord>) -> Vec<RunRecord> {
+fn dedup_fact_lifecycles(records: Vec<RunRecord>, o_types: &OTypeRegistry) -> Vec<RunRecord> {
     let mut out: Vec<RunRecord> = Vec::with_capacity(records.len());
-    // Winners for the current sort-prefix group, one per full identity
-    // (distinct `(i, lang_id)`). Groups are tiny, so a linear scan beats a
-    // map.
+    // Raw records of the current sort-prefix group (all dt/lang/list
+    // variants of one value); identities resolve at flush time.
     let mut group: Vec<RunRecord> = Vec::new();
 
     for rec in records {
-        if group.last().is_some_and(|w| !same_sort_prefix(w, &rec)) {
-            flush_deduped_group(&mut group, &mut out);
+        if group.last().is_some_and(|g| !same_sort_prefix(g, &rec)) {
+            flush_deduped_group(&mut group, o_types, &mut out);
         }
-        match group
-            .iter_mut()
-            .find(|w| w.i == rec.i && w.lang_id == rec.lang_id)
-        {
-            None => group.push(rec),
-            Some(winner) => {
-                let noop_reassert = rec.op == 1 && winner.op == 1;
-                let same_t_retract_wins = rec.op == 1 && winner.op == 0 && rec.t == winner.t;
-                if !noop_reassert && !same_t_retract_wins {
-                    *winner = rec;
-                }
-            }
-        }
+        group.push(rec);
     }
-    flush_deduped_group(&mut group, &mut out);
+    flush_deduped_group(&mut group, o_types, &mut out);
     out
 }
 
-/// Emit a sort-prefix group's winners in comparator order (`t`, then `op`)
-/// and clear the group.
-fn flush_deduped_group(group: &mut Vec<RunRecord>, out: &mut Vec<RunRecord>) {
-    group.sort_unstable_by(|a, b| a.t.cmp(&b.t).then(a.op.cmp(&b.op)));
-    out.append(group);
+/// Dedup one sort-prefix group to its per-identity winners and emit them in
+/// comparator order (`dt`, `t`, `op`), clearing the group.
+///
+/// The group is keyed by resolved V2 identity and re-sorted by
+/// `(identity, t, op)` first: the incoming `(g_id, SPOT)` order interleaves
+/// `dt` before `t`, so events of one identity spread across `dt` variants
+/// would otherwise arrive out of chronological order.
+fn flush_deduped_group(
+    group: &mut Vec<RunRecord>,
+    o_types: &OTypeRegistry,
+    out: &mut Vec<RunRecord>,
+) {
+    if group.len() == 1 {
+        // Overwhelmingly common: a single event needs no identity resolution.
+        out.append(group);
+        return;
+    }
+    if group.is_empty() {
+        return;
+    }
+
+    let mut keyed: Vec<(ResolvedIdentity, RunRecord)> = group
+        .drain(..)
+        .map(|rec| {
+            let o_type = o_types
+                .resolve(
+                    rec.obj_kind(),
+                    DatatypeDictId::from_u16(rec.dt),
+                    rec.lang_id,
+                )
+                .as_u16();
+            ((o_type, rec.i), rec)
+        })
+        .collect();
+    keyed.sort_unstable_by(|a, b| {
+        a.0.cmp(&b.0)
+            .then(a.1.t.cmp(&b.1.t))
+            .then(a.1.op.cmp(&b.1.op))
+    });
+
+    let mut winners: Vec<RunRecord> = Vec::new();
+    let mut current: Option<ResolvedIdentity> = None;
+    for (key, rec) in keyed {
+        if current != Some(key) {
+            // First event of a new identity always counts.
+            winners.push(rec);
+            current = Some(key);
+            continue;
+        }
+        let winner = winners.last_mut().expect("identity run has a winner");
+        let noop_reassert = rec.op == 1 && winner.op == 1;
+        let same_t_retract_wins = rec.op == 1 && winner.op == 0 && rec.t == winner.t;
+        if !noop_reassert && !same_t_retract_wins {
+            *winner = rec;
+        }
+    }
+
+    winners.sort_unstable_by(|a, b| a.dt.cmp(&b.dt).then(a.t.cmp(&b.t)).then(a.op.cmp(&b.op)));
+    out.append(&mut winners);
 }
 
 // ============================================================================
@@ -1525,9 +1575,23 @@ mod tests {
         }
     }
 
+    /// `rdf:langString` record: `lang_id` folds into the resolved `o_type`,
+    /// so distinct language tags are distinct fact identities.
     fn lang_rec(s_id: u64, p_id: u32, o_key: u64, lang_id: u16, t: u32, op: u8) -> RunRecord {
         RunRecord {
+            o_kind: ObjKind::LEX_ID.as_u8(),
+            dt: DatatypeDictId::LANG_STRING.as_u16(),
             lang_id,
+            ..rec(s_id, p_id, o_key, t, op)
+        }
+    }
+
+    /// Boolean record with an explicit datatype dict id: `resolve` ignores
+    /// `dt` for 1:1 object kinds, so `dt` variants share one fact identity.
+    fn bool_rec(s_id: u64, p_id: u32, o_key: u64, dt: u16, t: u32, op: u8) -> RunRecord {
+        RunRecord {
+            o_kind: ObjKind::BOOL.as_u8(),
+            dt,
             ..rec(s_id, p_id, o_key, t, op)
         }
     }
@@ -1539,12 +1603,27 @@ mod tests {
         }
     }
 
-    /// Field projection for assertions (`RunRecord` has no `Debug`).
-    fn key(r: &RunRecord) -> (u64, u32, u64, u32, u16, u32, u8) {
-        (r.s_id.as_u64(), r.p_id, r.o_key, r.i, r.lang_id, r.t, r.op)
+    fn dedup(records: Vec<RunRecord>) -> Vec<RunRecord> {
+        dedup_fact_lifecycles(records, &OTypeRegistry::builtin_only())
     }
 
-    fn keys(records: &[RunRecord]) -> Vec<(u64, u32, u64, u32, u16, u32, u8)> {
+    /// Field projection for assertions (`RunRecord` has no `Debug`).
+    type RecordKey = (u64, u32, u64, u16, u32, u16, u32, u8);
+
+    fn key(r: &RunRecord) -> RecordKey {
+        (
+            r.s_id.as_u64(),
+            r.p_id,
+            r.o_key,
+            r.dt,
+            r.i,
+            r.lang_id,
+            r.t,
+            r.op,
+        )
+    }
+
+    fn keys(records: &[RunRecord]) -> Vec<RecordKey> {
         records.iter().map(key).collect()
     }
 
@@ -1554,7 +1633,7 @@ mod tests {
     #[test]
     fn duplicate_asserts_dedup_to_first_assert() {
         let records = vec![rec(1, 1, 10, 5, OP_ASSERT), rec(1, 1, 10, 6, OP_ASSERT)];
-        let out = dedup_fact_lifecycles(records);
+        let out = dedup(records);
         assert_eq!(keys(&out), keys(&[rec(1, 1, 10, 5, OP_ASSERT)]));
     }
 
@@ -1564,7 +1643,7 @@ mod tests {
     #[test]
     fn assert_then_retract_dedups_to_retract() {
         let records = vec![rec(1, 1, 10, 5, OP_ASSERT), rec(1, 1, 10, 6, OP_RETRACT)];
-        let out = dedup_fact_lifecycles(records);
+        let out = dedup(records);
         assert_eq!(keys(&out), keys(&[rec(1, 1, 10, 6, OP_RETRACT)]));
     }
 
@@ -1575,14 +1654,14 @@ mod tests {
             rec(1, 1, 10, 4, OP_RETRACT),
             rec(1, 1, 10, 5, OP_ASSERT),
         ];
-        let out = dedup_fact_lifecycles(records);
+        let out = dedup(records);
         assert_eq!(keys(&out), keys(&[rec(1, 1, 10, 5, OP_ASSERT)]));
     }
 
     #[test]
     fn repeat_retract_keeps_highest_t() {
         let records = vec![rec(1, 1, 10, 5, OP_RETRACT), rec(1, 1, 10, 6, OP_RETRACT)];
-        let out = dedup_fact_lifecycles(records);
+        let out = dedup(records);
         assert_eq!(keys(&out), keys(&[rec(1, 1, 10, 6, OP_RETRACT)]));
     }
 
@@ -1591,12 +1670,13 @@ mod tests {
     #[test]
     fn same_t_retract_beats_assert() {
         let records = vec![rec(1, 1, 10, 5, OP_RETRACT), rec(1, 1, 10, 5, OP_ASSERT)];
-        let out = dedup_fact_lifecycles(records);
+        let out = dedup(records);
         assert_eq!(keys(&out), keys(&[rec(1, 1, 10, 5, OP_RETRACT)]));
     }
 
-    /// `lang_id` is part of fact identity but not of the sort comparator:
-    /// records differing only in language must not dedup into each other.
+    /// Distinct language tags on `rdf:langString` values are distinct fact
+    /// identities (the tag folds into the resolved `o_type`), so records
+    /// differing only in language must not dedup into each other.
     #[test]
     fn distinct_lang_ids_do_not_dedup() {
         let records = vec![
@@ -1604,13 +1684,58 @@ mod tests {
             lang_rec(1, 1, 10, 2, 5, OP_ASSERT),
             lang_rec(1, 1, 10, 1, 6, OP_ASSERT),
         ];
-        let out = dedup_fact_lifecycles(records);
+        let out = dedup(records);
         assert_eq!(
             keys(&out),
             keys(&[
                 lang_rec(1, 1, 10, 1, 5, OP_ASSERT),
                 lang_rec(1, 1, 10, 2, 5, OP_ASSERT),
             ])
+        );
+    }
+
+    /// V2 identity collapses `dt` for 1:1 object kinds: the same boolean
+    /// value asserted under two datatype IRIs is one fact, and the second
+    /// assert is a no-op re-assert even though the records differ in `dt`.
+    #[test]
+    fn datatype_iri_variants_of_one_value_dedup() {
+        let records = vec![
+            bool_rec(1, 1, 10, 5, 5, OP_ASSERT), // dt slot 5
+            bool_rec(1, 1, 10, 9, 6, OP_ASSERT), // dt slot 9, same V2 identity
+        ];
+        let out = dedup(records);
+        assert_eq!(keys(&out), keys(&[bool_rec(1, 1, 10, 5, 5, OP_ASSERT)]));
+    }
+
+    /// A lifecycle can span `dt` variants, and the input sort interleaves
+    /// `dt` before `t`, so the events arrive out of chronological order: the
+    /// retract@6 (dt 2) sorts before the assert@5 (dt 9). The lifecycle must
+    /// still resolve chronologically to the final retract.
+    #[test]
+    fn lifecycle_spans_datatype_variants_out_of_t_order() {
+        let records = vec![
+            bool_rec(1, 1, 10, 2, 6, OP_RETRACT),
+            bool_rec(1, 1, 10, 9, 5, OP_ASSERT),
+        ];
+        let out = dedup(records);
+        assert_eq!(keys(&out), keys(&[bool_rec(1, 1, 10, 2, 6, OP_RETRACT)]));
+    }
+
+    /// A stray `lang_id` on a non-langString record does not split identity:
+    /// `resolve` consults `lang_id` only for `rdf:langString`, matching
+    /// `FactKey::from_run_record`'s normalization.
+    #[test]
+    fn stray_lang_on_non_lang_string_does_not_split_identity() {
+        let stray = RunRecord {
+            lang_id: 3,
+            ..rec(1, 1, 10, 5, OP_ASSERT)
+        };
+        let records = vec![stray, rec(1, 1, 10, 6, OP_ASSERT)];
+        let out = dedup(records);
+        assert_eq!(
+            keys(&out),
+            keys(&[stray]),
+            "first assert wins; lang ignored"
         );
     }
 
@@ -1623,7 +1748,7 @@ mod tests {
             list_rec(1, 1, 10, 1, 5, OP_ASSERT),
             list_rec(1, 1, 10, 0, 6, OP_ASSERT),
         ];
-        let out = dedup_fact_lifecycles(records);
+        let out = dedup(records);
         assert_eq!(
             keys(&out),
             keys(&[
@@ -1643,7 +1768,7 @@ mod tests {
             rec(3, 2, 30, 7, OP_ASSERT),
         ];
         let expected = keys(&records);
-        let out = dedup_fact_lifecycles(records);
+        let out = dedup(records);
         assert_eq!(keys(&out), expected);
     }
 
@@ -1657,7 +1782,7 @@ mod tests {
             lang_rec(1, 1, 10, 1, 5, OP_ASSERT),  // lang 1: no-op re-assert
             lang_rec(1, 1, 10, 2, 6, OP_RETRACT), // lang 2: winner at t=6
         ];
-        let out = dedup_fact_lifecycles(records);
+        let out = dedup(records);
         assert_eq!(
             keys(&out),
             keys(&[

--- a/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
@@ -1405,3 +1405,170 @@ fn remap_record(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_db_core::subject_id::SubjectId;
+
+    const OP_RETRACT: u8 = 0;
+    const OP_ASSERT: u8 = 1;
+
+    /// Integer-valued record in the default graph, no list index, no language.
+    fn rec(s_id: u64, p_id: u32, o_key: u64, t: u32, op: u8) -> RunRecord {
+        RunRecord {
+            s_id: SubjectId::from_u64(s_id),
+            o_key,
+            p_id,
+            t,
+            i: u32::MAX,
+            g_id: 0,
+            dt: 0,
+            lang_id: 0,
+            o_kind: 1,
+            op,
+        }
+    }
+
+    fn lang_rec(s_id: u64, p_id: u32, o_key: u64, lang_id: u16, t: u32, op: u8) -> RunRecord {
+        RunRecord {
+            lang_id,
+            ..rec(s_id, p_id, o_key, t, op)
+        }
+    }
+
+    fn list_rec(s_id: u64, p_id: u32, o_key: u64, i: u32, t: u32, op: u8) -> RunRecord {
+        RunRecord {
+            i,
+            ..rec(s_id, p_id, o_key, t, op)
+        }
+    }
+
+    /// Field projection for assertions (`RunRecord` has no `Debug`).
+    fn key(r: &RunRecord) -> (u64, u32, u64, u32, u16, u32, u8) {
+        (r.s_id.as_u64(), r.p_id, r.o_key, r.i, r.lang_id, r.t, r.op)
+    }
+
+    fn keys(records: &[RunRecord]) -> Vec<(u64, u32, u64, u32, u16, u32, u8)> {
+        records.iter().map(key).collect()
+    }
+
+    /// Issue #1412: the same fact asserted by two commits in one window must
+    /// dedup to the first assert (the later one is a no-op re-assert), so
+    /// the leaf merge sees each identity at most once.
+    #[test]
+    fn duplicate_asserts_dedup_to_first_assert() {
+        let records = vec![rec(1, 1, 10, 5, OP_ASSERT), rec(1, 1, 10, 6, OP_ASSERT)];
+        let out = dedup_fact_lifecycles(records);
+        assert_eq!(keys(&out), keys(&[rec(1, 1, 10, 5, OP_ASSERT)]));
+    }
+
+    /// Assert-then-retract of a new fact within one window resolves to the
+    /// retract; without the dedup the leaf merge emits the assert as a row
+    /// and only logs the retract, leaving a ghost row.
+    #[test]
+    fn assert_then_retract_dedups_to_retract() {
+        let records = vec![rec(1, 1, 10, 5, OP_ASSERT), rec(1, 1, 10, 6, OP_RETRACT)];
+        let out = dedup_fact_lifecycles(records);
+        assert_eq!(keys(&out), keys(&[rec(1, 1, 10, 6, OP_RETRACT)]));
+    }
+
+    #[test]
+    fn reassert_after_retract_survives_with_reassert_t() {
+        let records = vec![
+            rec(1, 1, 10, 3, OP_ASSERT),
+            rec(1, 1, 10, 4, OP_RETRACT),
+            rec(1, 1, 10, 5, OP_ASSERT),
+        ];
+        let out = dedup_fact_lifecycles(records);
+        assert_eq!(keys(&out), keys(&[rec(1, 1, 10, 5, OP_ASSERT)]));
+    }
+
+    #[test]
+    fn repeat_retract_keeps_highest_t() {
+        let records = vec![rec(1, 1, 10, 5, OP_RETRACT), rec(1, 1, 10, 6, OP_RETRACT)];
+        let out = dedup_fact_lifecycles(records);
+        assert_eq!(keys(&out), keys(&[rec(1, 1, 10, 6, OP_RETRACT)]));
+    }
+
+    /// Same-`t` ties resolve retract-wins, matching `resolve_overlay_ops` and
+    /// `NoveltyFactState`. Sorted input puts the retract first (op 0 < 1).
+    #[test]
+    fn same_t_retract_beats_assert() {
+        let records = vec![rec(1, 1, 10, 5, OP_RETRACT), rec(1, 1, 10, 5, OP_ASSERT)];
+        let out = dedup_fact_lifecycles(records);
+        assert_eq!(keys(&out), keys(&[rec(1, 1, 10, 5, OP_RETRACT)]));
+    }
+
+    /// `lang_id` is part of fact identity but not of the sort comparator:
+    /// records differing only in language must not dedup into each other.
+    #[test]
+    fn distinct_lang_ids_do_not_dedup() {
+        let records = vec![
+            lang_rec(1, 1, 10, 1, 5, OP_ASSERT),
+            lang_rec(1, 1, 10, 2, 5, OP_ASSERT),
+            lang_rec(1, 1, 10, 1, 6, OP_ASSERT),
+        ];
+        let out = dedup_fact_lifecycles(records);
+        assert_eq!(
+            keys(&out),
+            keys(&[
+                lang_rec(1, 1, 10, 1, 5, OP_ASSERT),
+                lang_rec(1, 1, 10, 2, 5, OP_ASSERT),
+            ])
+        );
+    }
+
+    /// The list index `i` is part of fact identity but not of the sort
+    /// comparator: the same value at different list positions must not dedup.
+    #[test]
+    fn distinct_list_indices_do_not_dedup() {
+        let records = vec![
+            list_rec(1, 1, 10, 0, 5, OP_ASSERT),
+            list_rec(1, 1, 10, 1, 5, OP_ASSERT),
+            list_rec(1, 1, 10, 0, 6, OP_ASSERT),
+        ];
+        let out = dedup_fact_lifecycles(records);
+        assert_eq!(
+            keys(&out),
+            keys(&[
+                list_rec(1, 1, 10, 0, 5, OP_ASSERT),
+                list_rec(1, 1, 10, 1, 5, OP_ASSERT),
+            ])
+        );
+    }
+
+    /// Distinct facts pass through untouched, in input order.
+    #[test]
+    fn distinct_facts_are_preserved_in_order() {
+        let records = vec![
+            rec(1, 1, 10, 5, OP_ASSERT),
+            rec(1, 1, 20, 5, OP_ASSERT),
+            rec(2, 1, 10, 6, OP_RETRACT),
+            rec(3, 2, 30, 7, OP_ASSERT),
+        ];
+        let expected = keys(&records);
+        let out = dedup_fact_lifecycles(records);
+        assert_eq!(keys(&out), expected);
+    }
+
+    /// Winners within one sort-prefix group are emitted in `(t, op)` order so
+    /// the output stays sorted for the V1→V2 conversion and leaf slicing.
+    #[test]
+    fn group_winners_stay_sorted_by_t() {
+        let records = vec![
+            lang_rec(1, 1, 10, 1, 3, OP_ASSERT),  // lang 1: survives at t=3
+            lang_rec(1, 1, 10, 2, 4, OP_ASSERT),  // lang 2: superseded below
+            lang_rec(1, 1, 10, 1, 5, OP_ASSERT),  // lang 1: no-op re-assert
+            lang_rec(1, 1, 10, 2, 6, OP_RETRACT), // lang 2: winner at t=6
+        ];
+        let out = dedup_fact_lifecycles(records);
+        assert_eq!(
+            keys(&out),
+            keys(&[
+                lang_rec(1, 1, 10, 1, 3, OP_ASSERT),
+                lang_rec(1, 1, 10, 2, 6, OP_RETRACT),
+            ])
+        );
+    }
+}

--- a/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
@@ -766,6 +766,13 @@ fn same_sort_prefix(a: &RunRecord, b: &RunRecord) -> bool {
 /// Within a sort-prefix group, records for one full identity arrive in
 /// `(t, op)` order even when several identities interleave, so a linear walk
 /// per identity sees its events chronologically.
+///
+/// Dropped intermediate transitions do not reach the history sidecars, so
+/// index-served time travel cannot see a state a fact held only *within*
+/// this window (e.g. a fact asserted and retracted between two index builds
+/// has no lived interval in the index; `merge_novelty` records no history
+/// for its final retract). The live novelty view retains those intermediate
+/// ops until the window is indexed.
 fn dedup_fact_lifecycles(records: Vec<RunRecord>) -> Vec<RunRecord> {
     let mut out: Vec<RunRecord> = Vec::with_capacity(records.len());
     // Winners for the current sort-prefix group, one per full identity

--- a/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_resolve.rs
@@ -664,6 +664,25 @@ pub async fn resolve_incremental_commits_v6(
     v1_records.sort_unstable_by(|a, b| a.g_id.cmp(&b.g_id).then_with(|| spot_cmp(a, b)));
     let t_sort_ms = t0.elapsed().as_millis() as u64;
 
+    // 10a. Dedup fact lifecycles (RDF set semantics). Commit files are
+    //      event logs of user assertions, not state deltas: the same fact may
+    //      be asserted by several commits in this window, or asserted and
+    //      retracted within it. The leaf merge (`merge_novelty`) consumes at
+    //      most one op per fact identity, so each identity's event sequence
+    //      is resolved to its final state here.
+    let t0 = Instant::now();
+    let event_count = v1_records.len();
+    let v1_records = dedup_fact_lifecycles(v1_records);
+    let t_dedup_ms = t0.elapsed().as_millis() as u64;
+    let deduped_count = event_count - v1_records.len();
+    if deduped_count > 0 {
+        tracing::debug!(
+            event_count,
+            deduped_count,
+            "V6 incremental resolve: deduped fact lifecycles (set semantics)"
+        );
+    }
+
     // 11. Convert V1 → V2 + extract ops.
     let t0 = Instant::now();
     let mut records = Vec::with_capacity(v1_records.len());
@@ -686,6 +705,7 @@ pub async fn resolve_incremental_commits_v6(
         remap_fulltext_ms = t_remap_fulltext_ms,
         remap_records_ms = t_remap_records_ms,
         sort_ms = t_sort_ms,
+        dedup_ms = t_dedup_ms,
         convert_ms = t_convert_ms,
         total_ms = t_start.elapsed().as_millis() as u64,
         commit_count,
@@ -712,6 +732,74 @@ pub async fn resolve_incremental_commits_v6(
         base_numbig_counts,
         fulltext_string_bytes,
     })
+}
+
+// ============================================================================
+// Internal: Fact lifecycle dedup
+// ============================================================================
+
+/// True when two records agree on every field the `(g_id, SPOT)` comparator
+/// orders by, other than `t` and `op`. Records with the same prefix are
+/// adjacent in a sorted stream; full fact identity additionally distinguishes
+/// `i` and `lang_id`, which the comparator does not order by.
+fn same_sort_prefix(a: &RunRecord, b: &RunRecord) -> bool {
+    a.g_id == b.g_id
+        && a.s_id == b.s_id
+        && a.p_id == b.p_id
+        && a.o_kind == b.o_kind
+        && a.o_key == b.o_key
+        && a.dt == b.dt
+}
+
+/// Resolve each fact's event sequence within the commit window to a single
+/// final op, so the updated index materializes the same state the in-memory
+/// novelty view resolves:
+///
+/// - A re-assert of a currently-asserted fact is a no-op: the earlier assert
+///   (and its `t`) survives, matching `NoveltyFactState`'s skip rule.
+/// - Every other op becomes the identity's winner: a retract after an assert,
+///   an assert after a retract, and a repeat retract at higher `t`.
+/// - An assert at the same `t` as a winning retract loses (same-`t` ties
+///   resolve retract-wins), matching `resolve_overlay_ops`.
+///
+/// Input must be sorted by `(g_id, SPOT)`; output preserves that order.
+/// Within a sort-prefix group, records for one full identity arrive in
+/// `(t, op)` order even when several identities interleave, so a linear walk
+/// per identity sees its events chronologically.
+fn dedup_fact_lifecycles(records: Vec<RunRecord>) -> Vec<RunRecord> {
+    let mut out: Vec<RunRecord> = Vec::with_capacity(records.len());
+    // Winners for the current sort-prefix group, one per full identity
+    // (distinct `(i, lang_id)`). Groups are tiny, so a linear scan beats a
+    // map.
+    let mut group: Vec<RunRecord> = Vec::new();
+
+    for rec in records {
+        if group.last().is_some_and(|w| !same_sort_prefix(w, &rec)) {
+            flush_deduped_group(&mut group, &mut out);
+        }
+        match group
+            .iter_mut()
+            .find(|w| w.i == rec.i && w.lang_id == rec.lang_id)
+        {
+            None => group.push(rec),
+            Some(winner) => {
+                let noop_reassert = rec.op == 1 && winner.op == 1;
+                let same_t_retract_wins = rec.op == 1 && winner.op == 0 && rec.t == winner.t;
+                if !noop_reassert && !same_t_retract_wins {
+                    *winner = rec;
+                }
+            }
+        }
+    }
+    flush_deduped_group(&mut group, &mut out);
+    out
+}
+
+/// Emit a sort-prefix group's winners in comparator order (`t`, then `op`)
+/// and clear the group.
+fn flush_deduped_group(group: &mut Vec<RunRecord>, out: &mut Vec<RunRecord>) {
+    group.sort_unstable_by(|a, b| a.t.cmp(&b.t).then(a.op.cmp(&b.op)));
+    out.append(group);
 }
 
 // ============================================================================

--- a/fluree-db-indexer/src/run_index/build/index_build.rs
+++ b/fluree-db-indexer/src/run_index/build/index_build.rs
@@ -218,6 +218,21 @@ pub fn build_index(config: &IndexBuildConfig) -> Result<IndexBuildResult, IndexB
             let Some((record, op, history)) = merge.next_deduped_with_history()? else {
                 break;
             };
+            // A retract-winner whose identity was never asserted anywhere in
+            // the commit log (the full log — this is a rebuild) is a retract
+            // of a fact that never existed: not a state transition, and its
+            // entries would make time-travel replay fabricate the fact's
+            // presence before the retraction. Skip the whole lifecycle.
+            if op == 0 && history.iter().all(|&(_, hist_op)| hist_op == 0) {
+                progress_batch += 1;
+                if progress_batch >= PROGRESS_BATCH_SIZE {
+                    if let Some(ref ctr) = config.progress {
+                        ctr.fetch_add(progress_batch, Ordering::Relaxed);
+                    }
+                    progress_batch = 0;
+                }
+                continue;
+            }
             // Push history entries for non-winners (these become sidecar segments).
             for (hist_rec, hist_op) in &history {
                 writer.push_history_entry(
@@ -786,6 +801,99 @@ mod tests {
         // Verify o_type_const is set (single type per predicate).
         assert_eq!(leaf_dir[0].o_type_const, Some(OType::XSD_INTEGER.as_u16()));
         assert_eq!(leaf_dir[1].o_type_const, Some(OType::XSD_STRING.as_u16()));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A retract-winner whose identity was never asserted anywhere in the log
+    /// is a retract of a fact that never existed: it contributes no row and
+    /// no history entries (a bare retract entry would make time-travel replay
+    /// fabricate the fact's presence before the retraction). A lifecycle that
+    /// does contain an assert keeps its full history.
+    #[test]
+    fn build_skips_never_asserted_retract_lifecycles() {
+        let dir = std::env::temp_dir().join("fluree_test_build_v2_never_asserted");
+        let _ = std::fs::remove_dir_all(&dir);
+        let run_dir = dir.join("runs");
+        let index_dir = dir.join("index");
+        std::fs::create_dir_all(&run_dir).unwrap();
+
+        // SPOT-sorted (s ascending, then t):
+        // s=10: asserted@1, retracted@2  -> no row; history keeps both events
+        // s=20: retracted@3, never asserted -> no row, no history
+        // s=30: asserted@4               -> row
+        let records = vec![
+            make_rec(0, 10, 1, OType::XSD_INTEGER.as_u16(), 100, 1),
+            make_rec(0, 10, 1, OType::XSD_INTEGER.as_u16(), 100, 2),
+            make_rec(0, 20, 1, OType::XSD_INTEGER.as_u16(), 200, 3),
+            make_rec(0, 30, 1, OType::XSD_INTEGER.as_u16(), 300, 4),
+        ];
+        let ops = vec![1u8, 0, 0, 1];
+
+        crate::run_index::runs::run_file::write_run_file_with_op(
+            &run_dir.join("run_00000.frn"),
+            &records,
+            &ops,
+            RunSortOrder::Spot,
+            1,
+            4,
+        )
+        .unwrap();
+
+        let config = IndexBuildConfig {
+            run_dir,
+            index_dir: index_dir.clone(),
+            sort_order: RunSortOrder::Spot,
+            leaflet_target_rows: 100,
+            leaf_target_rows: 1000,
+            zstd_level: 1,
+            skip_dedup: false,
+            skip_history: false,
+            g_id: 0,
+            progress: None,
+        };
+
+        let result = build_index(&config).unwrap();
+        assert_eq!(result.total_rows, 1, "only s=30 survives to latest-state");
+
+        let leaf = &result.graphs[0].leaf_infos[0];
+        let leaf_bytes = std::fs::read(&leaf.leaf_path).unwrap();
+        let header = decode_leaf_header_v3(&leaf_bytes).unwrap();
+        let leaf_dir = decode_leaf_dir_v3(&leaf_bytes, &header).unwrap();
+
+        let sidecar_bytes =
+            std::fs::read(leaf.sidecar_path.as_ref().expect("history sidecar written")).unwrap();
+        let mut history: Vec<HistEntryV2> = Vec::new();
+        for entry in &leaf_dir {
+            if entry.history_len == 0 {
+                continue;
+            }
+            let seg = fluree_db_binary_index::format::history_sidecar::HistorySegmentRef {
+                offset: entry.history_offset,
+                len: entry.history_len,
+                min_t: entry.history_min_t,
+                max_t: entry.history_max_t,
+            };
+            history.extend(
+                fluree_db_binary_index::format::history_sidecar::decode_history_segment(
+                    &sidecar_bytes,
+                    &seg,
+                )
+                .unwrap(),
+            );
+        }
+
+        let mut events: Vec<(u64, u32, u8)> = history
+            .iter()
+            .map(|e| (e.s_id.as_u64(), e.t, e.op))
+            .collect();
+        events.sort_unstable();
+        assert_eq!(
+            events,
+            vec![(10, 1, 1), (10, 2, 0)],
+            "asserted-then-retracted lifecycle keeps its history; \
+             never-asserted retract leaves none"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/fluree-db-indexer/src/run_index/build/novelty_merge.rs
+++ b/fluree-db-indexer/src/run_index/build/novelty_merge.rs
@@ -275,7 +275,12 @@ fn dedup_adjacent_asserts(entries: &mut Vec<HistEntryV2>) {
 /// - **Existing < Novelty**: Emit existing row unchanged.
 /// - **Novelty < Existing**:
 ///   - Assert: Emit novelty to output; record in history.
-///   - Retract: Skip (retract of non-existent fact); still record in history.
+///   - Retract: Skip entirely — no row and no history entry. The fact was
+///     never materialized in this leaf, so the retraction is not a state
+///     transition; the history sidecar is a transition log (replay undoes a
+///     retract entry by marking the fact present before it), and a bare
+///     retract entry makes replay fabricate the fact's presence at every
+///     `t` before the retraction.
 /// - **Same identity** (Equal):
 ///   - Assert: Emit novelty (update); record retraction of old + new assert in history.
 ///   - Retract: Omit from output; record retraction in history.
@@ -310,11 +315,13 @@ pub fn merge_novelty(input: &MergeInput<'_>) -> MergeOutput {
                 ei += 1;
             }
             Ordering::Greater => {
-                // Novelty comes first (not in existing data).
+                // Novelty comes first (not in existing data). A retract of a
+                // fact this leaf never materialized is not a transition and
+                // records no history (see the doc comment above).
                 if op == 1 {
                     out.push(*nov);
+                    new_history.push(record_to_hist_entry(nov, op));
                 }
-                new_history.push(record_to_hist_entry(nov, op));
                 ni += 1;
             }
             Ordering::Equal => {
@@ -344,14 +351,15 @@ pub fn merge_novelty(input: &MergeInput<'_>) -> MergeOutput {
         ei += 1;
     }
 
-    // Drain remaining novelty.
+    // Drain remaining novelty. Same rule as the Greater arm: these identities
+    // have no base row, so only asserts transition state and record history.
     while ni < novelty_len {
         let nov = &input.novelty[ni];
         let op = input.novelty_ops[ni];
         if op == 1 {
             out.push(*nov);
+            new_history.push(record_to_hist_entry(nov, op));
         }
-        new_history.push(record_to_hist_entry(nov, op));
         ni += 1;
     }
 
@@ -539,6 +547,12 @@ mod tests {
         assert_eq!(matched_subjects, vec![1, 3]);
     }
 
+    /// A retract of a fact this leaf never materialized changes no rows and
+    /// records no history: replay undoes a retract entry by marking the fact
+    /// present before it, so a bare retract entry (no paired assert anywhere)
+    /// would fabricate the fact's presence at every `t` before the
+    /// retraction — both for a user retracting an absent fact and for an
+    /// in-window assert+retract lifecycle deduped to its final retract.
     #[test]
     fn test_merge_retract_nonexistent() {
         let existing = vec![rec2(1, 1, 10, 1)];
@@ -550,10 +564,22 @@ mod tests {
         let out = merge_novelty(&input);
         assert_eq!(out.records.len(), 1);
         assert_eq!(out.records[0].s_id.as_u64(), 1);
+        assert!(out.history.is_empty(), "non-transition records no history");
+    }
 
-        // History still records the retraction
-        assert_eq!(out.history.len(), 1);
-        assert_eq!(out.history[0].op, 0);
+    /// Same rule in the drain loop: retracts sorting after every existing row
+    /// have no base row either.
+    #[test]
+    fn test_merge_retract_nonexistent_after_last_row() {
+        let existing = vec![rec2(1, 1, 10, 1)];
+        let batch = batch_from_records(&existing);
+        let novelty = vec![rec2(5, 1, 50, 6)]; // after s=1
+        let ops = vec![0u8]; // retract
+        let input = make_input(&batch, &novelty, &ops, &[], RunSortOrder::Spot);
+
+        let out = merge_novelty(&input);
+        assert_eq!(out.records.len(), 1);
+        assert!(out.history.is_empty(), "non-transition records no history");
     }
 
     #[test]

--- a/fluree-db-indexer/src/run_index/build/novelty_merge.rs
+++ b/fluree-db-indexer/src/run_index/build/novelty_merge.rs
@@ -258,6 +258,12 @@ fn dedup_adjacent_asserts(entries: &mut Vec<HistEntryV2>) {
 
 /// Merge sorted novelty operations into a decoded V3 leaflet.
 ///
+/// The novelty stream must contain at most one op per fact identity
+/// (lifecycle-deduped; see `dedup_fact_lifecycles` in
+/// `incremental_resolve`). A second op for an identity already consumed by
+/// the Equal arm would compare against later rows and be emitted as a
+/// duplicate row (assert) or dropped without effect (retract).
+///
 /// Walks the existing batch rows and novelty cursors together in sort order:
 ///
 /// - **Existing < Novelty**: Emit existing row unchanged.

--- a/fluree-db-indexer/src/run_index/build/novelty_merge.rs
+++ b/fluree-db-indexer/src/run_index/build/novelty_merge.rs
@@ -47,6 +47,12 @@ pub struct MergeOutput {
     pub records: Vec<RunRecordV2>,
     /// History entries: new merge events ++ existing history, reverse chronological.
     pub history: Vec<HistEntryV2>,
+    /// Novelty ops whose fact identity matched an existing base row (the
+    /// Equal arm), asserts and retracts alike. A matched assert replaced a
+    /// base row and a matched retract removed one, so consumers deriving
+    /// materialized-state deltas (e.g. stats counts) can tell real
+    /// transitions from no-ops.
+    pub matched: Vec<RunRecordV2>,
 }
 
 // ============================================================================
@@ -287,6 +293,7 @@ pub fn merge_novelty(input: &MergeInput<'_>) -> MergeOutput {
 
     let mut out: Vec<RunRecordV2> = Vec::with_capacity(existing_len + novelty_len);
     let mut new_history: Vec<HistEntryV2> = Vec::with_capacity(novelty_len * 2);
+    let mut matched: Vec<RunRecordV2> = Vec::new();
 
     let mut ei = 0usize; // existing row index
     let mut ni = 0usize; // novelty index
@@ -312,6 +319,7 @@ pub fn merge_novelty(input: &MergeInput<'_>) -> MergeOutput {
             }
             Ordering::Equal => {
                 // Same fact identity.
+                matched.push(*nov);
                 if op == 1 {
                     // Assert (update): emit novelty, record retraction of old + new assert.
                     out.push(*nov);
@@ -351,6 +359,7 @@ pub fn merge_novelty(input: &MergeInput<'_>) -> MergeOutput {
     MergeOutput {
         records: out,
         history,
+        matched,
     }
 }
 
@@ -509,6 +518,25 @@ mod tests {
         assert_eq!(out.history[0].op, 0); // retract first (same t, op=0 < op=1)
         assert_eq!(out.history[1].t, 5);
         assert_eq!(out.history[1].op, 1); // then assert
+    }
+
+    /// Equal-arm ops (assert or retract of a base-present fact) are reported
+    /// in `matched`; Greater-arm ops (base-absent identities) are not.
+    #[test]
+    fn test_merge_matched_reports_base_row_hits() {
+        let existing = vec![rec2(1, 1, 10, 1), rec2(3, 1, 30, 1)];
+        let batch = batch_from_records(&existing);
+        let novelty = vec![
+            rec2(1, 1, 10, 5), // re-assert of existing fact -> matched
+            rec2(2, 1, 20, 5), // new fact -> not matched
+            rec2(3, 1, 30, 5), // retract of existing fact -> matched
+        ];
+        let ops = vec![1u8, 1, 0];
+        let input = make_input(&batch, &novelty, &ops, &[], RunSortOrder::Spot);
+
+        let out = merge_novelty(&input);
+        let matched_subjects: Vec<u64> = out.matched.iter().map(|r| r.s_id.as_u64()).collect();
+        assert_eq!(matched_subjects, vec![1, 3]);
     }
 
     #[test]

--- a/fluree-db-indexer/src/stats/id_hook.rs
+++ b/fluree-db-indexer/src/stats/id_hook.rs
@@ -345,10 +345,38 @@ impl IdStatsHook {
 
     /// Process a single record with resolved IDs.
     ///
-    /// Called per-op after the resolver maps Sids to numeric IDs.
+    /// Called per-op after the resolver maps Sids to numeric IDs. The signed
+    /// count delta is derived from the op alone (assert +1, retract -1),
+    /// which is correct when counts accumulate from scratch over an ordered
+    /// event replay (rebuild/import). For base-seeded counts use
+    /// [`Self::on_record_with_base_presence`].
     pub fn on_record(&mut self, rec: &StatsRecord) {
-        self.flake_count += 1;
         let delta: i64 = if rec.op { 1 } else { -1 };
+        self.apply_record(rec, delta);
+    }
+
+    /// Process a single record whose fact identity's presence in the base
+    /// index is known, deriving the signed count delta from the materialized
+    /// state transition instead of the raw op: an assert creates a row only
+    /// when the fact is base-absent, and a retract removes one only when it
+    /// is base-present; otherwise the record changes no rows and counts by 0.
+    /// Monotone accumulators (HLL sketches, touched-property sets,
+    /// `last_modified_t`) still observe every record.
+    ///
+    /// Use for base-seeded counts (the incremental path); commit event logs
+    /// legitimately contain re-asserts of present facts, and deriving ±1
+    /// from the op double-counts them against the seed.
+    pub fn on_record_with_base_presence(&mut self, rec: &StatsRecord, base_present: bool) {
+        let delta: i64 = match (rec.op, base_present) {
+            (true, false) => 1,
+            (false, true) => -1,
+            (true, true) | (false, false) => 0,
+        };
+        self.apply_record(rec, delta);
+    }
+
+    fn apply_record(&mut self, rec: &StatsRecord, delta: i64) {
+        self.flake_count += 1;
 
         // Track per-graph flake count
         *self.graph_flakes.entry(rec.g_id).or_insert(0) += delta;
@@ -858,5 +886,77 @@ mod tests {
         let key = GraphPropertyKey { g_id: 0, p_id: 1 };
         assert_eq!(props[&key].count, 5);
         assert_eq!(props[&key].last_modified_t, 3);
+    }
+
+    fn record(op: bool, t: i64) -> StatsRecord {
+        StatsRecord {
+            g_id: 0,
+            p_id: 1,
+            s_id: 10,
+            dt: fluree_db_core::value_id::ValueTypeTag::INTEGER,
+            o_hash: 42,
+            o_kind: 0,
+            o_key: 7,
+            t,
+            op,
+            lang_id: 0,
+        }
+    }
+
+    fn seeded_hook(count: i64) -> IdStatsHook {
+        let mut prior = HashMap::new();
+        let mut hll = IdPropertyHll::new();
+        hll.count = count;
+        prior.insert(GraphPropertyKey { g_id: 0, p_id: 1 }, hll);
+        IdStatsHook::with_prior_properties(prior)
+    }
+
+    fn property_count(hook: &IdStatsHook) -> i64 {
+        hook.properties()[&GraphPropertyKey { g_id: 0, p_id: 1 }].count
+    }
+
+    /// Base-seeded counts change only on real state transitions: assert of an
+    /// absent fact (+1) and retract of a present fact (-1).
+    #[test]
+    fn base_presence_delta_counts_transitions_only() {
+        let mut hook = seeded_hook(5);
+        hook.on_record_with_base_presence(&record(true, 1), false); // created
+        assert_eq!(property_count(&hook), 6);
+        hook.on_record_with_base_presence(&record(false, 2), true); // removed
+        assert_eq!(property_count(&hook), 5);
+    }
+
+    /// A re-assert of a base-present fact and a retract of a base-absent
+    /// fact are no-ops for counts; commit event logs legitimately contain
+    /// both (facts are re-asserted across commits, and a window's
+    /// assert+retract of a new fact dedups to a lone retract).
+    #[test]
+    fn base_presence_delta_ignores_noop_events() {
+        let mut hook = seeded_hook(5);
+        hook.on_record_with_base_presence(&record(true, 1), true); // re-assert
+        assert_eq!(property_count(&hook), 5);
+        hook.on_record_with_base_presence(&record(false, 2), false); // retract of absent
+        assert_eq!(property_count(&hook), 5);
+    }
+
+    /// Zero-delta records still feed the monotone accumulators: NDV sketches
+    /// and last-modified tracking observe every record.
+    #[test]
+    fn noop_events_still_feed_monotone_accumulators() {
+        let mut hook = seeded_hook(5);
+        hook.on_record_with_base_presence(&record(true, 9), true);
+        let hll = &hook.properties()[&GraphPropertyKey { g_id: 0, p_id: 1 }];
+        assert_eq!(hll.last_modified_t, 9);
+        assert!(hll.values_hll.estimate() > 0, "value sketch observed");
+    }
+
+    /// The op-derived path is unchanged: ±1 regardless of any base.
+    #[test]
+    fn event_delta_path_counts_every_op() {
+        let mut hook = seeded_hook(0);
+        hook.on_record(&record(true, 1));
+        hook.on_record(&record(true, 2));
+        hook.on_record(&record(false, 3));
+        assert_eq!(property_count(&hook), 1);
     }
 }

--- a/fluree-db-indexer/tests/it_incremental_indexing_strategy.rs
+++ b/fluree-db-indexer/tests/it_incremental_indexing_strategy.rs
@@ -79,6 +79,7 @@ fn incremental_branch_only_fetches_and_rewrites_touched_leaves() {
         zstd_level: 1,
         leaflet_target_rows: 50, // avoid splits in this test
         leaf_target_rows: 200,   // irrelevant unless split
+        collect_matched: false,
     };
 
     let fetched: std::cell::RefCell<Vec<ContentId>> = std::cell::RefCell::new(Vec::new());


### PR DESCRIPTION
Re-inserting triples that already exist in the database left the indexed view with duplicate rows: the same subject-property-object appearing many times (observed ~16× in the reporting ledger), along with spurious assert/retract churn in transaction history views. Live queries against in-memory novelty were correct; the duplicates appeared only after an incremental index build and compounded with each subsequent one. A full rebuild silently healed them, which made the bug look intermittent.

Root cause: commit files are event logs of user assertions, not state deltas — re-asserting a present fact is a legitimate event that records a new transaction, and every layer that materializes state from those events must apply RDF set semantics itself. Three of the four materializers did (in-memory novelty via `NoveltyFactState`, the query overlay via `resolve_overlay_ops`, and the full rebuild via `KWayMerge::next_deduped`), but the V6 incremental pipeline replayed raw commit events with no lifecycle resolution: `resolve_incremental_commits_v6` sorted records without collapsing them, and `merge_novelty`'s two-pointer walk assumes at most one op per fact identity, so each duplicate assertion event materialized as an additional physical row in the FLI3 leaves.

## Changes

### Set-semantics dedup in the incremental resolve (the core fix)

`dedup_fact_lifecycles` runs after the `(g_id, SPOT)` sort in `resolve_incremental_commits_v6` and resolves each fact's in-window event sequence to a single final op, mirroring the in-memory novelty rules exactly so the updated index materializes the same state a live query resolves: a re-assert of a currently-asserted fact is a no-op (the earlier assert and its `t` survive, matching `NoveltyFactState`'s skip rule), any other op becomes the identity's winner, and same-`t` ties resolve retract-wins (matching `resolve_overlay_ops`).

Fact identity is the resolved V2 identity `(o_type, o_i)` — the identity `merge_novelty`, replay, and the query overlay all compare by — rather than raw v1 fields. This matters because `OTypeRegistry::resolve` collapses the datatype dict id for 1:1 object kinds (a boolean is `xsd:boolean` whatever datatype IRI the commit carried) and consults `lang_id` only for `rdf:langString`, so datatype-IRI variants and stray language tags on one fact dedup together while genuine language tags and list positions stay distinct. The dedup compacts in place behind a write cursor: a window with no duplicate facts copies nothing, and multi-record groups resolve through a reused scratch buffer in O(k log k).

### Correct stats deltas via base presence

The signed stats hooks (per-property/datatype/graph flake counts and rdf:type class counts) previously derived ±1 deltas from each record's op against base-seeded counts, which double-counts re-asserts and, once lifecycles collapse, applies unbalanced deltas for retract-then-reassert and assert-then-retract windows. The Phase 2 SPOT merge now reports which novelty ops matched an existing base row (`MergeOutput::matched`, threaded through `update_leaf` → branch update → `Phase2TaskOutput`, collected for the SPOT order only), and the Phase 3b feed uses a new `IdStatsHook::on_record_with_base_presence`: +1 only for an assert of a base-absent fact, −1 only for a retract of a base-present one, 0 otherwise. Monotone accumulators (HLL sketches, touched-property sets, `last_modified_t`) still observe every record. The from-scratch event-replay feeds (rebuild/import) keep the unchanged legacy `on_record`. This also fixes a pre-existing bug: every re-assert of an indexed fact used to permanently inflate its property count.

### No history entries for non-transitions

The history sidecar is a transition log: time-travel replay undoes a retract entry by marking the fact present before it, so a retract entry with no paired assert anywhere makes replay fabricate the fact's presence at every `t` before the retraction. `merge_novelty` no longer writes a history entry for a retract of a fact the leaf never materialized (the `Greater` arm and the post-rows drain loop), and the rebuild path skips retract-winner lifecycles whose identity has no assert anywhere in the commit log. This fixes both the ghost introduced by lifecycle collapsing (a fact asserted and retracted within one window deduped to a bare retract) and a pre-existing ghost when a user retracts a fact that never existed.

## Known limitations and follow-ups

- A fact asserted and retracted within a single indexing window is invisible to index-served time travel during its brief lived interval (that interval was never materialized in any published leaf; before this branch it was "visible" only via the buggy ghost row). The live novelty view retains those intermediate ops until the window is indexed. Restoring full in-window fidelity requires a transition-log rework of the history sidecars; the full analysis, design, risks (including mixed-vintage sidecar compatibility), and testing strategy are captured in `history-transition-log-plan.md`.
- The full rebuild path resolves a re-asserted fact to the highest-`t` assert while novelty and the incremental path keep the first assert's `t`, so the two build paths can materialize different row `t` for the same event log. Pre-existing, out of scope here; folded into the plan file as a blocking design decision for the rework.
- Already-published leaves keep their duplicate rows, corrupted stats, and stale bare-retract history entries until affected ledgers run a full reindex; this branch stops new damage.

Fixes #1412 

