### PR TITLE
feat: Enrich Cypher transaction commit result for write parity

### DIFF
--- a/fluree-db-api/src/cypher_txn.rs
+++ b/fluree-db-api/src/cypher_txn.rs
@@ -42,7 +42,10 @@
 use crate::cypher_write::{self, WritePlan};
 use crate::error::ApiError;
 use crate::view::GraphDb;
-use crate::{Fluree, GovernanceOptions, Result, Tracker};
+use crate::{
+    CommitReceipt, Fluree, GovernanceOptions, IndexingStatus, Result, Tracker, TrackingOptions,
+    TransactResultRef,
+};
 use fluree_db_core::ContentId;
 use fluree_db_ledger::LedgerState;
 use fluree_db_nameservice::{CasResult, RefKind, RefValue};
@@ -64,12 +67,19 @@ pub struct CypherTransaction {
     /// Session identity + policy inputs pinned at BEGIN; governs every
     /// statement staged in this transaction.
     governance: GovernanceOptions,
+    /// Shared fuel/time/policy accumulator pinned at BEGIN. Every statement
+    /// (and every clause of a sequential statement) stages under this same
+    /// tracker, so its tally at COMMIT is the sum across the whole
+    /// transaction. Disabled when no tracking was requested.
+    tracker: Tracker,
 }
 
 struct PendingCommit {
     commit_id: ContentId,
     bytes: Vec<u8>,
     t: i64,
+    /// Flakes in this pending commit; summed into the commit receipt.
+    flake_count: usize,
 }
 
 /// Per-statement outcome of a write inside a transaction.
@@ -105,10 +115,14 @@ impl Fluree {
     /// Open an interactive Cypher transaction pinned to the ledger's
     /// current cached head. `governance` (the session's authenticated
     /// identity and policy inputs) governs every statement staged in it.
+    /// `tracking` selects fuel/time/policy accounting; the resulting tally
+    /// accumulates across every statement and surfaces in the commit result
+    /// (pass [`TrackingOptions::default()`] to opt out).
     pub async fn begin_cypher_transaction(
         &self,
         ledger_id: &str,
         governance: GovernanceOptions,
+        tracking: TrackingOptions,
     ) -> Result<CypherTransaction> {
         let handle = self.ledger_cached(ledger_id).await?;
         let state = handle.snapshot().await.to_ledger_state();
@@ -123,6 +137,7 @@ impl Fluree {
             state,
             pending: Vec::new(),
             governance,
+            tracker: Tracker::new(tracking),
         })
     }
 
@@ -208,7 +223,10 @@ impl Fluree {
         .await?;
 
         let index_config = crate::server_defaults::default_index_config();
-        let tracker = Tracker::disabled();
+        // Shared transaction tracker: fuel from this statement accumulates
+        // into the tally reported at COMMIT. Cheap Arc clone so the `&mut txn`
+        // borrow below is unencumbered.
+        let tracker = txn.tracker.clone();
         let stage_result = if let Some(followup) = resolved.followup {
             // Per-row relationship MERGE … ON MATCH SET: stage both branches into
             // this statement's single pending commit.
@@ -266,7 +284,9 @@ impl Fluree {
         .await?;
 
         let index_config = crate::server_defaults::default_index_config();
-        let tracker = Tracker::disabled();
+        // Shared transaction tracker: every clause of this sequential statement
+        // charges the same accumulator, so its fuel sums across clauses.
+        let tracker = txn.tracker.clone();
         let ledger_id = txn.ledger_id.clone();
         let outcome = self
             .stage_cypher_sequential(
@@ -369,6 +389,7 @@ impl Fluree {
             commit_id,
             bytes,
             t: receipt.t,
+            flake_count: receipt.flake_count,
         });
         txn.state = next_state;
         Ok(receipt.flake_count)
@@ -379,11 +400,48 @@ impl Fluree {
     /// whole transaction with [`TransactError::CommitConflict`] (map it to
     /// a driver-retryable transient error). On success all pending commit
     /// blobs are written and the head ref advances once, base → final
-    /// commit. Returns the final committed `t` (the base `t` for an
-    /// all-reads transaction).
-    pub async fn commit_cypher_transaction(&self, txn: CypherTransaction) -> Result<i64> {
+    /// commit.
+    ///
+    /// Returns a [`TransactResultRef`] with the same shape the autocommit
+    /// path yields, so callers map one result type:
+    /// - `receipt` — final commit id + `t`, and the flake count summed across
+    ///   every staged statement;
+    /// - `indexing` — post-commit reindex signals (`needed`, `novelty_size`);
+    /// - `tally` — accumulated fuel/time/policy across the whole transaction
+    ///   (`None` when tracking was not requested at `begin`);
+    /// - `cypher_return` — always `None` here; per-statement `RETURN` rows are
+    ///   already delivered by [`CypherTxnWriteOutcome::return_table`].
+    ///
+    /// An all-reads (or all-no-op) transaction publishes nothing and reports
+    /// the unchanged base head with a zero flake count.
+    pub async fn commit_cypher_transaction(
+        &self,
+        txn: CypherTransaction,
+    ) -> Result<TransactResultRef> {
+        let index_config = crate::server_defaults::default_index_config();
         if txn.pending.is_empty() {
-            return Ok(txn.base_t);
+            // Head unchanged at the pinned base. `begin` requires a resolvable
+            // ledger, so a prior commit — hence a base head id — always exists.
+            let commit_id = txn
+                .base_head
+                .as_ref()
+                .and_then(|r| r.id.clone())
+                .ok_or_else(|| {
+                    ApiError::internal(
+                        "cannot commit an all-reads Cypher transaction on an uncommitted ledger",
+                    )
+                })?;
+            let indexing = self.cypher_txn_indexing_status(&txn.state, &index_config, txn.base_t);
+            return Ok(TransactResultRef {
+                receipt: CommitReceipt {
+                    commit_id,
+                    t: txn.base_t,
+                    flake_count: 0,
+                },
+                indexing,
+                tally: txn.tracker.tally(),
+                cypher_return: None,
+            });
         }
         let handle = self.ledger_cached(&txn.ledger_id).await?;
         let guard = handle.lock_for_write().await;
@@ -434,11 +492,46 @@ impl Fluree {
             }
         }
 
-        let index_config = crate::server_defaults::default_index_config();
-        let needs_reindex = txn.state.should_reindex(&index_config);
         let final_t = last.t;
+        let commit_id = last.commit_id.clone();
+        // Total flakes across every staged statement — the single-commit
+        // accounting the transactor expects for a multi-statement transaction.
+        let flake_count = txn.pending.iter().map(|p| p.flake_count).sum();
+
+        // Capture indexing signals + tally before `txn.state` is moved into
+        // finalize_commit (which triggers background reindex when needed).
+        let needs_reindex = txn.state.should_reindex(&index_config);
+        let indexing = self.cypher_txn_indexing_status(&txn.state, &index_config, final_t);
+        let tally = txn.tracker.tally();
+
         self.finalize_commit(guard, txn.state, final_t, needs_reindex)
             .await?;
-        Ok(final_t)
+        Ok(TransactResultRef {
+            receipt: CommitReceipt {
+                commit_id,
+                t: final_t,
+                flake_count,
+            },
+            indexing,
+            tally,
+            cypher_return: None,
+        })
+    }
+
+    /// Build the post-commit [`IndexingStatus`] for a Cypher transaction,
+    /// mirroring the autocommit path's `finalize_owned_commit`.
+    fn cypher_txn_indexing_status(
+        &self,
+        state: &LedgerState,
+        index_config: &fluree_db_ledger::IndexConfig,
+        commit_t: i64,
+    ) -> IndexingStatus {
+        IndexingStatus {
+            enabled: self.indexing_mode.is_enabled() && self.defaults_indexing_enabled(),
+            needed: state.should_reindex(index_config),
+            novelty_size: state.novelty_size(),
+            index_t: state.index_t(),
+            commit_t,
+        }
     }
 }

--- a/fluree-db-api/src/cypher_txn.rs
+++ b/fluree-db-api/src/cypher_txn.rs
@@ -46,7 +46,7 @@ use crate::{
     CommitReceipt, Fluree, GovernanceOptions, IndexingStatus, Result, Tracker, TrackingOptions,
     TransactResultRef,
 };
-use fluree_db_core::ContentId;
+use fluree_db_core::{ContentId, ContentKind};
 use fluree_db_ledger::LedgerState;
 use fluree_db_nameservice::{CasResult, RefKind, RefValue};
 use fluree_db_transact::{CommitOpts, TransactError};
@@ -413,32 +413,32 @@ impl Fluree {
     ///   already delivered by [`CypherTxnWriteOutcome::return_table`].
     ///
     /// An all-reads (or all-no-op) transaction publishes nothing and reports
-    /// the unchanged base head with a zero flake count.
+    /// the same no-op receipt the autocommit paths return: the empty-content
+    /// commit id and the base `t` (legitimately `0` on a ledger registered by
+    /// `create_ledger`, which writes no genesis commit).
     pub async fn commit_cypher_transaction(
         &self,
         txn: CypherTransaction,
     ) -> Result<TransactResultRef> {
         let index_config = crate::server_defaults::default_index_config();
         if txn.pending.is_empty() {
-            // Head unchanged at the pinned base. `begin` requires a resolvable
-            // ledger, so a prior commit — hence a base head id — always exists.
-            let commit_id = txn
-                .base_head
-                .as_ref()
-                .and_then(|r| r.id.clone())
-                .ok_or_else(|| {
-                    ApiError::internal(
-                        "cannot commit an all-reads Cypher transaction on an uncommitted ledger",
-                    )
-                })?;
-            let indexing = self.cypher_txn_indexing_status(&txn.state, &index_config, txn.base_t);
+            // Nothing published, head unchanged — mirror the autocommit no-op
+            // receipt exactly. A `create_ledger` ledger has a nameservice
+            // record but no genesis commit, so `base_head` is legitimately
+            // `None` here; that must stay a successful no-op, not an error.
             return Ok(TransactResultRef {
                 receipt: CommitReceipt {
-                    commit_id,
+                    commit_id: ContentId::new(ContentKind::Commit, &[]),
                     t: txn.base_t,
                     flake_count: 0,
                 },
-                indexing,
+                indexing: IndexingStatus {
+                    enabled: self.indexing_mode.is_enabled(),
+                    needed: false,
+                    novelty_size: txn.state.novelty_size(),
+                    index_t: txn.state.index_t(),
+                    commit_t: txn.base_t,
+                },
                 tally: txn.tracker.tally(),
                 cypher_return: None,
             });

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -86,6 +86,9 @@ pub use iri::IriCompactor;
 
 /// Format a single result binding to JSON-LD (used by the graph-source crawl
 /// expansion to render object values identically to the normal formatter).
+/// Only the `iceberg` graph-source crawl reaches it through this re-export;
+/// every other caller uses `super::jsonld::format_binding_with_result`.
+#[cfg(feature = "iceberg")]
 pub(crate) use jsonld::format_binding_with_result;
 
 use crate::QueryResult;

--- a/fluree-db-api/tests/it_cypher_seq_writes.rs
+++ b/fluree-db-api/tests/it_cypher_seq_writes.rs
@@ -692,7 +692,11 @@ async fn bolt_transaction_pipelines_sequential_statements() {
 
     let governance = fluree_db_api::GovernanceOptions::default();
     let mut txn = fluree
-        .begin_cypher_transaction("it/cyseq:bolt", governance)
+        .begin_cypher_transaction(
+            "it/cyseq:bolt",
+            governance,
+            fluree_db_api::TrackingOptions::default(),
+        )
         .await
         .expect("begin");
 
@@ -721,8 +725,12 @@ async fn bolt_transaction_pipelines_sequential_statements() {
         .expect("second sequential statement");
     assert!(out2.flake_count > 0);
 
-    let committed_t = fluree.commit_cypher_transaction(txn).await.expect("commit");
-    assert!(committed_t > l.t());
+    let committed = fluree.commit_cypher_transaction(txn).await.expect("commit");
+    assert!(committed.receipt.t > l.t());
+    assert!(
+        committed.receipt.flake_count > 0,
+        "flake count summed across both statements"
+    );
 
     let handle = fluree
         .ledger_cached("it/cyseq:bolt")
@@ -738,4 +746,87 @@ async fn bolt_transaction_pipelines_sequential_statements() {
         count(&fluree, &state, "MATCH (n:City) RETURN count(n)").await,
         2
     );
+}
+
+#[tokio::test]
+async fn commit_result_carries_fuel_and_indexing_signals() {
+    // The commit result reaches parity with the autocommit `execute()` path:
+    // a fuel tally accumulated across every statement, plus the indexing
+    // signals a transactor needs to trigger background reindexing.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let l = genesis_ledger(&fluree, "it/cyseq:tracked");
+    let _ = fluree
+        .transact_cypher(l, r#"CREATE (s:Seed {name: "s"})"#)
+        .await
+        .expect("seed commit")
+        .ledger;
+
+    let mut txn = fluree
+        .begin_cypher_transaction(
+            "it/cyseq:tracked",
+            fluree_db_api::GovernanceOptions::default(),
+            fluree_db_api::TrackingOptions::all_enabled(),
+        )
+        .await
+        .expect("begin");
+
+    // Two separate statements: their fuel must sum into one tally.
+    fluree
+        .cypher_transaction_write(
+            &mut txn,
+            r#"MERGE (a:Person {name: "Alice"}) MERGE (b:City {name: "Rome"}) MERGE (a)-[:LIVES_IN]->(b)"#,
+            None,
+        )
+        .await
+        .expect("first statement");
+    fluree
+        .cypher_transaction_write(
+            &mut txn,
+            r#"MERGE (a:Person {name: "Alice"}) MERGE (c:City {name: "Oslo"}) MERGE (a)-[:VISITED]->(c)"#,
+            None,
+        )
+        .await
+        .expect("second statement");
+
+    let committed = fluree.commit_cypher_transaction(txn).await.expect("commit");
+
+    let fuel = committed
+        .tally
+        .as_ref()
+        .and_then(|t| t.fuel)
+        .expect("fuel tally present when tracking is enabled");
+    assert!(fuel > 0.0, "fuel accumulated across both statements: {fuel}");
+    assert!(committed.receipt.flake_count > 0);
+    // Indexing signals are populated (novelty reflects the staged flakes).
+    assert!(committed.indexing.novelty_size > 0);
+    assert_eq!(committed.indexing.commit_t, committed.receipt.t);
+}
+
+#[tokio::test]
+async fn commit_without_tracking_reports_no_tally() {
+    // Opting out of tracking leaves the tally empty — no accidental overhead.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let l = genesis_ledger(&fluree, "it/cyseq:untracked");
+    let _ = fluree
+        .transact_cypher(l, r#"CREATE (s:Seed {name: "s"})"#)
+        .await
+        .expect("seed commit")
+        .ledger;
+
+    let mut txn = fluree
+        .begin_cypher_transaction(
+            "it/cyseq:untracked",
+            fluree_db_api::GovernanceOptions::default(),
+            fluree_db_api::TrackingOptions::default(),
+        )
+        .await
+        .expect("begin");
+    fluree
+        .cypher_transaction_write(&mut txn, r#"CREATE (a:Person {name: "Bob"})"#, None)
+        .await
+        .expect("write");
+
+    let committed = fluree.commit_cypher_transaction(txn).await.expect("commit");
+    assert!(committed.tally.is_none(), "no tally without tracking");
+    assert!(committed.receipt.flake_count > 0);
 }

--- a/fluree-db-api/tests/it_cypher_seq_writes.rs
+++ b/fluree-db-api/tests/it_cypher_seq_writes.rs
@@ -806,6 +806,52 @@ async fn commit_result_carries_fuel_and_indexing_signals() {
 }
 
 #[tokio::test]
+async fn all_reads_commit_on_uncommitted_ledger_is_a_no_op() {
+    // `create_ledger` registers the nameservice record but writes no genesis
+    // commit, so the transaction's base head id is None and base t is 0. An
+    // all-reads COMMIT on such a ledger must succeed as a no-op — matching the
+    // autocommit no-op receipt — not error.
+    let fluree = FlureeBuilder::memory().build_memory();
+    fluree
+        .create_ledger("it/cyseq:uncommitted")
+        .await
+        .expect("create ledger");
+
+    let txn = fluree
+        .begin_cypher_transaction(
+            "it/cyseq:uncommitted",
+            fluree_db_api::GovernanceOptions::default(),
+            fluree_db_api::TrackingOptions::default(),
+        )
+        .await
+        .expect("begin on a ledger with no genesis commit");
+    assert!(!txn.has_writes());
+
+    let committed = fluree
+        .commit_cypher_transaction(txn)
+        .await
+        .expect("all-reads commit succeeds on an uncommitted ledger");
+    assert_eq!(committed.receipt.t, 0, "base t of an uncommitted ledger");
+    assert_eq!(committed.receipt.flake_count, 0);
+    assert!(!committed.indexing.needed, "a no-op needs no reindex");
+
+    // The ledger stays usable: data can still be added after the fact.
+    let handle = fluree
+        .ledger_cached("it/cyseq:uncommitted")
+        .await
+        .expect("cached handle");
+    let state = handle.snapshot().await.to_ledger_state();
+    let r = fluree
+        .transact_cypher(state, r#"CREATE (p:Person {name: "Ada"})"#)
+        .await
+        .expect("write after an all-reads no-op commit");
+    assert_eq!(
+        count(&fluree, &r.ledger, "MATCH (n:Person) RETURN count(n)").await,
+        1
+    );
+}
+
+#[tokio::test]
 async fn commit_without_tracking_reports_no_tally() {
     // Opting out of tracking leaves the tally empty — no accidental overhead.
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/tests/it_cypher_seq_writes.rs
+++ b/fluree-db-api/tests/it_cypher_seq_writes.rs
@@ -795,7 +795,10 @@ async fn commit_result_carries_fuel_and_indexing_signals() {
         .as_ref()
         .and_then(|t| t.fuel)
         .expect("fuel tally present when tracking is enabled");
-    assert!(fuel > 0.0, "fuel accumulated across both statements: {fuel}");
+    assert!(
+        fuel > 0.0,
+        "fuel accumulated across both statements: {fuel}"
+    );
     assert!(committed.receipt.flake_count > 0);
     // Indexing signals are populated (novelty reflects the staged flakes).
     assert!(committed.indexing.novelty_size > 0);

--- a/fluree-db-server/src/bolt.rs
+++ b/fluree-db-server/src/bolt.rs
@@ -478,7 +478,11 @@ async fn handle_begin(
     }
     match state
         .fluree
-        .begin_cypher_transaction(ledger_id, session_governance(auth))
+        .begin_cypher_transaction(
+            ledger_id,
+            session_governance(auth),
+            fluree_db_api::TrackingOptions::default(),
+        )
         .await
     {
         Ok(txn) => {
@@ -505,7 +509,9 @@ async fn handle_commit(
         );
     }
     match state.fluree.commit_cypher_transaction(txn).await {
-        Ok(t) => session.commit_succeeded(Some(format!("fluree:t:{t}"))),
+        Ok(result) => {
+            session.commit_succeeded(Some(format!("fluree:t:{}", result.receipt.t)))
+        }
         Err(fluree_db_api::ApiError::Transact(
             fluree_db_api::TransactError::CommitConflict { expected_t, head_t },
         )) => session.commit_failed(


### PR DESCRIPTION
## Problem

`commit_cypher_transaction` returned only the committed `t`, and both write staging helpers ran `Tracker::disabled()`. As of v4.1.3, `WritePlan` gained a `Sequential` variant for multi-clause statements that can only be driven through the `CypherTransaction` API — but that API couldn't report the signals a transactor reads off `stage().execute()`: `commit_id`, fuel (billing), and indexing state (`needed`, `novelty_size`). Without fuel, multi-clause writes can't be billed; without the indexing signals, novelty accumulates and never triggers background reindexing.

## Changes

- **Meter fuel.** `begin_cypher_transaction` now takes `TrackingOptions` and pins a shared `Tracker` on the transaction. Since `Tracker` accumulates atomically and fuel is charged at staging time, fuel sums automatically across every write statement and every clause of a sequential write — no per-clause bookkeeping. Both `Tracker::disabled()` sites now use the transaction's tracker.
- **Enrich the commit result.** `commit_cypher_transaction` returns `TransactResultRef` — the same struct the autocommit `execute()` path yields — so callers map one result shape. Carries the final `commit_id` + `t`, the flake count summed across all staged statements, the indexing signals (`needed`, `novelty_size`), and the accumulated fuel tally. Per-statement `RETURN` rows continue to flow via `CypherTxnWriteOutcome`.
- **Warning cleanup.** Gate the `format_binding_with_result` re-export to the `iceberg` feature (its only consumer), clearing an unused-import warning under default features.

Callers updated: `bolt.rs` (begin + commit) and the bolt transaction test. Added tests covering the fuel tally + indexing signals on the enriched result, and that opting out of tracking leaves the tally empty.

## Testing

- `it_cypher_seq_writes` — 20/20 pass (incl. 2 new).
- Server bolt/cypher suite — 48/48 pass.
- `cargo clippy -p fluree-db-api -p fluree-db-server --all-features --all-targets` clean; warning fix verified under both default and `iceberg` features.