### PR TITLE
Redact graph source config secrets

### DIFF
--- a/fluree-db-api/src/ledger_info.rs
+++ b/fluree-db-api/src/ledger_info.rs
@@ -1001,7 +1001,10 @@ fn is_secret_config_key(key: &str) -> bool {
 /// "default_val": "..."}`) keeps its `env_var` name (safe, aids debugging) while
 /// the inline `default_val` fallback is masked by the recursive walk. Returns
 /// `true` when anything was redacted.
-fn redact_json_secrets(value: &mut JsonValue) -> bool {
+///
+/// Value-level form of [`redact_graph_source_config`], for callers that
+/// already hold a parsed JSON tree.
+pub fn redact_json_secrets(value: &mut JsonValue) -> bool {
     let mut redacted = false;
     match value {
         JsonValue::Object(map) => {

--- a/fluree-db-api/src/ledger_info.rs
+++ b/fluree-db-api/src/ledger_info.rs
@@ -995,12 +995,26 @@ fn is_secret_config_key(key: &str) -> bool {
     SECRET_CONFIG_KEYS.iter().any(|s| *s == lower)
 }
 
-/// Recursively replace secret-bearing scalar values with `"[redacted]"`.
+/// Keys inside a secret-keyed reference object that identify where the secret
+/// comes from rather than what it is (the `ConfigValue::Dynamic` wire shape);
+/// their string values are preserved during subtree redaction.
+const SECRET_REF_SAFE_KEYS: &[&str] = &["env_var", "java_property"];
+
+fn is_secret_ref_safe_key(key: &str) -> bool {
+    let lower = key.to_ascii_lowercase();
+    SECRET_REF_SAFE_KEYS.iter().any(|s| *s == lower)
+}
+
+/// Recursively replace secret-bearing values with `"[redacted]"`.
 ///
-/// A secret held as an env-var reference object (`{"env_var": "...",
-/// "default_val": "..."}`) keeps its `env_var` name (safe, aids debugging) while
-/// the inline `default_val` fallback is masked by the recursive walk. Returns
-/// `true` when anything was redacted.
+/// A scalar under a secret key is masked outright. A container under a secret
+/// key is redacted with inverted strictness by [`redact_secret_subtree`]:
+/// every scalar leaf inside is masked except reference-identifier strings
+/// (`env_var`, `java_property` — safe, they aid debugging), so a secret held
+/// as `{"env_var": "...", "default_val": "..."}` keeps its `env_var` name
+/// while the inline `default_val` fallback is masked, and a secret hidden in
+/// an unrecognized container shape (`{"token": ["..."]}`) cannot escape.
+/// Returns `true` when anything was redacted.
 ///
 /// Value-level form of [`redact_graph_source_config`], for callers that
 /// already hold a parsed JSON tree.
@@ -1009,9 +1023,15 @@ pub fn redact_json_secrets(value: &mut JsonValue) -> bool {
     match value {
         JsonValue::Object(map) => {
             for (k, v) in map.iter_mut() {
-                if is_secret_config_key(k) && !v.is_object() && !v.is_array() && !v.is_null() {
-                    *v = JsonValue::String("[redacted]".to_string());
-                    redacted = true;
+                if is_secret_config_key(k) {
+                    if v.is_object() || v.is_array() {
+                        if redact_secret_subtree(v) {
+                            redacted = true;
+                        }
+                    } else if !v.is_null() {
+                        *v = JsonValue::String("[redacted]".to_string());
+                        redacted = true;
+                    }
                 } else if redact_json_secrets(v) {
                     redacted = true;
                 }
@@ -1025,6 +1045,37 @@ pub fn redact_json_secrets(value: &mut JsonValue) -> bool {
             }
         }
         _ => {}
+    }
+    redacted
+}
+
+/// Redact every scalar leaf beneath a secret-keyed container, keeping only
+/// reference-identifier strings ([`SECRET_REF_SAFE_KEYS`]) and nulls.
+fn redact_secret_subtree(value: &mut JsonValue) -> bool {
+    let mut redacted = false;
+    match value {
+        JsonValue::Object(map) => {
+            for (k, v) in map.iter_mut() {
+                if is_secret_ref_safe_key(k) && v.is_string() {
+                    continue;
+                }
+                if redact_secret_subtree(v) {
+                    redacted = true;
+                }
+            }
+        }
+        JsonValue::Array(arr) => {
+            for v in arr.iter_mut() {
+                if redact_secret_subtree(v) {
+                    redacted = true;
+                }
+            }
+        }
+        JsonValue::Null => {}
+        _ => {
+            *value = JsonValue::String("[redacted]".to_string());
+            redacted = true;
+        }
     }
     redacted
 }
@@ -2708,6 +2759,41 @@ mod tests {
         assert!(
             !redacted.contains("fallback-secret-value"),
             "inline default secret leaked: {redacted}"
+        );
+    }
+
+    #[test]
+    fn test_redact_graph_source_config_masks_secret_keyed_array() {
+        let config = r#"{"auth":{"token":["tok-1","tok-2"]},"table":"ns.t"}"#;
+        let redacted = redact_graph_source_config(config);
+        assert!(
+            !redacted.contains("tok-1"),
+            "array secret leaked: {redacted}"
+        );
+        assert!(
+            !redacted.contains("tok-2"),
+            "array secret leaked: {redacted}"
+        );
+        assert!(redacted.contains("[redacted]"));
+        assert!(redacted.contains("ns.t"));
+    }
+
+    #[test]
+    fn test_redact_graph_source_config_masks_unrecognized_secret_object_shape() {
+        let config = r#"{"auth":{"client_secret":{"value":"s3cret-inner",
+            "env_var":"POLARIS_SECRET","nested":{"deep":"s3cret-deep"}}}}"#;
+        let redacted = redact_graph_source_config(config);
+        assert!(
+            !redacted.contains("s3cret-inner"),
+            "object-wrapped secret leaked: {redacted}"
+        );
+        assert!(
+            !redacted.contains("s3cret-deep"),
+            "nested object secret leaked: {redacted}"
+        );
+        assert!(
+            redacted.contains("POLARIS_SECRET"),
+            "env var name should survive: {redacted}"
         );
     }
 

--- a/fluree-db-api/src/ledger_info.rs
+++ b/fluree-db-api/src/ledger_info.rs
@@ -1469,10 +1469,13 @@ pub fn build_generic_graph_source_info(record: &GraphSourceRecord) -> JsonValue 
     if !record.dependencies.is_empty() {
         obj["dependencies"] = json!(record.dependencies);
     }
-    if !record.config.is_empty() && record.config != "{}" {
+    if !record.config.is_empty() {
         let redacted = redact_graph_source_config(&record.config);
         if let Ok(parsed) = serde_json::from_str::<JsonValue>(&redacted) {
-            obj["config"] = parsed;
+            let empty_object = parsed.as_object().is_some_and(serde_json::Map::is_empty);
+            if !empty_object {
+                obj["config"] = parsed;
+            }
         }
     }
 
@@ -2795,6 +2798,17 @@ mod tests {
             redacted.contains("POLARIS_SECRET"),
             "env var name should survive: {redacted}"
         );
+    }
+
+    #[test]
+    fn test_generic_gs_info_omits_empty_config_regardless_of_whitespace() {
+        for empty in ["", "{}", "{ }", "{\n}"] {
+            let info = build_generic_graph_source_info(&virtual_record(empty));
+            assert!(
+                info.get("config").is_none(),
+                "empty config {empty:?} should be omitted: {info}"
+            );
+        }
     }
 
     #[test]

--- a/fluree-db-api/src/ledger_info.rs
+++ b/fluree-db-api/src/ledger_info.rs
@@ -1108,7 +1108,7 @@ pub fn redact_graph_source_config(config: &str) -> String {
 // ============================================================================
 
 /// Human-readable label for a graph-source type (e.g. `"Iceberg"`, `"R2RML"`).
-fn graph_source_type_label(source_type: &GraphSourceType) -> String {
+pub fn graph_source_type_label(source_type: &GraphSourceType) -> String {
     match source_type {
         GraphSourceType::Bm25 => "BM25".to_string(),
         GraphSourceType::Vector => "Vector".to_string(),
@@ -1449,11 +1449,11 @@ pub fn build_virtual_ledger_info(
     }
 }
 
-/// Thin (redacted) metadata view for a graph source that is not a virtual
-/// R2RML/Iceberg dataset (BM25 / Vector / Geo / Unknown). Preserves the
-/// historical `/info` stub shape but routes the config through
-/// [`redact_graph_source_config`] so no secret can leak.
-fn build_generic_graph_source_info(record: &GraphSourceRecord) -> JsonValue {
+/// Thin (redacted) metadata view of a graph-source record. Routes the config
+/// through [`redact_graph_source_config`] so no secret can leak; the historical
+/// `/info` stub shape for sources that are not virtual R2RML/Iceberg datasets
+/// (BM25 / Vector / Geo / Unknown).
+pub fn build_generic_graph_source_info(record: &GraphSourceRecord) -> JsonValue {
     let mut obj = json!({
         "name": record.name,
         "branch": record.branch,

--- a/fluree-db-cli/src/commands/iceberg.rs
+++ b/fluree-db-cli/src/commands/iceberg.rs
@@ -1,6 +1,9 @@
 use crate::cli::IcebergMapArgs;
 use crate::context;
 use crate::error::{CliError, CliResult};
+use crate::graph_source_display::{
+    format_source_type, print_local_graph_source, print_remote_graph_source,
+};
 use comfy_table::{ContentArrangement, Table};
 use fluree_db_api::server_defaults::FlureeDir;
 
@@ -147,7 +150,7 @@ pub async fn run_iceberg_info(
         )));
     }
 
-    print_graph_source_info(&gs);
+    print_local_graph_source(&gs);
     Ok(())
 }
 
@@ -486,7 +489,7 @@ fn print_iceberg_list_remote(
 
 fn print_iceberg_info_remote(name: &str, info: &serde_json::Value) -> CliResult<()> {
     ensure_remote_iceberg_info(name, info)?;
-    print_remote_graph_source_info(info);
+    print_remote_graph_source(info);
     Ok(())
 }
 
@@ -538,74 +541,6 @@ fn print_remote_drop_response(response: &serde_json::Value) -> CliResult<()> {
     }
 
     Ok(())
-}
-
-fn print_remote_graph_source_info(info: &serde_json::Value) {
-    let name = info.get("name").and_then(|v| v.as_str()).unwrap_or("?");
-    let branch = info.get("branch").and_then(|v| v.as_str()).unwrap_or("?");
-    let gs_type = info.get("type").and_then(|v| v.as_str()).unwrap_or("?");
-    let gs_id = info
-        .get("graph_source_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("?");
-
-    println!("Name:           {name}");
-    println!("Branch:         {branch}");
-    println!("Type:           {gs_type}");
-    println!("ID:             {gs_id}");
-
-    if let Some(t) = info.get("index_t").and_then(serde_json::Value::as_i64) {
-        println!("Index t:        {t}");
-    }
-    if let Some(id) = info.get("index_id").and_then(|v| v.as_str()) {
-        println!("Index ID:       {id}");
-    }
-    if let Some(deps) = info.get("dependencies").and_then(|v| v.as_array()) {
-        let dep_strs: Vec<&str> = deps.iter().filter_map(|v| v.as_str()).collect();
-        if !dep_strs.is_empty() {
-            println!("Dependencies:   {}", dep_strs.join(", "));
-        }
-    }
-    if let Some(config) = info.get("config") {
-        println!();
-        println!("Configuration:");
-        println!(
-            "{}",
-            serde_json::to_string_pretty(config).unwrap_or_default()
-        );
-    }
-}
-
-fn print_graph_source_info(gs: &fluree_db_nameservice::GraphSourceRecord) {
-    println!("Name:           {}", gs.name);
-    println!("Branch:         {}", gs.branch);
-    println!("Type:           {}", format_source_type(&gs.source_type));
-    println!("ID:             {}", gs.graph_source_id);
-    println!("Retracted:      {}", gs.retracted);
-    println!("Index t:        {}", gs.index_t);
-    println!(
-        "Index ID:       {}",
-        gs.index_id
-            .as_ref()
-            .map(std::string::ToString::to_string)
-            .as_deref()
-            .unwrap_or("(none)")
-    );
-
-    if !gs.dependencies.is_empty() {
-        println!("Dependencies:   {}", gs.dependencies.join(", "));
-    }
-
-    if !gs.config.is_empty() && gs.config != "{}" {
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&gs.config) {
-            println!();
-            println!("Configuration:");
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&parsed).unwrap_or_else(|_| gs.config.clone())
-            );
-        }
-    }
 }
 
 // =============================================================================
@@ -796,17 +731,6 @@ fn is_iceberg_family_source_type(st: &fluree_db_nameservice::GraphSourceType) ->
 
 fn is_iceberg_family_type_str(s: &str) -> bool {
     matches!(s, "Iceberg" | "R2RML")
-}
-
-fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) -> String {
-    match st {
-        fluree_db_nameservice::GraphSourceType::Bm25 => "BM25".to_string(),
-        fluree_db_nameservice::GraphSourceType::Vector => "Vector".to_string(),
-        fluree_db_nameservice::GraphSourceType::Geo => "Geo".to_string(),
-        fluree_db_nameservice::GraphSourceType::R2rml => "R2RML".to_string(),
-        fluree_db_nameservice::GraphSourceType::Iceberg => "Iceberg".to_string(),
-        fluree_db_nameservice::GraphSourceType::Unknown(s) => format!("Unknown({s})"),
-    }
 }
 
 #[cfg(test)]

--- a/fluree-db-cli/src/commands/iceberg.rs
+++ b/fluree-db-cli/src/commands/iceberg.rs
@@ -1,10 +1,9 @@
 use crate::cli::IcebergMapArgs;
 use crate::context;
 use crate::error::{CliError, CliResult};
-use crate::graph_source_display::{
-    format_source_type, print_local_graph_source, print_remote_graph_source,
-};
+use crate::graph_source_display::{print_local_graph_source, print_remote_graph_source};
 use comfy_table::{ContentArrangement, Table};
+use fluree_db_api::ledger_info::graph_source_type_label;
 use fluree_db_api::server_defaults::FlureeDir;
 
 // =============================================================================
@@ -95,7 +94,7 @@ pub async fn run_iceberg_list(
         table.add_row(vec![
             gs.name,
             gs.branch,
-            format_source_type(&gs.source_type),
+            graph_source_type_label(&gs.source_type),
             t_str,
         ]);
     }

--- a/fluree-db-cli/src/commands/info.rs
+++ b/fluree-db-cli/src/commands/info.rs
@@ -1,5 +1,6 @@
 use crate::context::{self, LedgerMode};
 use crate::error::{CliError, CliResult};
+use crate::graph_source_display::{print_local_graph_source, print_remote_graph_source};
 use fluree_db_api::server_defaults::FlureeDir;
 
 pub async fn run(
@@ -43,7 +44,7 @@ pub async fn run(
                             "--graph is not applicable to graph sources".to_string(),
                         ));
                     }
-                    print_graph_source_info(&gs);
+                    print_local_graph_source(&gs);
                     return Ok(());
                 }
                 // Neither ledger nor graph source
@@ -73,7 +74,7 @@ pub async fn run(
                         "--graph is not applicable to graph sources".to_string(),
                     ));
                 }
-                print_remote_graph_source_info(&info);
+                print_remote_graph_source(&info);
             } else {
                 println!(
                     "Ledger:         {} (tracked)",
@@ -156,7 +157,7 @@ pub async fn run(
                         "--graph is not applicable to graph sources".to_string(),
                     ));
                 }
-                print_graph_source_info(&gs);
+                print_local_graph_source(&gs);
             } else {
                 return Err(CliError::NotFound(format!(
                     "'{alias}' not found as a ledger or graph source"
@@ -166,85 +167,4 @@ pub async fn run(
     }
 
     Ok(())
-}
-
-/// Print graph source info from a JSON response (remote/server mode).
-fn print_remote_graph_source_info(info: &serde_json::Value) {
-    let name = info.get("name").and_then(|v| v.as_str()).unwrap_or("?");
-    let branch = info.get("branch").and_then(|v| v.as_str()).unwrap_or("?");
-    let gs_type = info.get("type").and_then(|v| v.as_str()).unwrap_or("?");
-    let gs_id = info
-        .get("graph_source_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("?");
-
-    println!("Name:           {name}");
-    println!("Branch:         {branch}");
-    println!("Type:           {gs_type}");
-    println!("ID:             {gs_id}");
-
-    if let Some(t) = info.get("index_t").and_then(serde_json::Value::as_i64) {
-        println!("Index t:        {t}");
-    }
-    if let Some(id) = info.get("index_id").and_then(|v| v.as_str()) {
-        println!("Index ID:       {id}");
-    }
-    if let Some(deps) = info.get("dependencies").and_then(|v| v.as_array()) {
-        let dep_strs: Vec<&str> = deps.iter().filter_map(|v| v.as_str()).collect();
-        if !dep_strs.is_empty() {
-            println!("Dependencies:   {}", dep_strs.join(", "));
-        }
-    }
-    if let Some(config) = info.get("config") {
-        println!();
-        println!("Configuration:");
-        println!(
-            "{}",
-            serde_json::to_string_pretty(config).unwrap_or_default()
-        );
-    }
-}
-
-fn print_graph_source_info(gs: &fluree_db_nameservice::GraphSourceRecord) {
-    println!("Name:           {}", gs.name);
-    println!("Branch:         {}", gs.branch);
-    println!("Type:           {}", format_source_type(&gs.source_type));
-    println!("ID:             {}", gs.graph_source_id);
-    println!("Retracted:      {}", gs.retracted);
-    println!("Index t:        {}", gs.index_t);
-    println!(
-        "Index ID:       {}",
-        gs.index_id
-            .as_ref()
-            .map(std::string::ToString::to_string)
-            .as_deref()
-            .unwrap_or("(none)")
-    );
-
-    if !gs.dependencies.is_empty() {
-        println!("Dependencies:   {}", gs.dependencies.join(", "));
-    }
-
-    // Print config JSON (pretty)
-    if !gs.config.is_empty() && gs.config != "{}" {
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&gs.config) {
-            println!();
-            println!("Configuration:");
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&parsed).unwrap_or_else(|_| gs.config.clone())
-            );
-        }
-    }
-}
-
-fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) -> String {
-    match st {
-        fluree_db_nameservice::GraphSourceType::Bm25 => "BM25".to_string(),
-        fluree_db_nameservice::GraphSourceType::Vector => "Vector".to_string(),
-        fluree_db_nameservice::GraphSourceType::Geo => "Geo".to_string(),
-        fluree_db_nameservice::GraphSourceType::R2rml => "R2RML".to_string(),
-        fluree_db_nameservice::GraphSourceType::Iceberg => "Iceberg".to_string(),
-        fluree_db_nameservice::GraphSourceType::Unknown(s) => format!("Unknown({s})"),
-    }
 }

--- a/fluree-db-cli/src/commands/info.rs
+++ b/fluree-db-cli/src/commands/info.rs
@@ -132,25 +132,15 @@ pub async fn run(
                 println!("Type:           Ledger");
                 println!("Ledger ID:      {}", record.ledger_id);
                 println!("Commit t:       {}", record.commit_t);
-                println!(
-                    "Commit ID:      {}",
-                    record
-                        .commit_head_id
-                        .as_ref()
-                        .map(std::string::ToString::to_string)
-                        .as_deref()
-                        .unwrap_or("(none)")
-                );
+                match &record.commit_head_id {
+                    Some(id) => println!("Commit ID:      {id}"),
+                    None => println!("Commit ID:      (none)"),
+                }
                 println!("Index t:        {}", record.index_t);
-                println!(
-                    "Index ID:       {}",
-                    record
-                        .index_head_id
-                        .as_ref()
-                        .map(std::string::ToString::to_string)
-                        .as_deref()
-                        .unwrap_or("(none)")
-                );
+                match &record.index_head_id {
+                    Some(id) => println!("Index ID:       {id}"),
+                    None => println!("Index ID:       (none)"),
+                }
             } else if let Some(gs) = fluree.nameservice().lookup_graph_source(&ledger_id).await? {
                 if graph.is_some() {
                     return Err(CliError::Usage(

--- a/fluree-db-cli/src/commands/list.rs
+++ b/fluree-db-cli/src/commands/list.rs
@@ -1,9 +1,9 @@
 use crate::config::{self, TomlSyncConfigStore};
 use crate::context;
 use crate::error::{CliError, CliResult};
-use crate::graph_source_display::format_source_type;
 use colored::Colorize;
 use comfy_table::{ContentArrangement, Table};
+use fluree_db_api::ledger_info::graph_source_type_label;
 use fluree_db_api::server_defaults::FlureeDir;
 
 pub async fn run(dirs: &FlureeDir, remote_flag: Option<&str>, direct: bool) -> CliResult<()> {
@@ -82,7 +82,7 @@ pub async fn run(dirs: &FlureeDir, remote_flag: Option<&str>, direct: bool) -> C
                     " ".to_string(),
                     gs.name.clone(),
                     gs.branch.clone(),
-                    format_source_type(&gs.source_type),
+                    graph_source_type_label(&gs.source_type),
                     t_str,
                 ]);
             }

--- a/fluree-db-cli/src/commands/list.rs
+++ b/fluree-db-cli/src/commands/list.rs
@@ -1,6 +1,7 @@
 use crate::config::{self, TomlSyncConfigStore};
 use crate::context;
 use crate::error::{CliError, CliResult};
+use crate::graph_source_display::format_source_type;
 use colored::Colorize;
 use comfy_table::{ContentArrangement, Table};
 use fluree_db_api::server_defaults::FlureeDir;
@@ -220,15 +221,4 @@ fn print_ledger_list(result: &serde_json::Value, remote_label: Option<&str>) -> 
 
     println!("{table}");
     Ok(())
-}
-
-fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) -> String {
-    match st {
-        fluree_db_nameservice::GraphSourceType::Bm25 => "BM25".to_string(),
-        fluree_db_nameservice::GraphSourceType::Vector => "Vector".to_string(),
-        fluree_db_nameservice::GraphSourceType::Geo => "Geo".to_string(),
-        fluree_db_nameservice::GraphSourceType::R2rml => "R2RML".to_string(),
-        fluree_db_nameservice::GraphSourceType::Iceberg => "Iceberg".to_string(),
-        fluree_db_nameservice::GraphSourceType::Unknown(s) => format!("Unknown({s})"),
-    }
 }

--- a/fluree-db-cli/src/graph_source_display.rs
+++ b/fluree-db-cli/src/graph_source_display.rs
@@ -2,15 +2,18 @@
 //!
 //! Every path that prints a graph-source config must go through this module:
 //! stored configs can carry literal auth secrets (OAuth2 client secrets,
-//! bearer tokens), so the config JSON is redacted before printing.
+//! bearer tokens), so the config JSON is redacted before printing. Local
+//! records are converted through [`build_generic_graph_source_info`] — the
+//! same redacted view the server's `/info` route emits — so local and remote
+//! sources render identically through one renderer.
 
 use std::fmt::Write;
 
-use fluree_db_api::ledger_info::redact_json_secrets;
+use fluree_db_api::ledger_info::{build_generic_graph_source_info, redact_json_secrets};
 
 /// Print graph source info from a JSON response (remote/server mode).
 pub(crate) fn print_remote_graph_source(info: &serde_json::Value) {
-    print!("{}", render_remote_graph_source(info));
+    print!("{}", render_graph_source(info));
 }
 
 /// Print graph source info from a locally-read nameservice record.
@@ -18,8 +21,13 @@ pub(crate) fn print_local_graph_source(gs: &fluree_db_nameservice::GraphSourceRe
     print!("{}", render_local_graph_source(gs));
 }
 
-/// Render graph source info from a JSON response (remote/server mode).
-fn render_remote_graph_source(info: &serde_json::Value) -> String {
+fn render_local_graph_source(gs: &fluree_db_nameservice::GraphSourceRecord) -> String {
+    render_graph_source(&build_generic_graph_source_info(gs))
+}
+
+/// Render graph-source info from its redacted JSON view (a server `/info`
+/// response, or [`build_generic_graph_source_info`] output for local records).
+fn render_graph_source(info: &serde_json::Value) -> String {
     let name = info.get("name").and_then(|v| v.as_str()).unwrap_or("?");
     let branch = info.get("branch").and_then(|v| v.as_str()).unwrap_or("?");
     let gs_type = info.get("type").and_then(|v| v.as_str()).unwrap_or("?");
@@ -34,12 +42,15 @@ fn render_remote_graph_source(info: &serde_json::Value) -> String {
     let _ = writeln!(out, "Type:           {gs_type}");
     let _ = writeln!(out, "ID:             {gs_id}");
 
+    if let Some(retracted) = info.get("retracted").and_then(serde_json::Value::as_bool) {
+        let _ = writeln!(out, "Retracted:      {retracted}");
+    }
     if let Some(t) = info.get("index_t").and_then(serde_json::Value::as_i64) {
         let _ = writeln!(out, "Index t:        {t}");
     }
-    if let Some(id) = info.get("index_id").and_then(|v| v.as_str()) {
-        let _ = writeln!(out, "Index ID:       {id}");
-    }
+    let index_id = info.get("index_id").and_then(|v| v.as_str());
+    let _ = writeln!(out, "Index ID:       {}", index_id.unwrap_or("(none)"));
+
     if let Some(deps) = info.get("dependencies").and_then(|v| v.as_array()) {
         let dep_strs: Vec<&str> = deps.iter().filter_map(|v| v.as_str()).collect();
         if !dep_strs.is_empty() {
@@ -52,64 +63,10 @@ fn render_remote_graph_source(info: &serde_json::Value) -> String {
     out
 }
 
-/// Render graph source info from a locally-read nameservice record.
-fn render_local_graph_source(gs: &fluree_db_nameservice::GraphSourceRecord) -> String {
-    let mut out = String::new();
-    let _ = writeln!(out, "Name:           {}", gs.name);
-    let _ = writeln!(out, "Branch:         {}", gs.branch);
-    let _ = writeln!(
-        out,
-        "Type:           {}",
-        format_source_type(&gs.source_type)
-    );
-    let _ = writeln!(out, "ID:             {}", gs.graph_source_id);
-    let _ = writeln!(out, "Retracted:      {}", gs.retracted);
-    let _ = writeln!(out, "Index t:        {}", gs.index_t);
-    let _ = writeln!(
-        out,
-        "Index ID:       {}",
-        gs.index_id
-            .as_ref()
-            .map(std::string::ToString::to_string)
-            .as_deref()
-            .unwrap_or("(none)")
-    );
-
-    if !gs.dependencies.is_empty() {
-        let _ = writeln!(out, "Dependencies:   {}", gs.dependencies.join(", "));
-    }
-
-    if !gs.config.is_empty() && gs.config != "{}" {
-        match serde_json::from_str::<serde_json::Value>(&gs.config) {
-            Ok(parsed) => write_config_section(&mut out, &parsed),
-            // Fail closed, matching redact_graph_source_config: a config that
-            // cannot be inspected is reported, never echoed or silently
-            // omitted.
-            Err(_) => write_config_body(&mut out, "[redacted:unparseable]"),
-        }
-    }
-    out
-}
-
-pub(crate) fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) -> String {
-    match st {
-        fluree_db_nameservice::GraphSourceType::Bm25 => "BM25".to_string(),
-        fluree_db_nameservice::GraphSourceType::Vector => "Vector".to_string(),
-        fluree_db_nameservice::GraphSourceType::Geo => "Geo".to_string(),
-        fluree_db_nameservice::GraphSourceType::R2rml => "R2RML".to_string(),
-        fluree_db_nameservice::GraphSourceType::Iceberg => "Iceberg".to_string(),
-        fluree_db_nameservice::GraphSourceType::Unknown(s) => format!("Unknown({s})"),
-    }
-}
-
 fn write_config_section(out: &mut String, config: &serde_json::Value) {
-    write_config_body(out, &redacted_config_pretty(config));
-}
-
-fn write_config_body(out: &mut String, body: &str) {
     let _ = writeln!(out);
     let _ = writeln!(out, "Configuration:");
-    let _ = writeln!(out, "{body}");
+    let _ = writeln!(out, "{}", redacted_config_pretty(config));
 }
 
 fn redacted_config_pretty(config: &serde_json::Value) -> String {
@@ -152,6 +109,9 @@ mod tests {
 
         let rendered = render_local_graph_source(&gs);
         assert!(rendered.contains("Name:           my-gs"));
+        assert!(rendered.contains("Type:           Iceberg"));
+        assert!(rendered.contains("Retracted:      false"));
+        assert!(rendered.contains("Index ID:       (none)"));
         assert!(rendered.contains("Configuration:"));
         assert!(!rendered.contains("super-secret-pat"));
         assert!(!rendered.contains("live-bearer-token"));
@@ -169,7 +129,7 @@ mod tests {
             "config": secret_bearing_config()
         });
 
-        let rendered = render_remote_graph_source(&info);
+        let rendered = render_graph_source(&info);
         assert!(rendered.contains("Name:           my-gs"));
         assert!(rendered.contains("Configuration:"));
         assert!(!rendered.contains("super-secret-pat"));

--- a/fluree-db-cli/src/graph_source_display.rs
+++ b/fluree-db-cli/src/graph_source_display.rs
@@ -116,6 +116,9 @@ mod tests {
         assert!(!rendered.contains("super-secret-pat"));
         assert!(!rendered.contains("live-bearer-token"));
         assert!(rendered.contains("[redacted]"));
+        // Non-secret identifying fields survive.
+        assert!(rendered.contains("my-client"));
+        assert!(rendered.contains("session:role:ICEBERG_READER"));
     }
 
     #[test]
@@ -154,34 +157,40 @@ mod tests {
     }
 
     #[test]
-    fn redacts_oauth_client_secret_and_bearer_token() {
-        let pretty = redacted_config_pretty(&secret_bearing_config());
-        assert!(!pretty.contains("super-secret-pat"));
-        assert!(!pretty.contains("live-bearer-token"));
-        assert!(pretty.contains("[redacted]"));
-        // Non-secret identifying fields survive.
-        assert!(pretty.contains("my-client"));
-        assert!(pretty.contains("session:role:ICEBERG_READER"));
-    }
-
-    #[test]
-    fn keeps_env_var_name_but_masks_inline_default() {
+    fn local_render_keeps_env_var_name_but_masks_inline_default() {
         let config = json!({
             "auth": {
                 "client_secret": { "env_var": "FLUREE_CLIENT_SECRET", "default_val": "fallback-secret" }
             }
         });
+        let gs = GraphSourceRecord::new(
+            "my-gs",
+            "main",
+            GraphSourceType::Iceberg,
+            config.to_string(),
+            vec![],
+        );
 
-        let pretty = redacted_config_pretty(&config);
-        assert!(pretty.contains("FLUREE_CLIENT_SECRET"));
-        assert!(!pretty.contains("fallback-secret"));
+        let rendered = render_local_graph_source(&gs);
+        assert!(rendered.contains("FLUREE_CLIENT_SECRET"));
+        assert!(!rendered.contains("fallback-secret"));
     }
 
     #[test]
-    fn non_secret_config_is_unchanged() {
+    fn local_render_shows_non_secret_config_in_full() {
         let config = json!({ "index": "bm25", "k1": 1.2, "b": 0.75 });
-        let pretty = redacted_config_pretty(&config);
-        let reparsed: serde_json::Value = serde_json::from_str(&pretty).unwrap();
-        assert_eq!(reparsed, config);
+        let gs = GraphSourceRecord::new(
+            "my-search",
+            "main",
+            GraphSourceType::Bm25,
+            config.to_string(),
+            vec![],
+        );
+
+        let rendered = render_local_graph_source(&gs);
+        assert!(rendered.contains("Type:           BM25"));
+        assert!(rendered.contains("\"k1\": 1.2"));
+        assert!(rendered.contains("\"b\": 0.75"));
+        assert!(!rendered.contains("[redacted]"));
     }
 }

--- a/fluree-db-cli/src/graph_source_display.rs
+++ b/fluree-db-cli/src/graph_source_display.rs
@@ -1,0 +1,142 @@
+//! Shared rendering of graph-source records for CLI commands.
+//!
+//! Every path that prints a graph-source config must go through this module:
+//! stored configs can carry literal auth secrets (OAuth2 client secrets,
+//! bearer tokens), so the config JSON is redacted before printing.
+
+use fluree_db_api::ledger_info::redact_json_secrets;
+
+/// Print graph source info from a JSON response (remote/server mode).
+pub(crate) fn print_remote_graph_source(info: &serde_json::Value) {
+    let name = info.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+    let branch = info.get("branch").and_then(|v| v.as_str()).unwrap_or("?");
+    let gs_type = info.get("type").and_then(|v| v.as_str()).unwrap_or("?");
+    let gs_id = info
+        .get("graph_source_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?");
+
+    println!("Name:           {name}");
+    println!("Branch:         {branch}");
+    println!("Type:           {gs_type}");
+    println!("ID:             {gs_id}");
+
+    if let Some(t) = info.get("index_t").and_then(serde_json::Value::as_i64) {
+        println!("Index t:        {t}");
+    }
+    if let Some(id) = info.get("index_id").and_then(|v| v.as_str()) {
+        println!("Index ID:       {id}");
+    }
+    if let Some(deps) = info.get("dependencies").and_then(|v| v.as_array()) {
+        let dep_strs: Vec<&str> = deps.iter().filter_map(|v| v.as_str()).collect();
+        if !dep_strs.is_empty() {
+            println!("Dependencies:   {}", dep_strs.join(", "));
+        }
+    }
+    if let Some(config) = info.get("config") {
+        print_config_section(config);
+    }
+}
+
+/// Print graph source info from a locally-read nameservice record.
+pub(crate) fn print_local_graph_source(gs: &fluree_db_nameservice::GraphSourceRecord) {
+    println!("Name:           {}", gs.name);
+    println!("Branch:         {}", gs.branch);
+    println!("Type:           {}", format_source_type(&gs.source_type));
+    println!("ID:             {}", gs.graph_source_id);
+    println!("Retracted:      {}", gs.retracted);
+    println!("Index t:        {}", gs.index_t);
+    println!(
+        "Index ID:       {}",
+        gs.index_id
+            .as_ref()
+            .map(std::string::ToString::to_string)
+            .as_deref()
+            .unwrap_or("(none)")
+    );
+
+    if !gs.dependencies.is_empty() {
+        println!("Dependencies:   {}", gs.dependencies.join(", "));
+    }
+
+    if !gs.config.is_empty() && gs.config != "{}" {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&gs.config) {
+            print_config_section(&parsed);
+        }
+    }
+}
+
+pub(crate) fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) -> String {
+    match st {
+        fluree_db_nameservice::GraphSourceType::Bm25 => "BM25".to_string(),
+        fluree_db_nameservice::GraphSourceType::Vector => "Vector".to_string(),
+        fluree_db_nameservice::GraphSourceType::Geo => "Geo".to_string(),
+        fluree_db_nameservice::GraphSourceType::R2rml => "R2RML".to_string(),
+        fluree_db_nameservice::GraphSourceType::Iceberg => "Iceberg".to_string(),
+        fluree_db_nameservice::GraphSourceType::Unknown(s) => format!("Unknown({s})"),
+    }
+}
+
+fn print_config_section(config: &serde_json::Value) {
+    println!();
+    println!("Configuration:");
+    println!("{}", redacted_config_pretty(config));
+}
+
+fn redacted_config_pretty(config: &serde_json::Value) -> String {
+    let mut redacted = config.clone();
+    redact_json_secrets(&mut redacted);
+    serde_json::to_string_pretty(&redacted).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn redacts_oauth_client_secret_and_bearer_token() {
+        let config = json!({
+            "catalog": {
+                "type": "rest",
+                "uri": "https://acct.snowflakecomputing.com/polaris/api/catalog",
+                "auth": {
+                    "type": "oauth2_client_credentials",
+                    "client_id": "my-client",
+                    "client_secret": "super-secret-pat",
+                    "scope": "session:role:ICEBERG_READER"
+                }
+            },
+            "bearer": { "token": "live-bearer-token" }
+        });
+
+        let pretty = redacted_config_pretty(&config);
+        assert!(!pretty.contains("super-secret-pat"));
+        assert!(!pretty.contains("live-bearer-token"));
+        assert!(pretty.contains("[redacted]"));
+        // Non-secret identifying fields survive.
+        assert!(pretty.contains("my-client"));
+        assert!(pretty.contains("session:role:ICEBERG_READER"));
+    }
+
+    #[test]
+    fn keeps_env_var_name_but_masks_inline_default() {
+        let config = json!({
+            "auth": {
+                "client_secret": { "env_var": "FLUREE_CLIENT_SECRET", "default_val": "fallback-secret" }
+            }
+        });
+
+        let pretty = redacted_config_pretty(&config);
+        assert!(pretty.contains("FLUREE_CLIENT_SECRET"));
+        assert!(!pretty.contains("fallback-secret"));
+    }
+
+    #[test]
+    fn non_secret_config_is_unchanged() {
+        let config = json!({ "index": "bm25", "k1": 1.2, "b": 0.75 });
+        let pretty = redacted_config_pretty(&config);
+        let reparsed: serde_json::Value = serde_json::from_str(&pretty).unwrap();
+        assert_eq!(reparsed, config);
+    }
+}

--- a/fluree-db-cli/src/graph_source_display.rs
+++ b/fluree-db-cli/src/graph_source_display.rs
@@ -4,10 +4,22 @@
 //! stored configs can carry literal auth secrets (OAuth2 client secrets,
 //! bearer tokens), so the config JSON is redacted before printing.
 
+use std::fmt::Write;
+
 use fluree_db_api::ledger_info::redact_json_secrets;
 
 /// Print graph source info from a JSON response (remote/server mode).
 pub(crate) fn print_remote_graph_source(info: &serde_json::Value) {
+    print!("{}", render_remote_graph_source(info));
+}
+
+/// Print graph source info from a locally-read nameservice record.
+pub(crate) fn print_local_graph_source(gs: &fluree_db_nameservice::GraphSourceRecord) {
+    print!("{}", render_local_graph_source(gs));
+}
+
+/// Render graph source info from a JSON response (remote/server mode).
+fn render_remote_graph_source(info: &serde_json::Value) -> String {
     let name = info.get("name").and_then(|v| v.as_str()).unwrap_or("?");
     let branch = info.get("branch").and_then(|v| v.as_str()).unwrap_or("?");
     let gs_type = info.get("type").and_then(|v| v.as_str()).unwrap_or("?");
@@ -16,37 +28,45 @@ pub(crate) fn print_remote_graph_source(info: &serde_json::Value) {
         .and_then(|v| v.as_str())
         .unwrap_or("?");
 
-    println!("Name:           {name}");
-    println!("Branch:         {branch}");
-    println!("Type:           {gs_type}");
-    println!("ID:             {gs_id}");
+    let mut out = String::new();
+    let _ = writeln!(out, "Name:           {name}");
+    let _ = writeln!(out, "Branch:         {branch}");
+    let _ = writeln!(out, "Type:           {gs_type}");
+    let _ = writeln!(out, "ID:             {gs_id}");
 
     if let Some(t) = info.get("index_t").and_then(serde_json::Value::as_i64) {
-        println!("Index t:        {t}");
+        let _ = writeln!(out, "Index t:        {t}");
     }
     if let Some(id) = info.get("index_id").and_then(|v| v.as_str()) {
-        println!("Index ID:       {id}");
+        let _ = writeln!(out, "Index ID:       {id}");
     }
     if let Some(deps) = info.get("dependencies").and_then(|v| v.as_array()) {
         let dep_strs: Vec<&str> = deps.iter().filter_map(|v| v.as_str()).collect();
         if !dep_strs.is_empty() {
-            println!("Dependencies:   {}", dep_strs.join(", "));
+            let _ = writeln!(out, "Dependencies:   {}", dep_strs.join(", "));
         }
     }
     if let Some(config) = info.get("config") {
-        print_config_section(config);
+        write_config_section(&mut out, config);
     }
+    out
 }
 
-/// Print graph source info from a locally-read nameservice record.
-pub(crate) fn print_local_graph_source(gs: &fluree_db_nameservice::GraphSourceRecord) {
-    println!("Name:           {}", gs.name);
-    println!("Branch:         {}", gs.branch);
-    println!("Type:           {}", format_source_type(&gs.source_type));
-    println!("ID:             {}", gs.graph_source_id);
-    println!("Retracted:      {}", gs.retracted);
-    println!("Index t:        {}", gs.index_t);
-    println!(
+/// Render graph source info from a locally-read nameservice record.
+fn render_local_graph_source(gs: &fluree_db_nameservice::GraphSourceRecord) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "Name:           {}", gs.name);
+    let _ = writeln!(out, "Branch:         {}", gs.branch);
+    let _ = writeln!(
+        out,
+        "Type:           {}",
+        format_source_type(&gs.source_type)
+    );
+    let _ = writeln!(out, "ID:             {}", gs.graph_source_id);
+    let _ = writeln!(out, "Retracted:      {}", gs.retracted);
+    let _ = writeln!(out, "Index t:        {}", gs.index_t);
+    let _ = writeln!(
+        out,
         "Index ID:       {}",
         gs.index_id
             .as_ref()
@@ -56,14 +76,15 @@ pub(crate) fn print_local_graph_source(gs: &fluree_db_nameservice::GraphSourceRe
     );
 
     if !gs.dependencies.is_empty() {
-        println!("Dependencies:   {}", gs.dependencies.join(", "));
+        let _ = writeln!(out, "Dependencies:   {}", gs.dependencies.join(", "));
     }
 
     if !gs.config.is_empty() && gs.config != "{}" {
         if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&gs.config) {
-            print_config_section(&parsed);
+            write_config_section(&mut out, &parsed);
         }
     }
+    out
 }
 
 pub(crate) fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) -> String {
@@ -77,10 +98,10 @@ pub(crate) fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) ->
     }
 }
 
-fn print_config_section(config: &serde_json::Value) {
-    println!();
-    println!("Configuration:");
-    println!("{}", redacted_config_pretty(config));
+fn write_config_section(out: &mut String, config: &serde_json::Value) {
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Configuration:");
+    let _ = writeln!(out, "{}", redacted_config_pretty(config));
 }
 
 fn redacted_config_pretty(config: &serde_json::Value) -> String {
@@ -92,11 +113,11 @@ fn redacted_config_pretty(config: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fluree_db_nameservice::{GraphSourceRecord, GraphSourceType};
     use serde_json::json;
 
-    #[test]
-    fn redacts_oauth_client_secret_and_bearer_token() {
-        let config = json!({
+    fn secret_bearing_config() -> serde_json::Value {
+        json!({
             "catalog": {
                 "type": "rest",
                 "uri": "https://acct.snowflakecomputing.com/polaris/api/catalog",
@@ -108,9 +129,49 @@ mod tests {
                 }
             },
             "bearer": { "token": "live-bearer-token" }
+        })
+    }
+
+    #[test]
+    fn local_render_masks_config_secrets() {
+        let gs = GraphSourceRecord::new(
+            "my-gs",
+            "main",
+            GraphSourceType::Iceberg,
+            secret_bearing_config().to_string(),
+            vec![],
+        );
+
+        let rendered = render_local_graph_source(&gs);
+        assert!(rendered.contains("Name:           my-gs"));
+        assert!(rendered.contains("Configuration:"));
+        assert!(!rendered.contains("super-secret-pat"));
+        assert!(!rendered.contains("live-bearer-token"));
+        assert!(rendered.contains("[redacted]"));
+    }
+
+    #[test]
+    fn remote_render_masks_config_secrets() {
+        let info = json!({
+            "name": "my-gs",
+            "branch": "main",
+            "type": "Iceberg",
+            "graph_source_id": "my-gs:main",
+            "index_t": 0,
+            "config": secret_bearing_config()
         });
 
-        let pretty = redacted_config_pretty(&config);
+        let rendered = render_remote_graph_source(&info);
+        assert!(rendered.contains("Name:           my-gs"));
+        assert!(rendered.contains("Configuration:"));
+        assert!(!rendered.contains("super-secret-pat"));
+        assert!(!rendered.contains("live-bearer-token"));
+        assert!(rendered.contains("[redacted]"));
+    }
+
+    #[test]
+    fn redacts_oauth_client_secret_and_bearer_token() {
+        let pretty = redacted_config_pretty(&secret_bearing_config());
         assert!(!pretty.contains("super-secret-pat"));
         assert!(!pretty.contains("live-bearer-token"));
         assert!(pretty.contains("[redacted]"));

--- a/fluree-db-cli/src/graph_source_display.rs
+++ b/fluree-db-cli/src/graph_source_display.rs
@@ -80,8 +80,12 @@ fn render_local_graph_source(gs: &fluree_db_nameservice::GraphSourceRecord) -> S
     }
 
     if !gs.config.is_empty() && gs.config != "{}" {
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&gs.config) {
-            write_config_section(&mut out, &parsed);
+        match serde_json::from_str::<serde_json::Value>(&gs.config) {
+            Ok(parsed) => write_config_section(&mut out, &parsed),
+            // Fail closed, matching redact_graph_source_config: a config that
+            // cannot be inspected is reported, never echoed or silently
+            // omitted.
+            Err(_) => write_config_body(&mut out, "[redacted:unparseable]"),
         }
     }
     out
@@ -99,9 +103,13 @@ pub(crate) fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) ->
 }
 
 fn write_config_section(out: &mut String, config: &serde_json::Value) {
+    write_config_body(out, &redacted_config_pretty(config));
+}
+
+fn write_config_body(out: &mut String, body: &str) {
     let _ = writeln!(out);
     let _ = writeln!(out, "Configuration:");
-    let _ = writeln!(out, "{}", redacted_config_pretty(config));
+    let _ = writeln!(out, "{body}");
 }
 
 fn redacted_config_pretty(config: &serde_json::Value) -> String {
@@ -167,6 +175,22 @@ mod tests {
         assert!(!rendered.contains("super-secret-pat"));
         assert!(!rendered.contains("live-bearer-token"));
         assert!(rendered.contains("[redacted]"));
+    }
+
+    #[test]
+    fn local_render_fails_closed_on_unparseable_config() {
+        let gs = GraphSourceRecord::new(
+            "my-gs",
+            "main",
+            GraphSourceType::Iceberg,
+            "client_secret=oops-not-json",
+            vec![],
+        );
+
+        let rendered = render_local_graph_source(&gs);
+        assert!(rendered.contains("Configuration:"));
+        assert!(rendered.contains("[redacted:unparseable]"));
+        assert!(!rendered.contains("oops-not-json"));
     }
 
     #[test]

--- a/fluree-db-cli/src/lib.rs
+++ b/fluree-db-cli/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod context;
 pub mod detect;
 pub mod error;
+pub mod graph_source_display;
 pub mod input;
 pub mod output;
 pub mod remote_client;

--- a/fluree-db-server/src/routes/ledger.rs
+++ b/fluree-db-server/src/routes/ledger.rs
@@ -473,23 +473,12 @@ pub async fn list_ledgers(State(state): State<Arc<AppState>>) -> Result<Json<Vec
         entries.push(ListEntry {
             name: gs.name.clone(),
             branch: gs.branch.clone(),
-            entry_type: format_source_type(&gs.source_type),
+            entry_type: fluree_db_api::ledger_info::graph_source_type_label(&gs.source_type),
             t: gs.index_t,
         });
     }
 
     Ok(Json(entries))
-}
-
-fn format_source_type(st: &fluree_db_nameservice::GraphSourceType) -> String {
-    match st {
-        fluree_db_nameservice::GraphSourceType::Bm25 => "BM25".to_string(),
-        fluree_db_nameservice::GraphSourceType::Vector => "Vector".to_string(),
-        fluree_db_nameservice::GraphSourceType::Geo => "Geo".to_string(),
-        fluree_db_nameservice::GraphSourceType::R2rml => "R2RML".to_string(),
-        fluree_db_nameservice::GraphSourceType::Iceberg => "Iceberg".to_string(),
-        fluree_db_nameservice::GraphSourceType::Unknown(s) => format!("Unknown({s})"),
-    }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Problem

`fluree info <gs>` and `fluree iceberg info <gs>` printed the full graph-source config as pretty JSON — including `catalog.auth.client_secret`, i.e. a live Snowflake PAT / OAuth2 client secret or bearer token. `ConfigValue` has a redacting `Debug` impl, but every CLI print path serializes via serde, which bypasses it, so the secret landed in terminal scrollback, `script` logs, and CI output. The server routes already redact through `redact_graph_source_config`; the CLI's local print paths were the unpatched surface. (A redacting `Serialize` on the type itself is not an option: persistence requires lossless serialization — CI-locked tests assert the stored config carries the secret for query-time catalog auth. The type-level fix, `ConfigValue::SecretRef`, is tracked separately in #1500 §3.)

## Fix

All CLI graph-source rendering now goes through a single new module, `fluree-db-cli/src/graph_source_display.rs`, which routes every config through the existing fail-closed redactor before printing. Local nameservice records are converted with `build_generic_graph_source_info` — the same redacted DTO the server's `/info` route emits (now `pub` in `fluree-db-api`) — so local and remote sources render identically through one renderer, and redaction happens at the API layer rather than being re-implemented per print site. Remote responses are re-redacted client-side as defense-in-depth against unredacting servers; the redactor is idempotent, so already-clean responses render unchanged.

The refactor also collapses duplication this bug was hiding in: the two print functions existed verbatim in both `info.rs` and `iceberg.rs`, and the source-type label mapping existed three times across the workspace (CLI ×1 after its own dedup, server ×1, plus the private `graph_source_type_label` in `fluree-db-api`). All of it now resolves to the one API helper, so a future label or field change cannot drift between the CLI, the server, and the API.

## Hardening beyond the original leak

- **Container-shaped secrets** (`fluree-db-api`): `redact_json_secrets` only masked scalar values under secret keys; a secret hidden in a container shape (`{"token": ["tok-1"]}`, `{"client_secret": {"value": "..."}}`) passed through unredacted. Containers under a secret key are now redacted with inverted strictness — every scalar leaf inside is masked except the `env_var`/`java_property` reference identifiers — closing the gap for hand-authored or out-of-band records while preserving the env-var debugging affordance. This hardens every consumer of the shared redactor (server `/info`, events route, CLI). Complements #1504, which tracks the key-name denylist failing open.
- **Fail-closed on unparseable configs**: a stored config that does not parse now renders as `[redacted:unparseable]` (matching the server-side semantics) instead of being silently omitted — an operator no longer concludes a misparsed (and possibly secret-bearing) config doesn't exist, and its raw bytes are never echoed.
- **The redaction property is a tested invariant**: the print functions are thin wrappers over `render_*` functions returning `String`, and tests feed secret-bearing records and server responses through the real render seam, asserting the secrets are absent, `[redacted]` is present, and non-secret identifying fields (client id, scope, catalog URI) survive. A refactor that drops the redaction call now fails the suite instead of silently reintroducing the leak.

## User-visible output changes

- `client_secret`, `token`, and other secret values print as `"[redacted]"` everywhere (the point of the PR).
- The unified renderer prints `Retracted:` whenever the field is present, so remote output for generic (BM25/Vector/Geo) sources gains that line; local output keeps it.
- `Index ID:` always prints, showing `(none)` when the source has no index; previously remote output omitted the line entirely.
- Empty configs are omitted consistently: `"{}"`, `"{ }"`, and `"{\n}"` all suppress the Configuration section (previously only the byte-exact `"{}"` did, via a string comparison in the server DTO builder).
- Unparseable configs render a Configuration section containing `[redacted:unparseable]` instead of nothing.

## Verification

Unit tests cover the render seam end-to-end (secret masking local and remote, env-var name preservation, fail-closed unparseable, non-secret configs rendering in full) plus new API-side tests for container-shaped secrets and whitespace-variant empty configs; the existing per-variant redaction canaries and lossless-storage assertions all still pass, including under `--features iceberg`. Verified live against the issue's reproduction: `fluree iceberg map --oauth2-client-secret "$PAT" ...` followed by `fluree info <gs> --direct` and `fluree iceberg info <gs>` prints `"client_secret": "[redacted]"` with zero occurrences of the raw secret, while the stored nameservice record still carries it (persistence remains lossless). Clippy is clean and `cargo fmt --check` passes across the touched crates.

Closes #1497