### PR TITLE
fix(query): close the memory-budget blind spot on the non-aggregate scan path

### DIFF
--- a/fluree-db-core/src/cancellation.rs
+++ b/fluree-db-core/src/cancellation.rs
@@ -65,9 +65,12 @@ impl fmt::Display for QueryCancellationReason {
 struct QueryCancellationInner {
     reason: AtomicU8,
     /// Bytes of retained query memory recorded via [`QueryCancellation::record_alloc`].
-    /// A monotonic, deliberately-conservative high-water accumulator: callers record
-    /// where a retained buffer grows, so the total tracks a query's live post-scan
-    /// memory across all its operators.
+    /// A deliberately-conservative accumulator: callers record where a retained buffer
+    /// grows, so the total tracks a query's live post-scan memory across all its
+    /// operators. Mostly grows (persistent join/aggregate builds, retained lookups);
+    /// an allocation with a PROVABLE drop point (a scan window handed off and dropped)
+    /// may be paired with [`QueryCancellation::release`], so this is a high-water of
+    /// *live* accounted memory, not a monotonic all-time sum.
     allocated: AtomicUsize,
     /// Optional per-query memory ceiling in bytes (`NO_MEMORY_LIMIT` = unset). Stored
     /// as an opaque number — this crate never compares or enforces it; the query
@@ -152,12 +155,34 @@ impl QueryCancellation {
     /// Record `bytes` of retained query memory into the shared counter. Callers record
     /// at the points where a retained buffer (a hash-join build table, a GROUP BY map,
     /// a fused dim-map) grows, so the counter tracks the query's live post-scan memory.
-    /// Monotonic and intentionally conservative — over-counting can only trip the guard
-    /// on a query already near its ceiling. No-op on a disabled handle.
+    /// Intentionally conservative — over-counting can only trip the guard on a query
+    /// already near its ceiling. Persistent allocations are never released; an
+    /// allocation with a provable drop point is paired with [`release`](Self::release).
+    /// No-op on a disabled handle.
     #[inline]
     pub fn record_alloc(&self, bytes: usize) {
         if let Some(inner) = &self.inner {
             inner.allocated.fetch_add(bytes, Ordering::Relaxed);
+        }
+    }
+
+    /// Release `bytes` previously recorded via [`record_alloc`](Self::record_alloc),
+    /// for an allocation whose drop point the caller can prove — e.g. a scan window
+    /// that has been handed off downstream and is about to drop, so a streaming scan
+    /// of N sequentially-freed windows accounts only the resident one rather than
+    /// their all-time sum. Saturating, so a double- or over-release can never
+    /// underflow the counter. It is a CALLER INVARIANT that `release` is paired only
+    /// with a matching non-persistent `record_alloc`: persistent buffers (join /
+    /// aggregate builds, retained lookups) must never be released, or the guard would
+    /// under-count live memory. No-op on a disabled handle.
+    #[inline]
+    pub fn release(&self, bytes: usize) {
+        if let Some(inner) = &self.inner {
+            let _ = inner
+                .allocated
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+                    Some(cur.saturating_sub(bytes))
+                });
         }
     }
 
@@ -259,6 +284,34 @@ mod tests {
         // The counter lives on the shared Arc, so both handles observe the total.
         assert_eq!(cancellation.allocated_bytes(), 150);
         assert_eq!(derived.allocated_bytes(), 150);
+    }
+
+    #[test]
+    fn release_subtracts_and_saturates_at_zero() {
+        let cancellation = QueryCancellation::new();
+        let derived = cancellation.clone();
+
+        cancellation.record_alloc(1000);
+        // A provable-drop allocation is released — the counter tracks LIVE memory, so
+        // charging then releasing nets zero (a streaming scan's per-window pattern).
+        cancellation.release(400);
+        assert_eq!(cancellation.allocated_bytes(), 600);
+        assert_eq!(
+            derived.allocated_bytes(),
+            600,
+            "release is shared across clones"
+        );
+
+        // Over-release saturates at zero rather than underflowing.
+        derived.release(10_000);
+        assert_eq!(cancellation.allocated_bytes(), 0);
+    }
+
+    #[test]
+    fn disabled_handle_release_is_a_noop() {
+        let cancellation = QueryCancellation::disabled();
+        cancellation.release(1 << 20);
+        assert_eq!(cancellation.allocated_bytes(), 0);
     }
 
     #[test]

--- a/fluree-db-query/src/context.rs
+++ b/fluree-db-query/src/context.rs
@@ -806,6 +806,16 @@ impl<'a> ExecutionContext<'a> {
         self.cancellation.record_alloc(bytes);
     }
 
+    /// Release `bytes` previously recorded via [`record_alloc`](Self::record_alloc)
+    /// for an allocation with a provable drop point (e.g. a materialized scan window
+    /// that has been emitted and is about to drop). Saturating. Only valid for
+    /// non-persistent allocations — persistent join/aggregate/lookup buffers must
+    /// never be released. See [`QueryCancellation::release`].
+    #[inline]
+    pub fn release(&self, bytes: usize) {
+        self.cancellation.release(bytes);
+    }
+
     /// Retained query memory recorded so far via [`record_alloc`](Self::record_alloc).
     #[inline]
     pub fn mem_used(&self) -> usize {

--- a/fluree-db-query/src/context.rs
+++ b/fluree-db-query/src/context.rs
@@ -49,12 +49,59 @@ pub fn query_memory_budget_bytes() -> usize {
     })
 }
 
-/// R3-B: conservative per-binding byte estimate for the approximate memory-budget
-/// accounting (a `Binding` is a small enum, occasionally with a heap `String`;
-/// over-counting is safe — a too-tight budget only aborts a query already near OOM).
-pub const BINDING_EST_BYTES: usize = 64;
+/// R3-B: per-binding byte estimate for the approximate memory-budget accounting.
+/// Derived from the true stack size of a [`Binding`](crate::binding::Binding)
+/// (`size_of::<Binding>()` = 88 bytes, documented at `binding.rs:14-17`) rather
+/// than a hand-picked number, so it can never silently under-count the stack
+/// footprint the way the previous `64` did (a 27% under-count of the 88-byte enum).
+///
+/// This still under-counts the HEAP a binding owns: an IRI-bearing row
+/// (`Binding::Iri(Arc<str>)`, `IriMatch { iri: Arc<str>, ledger_alias: Arc<str> }`,
+/// or a `Lit` with a `String` value) carries ~50-70 bytes of `Arc<str>` payload
+/// the stack size does not see, so a wide R2RML/Iceberg crawl of IRI rows is still
+/// counted at roughly 1/2.2 of its true resident bytes. Over-counting is safe (a
+/// too-tight budget only aborts a query already near OOM); this constant deliberately
+/// stays a floor. A heap-aware per-binding estimate is a documented follow-up.
+pub const BINDING_EST_BYTES: usize = std::mem::size_of::<crate::binding::Binding>();
+/// F-AUD-3 site D: compile-time guard. The estimate must never drop below the
+/// true `Binding` stack size — refusing any future edit that pins a smaller magic
+/// number (the very regression the `64` was). Trivially holds while it is DEFINED
+/// as `size_of`, and bites the moment someone changes that.
+const _: () = assert!(BINDING_EST_BYTES >= std::mem::size_of::<crate::binding::Binding>());
 /// R3-B: conservative per-group overhead estimate (key bindings + aggregate state).
+/// A flat estimate — like [`BINDING_EST_BYTES`] it ignores per-group heap (e.g. a
+/// `GROUP_CONCAT`/`Collect` accumulator), the same documented conservatism.
 pub const GROUP_EST_BYTES: usize = 128;
+
+/// F-AUD-3 site C: divisor applied to the process memory budget to derive a
+/// per-query ceiling, read from `FLUREE_QUERY_BUDGET_SHARE_DIV`. Default `1` (and
+/// any unparseable/zero value floors to `1`), which makes the per-query ceiling
+/// equal to the full budget — byte-for-byte today's behavior. Set it to the
+/// deployment's expected max query concurrency (e.g. a Lambda's reserved
+/// concurrency) so N concurrent queries share the budget instead of each
+/// comparing its own counter against the FULL budget (the over-admission V2 §3
+/// describes: two queries each accounting 5 GB both read "under 8 GB" while the
+/// node sits at 10 GB). See [`per_query_memory_ceiling`].
+///
+/// This is the sound, minimal static form. A dynamic divisor equal to the ACTUAL
+/// live concurrency (so a lone query keeps the full budget) needs a process-wide
+/// active-*top-level*-query count — which only the server request boundary
+/// (`fluree-db-server/src/query_control.rs`) can measure without miscounting
+/// nested policy/reasoning/sub-queries that re-enter the engine. Deferred there.
+pub fn query_budget_share_div() -> usize {
+    std::env::var("FLUREE_QUERY_BUDGET_SHARE_DIV")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(1)
+        .max(1)
+}
+
+/// F-AUD-3 site C: the per-query memory ceiling = `full_budget / share_div`, with
+/// `share_div` floored at 1. `share_div == 1` returns the full budget unchanged.
+/// Pure so the division is unit-testable without touching the environment.
+pub fn per_query_memory_ceiling(full_budget: usize, share_div: usize) -> usize {
+    full_budget / share_div.max(1)
+}
 
 /// Best-effort container/system memory limit (cgroup v2 → cgroup v1 →
 /// `/proc/meminfo`). `None` where none is readable (e.g. macOS dev), where the
@@ -1579,5 +1626,90 @@ impl WellKnownDatatypes {
             return true;
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod budget_tests {
+    use super::*;
+    use crate::binding::Binding;
+    use crate::error::QueryError;
+    use crate::var_registry::VarRegistry;
+    use fluree_db_core::{LedgerSnapshot, QueryCancellation};
+
+    /// F-AUD-3 site D: the per-binding estimate must never be below the true stack
+    /// size of a `Binding` (the 64→88 fix). Deriving it from `size_of` makes the
+    /// `>=` hold by construction; the equality canary documents the 88-byte size
+    /// (binding.rs:14-17) and fails loudly if the enum grows so the estimate is
+    /// re-examined for the heap it still omits.
+    #[test]
+    fn binding_est_bytes_is_at_least_binding_stack_size() {
+        // Derived from the type, so it equals the stack size and can never silently
+        // under-count it the way the previous hardcoded 64 did. The 88 canary
+        // documents binding.rs:14-17 and fails loudly if the enum grows (prompting a
+        // re-look at the heap the estimate still omits). The `>= size_of` invariant
+        // itself is a compile-time `const _` assertion next to the constant.
+        assert_eq!(BINDING_EST_BYTES, std::mem::size_of::<Binding>());
+        assert_eq!(
+            std::mem::size_of::<Binding>(),
+            88,
+            "binding.rs:14-17 documents size_of::<Binding>() == 88"
+        );
+    }
+
+    /// F-AUD-3 site C: the ceiling divides the full budget and floors the divisor
+    /// at 1, so `div == 1` (the default) is byte-for-byte the full budget.
+    #[test]
+    fn per_query_ceiling_divides_and_floors() {
+        let full = 8usize << 30; // 8 GiB
+        assert_eq!(
+            per_query_memory_ceiling(full, 1),
+            full,
+            "div=1 → full budget"
+        );
+        assert_eq!(
+            per_query_memory_ceiling(full, 4),
+            2usize << 30,
+            "div=4 → quarter"
+        );
+        assert_eq!(per_query_memory_ceiling(full, 0), full, "div=0 floors to 1");
+    }
+
+    /// F-AUD-3 site C: two concurrent queries pinned to a shared (divided) ceiling
+    /// each trip at their divided budget — neither can consume the full budget the
+    /// way today's undivided per-query counter allows (V2 §3 over-admission).
+    #[test]
+    fn shared_ceiling_trips_each_query_at_its_divided_budget() {
+        let full = 8usize << 30;
+        let ceiling = per_query_memory_ceiling(full, 2); // 4 GiB each
+        assert_eq!(ceiling, 4usize << 30);
+
+        let snapshot = LedgerSnapshot::genesis("test/main");
+        let vars = VarRegistry::new();
+        // Two independent queries, each pinned to the divided ceiling as the runner
+        // attach point does under FLUREE_QUERY_BUDGET_SHARE_DIV=2.
+        for _ in 0..2 {
+            let cancel = QueryCancellation::new();
+            cancel.set_memory_limit(ceiling);
+            let ctx = ExecutionContext::new(&snapshot, &vars).with_cancellation(cancel);
+            // Recording just over the DIVIDED ceiling trips, though it is well under
+            // the full 8 GiB budget an undivided query would compare against.
+            ctx.record_alloc(ceiling + 1);
+            match ctx.checkpoint() {
+                Err(QueryError::MemoryBudgetExceeded {
+                    used_bytes,
+                    budget_bytes,
+                }) => {
+                    assert_eq!(
+                        budget_bytes, ceiling,
+                        "enforced ceiling is the divided budget"
+                    );
+                    assert_eq!(used_bytes, ceiling + 1);
+                }
+                other => {
+                    panic!("expected MemoryBudgetExceeded at the divided ceiling, got {other:?}")
+                }
+            }
+        }
     }
 }

--- a/fluree-db-query/src/execute/runner.rs
+++ b/fluree-db-query/src/execute/runner.rs
@@ -826,6 +826,19 @@ async fn execute_prepared_into<'a, S: BatchSink>(
         ctx = ctx.with_tracker(tracker.clone());
     }
     if let Some(cancellation) = config.cancellation {
+        // F-AUD-3 site C: give this query its share of the process memory budget
+        // instead of letting it (and every concurrent query) compare its own counter
+        // against the FULL budget. `FLUREE_QUERY_BUDGET_SHARE_DIV` (default 1) is the
+        // divisor; div==1 pins nothing, so the checkpoint falls back to the full
+        // process budget exactly as before. An explicit ceiling already pinned by the
+        // embedder wins (never clobbered). See `context::per_query_memory_ceiling`.
+        let div = crate::context::query_budget_share_div();
+        if div > 1 && cancellation.memory_limit().is_none() {
+            let full = crate::context::query_memory_budget_bytes();
+            if full != 0 {
+                cancellation.set_memory_limit(crate::context::per_query_memory_ceiling(full, div));
+            }
+        }
         ctx = ctx.with_cancellation(cancellation);
     }
     if let Some(enforcer) = config.policy_enforcer {

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -245,12 +245,13 @@ fn topk_pushdown_enabled() -> bool {
 /// into, which the hash-join / group-aggregate `record_alloc`s never covered.
 /// OFF is a clean revert to the prior behavior (scan path invisible to the budget;
 /// the `checkpoint()` polls degrade to pure cancellation checks because the scan
-/// records nothing). The counter is query-lifetime cumulative and never
-/// decremented, so a genuinely-streaming large scan is accounted as if all its
-/// windows were simultaneously resident — the intended conservative direction
-/// (over-count only ever aborts a query already near the budget), matching the
-/// existing fold/join accounting; a high-water refinement is deferred with the
-/// excluded per-file buffer accounting (V2 site B).
+/// records nothing). Each materialized window is charged then RELEASED once emitted
+/// (it has a provable drop point), so a long streaming scan accounts only its
+/// resident window rather than the all-time sum of every freed window — that sum
+/// otherwise false-aborts a bounded-memory long scan (q038). The retained parent-map
+/// build (A2) and the per-file buffers (V2 site B, still excluded) are the remaining
+/// non-released allocations; A2 genuinely persists so its cumulative charge is
+/// correct, and site B needs its own release pairing.
 fn scan_mem_accounting_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| super::env_switch_enabled("FLUREE_SCAN_MEM_ACCOUNTING"))
@@ -1459,20 +1460,26 @@ impl R2rmlScanOperator {
 
             // F-AUD-3 site A1: account the materialized window against the query
             // memory budget so a wide non-aggregate crawl (the previously-blind scan
-            // path) trips a typed `MemoryBudgetExceeded` instead of OOMing. The window
-            // is bounded (~`materialize_window_rows`) so one window cannot itself OOM;
-            // `checkpoint()` here aborts once the cumulative recorded bytes (this
-            // window plus every prior one and any upstream fold/join) cross the
-            // budget, before the loop pulls another. Cumulative, never decremented —
-            // see `scan_mem_accounting_enabled`.
-            if scan_mem_accounting_enabled() {
-                let window_est = produced
+            // path) trips a typed `MemoryBudgetExceeded` instead of OOMing. Charge the
+            // resident window and `checkpoint()` BEFORE doing more work, so an oversized
+            // window (or this window on top of a retained A2 fact-parent build / an
+            // upstream fold) aborts typed. The window is then RELEASED once emitted
+            // (below) — it has a provable drop point, so a streaming scan of N
+            // sequentially-freed windows accounts only the resident one instead of
+            // their all-time sum. Without the release, ~70 freed 512K-row windows of a
+            // long un-fused-COUNT scan (q038) SUM past the budget and false-abort a
+            // query whose per-window resident memory is bounded and fine.
+            let window_est = if scan_mem_accounting_enabled() {
+                let est = produced
                     .len()
                     .saturating_mul(num_cols)
                     .saturating_mul(crate::context::BINDING_EST_BYTES);
-                ctx.record_alloc(window_est);
+                ctx.record_alloc(est);
                 ctx.checkpoint()?;
-            }
+                est
+            } else {
+                0
+            };
 
             if !produced.is_empty() {
                 emit_produced_window(
@@ -1487,6 +1494,16 @@ impl R2rmlScanOperator {
                     &mut self.pending,
                     ctx,
                 )?;
+            }
+
+            // The window has been handed off (its rows copied into `columns` / the
+            // bounded `self.pending` overflow) and `produced` drops at the end of this
+            // iteration — release its charge so only the in-flight window is counted.
+            // The retained overflow is bounded (≤ one window, drained before the next
+            // pull) and intentionally left untracked (minimal per V2 site B). The A2
+            // fact-parent build charge is NOT released — that map genuinely persists.
+            if window_est != 0 {
+                ctx.release(window_est);
             }
             // Geometric window growth. A budgeted (LIMIT) scan starts with a small
             // window (~the remaining budget) so a selective query does not explode
@@ -2554,9 +2571,10 @@ fn build_parent_lookup(
         // worst-case contribution and checkpoint inside the build loop so a
         // budget-exceeding build aborts typed (`MemoryBudgetExceeded`) BEFORE the
         // whole map is resident, instead of OOMing. `num_rows` over-counts skipped
-        // (null-subject / null-key) rows — deliberately conservative. Cumulative like
-        // site A1; the map is genuinely retained while built, so cumulative == the
-        // resident footprint for this structure.
+        // (null-subject / null-key) rows — deliberately conservative. Unlike the A1
+        // scan window (released on hand-off), this charge is NOT released: the lookup
+        // is genuinely retained for the whole join, so the cumulative charge correctly
+        // equals its resident footprint.
         if scan_mem_accounting_enabled() {
             ctx.record_alloc(batch.num_rows.saturating_mul(PARENT_ENTRY_EST_BYTES));
             ctx.checkpoint()?;
@@ -2904,6 +2922,125 @@ mod tests {
         assert!(
             matches!(err, QueryError::MemoryBudgetExceeded { .. }),
             "wide crawl window must abort typed, got {err:?}"
+        );
+    }
+
+    /// F-AUD-3 site A1 — q038 regression (the false-abort the live re-bless caught).
+    /// A long non-aggregate scan streams many windows that are each materialized then
+    /// FREED; the per-window budget charge is released on hand-off, so the windows do
+    /// not SUM to a false over-budget. Here 64 one-row windows (charge ~528 B each)
+    /// run under an 8000 B ceiling: each resident window fits and the scan COMPLETES —
+    /// whereas the pre-fix cumulative counter crossed the ceiling within ~16 windows
+    /// and false-aborted a bounded-memory scan. The single-window abort test above
+    /// (an oversized window on a 1-byte ceiling) still passes: the checkpoint fires
+    /// while the window is charged, before it is released.
+    #[tokio::test]
+    async fn r3b_scan_windows_release_no_false_abort() {
+        use crate::r2rml::R2rmlTableProvider;
+        use crate::seed::EmptyOperator;
+        use crate::var_registry::VarRegistry;
+        use fluree_db_core::QueryCancellation;
+        use fluree_db_r2rml::mapping::{
+            CompiledR2rmlMapping, ObjectMap, PredicateMap, PredicateObjectMap, TriplesMap,
+        };
+        use fluree_db_tabular::{BatchSchema, FieldInfo, FieldType};
+
+        const N_WINDOWS: usize = 64;
+
+        #[derive(Debug)]
+        struct ManyRowsProvider;
+        #[async_trait::async_trait]
+        impl R2rmlTableProvider for ManyRowsProvider {
+            async fn scan_table(
+                &self,
+                _graph_source_id: &str,
+                _table_name: &str,
+                _projection: &[String],
+                _filters: &[crate::r2rml::ScanFilter],
+                _topk: Option<&crate::r2rml::ScanTopK>,
+                _as_of_t: Option<i64>,
+            ) -> Result<ColumnBatchStream> {
+                let schema = Arc::new(BatchSchema::new(vec![FieldInfo {
+                    name: "STORE_KEY".to_string(),
+                    field_type: FieldType::Int64,
+                    nullable: true,
+                    field_id: 1,
+                }]));
+                // N single-row batches → with window_rows pinned to 1, one window each.
+                let batches: Vec<Result<ColumnBatch>> = (0..N_WINDOWS as i64)
+                    .map(|k| {
+                        Ok(ColumnBatch::new(
+                            Arc::clone(&schema),
+                            vec![Column::Int64(vec![Some(k + 1)])],
+                        )
+                        .unwrap())
+                    })
+                    .collect();
+                Ok(Box::pin(futures::stream::iter(batches)))
+            }
+        }
+
+        let tm = TriplesMap::new("#Store", "DIM_STORE")
+            .with_subject_template("http://ex/store/{STORE_KEY}")
+            .with_class("http://ex/Store")
+            .with_predicate_object(PredicateObjectMap {
+                predicate_map: PredicateMap::constant("http://ex/storeKey"),
+                object_map: ObjectMap::column("STORE_KEY"),
+            });
+        let mapping = Arc::new(CompiledR2rmlMapping::new(vec![tm]));
+        let snapshot = fluree_db_core::LedgerSnapshot::genesis("test/main");
+        let vars = VarRegistry::new();
+        let provider = ManyRowsProvider;
+
+        let cancel = QueryCancellation::new();
+        // Between one window (~528 B) and the naive cumulative (64×528 ≈ 34 KB): the
+        // pre-fix counter crosses this within ~16 windows; released windows never do.
+        cancel.set_memory_limit(8000);
+        let mut ctx = ExecutionContext::new(&snapshot, &vars).with_cancellation(cancel);
+        ctx.r2rml_table_provider = Some(&provider);
+
+        let pattern =
+            R2rmlPattern::new("gs:main", VarId(0), Some(VarId(2))).with_predicate_var(VarId(1));
+        let mut op = R2rmlScanOperator::new(Box::new(EmptyOperator::new()), pattern);
+        op.mapping = Some(Arc::clone(&mapping));
+
+        let mut progress = op
+            .build_progress(&ctx, Batch::single_empty())
+            .await
+            .expect("build_progress")
+            .expect("wildcard crawl resolves the one TriplesMap");
+        let num_cols = op.schema().len();
+        let mut columns: Vec<Vec<Binding>> = (0..num_cols).map(|_| Vec::new()).collect();
+
+        let mut windows = 0usize;
+        loop {
+            progress.window_rows = 1; // pin one row per window (bypass geometric growth) — env-free.
+            let more = op
+                .advance_one_window(&ctx, &mut progress, num_cols, &mut columns)
+                .await
+                .expect("a bounded-resident streaming scan must NOT false-abort on the budget");
+            // Simulate the consumer draining the emitted batch so nothing accumulates
+            // outside the released window charge.
+            for c in &mut columns {
+                c.clear();
+            }
+            op.pending.clear();
+            // The window charge is released on hand-off, so live accounted memory
+            // never approaches the naive cumulative — it stays within one window.
+            assert!(
+                ctx.mem_used() < 8000,
+                "released window charge must keep live memory under budget, got {}",
+                ctx.mem_used()
+            );
+            if !more {
+                break;
+            }
+            windows += 1;
+            assert!(windows < 1000, "safety bound");
+        }
+        assert!(
+            windows >= N_WINDOWS,
+            "the whole streaming scan must complete; got {windows} windows"
         );
     }
 

--- a/fluree-db-query/src/r2rml/operator.rs
+++ b/fluree-db-query/src/r2rml/operator.rs
@@ -236,6 +236,34 @@ fn topk_pushdown_enabled() -> bool {
     *ENABLED.get_or_init(|| super::env_switch_enabled("FLUREE_R2RML_TOPK_PUSHDOWN"))
 }
 
+/// F-AUD-3 kill switch: whether the non-aggregate scan/crawl path records its
+/// materialized windows and fact-parent lookup builds against the query memory
+/// budget. Default ON (`FLUREE_SCAN_MEM_ACCOUNTING`, family falsy spellings via
+/// [`super::env_switch_enabled`]). ON makes a wide crawl trip a typed
+/// `MemoryBudgetExceeded` (507) instead of OOMing — closing the blind spot the
+/// audit's specimen 071cd59f (a point-lookup crawl that hard-OOM'd at 10 GB) fell
+/// into, which the hash-join / group-aggregate `record_alloc`s never covered.
+/// OFF is a clean revert to the prior behavior (scan path invisible to the budget;
+/// the `checkpoint()` polls degrade to pure cancellation checks because the scan
+/// records nothing). The counter is query-lifetime cumulative and never
+/// decremented, so a genuinely-streaming large scan is accounted as if all its
+/// windows were simultaneously resident — the intended conservative direction
+/// (over-count only ever aborts a query already near the budget), matching the
+/// existing fold/join accounting; a high-water refinement is deferred with the
+/// excluded per-file buffer accounting (V2 site B).
+fn scan_mem_accounting_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| super::env_switch_enabled("FLUREE_SCAN_MEM_ACCOUNTING"))
+}
+
+/// F-AUD-3: conservative per-entry byte estimate for a `build_parent_lookup`
+/// entry (a join key vec + a materialized subject `RdfTerm`, typically an IRI
+/// string) used to account the fact-as-parent build against the budget. ~200 B is
+/// the V2 estimate; like [`crate::context::BINDING_EST_BYTES`] it is a floor
+/// (ignores per-entry heap beyond the term), safe because over-counting only trips
+/// a build already near OOM.
+const PARENT_ENTRY_EST_BYTES: usize = 200;
+
 /// How a window of produced rows is combined with the buffered child rows.
 ///
 /// The join is *flipped* relative to a naive per-child probe: the (small,
@@ -563,8 +591,7 @@ impl R2rmlScanOperator {
     /// — the production build calls THIS fn, so the test exercises the real
     /// admission, not a copy.
     fn ref_template_shortcut_enabled(trust_fk_refs: bool, pattern: &R2rmlPattern) -> bool {
-        let star_free =
-            pattern.star_bindings.is_empty() && pattern.star_constraints.is_empty();
+        let star_free = pattern.star_bindings.is_empty() && pattern.star_constraints.is_empty();
         trust_fk_refs
             && (star_free || Self::folded_wildcard_all_scalar(pattern))
             && pattern.predicate_filter.is_none()
@@ -833,17 +860,15 @@ impl R2rmlScanOperator {
         // WILDCARD emits per-(p,o) across co-subject maps, so a map lacking the
         // folded constraint predicate can still contribute rows — pruning it would
         // drop those rows for vertically-partitioned subjects (F10-class mappings).
-        let star_required_preds: Vec<String> = if star_prune_on
-            && self.pattern.predicate_var.is_none()
-            && self.has_star_members()
-        {
-            self.pattern_predicates()
-                .iter()
-                .map(|s| (*s).to_string())
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let star_required_preds: Vec<String> =
+            if star_prune_on && self.pattern.predicate_var.is_none() && self.has_star_members() {
+                self.pattern_predicates()
+                    .iter()
+                    .map(|s| (*s).to_string())
+                    .collect()
+            } else {
+                Vec::new()
+            };
         // PR-3 fix (b'): resolution-only class prune (template-disjoint; see
         // `R2rmlPattern::class_prune_hint`). Gated by the same switch as fix (a).
         let prune_class: Option<String> = if star_prune_on {
@@ -1286,6 +1311,7 @@ impl R2rmlScanOperator {
                     let parent_batches = collect_stream(parent_stream, ctx).await?;
 
                     let lookup = Arc::new(build_parent_lookup(
+                        ctx,
                         parent_tm,
                         &parent_join_cols,
                         parent_batches,
@@ -1430,6 +1456,23 @@ impl R2rmlScanOperator {
                 &progress.tms[i].ref_shortcuts,
                 ctx,
             )?;
+
+            // F-AUD-3 site A1: account the materialized window against the query
+            // memory budget so a wide non-aggregate crawl (the previously-blind scan
+            // path) trips a typed `MemoryBudgetExceeded` instead of OOMing. The window
+            // is bounded (~`materialize_window_rows`) so one window cannot itself OOM;
+            // `checkpoint()` here aborts once the cumulative recorded bytes (this
+            // window plus every prior one and any upstream fold/join) cross the
+            // budget, before the loop pulls another. Cumulative, never decremented —
+            // see `scan_mem_accounting_enabled`.
+            if scan_mem_accounting_enabled() {
+                let window_est = produced
+                    .len()
+                    .saturating_mul(num_cols)
+                    .saturating_mul(crate::context::BINDING_EST_BYTES);
+                ctx.record_alloc(window_est);
+                ctx.checkpoint()?;
+            }
 
             if !produced.is_empty() {
                 emit_produced_window(
@@ -2496,6 +2539,7 @@ fn materialize_batch(
 ///
 /// HashMap mapping join key (as `Vec<String>`) to parent subject `RdfTerm`.
 fn build_parent_lookup(
+    ctx: &ExecutionContext<'_>,
     parent_tm: &TriplesMap,
     parent_columns: &[String],
     batches: Vec<ColumnBatch>,
@@ -2503,6 +2547,20 @@ fn build_parent_lookup(
     let mut lookup = ParentLookup::new();
 
     for batch in batches {
+        // F-AUD-3 site A2: the fact-as-parent hazard (V2) — a RefObjectMap whose
+        // parent is a FACT table transiently builds a full parent-sized map (tens of
+        // millions of entries) here, unbounded by the memo cap, which only refuses to
+        // RETAIN an over-window lookup AFTER it is fully built. Account each batch's
+        // worst-case contribution and checkpoint inside the build loop so a
+        // budget-exceeding build aborts typed (`MemoryBudgetExceeded`) BEFORE the
+        // whole map is resident, instead of OOMing. `num_rows` over-counts skipped
+        // (null-subject / null-key) rows — deliberately conservative. Cumulative like
+        // site A1; the map is genuinely retained while built, so cumulative == the
+        // resident footprint for this structure.
+        if scan_mem_accounting_enabled() {
+            ctx.record_alloc(batch.num_rows.saturating_mul(PARENT_ENTRY_EST_BYTES));
+            ctx.checkpoint()?;
+        }
         for row_idx in 0..batch.num_rows {
             // Materialize parent subject
             let subject_term =
@@ -2607,13 +2665,16 @@ impl Operator for R2rmlScanOperator {
             .collect();
 
         loop {
-            // Cancellation checkpoint at the top of the internal loop: this loop
-            // can pull many windows / files / child batches before returning a
+            // Cancellation + memory checkpoint at the top of the internal loop: this
+            // loop can pull many windows / files / child batches before returning a
             // full output batch, so the runner's between-`next_batch` check would
             // otherwise never run for a whole-table scan. Covers the loop's
-            // non-advancing branches (overflow drain, child pull) that site 2
-            // does not.
-            ctx.check_cancelled()?;
+            // non-advancing branches (overflow drain, child pull) that site 2 does
+            // not. Upgraded from `check_cancelled()` to `checkpoint()` (F-AUD-3): it
+            // also enforces the query memory budget against the window bytes recorded
+            // by site A1 (a no-op for the budget when scan accounting is off, since
+            // nothing on this path records then).
+            ctx.checkpoint()?;
             // 1. Drain overflow from a prior window before doing more work.
             while !self.pending.is_empty() && columns[0].len() < ctx.batch_size {
                 let row = self.pending.pop_front().unwrap();
@@ -2761,6 +2822,120 @@ mod tests {
             collect_scan_capped(stream, 1000, &ctx).await,
             Err(QueryError::Cancelled { .. })
         ));
+    }
+
+    /// F-AUD-3 site A1 — specimen 071cd59f regression. A wide non-aggregate crawl
+    /// (`?s ?p ?o`) materializes a window of bindings that the pre-fix scan path
+    /// never recorded against the memory budget, so a runaway crawl OOM'd instead of
+    /// aborting typed. With scan accounting on (the default), the materialized
+    /// window is recorded and a tiny 1-byte ceiling makes the window checkpoint
+    /// abort TYPED (`MemoryBudgetExceeded`, a 507) rather than completing/OOMing.
+    #[tokio::test]
+    async fn r3b_scan_window_budget_aborts_typed() {
+        use crate::r2rml::R2rmlTableProvider;
+        use crate::seed::EmptyOperator;
+        use crate::var_registry::VarRegistry;
+        use fluree_db_core::QueryCancellation;
+        use fluree_db_r2rml::mapping::{
+            CompiledR2rmlMapping, ObjectMap, PredicateMap, PredicateObjectMap, TriplesMap,
+        };
+        use fluree_db_tabular::{BatchSchema, FieldInfo, FieldType};
+
+        #[derive(Debug)]
+        struct StoreProvider;
+        #[async_trait::async_trait]
+        impl R2rmlTableProvider for StoreProvider {
+            async fn scan_table(
+                &self,
+                _graph_source_id: &str,
+                _table_name: &str,
+                _projection: &[String],
+                _filters: &[crate::r2rml::ScanFilter],
+                _topk: Option<&crate::r2rml::ScanTopK>,
+                _as_of_t: Option<i64>,
+            ) -> Result<ColumnBatchStream> {
+                let schema = Arc::new(BatchSchema::new(vec![FieldInfo {
+                    name: "STORE_KEY".to_string(),
+                    field_type: FieldType::Int64,
+                    nullable: true,
+                    field_id: 1,
+                }]));
+                let batch =
+                    ColumnBatch::new(schema, vec![Column::Int64(vec![Some(1), Some(2), Some(3)])])
+                        .unwrap();
+                Ok(Box::pin(futures::stream::once(async move { Ok(batch) })))
+            }
+        }
+
+        let tm = TriplesMap::new("#Store", "DIM_STORE")
+            .with_subject_template("http://ex/store/{STORE_KEY}")
+            .with_class("http://ex/Store")
+            .with_predicate_object(PredicateObjectMap {
+                predicate_map: PredicateMap::constant("http://ex/storeKey"),
+                object_map: ObjectMap::column("STORE_KEY"),
+            });
+        let mapping = Arc::new(CompiledR2rmlMapping::new(vec![tm]));
+        let snapshot = fluree_db_core::LedgerSnapshot::genesis("test/main");
+        let vars = VarRegistry::new();
+        let provider = StoreProvider;
+
+        let cancel = QueryCancellation::new();
+        cancel.set_memory_limit(1); // 1-byte ceiling → the first window's record crosses it.
+        let mut ctx = ExecutionContext::new(&snapshot, &vars).with_cancellation(cancel);
+        ctx.r2rml_table_provider = Some(&provider);
+
+        // `?s ?p ?o` — the true-wildcard crawl the blind spot lived on.
+        let pattern =
+            R2rmlPattern::new("gs:main", VarId(0), Some(VarId(2))).with_predicate_var(VarId(1));
+        let mut op = R2rmlScanOperator::new(Box::new(EmptyOperator::new()), pattern);
+        op.mapping = Some(Arc::clone(&mapping));
+
+        let mut progress = op
+            .build_progress(&ctx, Batch::single_empty())
+            .await
+            .expect("build_progress")
+            .expect("wildcard crawl resolves the one TriplesMap");
+        let num_cols = op.schema().len();
+        let mut columns: Vec<Vec<Binding>> = (0..num_cols).map(|_| Vec::new()).collect();
+        let err = op
+            .advance_one_window(&ctx, &mut progress, num_cols, &mut columns)
+            .await
+            .expect_err("the materialized window must trip the 1-byte budget");
+        assert!(
+            matches!(err, QueryError::MemoryBudgetExceeded { .. }),
+            "wide crawl window must abort typed, got {err:?}"
+        );
+    }
+
+    /// F-AUD-3 site A2 — the fact-as-parent build. `build_parent_lookup` transiently
+    /// materializes a full parent-sized map; with a RefObjectMap whose parent is a
+    /// FACT table this is tens of millions of entries, unbounded by the memo cap.
+    /// The per-batch accounting + checkpoint makes a budget-exceeding build abort
+    /// TYPED before the whole map is resident (a 1-byte ceiling trips on the first
+    /// batch here) instead of OOMing.
+    #[test]
+    fn r3b_parent_build_budget_aborts_typed() {
+        use crate::var_registry::VarRegistry;
+        use fluree_db_core::{LedgerSnapshot, QueryCancellation};
+        use fluree_db_r2rml::mapping::TriplesMap;
+
+        let snapshot = LedgerSnapshot::genesis("test/main");
+        let vars = VarRegistry::new();
+        let cancel = QueryCancellation::new();
+        cancel.set_memory_limit(1); // 1-byte ceiling.
+        let ctx = ExecutionContext::new(&snapshot, &vars).with_cancellation(cancel);
+
+        let parent_tm = TriplesMap::new("#Customer", "customers")
+            .with_subject_template("http://ex/customer/{ID}");
+        // One batch of rows is enough — the per-batch record_alloc crosses the ceiling
+        // before any row is inserted, so the build aborts on the first batch.
+        let batch = single_col_batch("ID", vec![Some(1), Some(2), Some(3)]);
+        let err = build_parent_lookup(&ctx, &parent_tm, &["ID".to_string()], vec![batch])
+            .expect_err("the fact-parent build must trip the 1-byte budget");
+        assert!(
+            matches!(err, QueryError::MemoryBudgetExceeded { .. }),
+            "fact-parent build must abort typed, got {err:?}"
+        );
     }
 
     /// PR-5 soundness: the top-k pushdown must be declined whenever the scan
@@ -3607,12 +3782,7 @@ mod tests {
     #[test]
     fn f16_folded_wildcard_all_scalar_gate() {
         use crate::r2rml::{ObjectConstant, ScanValue};
-        let scalar = |p: &str| {
-            (
-                p.to_string(),
-                ObjectConstant::Scalar(ScanValue::Int(7)),
-            )
-        };
+        let scalar = |p: &str| (p.to_string(), ObjectConstant::Scalar(ScanValue::Int(7)));
         let iri = |p: &str| {
             (
                 p.to_string(),
@@ -3633,8 +3803,7 @@ mod tests {
 
         // Mixed scalar + IRI → disqualified (every constraint must be scalar).
         let mut mixed = pass.clone();
-        mixed.star_constraints =
-            vec![scalar("http://ex/lineNumber"), iri("http://ex/order")];
+        mixed.star_constraints = vec![scalar("http://ex/lineNumber"), iri("http://ex/order")];
         assert!(!R2rmlScanOperator::folded_wildcard_all_scalar(&mixed));
 
         // Fixed-predicate star member present → not the crawl fold.
@@ -3667,8 +3836,8 @@ mod tests {
         use crate::r2rml::{ObjectConstant, ScanValue};
         // The ref side: single-column templated FK — shortcut-eligible (the
         // deployed `edw:order` → FactOrder shape).
-        let parent =
-            TriplesMap::new("#Order", "FACT_ORDER").with_subject_template("http://ex/order/{ORDER_KEY}");
+        let parent = TriplesMap::new("#Order", "FACT_ORDER")
+            .with_subject_template("http://ex/order/{ORDER_KEY}");
         let rom = RefObjectMap::new("#Order", "ORDER_KEY", "ORDER_KEY");
         assert!(
             build_ref_shortcut(&parent, &rom).is_some(),
@@ -3683,7 +3852,9 @@ mod tests {
             "http://ex/lineNumber".to_string(),
             ObjectConstant::Scalar(ScanValue::Int(1)),
         )];
-        assert!(R2rmlScanOperator::ref_template_shortcut_enabled(true, &folded));
+        assert!(R2rmlScanOperator::ref_template_shortcut_enabled(
+            true, &folded
+        ));
 
         // Iri-folded → admission false (sound parent-scan path; catch #11).
         let mut iri_folded = folded.clone();
@@ -3705,7 +3876,9 @@ mod tests {
         // unchanged by the F-16 amendment).
         let plain =
             R2rmlPattern::new("gs:main", VarId(0), Some(VarId(2))).with_predicate_var(VarId(1));
-        assert!(R2rmlScanOperator::ref_template_shortcut_enabled(true, &plain));
+        assert!(R2rmlScanOperator::ref_template_shortcut_enabled(
+            true, &plain
+        ));
 
         // Fixed-predicate star + trust ON → admission false (star shapes keep
         // parent-scan + dangling-FK semantics; unchanged).
@@ -3714,7 +3887,9 @@ mod tests {
             "http://ex/lineNumber".to_string(),
             ObjectConstant::Scalar(ScanValue::Int(1)),
         )];
-        assert!(!R2rmlScanOperator::ref_template_shortcut_enabled(true, &star));
+        assert!(!R2rmlScanOperator::ref_template_shortcut_enabled(
+            true, &star
+        ));
     }
 
     /// A templated (non-constant) predicate binds `?p` from the row when the


### PR DESCRIPTION
## Forest map — where this PR sits

This is **PR #2 of 4** in the Tier-0/1/2 implementation of the 2026-07 big-iceberg audit (`audit-2026-07/`), the bundle composition decided in [`decisions/DEC-001-pr-bundling.md`](../blob/perf/audit-mem-guards/audit-2026-07/decisions/DEC-001-pr-bundling.md). Base = the integration branch `perf/audit-tier012` (perf tip `10e073fe9` + a clean merge of `origin/main` ≥ `7581f0a`, the #1508 resurrection fix). Siblings: PR-SAFE-MOR (on `main`), PR-COVERAGE, PR-HARNESS (the terminal re-bless leaf).

| This PR closes | Finding | Receipts |
|---|---|---|
| Memory-budget blind spot on the non-aggregate scan/crawl path | **F-AUD-3** (CONFIRMED, V2) | `00-MASTER-AUDIT.md` §2 F-AUD-3; `V2-membudget-verification.md` §1–§7 |

Four V2 fix sites, all here except V2 **site B** (per-file buffer accounting — excluded; see Residuals):

| Site | What | Where |
|---|---|---|
| **D** | `BINDING_EST_BYTES` 64 → `size_of::<Binding>()` (=88) + compile-time floor guard | `fluree-db-query/src/context.rs` |
| **C** | Per-query budget division at the runner attach point | `fluree-db-query/src/execute/runner.rs` |
| **A1** | `record_alloc` + `checkpoint` on the materialized scan window, **released on hand-off** (see below) | `fluree-db-query/src/r2rml/operator.rs` (`advance_one_window`, pull-loop poll) |
| **A2** | `record_alloc` + `checkpoint` inside the fact-as-parent build loop (stays cumulative — persistent map) | `fluree-db-query/src/r2rml/operator.rs` (`build_parent_lookup`) |
| **release** | saturating `release` decrement primitive on the budget counter (pairs the A1 window charge) | `fluree-db-core/src/cancellation.rs` + `context.rs` wrapper |

**A1 window-scoped release (q038 fix).** The first cut of A1 charged each window cumulatively with no decrement — the documented V2 conservative edge. The live re-bless proved it bites a mainstream shape: **q038** (a 36M-row un-fused COUNT on the per-row materialize path) false-aborted typed at 38 s (`~8.61 GB > 8.59 GB`) while completing fine at 52.5 s with the accounting off, because ~70 sequentially-**freed** 512K-row windows *summed* past the budget though only one is ever resident. Fix: charge + `checkpoint()` **before** emit (an oversized single window, or this window atop a retained A2 build / upstream fold, still aborts typed), then **`release()` the charge once the window is handed off** (`produced` drops). A streaming scan now accounts only its resident window. A2 and the fold/join/fused builds are **not** released — they genuinely persist, so their cumulative charge is correct.

## Why — the V2 worst-case arithmetic

The R3-B memory budget instruments the aggregating/joining operators (`record_alloc` at 7 sites in `hash_join.rs` / `group_aggregate.rs` / `fused_aggregate.rs`). The **non-aggregate `R2rmlScanOperator` path had zero** — six `check_cancelled()` and no `record_alloc`/`checkpoint`. So a single wide crawl (default switches) carries, entirely unaccounted:

| Component | Bound | Resident | Accounted before? |
|---|---|---|---|
| Overflow window `self.pending` | ≤512K rows | ~1.19 GB | NO |
| Scan-replay cache (correlated) | ≤512K rows | ~1.19 GB | NO |
| In-flight file buffers | ≤32 files | ~2 GB (up to ~8 GB broad) | NO |
| **Transient fact-as-parent build** | fact rows (uncapped) | **up to ~7 GB (36M entries)** | NO |

≈ **4.4 GB** unaccounted for a modest wide crawl, **~11 GB** with one fact-as-parent lookup — past both the 8 GiB budget and the 10 GiB Lambda ceiling, with `record_alloc` seeing zero of it. With no per-query division (site C), N×4.4 GB OOMs a 10 GiB node at N≈2. This is not hypothetical: forensic specimen **`071cd59f`** — the point-lookup crawl `?ol ex:orderLineKey "1" . ?ol ?p ?o` — hard-OOM'd at **10237 MB** on exactly this path (`R2rmlScanOperator` wildcard crawl + `build_parent_lookup` over a 36M-row fact). It is now the regression test `r3b_scan_window_budget_aborts_typed`.

After this PR the scan path trips a typed `QueryError::MemoryBudgetExceeded` (507, distinct from a 408 timeout) instead of OOMing — **A1** catches accumulated bounded windows at the pull-loop checkpoint; **A2** aborts the unbounded parent build *before* the whole map is resident.

## Design note — the per-query division (site C)

V2 §3: `set_memory_limit` had **no production caller**, so `checkpoint()` always compared each query's own counter against the *full* process budget — N concurrent queries each read "under 8 GB" while the node sat at 10 GB.

I shipped the **sound minimal static form**: pin `budget / FLUREE_QUERY_BUDGET_SHARE_DIV` at the runner attach (`execute_prepared_into`, the `with_cancellation` seam). **Default `div=1` pins nothing** — checkpoint falls back to the full process budget, byte-for-byte today's behavior; an embedder's explicit ceiling is never clobbered. Operators set `div` to their deployment's max query concurrency (e.g. a Lambda's reserved concurrency) to opt into sharing.

I deliberately did **not** ship the *dynamic* divisor (divide by live concurrency so a lone query keeps the full budget), even though the audit recommends default-on sharing: a correct live count must count only **top-level** queries, and the runner attach point is also re-entered by nested policy `f:query` / reasoning / sub-queries — an in-engine counter there would over-divide and abort legitimate queries. V2 §7(C) reaches the same conclusion ("the authoritative source is the server that spawns the watchdog and holds the handle, `fluree-db-server/src/query_control.rs`"). So the dynamic count is deferred to the server request boundary; the static form is present, neutral by default, and sound. A non-1 *default* is intentionally NOT set here — it would shrink every query's budget and risk aborting today-passing queries in a safety PR.

## Residuals (deferred, documented)

- **V2 site B — per-file in-flight buffer accounting** (`r2rml.rs` fan-out, ≤32 files × up to 256 MB) is **excluded**: releasing on batch flush needs a *decrement* primitive the current monotonic `AtomicUsize` counter lacks. Adding one is a larger change to `fluree-db-core::cancellation`; deferred. The file buffers remain invisible to the budget (bounded O(32) by `buffer_unordered` backpressure, so not unbounded — but GB-scale).
- **Heap under-count beyond the constant** — `BINDING_EST_BYTES` is now the true 88-byte *stack* size but still omits the `Arc<str>` IRI heap (~50–70 B) an Iceberg row carries, so a wide IRI-crawl is counted at ~1/2.2 of true resident bytes. Deliberate floor (over-count only ever aborts a query already near OOM); a heap-aware estimate is follow-up. `GROUP_EST_BYTES` is likewise a flat estimate.
- **Cumulative conservatism now applies only to PERSISTENT allocations** — after the q038 fix, scan windows are charged then **released** on hand-off, so a long streaming scan accounts only its resident window rather than the all-time sum (that sum was the q038 false-abort). The remaining non-released charges are the *genuinely persistent* ones — the A2 fact-parent map and the fold/join/fused builds — where cumulative == resident and the conservatism is correct. The retained scan overflow (`self.pending`, ≤ one window, drained before the next pull) is left untracked (minimal). Per-file buffers (site B) still need their own release pairing (deferred).
- **SWITCHES.md** — the two new switches below are documented here and in code but the registry regeneration is PR-HARNESS's job per DEC-001 (item 4). Flagged for that leaf.

## Kill-switch ledger (house rule: no unswitched mechanism)

| Switch | Default | Mechanism | Revert |
|---|---|---|---|
| `FLUREE_SCAN_MEM_ACCOUNTING` | **on** | A1 + A2 scan/crawl `record_alloc` + `checkpoint` | `=off` → scan path records nothing; `checkpoint()` degrades to a pure cancellation poll (prior behavior) |
| `FLUREE_QUERY_BUDGET_SHARE_DIV` | **1** | C per-query budget = full / div | `=1` (default) → full budget per query, exactly today |

Both read via the established idioms (`env_switch_enabled` OnceLock for the on/off; parsed env for the divisor). `FLUREE_QUERY_MEMORY_BUDGET_BYTES=0` still disables the whole budget guard, unchanged.

## Local gate record — verification of record

CI does **not** fire on this PR: `ci.yml` gates only when `base == main`, and this PR's base is `perf/audit-tier012` (verified in DEC-001 Adjudication B.3). The local record below **is** the verification of record. Reproduced in a worktree at branch head `cfd773d75` (base = integration tip `9c6739c3b`, the PR-SAFE-MOR guard + its cache-hit re-apply arm, all in `fluree-db-iceberg/*` + `fluree-db-api`/`iceberg_catalog.rs`, zero overlap with this PR's four files). This PR touches **four files** — `fluree-db-core/src/cancellation.rs` (the `release` primitive) plus `fluree-db-query/src/{context.rs, execute/runner.rs, r2rml/operator.rs}`:

- `cargo fmt --check` — the **four files this PR changes are clean** (0 diffs each). The workspace check reports **2 pre-existing** drift spots in `fluree-db-query/src/hash_join.rs:1070,1120` that this PR does **not** touch — present at the base (`git show origin/perf/audit-tier012:fluree-db-query/src/hash_join.rs | rustfmt --check` shows them), part of the perf line's known fmt debt, left for the hygiene pass (db-verify-gotchas: don't fix pre-existing debt in a scoped PR).
- `cargo clippy -p fluree-db-core --all-targets --no-deps` — clean re: this PR (1 pre-existing `unused import` in `commit.rs:943`, untouched by this PR). `cargo clippy -p fluree-db-query --all-targets --no-deps` — **clean, 0 warnings** (clippy 1.97.0).
- `cargo test -p fluree-db-core` — **704 lib + bins pass, 0 failed** (incl. the 2 new `release` tests).
- `cargo test -p fluree-db-query` — **1296 lib + all integration bins pass, 0 failed** (incl. the 6 new hermetics).
- `cargo test -p fluree-db-api` (grp_* bins, full package) — **all bins pass, 0 failed** (99 ignored = live-credential Snowflake/Iceberg suites).

No `fluree-db-server` changes (site C lives in the query runner, not the server), so that gate is not applicable. The `release` primitive lands in `fluree-db-core` (the budget counter's home) — minimal (a single saturating decrement), per the design guardrail not to introduce a general decrement surface beyond the window pairing.

## Hermetic tests (extend the `r3b_*_budget_aborts_typed` pattern)

- `r3b_scan_window_budget_aborts_typed` — **specimen 071cd59f regression**: a `?s ?p ?o` wildcard crawl with a 1-byte ceiling aborts typed (A1; still aborts after the release fix — the checkpoint fires while the window is charged, before it is released).
- `r3b_scan_windows_release_no_false_abort` — **q038 regression**: 64 one-row windows under an 8000-byte ceiling COMPLETE (verified to fail pre-fix at window ~16 with `MemoryBudgetExceeded 8448 > 8000`) — the released per-window charge never accumulates.
- `release_subtracts_and_saturates_at_zero` + `disabled_handle_release_is_a_noop` (`fluree-db-core`) — the `release` primitive decrements, is shared across clones, and saturates.
- `r3b_parent_build_budget_aborts_typed` — a fact-as-parent `build_parent_lookup` with a 1-byte ceiling aborts typed on the first batch (A2, still cumulative).
- `shared_ceiling_trips_each_query_at_its_divided_budget` + `per_query_ceiling_divides_and_floors` — two queries under a divided ceiling each trip at budget/N, not the full budget (C).
- `binding_est_bytes_is_at_least_binding_stack_size` — the 88-byte canary; the `>= size_of` invariant is a compile-time `const _` next to the constant (D).
