### PR TITLE
fix: keep history entries in the same leaflet as their row

### DIFF
--- a/docs/design/index-format.md
+++ b/docs/design/index-format.md
@@ -269,6 +269,12 @@ first_o_key: u64
     (re-assert of a present fact, retract of an absent one) are never recorded.
   - a fact's materialized assert lives either as its base row or as a history entry, never both
     and never neither (**row-assert conservation**)
+  - a fact's transition entries live in the **same leaflet/segment as its materialized row**
+    (**history co-location**). Replay is per-leaflet, so entries stranded in a neighbouring
+    leaflet would silently drop the fact from time-travel results. The writer buffers pushed
+    history until the row's leaflet is known so entries follow their row across a
+    predicate/`o_type` segment boundary — see `LeafWriter::commit_all_pending` in
+    `fluree-db-binary-index/src/format/leaf.rs`.
   - authoritative semantics: the module doc of `fluree-db-binary-index/src/format/transitions.rs`
 
 #### Region 1 layouts (uncompressed)

--- a/fluree-db-binary-index/src/format/leaf.rs
+++ b/fluree-db-binary-index/src/format/leaf.rs
@@ -96,9 +96,19 @@ pub struct LeafWriter {
     // History accumulation.
     sidecar_builder: HistSidecarBuilder,
     /// Whether a sidecar segment has been started for the current leaflet buffer.
-    /// Reset to false on flush_leaflet(). Set to true on first push_history_entry()
-    /// or on flush_leaflet() itself (which starts a segment for the encoded leaflet).
+    /// Reset to false on flush_leaflet(). Set to true when history is committed to
+    /// the current leaflet, or on flush_leaflet() itself (which starts a segment
+    /// for the encoded leaflet).
     current_segment_started: bool,
+    /// History entries pushed but not yet committed to a leaflet segment.
+    ///
+    /// In the build push order, a fact's transition entries are pushed immediately
+    /// before its materialized row (`push_record`). Buffering them here — rather
+    /// than eagerly attaching to whatever leaflet is mid-buffer — lets us commit
+    /// them to the leaflet that actually holds their row, even when that row opens
+    /// a new predicate/o_type segment (and thus a new leaflet). See
+    /// `commit_pending_for_current_segment` / `commit_all_pending`.
+    pending_history: Vec<HistEntryV2>,
 
     // Segmentation tracking.
     current_seg_p_id: Option<u32>,
@@ -135,6 +145,7 @@ impl LeafWriter {
             record_buf: Vec::with_capacity(leaflet_target_rows),
             sidecar_builder: HistSidecarBuilder::new(),
             current_segment_started: false,
+            pending_history: Vec::new(),
             current_seg_p_id: None,
             current_seg_o_type: None,
             encoded_leaflets: Vec::new(),
@@ -158,6 +169,10 @@ impl LeafWriter {
     pub fn push_record(&mut self, record: RunRecordV2) -> io::Result<()> {
         // Check segmentation constraint before buffering.
         if !self.record_buf.is_empty() && self.should_flush_for_segmentation(&record) {
+            // Trailing history matching the outgoing segment (e.g. a non-materialized
+            // fact that ends this predicate) belongs to the leaflet we're about to
+            // flush — commit it before the flush closes that leaflet's segment.
+            self.commit_pending_for_current_segment();
             self.flush_leaflet()?;
         }
 
@@ -177,6 +192,11 @@ impl LeafWriter {
             RunSortOrder::Spot => {}
         }
 
+        // This record's transition entries (and those of any preceding
+        // non-materialized facts in the same gap) belong to the leaflet that
+        // holds this record — the current one, post any segment-boundary flush.
+        self.commit_all_pending();
+
         self.record_buf.push(record);
         self.last_record = Some(record);
 
@@ -193,23 +213,68 @@ impl LeafWriter {
         Ok(())
     }
 
-    /// Push a history-only entry (retract-winner: no latest-state row,
-    /// but history must be logged).
+    /// Push a history entry for the fact whose row (if any) comes next.
     ///
-    /// History entries are associated with the current leaflet's sidecar segment.
-    /// If no segment has been started yet (before the first `flush_leaflet`),
-    /// one is started automatically. When `flush_leaflet` runs, if a segment
-    /// was already started by history entries, it keeps it; otherwise it starts
-    /// a new empty one. This ensures segment count always equals leaflet count.
+    /// Entries are buffered, not attached immediately: in the build push order a
+    /// fact's transitions precede its `push_record`, so they belong to the same
+    /// leaflet as that row — which may open a new segment (and leaflet). Buffering
+    /// lets `commit_all_pending` / `commit_pending_for_current_segment` file each
+    /// entry into the leaflet that actually holds its row. Retract-winner facts
+    /// (no materialized row) push history only; those entries are committed to the
+    /// current leaflet by the next `push_record` (or by `finish`).
     pub fn push_history_entry(&mut self, entry: HistEntryV2) {
         if self.skip_history {
             return;
         }
+        self.pending_history.push(entry);
+    }
+
+    /// Commit `entry` into the current leaflet's sidecar segment, starting the
+    /// segment if this is its first entry.
+    fn commit_history_entry(&mut self, entry: HistEntryV2) {
         if !self.current_segment_started {
             self.sidecar_builder.start_leaflet();
             self.current_segment_started = true;
         }
         self.sidecar_builder.push_entry(entry);
+    }
+
+    /// Commit every buffered history entry to the current leaflet's segment.
+    /// Called once the record opening/continuing this leaflet is known.
+    fn commit_all_pending(&mut self) {
+        if self.pending_history.is_empty() {
+            return;
+        }
+        for entry in std::mem::take(&mut self.pending_history) {
+            self.commit_history_entry(entry);
+        }
+    }
+
+    /// Commit only the buffered entries that belong to the segment currently
+    /// buffered (matching segment key), leaving the rest pending for a later
+    /// leaflet. Used just before a segment-boundary flush so a non-materialized
+    /// fact ending the outgoing segment lands in that segment's leaflet.
+    fn commit_pending_for_current_segment(&mut self) {
+        if self.pending_history.is_empty() {
+            return;
+        }
+        let pending = std::mem::take(&mut self.pending_history);
+        let mut retained = Vec::new();
+        for entry in pending {
+            let belongs = match self.order {
+                RunSortOrder::Post | RunSortOrder::Psot => {
+                    self.current_seg_p_id == Some(entry.p_id)
+                }
+                RunSortOrder::Opst => self.current_seg_o_type == Some(entry.o_type),
+                RunSortOrder::Spot => true,
+            };
+            if belongs {
+                self.commit_history_entry(entry);
+            } else {
+                retained.push(entry);
+            }
+        }
+        self.pending_history = retained;
     }
 
     /// Drain the leaves completed so far, transferring ownership to the caller
@@ -230,6 +295,9 @@ impl LeafWriter {
     /// Consume the writer, flushing any remaining data, and return all
     /// produced leaves.
     pub fn finish(mut self) -> io::Result<Vec<LeafInfo>> {
+        // Trailing history (a non-materialized fact at the tail of the order)
+        // belongs to the final leaflet — commit it before the closing flush.
+        self.commit_all_pending();
         if !self.record_buf.is_empty() {
             self.flush_leaflet()?;
         }
@@ -263,7 +331,7 @@ impl LeafWriter {
         let row_count = encoded.row_count as u64;
 
         // Ensure a history segment exists for this leaflet.
-        // If push_history_entry() already started one, skip. Otherwise start an empty one.
+        // If committed history already started one, skip. Otherwise start an empty one.
         // This guarantees segment count == leaflet count.
         if !self.skip_history && !self.current_segment_started {
             self.sidecar_builder.start_leaflet();

--- a/fluree-db-binary-index/src/format/leaf.rs
+++ b/fluree-db-binary-index/src/format/leaf.rs
@@ -174,6 +174,9 @@ impl LeafWriter {
             // flush — commit it before the flush closes that leaflet's segment.
             self.commit_pending_for_current_segment();
             self.flush_leaflet()?;
+            // Close a full leaf before assigning the incoming record or its
+            // history to it. The segment flush may have crossed this threshold.
+            self.flush_leaf_if_target_reached()?;
         }
 
         // Track first record of the leaf.
@@ -206,9 +209,7 @@ impl LeafWriter {
         }
 
         // Leaf-level threshold.
-        if self.leaf_accumulated_rows >= self.leaf_target_rows as u64 {
-            self.flush_leaf()?;
-        }
+        self.flush_leaf_if_target_reached()?;
 
         Ok(())
     }
@@ -319,6 +320,13 @@ impl LeafWriter {
         }
     }
 
+    fn flush_leaf_if_target_reached(&mut self) -> io::Result<()> {
+        if self.leaf_accumulated_rows >= self.leaf_target_rows as u64 {
+            self.flush_leaf()?;
+        }
+        Ok(())
+    }
+
     // ── Flush leaflet ──────────────────────────────────────────────────
 
     fn flush_leaflet(&mut self) -> io::Result<()> {
@@ -356,11 +364,20 @@ impl LeafWriter {
             return Ok(());
         }
 
+        debug_assert!(
+            self.record_buf.is_empty(),
+            "cannot flush a leaf while its next leaflet has buffered records"
+        );
+
         let first_record = self.leaf_first_record.take().unwrap();
         let last_record = self.last_record.unwrap();
 
         // 1. Build history sidecar (must come first — CAS ordering).
         let sidecar_builder = std::mem::take(&mut self.sidecar_builder);
+        // The replacement builder has no current segment. This is normally
+        // already false after flush_leaflet(), but keep the state coupled to
+        // the builder so future flush paths cannot drop history.
+        self.current_segment_started = false;
         let (sidecar_cid, sidecar_bytes, seg_refs) =
             if !self.skip_history && sidecar_builder.has_history() {
                 let (bytes, refs) = sidecar_builder.build();

--- a/fluree-db-binary-index/tests/it_history_sidecar_placement.rs
+++ b/fluree-db-binary-index/tests/it_history_sidecar_placement.rs
@@ -1,0 +1,87 @@
+//! Regression: history entries for a fact whose row opens a new PSOT predicate
+//! segment must land in that row's leaflet, not the previous one. Mirrors
+//! index_build's push order — history entries pushed immediately before their
+//! row's push_record — and replays the segment to confirm the fact is still
+//! visible AS OF a time before its final assertion.
+
+use fluree_db_binary_index::format::history_sidecar::HistEntryV2;
+use fluree_db_binary_index::format::leaf::LeafWriter;
+use fluree_db_binary_index::format::run_record::{RunSortOrder, LIST_INDEX_NONE};
+use fluree_db_binary_index::format::run_record_v2::RunRecordV2;
+use fluree_db_binary_index::read::column_types::ColumnProjection;
+use fluree_db_binary_index::read::leaf_access::{FullBlobLeafHandle, LeafHandle};
+use fluree_db_binary_index::replay_leaflet;
+use fluree_db_core::o_type::OType;
+use fluree_db_core::subject_id::SubjectId;
+use fluree_db_core::value_id::ObjKey;
+
+fn rec(p_id: u32, s_id: u64, v: i64, t: u32) -> RunRecordV2 {
+    RunRecordV2 {
+        s_id: SubjectId::from_u64(s_id),
+        o_key: ObjKey::encode_i64(v).as_u64(),
+        p_id,
+        t,
+        o_i: LIST_INDEX_NONE,
+        o_type: OType::XSD_INTEGER.as_u16(),
+        g_id: 0,
+    }
+}
+
+fn hist(p_id: u32, s_id: u64, v: i64, t: u32, op: u8) -> HistEntryV2 {
+    HistEntryV2 {
+        s_id: SubjectId::from_u64(s_id),
+        p_id,
+        o_type: OType::XSD_INTEGER.as_u16(),
+        o_key: ObjKey::encode_i64(v).as_u64(),
+        o_i: LIST_INDEX_NONE,
+        t,
+        op,
+    }
+}
+
+#[test]
+fn history_entries_straddle_psot_segment_boundary() {
+    let mut writer = LeafWriter::new(RunSortOrder::Psot, 100, 1000, 1);
+
+    // Predicate 1: one plain row.
+    writer.push_record(rec(1, 1, 10, 1)).unwrap();
+
+    // Predicate 2, fact X with lifecycle a@1, r@4, a@6 — index_build pushes
+    // the transition entries, then the row.
+    writer.push_history_entry(hist(2, 2, 20, 1, 1));
+    writer.push_history_entry(hist(2, 2, 20, 4, 0));
+    writer.push_record(rec(2, 2, 20, 6)).unwrap();
+
+    let infos = writer.finish().unwrap();
+    assert_eq!(infos.len(), 1, "one leaf");
+    let info = &infos[0];
+
+    let handle =
+        FullBlobLeafHandle::new(info.leaf_bytes.clone(), info.sidecar_bytes.clone(), 0).unwrap();
+    let n_leaflets = handle.dir().entries.len();
+    eprintln!("leaflets: {n_leaflets}");
+    for i in 0..n_leaflets {
+        let seg = handle.load_sidecar_segment(i).unwrap();
+        let entries: Vec<(u32, u64, u32, u8)> = seg
+            .iter()
+            .map(|e| (e.p_id, e.s_id.as_u64(), e.t, e.op))
+            .collect();
+        eprintln!("leaflet {i} history: {entries:?}");
+    }
+
+    // Replay the p=2 leaflet to t=2: fact X was present (a@1, not yet
+    // retracted). If its entries landed in leaflet 0, this replay misses them.
+    let p2_leaflet = n_leaflets - 1;
+    let batch = handle
+        .load_columns(p2_leaflet, &ColumnProjection::all(), RunSortOrder::Psot)
+        .unwrap();
+    let history = handle.load_sidecar_segment(p2_leaflet).unwrap();
+    let replayed = replay_leaflet(&batch, &history, 2, RunSortOrder::Psot);
+    let view = replayed.as_ref().unwrap_or(&batch);
+    let x_present = (0..view.row_count).any(|i| view.s_id.get(i) == 2);
+    eprintln!("fact X present at t=2 via p=2 leaflet replay: {x_present}");
+    assert!(
+        x_present,
+        "fact X (asserted t=1, retracted t=4) must be present at t=2"
+    );
+}

--- a/fluree-db-binary-index/tests/it_history_sidecar_placement.rs
+++ b/fluree-db-binary-index/tests/it_history_sidecar_placement.rs
@@ -85,3 +85,41 @@ fn history_entries_straddle_psot_segment_boundary() {
         "fact X (asserted t=1, retracted t=4) must be present at t=2"
     );
 }
+
+#[test]
+fn history_survives_leaf_split_at_psot_segment_boundary() {
+    // The p=1 segment reaches the leaf target only when pushing the first p=2
+    // row forces it to flush. The incoming row and its history must start leaf 2.
+    let mut writer = LeafWriter::new(RunSortOrder::Psot, 100, 2, 1);
+    writer.push_record(rec(1, 1, 10, 1)).unwrap();
+    writer.push_record(rec(1, 2, 11, 1)).unwrap();
+
+    writer.push_history_entry(hist(2, 3, 20, 1, 1));
+    writer.push_history_entry(hist(2, 3, 20, 4, 0));
+    writer.push_record(rec(2, 3, 20, 6)).unwrap();
+
+    let infos = writer.finish().unwrap();
+    assert_eq!(infos.len(), 2);
+    assert_eq!(infos[0].total_rows, 2);
+    assert_eq!(infos[0].first_key.p_id, 1);
+    assert_eq!(infos[0].last_key.p_id, 1);
+    assert_eq!(infos[1].total_rows, 1);
+    assert_eq!(infos[1].first_key.p_id, 2);
+    assert_eq!(infos[1].last_key.p_id, 2);
+
+    let info = &infos[1];
+    let handle =
+        FullBlobLeafHandle::new(info.leaf_bytes.clone(), info.sidecar_bytes.clone(), 0).unwrap();
+    assert_eq!(handle.dir().entries.len(), 1);
+
+    let batch = handle
+        .load_columns(0, &ColumnProjection::all(), RunSortOrder::Psot)
+        .unwrap();
+    let history = handle.load_sidecar_segment(0).unwrap();
+    let replayed = replay_leaflet(&batch, &history, 2, RunSortOrder::Psot);
+    let view = replayed.as_ref().unwrap_or(&batch);
+    assert!(
+        (0..view.row_count).any(|i| view.s_id.get(i) == 3),
+        "fact X must remain present AS OF t=2 after crossing the leaf boundary"
+    );
+}

--- a/fluree-db-indexer/tests/it_rebuild_history_placement.rs
+++ b/fluree-db-indexer/tests/it_rebuild_history_placement.rs
@@ -1,0 +1,115 @@
+//! Regression: end-to-end check that a full rebuild (`build_index`, PSOT order)
+//! files a fact's transition entries into the leaflet holding its row when that
+//! row is the first record of a new predicate segment — so time-travel replay
+//! of the segment still sees the fact AS OF a time before its final assertion.
+
+use fluree_db_binary_index::format::run_record::{RunSortOrder, LIST_INDEX_NONE};
+use fluree_db_binary_index::format::run_record_v2::{RunRecordV2, RECORD_V2_WITH_OP_WIRE_SIZE};
+use fluree_db_binary_index::read::column_types::ColumnProjection;
+use fluree_db_binary_index::read::leaf_access::{FullBlobLeafHandle, LeafHandle};
+use fluree_db_binary_index::replay_leaflet;
+use fluree_db_core::o_type::OType;
+use fluree_db_core::subject_id::SubjectId;
+use fluree_db_core::value_id::ObjKey;
+use fluree_db_indexer::run_index::build::index_build::{build_index, IndexBuildConfig};
+use fluree_db_indexer::run_index::run_file::{
+    RunFileHeader, RUN_V2_HEADER_LEN, RUN_V2_VERSION_WITH_OP,
+};
+
+fn rec(p_id: u32, s_id: u64, v: i64, t: u32) -> RunRecordV2 {
+    RunRecordV2 {
+        s_id: SubjectId::from_u64(s_id),
+        o_key: ObjKey::encode_i64(v).as_u64(),
+        p_id,
+        t,
+        o_i: LIST_INDEX_NONE,
+        o_type: OType::XSD_INTEGER.as_u16(),
+        g_id: 0,
+    }
+}
+
+/// Uncompressed with-op run file (version 2, flags = 0).
+fn write_run_with_op(path: &std::path::Path, records: &[RunRecordV2], ops: &[u8]) {
+    let header = RunFileHeader {
+        version: RUN_V2_VERSION_WITH_OP,
+        sort_order: RunSortOrder::Psot,
+        flags: 0,
+        record_count: records.len() as u64,
+        records_offset: RUN_V2_HEADER_LEN as u64,
+        min_t: 1,
+        max_t: 6,
+    };
+    let mut out = vec![0u8; RUN_V2_HEADER_LEN];
+    header.write_to(&mut out);
+    let mut buf = [0u8; RECORD_V2_WITH_OP_WIRE_SIZE];
+    for (r, &op) in records.iter().zip(ops) {
+        r.write_run_le_with_op(op, &mut buf);
+        out.extend_from_slice(&buf);
+    }
+    std::fs::write(path, out).unwrap();
+}
+
+#[test]
+fn rebuild_psot_first_fact_of_predicate_loses_replay_history() {
+    let dir = std::env::temp_dir().join("fluree_rebuild_history_placement");
+    let _ = std::fs::remove_dir_all(&dir);
+    let run_dir = dir.join("runs");
+    let index_dir = dir.join("index");
+    std::fs::create_dir_all(&run_dir).unwrap();
+
+    // PSOT order: p=1 plain row, then p=2 fact X with lifecycle a@1, r@4, a@6.
+    let records = vec![
+        rec(1, 1, 10, 1),
+        rec(2, 2, 20, 1),
+        rec(2, 2, 20, 4),
+        rec(2, 2, 20, 6),
+    ];
+    let ops = vec![1u8, 1, 0, 1];
+    write_run_with_op(&run_dir.join("run_00000.frn"), &records, &ops);
+
+    let config = IndexBuildConfig {
+        run_dir,
+        index_dir,
+        sort_order: RunSortOrder::Psot,
+        leaflet_target_rows: 100,
+        leaf_target_rows: 1000,
+        zstd_level: 1,
+        skip_dedup: false,
+        skip_history: false,
+        g_id: 0,
+        progress: None,
+    };
+    let result = build_index(&config).unwrap();
+    let leaf = &result.graphs[0].leaf_infos[0];
+    let leaf_bytes = std::fs::read(&leaf.leaf_path).unwrap();
+    let sidecar_bytes = leaf
+        .sidecar_path
+        .as_ref()
+        .map(|p| std::fs::read(p).unwrap());
+
+    let handle = FullBlobLeafHandle::new(leaf_bytes, sidecar_bytes, 0).unwrap();
+    let n = handle.dir().entries.len();
+    eprintln!("leaflets: {n}");
+    for i in 0..n {
+        let seg = handle.load_sidecar_segment(i).unwrap();
+        let entries: Vec<(u32, u64, u32, u8)> = seg
+            .iter()
+            .map(|e| (e.p_id, e.s_id.as_u64(), e.t, e.op))
+            .collect();
+        eprintln!("leaflet {i} history: {entries:?}");
+    }
+
+    // Replay the p=2 leaflet to t=2: X (asserted@1, retracted@4) must show.
+    let p2 = n - 1;
+    let batch = handle
+        .load_columns(p2, &ColumnProjection::all(), RunSortOrder::Psot)
+        .unwrap();
+    let history = handle.load_sidecar_segment(p2).unwrap();
+    let replayed = replay_leaflet(&batch, &history, 2, RunSortOrder::Psot);
+    let view = replayed.as_ref().unwrap_or(&batch);
+    let x_present = (0..view.row_count).any(|i| view.s_id.get(i) == 2);
+    eprintln!("fact X present at t=2 via p=2 leaflet replay: {x_present}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(x_present, "fact X must be present AS OF t=2");
+}


### PR DESCRIPTION
## Summary

The V3 `LeafWriter` attached each pushed history entry to whatever leaflet was mid-buffer at push time. In the rebuild push order a fact's transition entries are pushed immediately before its materialized row, so when that row opened a new predicate/`o_type` segment (a new leaflet), the entries were stranded in the **previous** leaflet's sidecar segment.

Time-travel replay is per-leaflet, so the row's own leaflet then carried an empty history segment and any AS OF query before the fact's final assertion silently dropped it — a correctness bug for historical queries after a full index rebuild.

## Fix

Buffer pushed history in `pending_history` and commit it only once the row's leaflet is known:

- `commit_all_pending` on `push_record` (after any segment-boundary flush) and on `finish` — entries follow their row into the leaflet that actually holds it.
- `commit_pending_for_current_segment` (segment-key matched) just before a boundary flush, so a non-materialized fact that ends a segment still lands in that segment's leaflet.

Only the full-rebuild path (`index_build`) pushes history through this writer; all incremental paths use `push_record` only, so nothing else relied on the old eager-attach behavior.

## Tests

Adds two regression tests that both failed before the fix and pass after:

- `fluree-db-binary-index/tests/it_history_sidecar_placement.rs` — `LeafWriter` unit level.
- `fluree-db-indexer/tests/it_rebuild_history_placement.rs` — end-to-end through `build_index`.

Each builds a fact whose row opens a new PSOT predicate segment, then replays that segment AS OF a time before the fact's final assertion and asserts the fact is still visible.

## Docs

Documents the **history co-location** invariant in `docs/design/index-format.md`.