### PR TITLE
release v4.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,7 +2422,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-bench-support"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "chrono",
  "rand 0.8.5",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-api"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2544,14 +2544,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-bolt"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-db-cli"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-consensus"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cypher"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-docs"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "pulldown-cmark",
  "rust-embed",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-iceberg"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-mcp"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-db-docs",
  "fluree-db-memory",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-memory"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "chrono",
  "fluree-db-api",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice-sync"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-peer"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3068,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-server"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-aws"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-ipfs"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "cid",
@@ -3239,14 +3239,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-vocab",
  "pretty_assertions",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-httpd"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "axum",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-service"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3390,14 +3390,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-sse"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-vocab"
-version = "4.1.2"
+version = "4.1.3"
 
 [[package]]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 exclude = ["testsuite-sparql", "testsuite-shacl", "scripts/local/load"]
 
 [workspace.package]
-version = "4.1.2"
+version = "4.1.3"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/fluree/db"

--- a/testsuite-shacl/Cargo.lock
+++ b/testsuite-shacl/Cargo.lock
@@ -668,7 +668,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-db-api"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -703,11 +703,11 @@ dependencies = [
  "hex",
  "indexmap",
  "itoa",
+ "lru",
  "moka",
  "parking_lot",
  "percent-encoding",
  "rustc-hash",
- "ryu",
  "serde",
  "serde_json",
  "sysinfo",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "bigdecimal 0.4.10",
  "chrono",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "base64",
  "bs58",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cypher"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -968,6 +968,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "once_cell",
+ "parking_lot",
  "percent-encoding",
  "postcard",
  "rand 0.8.6",
@@ -989,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -1005,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1021,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -1034,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -1051,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -1079,14 +1080,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1126,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-graph-ir",
  "serde",
@@ -1136,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-vocab",
  "serde",
@@ -1146,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1158,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1171,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1180,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-vocab"
-version = "4.1.2"
+version = "4.1.3"
 
 [[package]]
 name = "foldhash"
@@ -2395,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "testsuite-shacl"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "anyhow",
  "fluree-db-api",

--- a/testsuite-shacl/Cargo.toml
+++ b/testsuite-shacl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testsuite-shacl"
-version = "4.1.2"
+version = "4.1.3"
 edition = "2021"
 publish = false
 

--- a/testsuite-sparql/Cargo.lock
+++ b/testsuite-sparql/Cargo.lock
@@ -662,7 +662,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-db-api"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "bigdecimal 0.4.10",
  "chrono",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "base64",
  "bs58",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cypher"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -1060,14 +1060,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-graph-ir",
  "serde",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-vocab",
  "serde",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-vocab"
-version = "4.1.2"
+version = "4.1.3"
 
 [[package]]
 name = "foldhash"
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "testsuite-sparql"
-version = "4.1.2"
+version = "4.1.3"
 dependencies = [
  "anyhow",
  "fluree-db-api",

--- a/testsuite-sparql/Cargo.toml
+++ b/testsuite-sparql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testsuite-sparql"
-version = "4.1.2"
+version = "4.1.3"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Bumps the workspace version to 4.1.3 (root + testsuite-sparql + testsuite-shacl, with refreshed Cargo.locks).

Branched from the tip of `feat/cli-model-access`, so this release PR also carries the `fluree model` governance tooling (#1516). After merge, tag the merge commit `v4.1.3` to trigger cargo-dist per docs/contributing/releasing.md.