### PR TITLE
docs: Correct time-travel and history query documentation

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1108,6 +1108,23 @@ mem:fact-01kp4g1wa8yyty4sd2p03k6bg9 a mem:Fact ;
     mem:artifactRef "fluree-graph-json-ld/src/expand.rs" ;
     mem:createdAt "2026-04-13T22:40:33.608461+00:00"^^xsd:dateTime .
 
+mem:fact-01ky55dwckmwazppht36vrn5hk a mem:Fact ;
+    mem:content "SPARQL history queries use the legacy RDF-star form: `FROM <l@t:1> TO <l@t:latest>` + `<< s p ?o >> f:t ?t ; f:op ?op`. The carve-out fires ONLY when the quoted-triple subject is reifier-less AND the predicate is f:t/f:op; anything else takes the RDF 1.2 reification path. Inner object must be a variable (BIND target). `f:op`/`@op` is xsd:boolean — \"assert\"/\"retract\" strings match nothing. Selecting ?t/?op WITHOUT the bindings does NOT error: it returns history rows with null metadata (issue #1532; pinned by history_metadata_vars_without_bindings_are_null). `FROM..TO` is rejected on the ledger-scoped and streaming endpoints — connection-scoped `/v1/fluree/query` only." ;
+    mem:tag "docs" ;
+    mem:tag "history" ;
+    mem:tag "rdf-star" ;
+    mem:tag "sparql" ;
+    mem:tag "time-travel" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "docs/guides/cookbook-time-travel.md" ;
+    mem:artifactRef "fluree-db-api/tests/it_query_history_sparql.rs" ;
+    mem:artifactRef "fluree-db-query/src/eval/fluree.rs" ;
+    mem:artifactRef "fluree-db-server/src/routes/query.rs" ;
+    mem:artifactRef "fluree-db-sparql/src/lower/rdf_star.rs" ;
+    mem:branch "docs/time-travel-history-audit" ;
+    mem:createdAt "2026-07-22T14:59:41.587318+00:00"^^xsd:dateTime ;
+    mem:rationale "The cookbook drifted into fully non-runnable syntax because this path had parser tests but no e2e coverage, and the unbound-metadata case fails silently rather than erroring." .
+
 mem:decision-01kwwmmezehttr76cjq1kdtfqf a mem:Decision ;
     mem:content "Bolt/Cypher node-emit strings are Arc<str> end-to-end: CypherNode/Relationship/Path fields, the hydrator memos, AND the bolt codec's Value::String + MapValue keys — names alloc once per distinct name per result, never per use (87→73ms on the 20k-node probe). IriCompactor::decode_sid_shared returns the Sid's own name (refcount bump, no alloc) for EMPTY/OVERFLOW/empty-prefix namespaces — the ready-made hot path for the planned move of default Cypher identifiers to namespace 0 (no IRI prefix instead of http://example.org/). Note: the dict already stores split (ns_code, suffix), so NS-0's win is decode-side only." ;
     mem:tag "bolt" ;

--- a/docs/cli/history.md
+++ b/docs/cli/history.md
@@ -23,14 +23,24 @@ fluree history <ENTITY> [OPTIONS]
 | `--to <TIME>` | End of time range (default: `latest`) |
 | `-p, --predicate <PRED>` | Filter to specific predicate |
 | `--format <FORMAT>` | Output format: `json`, `table`, or `csv` (default: `table`) |
+| `--remote <NAME>` | Execute against a remote server (e.g. `origin`) |
 
 ## Description
 
 Shows the change history for a specific entity across transactions. Each change shows:
 - `t` - Transaction number
-- `op` - Operation: `+` (assert) or `-` (retract)
+- `op` - Operation: `+` (assert) or `-` (retract) in table/CSV output; `true` / `false` in JSON
 - `predicate` - The property that changed (if not filtered)
 - `value` - The value asserted or retracted
+
+The argument is an **entity IRI**, not a query. This command builds the
+underlying history query for you; to write your own history query — across
+multiple subjects, with filters, or in SPARQL — use
+[`fluree query`](query.md) with `from` and `to`, as shown in
+[Cookbook: Time Travel](../guides/cookbook-time-travel.md#history-queries).
+
+History requires a local commit chain. On a *tracked* ledger it is
+unavailable locally; pass `--remote <name>` to query the upstream.
 
 ## Prefix Expansion
 

--- a/docs/concepts/time-travel.md
+++ b/docs/concepts/time-travel.md
@@ -376,6 +376,19 @@ WHERE {
 ORDER BY ?t
 ```
 
+The `<< ... >>` bindings are what populate `?t` and `?op`. Selecting those
+variables without them is **not** an error — the query returns history rows
+with both columns null, and no way to tell an assert from a retract. The
+quoted triple's object must be a variable; a constant object is rejected.
+
+Two restrictions on the SPARQL form:
+
+- `FROM ... TO ...` is accepted only on the **connection-scoped** endpoint
+  (`POST /v1/fluree/query`). The ledger-scoped path (`/v1/fluree/query/{ledger}`)
+  and the streaming path (`/v1/fluree/stream/query`) reject it.
+- History mode and [reasoning](../query/reasoning.md) are mutually exclusive;
+  a history-range query that requests reasoning is rejected.
+
 ### Property-Specific History
 
 Query changes for specific properties:
@@ -428,7 +441,9 @@ Query history using ISO 8601 datetime strings:
 
 ### Filter by Operation Type
 
-Filter to show only assertions or only retractions:
+Filter to show only assertions or only retractions. `@op` is a **boolean**
+(`true` = assert, `false` = retract), so filter against `true` / `false` —
+the strings `"assert"` / `"retract"` are not accepted and match nothing:
 
 ```json
 {
@@ -438,9 +453,16 @@ Filter to show only assertions or only retractions:
   "select": ["?name", "?t"],
   "where": [
     { "@id": "ex:alice", "ex:name": { "@value": "?name", "@t": "?t", "@op": "?op" } },
-    ["filter", "(= ?op \"retract\")"]
+    ["filter", "(= ?op false)"]
   ]
 }
+```
+
+The constant shorthand is equivalent and shorter — `"@op": false` lowers to
+the same filter without binding a variable:
+
+```json
+{ "@id": "ex:alice", "ex:name": { "@value": "?name", "@t": "?t", "@op": false } }
 ```
 
 ### Pattern History Across Subjects

--- a/docs/guides/cookbook-time-travel.md
+++ b/docs/guides/cookbook-time-travel.md
@@ -1,8 +1,18 @@
 # Cookbook: Time Travel
 
-Every transaction in Fluree is immutable. The database preserves complete history automatically — no audit tables, no trigger-based logging, no slowly-changing dimensions. This guide covers practical patterns for using time travel.
+Every transaction in Fluree is immutable. The database preserves complete history automatically — no audit tables, no trigger-based logging, no slowly-changing dimensions.
 
-## Basics
+There are two distinct capabilities, and it's worth keeping them straight:
+
+| | **Time travel** | **History queries** |
+|---|---|---|
+| Question | "What did the graph look like *at* time T?" | "What *changed* between T1 and T2?" |
+| Result | An ordinary graph, as of one moment | A change log: value + `t` + assert/retract |
+| Syntax | `@t:` / `@iso:` / `@recorded:` / `@commit:` on a ledger reference | `from` **and** `to`, plus per-value metadata bindings |
+
+Time travel needs nothing special in the query body — you write a normal query and pin the snapshot. History queries need explicit metadata bindings, covered under [History queries](#history-queries) below.
+
+## Time travel
 
 ### Query by transaction number
 
@@ -30,6 +40,8 @@ fluree query --at 2025-01-15T00:00:00Z \
 
 Fluree finds the most recent transaction at or before the given timestamp.
 
+This resolves along the **event** axis — the time each commit's changes are *about*, which for backdated imports is not the same as when they were loaded. To ask "what had been loaded by this time?" instead, use `@recorded:` (see [Time Travel Concepts](../concepts/time-travel.md#recorded-time-the-audit-axis-recorded)).
+
 ### Query by commit ID
 
 Every commit has a content-addressed ID (CID). Query by exact commit:
@@ -39,21 +51,9 @@ fluree query --at bafyreif... \
   'SELECT ?s ?p ?o WHERE { ?s ?p ?o }'
 ```
 
-### HTTP API
-
-```bash
-# By transaction number
-curl -X POST 'http://localhost:8090/v1/fluree/query?ledger=mydb:main&t=5' \
-  -H "Content-Type: application/sparql-query" \
-  -d 'SELECT ?s ?p ?o WHERE { ?s ?p ?o }'
-
-# By timestamp (URL-encoded)
-curl -X POST 'http://localhost:8090/v1/fluree/query?ledger=mydb:main&t=2025-01-15T00%3A00%3A00Z' \
-  -H "Content-Type: application/sparql-query" \
-  -d 'SELECT ?s ?p ?o WHERE { ?s ?p ?o }'
-```
-
 ### JSON-LD query with time specifier
+
+In a query body, the time specifier is a suffix on the ledger reference in `from`:
 
 ```json
 {
@@ -63,28 +63,208 @@ curl -X POST 'http://localhost:8090/v1/fluree/query?ledger=mydb:main&t=2025-01-1
 }
 ```
 
-## Patterns
+The structured form is equivalent and composes with named-graph selection:
 
-### Audit trail: who changed what
-
-View the history of changes to a specific entity:
-
-```bash
-fluree history 'PREFIX schema: <http://schema.org/>
-PREFIX ex: <http://example.org/>
-
-SELECT ?prop ?value ?t ?op WHERE {
-  ex:alice ?prop ?value .
-}'
+```json
+{
+  "from": {"@id": "mydb:main", "t": 5},
+  "select": ["?name"],
+  "where": [{"@id": "?p", "schema:name": "?name"}]
+}
 ```
 
-Each result includes:
-- `?t` — the transaction number
-- `?op` — `assert` (added) or `retract` (removed)
+The suffix forms are `@t:5`, `@t:latest`, `@iso:2025-01-15T00:00:00Z`, `@recorded:2025-01-15T00:00:00Z`, and `@commit:bafyreif...`.
+
+### SPARQL with a time specifier
+
+The `@t:` suffix is parsed on ledger references inside a `FROM` clause, which means SPARQL time travel goes through the **connection-scoped** endpoint:
+
+```sparql
+PREFIX schema: <http://schema.org/>
+
+SELECT ?name
+FROM <mydb:main@t:5>
+WHERE { ?p schema:name ?name }
+```
+
+### HTTP API
+
+Ledger-scoped queries put the ledger in the path; time travel rides on the `FROM` clause (SPARQL) or the `from` key (JSON-LD) at the connection-scoped endpoint.
+
+```bash
+# Ledger-scoped, current state
+curl -X POST 'http://localhost:8090/v1/fluree/query/mydb:main' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'SELECT ?s ?p ?o WHERE { ?s ?p ?o }'
+
+# Connection-scoped, pinned to t=5
+curl -X POST 'http://localhost:8090/v1/fluree/query' \
+  -H 'Content-Type: application/sparql-query' \
+  -d 'SELECT ?s ?p ?o FROM <mydb:main@t:5> WHERE { ?s ?p ?o }'
+
+# Connection-scoped JSON-LD, pinned to a timestamp
+curl -X POST 'http://localhost:8090/v1/fluree/query' \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "from": "mydb:main@iso:2025-01-15T00:00:00Z",
+        "select": ["?s", "?p", "?o"],
+        "where": [{"@id": "?s", "?p": "?o"}]
+      }'
+```
+
+There is no `?t=` URL parameter — a numeric pin like `from: "mydb:main@t:42"` also makes the server observe at least `t=42` before executing, giving read-after-write on a pinned snapshot. See [Time Travel Concepts](../concepts/time-travel.md#consistency-and-read-after-write) for the `fluree-min-t` header.
+
+## History queries
+
+A history query is one with **both** `from` and `to`. It returns a change log rather than a snapshot: every assert and retract in the range, each carrying the transaction time and the operation.
+
+Two things must be bound explicitly, or you get rows with no metadata:
+
+- **`@t`** — the transaction number (integer)
+- **`@op`** — a **boolean**: `true` = assert, `false` = retract
+
+### Entity history (CLI)
+
+`fluree history` takes an **entity IRI**, not a query — it builds the history query for you:
+
+```bash
+# All changes to an entity
+fluree history ex:alice
+
+# Filter to a single predicate
+fluree history ex:alice -p ex:salary
+
+# Bound the range
+fluree history ex:alice --from 1 --to 5
+
+# Machine-readable
+fluree history ex:alice --format json
+```
+
+Output (table format renders `op` as `+` / `-`):
+
+```
+┌───┬────┬─────────────────────────────┬─────────┐
+│ t │ op │ predicate                   │ value   │
+├───┼────┼─────────────────────────────┼─────────┤
+│ 1 │ +  │ http://example.org/salary   │ 85000   │
+│ 4 │ -  │ http://example.org/salary   │ 85000   │
+│ 4 │ +  │ http://example.org/salary   │ 95000   │
+└───┴────┴─────────────────────────────┴─────────┘
+```
+
+Each update produces a retract/assert pair at the same `t`.
+
+For anything beyond a single entity, write the query yourself with `fluree query`.
+
+### Entity history (JSON-LD)
+
+Bind `@t` and `@op` on the value object:
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "from": "mydb:main@t:1",
+  "to": "mydb:main@t:latest",
+  "select": ["?prop", "?value", "?t", "?op"],
+  "where": [
+    {"@id": "ex:alice", "?prop": {"@value": "?value", "@t": "?t", "@op": "?op"}}
+  ],
+  "orderBy": ["?t"]
+}
+```
+
+### Entity history (SPARQL)
+
+SPARQL uses the `FROM ... TO ...` range plus RDF-star quoted triples to bind the metadata. `f:t` and `f:op` on a quoted triple extract the flake metadata for that triple's object:
+
+```sparql
+PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+
+SELECT ?value ?t ?op
+FROM <mydb:main@t:1>
+TO <mydb:main@t:latest>
+WHERE {
+  << ex:alice ex:salary ?value >> f:t ?t ; f:op ?op .
+}
+ORDER BY ?t
+```
+
+Results:
+
+```
+?value   ?t  ?op
+85000    1   true      ← initial salary
+85000    4   false     ← old value retracted
+95000    4   true      ← new value asserted
+```
+
+### Find when a value changed
+
+```bash
+fluree history ex:alice -p ex:salary
+```
+
+or, across every subject with that property:
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "from": "mydb:main@t:1",
+  "to": "mydb:main@t:latest",
+  "select": ["?person", "?salary", "?t", "?op"],
+  "where": [
+    {"@id": "?person", "ex:salary": {"@value": "?salary", "@t": "?t", "@op": "?op"}}
+  ],
+  "orderBy": ["?t"]
+}
+```
+
+### Show only retractions
+
+`@op` is a boolean. The constant shorthand filters without binding a variable:
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "from": "mydb:main@t:1",
+  "to": "mydb:main@t:latest",
+  "select": ["?salary", "?t"],
+  "where": [
+    {"@id": "ex:alice", "ex:salary": {"@value": "?salary", "@t": "?t", "@op": false}}
+  ]
+}
+```
+
+In SPARQL, filter the bound variable:
+
+```sparql
+FILTER(?op = false)
+```
+
+### Scope a range
+
+Bound the range with `from` / `to` rather than filtering on `?t` after the fact — the endpoints are what drive the scan:
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "from": "mydb:main@t:10",
+  "to": "mydb:main@t:15",
+  "select": ["?s", "?p", "?v", "?t", "?op"],
+  "where": [
+    {"@id": "?s", "?p": {"@value": "?v", "@t": "?t", "@op": "?op"}}
+  ],
+  "orderBy": ["?t"]
+}
+```
+
+ISO timestamps work as endpoints too: `"from": "mydb:main@iso:2025-01-01T00:00:00Z"`.
+
+## Patterns
 
 ### Point-in-time comparison
-
-Compare an entity before and after a change:
 
 ```bash
 # Before the change (t=5)
@@ -93,26 +273,6 @@ fluree query --at 5 'SELECT ?salary WHERE { ex:alice ex:salary ?salary }'
 # After the change (t=6)
 fluree query --at 6 'SELECT ?salary WHERE { ex:alice ex:salary ?salary }'
 ```
-
-### Find when a value changed
-
-Track salary history:
-
-```bash
-fluree history 'SELECT ?salary ?t ?op WHERE { ex:alice ex:salary ?salary }'
-```
-
-Output:
-```
-?salary  ?t  ?op
-85000    1   assert      ← Initial salary
-85000    4   retract     ← Old value removed
-95000    4   assert      ← New value added
-95000    7   retract
-110000   7   assert      ← Another raise
-```
-
-Each update produces a retract/assert pair at the same `t`.
 
 ### Compliance snapshot
 
@@ -133,19 +293,7 @@ fluree query --at 2025-06-30T23:59:59Z --format csv \
    ORDER BY ?department ?name' > compliance-report-2025-Q2.csv
 ```
 
-This is a reproducible snapshot — running the same query with the same timestamp always returns the same results.
-
-### Debugging: find what changed between two points
-
-Compare entity states across a range:
-
-```bash
-# What was added or removed between t=10 and t=15?
-fluree history 'SELECT ?s ?p ?o ?t ?op WHERE {
-  ?s ?p ?o .
-  FILTER(?t >= 10 && ?t <= 15)
-}'
-```
+This is a reproducible snapshot — the same query with the same timestamp always returns the same results.
 
 ### Recover deleted data
 
@@ -156,47 +304,35 @@ Data that was retracted still exists in history:
 fluree query --at 7 'SELECT ?prop ?value WHERE { ex:carol ?prop ?value }'
 ```
 
-To restore, simply re-insert the data from the historical query.
+To restore, re-insert the data from the historical query.
 
 ### Multi-ledger time travel
 
-Query two ledgers at different points in time:
+Each ledger reference in `from` carries its own time specifier, so you can join two ledgers at different moments — useful for price-at-time-of-purchase analysis:
 
 ```json
 {
-  "from": {
-    "products": {"ledger": "catalog:main", "t": 10},
-    "orders": {"ledger": "orders:main", "t": 25}
-  },
+  "@context": {"ex": "http://example.org/", "schema": "http://schema.org/"},
+  "from": ["catalog:main@t:10", "orders:main@t:25"],
   "select": ["?product", "?price", "?qty"],
   "where": [
-    {"@id": "?order", "ex:product": "?p", "ex:quantity": "?qty", "@graph": "orders"},
-    {"@id": "?p", "schema:name": "?product", "schema:price": "?price", "@graph": "products"}
+    {"@id": "?order", "ex:product": "?p", "ex:quantity": "?qty"},
+    {"@id": "?p", "schema:name": "?product", "schema:price": "?price"}
   ]
 }
 ```
 
-This joins product data from `t=10` with order data from `t=25` — useful for price-at-time-of-purchase analysis.
-
-### Temporal aggregation
-
-Track how a metric changed over time:
-
-```bash
-fluree history 'SELECT ?count ?t ?op WHERE {
-  ex:dashboard ex:activeUsers ?count
-}'
-```
+For named-graph scoping alongside a time pin, use the structured form — `{"@id": "catalog:main", "t": 10, "graph": "..."}`. See [Datasets and named graphs](../query/datasets.md).
 
 ### Transaction metadata
 
-Every commit records metadata. Query it via the `txn-meta` graph:
+Every commit records metadata in the built-in `txn-meta` named graph, addressed with a `#txn-meta` fragment on the ledger reference:
 
 ```sparql
 PREFIX f: <https://ns.flur.ee/db#>
 
 SELECT ?t ?timestamp ?author
-FROM <urn:fluree:knowledge-base:main#txn-meta>
+FROM <mydb:main#txn-meta>
 WHERE {
   ?commit f:t ?t ;
           f:time ?timestamp .
@@ -206,23 +342,49 @@ ORDER BY DESC(?t)
 LIMIT 10
 ```
 
+`f:receivedAt` is also present on ledgers that dual-stamp (see [Recorded time](../concepts/time-travel.md#recorded-time-the-audit-axis-recorded)).
+
+## Gotchas
+
+**Selecting `?t` / `?op` without binding them silently returns nulls.**
+This is the most common mistake. A history query that selects `?t` and `?op` but never binds them via `@t`/`@op` (JSON-LD) or `f:t`/`f:op` (SPARQL) succeeds, returns history rows, and leaves both columns null — so asserts and retracts are indistinguishable. There is no error or warning. Always bind the metadata.
+
+**`@op` / `f:op` is a boolean, not a string.**
+`true` = assert, `false` = retract. `"assert"` and `"retract"` are not accepted and match nothing. The CLI's *table* renderer displays `+` / `-`, but the underlying value in JSON output is `true` / `false`.
+
+**A history query needs both `from` and `to`.**
+With only `from`, you get a point-in-time snapshot, and the metadata bindings have nothing to report.
+
+**SPARQL `FROM ... TO ...` is connection-scoped only.**
+It is rejected on `/v1/fluree/query/{ledger}` and on the streaming endpoint `/v1/fluree/stream/query`. Post to `/v1/fluree/query` instead.
+
+**The quoted triple's object must be a variable.**
+`<< ex:alice ex:name ?name >> f:t ?t` is valid; `<< ex:alice ex:name "Alice" >> f:t ?t` is rejected — there is no object binding to attach metadata to.
+
+**`<< s p o >>` and `<<( s p o )>>` are different things.**
+The bare form is this Fluree-specific flake-metadata construct. The parenthesized triple term is RDF 1.2 reification, valid only as the object of `rdf:reifies`. They do not compose — see [Edge annotations](../concepts/edge-annotations.md).
+
+**Reasoning is rejected in history mode.**
+A history-range query that requests reasoning returns an error rather than silently dropping derived facts.
+
+**History is not available locally for tracked ledgers.**
+A tracked ledger has no local commit chain; use `--remote <name>` to query the upstream.
+
 ## Common questions
 
 **Is time travel expensive?**
-No. Querying a historical state uses the same indexes as querying the current state. The cost is O(log n) for index lookups.
+No. Querying a historical state uses the same indexes as querying the current state. The cost is O(log n) for index lookups. `@t:` is cheapest (no resolution); `@iso:` / `@recorded:` cost a binary search over commit timestamps; `@commit:` costs a bounded scan.
 
 **Does old data use extra storage?**
 Yes — immutability means retracted values are preserved. Storage grows with the number of changes, not just the current state size. For most workloads this is negligible.
-
-**Can I query "between" two points?**
-History queries return all changes with their transaction numbers. Use `FILTER` on `?t` to scope to a range.
 
 **Can I delete history?**
 No. Immutability is a core guarantee. If you need to remove data for compliance (e.g., GDPR right to erasure), contact the Fluree team about data compaction options.
 
 ## Related documentation
 
-- [Time Travel Concepts](../concepts/time-travel.md) — Architecture and design
-- [SPARQL Reference](../query/sparql.md) — History query syntax
-- [JSON-LD Query](../query/jsonld-query.md) — Time specifiers in JSON-LD
-- [Commit Receipts](../transactions/commit-receipts.md) — Transaction metadata
+- [Time Travel Concepts](../concepts/time-travel.md) — Architecture, event vs. recorded axis, read-after-write
+- [SPARQL Reference](../query/sparql.md#history-queries) — RDF-star history syntax
+- [JSON-LD Query](../query/jsonld-query.md) — `@t` / `@op` annotations
+- [Datasets and named graphs](../query/datasets.md) — Structured `from`, `txn-meta`
+- [fluree history](../cli/history.md) — CLI reference

--- a/docs/guides/cookbook-time-travel.md
+++ b/docs/guides/cookbook-time-travel.md
@@ -176,7 +176,7 @@ Bind `@t` and `@op` on the value object:
 
 ### Entity history (SPARQL)
 
-SPARQL uses the `FROM ... TO ...` range plus RDF-star quoted triples to bind the metadata. `f:t` and `f:op` on a quoted triple extract the flake metadata for that triple's object:
+SPARQL uses the `FROM ... TO ...` range plus an RDF-star quoted triple to bind the metadata. `f:t` and `f:op` on a quoted triple extract the flake metadata for that triple's object:
 
 ```sparql
 PREFIX ex: <http://example.org/>
@@ -200,13 +200,56 @@ Results:
 95000    4   true      ← new value asserted
 ```
 
+The `;` continuation is the idiomatic form — it binds one inner triple with two metadata extractions. Writing the quoted triple out twice is equivalent:
+
+```sparql
+<< ex:alice ex:salary ?value >> f:t ?t .
+<< ex:alice ex:salary ?value >> f:op ?op .
+```
+
+Bind only what you need — `f:t` alone is fine if you don't care about assert vs. retract.
+
+### All properties of an entity (SPARQL)
+
+Put a variable in the predicate position to get every change to a subject — the SPARQL twin of the JSON-LD `"?prop": {...}` form:
+
+```sparql
+PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+
+SELECT ?prop ?value ?t ?op
+FROM <mydb:main@t:1>
+TO <mydb:main@t:latest>
+WHERE {
+  << ex:alice ?prop ?value >> f:t ?t ; f:op ?op .
+}
+ORDER BY ?t ?prop
+```
+
 ### Find when a value changed
+
+For a single entity, the CLI is enough:
 
 ```bash
 fluree history ex:alice -p ex:salary
 ```
 
-or, across every subject with that property:
+Across every subject with that property, put a variable in the subject position:
+
+```sparql
+PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+
+SELECT ?person ?salary ?t ?op
+FROM <mydb:main@t:1>
+TO <mydb:main@t:latest>
+WHERE {
+  << ?person ex:salary ?salary >> f:t ?t ; f:op ?op .
+}
+ORDER BY ?t
+```
+
+The JSON-LD equivalent:
 
 ```json
 {
@@ -223,7 +266,23 @@ or, across every subject with that property:
 
 ### Show only retractions
 
-`@op` is a boolean. The constant shorthand filters without binding a variable:
+`f:op` is a boolean, so filter it as one — `"retract"` as a string matches nothing:
+
+```sparql
+PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+
+SELECT ?person ?old ?t
+FROM <mydb:main@t:1>
+TO <mydb:main@t:latest>
+WHERE {
+  << ?person ex:salary ?old >> f:t ?t ; f:op ?op .
+  FILTER(?op = false)
+}
+ORDER BY ?t
+```
+
+In JSON-LD the constant shorthand filters without binding a variable at all:
 
 ```json
 {
@@ -237,15 +296,24 @@ or, across every subject with that property:
 }
 ```
 
-In SPARQL, filter the bound variable:
-
-```sparql
-FILTER(?op = false)
-```
-
 ### Scope a range
 
-Bound the range with `from` / `to` rather than filtering on `?t` after the fact — the endpoints are what drive the scan:
+Bound the range with the `FROM` / `TO` endpoints rather than filtering on `?t` afterwards — the endpoints are what drive the scan, and a `FILTER` cannot narrow what was already read:
+
+```sparql
+PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+
+SELECT ?s ?p ?v ?t ?op
+FROM <mydb:main@t:10>
+TO <mydb:main@t:15>
+WHERE {
+  << ?s ?p ?v >> f:t ?t ; f:op ?op .
+}
+ORDER BY ?t
+```
+
+The JSON-LD equivalent:
 
 ```json
 {
@@ -260,7 +328,26 @@ Bound the range with `from` / `to` rather than filtering on `?t` after the fact 
 }
 ```
 
-ISO timestamps work as endpoints too: `"from": "mydb:main@iso:2025-01-01T00:00:00Z"`.
+ISO timestamps work as endpoints too, in either syntax: `FROM <mydb:main@iso:2025-01-01T00:00:00Z>`.
+
+### Count changes per entity (SPARQL)
+
+Aggregates work over history rows like any other solution sequence — here, churn per person:
+
+```sparql
+PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+
+SELECT ?person (COUNT(*) AS ?changes)
+FROM <mydb:main@t:1>
+TO <mydb:main@t:latest>
+WHERE {
+  << ?person ex:salary ?value >> f:t ?t ; f:op ?op .
+  FILTER(?op = true)
+}
+GROUP BY ?person
+ORDER BY DESC(?changes)
+```
 
 ## Patterns
 
@@ -346,8 +433,10 @@ LIMIT 10
 
 ## Gotchas
 
-**Selecting `?t` / `?op` without binding them silently returns nulls.**
-This is the most common mistake. A history query that selects `?t` and `?op` but never binds them via `@t`/`@op` (JSON-LD) or `f:t`/`f:op` (SPARQL) succeeds, returns history rows, and leaves both columns null — so asserts and retracts are indistinguishable. There is no error or warning. Always bind the metadata.
+**`?t` and `?op` are ordinary variables — you must bind them.**
+This is the most common mistake. A history query that selects `?t` and `?op` but never binds them via `@t`/`@op` (JSON-LD) or `f:t`/`f:op` (SPARQL) returns history rows with both columns null, so asserts and retracts are indistinguishable.
+
+There is no error, and there shouldn't be: this is ordinary SPARQL semantics. Selecting a variable the WHERE clause never binds is legal and yields unbound — `?t` and `?op` behave exactly as `?anythingElse` would, in history mode and out of it. They are not reserved names, and nothing about a `from`/`to` range makes them special. The metadata is available only through the binding syntax; write it explicitly.
 
 **`@op` / `f:op` is a boolean, not a string.**
 `true` = assert, `false` = retract. `"assert"` and `"retract"` are not accepted and match nothing. The CLI's *table* renderer displays `+` / `-`, but the underlying value in JSON output is `true` / `false`.

--- a/fluree-db-api/tests/grp_query_history.rs
+++ b/fluree-db-api/tests/grp_query_history.rs
@@ -7,6 +7,8 @@ mod it_event_time;
 mod it_query_history_combinations;
 #[path = "it_query_history_range.rs"]
 mod it_query_history_range;
+#[path = "it_query_history_sparql.rs"]
+mod it_query_history_sparql;
 #[path = "it_query_time_travel.rs"]
 mod it_query_time_travel;
 #[path = "it_query_time_travel_bgp.rs"]

--- a/fluree-db-api/tests/it_query_history_sparql.rs
+++ b/fluree-db-api/tests/it_query_history_sparql.rs
@@ -1,0 +1,233 @@
+//! End-to-end coverage for the SPARQL history surface.
+//!
+//! `fluree-db-sparql` had parser-level tests for the legacy RDF-star form
+//! (`<< s p ?o >> f:t ?t`) but no test that ran one against a real ledger.
+//! The lowering path in `fluree-db-sparql/src/lower/rdf_star.rs` was
+//! therefore uncovered end-to-end, and the docs drifted away from it.
+//!
+//! These tests pin the documented behaviour in `docs/query/sparql.md`
+//! and `docs/guides/cookbook-time-travel.md`.
+
+#![cfg(feature = "native")]
+
+use fluree_db_api::{FlureeBuilder, FormatterConfig};
+use serde_json::{json, Value};
+
+fn ctx() -> Value {
+    json!({ "ex": "http://example.org/" })
+}
+
+/// Ledger with `ex:alice ex:name` asserted at t=1 and overwritten at t=2.
+async fn alice_ledger(name: &str) -> (tempfile::TempDir, fluree_db_api::Fluree, String) {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let ledger_id = format!("test/history-sparql-{name}:main");
+
+    let l0 = fluree.create_ledger(&ledger_id).await.expect("create");
+    let r1 = fluree
+        .insert(
+            l0,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alice"}),
+        )
+        .await
+        .expect("t=1");
+    assert_eq!(r1.receipt.t, 1);
+    let r2 = fluree
+        .upsert(
+            r1.ledger,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alicia"}),
+        )
+        .await
+        .expect("t=2");
+    assert_eq!(r2.receipt.t, 2);
+
+    (tmp, fluree, ledger_id)
+}
+
+async fn run_sparql(fluree: &fluree_db_api::Fluree, sparql: &str) -> Value {
+    let result = fluree
+        .query_from()
+        .sparql(sparql)
+        .format(FormatterConfig::typed_json().with_normalize_arrays())
+        .execute_tracked()
+        .await
+        .expect("sparql history query");
+    serde_json::to_value(&result.result).expect("serialize")
+}
+
+/// Pull `(?name, ?t, ?op)` out of a typed-json binding row.
+fn row_name_t_op(row: &Value) -> (String, i64, bool) {
+    let name = row["?name"]["@value"].as_str().expect("?name").to_string();
+    let t = row["?t"]["@value"].as_i64().expect("?t bound");
+    let op = row["?op"]["@value"].as_bool().expect("?op bound");
+    (name, t, op)
+}
+
+const EXPECTED: [(&str, i64, bool); 3] = [
+    ("Alice", 1, true),  // original assert
+    ("Alice", 2, false), // retracted by the upsert
+    ("Alicia", 2, true), // new value
+];
+
+/// The documented history form: `FROM <l@t:1> TO <l@t:latest>` with the
+/// legacy RDF-star quoted triple binding `f:t` and `f:op`.
+#[tokio::test]
+async fn rdf_star_history_binds_t_and_op() {
+    let (_tmp, fluree, ledger_id) = alice_ledger("basic").await;
+
+    let sparql = format!(
+        r"PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+SELECT ?name ?t ?op
+FROM <{ledger_id}@t:1>
+TO <{ledger_id}@t:latest>
+WHERE {{
+  << ex:alice ex:name ?name >> f:t ?t .
+  << ex:alice ex:name ?name >> f:op ?op .
+}}
+ORDER BY ?t ?op"
+    );
+
+    let rows = run_sparql(&fluree, &sparql).await;
+    let got: Vec<(String, i64, bool)> = rows
+        .as_array()
+        .expect("rows")
+        .iter()
+        .map(row_name_t_op)
+        .collect();
+
+    let want: Vec<(String, i64, bool)> = EXPECTED
+        .iter()
+        .map(|(n, t, o)| (n.to_string(), *t, *o))
+        .collect();
+    assert_eq!(got, want, "rows: {rows:#?}");
+}
+
+/// The `;`-continued form binds one inner triple, not two. Same results.
+#[tokio::test]
+async fn rdf_star_history_semicolon_form() {
+    let (_tmp, fluree, ledger_id) = alice_ledger("semicolon").await;
+
+    let sparql = format!(
+        r"PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+SELECT ?name ?t ?op
+FROM <{ledger_id}@t:1>
+TO <{ledger_id}@t:latest>
+WHERE {{ << ex:alice ex:name ?name >> f:t ?t ; f:op ?op . }}
+ORDER BY ?t ?op"
+    );
+
+    let rows = run_sparql(&fluree, &sparql).await;
+    let got: Vec<(String, i64, bool)> = rows
+        .as_array()
+        .expect("rows")
+        .iter()
+        .map(row_name_t_op)
+        .collect();
+
+    let want: Vec<(String, i64, bool)> = EXPECTED
+        .iter()
+        .map(|(n, t, o)| (n.to_string(), *t, *o))
+        .collect();
+    assert_eq!(got, want, "rows: {rows:#?}");
+}
+
+/// `f:op` is a boolean, so retractions are selected with `= false`.
+/// (`"retract"` as a string matches nothing — see the gotchas section of
+/// docs/guides/cookbook-time-travel.md.)
+#[tokio::test]
+async fn rdf_star_history_op_filter_is_boolean() {
+    let (_tmp, fluree, ledger_id) = alice_ledger("opfilter").await;
+
+    let query = |pred: &str| {
+        format!(
+            r"PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+SELECT ?name ?t ?op
+FROM <{ledger_id}@t:1>
+TO <{ledger_id}@t:latest>
+WHERE {{
+  << ex:alice ex:name ?name >> f:t ?t ; f:op ?op .
+  FILTER({pred})
+}}"
+        )
+    };
+
+    let retracts = run_sparql(&fluree, &query("?op = false")).await;
+    let got: Vec<(String, i64, bool)> = retracts
+        .as_array()
+        .expect("rows")
+        .iter()
+        .map(row_name_t_op)
+        .collect();
+    assert_eq!(got, vec![("Alice".to_string(), 2, false)]);
+
+    // The string form is a type mismatch, not a synonym: it matches nothing.
+    let as_string = run_sparql(&fluree, &query(r#"?op = "retract""#)).await;
+    assert_eq!(
+        as_string.as_array().expect("rows").len(),
+        0,
+        "f:op is xsd:boolean; string constants must not match"
+    );
+}
+
+/// The quoted triple's object must be a variable — there is nothing to
+/// hang the metadata binding off otherwise. This must be a clean error,
+/// not silently-null metadata.
+#[tokio::test]
+async fn rdf_star_history_requires_variable_object() {
+    let (_tmp, fluree, ledger_id) = alice_ledger("constobj").await;
+
+    let sparql = format!(
+        r#"PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+SELECT ?t
+FROM <{ledger_id}@t:1>
+TO <{ledger_id}@t:latest>
+WHERE {{ << ex:alice ex:name "Alice" >> f:t ?t . }}"#
+    );
+
+    let err = fluree
+        .query_from()
+        .sparql(&sparql)
+        .execute_tracked()
+        .await
+        .expect_err("constant object must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("variable"),
+        "expected a variable-object diagnostic, got: {msg}"
+    );
+}
+
+/// Documents a known sharp edge: selecting `?t` / `?op` in history mode
+/// WITHOUT the `<< ... >> f:t|f:op` bindings succeeds and returns history
+/// rows with both metadata columns null, giving no way to tell an assert
+/// from a retract.
+///
+/// This is a regression lock on *current* behaviour, not an endorsement of
+/// it. If unbound history metadata is ever promoted to a warning or an
+/// error, update this test — do not delete the coverage.
+#[tokio::test]
+async fn history_metadata_vars_without_bindings_are_null() {
+    let (_tmp, fluree, ledger_id) = alice_ledger("unbound").await;
+
+    let sparql = format!(
+        r"PREFIX ex: <http://example.org/>
+SELECT ?name ?t ?op
+FROM <{ledger_id}@t:1>
+TO <{ledger_id}@t:latest>
+WHERE {{ ex:alice ex:name ?name . }}"
+    );
+
+    let rows = run_sparql(&fluree, &sparql).await;
+    let rows = rows.as_array().expect("rows");
+    assert_eq!(rows.len(), 3, "history rows are still emitted: {rows:#?}");
+    for row in rows {
+        assert!(row["?t"].is_null(), "?t is unbound without f:t: {row}");
+        assert!(row["?op"].is_null(), "?op is unbound without f:op: {row}");
+    }
+}

--- a/fluree-db-api/tests/it_query_history_sparql.rs
+++ b/fluree-db-api/tests/it_query_history_sparql.rs
@@ -46,6 +46,49 @@ async fn alice_ledger(name: &str) -> (tempfile::TempDir, fluree_db_api::Fluree, 
     (tmp, fluree, ledger_id)
 }
 
+/// Two subjects, two properties, one overwrite each — enough to exercise
+/// variable subjects and variable predicates inside the quoted triple.
+///
+/// t=1: alice{name=Alice, dept=Eng}, bob{name=Bob}
+/// t=2: alice.name -> Alicia  (retract Alice, assert Alicia)
+/// t=3: bob.name   -> Bobby   (retract Bob, assert Bobby)
+async fn team_ledger(name: &str) -> (tempfile::TempDir, fluree_db_api::Fluree, String) {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let fluree = FlureeBuilder::file(tmp.path().to_str().unwrap())
+        .build()
+        .expect("build");
+    let ledger_id = format!("test/history-sparql-team-{name}:main");
+
+    let l0 = fluree.create_ledger(&ledger_id).await.expect("create");
+    let r1 = fluree
+        .insert(
+            l0,
+            &json!({"@context": ctx(), "@graph": [
+                {"@id": "ex:alice", "ex:name": "Alice", "ex:dept": "Eng"},
+                {"@id": "ex:bob", "ex:name": "Bob"},
+            ]}),
+        )
+        .await
+        .expect("t=1");
+    let r2 = fluree
+        .upsert(
+            r1.ledger,
+            &json!({"@context": ctx(), "@id": "ex:alice", "ex:name": "Alicia"}),
+        )
+        .await
+        .expect("t=2");
+    let r3 = fluree
+        .upsert(
+            r2.ledger,
+            &json!({"@context": ctx(), "@id": "ex:bob", "ex:name": "Bobby"}),
+        )
+        .await
+        .expect("t=3");
+    assert_eq!(r3.receipt.t, 3);
+
+    (tmp, fluree, ledger_id)
+}
+
 async fn run_sparql(fluree: &fluree_db_api::Fluree, sparql: &str) -> Value {
     let result = fluree
         .query_from()
@@ -55,6 +98,19 @@ async fn run_sparql(fluree: &fluree_db_api::Fluree, sparql: &str) -> Value {
         .await
         .expect("sparql history query");
     serde_json::to_value(&result.result).expect("serialize")
+}
+
+/// Local name of an IRI binding, which typed-json may render as a bare
+/// string, `{"@id": ...}`, or `{"@value": ...}`, and either full or
+/// prefix-compacted. `http://example.org/name` and `ex:name` both yield
+/// `name`.
+fn local_name(v: &Value) -> String {
+    let s = v
+        .as_str()
+        .or_else(|| v["@id"].as_str())
+        .or_else(|| v["@value"].as_str())
+        .unwrap_or_else(|| panic!("expected an IRI binding, got {v}"));
+    s.rsplit(['/', '#', ':']).next().unwrap_or(s).to_string()
 }
 
 /// Pull `(?name, ?t, ?op)` out of a typed-json binding row.
@@ -203,14 +259,16 @@ WHERE {{ << ex:alice ex:name "Alice" >> f:t ?t . }}"#
     );
 }
 
-/// Documents a known sharp edge: selecting `?t` / `?op` in history mode
-/// WITHOUT the `<< ... >> f:t|f:op` bindings succeeds and returns history
-/// rows with both metadata columns null, giving no way to tell an assert
-/// from a retract.
+/// `?t` / `?op` are ordinary variables, not reserved names: selecting them
+/// without the `<< ... >> f:t|f:op` bindings yields unbound, exactly as any
+/// other never-bound variable would. This is standard SPARQL behaviour and
+/// is deliberately NOT an error — `?t` is a plausible user variable name
+/// ("type", "total"), and special-casing it in history mode would both
+/// deviate from the spec and break those queries.
 ///
-/// This is a regression lock on *current* behaviour, not an endorsement of
-/// it. If unbound history metadata is ever promoted to a warning or an
-/// error, update this test — do not delete the coverage.
+/// The trap is a documentation problem, handled in the gotchas section of
+/// docs/guides/cookbook-time-travel.md. This test pins the semantics so a
+/// well-meaning "fix" doesn't quietly introduce reserved variable names.
 #[tokio::test]
 async fn history_metadata_vars_without_bindings_are_null() {
     let (_tmp, fluree, ledger_id) = alice_ledger("unbound").await;
@@ -230,4 +288,207 @@ WHERE {{ ex:alice ex:name ?name . }}"
         assert!(row["?t"].is_null(), "?t is unbound without f:t: {row}");
         assert!(row["?op"].is_null(), "?op is unbound without f:op: {row}");
     }
+}
+
+/// A variable predicate inside the quoted triple gives "every change to
+/// this entity" — the SPARQL twin of the JSON-LD `"?prop": {...}` form.
+#[tokio::test]
+async fn rdf_star_history_variable_predicate() {
+    let (_tmp, fluree, ledger_id) = team_ledger("varpred").await;
+
+    let sparql = format!(
+        r"PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+SELECT ?prop ?value ?t ?op
+FROM <{ledger_id}@t:1>
+TO <{ledger_id}@t:latest>
+WHERE {{ << ex:alice ?prop ?value >> f:t ?t ; f:op ?op . }}
+ORDER BY ?t ?op ?prop"
+    );
+
+    let rows = run_sparql(&fluree, &sparql).await;
+    let got: Vec<(String, String, i64, bool)> = rows
+        .as_array()
+        .expect("rows")
+        .iter()
+        .map(|r| {
+            (
+                local_name(&r["?prop"]),
+                r["?value"]["@value"].as_str().expect("?value").to_string(),
+                r["?t"]["@value"].as_i64().expect("?t bound"),
+                r["?op"]["@value"].as_bool().expect("?op bound"),
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        got,
+        vec![
+            ("dept".into(), "Eng".into(), 1, true),
+            ("name".into(), "Alice".into(), 1, true),
+            ("name".into(), "Alice".into(), 2, false),
+            ("name".into(), "Alicia".into(), 2, true),
+        ],
+        "rows: {rows:#?}"
+    );
+}
+
+/// A variable subject gives "every change to this property, across
+/// subjects" — and it composes with an ordinary (non-history) triple
+/// pattern in the same WHERE block.
+#[tokio::test]
+async fn rdf_star_history_variable_subject() {
+    let (_tmp, fluree, ledger_id) = team_ledger("varsubj").await;
+
+    let sparql = format!(
+        r"PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+SELECT ?person ?value ?t ?op
+FROM <{ledger_id}@t:1>
+TO <{ledger_id}@t:latest>
+WHERE {{ << ?person ex:name ?value >> f:t ?t ; f:op ?op . }}
+ORDER BY ?t ?op ?value"
+    );
+
+    let rows = run_sparql(&fluree, &sparql).await;
+    let got: Vec<(String, String, i64, bool)> = rows
+        .as_array()
+        .expect("rows")
+        .iter()
+        .map(|r| {
+            (
+                local_name(&r["?person"]),
+                r["?value"]["@value"].as_str().expect("?value").to_string(),
+                r["?t"]["@value"].as_i64().expect("?t bound"),
+                r["?op"]["@value"].as_bool().expect("?op bound"),
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        got,
+        vec![
+            ("alice".into(), "Alice".into(), 1, true),
+            ("bob".into(), "Bob".into(), 1, true),
+            ("alice".into(), "Alice".into(), 2, false),
+            ("alice".into(), "Alicia".into(), 2, true),
+            ("bob".into(), "Bob".into(), 3, false),
+            ("bob".into(), "Bobby".into(), 3, true),
+        ],
+        "rows: {rows:#?}"
+    );
+}
+
+/// Retractions only, as a complete query — `f:op` is a boolean.
+#[tokio::test]
+async fn rdf_star_history_retractions_only() {
+    let (_tmp, fluree, ledger_id) = team_ledger("retractonly").await;
+
+    let sparql = format!(
+        r"PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+SELECT ?person ?old ?t
+FROM <{ledger_id}@t:1>
+TO <{ledger_id}@t:latest>
+WHERE {{
+  << ?person ex:name ?old >> f:t ?t ; f:op ?op .
+  FILTER(?op = false)
+}}
+ORDER BY ?t"
+    );
+
+    let rows = run_sparql(&fluree, &sparql).await;
+    let got: Vec<(String, i64)> = rows
+        .as_array()
+        .expect("rows")
+        .iter()
+        .map(|r| {
+            (
+                r["?old"]["@value"].as_str().expect("?old").to_string(),
+                r["?t"]["@value"].as_i64().expect("?t"),
+            )
+        })
+        .collect();
+
+    assert_eq!(got, vec![("Alice".to_string(), 2), ("Bob".to_string(), 3)]);
+}
+
+/// A narrowed `FROM ... TO ...` window is what scopes the scan; rows
+/// outside it are not emitted at all.
+#[tokio::test]
+async fn rdf_star_history_narrowed_range() {
+    let (_tmp, fluree, ledger_id) = team_ledger("range").await;
+
+    let sparql = format!(
+        r"PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+SELECT ?person ?value ?t ?op
+FROM <{ledger_id}@t:3>
+TO <{ledger_id}@t:latest>
+WHERE {{ << ?person ex:name ?value >> f:t ?t ; f:op ?op . }}
+ORDER BY ?op"
+    );
+
+    let rows = run_sparql(&fluree, &sparql).await;
+    let got: Vec<(String, i64, bool)> = rows
+        .as_array()
+        .expect("rows")
+        .iter()
+        .map(|r| {
+            (
+                r["?value"]["@value"].as_str().expect("?value").to_string(),
+                r["?t"]["@value"].as_i64().expect("?t"),
+                r["?op"]["@value"].as_bool().expect("?op"),
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        got,
+        vec![
+            ("Bob".to_string(), 3, false),
+            ("Bobby".to_string(), 3, true)
+        ],
+        "only the t=3 change is in range: {rows:#?}"
+    );
+}
+
+/// Aggregates work over history rows like any other solution sequence.
+#[tokio::test]
+async fn rdf_star_history_group_by_count() {
+    let (_tmp, fluree, ledger_id) = team_ledger("aggregate").await;
+
+    let sparql = format!(
+        r"PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+SELECT ?person (COUNT(*) AS ?changes)
+FROM <{ledger_id}@t:1>
+TO <{ledger_id}@t:latest>
+WHERE {{
+  << ?person ex:name ?value >> f:t ?t ; f:op ?op .
+  FILTER(?op = true)
+}}
+GROUP BY ?person
+ORDER BY DESC(?changes) ?person"
+    );
+
+    let rows = run_sparql(&fluree, &sparql).await;
+    let got: Vec<(String, i64)> = rows
+        .as_array()
+        .expect("rows")
+        .iter()
+        .map(|r| {
+            (
+                local_name(&r["?person"]),
+                r["?changes"]["@value"].as_i64().expect("?changes"),
+            )
+        })
+        .collect();
+
+    // Each person has two asserts: the original and the replacement.
+    assert_eq!(
+        got,
+        vec![("alice".to_string(), 2), ("bob".to_string(), 2)],
+        "rows: {rows:#?}"
+    );
 }

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -782,7 +782,7 @@ pub enum Commands {
         #[arg(short = 'p', long)]
         predicate: Option<String>,
 
-        /// Output format (json, table, csv, or tsv)
+        /// Output format (json, table, or csv)
         #[arg(long, default_value = "table")]
         format: String,
 


### PR DESCRIPTION
The time-travel cookbook had drifted badly from the implementation — most of its examples were not runnable. Audited every documented form against a real ledger and rewrote what was wrong.

## What was broken

| Doc | Problem |
|---|---|
| `cookbook-time-travel.md` | `fluree history` shown taking a SPARQL query string; it takes an **entity IRI** and builds the query itself. Every `fluree history` example was invalid. |
| `cookbook-time-travel.md` | HTTP examples used `?ledger=` and `?t=` URL params. Neither exists — `SparqlParams` has only `query` / `default_context` / `default_graph_uri`. |
| `cookbook-time-travel.md` | Multi-ledger example used an invented `{alias: {ledger, t}}` map plus `@graph` aliases. |
| `cookbook-time-travel.md` | `FILTER(?t >= 10 && ?t <= 15)` against a never-bound `?t` — silently returns `[]`. |
| `cookbook-time-travel.md` | Claimed `?op` renders as `assert` / `retract`. It is `xsd:boolean`; only the CLI *table* renderer shows `+` / `-`. |
| `concepts/time-travel.md` | `["filter", "(= ?op \"retract\")"]` matches nothing — contradicted `jsonld-query.md`, which already says string constants are not accepted. |
| `cli/history.md` | Missing `--remote`; did not say the argument is an entity IRI rather than a query. |

The cookbook also never mentioned the RDF-star form that history queries actually use, nor `@recorded:`.

`docs/query/sparql.md` and `docs/query/jsonld-query.md` were already correct and are essentially untouched.

## SPARQL coverage

Several history patterns had been shown only in JSON-LD. The cookbook now carries SPARQL for all of them — variable-predicate (all properties of an entity), variable-subject (one property across subjects), retractions-only as a complete query rather than a bare `FILTER` fragment, range scoping, and a `GROUP BY` aggregate over history rows.

## What is now documented that was not

- SPARQL `FROM ... TO ...` is **connection-scoped only** — rejected on `/v1/fluree/query/{ledger}` (`routes/query.rs:2687`) and on `/v1/fluree/stream/query` (`routes/stream_query.rs:306`).
- History mode rejects reasoning.
- The quoted triple's object must be a variable.
- `<< s p o >>` (flake metadata) vs `<<( s p o )>>` (RDF 1.2 reification) do not compose.
- The cookbook now separates point-in-time travel from history queries up front — they are different capabilities that were being run together.

## On unbound `?t` / `?op`

I originally filed #1532 arguing the engine should error when a history query selects `?t` / `?op` without binding them. That was wrong and the issue is closed.

The same shape in a non-history query behaves identically — `SELECT ?name ?zzz ?t ?op` returns null for all three unbound variables. This is just SPARQL 1.1: selecting a variable the WHERE clause never binds is legal and yields unbound. Erroring would deviate from the spec, reserve `?t` as a magic name (breaking anyone using it for "type"/"total"), and be arbitrary — there is no principled reason to reject `?t` but accept `?zzz`. We already have real syntax for this, and the engine already errors cleanly on genuine misuse of it.

It was a documentation failure, not an engine one. The gotchas section now explains the semantics rather than implying a defect.

## Root cause of the drift

The SPARQL history lowering path (`lower/rdf_star.rs`) had parser-level tests but **no end-to-end coverage** — the five existing `it_query_history*` / `it_query_time_travel*` files are all JSON-LD. Nothing would have caught the docs describing syntax that does not work.

Adds `it_query_history_sparql.rs` (10 tests) covering every SPARQL form the cookbook now shows: metadata binding, the `;`-continued form, variable predicate, variable subject, boolean `f:op` filtering, retractions-only, narrowed ranges, `GROUP BY` aggregates, rejection of constant quoted-triple objects, and the unbound-variable semantics above.

## Also

`fluree history --format` advertised `tsv` in its clap help, which the command rejects at runtime. Dropped from the help text.

## Verification

Every example in the rewritten cookbook was executed against a real ledger — including the multi-ledger `from` array with per-ledger `@t:` suffixes and both structured `from` shapes. All cross-reference anchors checked.

`cargo clippy -p fluree-db-cli -p fluree-db-api --all-features --all-targets -- -D warnings` clean; `grp_query_history` 45/45 passing.