### PR TITLE
fix(iceberg): fail closed on merge-on-read delete files (silent stale-row risk)

### DIFF
--- a/docs/graph-sources/iceberg.md
+++ b/docs/graph-sources/iceberg.md
@@ -525,6 +525,24 @@ ORDER BY DESC(?total)
 1. **Read-Only:** Iceberg graph sources are read-only (no writes via Fluree)
 2. **Complex Joins:** Large joins between Fluree and Iceberg may be slow
 3. **No Full-Text Search:** Use Fluree's BM25 for text search
+4. **Merge-on-read deletes are not yet applied (fail-closed):** Fluree reads the
+   live data files of a snapshot but does **not** apply Iceberg *merge-on-read*
+   position/equality delete files. To avoid silently returning deleted rows (or
+   over-counting `COUNT(*)`/row totals), a query over a snapshot that carries
+   delete files is **refused** with a `Merge-on-read deletes not applied` error.
+   Copy-on-write deletes (the Snowflake-managed v2 default today) rewrite data
+   files and are handled correctly — this only affects tables written with
+   merge-on-read semantics (e.g. Athena `DELETE`, Flink/CDC upserts, Snowflake v3
+   deletion vectors, or Snowflake v2 once `ENABLE_ICEBERG_MERGE_ON_READ` is on).
+   See the switch below to override.
+
+### Environment switches
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `FLUREE_ICEBERG_ALLOW_MOR_DELETES` | off | When truthy (`1`/`true`/`yes`/`on`), **disables** the fail-closed merge-on-read guard: delete files are ignored and the read proceeds. **Results may include deleted rows and row counts may be over-counted.** A one-time warning is logged per table. |
+| `FLUREE_ICEBERG_PREDICATE_PUSHDOWN` | on | When falsy (`0`/`false`/`off`), disables row-group / row-level predicate pushdown during Parquet reads. |
+| `FLUREE_ICEBERG_INFO_COUNT_BUDGET_MS` | `10000` | Wall-clock budget for the virtual `/info` row-count fetch; `0` returns structure only. |
 
 ## Troubleshooting
 

--- a/fluree-db-api/src/error.rs
+++ b/fluree-db-api/src/error.rs
@@ -190,6 +190,20 @@ pub enum ApiError {
     #[error("Credential error: {0}")]
     Credential(#[from] fluree_db_credential::CredentialError),
 
+    /// Iceberg graph-source errors (requires `iceberg` feature).
+    ///
+    /// Preserves the typed discriminant from `fluree_db_iceberg` — notably
+    /// [`fluree_db_iceberg::IcebergError::MergeOnReadDeletes`], which the
+    /// fail-closed MoR guard raises for a correctly-configured table that merely
+    /// carries delete files (a 409 Conflict, not a 400 config error). Display is
+    /// the inner error verbatim (no prefix) so the guard's actionable message —
+    /// including the `merge-on-read` substring the CLI/solo classifiers match on
+    /// and the `FLUREE_ICEBERG_ALLOW_MOR_DELETES` override name — reaches the
+    /// caller unchanged.
+    #[cfg(feature = "iceberg")]
+    #[error("{0}")]
+    Iceberg(#[from] fluree_db_iceberg::IcebergError),
+
     /// Core/Storage errors
     #[error("Core error: {0}")]
     Core(#[from] fluree_db_core::Error),
@@ -399,6 +413,15 @@ impl ApiError {
             ApiError::Http { status, .. } => *status,
             #[cfg(feature = "credential")]
             ApiError::Credential(e) => e.status_code(),
+            // A correctly-configured Iceberg table that merely carries
+            // merge-on-read delete files is a conflict (unsupported state), not
+            // bad input — 409. Other Iceberg errors preserve the pre-typed-variant
+            // 400 (they previously flowed through `ApiError::config`).
+            #[cfg(feature = "iceberg")]
+            ApiError::Iceberg(e) => match e {
+                fluree_db_iceberg::IcebergError::MergeOnReadDeletes(_) => 409,
+                _ => 400,
+            },
             ApiError::InvalidBranch(_) => 400,
             ApiError::BranchConflict(_) => 409,
             ApiError::NotFound(_) => 404,

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -242,6 +242,13 @@ pub(crate) const DISTINCT_COUNT_WARNING: &str =
     "distinct_count (NDV) is unavailable from metadata alone; it requires column \
      profiling and is deferred to PR-5.";
 
+/// Caveat pushed onto a preview that proceeded past the fail-closed MoR guard
+/// under the `FLUREE_ICEBERG_ALLOW_MOR_DELETES` override: its counts include
+/// deleted rows and are therefore upper bounds. Shared by both preview tiers.
+const MOR_UPPER_BOUND_WARNING: &str =
+    "Table has merge-on-read delete files; row/value/null counts are upper bounds \
+     (position/equality deletes are not subtracted).";
+
 /// Which statistics tier a preview should compute.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -584,6 +591,42 @@ pub(crate) fn table_schema_from_metadata(
     })
 }
 
+/// Run the zero-I/O snapshot-summary MoR guard (audit F-AUD-1) that BOTH preview
+/// tiers share, BEFORE any summary-derived count is surfaced. The Schema tier
+/// fills `row_count` from `total-records` and the Stats tier aggregates over the
+/// live data files; neither subtracts merge-on-read deletes, so both over-count a
+/// MoR snapshot. Mirrors the two scan planners (`ensure_summary_scannable`), so
+/// the preview can no longer return silent over-counts the planners would refuse.
+///
+/// Returns the operator override flag (`FLUREE_ICEBERG_ALLOW_MOR_DELETES`) so the
+/// Stats-tier manifest-list backstop reuses it and the env is read exactly once.
+/// `table_display` is the W2 "qualified (location)" identifier. Extracted so the
+/// two-tier guard is unit-testable without a live catalog.
+fn preview_summary_guard(metadata: &TableMetadata, table_display: &str) -> Result<bool> {
+    match metadata.current_snapshot() {
+        Some(snapshot) => Ok(fluree_db_iceberg::ensure_summary_scannable(
+            snapshot,
+            table_display,
+        )?),
+        // No current snapshot ⇒ no counts to over-count; still surface the
+        // override flag for the (delete-free) Stats manifest path.
+        None => Ok(fluree_db_iceberg::mor_deletes_allowed()),
+    }
+}
+
+/// Whether a proceeded preview must caveat that its counts are upper bounds: true
+/// iff the read proceeded under the override AND either delete signal fired — the
+/// manifest-list (`has_delete_files`) or the snapshot summary. The summary arm
+/// covers a delete manifest that mis-parsed as data (F-AUD-1 sub-claim (a)), the
+/// gap that made the preview's two "signals" effectively one.
+fn preview_counts_are_upper_bounds(
+    allow_mor: bool,
+    has_delete_files: bool,
+    summary_deletes: bool,
+) -> bool {
+    allow_mor && (has_delete_files || summary_deletes)
+}
+
 /// Preview an Iceberg table's schema (Tier-A) and, at `tier = Stats`, its
 /// per-column statistics (Tier-B).
 ///
@@ -613,19 +656,41 @@ pub async fn preview_iceberg_table(
         ))
     })?;
 
+    // W2: name BOTH the catalog-qualified table and its storage location, so an
+    // operator grepping logs finds the same identifier the scan planners emit
+    // (they pass the location) plus the friendlier qualified name.
+    let table_display = format!("{} ({})", table.qualified(), metadata.location);
+
+    // D1 (audit F-AUD-1): run the summary MoR guard for EVERY tier before any
+    // summary-derived count is surfaced. Returns the override flag reused by the
+    // Stats-tier manifest backstop below.
+    let allow_mor = preview_summary_guard(metadata, &table_display)?;
+
     let mut schema = table_schema_from_metadata(&table, metadata)?;
 
     match tier {
-        StatsTier::Schema => Ok(TablePreview {
-            schema,
-            stats_completeness: StatsCompleteness {
-                tier: "schema".to_string(),
-                manifests_read: 0,
-                had_column_bounds: false,
-                has_delete_files: false,
-            },
-            warnings: Vec::new(),
-        }),
+        StatsTier::Schema => {
+            // Schema tier reads no manifests (`has_delete_files` stays false), but
+            // its `row_count` comes from `total-records`, which over-counts a MoR
+            // snapshot. Under the override the guard proceeded, so caveat the count.
+            let mut warnings = Vec::new();
+            let summary_deletes = metadata
+                .current_snapshot()
+                .is_some_and(fluree_db_iceberg::summary_indicates_deletes);
+            if preview_counts_are_upper_bounds(allow_mor, false, summary_deletes) {
+                warnings.push(MOR_UPPER_BOUND_WARNING.to_string());
+            }
+            Ok(TablePreview {
+                schema,
+                stats_completeness: StatsCompleteness {
+                    tier: "schema".to_string(),
+                    manifests_read: 0,
+                    had_column_bounds: false,
+                    has_delete_files: false,
+                },
+                warnings,
+            })
+        }
         StatsTier::Stats => {
             let mut warnings = vec![DISTINCT_COUNT_WARNING.to_string()];
 
@@ -677,24 +742,27 @@ pub async fn preview_iceberg_table(
                     schema.total_bytes = schema.total_bytes.or(Some(agg.total_bytes));
 
                     if has_delete_files {
-                        // Fail closed (F-AUD-1): the aggregated row/value/null
-                        // counts sum live data-file records and do NOT subtract
-                        // merge-on-read deletes, so they over-count. Refuse unless
-                        // the operator opted out via FLUREE_ICEBERG_ALLOW_MOR_DELETES.
-                        let allow_mor = fluree_db_iceberg::mor_deletes_allowed();
+                        // Manifest-list backstop (F-AUD-1): the aggregated
+                        // row/value/null counts sum live data-file records and do
+                        // NOT subtract merge-on-read deletes, so they over-count.
+                        // Reuse the hoisted override flag (env read once) and raise
+                        // the TYPED error (W3) so the 409 discriminant survives
+                        // instead of flattening to a 400 "Invalid configuration".
                         fluree_db_iceberg::ensure_no_delete_manifests(
                             usize::from(has_delete_files),
-                            &table.qualified(),
+                            &table_display,
                             allow_mor,
-                        )
-                        .map_err(|e| crate::ApiError::config(e.to_string()))?;
-                        // Only reached under the override: surface the caveat.
-                        warnings.push(
-                            "Table has merge-on-read delete files; aggregated row/value/null \
-                                 counts are upper bounds (position/equality deletes are not \
-                                 subtracted)."
-                                .to_string(),
-                        );
+                        )?;
+                    }
+                    // Reachable only under the override once a delete signal fired;
+                    // caveat the counts regardless of WHICH signal saw them (the
+                    // summary arm covers a delete manifest that mis-parsed as data).
+                    if preview_counts_are_upper_bounds(
+                        allow_mor,
+                        has_delete_files,
+                        fluree_db_iceberg::summary_indicates_deletes(snapshot),
+                    ) {
+                        warnings.push(MOR_UPPER_BOUND_WARNING.to_string());
                     }
 
                     (manifests_read, agg.had_column_bounds, has_delete_files)
@@ -990,6 +1058,75 @@ mod tests {
                 .await
                 .expect_err("Direct mode must not be previewable");
         assert!(err.to_string().contains("Direct catalog mode"));
+    }
+
+    /// Clone `SAMPLE_METADATA` and inject a merge-on-read delete counter into the
+    /// CURRENT snapshot summary, so the summary-signal guard fires.
+    fn metadata_with_summary_deletes() -> TableMetadata {
+        let mut metadata = TableMetadata::from_json_str(SAMPLE_METADATA).unwrap();
+        let cur_id = metadata.current_snapshot_id.unwrap();
+        let cur = metadata
+            .snapshots
+            .iter_mut()
+            .find(|s| s.snapshot_id == cur_id)
+            .expect("current snapshot present");
+        cur.summary
+            .insert("total-position-deletes".to_string(), "3".to_string());
+        metadata
+    }
+
+    #[test]
+    fn preview_summary_guard_refuses_mor_deletes_for_both_tiers() {
+        // D1: the summary guard runs BEFORE the tier split, so a single refusal
+        // covers Schema AND Stats (the tier arms are unreachable once it errors).
+        // Guard active: FLUREE_ICEBERG_ALLOW_MOR_DELETES is unset in the test env.
+        let metadata = metadata_with_summary_deletes();
+        let err = preview_summary_guard(&metadata, "DW.SALES (s3://bucket/dw/sales)")
+            .expect_err("summary-reported deletes must refuse");
+        // W3: typed error → 409 Conflict, not a 400 config error.
+        assert_eq!(
+            err.status_code(),
+            409,
+            "MoR refusal is a 409 conflict, not 400 config"
+        );
+        let msg = err.to_string();
+        assert!(
+            !msg.starts_with("Invalid configuration"),
+            "typed variant must not flatten to a config error: {msg}"
+        );
+        assert!(
+            msg.contains("merge-on-read"),
+            "guard message verbatim: {msg}"
+        );
+        assert!(
+            msg.contains("FLUREE_ICEBERG_ALLOW_MOR_DELETES"),
+            "names the override switch: {msg}"
+        );
+        // W2: both identifiers are present in the refusal.
+        assert!(msg.contains("DW.SALES"), "names the qualified table: {msg}");
+        assert!(
+            msg.contains("s3://bucket/dw/sales"),
+            "names the storage location: {msg}"
+        );
+    }
+
+    #[test]
+    fn preview_summary_guard_allows_clean_table() {
+        // No delete counters + guard active ⇒ proceed; override flag off in the
+        // test env.
+        let metadata = TableMetadata::from_json_str(SAMPLE_METADATA).unwrap();
+        assert!(!preview_summary_guard(&metadata, "DW.SALES (s3://bucket/dw/sales)").unwrap());
+    }
+
+    #[test]
+    fn preview_upper_bound_caveat_only_under_override_with_deletes() {
+        // Reached only when the read proceeded under the override AND a delete
+        // signal fired; the summary arm covers a delete manifest that mis-parsed
+        // to `has_delete_files = false` (the D1 two-signal gap).
+        assert!(preview_counts_are_upper_bounds(true, true, false));
+        assert!(preview_counts_are_upper_bounds(true, false, true));
+        assert!(!preview_counts_are_upper_bounds(true, false, false));
+        assert!(!preview_counts_are_upper_bounds(false, true, true));
     }
 
     /// Preview surfaces the emitter's canonical `xsd_datatype` map (pinned at

--- a/fluree-db-api/src/graph_source/iceberg_catalog.rs
+++ b/fluree-db-api/src/graph_source/iceberg_catalog.rs
@@ -677,6 +677,18 @@ pub async fn preview_iceberg_table(
                     schema.total_bytes = schema.total_bytes.or(Some(agg.total_bytes));
 
                     if has_delete_files {
+                        // Fail closed (F-AUD-1): the aggregated row/value/null
+                        // counts sum live data-file records and do NOT subtract
+                        // merge-on-read deletes, so they over-count. Refuse unless
+                        // the operator opted out via FLUREE_ICEBERG_ALLOW_MOR_DELETES.
+                        let allow_mor = fluree_db_iceberg::mor_deletes_allowed();
+                        fluree_db_iceberg::ensure_no_delete_manifests(
+                            usize::from(has_delete_files),
+                            &table.qualified(),
+                            allow_mor,
+                        )
+                        .map_err(|e| crate::ApiError::config(e.to_string()))?;
+                        // Only reached under the override: surface the caveat.
                         warnings.push(
                             "Table has merge-on-read delete files; aggregated row/value/null \
                                  counts are upper bounds (position/equality deletes are not \

--- a/fluree-db-iceberg/src/error.rs
+++ b/fluree-db-iceberg/src/error.rs
@@ -49,6 +49,12 @@ pub enum IcebergError {
     #[error("Scan error: {0}")]
     Scan(String),
 
+    /// Merge-on-read delete files are present but not yet applied. Raised by the
+    /// fail-closed guard (see [`crate::mor_guard`]) rather than silently
+    /// returning deleted rows / over-counting. Audit finding F-AUD-1.
+    #[error("Merge-on-read deletes not applied: {0}")]
+    MergeOnReadDeletes(String),
+
     /// Unsupported file format
     #[error("Unsupported file format: {0}")]
     UnsupportedFormat(String),
@@ -85,6 +91,10 @@ impl IcebergError {
 
     pub fn scan(msg: impl Into<String>) -> Self {
         Self::Scan(msg.into())
+    }
+
+    pub fn merge_on_read_deletes(msg: impl Into<String>) -> Self {
+        Self::MergeOnReadDeletes(msg.into())
     }
 
     pub fn unsupported_format(msg: impl Into<String>) -> Self {

--- a/fluree-db-iceberg/src/lib.rs
+++ b/fluree-db-iceberg/src/lib.rs
@@ -60,6 +60,7 @@ pub mod error;
 pub mod io;
 pub mod manifest;
 pub mod metadata;
+pub mod mor_guard;
 pub mod net;
 pub mod scan;
 pub mod stats;
@@ -68,6 +69,10 @@ pub mod stats;
 pub use config::{CatalogConfig, IcebergGsConfig, IoConfig, MappingSource, TableConfig};
 pub use config_value::ConfigValue;
 pub use error::{IcebergError, Result};
+pub use mor_guard::{
+    ensure_no_delete_manifests, ensure_no_summary_deletes, mor_deletes_allowed,
+    ALLOW_MOR_DELETES_ENV,
+};
 
 // Re-export Phase 2 types for convenience
 pub use io::{BatchSchema, Column, ColumnBatch, FieldInfo, FieldType, IcebergStorage};

--- a/fluree-db-iceberg/src/lib.rs
+++ b/fluree-db-iceberg/src/lib.rs
@@ -71,7 +71,8 @@ pub use config_value::ConfigValue;
 pub use error::{IcebergError, Result};
 pub use mor_guard::{
     ensure_manifests_scannable, ensure_no_delete_manifests, ensure_no_summary_deletes,
-    ensure_summary_scannable, mor_deletes_allowed, ALLOW_MOR_DELETES_ENV,
+    ensure_summary_scannable, mor_deletes_allowed, summary_indicates_deletes,
+    ALLOW_MOR_DELETES_ENV,
 };
 
 // Re-export Phase 2 types for convenience

--- a/fluree-db-iceberg/src/lib.rs
+++ b/fluree-db-iceberg/src/lib.rs
@@ -70,8 +70,8 @@ pub use config::{CatalogConfig, IcebergGsConfig, IoConfig, MappingSource, TableC
 pub use config_value::ConfigValue;
 pub use error::{IcebergError, Result};
 pub use mor_guard::{
-    ensure_no_delete_manifests, ensure_no_summary_deletes, mor_deletes_allowed,
-    ALLOW_MOR_DELETES_ENV,
+    ensure_manifests_scannable, ensure_no_delete_manifests, ensure_no_summary_deletes,
+    ensure_summary_scannable, mor_deletes_allowed, ALLOW_MOR_DELETES_ENV,
 };
 
 // Re-export Phase 2 types for convenience

--- a/fluree-db-iceberg/src/metadata/snapshot.rs
+++ b/fluree-db-iceberg/src/metadata/snapshot.rs
@@ -86,6 +86,32 @@ impl Snapshot {
             .get("deleted-records")
             .and_then(|s| s.parse().ok())
     }
+
+    /// Get the total number of merge-on-read **delete files** from the snapshot
+    /// summary (`total-delete-files`), if present. A value `> 0` means the
+    /// snapshot carries position/equality delete files that Fluree does not yet
+    /// apply — see [`crate::mor_guard`].
+    pub fn total_delete_files(&self) -> Option<i64> {
+        self.summary
+            .get("total-delete-files")
+            .and_then(|s| s.parse().ok())
+    }
+
+    /// Get the total number of merge-on-read **position deletes** from the
+    /// snapshot summary (`total-position-deletes`), if present.
+    pub fn total_position_deletes(&self) -> Option<i64> {
+        self.summary
+            .get("total-position-deletes")
+            .and_then(|s| s.parse().ok())
+    }
+
+    /// Get the total number of merge-on-read **equality deletes** from the
+    /// snapshot summary (`total-equality-deletes`), if present.
+    pub fn total_equality_deletes(&self) -> Option<i64> {
+        self.summary
+            .get("total-equality-deletes")
+            .and_then(|s| s.parse().ok())
+    }
 }
 
 /// Snapshot selection criteria for time travel queries.
@@ -243,6 +269,31 @@ mod tests {
         assert_eq!(snap.operation(), Some("append"));
         assert_eq!(snap.added_records(), Some(50));
         assert_eq!(snap.deleted_records(), Some(10));
+        // This append snapshot carries no delete-file counters.
+        assert_eq!(snap.total_delete_files(), None);
+        assert_eq!(snap.total_position_deletes(), None);
+        assert_eq!(snap.total_equality_deletes(), None);
+    }
+
+    #[test]
+    fn test_mor_delete_summary_accessors() {
+        let mut summary = HashMap::new();
+        summary.insert("total-delete-files".to_string(), "2".to_string());
+        summary.insert("total-position-deletes".to_string(), "17".to_string());
+        summary.insert("total-equality-deletes".to_string(), "0".to_string());
+        let snap = Snapshot {
+            snapshot_id: 1,
+            parent_snapshot_id: None,
+            sequence_number: 1,
+            timestamp_ms: 1000,
+            manifest_list: Some("path".to_string()),
+            manifests: None,
+            summary,
+            schema_id: None,
+        };
+        assert_eq!(snap.total_delete_files(), Some(2));
+        assert_eq!(snap.total_position_deletes(), Some(17));
+        assert_eq!(snap.total_equality_deletes(), Some(0));
     }
 
     #[test]

--- a/fluree-db-iceberg/src/mor_guard.rs
+++ b/fluree-db-iceberg/src/mor_guard.rs
@@ -61,26 +61,72 @@ fn env_truthy(value: Option<&str>) -> bool {
     )
 }
 
+/// The three snapshot-summary counters that report merge-on-read delete files.
+/// The Iceberg spec types `summary` as `map<string,string>` with these as
+/// string-encoded integers, so a conforming writer never emits a non-integer.
+const SUMMARY_DELETE_KEYS: [&str; 3] = [
+    "total-delete-files",
+    "total-position-deletes",
+    "total-equality-deletes",
+];
+
+/// Scan the summary delete counters with **fail-closed** semantics, returning a
+/// human-readable evidence fragment for every counter that indicates — or might
+/// indicate — deletes. A counter contributes evidence when it is *present* and
+/// either fails to parse as `i64` or parses to a non-zero value (a negative is
+/// treated as deletes-present, not clamped to zero). An *absent* counter
+/// contributes nothing: the manifest-list check ([`ensure_no_delete_manifests`])
+/// is the backstop for writers that omit the counters. An empty result means the
+/// summary is clean.
+///
+/// The distinction between "absent" and "present-but-unparseable" has to be drawn
+/// here, on the raw `summary` map: the typed accessors on [`Snapshot`] collapse
+/// both to `None`, which would let a garbled counter read as zero (fail-open) —
+/// the exact hole this guard closes.
+fn summary_delete_evidence(snapshot: &Snapshot) -> Vec<String> {
+    let mut evidence = Vec::new();
+    for key in SUMMARY_DELETE_KEYS {
+        let Some(raw) = snapshot.summary.get(key) else {
+            continue; // absent → manifest-list backstop covers it
+        };
+        match raw.parse::<i64>() {
+            Ok(0) => {}
+            Ok(n) if n < 0 => evidence.push(format!("{key}={n} (negative)")),
+            Ok(n) => evidence.push(format!("{key}={n}")),
+            Err(_) => evidence.push(format!("{key}={raw:?} (unparseable)")),
+        }
+    }
+    evidence
+}
+
+/// Whether the snapshot summary indicates (or, fail-closed, might indicate)
+/// merge-on-read delete files: any present counter that is non-zero, negative, or
+/// unparseable. Used to caveat a read that proceeds under the override
+/// ([`ALLOW_MOR_DELETES_ENV`]) — its row/COUNT totals are then upper bounds.
+pub fn summary_indicates_deletes(snapshot: &Snapshot) -> bool {
+    !summary_delete_evidence(snapshot).is_empty()
+}
+
 /// Fail closed if the snapshot **summary** reports any merge-on-read delete
-/// files. Zero extra I/O: `snapshot.summary` is already loaded. An absent
-/// counter reads as `0` (the manifest-list check in [`ensure_no_delete_manifests`]
-/// is the backstop for writers that omit the counters).
+/// files. Zero extra I/O: `snapshot.summary` is already loaded. A *present*
+/// counter that is non-zero, negative, or unparseable refuses; only an *absent*
+/// counter proceeds (the manifest-list check in [`ensure_no_delete_manifests`] is
+/// the backstop for writers that omit the counters). Failing closed on a
+/// malformed value has ~zero false-positive risk against a spec-conforming writer
+/// (the counters are always string-encoded integers).
 ///
 /// `allowed` is the operator opt-out ([`mor_deletes_allowed`]); pass it in so
 /// callers read the env once and this stays pure/testable.
 pub fn ensure_no_summary_deletes(snapshot: &Snapshot, table: &str, allowed: bool) -> Result<()> {
-    let files = snapshot.total_delete_files().unwrap_or(0).max(0);
-    let pos = snapshot.total_position_deletes().unwrap_or(0).max(0);
-    let eq = snapshot.total_equality_deletes().unwrap_or(0).max(0);
-    if files == 0 && pos == 0 && eq == 0 {
+    let evidence = summary_delete_evidence(snapshot);
+    if evidence.is_empty() {
         return Ok(());
     }
     decide(
         table,
         &format!(
-            "snapshot summary reports merge-on-read delete files \
-             (total-delete-files={files}, total-position-deletes={pos}, \
-             total-equality-deletes={eq})"
+            "snapshot summary reports merge-on-read delete files ({})",
+            evidence.join(", ")
         ),
         allowed,
     )
@@ -284,18 +330,89 @@ mod tests {
     }
 
     #[test]
+    fn summary_unparseable_counter_refuses() {
+        // W1: a present-but-unparseable counter must FAIL CLOSED (read as
+        // deletes-present), not silently read as zero via `.parse().ok()`.
+        let snap = snapshot_with(&[("total-delete-files", "garbage")]);
+        let err = ensure_no_summary_deletes(&snap, "t", false).unwrap_err();
+        assert!(matches!(err, IcebergError::MergeOnReadDeletes(_)));
+        assert!(
+            err.to_string().contains("garbage"),
+            "evidence names the malformed value: {err}"
+        );
+    }
+
+    #[test]
+    fn summary_negative_counter_refuses() {
+        // W1: a negative counter is nonsensical for a count; fail closed rather
+        // than clamp-to-zero-and-proceed.
+        let snap = snapshot_with(&[("total-position-deletes", "-1")]);
+        assert!(ensure_no_summary_deletes(&snap, "t", false).is_err());
+    }
+
+    #[test]
+    fn summary_absent_counters_proceed() {
+        // W1: absent counters still proceed here — the manifest-list backstop
+        // covers omission — and are not flagged by `summary_indicates_deletes`.
+        let snap = snapshot_with(&[("total-records", "1000"), ("operation", "append")]);
+        assert!(ensure_no_summary_deletes(&snap, "t", false).is_ok());
+        assert!(!summary_indicates_deletes(&snap));
+    }
+
+    #[test]
+    fn summary_indicates_deletes_classifies_counters() {
+        // Non-zero / unparseable ⇒ deletes; zero / absent ⇒ clean.
+        assert!(summary_indicates_deletes(&snapshot_with(&[(
+            "total-delete-files",
+            "1"
+        )])));
+        assert!(summary_indicates_deletes(&snapshot_with(&[(
+            "total-equality-deletes",
+            "garbage"
+        )])));
+        assert!(!summary_indicates_deletes(&snapshot_with(&[(
+            "total-delete-files",
+            "0"
+        )])));
+        assert!(!summary_indicates_deletes(&snapshot_with(&[(
+            "total-records",
+            "5"
+        )])));
+    }
+
+    #[test]
     fn error_message_is_actionable() {
-        // (d) the error names the table and the override switch verbatim.
+        // W2: the refusal must name the identifier the REAL call sites pass, the
+        // override switch, and the risk. The scan planners pass `metadata.location`
+        // (`scan/planner.rs`, `scan/send_planner.rs`); the preview passes
+        // "qualified (location)" (`fluree-db-api` `iceberg_catalog.rs`). Assert
+        // both shapes so the test tracks what the sites actually emit, not a bare
+        // literal no site produces.
         let snap = snapshot_with(&[("total-delete-files", "9")]);
-        let msg = ensure_no_summary_deletes(&snap, "dw.dim_customer", false)
+
+        // Planner shape: storage location only.
+        let location = "s3://bucket/dw/dim_customer";
+        let msg = ensure_no_summary_deletes(&snap, location, false)
             .unwrap_err()
             .to_string();
-        assert!(msg.contains("dw.dim_customer"), "names the table: {msg}");
+        assert!(msg.contains(location), "names the storage location: {msg}");
         assert!(
             msg.contains(ALLOW_MOR_DELETES_ENV),
             "names the override switch: {msg}"
         );
         assert!(msg.contains("deleted rows"), "explains the risk: {msg}");
+
+        // Preview shape: catalog-qualified name AND storage location, so an
+        // operator grepping logs from either path finds a common identifier.
+        let preview_id = format!("dw.dim_customer ({location})");
+        let msg = ensure_no_summary_deletes(&snap, &preview_id, false)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            msg.contains("dw.dim_customer"),
+            "names the qualified table: {msg}"
+        );
+        assert!(msg.contains(location), "names the storage location: {msg}");
     }
 
     #[test]

--- a/fluree-db-iceberg/src/mor_guard.rs
+++ b/fluree-db-iceberg/src/mor_guard.rs
@@ -32,6 +32,7 @@ use std::collections::HashSet;
 use std::sync::Mutex;
 
 use crate::error::{IcebergError, Result};
+use crate::manifest::ManifestListEntry;
 use crate::metadata::Snapshot;
 
 /// Environment switch that disables the fail-closed MoR delete guard.
@@ -104,6 +105,29 @@ pub fn ensure_no_delete_manifests(
         &format!("manifest list contains {delete_manifests} merge-on-read delete manifest(s)"),
         allowed,
     )
+}
+
+/// Read the override switch once and apply the zero-I/O summary-counter guard
+/// (before the manifest-list read). Returns the override flag to thread into the
+/// post-read [`ensure_manifests_scannable`] check. Both scan planners call this
+/// pair so the fail-closed guard cannot drift between them (audit F-AUD-1).
+pub fn ensure_summary_scannable(snapshot: &Snapshot, table: &str) -> Result<bool> {
+    let allowed = mor_deletes_allowed();
+    ensure_no_summary_deletes(snapshot, table, allowed)?;
+    Ok(allowed)
+}
+
+/// Belt-and-suspenders guard over an already-parsed manifest list: refuse if any
+/// `content=1` delete manifest is present (covers a snapshot whose summary omits
+/// the counters). `allowed` is the override returned by [`ensure_summary_scannable`].
+/// Shared by both scan planners so the count-and-check cannot drift.
+pub fn ensure_manifests_scannable(
+    entries: &[ManifestListEntry],
+    table: &str,
+    allowed: bool,
+) -> Result<()> {
+    let delete_manifests = entries.iter().filter(|e| e.is_deletes()).count();
+    ensure_no_delete_manifests(delete_manifests, table, allowed)
 }
 
 /// Shared decision: refuse (fail-closed) unless the operator opted out, in which
@@ -209,6 +233,54 @@ mod tests {
         assert!(ensure_no_delete_manifests(0, "t", false).is_ok());
         assert!(ensure_no_delete_manifests(2, "t", false).is_err());
         assert!(ensure_no_delete_manifests(2, "t", true).is_ok());
+    }
+
+    #[test]
+    fn summary_scannable_returns_override_and_refuses_deletes() {
+        // The shared planner helper: a delete-free snapshot proceeds and reports
+        // the override flag (false in the test env); a delete-bearing one refuses.
+        let clean = snapshot_with(&[("total-records", "10")]);
+        assert!(
+            !ensure_summary_scannable(&clean, "t").unwrap(),
+            "override is off in the test env"
+        );
+        let dirty = snapshot_with(&[("total-position-deletes", "1")]);
+        assert!(matches!(
+            ensure_summary_scannable(&dirty, "t"),
+            Err(IcebergError::MergeOnReadDeletes(_))
+        ));
+    }
+
+    #[test]
+    fn manifests_scannable_refuses_a_delete_manifest() {
+        use crate::manifest::ManifestContent;
+        fn entry(content: ManifestContent) -> ManifestListEntry {
+            ManifestListEntry {
+                manifest_path: "m.avro".to_string(),
+                manifest_length: 0,
+                partition_spec_id: 0,
+                content,
+                sequence_number: 0,
+                min_sequence_number: 0,
+                added_snapshot_id: 0,
+                added_data_files_count: 0,
+                existing_data_files_count: 0,
+                deleted_data_files_count: 0,
+                added_rows_count: 0,
+                existing_rows_count: 0,
+                deleted_rows_count: 0,
+                partitions: vec![],
+            }
+        }
+        // Only data manifests → proceeds.
+        assert!(ensure_manifests_scannable(&[entry(ManifestContent::Data)], "t", false).is_ok());
+        // A content=1 delete manifest → refuse (guard active); proceed under override.
+        let with_delete = [
+            entry(ManifestContent::Data),
+            entry(ManifestContent::Deletes),
+        ];
+        assert!(ensure_manifests_scannable(&with_delete, "t", false).is_err());
+        assert!(ensure_manifests_scannable(&with_delete, "t", true).is_ok());
     }
 
     #[test]

--- a/fluree-db-iceberg/src/mor_guard.rs
+++ b/fluree-db-iceberg/src/mor_guard.rs
@@ -1,0 +1,247 @@
+//! Fail-closed guard for Iceberg merge-on-read (MoR) delete files.
+//!
+//! Fluree's virtual Iceberg read path *recognizes* position/equality delete
+//! files (content=1 manifests) but does **not** apply them: it drops the delete
+//! manifests and reads only the live data files (see
+//! [`crate::scan::planner`] / [`crate::stats`]). On a table maintained with
+//! merge-on-read semantics that silently returns deleted rows as if live and
+//! over-counts `COUNT(*)` / row totals by the delete cardinality — a silent
+//! wrong answer, the worst failure class for a database. Copy-on-write deletes
+//! (which rewrite data files and mark old manifest entries `DELETED`) are
+//! handled correctly and are unaffected by this guard.
+//!
+//! Until delete application is implemented, this module **fails closed**: any
+//! read whose snapshot carries delete files is refused with an actionable typed
+//! error ([`IcebergError::MergeOnReadDeletes`]). Two independent signals are
+//! checked so a snapshot cannot slip through:
+//!
+//! 1. the snapshot summary counters (`total-delete-files` /
+//!    `total-position-deletes` / `total-equality-deletes`) — a zero-I/O check,
+//!    the summary is already in memory ([`ensure_no_summary_deletes`]); and
+//! 2. the manifest list — a delete manifest (`content=1`) present even when the
+//!    summary omits/under-counts it ([`ensure_no_delete_manifests`]).
+//!
+//! The refusal is disabled by the [`ALLOW_MOR_DELETES_ENV`] escape hatch
+//! (default off). When set truthy the old skip-and-proceed behavior is restored
+//! and a once-per-table warning is logged that results may include deleted rows.
+//!
+//! See audit finding F-AUD-1 (`audit-2026-07/00-MASTER-AUDIT.md`,
+//! `V1-mor-verification.md`) for the verified gap and exposure bounding.
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use crate::error::{IcebergError, Result};
+use crate::metadata::Snapshot;
+
+/// Environment switch that disables the fail-closed MoR delete guard.
+///
+/// Default (unset or falsy): the guard is **active** — reads over snapshots that
+/// carry delete files are refused. Truthy (`1` / `true` / `yes` / `on`,
+/// case-insensitive): the guard is disabled, the old behavior (delete files
+/// ignored) is restored, and a once-per-table warning is logged.
+pub const ALLOW_MOR_DELETES_ENV: &str = "FLUREE_ICEBERG_ALLOW_MOR_DELETES";
+
+/// Whether the operator has opted OUT of the fail-closed guard via
+/// [`ALLOW_MOR_DELETES_ENV`]. Read fresh on each call — this is only consulted
+/// on the (cold) metadata/scan-plan path, never per row.
+pub fn mor_deletes_allowed() -> bool {
+    env_truthy(std::env::var(ALLOW_MOR_DELETES_ENV).ok().as_deref())
+}
+
+/// Truthy semantics for the opt-out switch, matching the repo's `env_flag`
+/// default-off flags (`1`/`true`/`yes`/`on`, case-insensitive; anything else,
+/// including absent, is off). Split out from [`mor_deletes_allowed`] so it can be
+/// unit-tested without mutating the shared process environment.
+fn env_truthy(value: Option<&str>) -> bool {
+    matches!(
+        value.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
+}
+
+/// Fail closed if the snapshot **summary** reports any merge-on-read delete
+/// files. Zero extra I/O: `snapshot.summary` is already loaded. An absent
+/// counter reads as `0` (the manifest-list check in [`ensure_no_delete_manifests`]
+/// is the backstop for writers that omit the counters).
+///
+/// `allowed` is the operator opt-out ([`mor_deletes_allowed`]); pass it in so
+/// callers read the env once and this stays pure/testable.
+pub fn ensure_no_summary_deletes(snapshot: &Snapshot, table: &str, allowed: bool) -> Result<()> {
+    let files = snapshot.total_delete_files().unwrap_or(0).max(0);
+    let pos = snapshot.total_position_deletes().unwrap_or(0).max(0);
+    let eq = snapshot.total_equality_deletes().unwrap_or(0).max(0);
+    if files == 0 && pos == 0 && eq == 0 {
+        return Ok(());
+    }
+    decide(
+        table,
+        &format!(
+            "snapshot summary reports merge-on-read delete files \
+             (total-delete-files={files}, total-position-deletes={pos}, \
+             total-equality-deletes={eq})"
+        ),
+        allowed,
+    )
+}
+
+/// Fail closed if the manifest list carried any delete manifests (`content=1`).
+/// This is the backstop for snapshots whose summary omits or under-counts the
+/// delete counters — the manifest list is read on the scan/stats path anyway, so
+/// counting `is_deletes()` entries is free.
+///
+/// `delete_manifests` is the number of delete manifests observed (`0` proceeds).
+pub fn ensure_no_delete_manifests(
+    delete_manifests: usize,
+    table: &str,
+    allowed: bool,
+) -> Result<()> {
+    if delete_manifests == 0 {
+        return Ok(());
+    }
+    decide(
+        table,
+        &format!("manifest list contains {delete_manifests} merge-on-read delete manifest(s)"),
+        allowed,
+    )
+}
+
+/// Shared decision: refuse (fail-closed) unless the operator opted out, in which
+/// case warn once per table and proceed.
+fn decide(table: &str, evidence: &str, allowed: bool) -> Result<()> {
+    if allowed {
+        warn_once(table);
+        return Ok(());
+    }
+    Err(IcebergError::MergeOnReadDeletes(format!(
+        "Refusing to read Iceberg table `{table}`: {evidence}. Merge-on-read \
+         delete files are recognized but NOT applied yet, so query results would \
+         include deleted rows and COUNT/row totals would be over-counted. Set \
+         {ALLOW_MOR_DELETES_ENV}=1 to read anyway (results may include deleted rows)."
+    )))
+}
+
+/// Emit the "deletes ignored" warning at most once per table for the life of the
+/// process, so the opt-out does not spam the log on every query.
+fn warn_once(table: &str) {
+    static WARNED: Mutex<Option<HashSet<String>>> = Mutex::new(None);
+    let mut guard = WARNED
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let seen = guard.get_or_insert_with(HashSet::new);
+    if seen.insert(table.to_string()) {
+        tracing::warn!(
+            table = %table,
+            env = %ALLOW_MOR_DELETES_ENV,
+            "Iceberg merge-on-read delete files are being IGNORED (guard disabled via \
+             {ALLOW_MOR_DELETES_ENV}); query results may include deleted rows and row \
+             counts may be over-counted"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn snapshot_with(summary: &[(&str, &str)]) -> Snapshot {
+        Snapshot {
+            snapshot_id: 1,
+            parent_snapshot_id: None,
+            sequence_number: 1,
+            timestamp_ms: 1000,
+            manifest_list: Some("s3://b/t/metadata/snap.avro".to_string()),
+            manifests: None,
+            summary: summary
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect::<HashMap<_, _>>(),
+            schema_id: Some(0),
+        }
+    }
+
+    #[test]
+    fn summary_position_deletes_refused_when_guard_active() {
+        // total-position-deletes > 0 → refuse (guard active, allowed=false).
+        let snap = snapshot_with(&[
+            ("total-delete-files", "1"),
+            ("total-position-deletes", "42"),
+            ("total-equality-deletes", "0"),
+        ]);
+        let err = ensure_no_summary_deletes(&snap, "dw.fact_order_line", false).unwrap_err();
+        assert!(matches!(err, IcebergError::MergeOnReadDeletes(_)));
+    }
+
+    #[test]
+    fn summary_equality_deletes_refused_when_guard_active() {
+        // Equality deletes alone (CDC/Flink shape) must also refuse.
+        let snap = snapshot_with(&[("total-equality-deletes", "3")]);
+        assert!(ensure_no_summary_deletes(&snap, "t", false).is_err());
+    }
+
+    #[test]
+    fn summary_zero_or_absent_proceeds() {
+        // All-zero counters proceed (the deployed Snowflake v2 append shape).
+        let zeroed = snapshot_with(&[
+            ("total-delete-files", "0"),
+            ("total-position-deletes", "0"),
+            ("total-equality-deletes", "0"),
+        ]);
+        assert!(ensure_no_summary_deletes(&zeroed, "t", false).is_ok());
+        // Absent counters (summary omits them) also proceed at this check — the
+        // manifest-list backstop covers the omit case.
+        let absent = snapshot_with(&[("total-records", "1000"), ("operation", "append")]);
+        assert!(ensure_no_summary_deletes(&absent, "t", false).is_ok());
+    }
+
+    #[test]
+    fn summary_deletes_allowed_under_override() {
+        let snap = snapshot_with(&[("total-position-deletes", "5")]);
+        assert!(
+            ensure_no_summary_deletes(&snap, "t", true).is_ok(),
+            "override must let the read proceed"
+        );
+    }
+
+    #[test]
+    fn delete_manifests_refused_then_allowed_under_override() {
+        assert!(ensure_no_delete_manifests(0, "t", false).is_ok());
+        assert!(ensure_no_delete_manifests(2, "t", false).is_err());
+        assert!(ensure_no_delete_manifests(2, "t", true).is_ok());
+    }
+
+    #[test]
+    fn error_message_is_actionable() {
+        // (d) the error names the table and the override switch verbatim.
+        let snap = snapshot_with(&[("total-delete-files", "9")]);
+        let msg = ensure_no_summary_deletes(&snap, "dw.dim_customer", false)
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("dw.dim_customer"), "names the table: {msg}");
+        assert!(
+            msg.contains(ALLOW_MOR_DELETES_ENV),
+            "names the override switch: {msg}"
+        );
+        assert!(msg.contains("deleted rows"), "explains the risk: {msg}");
+    }
+
+    #[test]
+    fn env_override_parsing() {
+        // Pure parsing test — never touches the shared process env, so it can
+        // never race the fixture tests that call `mor_deletes_allowed()`.
+        assert!(!env_truthy(None), "absent defaults to guard-active");
+        for truthy in ["1", "true", "TRUE", "yes", "On", " on "] {
+            assert!(
+                env_truthy(Some(truthy)),
+                "{truthy:?} should disable the guard"
+            );
+        }
+        for falsy in ["0", "false", "off", "no", "", "maybe"] {
+            assert!(
+                !env_truthy(Some(falsy)),
+                "{falsy:?} should keep the guard active"
+            );
+        }
+    }
+}

--- a/fluree-db-iceberg/src/scan/planner.rs
+++ b/fluree-db-iceberg/src/scan/planner.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use crate::error::{IcebergError, Result};
 use crate::io::IcebergStorage;
-use crate::manifest::{parse_manifest, parse_manifest_list, DataFile};
+use crate::manifest::{parse_manifest, parse_manifest_list_with_deletes, DataFile};
 use crate::metadata::{Schema, Snapshot, TableMetadata};
 use crate::scan::predicate::Expression;
 use crate::scan::pruning::can_contain_file;
@@ -199,6 +199,12 @@ impl<'a, S: IcebergStorage> ScanPlanner<'a, S> {
         // Determine projection
         let (projected_field_ids, projected_columns) = self.resolve_projection(schema)?;
 
+        // Fail closed on merge-on-read delete files (F-AUD-1): the scan reads
+        // only live data files and never applies deletes, so a MoR snapshot
+        // would silently return deleted rows. Cheap zero-I/O check first.
+        let allow_mor = crate::mor_guard::mor_deletes_allowed();
+        crate::mor_guard::ensure_no_summary_deletes(snapshot, &self.metadata.location, allow_mor)?;
+
         // Load manifest list
         let manifest_list_path = snapshot.manifest_list.as_ref().ok_or_else(|| {
             IcebergError::Manifest(
@@ -207,7 +213,15 @@ impl<'a, S: IcebergStorage> ScanPlanner<'a, S> {
         })?;
 
         let manifest_list_data = self.storage.read(manifest_list_path).await?;
-        let manifest_entries = parse_manifest_list(&manifest_list_data)?;
+        // Parse WITH delete manifests so the belt-and-suspenders guard can DETECT
+        // them even when the snapshot summary omits/under-counts the counters.
+        let manifest_entries = parse_manifest_list_with_deletes(&manifest_list_data, true)?;
+        let delete_manifests = manifest_entries.iter().filter(|e| e.is_deletes()).count();
+        crate::mor_guard::ensure_no_delete_manifests(
+            delete_manifests,
+            &self.metadata.location,
+            allow_mor,
+        )?;
 
         tracing::debug!(
             manifest_count = manifest_entries.len(),
@@ -221,7 +235,9 @@ impl<'a, S: IcebergStorage> ScanPlanner<'a, S> {
         let mut estimated_row_count = 0i64;
 
         for manifest_entry in &manifest_entries {
-            // Skip delete manifests (already filtered by parse_manifest_list)
+            // Skip delete manifests. Under the guard's default they never reach
+            // here (refused above); under the override they are ignored (the
+            // documented, pre-guard behavior).
             if manifest_entry.is_deletes() {
                 continue;
             }
@@ -362,5 +378,190 @@ mod tests {
         assert!(task.residual_filter.is_none());
         assert_eq!(task.start, 0);
         assert_eq!(task.length, 10240);
+    }
+}
+
+/// Fail-closed merge-on-read guard, exercised end-to-end through `plan_scan`
+/// (F-AUD-1). These build a REAL Avro manifest list with a `content=1` delete
+/// manifest — the fixture that did not previously exist — so the CI actually
+/// covers the guard rather than asserting on a synthetic bool.
+#[cfg(test)]
+mod mor_guard_tests {
+    use super::*;
+    use crate::error::IcebergError;
+    use crate::io::MemoryStorage;
+    use crate::metadata::{Schema, SchemaField, Snapshot, TableMetadata};
+    use apache_avro::{types::Record, Schema as AvroSchema, Writer};
+    use bytes::Bytes;
+    use std::collections::HashMap;
+
+    const MANIFEST_LIST_SCHEMA: &str = r#"{
+      "type": "record",
+      "name": "manifest_file",
+      "fields": [
+        {"name": "manifest_path", "type": "string"},
+        {"name": "manifest_length", "type": "long"},
+        {"name": "partition_spec_id", "type": "int"},
+        {"name": "content", "type": "int", "default": 0},
+        {"name": "sequence_number", "type": "long", "default": 0},
+        {"name": "min_sequence_number", "type": "long", "default": 0},
+        {"name": "added_snapshot_id", "type": "long"},
+        {"name": "added_data_files_count", "type": "int", "default": 0},
+        {"name": "existing_data_files_count", "type": "int", "default": 0},
+        {"name": "deleted_data_files_count", "type": "int", "default": 0},
+        {"name": "added_rows_count", "type": "long", "default": 0},
+        {"name": "existing_rows_count", "type": "long", "default": 0},
+        {"name": "deleted_rows_count", "type": "long", "default": 0},
+        {"name": "partitions", "type": ["null", {"type": "array", "items": {
+          "type": "record", "name": "field_summary",
+          "fields": [{"name": "contains_null", "type": "boolean"}]
+        }}], "default": null}
+      ]
+    }"#;
+
+    /// Build a manifest-list Avro carrying the given `(path, content)` entries
+    /// (content 0 = data, 1 = delete).
+    fn build_manifest_list(entries: &[(&str, i32)]) -> Bytes {
+        let schema = AvroSchema::parse_str(MANIFEST_LIST_SCHEMA).unwrap();
+        let mut writer = Writer::new(&schema, Vec::new());
+        for (path, content) in entries {
+            let mut record = Record::new(writer.schema()).unwrap();
+            record.put("manifest_path", *path);
+            record.put("manifest_length", 100i64);
+            record.put("partition_spec_id", 0i32);
+            record.put("content", *content);
+            record.put("sequence_number", 1i64);
+            record.put("min_sequence_number", 1i64);
+            record.put("added_snapshot_id", 100i64);
+            record.put("added_data_files_count", 1i32);
+            record.put("existing_data_files_count", 0i32);
+            record.put("deleted_data_files_count", 0i32);
+            record.put("added_rows_count", 1000i64);
+            record.put("existing_rows_count", 0i64);
+            record.put("deleted_rows_count", 0i64);
+            record.put(
+                "partitions",
+                apache_avro::types::Value::Union(0, Box::new(apache_avro::types::Value::Null)),
+            );
+            writer.append(record).unwrap();
+        }
+        Bytes::from(writer.into_inner().unwrap())
+    }
+
+    fn one_field_schema() -> Schema {
+        Schema {
+            schema_id: 0,
+            identifier_field_ids: vec![1],
+            fields: vec![SchemaField {
+                id: 1,
+                name: "ID".to_string(),
+                required: true,
+                field_type: serde_json::json!("long"),
+                doc: None,
+            }],
+        }
+    }
+
+    /// A single-snapshot table whose current snapshot points at `list_path` and
+    /// carries `summary`.
+    fn metadata(list_path: &str, summary: &[(&str, &str)]) -> TableMetadata {
+        TableMetadata {
+            format_version: 2,
+            table_uuid: None,
+            location: "s3://bucket/dw/fact_orders".to_string(),
+            last_sequence_number: 1,
+            last_updated_ms: 1000,
+            last_column_id: 1,
+            current_schema_id: 0,
+            schemas: vec![one_field_schema()],
+            current_snapshot_id: Some(100),
+            snapshots: vec![Snapshot {
+                snapshot_id: 100,
+                parent_snapshot_id: None,
+                sequence_number: 1,
+                timestamp_ms: 1000,
+                manifest_list: Some(list_path.to_string()),
+                manifests: None,
+                summary: summary
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                    .collect::<HashMap<_, _>>(),
+                schema_id: Some(0),
+            }],
+            snapshot_log: vec![],
+            default_spec_id: 0,
+            partition_specs: vec![],
+            last_partition_id: 0,
+            sort_orders: vec![],
+            default_sort_order_id: 0,
+            properties: HashMap::new(),
+        }
+    }
+
+    // NOTE on the override arm: the "skipped under override" behavior is proven
+    // at the guard-function level (mor_guard::delete_manifests_refused_then_
+    // allowed_under_override) rather than here, because driving it through the
+    // planner would require mutating the shared process env, which races other
+    // tests. These planner tests assert the fail-CLOSED default only, so they
+    // never touch the env (mor_deletes_allowed() reads false throughout).
+
+    #[tokio::test]
+    async fn plan_scan_refuses_when_manifest_list_has_delete_manifest() {
+        // Summary omits the delete counters (a "summary lies/omits" snapshot);
+        // the belt-and-suspenders manifest-list check must still refuse.
+        let list_path = "s3://bucket/dw/fact_orders/metadata/snap.avro";
+        let mut mem = MemoryStorage::new();
+        mem.add_file(
+            list_path,
+            build_manifest_list(&[
+                ("s3://bucket/dw/fact_orders/metadata/m-data.avro", 0),
+                ("s3://bucket/dw/fact_orders/metadata/m-del.avro", 1),
+            ]),
+        );
+        let md = metadata(list_path, &[("total-records", "1000")]);
+        let planner = ScanPlanner::new(&mem, &md, ScanConfig::new());
+
+        let err = planner.plan_scan().await.unwrap_err();
+        assert!(
+            matches!(err, IcebergError::MergeOnReadDeletes(_)),
+            "expected fail-closed refusal, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_scan_refuses_on_summary_delete_counters() {
+        // The cheap zero-I/O arm: the summary carries delete counters, so the
+        // planner refuses before the manifest list is even read (the path here
+        // is intentionally absent from storage).
+        let md = metadata(
+            "s3://bucket/dw/fact_orders/metadata/never-read.avro",
+            &[("total-position-deletes", "42")],
+        );
+        let mem = MemoryStorage::new();
+        let planner = ScanPlanner::new(&mem, &md, ScanConfig::new());
+
+        let err = planner.plan_scan().await.unwrap_err();
+        assert!(
+            matches!(err, IcebergError::MergeOnReadDeletes(_)),
+            "expected fail-closed refusal from the summary counters, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_scan_proceeds_when_no_deletes() {
+        // Control: a delete-free snapshot plans normally (guard is a no-op). An
+        // empty manifest list (zero manifests) keeps the fixture minimal — the
+        // point is that the guard does not fire, not the file count.
+        let list_path = "s3://bucket/dw/fact_orders/metadata/snap.avro";
+        let mut mem = MemoryStorage::new();
+        mem.add_file(list_path, build_manifest_list(&[]));
+        let md = metadata(list_path, &[("total-records", "0")]);
+        let planner = ScanPlanner::new(&mem, &md, ScanConfig::new());
+
+        let plan = planner
+            .plan_scan()
+            .await
+            .expect("delete-free snapshot must plan");
+        assert_eq!(plan.files_selected, 0, "empty manifest list → no files");
     }
 }

--- a/fluree-db-iceberg/src/scan/planner.rs
+++ b/fluree-db-iceberg/src/scan/planner.rs
@@ -202,8 +202,8 @@ impl<'a, S: IcebergStorage> ScanPlanner<'a, S> {
         // Fail closed on merge-on-read delete files (F-AUD-1): the scan reads
         // only live data files and never applies deletes, so a MoR snapshot
         // would silently return deleted rows. Cheap zero-I/O check first.
-        let allow_mor = crate::mor_guard::mor_deletes_allowed();
-        crate::mor_guard::ensure_no_summary_deletes(snapshot, &self.metadata.location, allow_mor)?;
+        let allow_mor =
+            crate::mor_guard::ensure_summary_scannable(snapshot, &self.metadata.location)?;
 
         // Load manifest list
         let manifest_list_path = snapshot.manifest_list.as_ref().ok_or_else(|| {
@@ -216,9 +216,8 @@ impl<'a, S: IcebergStorage> ScanPlanner<'a, S> {
         // Parse WITH delete manifests so the belt-and-suspenders guard can DETECT
         // them even when the snapshot summary omits/under-counts the counters.
         let manifest_entries = parse_manifest_list_with_deletes(&manifest_list_data, true)?;
-        let delete_manifests = manifest_entries.iter().filter(|e| e.is_deletes()).count();
-        crate::mor_guard::ensure_no_delete_manifests(
-            delete_manifests,
+        crate::mor_guard::ensure_manifests_scannable(
+            &manifest_entries,
             &self.metadata.location,
             allow_mor,
         )?;

--- a/fluree-db-iceberg/src/scan/send_planner.rs
+++ b/fluree-db-iceberg/src/scan/send_planner.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::error::{IcebergError, Result};
 use crate::io::SendIcebergStorage;
-use crate::manifest::{parse_manifest, parse_manifest_list};
+use crate::manifest::{parse_manifest, parse_manifest_list_with_deletes};
 use crate::metadata::{Schema, Snapshot, TableMetadata};
 use crate::scan::planner::{FileScanTask, ScanConfig, ScanPlan};
 use crate::scan::pruning::can_contain_file;
@@ -81,6 +81,12 @@ impl<'a, S: SendIcebergStorage> SendScanPlanner<'a, S> {
         // Determine projection
         let (projected_field_ids, projected_columns) = self.resolve_projection(schema)?;
 
+        // Fail closed on merge-on-read delete files (F-AUD-1): the scan reads
+        // only live data files and never applies deletes, so a MoR snapshot
+        // would silently return deleted rows. Cheap zero-I/O check first.
+        let allow_mor = crate::mor_guard::mor_deletes_allowed();
+        crate::mor_guard::ensure_no_summary_deletes(snapshot, &self.metadata.location, allow_mor)?;
+
         // Load manifest list
         let manifest_list_path = snapshot.manifest_list.as_ref().ok_or_else(|| {
             IcebergError::Manifest(
@@ -89,7 +95,15 @@ impl<'a, S: SendIcebergStorage> SendScanPlanner<'a, S> {
         })?;
 
         let manifest_list_data = self.storage.read(manifest_list_path).await?;
-        let manifest_entries = parse_manifest_list(&manifest_list_data)?;
+        // Parse WITH delete manifests so the belt-and-suspenders guard can DETECT
+        // them even when the snapshot summary omits/under-counts the counters.
+        let manifest_entries = parse_manifest_list_with_deletes(&manifest_list_data, true)?;
+        let delete_manifests = manifest_entries.iter().filter(|e| e.is_deletes()).count();
+        crate::mor_guard::ensure_no_delete_manifests(
+            delete_manifests,
+            &self.metadata.location,
+            allow_mor,
+        )?;
 
         tracing::debug!(
             manifest_count = manifest_entries.len(),
@@ -103,7 +117,9 @@ impl<'a, S: SendIcebergStorage> SendScanPlanner<'a, S> {
         let mut estimated_row_count = 0i64;
 
         for manifest_entry in &manifest_entries {
-            // Skip delete manifests (already filtered by parse_manifest_list)
+            // Skip delete manifests. Under the guard's default they never reach
+            // here (refused above); under the override they are ignored (the
+            // documented, pre-guard behavior).
             if manifest_entry.is_deletes() {
                 continue;
             }

--- a/fluree-db-iceberg/src/scan/send_planner.rs
+++ b/fluree-db-iceberg/src/scan/send_planner.rs
@@ -81,11 +81,12 @@ impl<'a, S: SendIcebergStorage> SendScanPlanner<'a, S> {
         // Determine projection
         let (projected_field_ids, projected_columns) = self.resolve_projection(schema)?;
 
-        // Fail closed on merge-on-read delete files (F-AUD-1): the scan reads
-        // only live data files and never applies deletes, so a MoR snapshot
-        // would silently return deleted rows. Cheap zero-I/O check first.
-        let allow_mor = crate::mor_guard::mor_deletes_allowed();
-        crate::mor_guard::ensure_no_summary_deletes(snapshot, &self.metadata.location, allow_mor)?;
+        // Fail closed on merge-on-read delete files (F-AUD-1): the scan reads only
+        // live data files and never applies deletes, so a MoR snapshot would
+        // silently return deleted rows. Same shared guard as `ScanPlanner`: a
+        // zero-I/O summary check first, then the manifest-list belt-and-suspenders.
+        let allow_mor =
+            crate::mor_guard::ensure_summary_scannable(snapshot, &self.metadata.location)?;
 
         // Load manifest list
         let manifest_list_path = snapshot.manifest_list.as_ref().ok_or_else(|| {
@@ -98,9 +99,8 @@ impl<'a, S: SendIcebergStorage> SendScanPlanner<'a, S> {
         // Parse WITH delete manifests so the belt-and-suspenders guard can DETECT
         // them even when the snapshot summary omits/under-counts the counters.
         let manifest_entries = parse_manifest_list_with_deletes(&manifest_list_data, true)?;
-        let delete_manifests = manifest_entries.iter().filter(|e| e.is_deletes()).count();
-        crate::mor_guard::ensure_no_delete_manifests(
-            delete_manifests,
+        crate::mor_guard::ensure_manifests_scannable(
+            &manifest_entries,
             &self.metadata.location,
             allow_mor,
         )?;
@@ -201,5 +201,103 @@ impl<'a, S: SendIcebergStorage> SendScanPlanner<'a, S> {
                 Ok((field_ids, names))
             }
         }
+    }
+}
+
+/// The production COUNT/scan path routes through `SendScanPlanner` (r2rml
+/// `scan_table` → `SendScanPlanner::plan_scan`), so the fail-closed merge-on-read
+/// guard must fire here too — a COUNT over a delete-bearing snapshot refuses
+/// rather than returning an over-count (audit F-AUD-1, the table_row_count path).
+/// The runtime-agnostic `ScanPlanner` is covered separately; this proves the
+/// Send variant (which shares the guard helpers) inherits it.
+#[cfg(test)]
+mod mor_guard_tests {
+    use super::*;
+    use crate::metadata::SchemaField;
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use std::collections::HashMap;
+    use std::ops::Range;
+
+    /// A `SendIcebergStorage` that errors on every read. The zero-I/O summary
+    /// guard must refuse a delete-bearing snapshot BEFORE any manifest-list read,
+    /// so nothing here should ever be called.
+    #[derive(Debug)]
+    struct NoReadStorage;
+
+    #[async_trait]
+    impl SendIcebergStorage for NoReadStorage {
+        async fn read(&self, _path: &str) -> Result<Bytes> {
+            Err(IcebergError::storage(
+                "planner must not read: the summary guard should refuse first",
+            ))
+        }
+        async fn read_range(&self, _path: &str, _range: Range<u64>) -> Result<Bytes> {
+            Err(IcebergError::storage("planner must not read"))
+        }
+        async fn file_size(&self, _path: &str) -> Result<u64> {
+            Err(IcebergError::storage("planner must not read"))
+        }
+    }
+
+    fn metadata_with_summary(summary: &[(&str, &str)]) -> TableMetadata {
+        TableMetadata {
+            format_version: 2,
+            table_uuid: None,
+            location: "s3://bucket/dw/fact_orders".to_string(),
+            last_sequence_number: 1,
+            last_updated_ms: 1000,
+            last_column_id: 1,
+            current_schema_id: 0,
+            schemas: vec![Schema {
+                schema_id: 0,
+                identifier_field_ids: vec![1],
+                fields: vec![SchemaField {
+                    id: 1,
+                    name: "ID".to_string(),
+                    required: true,
+                    field_type: serde_json::json!("long"),
+                    doc: None,
+                }],
+            }],
+            current_snapshot_id: Some(100),
+            snapshots: vec![Snapshot {
+                snapshot_id: 100,
+                parent_snapshot_id: None,
+                sequence_number: 1,
+                timestamp_ms: 1000,
+                manifest_list: Some(
+                    "s3://bucket/dw/fact_orders/metadata/never-read.avro".to_string(),
+                ),
+                manifests: None,
+                summary: summary
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                    .collect::<HashMap<_, _>>(),
+                schema_id: Some(0),
+            }],
+            snapshot_log: vec![],
+            default_spec_id: 0,
+            partition_specs: vec![],
+            last_partition_id: 0,
+            sort_orders: vec![],
+            default_sort_order_id: 0,
+            properties: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_planner_refuses_delete_bearing_snapshot() {
+        let md = metadata_with_summary(&[("total-position-deletes", "17")]);
+        let storage = NoReadStorage;
+        let planner = SendScanPlanner::new(&storage, &md, ScanConfig::new());
+        let err = planner
+            .plan_scan()
+            .await
+            .expect_err("the Send planner (production COUNT/scan path) must fail closed");
+        assert!(
+            matches!(err, IcebergError::MergeOnReadDeletes(_)),
+            "expected a merge-on-read refusal, got {err:?}"
+        );
     }
 }

--- a/fluree-db-iceberg/src/stats.rs
+++ b/fluree-db-iceberg/src/stats.rs
@@ -951,4 +951,37 @@ mod tests {
             "the delete manifest must never be fetched: {reads:?}"
         );
     }
+
+    /// The stats/COUNT path: once `read_snapshot_data_files` reports delete
+    /// manifests, the fail-closed guard must refuse (default) rather than let the
+    /// over-counting `row_count` sum be returned — and proceed under the
+    /// override. This mirrors exactly what the metadata-preview consumer
+    /// (`iceberg_catalog.rs`) does with the returned flag (F-AUD-1).
+    #[tokio::test]
+    async fn stats_path_refuses_delete_manifests_unless_overridden() {
+        use crate::mor_guard::ensure_no_delete_manifests;
+
+        let list_path = "s3://b/t/metadata/snap.avro";
+        let data_manifest = "s3://b/t/metadata/m-data.avro";
+        let delete_manifest = "s3://b/t/metadata/m-del.avro";
+
+        let mut mem = crate::io::MemoryStorage::new();
+        mem.add_file(
+            list_path,
+            build_manifest_list_with_delete(data_manifest, delete_manifest),
+        );
+        mem.add_file(data_manifest, build_manifest("s3://b/t/data/f1.parquet"));
+        let snapshot = snapshot_with_list(list_path);
+
+        let (_data_files, _read, has_deletes) =
+            read_snapshot_data_files(&mem, &snapshot).await.unwrap();
+        assert!(has_deletes);
+
+        // Guard active (default): refuse.
+        let err =
+            ensure_no_delete_manifests(usize::from(has_deletes), "dw.fact", false).unwrap_err();
+        assert!(matches!(err, crate::IcebergError::MergeOnReadDeletes(_)));
+        // Operator opted out: proceed (upper-bound counts, with a logged warning).
+        assert!(ensure_no_delete_manifests(usize::from(has_deletes), "dw.fact", true).is_ok());
+    }
 }


### PR DESCRIPTION
fix(iceberg): fail closed on merge-on-read delete files (silent stale-row risk)

This is one of five surviving pull requests in the consolidated virtual-dataset review program, which collapses the #1475–#1529 lineage into five reviewable units at the maintainers' request. #1520 is the standalone correctness fix and the only member based on `main`, so it receives full CI on its own branch; it is meant to land first, ahead of the four stacked survivors. Reading order across the program: **#1520 (this PR)** → #1507 (R2RML/Iceberg virtual-dataset performance program) → #1514 (serverless Lambda-usability + BYO-IAM) → #1528 (big-Iceberg-audit implementation) → #1529 (native-twin materialize builder). The durable, outward-facing audit record these PRs draw on is published on the `docs/virtual-dataset-audit-2026-07` branch — for this PR start with [00-MASTER-AUDIT.md](https://github.com/fluree/db/blob/docs/virtual-dataset-audit-2026-07/00-MASTER-AUDIT.md) §2 (finding F-AUD-1) and the independent verification in [V1-mor-verification.md](https://github.com/fluree/db/blob/docs/virtual-dataset-audit-2026-07/V1-mor-verification.md).

## Original PR body

## Forest map

This is **PR-SAFE-MOR**, the first (and only main-based) implementation PR of the big Iceberg audit. It closes audit finding **F-AUD-1** (silent merge-on-read staleness).

| This PR | Finding | Tier | Where it sits in the program |
| --- | --- | --- | --- |
| Fail-closed MoR delete-file guard | [F-AUD-1](https://github.com/fluree/db/blob/docs/virtual-dataset-audit-2026-07/00-MASTER-AUDIT.md) | Tier-0 (ship regardless) | Base = `main` (portable, gets real CI). The other Tier-0/1/2 items are branch-coupled and stack on the `perf/audit-tier012` integration branch (see #1528). |

Audit references: [00-MASTER-AUDIT.md](https://github.com/fluree/db/blob/docs/virtual-dataset-audit-2026-07/00-MASTER-AUDIT.md) (§2 F-AUD-1, §6 Tier-0) · [V1-mor-verification.md](https://github.com/fluree/db/blob/docs/virtual-dataset-audit-2026-07/V1-mor-verification.md) (the verified gap + fix sites).

## The bug

Fluree's virtual Iceberg read path **recognizes** merge-on-read (MoR) position/equality delete files (`content=1` manifests) but never **applies** them: delete manifests are dropped with a `debug!` log and only the live data files are read (`manifest_list.rs`, `planner.rs`, and no delete reader anywhere in `io/`). Consequences, both silent:

- A query over a MoR-maintained table **returns deleted rows as if live**.
- The manifest `COUNT(*)` / row-total shortcut **over-counts** by exactly the delete cardinality (`stats.rs` sums `record_count`, never subtracting deletes).

Copy-on-write deletes are **not** affected — status=`DELETED` manifest entries are already dropped correctly, so CoW scans exactly ADDED+EXISTING files. The gap is strictly MoR delete *files*.

## Exposure (why this matters now)

- **Snowflake-managed v2 (what the smoke datasets are today): SAFE.** V1 measured the deployed `fl-svl-iceberg-smoke-use2` tables as format-v2, append-only, `total-delete-files/position/equality = 0` — Snowflake's current copy-on-write default. The bug is **not** triggered by today's data.
- **External writers: MoR now.** Athena `DELETE` writes position delete files by default; Flink/CDC upserts write equality deletes by design; Spark is one table-property away. The BYO-IAM segment (#1505) is the highest-exposure surface.
- **Snowflake, imminent.** `ICEBERG_MERGE_ON_READ_BEHAVIOR=AUTO` already means MoR for v3 (deletion vectors) and for **all** externally-managed tables. A pending Snowflake BCR bundle (`2026_03` / bcr-2279) would flip SF-managed **v2** to MoR positional deletes by default. **The `2026_03` date is WEB-sourced and unverified** — verify the BCR before scheduling against it; the *gap* is V1-verified, the *date* is not.

Severity: **latent-but-certain** — no delete files in today's smoke data, but MoR arrives with certainty down at least four independent paths. The failure mode (silent wrong answers, no error/log/metric) is the worst class for a database, which is why this ships fail-closed regardless of the trigger date.

## The guard (fail-closed, with an escape hatch)

Refuse — never silently mis-answer — any Iceberg read whose snapshot carries delete files, until MoR application is implemented. Two independent signals so a snapshot cannot slip through:

1. **Snapshot summary counters** (`total-delete-files` / `total-position-deletes` / `total-equality-deletes`) — a zero extra-I/O check; the summary is already in memory. New `Snapshot` accessors mirror `deleted_records()`.
2. **Manifest list** — a `content=1` delete manifest present even when the summary omits/under-counts it. The scan planners now parse the manifest list *with* deletes and count them (the list is read anyway).

Both scan planners (`ScanPlanner` + the Send-safe `SendScanPlanner` used by the server) and the stats/COUNT preview consumer (`iceberg_catalog.rs`) inherit the guard, so scan results **and** row/COUNT totals are covered. On refusal the error is typed (`IcebergError::MergeOnReadDeletes`) and actionable — it names the table, the counters/evidence, why (deletes not applied → deleted rows / over-count), and the override switch.

### Switch | test | behavior ledger

| Switch | Default | Effect | Coverage |
| --- | --- | --- | --- |
| `FLUREE_ICEBERG_ALLOW_MOR_DELETES` | **off** (guard active) | Truthy (`1`/`true`/`yes`/`on`) disables the guard: delete files ignored, read proceeds, **results may include deleted rows / over-count**, warns once per table. | `mor_guard` unit tests (both arms) + planner + stats fixture tests |

Field revert is per-mechanism via the switch (no redeploy needed). Docs: added to `docs/graph-sources/iceberg.md` (Limitations + a new "Environment switches" table). There is no `SWITCHES.md` on `main`; the harness PR (PR-HARNESS) folds this row into the regenerated registry.

## Tests (the fixture that did not exist before)

V1 flagged that **no MoR delete fixtures existed**, so CI proved nothing about this class. This PR adds real `content=1` delete fixtures (in-code Avro) that drive the guard end-to-end:

- **Snapshot accessors** — present/absent counters (`snapshot.rs`).
- **Guard logic** (`mor_guard.rs`) — position>0 refuses; equality>0 refuses; zero/absent proceeds; override proceeds; error message names the table + switch; pure truthy-parsing.
- **Planner, real Avro** (`planner.rs`) — a manifest list with a `content=1` entry drives `plan_scan()` to `MergeOnReadDeletes`; a summary-counter snapshot refuses before any I/O; a delete-free snapshot plans normally.
- **Stats/COUNT path** (`stats.rs`) — `read_snapshot_data_files` detects deletes, then the guard refuses (default) / proceeds (override), mirroring the `iceberg_catalog.rs` consumer exactly.

The override "skipped under override" arm is proven at the guard-function level rather than through the planner, to avoid mutating the shared process env in a parallel test run (documented in-code).

## Verification record

All run locally in this branch's worktree (base = `main` @ `7581f0ac8`). **CI runs live on this PR** (base=main fires `fmt`/`clippy`/`test`/`testsuite-sparql`, even while draft).

| Gate | Command | Result |
| --- | --- | --- |
| fmt | `cargo fmt -p fluree-db-iceberg -p fluree-db-api -- --check` | clean |
| clippy (scoped, `-D warnings`) | `cargo clippy -p fluree-db-iceberg --all-features --all-targets --no-deps -- -D warnings` | clean (no pre-existing lints in this crate) |
| iceberg tests | `cargo test -p fluree-db-iceberg --all-features` | **200 passed**, 0 failed (was 188; +12 new) |
| api tests (compile surface) | `cargo test -p fluree-db-api --features iceberg` | all bins pass, 0 failed (102 ignored = live-Snowflake) |
| featureless / default build | `cargo build -p fluree-db-iceberg --no-default-features` + default | both clean |
| api clippy (edited file) | `cargo clippy -p fluree-db-api --features iceberg --no-deps` | no findings in `iceberg_catalog.rs` |

Perf arm: not applicable (this is a correctness guard, not an optimization) — no vbench claim.

## Update — review follow-ups (commit `c5f7feaff`)

Two review follow-ups, behavior-preserving:

- **Shared planner guard helpers.** The identical guard block in `ScanPlanner` and `SendScanPlanner` is extracted into two `mor_guard` helpers — `ensure_summary_scannable` (zero-I/O summary check before the manifest-list read, returns the override flag) and `ensure_manifests_scannable` (the post-read belt-and-suspenders) — so the fail-closed check cannot drift between the two planners. Same checks, same order, same override.
- **Production COUNT-path refusal test.** A COUNT / `table_row_count` query routes through the production `SendScanPlanner`; #1520 originally tested only the runtime-agnostic `ScanPlanner`. Added a hermetic test proving `SendScanPlanner::plan_scan()` fails closed on a delete-bearing snapshot (`MergeOnReadDeletes`), so the guard is not merely transitive. Both new helpers are also unit-tested directly.

Gates re-run at this head: fmt clean; `clippy -p fluree-db-iceberg -D warnings` clean; iceberg 203 tests pass; `cargo test -p fluree-db-api --features iceberg` 0 failures. CI re-fires on this push (base=main).

Note (residual, out of scope for this PR): the `/info` `table_row_counts` display (`ledger_info.rs::fetch_virtual_table_row_counts`) derives counts from the snapshot summary `total-records`, which over-counts a merge-on-read table. It is a metadata display, not a query answer, and is not guarded here — flagged for the audit follow-up if a guarded `/info` count is wanted.

## Consolidated scope

#1520 folds in no other pull requests — it is the standalone Tier-0 correctness fix and stands exactly as scoped. Its two commits are the guard (`771f6e88b`) and the review-follow-up test plus shared planner helpers (`c5f7feaff`). The pre-consolidation tip is preserved at tag `archive/pre-refactor-2026-07-21/fix_iceberg-mor-delete-guard`; nothing was rewritten.

## Verification of record

CI fires on this PR because its base is `main`, so `fmt`/`clippy`/`test`/`testsuite-sparql` run against the change directly — it is the one survivor with real CI on its own diff, and the in-body gate table records the local reproduction.

The independent adversarial diff review is recorded under R-1520 in [pr-reviews-impl.md](https://github.com/fluree/db/blob/docs/virtual-dataset-audit-2026-07/pr-reviews-impl.md): verdict SHIP on main — the guard is complete there (both live planners plus the stats/preview consumer guarded, the in-memory scan-files cache safe by construction, and the branch-only disk cache does not exist on `main`). The same review flagged that the guard was incomplete on the stacked perf line, where a cached scan-files hit-arm rebuilds scan tasks around `plan_scan`; that gap was closed on the audit line and is recorded under R-CACHE-ARM in the same file (verdict CLOSED — delete-flag on the cached entry, re-check on both hit arms, and a `CACHE_FORMAT_VERSION` bump so pre-guard entries miss and recompute through the guard). That fix travels into the program via #1528, so the guard is complete on both the main-based and stacked paths.

The finding itself and its fix sites are verified independently in [V1-mor-verification.md](https://github.com/fluree/db/blob/docs/virtual-dataset-audit-2026-07/V1-mor-verification.md) with live AWS metadata measurement, and the exposure timeline is summarized in [00-MASTER-AUDIT.md](https://github.com/fluree/db/blob/docs/virtual-dataset-audit-2026-07/00-MASTER-AUDIT.md) §2.

## Native-impact appendix

**Zero native surface.** Every edit is in `fluree-db-iceberg` (`planner.rs`, `send_planner.rs`, `stats.rs`, `mor_guard.rs`, `snapshot.rs`) plus `fluree-db-api/iceberg_catalog.rs`, and each is reached only through the Iceberg scan / stats path — never through a native SPARQL query. The one switch, `FLUREE_ICEBERG_ALLOW_MOR_DELETES`, defaults off (guard active) and is an inverted-polarity escape hatch. Coverage is 203 iceberg tests including real `content=1` Avro delete fixtures. There is nothing on this PR for a native-pathway reviewer to check.

## Landing and hand-off notes

Land #1520 first. It shares its fail-closed guard content with #1528's line (the same guard was re-applied on the audit integration branch). The two guard commits carry different git patch-ids only because they were cut against different base trees, but their added and removed lines are byte-identical, so once #1520 merges to `main`, #1528's guard portion resolves as an identical-content merge and the audit line's cache-arm guard (`CACHE_FORMAT_VERSION` 2→3) rides on top cleanly.

The `/info` `table_row_counts` over-count noted above as out of scope is picked up downstream: #1528 carries the rider that flags delete-bearing tables into an `mor-approximate-tables` list (upper-bound counts), so this PR's deferral is closed there rather than left open.
