### PR TITLE
feat: Add auth token and model access disable CLI commands

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -1280,6 +1280,33 @@ mem:fact-01kwx8z7tx43vecccdww6w19j9 a mem:Fact ;
     mem:createdAt "2026-07-07T03:11:58.813517+00:00"^^xsd:dateTime ;
     mem:rationale "Supersedes the earlier reverted-batched-frontier memory: the revert's conclusion (per-node reads fit early-exit searches) held only on the old substrate; with shared mmaps + cascaded seeks + galloping lookups, batched level expansion wins at every scale. Novelty semantics pinned by cypher_shortest_path_batched_lane_respects_novelty." .
 
+mem:constraint-01ky5xtjzq1mvmzatgmmpvh8pq a mem:Constraint ;
+    mem:content "RemoteAuth (nameservice-sync) round-trips asymmetrically in the CLI config store: reads go through serde (toml::from_str), but writes are HAND-ROLLED via toml_edit in write_sync_config_toml. Adding a field to RemoteAuth silently drops it on every config save unless you also add a branch to the auth_table builder AND the has_any guard in fluree-db-cli/src/config.rs. login_flow (added for honest `auth status` flow reporting) followed this pattern." ;
+    mem:tag "cli" ;
+    mem:tag "config" ;
+    mem:tag "gotcha" ;
+    mem:tag "remote-auth" ;
+    mem:tag "serialization" ;
+    mem:scope mem:repo ;
+    mem:severity "must" ;
+    mem:artifactRef "fluree-db-cli/src/config.rs" ;
+    mem:artifactRef "fluree-db-nameservice-sync/src/config.rs" ;
+    mem:branch "feature/cli-auth-token-and-access-disable" ;
+    mem:createdAt "2026-07-22T22:06:03.767306+00:00"^^xsd:dateTime .
+
+mem:constraint-01ky5xtw9tzntfmqwqa62zzyd1 a mem:Constraint ;
+    mem:content "Hosted-stack grants API: an EMPTY policyClasses list on a grant reads as instance-wide access (classes are optional narrowing), so `model access disable --space` must never POST an empty class list when detaching the last policy class — that would WIDEN the grant instead of revoking it. It leaves the grant untouched and tells the user to delete the grant itself; a grant naming a deleted policy class is fail-closed (selects no policies). Related parked decision (#4 of the internal CLI report): whether a class-less write grant should dominate over a class-carrying read grant in merged access reporting — router-side, undecided." ;
+    mem:tag "cli" ;
+    mem:tag "grants" ;
+    mem:tag "hosted-stack" ;
+    mem:tag "model-access" ;
+    mem:tag "policy" ;
+    mem:scope mem:repo ;
+    mem:severity "must" ;
+    mem:artifactRef "fluree-db-cli/src/commands/model/access.rs" ;
+    mem:branch "feature/cli-auth-token-and-access-disable" ;
+    mem:createdAt "2026-07-22T22:06:13.306994+00:00"^^xsd:dateTime .
+
 mem:decision-01kkymgaynzn5mrgy21pw22tf6 a mem:Decision ;
     mem:content "CLI write command naming: \"transact\" is the umbrella (API builder, HTTP endpoint), while specific operations are \"insert\", \"upsert\", and \"update\". The CLI command is `fluree update` (not `transact`) matching the API's `.transact().update()` pattern. Code: Commands::Update, commands::update::run(), UpdateFormat enum. Remote: update_jsonld()/update_sparql() both route to HTTP /transact. Internal types use \"transact\" for the generic write concept (TransactCore, GraphTransactBuilder, fluree-db-transact crate)." ;
     mem:tag "api-alignment" ;

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -102,7 +102,7 @@ If you're building a custom server that must support the CLI end-to-end (for exa
 | Command | Description |
 |---------|-------------|
 | [`token`](token.md) | Create, inspect, and manage JWS tokens |
-| [`auth`](auth.md) | Manage bearer tokens stored on remotes (login/logout/status) |
+| [`auth`](auth.md) | Manage bearer tokens stored on remotes (login/logout/status/token) |
 
 ### Configuration
 

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -2,7 +2,7 @@
 
 Manage authentication tokens for remote servers. Tokens are stored in `.fluree/config.toml` as part of the remote configuration.
 
-Token values are never printed to stdout. The `status` command shows token presence, expiry, and identity only.
+Token values reach stdout only through the explicit `auth token` subcommand, which prints exactly one access token for scripting. The `status` command shows token presence, expiry, and identity only, and refresh tokens are never printed by any command.
 
 ## Subcommands
 
@@ -11,6 +11,7 @@ Token values are never printed to stdout. The `status` command shows token prese
 | `status` | Show authentication status for a remote |
 | `login` | Store a bearer token for a remote |
 | `logout` | Clear the stored token for a remote |
+| `token` | Print the stored access token for a remote (for scripting) |
 
 ---
 
@@ -51,6 +52,17 @@ Auth Status:
   Identity: did:example:alice
   Issuer: did:key:z6Mk...
   Subject: alice@example.com
+```
+
+For OIDC remotes, the auth type is shown as `oidc` together with the OAuth flow the last login actually used (recorded at login; the flow is re-detected from the IdP's discovery document on every login):
+```
+Auth Status:
+  Remote: origin
+  Auth type: oidc
+  Login flow: authorization code + PKCE
+  Issuer: https://cognito-idp.us-east-1.amazonaws.com/...
+  Token:  configured
+  ...
 ```
 
 When no token is configured:
@@ -123,6 +135,36 @@ Token stored for remote 'origin'
 
 ---
 
+## fluree auth token
+
+Print the stored access token for a remote — the scripting escape hatch for `.env`-style workflows. Exactly the token is written to stdout (no decoration), so it composes into shell substitution and pipelines. Diagnostics go to stderr: if the stored token is expired, a warning is printed there and the token is still emitted.
+
+Only the access token is printed. Refresh tokens stay in the config file and are never emitted by any command.
+
+### Usage
+
+```bash
+fluree auth token [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--remote <NAME>` | Remote name (defaults to the only configured remote) |
+
+### Examples
+
+```bash
+# Write the token into an .env file
+echo "FLUREE_TOKEN=$(fluree auth token --remote prod)" >> .env
+
+# Use it inline
+curl -H "Authorization: Bearer $(fluree auth token)" https://db.example.com/v1/fluree/...
+```
+
+---
+
 ## fluree auth logout
 
 Clear the stored token for a remote.
@@ -186,7 +228,7 @@ When `--remote` is omitted:
 ## Security Notes
 
 - Tokens are stored in plaintext in `.fluree/config.toml`. On Unix, the CLI restricts the config file to `0600` and the `.fluree` directory to `0700` (owner-only) whenever it writes token material, so the file is not group/world-readable. On other platforms, protect the file with appropriate filesystem permissions yourself.
-- The `status` command never displays the raw token value.
+- The `status` command never displays the raw token value. `auth token` is the single, explicit command that prints an access token (refresh tokens are never printed) — prefer it over `fluree config list` in scripts so credentials for other remotes never enter your pipeline.
 - On 401 errors from remote operations, the CLI checks token expiry and suggests `fluree auth login` if the token appears expired.
 
 ## OIDC login flow

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -57,6 +57,8 @@ storage.path = "/custom/storage/path"
 storage.encryption = "aes256"
 ```
 
+> **Credential note:** `config list` dumps the entire config file, including access **and refresh** tokens for every configured remote. For scripts that need a single access token (e.g. `.env` workflows), use [`fluree auth token`](auth.md#fluree-auth-token) instead — it prints exactly one token and never exposes refresh tokens.
+
 If no configuration is set:
 ```
 (no configuration set)

--- a/docs/cli/model.md
+++ b/docs/cli/model.md
@@ -26,6 +26,7 @@ Compile an access profile into policies on a dataset.
 
 ```bash
 fluree model access enable <DATASET> --profile <read|write|intake> --class <IRI> [OPTIONS]
+fluree model access disable <DATASET> (--profile <p> --class <IRI> | --policy-class <IRI>) [OPTIONS]
 fluree model access show <DATASET>
 ```
 
@@ -56,6 +57,24 @@ Three class-shaped things are in play, with distinct roles: `--class` restricts 
 ### Semantics of re-running
 
 `enable` **replaces** the two policy nodes it owns (`{policy-class}/view`, `{policy-class}/write`) atomically: one transaction wildcard-deletes both ids and inserts the fresh compilation. A property from a previous run cannot linger (the policy loader gives `f:allow` precedence over `f:query`, so a stale `f:allow: true` would silently disable a newly added `--connected` gate), and profile switches on the same policy class are exact — switching `write` → `read` revokes `{policy-class}/write`.
+
+### Disabling a profile
+
+`disable` is the inverse of `enable`: it deletes the policy class node and both owned policy nodes (`{policy-class}/view`, `{policy-class}/write`) in one transaction. Identify the policy class the same way it was enabled — `--profile` + `--class` derives the default `{class}/access/{profile}` id; pass `--policy-class` instead if enable used an override. Deletes are delete-if-exists, so disabling an already-disabled profile is a no-op.
+
+With `--space <id> --remote <r>`, the policy class is first detached from the space's grant on the dataset (grant detach runs before policy deletion, mirroring enable's policies-before-grant ordering). Other classes on the grant — and the grant itself, with its access level — are left in place. If the class being detached is the grant's **last** policy class, the grant is left unchanged: on hosted stacks a class-less grant reads as instance-wide access, so posting an empty class list would widen the grant rather than revoke it. The stale class reference is fail-closed (it selects no policies once they're deleted); remove the grant itself via the stack UI/API to revoke the space's access entirely.
+
+```bash
+# Undo an enable (same identification)
+fluree model access disable crm --profile write --class https://example.org/Lead
+
+# Hosted stack: also detach the policy class from the space grant
+fluree model access disable crm --profile write --class https://example.org/Lead \
+  --space 01hx... --remote prod
+
+# Enable used --policy-class? Disable takes it directly
+fluree model access disable crm --policy-class https://example.org/custom-policy-class
+```
 
 ### Examples
 

--- a/docs/cli/token.md
+++ b/docs/cli/token.md
@@ -217,7 +217,7 @@ The `--all` flag sets events, storage, read, and write access for all ledgers.
 
 ## See Also
 
-- [auth](auth.md) - Store/manage tokens on remotes
+- [auth](auth.md) - Store/manage tokens on remotes (`fluree auth token` prints the stored access token for scripting)
 - [remote](remote.md) - Configure remote servers
 - [Authentication](../security/authentication.md) - Auth model, modes, and token claims
 - [fetch](fetch.md) - Fetch from remotes (requires auth token)

--- a/docs/design/auth-contract.md
+++ b/docs/design/auth-contract.md
@@ -190,6 +190,10 @@ scopes = ["openid", "profile"]
 redirect_port = 8400
 token = "eyJ..."           # cached Fluree Bearer token (written by 'fluree auth login')
 refresh_token = "eyJ..."   # refresh token (written by 'fluree auth login')
+login_flow = "auth_code_pkce"  # OAuth flow the last login used: "device_code" or
+                               # "auth_code_pkce" (written by 'fluree auth login',
+                               # cleared by logout/manual logins; display-only —
+                               # flow selection is re-discovered on every login)
 
 [[remotes]]
 name = "local"

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -1673,6 +1673,50 @@ pub enum ModelAccessAction {
         remote: Option<String>,
     },
 
+    /// Disable an access profile: delete its compiled policies from the
+    /// dataset and optionally detach the policy class from a space grant
+    ///
+    /// The inverse of `enable`. Identify the policy class either the same
+    /// way it was enabled (--profile + --class, deriving the default
+    /// {class}/access/{profile} id) or explicitly via --policy-class.
+    /// Deletes the policy class node and its owned policy nodes
+    /// ({policy-class}/view, {policy-class}/write) in one transaction.
+    /// With --space/--remote, first removes the policy class from the
+    /// space's grant on the dataset (other classes on the grant survive;
+    /// the grant itself and its access level are left in place).
+    Disable {
+        /// Target dataset (ledger alias)
+        dataset: String,
+
+        /// Profile the policy class was enabled with (with --class):
+        /// read | write | intake. Not needed with --policy-class.
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Class IRI the profile was enabled on (with --profile).
+        /// Not needed with --policy-class.
+        #[arg(long)]
+        class: Option<String>,
+
+        /// Policy class IRI to disable (overrides --profile/--class
+        /// derivation; required if enable used a --policy-class override)
+        #[arg(long)]
+        policy_class: Option<String>,
+
+        /// Detach the policy class from this space's grant on the dataset
+        /// (hosted stacks; requires --remote)
+        #[arg(long)]
+        space: Option<String>,
+
+        /// Print the delete transaction without transacting
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Remote to run against
+        #[arg(long)]
+        remote: Option<String>,
+    },
+
     /// Show compiled access policies on a dataset (grouped by policy class)
     Show {
         /// Target dataset (ledger alias)
@@ -2422,6 +2466,19 @@ pub enum AuthAction {
 
     /// Clear the stored token for a remote
     Logout {
+        /// Remote name (defaults to only configured remote)
+        #[arg(long)]
+        remote: Option<String>,
+    },
+
+    /// Print the stored access token for a remote (for scripting)
+    ///
+    /// Prints exactly the access token to stdout — nothing else — so it
+    /// composes into .env files and shell substitution:
+    /// `FLUREE_TOKEN=$(fluree auth token --remote prod)`. Warns on stderr
+    /// if the token is expired. The refresh token is never printed; use
+    /// `fluree config list` only if you truly need the raw config.
+    Token {
         /// Remote name (defaults to only configured remote)
         #[arg(long)]
         remote: Option<String>,

--- a/fluree-db-cli/src/commands/auth.rs
+++ b/fluree-db-cli/src/commands/auth.rs
@@ -1,10 +1,12 @@
-//! Auth management commands: status, login, logout
+//! Auth management commands: status, login, logout, token
 //!
 //! Manages bearer tokens stored in remote configs. Tokens are stored
 //! in `.fluree/config.toml` as part of the remote's `auth` section.
 //!
-//! Token values are never printed to stdout — `status` shows presence,
-//! expiry, and identity only.
+//! Token values reach stdout only through the explicit `auth token`
+//! subcommand (the scripting escape hatch — one access token, nothing
+//! else). `status` shows presence, expiry, and identity only, and
+//! refresh tokens are never printed by any command.
 //!
 //! For OIDC remotes (`auth.type = "oidc_device"`), `login` auto-detects
 //! the appropriate OAuth flow based on the IdP's discovery document:
@@ -20,7 +22,7 @@ use crate::error::{CliError, CliResult};
 use colored::Colorize;
 use fluree_db_api::server_defaults::FlureeDir;
 use fluree_db_nameservice::RemoteName;
-use fluree_db_nameservice_sync::{RemoteAuthType, RemoteEndpoint, SyncConfigStore};
+use fluree_db_nameservice_sync::{OidcLoginFlow, RemoteAuthType, RemoteEndpoint, SyncConfigStore};
 use std::io::{self, Read};
 
 pub async fn run(action: AuthAction, dirs: &FlureeDir) -> CliResult<()> {
@@ -30,6 +32,7 @@ pub async fn run(action: AuthAction, dirs: &FlureeDir) -> CliResult<()> {
         AuthAction::Status { remote } => run_status(&store, remote.as_deref()).await,
         AuthAction::Login { remote, token } => run_login(&store, remote.as_deref(), token).await,
         AuthAction::Logout { remote } => run_logout(&store, remote.as_deref()).await,
+        AuthAction::Token { remote } => run_token(&store, remote.as_deref()).await,
     }
 }
 
@@ -74,10 +77,23 @@ async fn run_status(store: &TomlSyncConfigStore, remote: Option<&str>) -> CliRes
     println!("{}", "Auth Status:".bold());
     println!("  Remote: {}", name.green());
 
-    // Show auth type
+    // Show auth type. The config discriminator for OIDC is `oidc_device`
+    // for historical reasons, but the flow is auto-detected per login —
+    // report what the last login actually ran, not the config label.
     match config.auth.auth_type.as_ref() {
         Some(RemoteAuthType::OidcDevice) => {
-            println!("  Auth type: {}", "oidc_device".cyan());
+            println!("  Auth type: {}", "oidc".cyan());
+            match config.auth.login_flow {
+                Some(OidcLoginFlow::DeviceCode) => {
+                    println!("  Login flow: device code");
+                }
+                Some(OidcLoginFlow::AuthCodePkce) => {
+                    println!("  Login flow: authorization code + PKCE");
+                }
+                None => {
+                    println!("  Login flow: auto-detected at login");
+                }
+            }
             if let Some(ref issuer) = config.auth.issuer {
                 println!("  Issuer: {issuer}");
             }
@@ -163,11 +179,13 @@ async fn run_login(
             // No discovery available — fall back to manual token prompt
             let token = read_token(token_arg)?;
             config.auth.token = Some(token);
+            config.auth.login_flow = None;
         }
     } else {
         // Manual token flow (explicit token or token auth type)
         let token = read_token(token_arg)?;
         config.auth.token = Some(token);
+        config.auth.login_flow = None;
     }
 
     store
@@ -353,6 +371,7 @@ async fn run_oidc_login(config: &mut fluree_db_nameservice_sync::RemoteConfig) -
             device_authorization_endpoint,
             token_endpoint,
         } => {
+            config.auth.login_flow = Some(OidcLoginFlow::DeviceCode);
             run_device_code_flow(
                 &http,
                 &device_authorization_endpoint,
@@ -370,6 +389,7 @@ async fn run_oidc_login(config: &mut fluree_db_nameservice_sync::RemoteConfig) -
                 "  {} IdP does not support device flow; using authorization code + PKCE",
                 "info:".cyan().bold()
             );
+            config.auth.login_flow = Some(OidcLoginFlow::AuthCodePkce);
             run_auth_code_flow(
                 &http,
                 &authorization_endpoint,
@@ -1102,6 +1122,7 @@ async fn run_logout(store: &TomlSyncConfigStore, remote: Option<&str>) -> CliRes
 
     config.auth.token = None;
     config.auth.refresh_token = None;
+    config.auth.login_flow = None;
     store
         .set_remote(&config)
         .await
@@ -1112,11 +1133,49 @@ async fn run_logout(store: &TomlSyncConfigStore, remote: Option<&str>) -> CliRes
 }
 
 // =============================================================================
+// Token (print the stored access token for scripting)
+// =============================================================================
+
+/// Print the stored access token for one remote — the scripting escape
+/// hatch (`FLUREE_TOKEN=$(fluree auth token)` in .env workflows). Exactly
+/// the token goes to stdout; diagnostics (expiry warning) go to stderr.
+/// The refresh token is never printed.
+async fn run_token(store: &TomlSyncConfigStore, remote: Option<&str>) -> CliResult<()> {
+    let name = resolve_remote_name(store, remote).await?;
+    let remote_name = RemoteName::new(&name);
+    let config = store
+        .get_remote(&remote_name)
+        .await
+        .map_err(|e| CliError::Config(e.to_string()))?
+        .ok_or_else(|| CliError::NotFound(format!("remote '{name}' not found")))?;
+
+    let token = config.auth.token.ok_or_else(|| {
+        CliError::NotFound(format!(
+            "no token stored for remote '{name}'; run `fluree auth login --remote {name}`"
+        ))
+    })?;
+
+    if let Ok(summary) = decode_token_summary(&token) {
+        if summary.expired {
+            eprintln!(
+                "{} token for remote '{name}' is expired; run `fluree auth login --remote {name}`",
+                "warning:".yellow().bold()
+            );
+        }
+    }
+
+    println!("{token}");
+    Ok(())
+}
+
+// =============================================================================
 // Token summary decoding (no verification)
 // =============================================================================
 
 struct TokenSummary {
     expiry: Option<String>,
+    /// True when the `exp` claim is present and in the past.
+    expired: bool,
     identity: Option<String>,
     issuer: Option<String>,
     subject: Option<String>,
@@ -1134,22 +1193,21 @@ fn decode_token_summary(token: &str) -> Result<TokenSummary, ()> {
     let payload_bytes = URL_SAFE_NO_PAD.decode(parts[1]).map_err(|_| ())?;
     let claims: serde_json::Value = serde_json::from_slice(&payload_bytes).map_err(|_| ())?;
 
-    let expiry = claims
-        .get("exp")
-        .and_then(serde_json::Value::as_u64)
-        .map(|exp| {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            if exp < now {
-                format!("{} (expired)", format_timestamp(exp))
-                    .red()
-                    .to_string()
-            } else {
-                format_timestamp(exp)
-            }
-        });
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let exp_claim = claims.get("exp").and_then(serde_json::Value::as_u64);
+    let expired = exp_claim.is_some_and(|exp| exp < now);
+    let expiry = exp_claim.map(|exp| {
+        if exp < now {
+            format!("{} (expired)", format_timestamp(exp))
+                .red()
+                .to_string()
+        } else {
+            format_timestamp(exp)
+        }
+    });
 
     let identity = claims
         .get("fluree.identity")
@@ -1162,6 +1220,7 @@ fn decode_token_summary(token: &str) -> Result<TokenSummary, ()> {
 
     Ok(TokenSummary {
         expiry,
+        expired,
         identity,
         issuer,
         subject,

--- a/fluree-db-cli/src/commands/model/access.rs
+++ b/fluree-db-cli/src/commands/model/access.rs
@@ -37,7 +37,7 @@
 
 use serde_json::{json, Value};
 
-use super::{query, replace_nodes, require_absolute_iri, resolve_mode};
+use super::{query, replace_nodes, replace_txn, require_absolute_iri, resolve_mode, update};
 use crate::cli::ModelAccessAction;
 use crate::error::{CliError, CliResult};
 use fluree_db_api::server_defaults::FlureeDir;
@@ -112,6 +112,28 @@ pub async fn run(action: &ModelAccessAction, dirs: &FlureeDir, direct: bool) -> 
                 policy_class.as_deref(),
                 space.as_deref(),
                 connected.as_deref(),
+                *dry_run,
+                remote.as_deref(),
+                dirs,
+                direct,
+            )
+            .await
+        }
+        ModelAccessAction::Disable {
+            dataset,
+            profile,
+            class,
+            policy_class,
+            space,
+            dry_run,
+            remote,
+        } => {
+            run_disable(
+                dataset,
+                profile.as_deref(),
+                class.as_deref(),
+                policy_class.as_deref(),
+                space.as_deref(),
                 *dry_run,
                 remote.as_deref(),
                 dirs,
@@ -256,6 +278,116 @@ fn validate_connected_path(path: &str) -> CliResult<()> {
         )));
     }
     Ok(())
+}
+
+// ── disable ─────────────────────────────────────────────────────────────
+
+/// Undo `enable`: delete the policy class node and both owned policy
+/// nodes, and (with --space/--remote) detach the policy class from the
+/// space's grant. Grant detach runs FIRST — the mirror of enable's
+/// ordering rationale: a partial failure leaves policies without a grant
+/// referencing them (harmless) rather than deleting policies while a
+/// grant still points at them mid-operation. A grant that does end up
+/// naming a deleted policy class is fail-closed (the class selects no
+/// policies), but we avoid creating that state deliberately.
+#[allow(clippy::too_many_arguments)]
+async fn run_disable(
+    dataset: &str,
+    profile: Option<&str>,
+    class: Option<&str>,
+    policy_class_override: Option<&str>,
+    space: Option<&str>,
+    dry_run: bool,
+    remote: Option<&str>,
+    dirs: &FlureeDir,
+    direct: bool,
+) -> CliResult<()> {
+    let policy_class = resolve_policy_class(policy_class_override, profile, class)?;
+    if space.is_some() && remote.is_none() {
+        return Err(CliError::Usage(
+            "--space detaches the policy class from a hosted stack's grant; pass --remote <r>"
+                .into(),
+        ));
+    }
+
+    let txn = disable_txn(&policy_class);
+    println!("Policy class: {policy_class}");
+    println!(
+        "Removes:      {policy_class}\n              {policy_class}/view\n              {policy_class}/write"
+    );
+
+    if dry_run {
+        println!("\n-- dry run; delete transaction --");
+        println!("{}", serde_json::to_string_pretty(&txn)?);
+        return Ok(());
+    }
+
+    if let (Some(space_id), Some(remote_name)) = (space, remote) {
+        detach_grant(dirs, remote_name, dataset, space_id, &policy_class).await?;
+    }
+
+    let mode = resolve_mode(dataset, remote, dirs, direct).await?;
+    update(&mode, &txn).await?;
+    println!("\nPolicies removed from '{dataset}'.");
+
+    if space.is_none() {
+        println!(
+            "If a space grant carries {policy_class}, the reference is now inert \
+             (it selects no policies). Detach it with:\n  \
+             fluree model access disable {dataset} --policy-class {policy_class} \
+             --space <spaceId> --remote <r>"
+        );
+    }
+    Ok(())
+}
+
+/// Resolve the policy class to operate on: an explicit --policy-class, or
+/// the deterministic default enable minted from --profile + --class.
+fn resolve_policy_class(
+    policy_class: Option<&str>,
+    profile: Option<&str>,
+    class: Option<&str>,
+) -> CliResult<String> {
+    if let Some(pc) = policy_class {
+        require_absolute_iri("--policy-class", pc)?;
+        return Ok(pc.to_string());
+    }
+    match (profile, class) {
+        (Some(p), Some(c)) => {
+            let profile = Profile::parse(p)?;
+            require_absolute_iri("--class", c)?;
+            Ok(format!(
+                "{}/access/{}",
+                c.trim_end_matches('/'),
+                profile.as_str()
+            ))
+        }
+        _ => Err(CliError::Usage(
+            "identify the policy class to disable: --profile <p> --class <iri> \
+             (as it was enabled), or --policy-class <iri>"
+                .into(),
+        )),
+    }
+}
+
+/// Delete-only transaction covering every node enable owns: the policy
+/// class and its view/write policies. Wildcard-deletes are delete-if-exists,
+/// so disabling an already-disabled (or read-only) profile is a no-op for
+/// the nodes that aren't there.
+fn disable_txn(policy_class: &str) -> Value {
+    let owned = [
+        policy_class.to_string(),
+        format!("{policy_class}/view"),
+        format!("{policy_class}/write"),
+    ];
+    let owned_refs: Vec<&str> = owned.iter().map(String::as_str).collect();
+    let mut txn = replace_txn(&json!({"@graph": []}), &owned_refs, &[]);
+    // Delete-only: an empty insert clause adds nothing but confuses readers
+    // of --dry-run output (and not every endpoint accepts it).
+    txn.as_object_mut()
+        .expect("replace_txn returns an object")
+        .remove("insert");
+    txn
 }
 
 // ── compile ─────────────────────────────────────────────────────────────
@@ -443,6 +575,128 @@ fn list_values(v: Option<&Value>) -> Vec<String> {
     out
 }
 
+/// Resolved handle on a hosted stack's grants API for one dataset.
+struct GrantsApi {
+    url: String,
+    token: String,
+    dataset_id: String,
+}
+
+impl GrantsApi {
+    /// Resolve the grants endpoint from a configured remote. The remote
+    /// points at the data plane (…/v1/fluree); the grants API lives at the
+    /// stack root.
+    async fn resolve(dirs: &FlureeDir, remote_name: &str, dataset: &str) -> CliResult<Self> {
+        use crate::config::TomlSyncConfigStore;
+        use fluree_db_nameservice::RemoteName;
+        use fluree_db_nameservice_sync::{RemoteEndpoint, SyncConfigStore};
+
+        let store = TomlSyncConfigStore::new(dirs.config_dir().to_path_buf());
+        let remote = store
+            .get_remote(&RemoteName::new(remote_name))
+            .await
+            .map_err(|e| CliError::Config(e.to_string()))?
+            .ok_or_else(|| CliError::NotFound(format!("remote '{remote_name}' not found")))?;
+        let base_url = match &remote.endpoint {
+            RemoteEndpoint::Http { base_url } => base_url.clone(),
+            _ => {
+                return Err(CliError::Config(format!(
+                    "remote '{remote_name}' is not an HTTP remote"
+                )));
+            }
+        };
+
+        let trimmed = base_url.trim_end_matches('/');
+        let root = trimmed.strip_suffix("/v1/fluree").ok_or_else(|| {
+            CliError::Config(format!(
+                "remote '{remote_name}' ({base_url}) does not look like a hosted stack \
+                 (expected a …/v1/fluree data-plane URL); manage the grant manually"
+            ))
+        })?;
+        let token = remote.auth.token.clone().ok_or_else(|| {
+            CliError::Config(format!(
+                "remote '{remote_name}' has no auth token; run `fluree auth login` first"
+            ))
+        })?;
+
+        // Base ledger name (no branch) is the dataset id on the stack.
+        let dataset_id = dataset.split(':').next().unwrap_or(dataset).to_string();
+        Ok(Self {
+            url: format!("{root}/v1/datasets/{dataset_id}/grants"),
+            token,
+            dataset_id,
+        })
+    }
+
+    /// Fetch the space-scoped grant for `space_id`, if any.
+    async fn space_grant(
+        &self,
+        http: &reqwest::Client,
+        space_id: &str,
+    ) -> CliResult<Option<Value>> {
+        let list: Value = http
+            .get(&self.url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|e| CliError::Config(format!("grants read failed: {e}")))?
+            .error_for_status()
+            .map_err(|e| CliError::Config(format!("grants read failed: {e}")))?
+            .json()
+            .await
+            .map_err(|e| CliError::Config(format!("grants read returned non-JSON: {e}")))?;
+        Ok(list["grants"]
+            .as_array()
+            .map(|grants| {
+                grants
+                    .iter()
+                    .find(|g| {
+                        g["scopeType"].as_str() == Some("space")
+                            && g["scopeRef"].as_str() == Some(space_id)
+                    })
+                    .cloned()
+            })
+            .unwrap_or(None))
+    }
+
+    /// Upsert the space grant with the given access level and class list.
+    async fn upsert(
+        &self,
+        http: &reqwest::Client,
+        space_id: &str,
+        access: &str,
+        classes: &[String],
+    ) -> CliResult<()> {
+        let body = json!({
+            "scopeType": "space",
+            "scopeRef": space_id,
+            "access": access,
+            "policyClasses": classes,
+        });
+        http.post(&self.url)
+            .bearer_auth(&self.token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| CliError::Config(format!("grant upsert failed: {e}")))?
+            .error_for_status()
+            .map_err(|e| CliError::Config(format!("grant upsert rejected: {e}")))?;
+        Ok(())
+    }
+}
+
+/// Extract the policyClasses list from a grant object.
+fn grant_classes(grant: Option<&Value>) -> Vec<String> {
+    grant
+        .and_then(|g| g["policyClasses"].as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Merge `policy_class` into the space's grant on the dataset via the stack's
 /// grants API. System-plane state (grants) is the one place the compiler
 /// talks to an API instead of the data plane — grants are router-owned
@@ -455,80 +709,13 @@ async fn attach_grant(
     policy_class: &str,
     wants_write: bool,
 ) -> CliResult<()> {
-    use crate::config::TomlSyncConfigStore;
-    use fluree_db_nameservice::RemoteName;
-    use fluree_db_nameservice_sync::{RemoteEndpoint, SyncConfigStore};
-
-    let store = TomlSyncConfigStore::new(dirs.config_dir().to_path_buf());
-    let remote = store
-        .get_remote(&RemoteName::new(remote_name))
-        .await
-        .map_err(|e| CliError::Config(e.to_string()))?
-        .ok_or_else(|| CliError::NotFound(format!("remote '{remote_name}' not found")))?;
-    let base_url = match &remote.endpoint {
-        RemoteEndpoint::Http { base_url } => base_url.clone(),
-        _ => {
-            return Err(CliError::Config(format!(
-                "remote '{remote_name}' is not an HTTP remote"
-            )));
-        }
-    };
-
-    // The remote points at the data plane (…/v1/fluree); the grants API
-    // lives at the stack root.
-    let trimmed = base_url.trim_end_matches('/');
-    let root = trimmed.strip_suffix("/v1/fluree").ok_or_else(|| {
-        CliError::Config(format!(
-            "remote '{remote_name}' ({base_url}) does not look like a hosted stack \
-             (expected a …/v1/fluree data-plane URL); attach the grant manually"
-        ))
-    })?;
-    let token = remote.auth.token.clone().ok_or_else(|| {
-        CliError::Config(format!(
-            "remote '{remote_name}' has no auth token; run `fluree auth login` first"
-        ))
-    })?;
-
-    // Base ledger name (no branch) is the dataset id on the stack.
-    let dataset_id = dataset.split(':').next().unwrap_or(dataset);
-    let grants_url = format!("{root}/v1/datasets/{dataset_id}/grants");
+    let api = GrantsApi::resolve(dirs, remote_name, dataset).await?;
     let http = reqwest::Client::new();
 
     // Read existing grants: merge classes, never clobber; keep (or upgrade)
     // the access level.
-    let list: Value = http
-        .get(&grants_url)
-        .bearer_auth(&token)
-        .send()
-        .await
-        .map_err(|e| CliError::Config(format!("grants read failed: {e}")))?
-        .error_for_status()
-        .map_err(|e| CliError::Config(format!("grants read failed: {e}")))?
-        .json()
-        .await
-        .map_err(|e| CliError::Config(format!("grants read returned non-JSON: {e}")))?;
-    let existing = list["grants"]
-        .as_array()
-        .map(|grants| {
-            grants
-                .iter()
-                .find(|g| {
-                    g["scopeType"].as_str() == Some("space")
-                        && g["scopeRef"].as_str() == Some(space_id)
-                })
-                .cloned()
-        })
-        .unwrap_or(None);
-
-    let mut classes: Vec<String> = existing
-        .as_ref()
-        .and_then(|g| g["policyClasses"].as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
+    let existing = api.space_grant(&http, space_id).await?;
+    let mut classes = grant_classes(existing.as_ref());
     if !classes.iter().any(|c| c == policy_class) {
         classes.push(policy_class.to_string());
     }
@@ -547,23 +734,66 @@ async fn attach_grant(
         (None, false) => "read".to_string(),
     };
 
-    let body = json!({
-        "scopeType": "space",
-        "scopeRef": space_id,
-        "access": access,
-        "policyClasses": classes,
-    });
-    http.post(&grants_url)
-        .bearer_auth(&token)
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| CliError::Config(format!("grant upsert failed: {e}")))?
-        .error_for_status()
-        .map_err(|e| CliError::Config(format!("grant upsert rejected: {e}")))?;
+    api.upsert(&http, space_id, &access, &classes).await?;
 
+    // Report the grant's MERGED state and label it as such — the access
+    // level and class count reflect every enable that ever touched this
+    // grant, not just the profile attached by this run.
+    println!("Grant attached: space {space_id} → {}", api.dataset_id);
     println!(
-        "Grant attached: space {space_id} → {dataset_id} ({access}, {} class{})",
+        "  grant now carries {} policy class{} at {access} access (cumulative across enables)",
+        classes.len(),
+        if classes.len() == 1 { "" } else { "es" }
+    );
+    Ok(())
+}
+
+/// Remove `policy_class` from the space's grant on the dataset. Other
+/// classes on the grant — and the grant itself, with its access level —
+/// survive. Never posts an empty class list: on the hosted stack a
+/// class-less grant reads as instance-wide access, so dropping the last
+/// class would WIDEN the grant instead of revoking it.
+async fn detach_grant(
+    dirs: &FlureeDir,
+    remote_name: &str,
+    dataset: &str,
+    space_id: &str,
+    policy_class: &str,
+) -> CliResult<()> {
+    let api = GrantsApi::resolve(dirs, remote_name, dataset).await?;
+    let http = reqwest::Client::new();
+
+    let existing = api.space_grant(&http, space_id).await?;
+    let Some(grant) = existing else {
+        println!(
+            "  no grant for space {space_id} on '{}'; nothing to detach",
+            api.dataset_id
+        );
+        return Ok(());
+    };
+
+    let mut classes = grant_classes(Some(&grant));
+    let before = classes.len();
+    classes.retain(|c| c != policy_class);
+    if classes.len() == before {
+        println!("  grant for space {space_id} does not carry {policy_class}; nothing to detach");
+        return Ok(());
+    }
+    if classes.is_empty() {
+        println!(
+            "  {policy_class} is the grant's last policy class; grant left unchanged \
+             (an empty class list would make the grant instance-wide, not revoke it).\n  \
+             The reference is inert once the policies are deleted; remove the grant \
+             itself via the stack UI/API to revoke the space's access entirely."
+        );
+        return Ok(());
+    }
+
+    let access = grant["access"].as_str().unwrap_or("read");
+    api.upsert(&http, space_id, access, &classes).await?;
+    println!(
+        "Grant updated: space {space_id} → {} now carries {} policy class{} at {access} access",
+        api.dataset_id,
         classes.len(),
         if classes.len() == 1 { "" } else { "es" }
     );
@@ -699,5 +929,65 @@ mod tests {
     #[test]
     fn profile_parse_rejects_unknown() {
         assert!(Profile::parse("admin").is_err());
+    }
+
+    #[test]
+    fn resolve_policy_class_derives_enable_default() {
+        // Must mint the exact same id enable derives, or disable would
+        // delete the wrong nodes.
+        assert_eq!(
+            resolve_policy_class(None, Some("write"), Some(LEAD)).unwrap(),
+            POLICY_CLASS
+        );
+    }
+
+    #[test]
+    fn resolve_policy_class_override_wins() {
+        let pc = resolve_policy_class(Some("https://example.org/custom"), Some("read"), Some(LEAD))
+            .unwrap();
+        assert_eq!(pc, "https://example.org/custom");
+    }
+
+    #[test]
+    fn resolve_policy_class_requires_identification() {
+        assert!(resolve_policy_class(None, Some("write"), None).is_err());
+        assert!(resolve_policy_class(None, None, Some(LEAD)).is_err());
+        assert!(resolve_policy_class(None, None, None).is_err());
+    }
+
+    #[test]
+    fn disable_txn_deletes_all_owned_nodes_without_insert() {
+        let txn = disable_txn(POLICY_CLASS);
+        assert!(txn.get("insert").is_none(), "delete-only transaction");
+
+        let deleted: Vec<&str> = txn["delete"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|d| d["@id"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            deleted,
+            vec![
+                POLICY_CLASS,
+                &format!("{POLICY_CLASS}/view"),
+                &format!("{POLICY_CLASS}/write"),
+            ]
+        );
+        // Every delete is guarded by an optional match (delete-if-exists),
+        // so disabling a read profile (no write node) is not an error.
+        let where_clause = txn["where"].as_array().unwrap();
+        assert_eq!(where_clause.len(), 3);
+        assert!(where_clause.iter().all(|w| w[0] == "optional"));
+    }
+
+    #[test]
+    fn grant_classes_extracts_list() {
+        let grant = json!({"policyClasses": ["https://x/a", "https://x/b"]});
+        assert_eq!(
+            grant_classes(Some(&grant)),
+            vec!["https://x/a".to_string(), "https://x/b".to_string()]
+        );
+        assert!(grant_classes(None).is_empty());
     }
 }

--- a/fluree-db-cli/src/commands/model/access.rs
+++ b/fluree-db-cli/src/commands/model/access.rs
@@ -250,6 +250,7 @@ async fn run_enable(
             dataset,
             space_id,
             &policy_class,
+            profile.as_str(),
             !profile.write_verbs().is_empty(),
         )
         .await?;
@@ -697,6 +698,28 @@ fn grant_classes(grant: Option<&Value>) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Resolve the grant's post-upsert access level plus a provenance note
+/// explaining where that level came from. The note is what keeps a read
+/// enable onto a pre-existing write grant from reading as "I just granted
+/// write": the level line always says whether THIS enable set, upgraded,
+/// or merely inherited it.
+fn grant_access_transition(
+    existing_access: Option<&str>,
+    wants_write: bool,
+) -> (String, &'static str) {
+    match (existing_access, wants_write) {
+        (Some("read"), true) => (
+            "write".to_string(),
+            "upgraded from read — this profile requires writes",
+        ),
+        (Some(a), _) => (a.to_string(), "pre-existing, unchanged by this enable"),
+        (None, _) => (
+            if wants_write { "write" } else { "read" }.to_string(),
+            "set by this enable",
+        ),
+    }
+}
+
 /// Merge `policy_class` into the space's grant on the dataset via the stack's
 /// grants API. System-plane state (grants) is the one place the compiler
 /// talks to an API instead of the data plane — grants are router-owned
@@ -707,6 +730,7 @@ async fn attach_grant(
     dataset: &str,
     space_id: &str,
     policy_class: &str,
+    profile: &str,
     wants_write: bool,
 ) -> CliResult<()> {
     let api = GrantsApi::resolve(dirs, remote_name, dataset).await?;
@@ -724,26 +748,25 @@ async fn attach_grant(
         .as_ref()
         .and_then(|g| g["access"].as_str())
         .map(String::from);
-    let access = match (&existing_access, wants_write) {
-        (Some(a), true) if a == "read" => {
-            println!("  grant access upgraded read → write (profile requires writes)");
-            "write".to_string()
-        }
-        (Some(a), _) => a.clone(),
-        (None, true) => "write".to_string(),
-        (None, false) => "read".to_string(),
-    };
+    let (access, access_note) = grant_access_transition(existing_access.as_deref(), wants_write);
 
     api.upsert(&http, space_id, &access, &classes).await?;
 
-    // Report the grant's MERGED state and label it as such — the access
-    // level and class count reflect every enable that ever touched this
-    // grant, not just the profile attached by this run.
+    // Two separate facts, two separate lines: what THIS enable attached
+    // (the class and its profile), and the grant's merged state (class
+    // count + grant-wide access level, which may predate this enable).
+    // The access level is a grant-wide ceiling; what each class actually
+    // permits is its compiled policies — point at `show` for that view.
     println!("Grant attached: space {space_id} → {}", api.dataset_id);
+    println!("  attached:    {policy_class} ({profile} profile)");
     println!(
-        "  grant now carries {} policy class{} at {access} access (cumulative across enables)",
+        "  grant state: {} policy class{}; access level: {access} ({access_note})",
         classes.len(),
         if classes.len() == 1 { "" } else { "es" }
+    );
+    println!(
+        "  per-class grants: fluree model access show {} --remote {remote_name}",
+        api.dataset_id
     );
     Ok(())
 }
@@ -979,6 +1002,32 @@ mod tests {
         let where_clause = txn["where"].as_array().unwrap();
         assert_eq!(where_clause.len(), 3);
         assert!(where_clause.iter().all(|w| w[0] == "optional"));
+    }
+
+    #[test]
+    fn grant_access_transition_labels_provenance() {
+        // The confusing case from user feedback: read profile attached to a
+        // pre-existing write grant — level stays write but must read as
+        // inherited, not as the result of this enable.
+        let (access, note) = grant_access_transition(Some("write"), false);
+        assert_eq!(access, "write");
+        assert_eq!(note, "pre-existing, unchanged by this enable");
+
+        let (access, note) = grant_access_transition(Some("read"), true);
+        assert_eq!(access, "write");
+        assert!(note.starts_with("upgraded from read"));
+
+        let (access, note) = grant_access_transition(Some("write"), true);
+        assert_eq!(access, "write");
+        assert_eq!(note, "pre-existing, unchanged by this enable");
+
+        let (access, note) = grant_access_transition(None, false);
+        assert_eq!(access, "read");
+        assert_eq!(note, "set by this enable");
+
+        let (access, note) = grant_access_transition(None, true);
+        assert_eq!(access, "write");
+        assert_eq!(note, "set by this enable");
     }
 
     #[test]

--- a/fluree-db-cli/src/config.rs
+++ b/fluree-db-cli/src/config.rs
@@ -1036,6 +1036,83 @@ mod tests {
         assert_eq!(result, fluree_dir.join("storage"));
     }
 
+    /// Regression guard for the read/write asymmetry of the remote config:
+    /// reads deserialize via serde, but writes go through the hand-rolled
+    /// `toml_edit` builder in `write_sync_config_toml` — a field missing
+    /// from that builder round-trips to `None` with green CI everywhere
+    /// else. Every `RemoteAuth` field is constructed here WITHOUT
+    /// `..Default::default()`, so adding a field breaks this test at
+    /// compile time and forces both the writer branch and this assertion
+    /// to be updated together.
+    #[tokio::test]
+    async fn remote_auth_round_trips_every_field_through_toml_store() {
+        use fluree_db_nameservice::RemoteName;
+        use fluree_db_nameservice_sync::{
+            OidcLoginFlow, RemoteAuth, RemoteAuthType, RemoteConfig, RemoteEndpoint,
+            SyncConfigStore,
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store = TomlSyncConfigStore::new(tmp.path().to_path_buf());
+
+        let auth = RemoteAuth {
+            auth_type: Some(RemoteAuthType::OidcDevice),
+            token: Some("access-tok".into()),
+            issuer: Some("https://idp.example.com".into()),
+            client_id: Some("fluree-cli".into()),
+            exchange_url: Some("https://api.example.com/auth/exchange".into()),
+            refresh_token: Some("refresh-tok".into()),
+            scopes: Some(vec!["openid".into(), "offline_access".into()]),
+            redirect_port: Some(8400),
+            login_flow: Some(OidcLoginFlow::AuthCodePkce),
+        };
+        store
+            .set_remote(&RemoteConfig {
+                name: RemoteName::new("origin"),
+                endpoint: RemoteEndpoint::Http {
+                    base_url: "https://api.example.com/v1/fluree".into(),
+                },
+                auth: auth.clone(),
+                fetch_interval_secs: Some(30),
+            })
+            .await
+            .unwrap();
+
+        let read = store
+            .get_remote(&RemoteName::new("origin"))
+            .await
+            .unwrap()
+            .expect("remote persisted")
+            .auth;
+
+        assert_eq!(read.auth_type, auth.auth_type);
+        assert_eq!(read.token, auth.token);
+        assert_eq!(read.issuer, auth.issuer);
+        assert_eq!(read.client_id, auth.client_id);
+        assert_eq!(read.exchange_url, auth.exchange_url);
+        assert_eq!(read.refresh_token, auth.refresh_token);
+        assert_eq!(read.scopes, auth.scopes);
+        assert_eq!(read.redirect_port, auth.redirect_port);
+        assert_eq!(read.login_flow, auth.login_flow);
+
+        // Second write cycle: set_remote reads the existing file, rebuilds
+        // the auth table, and rewrites it — the pass where a writer-omitted
+        // field actually vanishes. Flip the flow to prove overwrites stick.
+        let mut updated = store
+            .get_remote(&RemoteName::new("origin"))
+            .await
+            .unwrap()
+            .unwrap();
+        updated.auth.login_flow = Some(OidcLoginFlow::DeviceCode);
+        store.set_remote(&updated).await.unwrap();
+        let reread = store
+            .get_remote(&RemoteName::new("origin"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(reread.auth.login_flow, Some(OidcLoginFlow::DeviceCode));
+    }
+
     #[cfg(unix)]
     #[test]
     fn init_fluree_dir_restricts_token_file_permissions() {

--- a/fluree-db-cli/src/config.rs
+++ b/fluree-db-cli/src/config.rs
@@ -642,7 +642,7 @@ impl TomlSyncConfigStore {
 
             // Build [remotes.auth] sub-table with all populated fields
             {
-                use fluree_db_nameservice_sync::RemoteAuthType;
+                use fluree_db_nameservice_sync::{OidcLoginFlow, RemoteAuthType};
 
                 let auth = &remote.auth;
                 let has_any = auth.auth_type.is_some()
@@ -652,7 +652,8 @@ impl TomlSyncConfigStore {
                     || auth.exchange_url.is_some()
                     || auth.refresh_token.is_some()
                     || auth.scopes.is_some()
-                    || auth.redirect_port.is_some();
+                    || auth.redirect_port.is_some()
+                    || auth.login_flow.is_some();
 
                 if has_any {
                     let mut auth_table = Table::new();
@@ -685,6 +686,13 @@ impl TomlSyncConfigStore {
                     }
                     if let Some(port) = auth.redirect_port {
                         auth_table.insert("redirect_port", Value::from(i64::from(port)).into());
+                    }
+                    if let Some(flow) = auth.login_flow {
+                        let flow_str = match flow {
+                            OidcLoginFlow::DeviceCode => "device_code",
+                            OidcLoginFlow::AuthCodePkce => "auth_code_pkce",
+                        };
+                        auth_table.insert("login_flow", Value::from(flow_str).into());
                     }
                     table.insert("auth", Item::Table(auth_table));
                 }

--- a/fluree-db-cli/tests/integration.rs
+++ b/fluree-db-cli/tests/integration.rs
@@ -2048,6 +2048,88 @@ fn auth_logout_clears_token() {
 }
 
 #[test]
+fn model_access_disable_dry_run_prints_delete_only_txn() {
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    fluree_cmd(&tmp)
+        .args([
+            "model",
+            "access",
+            "disable",
+            "crm",
+            "--profile",
+            "write",
+            "--class",
+            "https://example.org/Lead",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "https://example.org/Lead/access/write/view",
+        ))
+        .stdout(predicate::str::contains(
+            "https://example.org/Lead/access/write/write",
+        ))
+        .stdout(predicate::str::contains("delete"))
+        .stdout(predicate::str::contains("insert").not());
+}
+
+#[test]
+fn model_access_disable_requires_identification() {
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    fluree_cmd(&tmp)
+        .args(["model", "access", "disable", "crm"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--policy-class"));
+}
+
+#[test]
+fn auth_token_prints_exactly_the_stored_token() {
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    fluree_cmd(&tmp)
+        .args(["remote", "add", "origin", "http://localhost:8090"])
+        .assert()
+        .success();
+
+    fluree_cmd(&tmp)
+        .args(["auth", "login", "--remote", "origin", "--token", "tok-789"])
+        .assert()
+        .success();
+
+    // Stdout is the token and nothing else — it must compose into
+    // FLUREE_TOKEN=$(fluree auth token) without trailing decoration.
+    fluree_cmd(&tmp)
+        .args(["auth", "token", "--remote", "origin"])
+        .assert()
+        .success()
+        .stdout(predicate::eq("tok-789\n"));
+}
+
+#[test]
+fn auth_token_without_stored_token_errors() {
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    fluree_cmd(&tmp)
+        .args(["remote", "add", "origin", "http://localhost:8090"])
+        .assert()
+        .success();
+
+    fluree_cmd(&tmp)
+        .args(["auth", "token", "--remote", "origin"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no token stored"));
+}
+
+#[test]
 fn auth_login_no_remote_single_remote_default() {
     let tmp = TempDir::new().unwrap();
     fluree_cmd(&tmp).arg("init").assert().success();

--- a/fluree-db-nameservice-sync/src/config.rs
+++ b/fluree-db-nameservice-sync/src/config.rs
@@ -30,6 +30,18 @@ pub enum RemoteAuthType {
     OidcDevice,
 }
 
+/// Which OAuth flow an interactive OIDC login actually used. The flow is
+/// auto-detected per login from the IdP's discovery document, so this is a
+/// record of the last login — not a configuration input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OidcLoginFlow {
+    /// Device Authorization Grant (RFC 8628)
+    DeviceCode,
+    /// Authorization Code + PKCE (RFC 7636)
+    AuthCodePkce,
+}
+
 /// Authentication for a remote
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct RemoteAuth {
@@ -56,6 +68,11 @@ pub struct RemoteAuth {
     /// Default tries ports 8400..8405.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub redirect_port: Option<u16>,
+    /// OAuth flow the last interactive OIDC login used (set by `auth login`,
+    /// cleared by `auth logout` and manual token logins). Display-only:
+    /// flow selection is re-discovered on every login.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub login_flow: Option<OidcLoginFlow>,
 }
 
 /// Configuration for a named remote

--- a/fluree-db-nameservice-sync/src/lib.rs
+++ b/fluree-db-nameservice-sync/src/lib.rs
@@ -37,7 +37,7 @@ pub mod watch_sse;
 
 pub use client::{HttpRemoteClient, RemoteNameserviceClient, RemoteSnapshot};
 pub use config::{
-    MemorySyncConfigStore, RemoteAuth, RemoteAuthType, RemoteConfig, RemoteEndpoint,
+    MemorySyncConfigStore, OidcLoginFlow, RemoteAuth, RemoteAuthType, RemoteConfig, RemoteEndpoint,
     SyncConfigStore, UpstreamConfig,
 };
 pub use driver::{FetchResult, PullResult, PushResult, SyncDriver};


### PR DESCRIPTION
## Summary

Addresses an internal user report on CLI gaps around credential handling and access-profile lifecycle:

- **`fluree auth token [--remote <name>]`** — prints exactly the stored access token to stdout for `.env`-style scripting (`FLUREE_TOKEN=$(fluree auth token)`). Previously the only way to get a token was `fluree config list`, which dumps the entire config including refresh tokens for every remote. Diagnostics (expired-token warning) go to stderr; refresh tokens are never printed by any command.

- **`fluree model access disable`** — the inverse of `enable`. Identifies the policy class the same way it was enabled (`--profile` + `--class` derives the default `{class}/access/{profile}` id, or `--policy-class` for overrides), deletes the policy class node and both owned policy nodes in one delete-only transaction (delete-if-exists, so re-running is a no-op), and supports `--dry-run`. With `--space`/`--remote` it first detaches the policy class from the space grant, mirroring enable's ordering rationale. It never posts an empty `policyClasses` list: on hosted stacks a class-less grant reads as instance-wide access, so dropping the last class would widen the grant instead of revoking it — the CLI leaves the grant unchanged (fail-closed stale reference) and says to delete the grant itself.

- **`fluree auth status` honest flow label** — status previously echoed the config discriminator `oidc_device` even when login fell back to authorization-code + PKCE, contradicting the "IdP does not support device flow" message in the same session. Login now records the flow that actually ran in a new optional `login_flow` field (cleared by logout and manual-token logins), and status shows `Auth type: oidc` plus `Login flow: device code` / `authorization code + PKCE`. The config discriminator is unchanged for back-compat.

- **`model access enable` grant message** — the final line now labels the reported access level and class count as the grant's merged state (cumulative across enables), not the profile just attached.

## Testing

- New unit tests: policy-class resolution (derivation, override, missing-identification errors), delete-only disable transaction shape, grant class extraction
- New integration tests: `auth token` prints exactly the token (stdout composability contract), errors without a stored token; `model access disable` dry-run output and identification requirement
- `cargo test -p fluree-db-cli` (151 lib + 118 integration) and `cargo clippy --all-targets -D warnings` on both touched crates pass

## Docs

- `docs/cli/auth.md`: `auth token` section, updated status output, security notes
- `docs/cli/model.md`: disable semantics including the last-policy-class grant guard