### PR TITLE
Substitute property-position variables in datalog rules

### DIFF
--- a/docs/query/datalog-rules.md
+++ b/docs/query/datalog-rules.md
@@ -331,7 +331,13 @@ This means:
 - **Recursive rules work.** A rule can produce facts that trigger itself again.
 - **Rule chaining works.** Rule A can produce facts that trigger Rule B, and
   vice versa.
-- **Termination is guaranteed** by a maximum fixpoint-iteration bound.
+- **Termination is guaranteed** by a maximum fixpoint-iteration bound and by
+  the shared reasoning budget — a maximum derived-fact count and a maximum
+  wall-clock time, the same budget OWL2-RL uses. Hitting the budget stops
+  early and marks the result `capped` in the tracked response's `reasoning`
+  block. Configure it with `f:reasoningMaxFacts` / `f:reasoningMaxSeconds`
+  (ledger config), `"reasoningBudget"` (query), or
+  `FLUREE_REASONING_MAX_FACTS` / `FLUREE_REASONING_MAX_SECONDS` (server).
 
 ### Execution order
 

--- a/docs/query/datalog-rules.md
+++ b/docs/query/datalog-rules.md
@@ -68,6 +68,19 @@ follows the same pattern syntax as JSON-LD queries.
 ```
 This is equivalent to two patterns joined on an intermediate variable.
 
+**Property-position variables (the predicate is a variable):**
+```json
+"where": [
+  {"@id": "?s", "ex:sameAs": {"@id": "?other"}},
+  {"@id": "?other", "?prop": "?val"}
+]
+```
+A variable in predicate position matches any predicate and binds it — here
+`?prop` / `?val` range over every property of `?other`. The bound predicate can
+then be reused in the `insert` clause. (A leading pattern whose subject **and**
+predicate are both unbound, e.g. `{"@id": "?s", "?p": "?o"}`, scans the whole
+ledger — see the reasoning budget under [Fixpoint evaluation](#fixpoint-evaluation).)
+
 **With filters:**
 ```json
 "where": [
@@ -85,7 +98,10 @@ variable bindings.
 "insert": {"@id": "?person", "ex:grandparent": {"@id": "?gp"}}
 ```
 
-- Variables (`?person`, `?gp`) are replaced with the bound values from `where`.
+- Variables in any position — subject, **predicate**, or object — are replaced
+  with the bound values from `where`. A predicate variable lets a rule write a
+  property whose name is computed: e.g. `"insert": {"@id": "?s", "?prop": "?val"}`
+  copies every `?prop`/`?val` bound in the `where` clause onto `?s`.
 - Use `{"@id": "?var"}` for IRI/entity values; use `"?var"` directly for
   literal values.
 - Multiple triples can be generated from a single insert pattern.
@@ -341,9 +357,11 @@ This means:
 
 ### Execution order
 
-Rules are topologically sorted by their predicate dependencies: a rule that
-generates `ex:uncle` triples runs before a rule that consumes `ex:uncle` in its
-`where` clause. This minimizes the number of fixpoint iterations needed.
+Rules are ordered before the fixpoint by a lightweight heuristic (fewest
+predicate dependencies first). Because the fixpoint re-runs every rule each
+iteration until no new facts are produced, this ordering only affects how
+quickly the fixpoint converges — never the final set of derived facts. Rule
+chaining (rule A's output feeding rule B) works regardless of the order.
 
 ### Interaction with OWL 2 RL
 

--- a/docs/query/datalog-rules.md
+++ b/docs/query/datalog-rules.md
@@ -331,8 +331,7 @@ This means:
 - **Recursive rules work.** A rule can produce facts that trigger itself again.
 - **Rule chaining works.** Rule A can produce facts that trigger Rule B, and
   vice versa.
-- **Termination is guaranteed** by the budget controls (max iterations, max
-  facts, max time, max memory).
+- **Termination is guaranteed** by a maximum fixpoint-iteration bound.
 
 ### Execution order
 

--- a/fluree-db-api/tests/it_datalog_rules.rs
+++ b/fluree-db-api/tests/it_datalog_rules.rs
@@ -1095,3 +1095,133 @@ async fn datalog_query_time_rules_stripped_under_non_root_policy() {
         "query-time datalog rules must be stripped under a non-root view policy, got {policed_rows:?}"
     );
 }
+
+// =============================================================================
+// Property-Position Variables (issue #1531)
+// =============================================================================
+
+/// A variable in property position of an `insert` pattern must be replaced
+/// with its bound value, not committed as the literal property name (#1531).
+///
+/// The rule binds `?rel` to a predicate IRI via an object reference in the
+/// where clause, then uses it as the property of the derived fact:
+/// `{"@id": "?s", "?rel": "?o"}` with `?rel` = `ex:knows` must derive
+/// `ex:alice ex:knows ex:bob`.
+#[tokio::test]
+async fn datalog_rule_insert_property_variable_substituted() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/insert-prop-var");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:relateRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "ex:relates": {"@id": "?o"}},
+                            {"@id": "?s", "ex:relType": {"@id": "?rel"}}
+                        ],
+                        "insert": {"@id": "?s", "?rel": {"@id": "?o"}}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice",
+             "ex:relates": {"@id": "ex:bob"},
+             "ex:relType": {"@id": "ex:knows"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?who",
+        "where": {"@id": "ex:alice", "ex:knows": "?who"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+    assert!(
+        results.contains(&json!("ex:bob")),
+        "insert-position property var ?rel must resolve to ex:knows, got {results:?}"
+    );
+}
+
+/// A variable in property position of a `where` pattern must match any
+/// predicate and bind it, so the insert clause can re-use it (#1531).
+///
+/// The rule copies every property of a `ex:sameAs` target onto the subject:
+/// `where {?s ex:sameAs ?other . ?other ?prop ?val}` /
+/// `insert {?s ?prop ?val}`.
+#[tokio::test]
+async fn datalog_rule_where_property_variable_binds_and_substitutes() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/where-prop-var");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:copyRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "ex:sameAs": {"@id": "?other"}},
+                            {"@id": "?other", "?prop": "?val"}
+                        ],
+                        "insert": {"@id": "?s", "?prop": "?val"}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:a", "ex:sameAs": {"@id": "ex:b"}},
+            {"@id": "ex:b", "ex:color": "blue", "ex:size": 5}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": ["?color", "?size"],
+        "where": {"@id": "ex:a", "ex:color": "?color", "ex:size": "?size"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+    assert!(
+        results.contains(&json!(["blue", 5])),
+        "where-position property var ?prop must match and carry into insert, got {results:?}"
+    );
+}

--- a/fluree-db-api/tests/it_datalog_rules.rs
+++ b/fluree-db-api/tests/it_datalog_rules.rs
@@ -1299,3 +1299,74 @@ async fn datalog_rule_literal_bound_property_variable_does_not_abort_other_rules
          predicate var, got {results:?}"
     );
 }
+
+/// A literal *constant* in subject position (a plausible typo for a prefixed
+/// IRI, e.g. `{"@id": "Alice"}` instead of `{"@id": "ex:Alice"}`) can never
+/// match a flake, so that rule derives nothing — but it must not abort the
+/// fixpoint and drop every other rule's derivations.
+#[tokio::test]
+async fn datalog_rule_literal_subject_constant_does_not_abort_other_rules() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/literal-subject");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:grandparentRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": {"@id": "?person", "ex:parent": {"ex:parent": "?grandparent"}},
+                        "insert": {"@id": "?person", "ex:grandparent": {"@id": "?grandparent"}}
+                    }
+                }
+            },
+            {
+                // `"Alice"` is colon-less and non-`?`, so it parses as a string
+                // literal in subject position — a rule that can never match.
+                "@id": "ex:literalSubjectRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": {"@id": "Alice", "ex:parent": "?p"},
+                        "insert": {"@id": "Alice", "ex:derived": "?p"}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:parent": {"@id": "ex:bob"}},
+            {"@id": "ex:bob", "ex:parent": {"@id": "ex:charlie"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?grandparent",
+        "where": {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+    assert!(
+        results.contains(&json!("ex:charlie")),
+        "sound rule's derivations must survive a sibling rule's literal subject \
+         constant, got {results:?}"
+    );
+}

--- a/fluree-db-api/tests/it_datalog_rules.rs
+++ b/fluree-db-api/tests/it_datalog_rules.rs
@@ -1370,3 +1370,65 @@ async fn datalog_rule_literal_subject_constant_does_not_abort_other_rules() {
          constant, got {results:?}"
     );
 }
+
+/// A copy-properties rule whose all-unbound pattern `{?other ?prop ?val}` is
+/// written FIRST (the full-scan-leading order) must still derive correctly —
+/// the matcher reorders patterns most-constrained-first, hoisting the
+/// grounding `ex:sameAs` pattern ahead of it. Mirrors
+/// `datalog_rule_where_property_variable_binds_and_substitutes` with the
+/// where patterns reversed.
+#[tokio::test]
+async fn datalog_rule_all_unbound_leading_pattern_still_derives_correctly() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/reorder-leading-unbound");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:copyRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?other", "?prop": "?val"},
+                            {"@id": "?s", "ex:sameAs": {"@id": "?other"}}
+                        ],
+                        "insert": {"@id": "?s", "?prop": "?val"}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:a", "ex:sameAs": {"@id": "ex:b"}},
+            {"@id": "ex:b", "ex:color": "blue", "ex:size": 5}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": ["?color", "?size"],
+        "where": {"@id": "ex:a", "ex:color": "?color", "ex:size": "?size"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+    assert!(
+        results.contains(&json!(["blue", 5])),
+        "reordered rule with all-unbound leading pattern must still derive, got {results:?}"
+    );
+}

--- a/fluree-db-api/tests/it_datalog_rules.rs
+++ b/fluree-db-api/tests/it_datalog_rules.rs
@@ -1225,3 +1225,77 @@ async fn datalog_rule_where_property_variable_binds_and_substitutes() {
         "where-position property var ?prop must match and carry into insert, got {results:?}"
     );
 }
+
+/// A rule whose predicate variable ends up bound to a literal (not an IRI)
+/// matches nothing for that row — it must not abort rule execution and drop
+/// every other rule's derived facts.
+#[tokio::test]
+async fn datalog_rule_literal_bound_property_variable_does_not_abort_other_rules() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/literal-prop-var");
+
+    // Rule 1 (sound): derives grandparent. Rule 2 (unsatisfiable): binds ?p to
+    // the string value of ex:tag, then reuses ?p in predicate position, where
+    // a literal can never match.
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:grandparentRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": {"@id": "?person", "ex:parent": {"ex:parent": "?grandparent"}},
+                        "insert": {"@id": "?person", "ex:grandparent": {"@id": "?grandparent"}}
+                    }
+                }
+            },
+            {
+                "@id": "ex:literalPredicateRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?x", "ex:tag": "?p"},
+                            {"@id": "?x", "?p": "?v"}
+                        ],
+                        "insert": {"@id": "?x", "ex:derived": "?v"}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:parent": {"@id": "ex:bob"}, "ex:tag": "blue"},
+            {"@id": "ex:bob", "ex:parent": {"@id": "ex:charlie"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?grandparent",
+        "where": {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+    assert!(
+        results.contains(&json!("ex:charlie")),
+        "sound rule's derivations must survive a sibling rule's literal-bound \
+         predicate var, got {results:?}"
+    );
+}

--- a/fluree-db-api/tests/it_datalog_rules_sparql.rs
+++ b/fluree-db-api/tests/it_datalog_rules_sparql.rs
@@ -191,3 +191,69 @@ async fn sparql_rule_unsupported_construct_skipped() {
         "unsupported rule must be skipped, not partially applied"
     );
 }
+
+/// SPARQL twin of `datalog_rule_literal_bound_property_variable_does_not_abort_other_rules`
+/// in `it_datalog_rules.rs`. `TermResolution::Incompatible` is shared engine
+/// code below both front-ends, and a SPARQL rule can put a variable in
+/// predicate position too (`?x ?p ?v`). A rule that binds `?p` to a literal and
+/// then reuses it as a predicate matches nothing — but must NOT abort the
+/// sibling rule's derivations for the whole query (the pre-fix behaviour turned
+/// the literal-in-predicate case into a hard error that dropped every rule).
+#[tokio::test]
+async fn sparql_rule_literal_bound_predicate_variable_does_not_abort_other_rules() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/sparql-literal-pred");
+
+    let rule_data = json!({
+        "@context": { "f": "https://ns.flur.ee/db#" },
+        "@graph": [
+            {
+                "@id": "http://example.org/grandparentRule",
+                "f:rule": {
+                    "@type": "https://ns.flur.ee/db#sparql",
+                    "@value": "PREFIX ex: <http://example.org/> \
+                               CONSTRUCT { ?person ex:grandparent ?gp } \
+                               WHERE { ?person ex:parent ?p . ?p ex:parent ?gp }"
+                }
+            },
+            {
+                // `?tp` binds to the STRING value of ex:tag, then is reused in
+                // predicate position — a literal can never be a predicate.
+                "@id": "http://example.org/literalPredicateRule",
+                "f:rule": {
+                    "@type": "https://ns.flur.ee/db#sparql",
+                    "@value": "PREFIX ex: <http://example.org/> \
+                               CONSTRUCT { ?x ex:derived ?v } \
+                               WHERE { ?x ex:tag ?tp . ?x ?tp ?v }"
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": { "ex": "http://example.org/" },
+        "@graph": [
+            {"@id": "ex:alice", "ex:parent": {"@id": "ex:bob"}, "ex:tag": "blue"},
+            {"@id": "ex:bob", "ex:parent": {"@id": "ex:charlie"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": { "ex": "http://example.org/" },
+        "select": "?grandparent",
+        "where": {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    assert!(
+        normalize_rows(&rows).contains(&json!("ex:charlie")),
+        "sound rule's derivations must survive a sibling SPARQL rule's literal-bound \
+         predicate variable, got {rows:?}"
+    );
+}

--- a/fluree-db-api/tests/it_reasoning_budget.rs
+++ b/fluree-db-api/tests/it_reasoning_budget.rs
@@ -281,3 +281,87 @@ async fn query_budget_overrides_permissive_config_budget() {
     );
     assert_eq!(reasoning.derived_facts, 3);
 }
+
+// ============================================================================
+// Datalog rules honour the same budget and surface `capped` the same way
+// ============================================================================
+
+/// Seed a few plain entities (no OWL) for datalog rules to scan.
+async fn seed_entities(fluree: &fluree_db_api::Fluree, ledger_id: &str) {
+    let ledger = genesis_ledger(fluree, ledger_id);
+    let _ = apply_trig(
+        fluree,
+        ledger,
+        r#"
+        @prefix ex: <http://example.org/> .
+        ex:a ex:name "a" .
+        ex:b ex:name "b" .
+        ex:c ex:name "c" .
+        "#,
+    )
+    .await;
+}
+
+/// A datalog query whose one rule has an ALL-UNBOUND leading `where` pattern
+/// `{?s ?p ?o}` — the full-ledger-scan shape the budget must bound (issue
+/// #1541 review) — deriving `ex:touched true` for every subject.
+fn datalog_fullscan_query(ledger_id: &str) -> serde_json::Value {
+    json!({
+        "@context": {"ex": "http://example.org/"},
+        "from": ledger_id,
+        "select": ["?s"],
+        "where": {"@id": "?s", "ex:touched": true},
+        "reasoning": "datalog",
+        "rules": [{
+            "@context": {"ex": "http://example.org/"},
+            "where": {"@id": "?s", "?p": "?o"},
+            "insert": {"@id": "?s", "ex:touched": true}
+        }]
+    })
+}
+
+#[tokio::test]
+async fn datalog_uncapped_reports_complete_in_tracking() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/datalog-budget-uncapped:main";
+    seed_entities(&fluree, ledger_id).await;
+
+    let resp = run_tracked(&fluree, &datalog_fullscan_query(ledger_id)).await;
+
+    let reasoning = resp
+        .reasoning
+        .expect("tracked datalog query reports a reasoning block");
+    assert!(
+        !reasoning.capped,
+        "unbounded budget must not cap: {reasoning:?}"
+    );
+    assert!(reasoning.capped_reason.is_none());
+    assert!(
+        reasoning.derived_facts >= 3,
+        "every seeded subject is touched: {reasoning:?}"
+    );
+}
+
+#[tokio::test]
+async fn datalog_query_budget_caps_fixpoint_and_surfaces_in_tracking() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/datalog-budget-query:main";
+    seed_entities(&fluree, ledger_id).await;
+
+    let mut query = datalog_fullscan_query(ledger_id);
+    query["reasoningBudget"] = json!({"maxFacts": 1});
+
+    let resp = run_tracked(&fluree, &query).await;
+
+    let reasoning = resp
+        .reasoning
+        .expect("tracked datalog query reports a reasoning block");
+    assert!(
+        reasoning.capped,
+        "maxFacts=1 must cap a multi-subject full-scan rule: {reasoning:?}"
+    );
+    assert!(
+        reasoning.capped_reason.is_some(),
+        "capped result carries a reason"
+    );
+}

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -769,12 +769,12 @@ async fn match_pattern_with_bindings(
     // variable bound to a non-Sid value can never occupy that position in a
     // flake, so the pattern matches nothing for this binding row.
     let Some((subject_sid, subject_var)) =
-        resolve_term_with_bindings(&pattern.subject, bindings)?.split()
+        resolve_term_with_bindings(&pattern.subject, bindings).split()
     else {
         return Ok(Vec::new());
     };
     let Some((predicate_sid, predicate_var)) =
-        resolve_term_with_bindings(&pattern.predicate, bindings)?.split()
+        resolve_term_with_bindings(&pattern.predicate, bindings).split()
     else {
         return Ok(Vec::new());
     };
@@ -862,8 +862,9 @@ enum TermResolution {
     Bound(Sid),
     /// Unbound variable, to be bound from each matched flake
     Unbound(Arc<str>),
-    /// Variable bound to a non-Sid value: no flake can carry it in this
-    /// position, so the pattern matches nothing (an empty join, not an error)
+    /// A literal constant, or a variable bound to a non-Sid value: no flake
+    /// can carry a literal in subject/predicate position, so the pattern
+    /// matches nothing (an empty join, not an error)
     Incompatible,
 }
 
@@ -878,18 +879,22 @@ impl TermResolution {
     }
 }
 
-/// Resolve a subject- or predicate-position term using existing bindings
-fn resolve_term_with_bindings(term: &RuleTerm, bindings: &Bindings) -> Result<TermResolution> {
+/// Resolve a subject- or predicate-position term using existing bindings.
+///
+/// Total: a literal constant (`RuleTerm::Value`) — a plausible typo for an
+/// unprefixed IRI like `{"@id": "Alice"}` — can no more occupy subject or
+/// predicate position than a variable bound to a literal, so it resolves to
+/// `Incompatible` (that pattern matches nothing) rather than erroring, which
+/// would abort the whole fixpoint and drop every rule's derivations.
+fn resolve_term_with_bindings(term: &RuleTerm, bindings: &Bindings) -> TermResolution {
     match term {
-        RuleTerm::Sid(sid) => Ok(TermResolution::Bound(sid.clone())),
+        RuleTerm::Sid(sid) => TermResolution::Bound(sid.clone()),
         RuleTerm::Var(var) => match bindings.get(var.as_ref()) {
-            Some(BindingValue::Sid(sid)) => Ok(TermResolution::Bound(sid.clone())),
-            Some(_) => Ok(TermResolution::Incompatible),
-            None => Ok(TermResolution::Unbound(var.clone())),
+            Some(BindingValue::Sid(sid)) => TermResolution::Bound(sid.clone()),
+            Some(_) => TermResolution::Incompatible,
+            None => TermResolution::Unbound(var.clone()),
         },
-        RuleTerm::Value(_) => Err(QueryError::InvalidQuery(
-            "Literal value not allowed in subject/predicate position".to_string(),
-        )),
+        RuleTerm::Value(_) => TermResolution::Incompatible,
     }
 }
 
@@ -1327,7 +1332,21 @@ mod tests {
         let mut bindings = Bindings::new();
         bindings.insert(Arc::from("?p"), BindingValue::String("blue".to_string()));
 
-        let resolved = resolve_term_with_bindings(&RuleTerm::var("?p"), &bindings).unwrap();
+        let resolved = resolve_term_with_bindings(&RuleTerm::var("?p"), &bindings);
+        assert!(matches!(resolved, TermResolution::Incompatible));
+        assert!(resolved.split().is_none());
+    }
+
+    #[test]
+    fn resolve_term_literal_constant_is_incompatible() {
+        // A literal constant in subject/predicate position (e.g. a typo like
+        // `{"@id": "Alice"}` parsed as a string value) can never match a
+        // flake; resolution must report an empty join, not an error, so the
+        // authoring mistake cannot abort the whole fixpoint.
+        let bindings = Bindings::new();
+        let literal = RuleTerm::Value(RuleValue::String("Alice".to_string()));
+
+        let resolved = resolve_term_with_bindings(&literal, &bindings);
         assert!(matches!(resolved, TermResolution::Incompatible));
         assert!(resolved.split().is_none());
     }

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -405,25 +405,16 @@ fn parse_node_pattern(
             continue;
         }
 
-        // Resolve predicate IRI
-        let predicate_iri = expand_iri(key, context)?;
-        let predicate_sid = resolve_iri(&predicate_iri, snapshot)?;
+        let predicate = parse_predicate_term(key, context, snapshot)?;
 
         // Parse object(s)
         match value {
             JsonValue::Array(arr) => {
                 for item in arr {
-                    let obj = parse_object_value(
-                        item,
-                        context,
-                        snapshot,
-                        patterns,
-                        &subject,
-                        &predicate_sid,
-                    )?;
+                    let obj = parse_object_value(item, context, snapshot, patterns)?;
                     patterns.push(RuleTriplePattern {
                         subject: subject.clone(),
-                        predicate: RuleTerm::Sid(predicate_sid.clone()),
+                        predicate: predicate.clone(),
                         object: obj,
                     });
                 }
@@ -441,7 +432,7 @@ fn parse_node_pattern(
                 // Add pattern linking parent to nested subject
                 patterns.push(RuleTriplePattern {
                     subject: subject.clone(),
-                    predicate: RuleTerm::Sid(predicate_sid.clone()),
+                    predicate: predicate.clone(),
                     object: nested_subject.clone(),
                 });
 
@@ -460,7 +451,7 @@ fn parse_node_pattern(
                 let obj = parse_term(value, context, snapshot)?;
                 patterns.push(RuleTriplePattern {
                     subject: subject.clone(),
-                    predicate: RuleTerm::Sid(predicate_sid.clone()),
+                    predicate: predicate.clone(),
                     object: obj,
                 });
             }
@@ -470,14 +461,27 @@ fn parse_node_pattern(
     Ok(())
 }
 
+/// Parse a node-map key into a predicate term: a `?`-prefixed key is a
+/// variable; anything else expands and resolves as an IRI.
+fn parse_predicate_term(
+    key: &str,
+    context: &JsonValue,
+    snapshot: &LedgerSnapshot,
+) -> Result<RuleTerm> {
+    if key.starts_with('?') {
+        Ok(RuleTerm::var(key))
+    } else {
+        let iri = expand_iri(key, context)?;
+        Ok(RuleTerm::Sid(resolve_iri(&iri, snapshot)?))
+    }
+}
+
 /// Parse an object value, handling nested structures
 fn parse_object_value(
     value: &JsonValue,
     context: &JsonValue,
     snapshot: &LedgerSnapshot,
     patterns: &mut Vec<RuleTriplePattern>,
-    _parent_subject: &RuleTerm,
-    _predicate_sid: &Sid,
 ) -> Result<RuleTerm> {
     match value {
         JsonValue::Object(nested) if nested.contains_key("@id") => {

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -23,12 +23,14 @@ use fluree_db_core::value::FlakeValue;
 use fluree_db_core::{GraphDbRef, LedgerSnapshot, Sid};
 use fluree_db_reasoner::{
     BindingValue, Bindings, CompareOp, DatalogRule, DatalogRuleSet, DerivedFactsBuilder,
-    FrozenSameAs, RuleFilter, RuleTerm, RuleTriplePattern, RuleValue,
+    FrozenSameAs, ReasoningBudget, ReasoningDiagnostics, RuleFilter, RuleTerm, RuleTriplePattern,
+    RuleValue,
 };
 use fluree_vocab::namespaces::FLUREE_DB;
 use serde_json::Value as JsonValue;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Instant;
 
 use crate::error::{QueryError, Result};
 
@@ -1172,10 +1174,10 @@ fn bindings_equal(a: &BindingValue, b: &BindingValue) -> bool {
 pub struct DatalogExecutionResult {
     /// Derived flakes from rule execution
     pub derived_flakes: Vec<Flake>,
-    /// Number of fixpoint iterations
-    pub iterations: usize,
-    /// Number of rules executed
-    pub rules_executed: usize,
+    /// Fixpoint diagnostics (iterations, facts, capped flag, duration) — the
+    /// same type OWL2-RL returns, so a capped run surfaces on the query
+    /// response the same way (see `reasoning_prep`).
+    pub diagnostics: ReasoningDiagnostics,
 }
 
 /// Execute datalog rules to fixpoint, generating derived facts
@@ -1201,7 +1203,14 @@ pub async fn execute_datalog_rules(
     db: GraphDbRef<'_>,
     max_iterations: usize,
 ) -> Result<DatalogExecutionResult> {
-    execute_datalog_rules_with_query_rules(db, max_iterations, &[], None).await
+    execute_datalog_rules_with_query_rules(
+        db,
+        max_iterations,
+        &[],
+        None,
+        &ReasoningBudget::unlimited(),
+    )
+    .await
 }
 
 /// Execute datalog rules with optional query-time rules
@@ -1214,11 +1223,19 @@ pub async fn execute_datalog_rules(
 /// `db.g_id` (legacy behaviour). When `Some(g)`, a separate
 /// `GraphDbRef` is built at graph `g` and used only for rule
 /// extraction — the fixpoint loop still executes against `db`.
+///
+/// `budget` bounds the fixpoint by derived-fact count and wall-clock time
+/// (checked between iterations, mirroring OWL2-RL's `fixpoint.rs`). This is
+/// load-bearing because a rule with an unbound-subject-and-predicate `where`
+/// pattern scans the whole ledger every iteration; `max_iterations` alone is
+/// not a defensible ceiling for that. Exhausting the budget stops early and
+/// sets `diagnostics.capped`.
 pub async fn execute_datalog_rules_with_query_rules(
     db: GraphDbRef<'_>,
     max_iterations: usize,
     query_time_rules: &[serde_json::Value],
     rules_source_g_id: Option<fluree_db_core::GraphId>,
+    budget: &ReasoningBudget,
 ) -> Result<DatalogExecutionResult> {
     // Extract rules from the configured source graph if set,
     // otherwise from the query graph. The fixpoint loop below
@@ -1244,8 +1261,7 @@ pub async fn execute_datalog_rules_with_query_rules(
     if rule_set.is_empty() {
         return Ok(DatalogExecutionResult {
             derived_flakes: Vec::new(),
-            iterations: 0,
-            rules_executed: 0,
+            diagnostics: ReasoningDiagnostics::completed(0, 0, std::time::Duration::ZERO),
         });
     }
 
@@ -1266,7 +1282,6 @@ pub async fn execute_datalog_rules_with_query_rules(
         Flake,
     > = HashMap::new();
     let mut iterations = 0;
-    let mut rules_executed = 0;
 
     // Use the same t as the query for derived facts (matching OWL2-RL approach)
     // This is important because the overlay filters with flake.t <= to_t
@@ -1275,7 +1290,22 @@ pub async fn execute_datalog_rules_with_query_rules(
     // Track derived overlay for recursive rule support
     let mut derived_overlay: Option<Arc<fluree_db_reasoner::DerivedFactsOverlay>> = None;
 
+    let start = Instant::now();
+    let mut capped: Option<&str> = None;
+
     loop {
+        // Budget check BEFORE another round — a round can scan the whole ledger
+        // per rule, so stop before paying for one we can't afford. Mirrors the
+        // OWL2-RL fixpoint (`fluree-db-reasoner/src/fixpoint.rs`).
+        if start.elapsed() > budget.max_duration {
+            capped = Some("time");
+            break;
+        }
+        if all_derived.len() > budget.max_facts {
+            capped = Some("facts");
+            break;
+        }
+
         iterations += 1;
         let mut new_facts_this_round = 0;
 
@@ -1292,8 +1322,6 @@ pub async fn execute_datalog_rules_with_query_rules(
 
         // Execute each rule in order
         for rule in rule_set.iter_in_order() {
-            rules_executed += 1;
-
             // Find all bindings matching the where patterns
             // Use effective_overlay which includes derived facts from previous iterations
             let iter_db = GraphDbRef::new(db.snapshot, db.g_id, effective_overlay.as_ref(), db.t);
@@ -1344,10 +1372,17 @@ pub async fn execute_datalog_rules_with_query_rules(
         ));
     }
 
+    let facts = all_derived.len();
+    let elapsed = start.elapsed();
+    let mut diagnostics = ReasoningDiagnostics::default();
+    match capped {
+        Some(reason) => diagnostics.mark_capped(reason, iterations, facts, elapsed),
+        None => diagnostics.mark_completed(iterations, facts, elapsed),
+    }
+
     Ok(DatalogExecutionResult {
         derived_flakes: all_derived.into_values().collect(),
-        iterations,
-        rules_executed,
+        diagnostics,
     })
 }
 

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -572,11 +572,6 @@ fn expand_iri(compact: &str, context: &JsonValue) -> Result<String> {
         return Ok(compact.to_string());
     }
 
-    // Check if it's a variable
-    if compact.starts_with('?') {
-        return Ok(compact.to_string());
-    }
-
     // Try to expand using context
     if let Some(colon_pos) = compact.find(':') {
         let prefix = &compact[..colon_pos];
@@ -770,9 +765,19 @@ async fn match_pattern_with_bindings(
     db: GraphDbRef<'_>,
     bindings: &Bindings,
 ) -> Result<Vec<Bindings>> {
-    // Resolve pattern terms using existing bindings
-    let (subject_sid, subject_var) = resolve_term_with_bindings(&pattern.subject, bindings)?;
-    let (predicate_sid, predicate_var) = resolve_term_with_bindings(&pattern.predicate, bindings)?;
+    // Resolve pattern terms using existing bindings. A subject/predicate
+    // variable bound to a non-Sid value can never occupy that position in a
+    // flake, so the pattern matches nothing for this binding row.
+    let Some((subject_sid, subject_var)) =
+        resolve_term_with_bindings(&pattern.subject, bindings)?.split()
+    else {
+        return Ok(Vec::new());
+    };
+    let Some((predicate_sid, predicate_var)) =
+        resolve_term_with_bindings(&pattern.predicate, bindings)?.split()
+    else {
+        return Ok(Vec::new());
+    };
     let (object_match, object_var) = resolve_object_term_with_bindings(&pattern.object, bindings)?;
 
     // Choose index based on what's bound
@@ -851,26 +856,37 @@ async fn match_pattern_with_bindings(
     Ok(results)
 }
 
-/// Resolve a term using existing bindings, returning (resolved_sid, unbound_var_name)
-fn resolve_term_with_bindings(
-    term: &RuleTerm,
-    bindings: &Bindings,
-) -> Result<(Option<Sid>, Option<Arc<str>>)> {
-    match term {
-        RuleTerm::Sid(sid) => Ok((Some(sid.clone()), None)),
-        RuleTerm::Var(var) => {
-            // Check if variable is already bound
-            if let Some(binding) = bindings.get(var.as_ref()) {
-                match binding {
-                    BindingValue::Sid(sid) => Ok((Some(sid.clone()), None)),
-                    _ => Err(QueryError::InvalidQuery(format!(
-                        "Variable {var} bound to non-SID value in subject/predicate position"
-                    ))),
-                }
-            } else {
-                Ok((None, Some(var.clone())))
-            }
+/// Resolution of a subject- or predicate-position term against existing bindings
+enum TermResolution {
+    /// Constant, or a variable already bound to a Sid
+    Bound(Sid),
+    /// Unbound variable, to be bound from each matched flake
+    Unbound(Arc<str>),
+    /// Variable bound to a non-Sid value: no flake can carry it in this
+    /// position, so the pattern matches nothing (an empty join, not an error)
+    Incompatible,
+}
+
+impl TermResolution {
+    /// Split into `(bound_sid, unbound_var)`, or `None` when incompatible
+    fn split(self) -> Option<(Option<Sid>, Option<Arc<str>>)> {
+        match self {
+            TermResolution::Bound(sid) => Some((Some(sid), None)),
+            TermResolution::Unbound(var) => Some((None, Some(var))),
+            TermResolution::Incompatible => None,
         }
+    }
+}
+
+/// Resolve a subject- or predicate-position term using existing bindings
+fn resolve_term_with_bindings(term: &RuleTerm, bindings: &Bindings) -> Result<TermResolution> {
+    match term {
+        RuleTerm::Sid(sid) => Ok(TermResolution::Bound(sid.clone())),
+        RuleTerm::Var(var) => match bindings.get(var.as_ref()) {
+            Some(BindingValue::Sid(sid)) => Ok(TermResolution::Bound(sid.clone())),
+            Some(_) => Ok(TermResolution::Incompatible),
+            None => Ok(TermResolution::Unbound(var.clone())),
+        },
         RuleTerm::Value(_) => Err(QueryError::InvalidQuery(
             "Literal value not allowed in subject/predicate position".to_string(),
         )),
@@ -1304,10 +1320,16 @@ mod tests {
     }
 
     #[test]
-    fn test_expand_iri_variable() {
-        let context = serde_json::json!({});
-        let result = expand_iri("?person", &context).unwrap();
-        assert_eq!(result, "?person");
+    fn resolve_term_non_sid_binding_is_incompatible() {
+        // A subject/predicate variable bound to a literal can never match a
+        // flake; resolution must report an empty join, not an error, so one
+        // bad binding row cannot abort the whole rule execution.
+        let mut bindings = Bindings::new();
+        bindings.insert(Arc::from("?p"), BindingValue::String("blue".to_string()));
+
+        let resolved = resolve_term_with_bindings(&RuleTerm::var("?p"), &bindings).unwrap();
+        assert!(matches!(resolved, TermResolution::Incompatible));
+        assert!(resolved.split().is_none());
     }
 
     fn dec(s: &str) -> FlakeValue {

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -27,7 +27,7 @@ use fluree_db_reasoner::{
 };
 use fluree_vocab::namespaces::FLUREE_DB;
 use serde_json::Value as JsonValue;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::error::{QueryError, Result};
@@ -600,6 +600,69 @@ fn resolve_iri(iri: &str, snapshot: &LedgerSnapshot) -> Result<Sid> {
 // Pattern Matching Execution
 // ============================================================================
 
+/// Whether `term` grounds an index lookup: a constant, or a variable already
+/// bound by an earlier pattern. Grounding the subject or predicate keeps a
+/// pattern off the full-scan path in [`choose_index_and_match`].
+fn term_is_grounded(term: &RuleTerm, bound: &HashSet<Arc<str>>) -> bool {
+    match term {
+        RuleTerm::Sid(_) | RuleTerm::Value(_) => true,
+        RuleTerm::Var(v) => bound.contains(v),
+    }
+}
+
+/// Selectivity score for matching `pattern` given the currently-bound
+/// variables. A grounded subject or predicate (worth 2 each) avoids the
+/// `(None, None)` full ledger scan; a grounded object (worth 1) constrains
+/// the result further. Higher is cheaper to match.
+fn pattern_selectivity(pattern: &RuleTriplePattern, bound: &HashSet<Arc<str>>) -> u32 {
+    2 * term_is_grounded(&pattern.subject, bound) as u32
+        + 2 * term_is_grounded(&pattern.predicate, bound) as u32
+        + term_is_grounded(&pattern.object, bound) as u32
+}
+
+/// Record `pattern`'s variables as bound (they will be after it matches).
+fn bind_pattern_vars(pattern: &RuleTriplePattern, bound: &mut HashSet<Arc<str>>) {
+    for term in [&pattern.subject, &pattern.predicate, &pattern.object] {
+        if let RuleTerm::Var(v) = term {
+            bound.insert(v.clone());
+        }
+    }
+}
+
+/// Order `patterns` most-constrained-first via a greedy join order: at each
+/// step take the pattern with the highest [`pattern_selectivity`] given the
+/// variables already bound, then mark its variables bound. A where-clause is
+/// a conjunction, so the join result is order-independent — this only lowers
+/// matching cost, keeping an all-unbound pattern (a full ledger scan) from
+/// leading when another pattern can ground its variables first. Ties keep
+/// source order.
+fn selective_pattern_order(patterns: &[RuleTriplePattern]) -> Vec<usize> {
+    let mut bound: HashSet<Arc<str>> = HashSet::new();
+    let mut remaining: Vec<usize> = (0..patterns.len()).collect();
+    let mut order = Vec::with_capacity(patterns.len());
+
+    while !remaining.is_empty() {
+        let best = remaining
+            .iter()
+            .enumerate()
+            .max_by_key(|(rank, &idx)| {
+                // Higher selectivity wins; on ties the lower source index
+                // (earlier `rank`) wins, so `max_by_key` compares Reverse.
+                (
+                    pattern_selectivity(&patterns[idx], &bound),
+                    std::cmp::Reverse(*rank),
+                )
+            })
+            .map(|(rank, _)| rank)
+            .expect("remaining is non-empty");
+        let idx = remaining.remove(best);
+        bind_pattern_vars(&patterns[idx], &mut bound);
+        order.push(idx);
+    }
+
+    order
+}
+
 /// Execute pattern matching for a datalog rule against the database
 ///
 /// Finds all bindings that satisfy the rule's where patterns and filters, and returns them.
@@ -612,11 +675,20 @@ pub async fn execute_rule_matching(
         return Ok(Vec::new());
     }
 
+    // Match patterns most-constrained-first so a pattern whose subject and
+    // predicate are both unbound variables — a full ledger scan (the
+    // `(None, None)` arm of `choose_index_and_match`), now reachable via
+    // property-position variables — does not lead when another pattern can
+    // ground its variables first.
+    let order = selective_pattern_order(&rule.where_patterns);
+    let mut patterns = order.iter().map(|&i| &rule.where_patterns[i]);
+
     // Start with the first pattern to get initial bindings
-    let mut binding_rows = match_pattern(&rule.where_patterns[0], db, &[]).await?;
+    let first = patterns.next().expect("where_patterns is non-empty");
+    let mut binding_rows = match_pattern(first, db, &[]).await?;
 
     // Join with subsequent patterns
-    for pattern in rule.where_patterns.iter().skip(1) {
+    for pattern in patterns {
         if binding_rows.is_empty() {
             break;
         }
@@ -1335,6 +1407,49 @@ mod tests {
         let resolved = resolve_term_with_bindings(&RuleTerm::var("?p"), &bindings);
         assert!(matches!(resolved, TermResolution::Incompatible));
         assert!(resolved.split().is_none());
+    }
+
+    fn triple(subject: RuleTerm, predicate: RuleTerm, object: RuleTerm) -> RuleTriplePattern {
+        RuleTriplePattern {
+            subject,
+            predicate,
+            object,
+        }
+    }
+
+    #[test]
+    fn selective_order_hoists_grounded_pattern_ahead_of_all_unbound_leading() {
+        // where: [ {?s ?p ?o}, {?s ex:parent ?o} ]
+        // The all-unbound pattern is written first (a full ledger scan), but
+        // the constant-predicate pattern must be matched first so it grounds
+        // ?s/?o before the unbound pattern runs.
+        let ex_parent = Sid::new(0, "http://example.org/parent");
+        let patterns = vec![
+            triple(
+                RuleTerm::var("?s"),
+                RuleTerm::var("?p"),
+                RuleTerm::var("?o"),
+            ),
+            triple(
+                RuleTerm::var("?s"),
+                RuleTerm::sid(ex_parent),
+                RuleTerm::var("?o"),
+            ),
+        ];
+        assert_eq!(selective_pattern_order(&patterns), vec![1, 0]);
+    }
+
+    #[test]
+    fn selective_order_keeps_source_order_on_ties() {
+        // Two equally-grounded patterns (both constant predicate) keep their
+        // written order — reordering is deterministic.
+        let p1 = Sid::new(0, "http://example.org/a");
+        let p2 = Sid::new(0, "http://example.org/b");
+        let patterns = vec![
+            triple(RuleTerm::var("?s"), RuleTerm::sid(p1), RuleTerm::var("?o")),
+            triple(RuleTerm::var("?x"), RuleTerm::sid(p2), RuleTerm::var("?y")),
+        ];
+        assert_eq!(selective_pattern_order(&patterns), vec![0, 1]);
     }
 
     #[test]

--- a/fluree-db-query/src/execute/reasoning_prep.rs
+++ b/fluree-db-query/src/execute/reasoning_prep.rs
@@ -243,11 +243,15 @@ pub async fn compute_derived_facts(
     let mut same_as = FrozenSameAs::empty();
     let mut diagnostics = None;
 
+    // One budget for both reasoning mechanisms — datalog reuses it rather than
+    // standing up a second cap.
+    let budget = reasoning_budget(reasoning);
+
     // OWL2-RL materialization
     if reasoning.owl2rl {
         tracing::debug!("computing OWL2-RL derived facts");
         let reasoning_opts = ReasoningOptions {
-            budget: reasoning_budget(reasoning),
+            budget: budget.clone(),
             ..Default::default()
         };
         let cache = global_reasoning_cache();
@@ -337,6 +341,7 @@ pub async fn compute_derived_facts(
                 MAX_DATALOG_ITERATIONS,
                 &reasoning.rules,
                 rules_source_g_id,
+                &budget,
             )
             .await
         } else {
@@ -346,16 +351,49 @@ pub async fn compute_derived_facts(
                 MAX_DATALOG_ITERATIONS,
                 &reasoning.rules,
                 rules_source_g_id,
+                &budget,
             )
             .await
         };
 
         match datalog_result {
             Ok(datalog_result) => {
-                tracing::debug!(
-                    datalog_facts = datalog_result.derived_flakes.len(),
-                    "datalog rules completed"
-                );
+                let dl_diag = datalog_result.diagnostics;
+                if dl_diag.capped {
+                    // A capped fixpoint is an INCOMPLETE derivation: reasoning
+                    // queries silently miss facts. Loud, like OWL2-RL — a
+                    // correctness event, not a perf detail.
+                    tracing::warn!(
+                        derived_facts = dl_diag.facts_derived,
+                        capped_reason = dl_diag.capped_reason.as_deref(),
+                        iterations = dl_diag.iterations,
+                        duration_ms = dl_diag.duration.as_millis() as u64,
+                        "datalog rule materialization hit its budget before reaching \
+                         fixpoint; query results may be missing derived facts. \
+                         Raise the budget via f:reasoningMaxFacts/f:reasoningMaxSeconds \
+                         (ledger config), \"reasoningBudget\" (query), or \
+                         FLUREE_REASONING_MAX_FACTS/FLUREE_REASONING_MAX_SECONDS (server)."
+                    );
+                } else {
+                    tracing::debug!(
+                        datalog_facts = datalog_result.derived_flakes.len(),
+                        "datalog rules completed"
+                    );
+                }
+                // Fold datalog diagnostics into the outcome; if OWL2-RL also
+                // ran, OR the capped flags and combine the counts so one tally
+                // reflects both mechanisms.
+                diagnostics = Some(match diagnostics.take() {
+                    None => dl_diag,
+                    Some(owl) => fluree_db_reasoner::ReasoningDiagnostics {
+                        iterations: owl.iterations + dl_diag.iterations,
+                        facts_derived: owl.facts_derived + dl_diag.facts_derived,
+                        capped: owl.capped || dl_diag.capped,
+                        capped_reason: owl.capped_reason.or(dl_diag.capped_reason),
+                        duration: owl.duration + dl_diag.duration,
+                        rules_fired: owl.rules_fired,
+                    },
+                });
                 all_flakes.extend(datalog_result.derived_flakes);
             }
             Err(e) => {

--- a/fluree-db-reasoner/src/datalog.rs
+++ b/fluree-db-reasoner/src/datalog.rs
@@ -130,9 +130,17 @@ pub struct DatalogRule {
     pub filters: Vec<RuleFilter>,
     /// Triple patterns in the insert clause (head)
     pub insert_patterns: Vec<RuleTriplePattern>,
-    /// Predicates this rule depends on (from where patterns)
+    /// Constant predicates this rule reads (from where-pattern `Sid`
+    /// predicates only — variable predicates contribute nothing). NOT
+    /// load-bearing despite the name: it only feeds the execution-order sort
+    /// heuristic in `compute_execution_order`, and since the fixpoint re-runs
+    /// every rule to convergence, that ordering affects convergence speed, not
+    /// the result. A rule with only variable predicates therefore sorts as
+    /// zero-dependency (first), which is harmless.
     pub depends_on: Vec<Sid>,
-    /// Predicates this rule generates (from insert patterns)
+    /// Constant predicates this rule writes (from insert patterns). Currently
+    /// has no readers anywhere in the workspace; kept for symmetry with
+    /// `depends_on` and potential future dependency-aware scheduling.
     pub generates: Vec<Sid>,
 }
 


### PR DESCRIPTION
Issue #1531 reported that variables in property position of a datalog rule's `insert` pattern were not replaced with their bound values: a rule like `{"insert": {"@id": "?foo", "?bar": "?baz"}}` substituted `?foo` and `?baz` but emitted the literal string `?bar` as the property of the derived fact.

The root cause was in the JSON-LD rule parser, not the substitution logic. `parse_node_pattern` in `fluree-db-query/src/datalog_rules.rs` unconditionally resolved every node-map key as an IRI, so a `"?bar"` key was encoded as a `RuleTerm::Sid` for the literal IRI `?bar`. Everything downstream already supported predicate variables — the where-clause matcher binds them, `instantiate_pattern` substitutes them, and the SPARQL rule-lowering path (`fluree-db-api/src/sparql_lang.rs`) maps them correctly — the JSON-LD parser just never produced one. This broke both clauses: a property variable in `where` matched nothing (its literal-IRI predicate exists on no triples), and one in `insert` derived facts under the bogus literal predicate.

## Changes

- `fluree-db-query/src/datalog_rules.rs`:
  - New `parse_predicate_term` helper: a `?`-prefixed node-map key parses as `RuleTerm::var`; anything else expands and resolves as an IRI. Used at all three pattern-construction sites in `parse_node_pattern`, so predicate variables now work in both `where` and `insert` clauses.
  - Dropped `parse_object_value`'s two already-unused parameters, which the change orphaned.
  - A predicate or subject variable that ends up bound to a non-Sid value (e.g. `?p` bound to a string via an object position, then reused as a predicate) now resolves to a new `TermResolution::Incompatible` variant and the pattern matches nothing for that binding row, instead of returning an error. Previously that error propagated out of rule execution and caused the reasoning layer to silently discard every datalog-derived fact for the query; a literal can never occupy subject/predicate position, so an empty join is the correct semantics. A literal constant in those positions (a malformed rule) still errors.
  - Removed the `?`-prefix branch in `expand_iri` that the parser change made unreachable (both remaining callers check for variables before calling it).

## Tests

- `datalog_rule_insert_property_variable_substituted` — the issue's verbatim shape: `?rel` bound to a predicate IRI via an object reference in `where`, used as the property in `insert`; the derived fact must appear under the resolved predicate.
- `datalog_rule_where_property_variable_binds_and_substitutes` — a copy-properties rule binding `?prop` in `where` and reusing it in `insert`.
- `datalog_rule_literal_bound_property_variable_does_not_abort_other_rules` — a rule whose predicate variable binds to a string must derive nothing itself while a sibling rule's derivations survive.
- A unit test pinning that a literal-bound subject/predicate variable resolves to `Incompatible` rather than an error.

Fixes #1531 