### PR TITLE
feat(BM25): embedded BM25 full-text search over the standard query path + a bm25 CLI

### DIFF
--- a/docs/graph-sources/bm25.md
+++ b/docs/graph-sources/bm25.md
@@ -271,10 +271,11 @@ A `vector_similar_to` variant takes a `to_iri` instead of an explicit vector —
 
 ### Where this fits in your architecture
 
-Two ways to use the search service today:
+Three ways to run BM25 search:
 
-1. **Direct client → search service.** Your application sends BM25 / vector requests straight to `fluree-search-httpd` and joins the resulting IRIs back to the main Fluree server's query API on the application side. This is the path that works end-to-end today and is appropriate when search traffic dominates and you want it isolated from your main Fluree process.
-2. **Main Fluree server → search service (transparent delegation).** The query path inside the main server has the plumbing to consult a per-graph-source `SearchDeploymentConfig` and forward to a remote endpoint. This wiring is **not yet exposed** end-to-end through the create APIs — `Bm25CreateConfig` has no deployment builder, and the deployment field is not persisted to the nameservice config record by today's create flow. Track this as a near-term gap; until then, query the search service directly.
+1. **Embedded, in the main Fluree server.** An `f:searchText` query against `POST /v1/fluree/query` is scored in-process against the local index — no search service required — and the hits can be joined with ledger data in the same query. This is the default and the simplest path (see [Embedded Mode](../indexing-and-search/bm25.md#embedded-mode-default)); use it when search runs on the same node that holds the index.
+2. **Direct client → search service.** Your application sends BM25 / vector requests straight to `fluree-search-httpd` and joins the resulting IRIs back to the main Fluree server's query API on the application side. Appropriate when search traffic dominates and you want it isolated from (or scaled independently of) your main Fluree process.
+3. **Main Fluree server → search service (transparent delegation).** The query path inside the main server has the plumbing to consult a per-graph-source `SearchDeploymentConfig` and forward to a *remote* endpoint. Embedded search over the query API (path 1) is wired; the *remote-delegation* half is **not yet exposed** end-to-end through the create APIs — `Bm25CreateConfig` has no deployment builder, and the deployment field is not persisted to the nameservice config record by today's create flow. Track this as a near-term gap; until then, for remote search query the service directly (path 2).
 
 ### Parity Guarantee
 

--- a/docs/indexing-and-search/bm25.md
+++ b/docs/indexing-and-search/bm25.md
@@ -110,6 +110,8 @@ The analyzer is not configurable — it always uses the English pipeline for con
 
 BM25 search is expressed with the `f:` namespace predicates in a query's `where` clause. It is a **JSON-LD (FQL) feature** and executes over the standard query endpoint — `POST /v1/fluree/query` — so search hits can be joined with ledger data in a single query. It is **not** available via SPARQL: the SPARQL parser does not recognize the `f:` search block, so those predicates would be matched as ordinary triples and return nothing.
 
+> **Policy-enforced search must be scoped to a single ledger.** A search whose `from` names more than one ledger conservatively returns **no hits** when any of those ledgers enforces a policy — not filtered hits. Per-flake readability cannot be resolved across a multi-graph scope, so the check hides everything rather than risk leaking. This is fail-closed and therefore safe, but silent: the same query returns rows with policies off and zero rows with them on, and no error explains the difference. Scope policy-enforced searches to one ledger.
+
 ### JSON-LD Query Syntax
 
 BM25 search is integrated into Fluree's query system via the `f:` namespace predicates:
@@ -326,7 +328,7 @@ The `fluree bm25` command group manages indexes without writing Rust. Each comma
 | `fluree bm25 create --name <n> --ledger <l> -f <index-query.json>` | Build a BM25 index over a source ledger from an indexing query |
 | `fluree bm25 list [--stale]` | List indexes with their source ledger, `INDEX_T`/`LEDGER_T`, and staleness. `--stale` prints `name:branch` per line for scripting |
 | `fluree bm25 sync --index <gs>` | Incrementally sync an index up to its source ledger's head (prints the watermark `old -> new` and upserted/removed counts) |
-| `fluree bm25 drop --index <gs>` | Retract the index and delete its snapshot blobs |
+| `fluree bm25 drop --index <gs> --force` | Retract the index and delete its snapshot blobs (`--force` required — drop is destructive) |
 
 A maintenance loop syncs every stale index:
 

--- a/docs/indexing-and-search/bm25.md
+++ b/docs/indexing-and-search/bm25.md
@@ -17,7 +17,7 @@ BM25 is a probabilistic ranking function that scores documents based on query te
 
 ## Creating a BM25 Index
 
-BM25 indexes are created via the Rust API using `Bm25CreateConfig`. There are no HTTP endpoints for index management yet — indexes are managed programmatically.
+BM25 indexes are managed via the Rust API (`Bm25CreateConfig`) or the `fluree bm25` CLI — there is no HTTP endpoint for index management. The CLI (`fluree bm25 create/list/sync/drop`) runs in-process against local storage, so it works under `docker exec` against a running server's data directory; see [CLI Management](#cli-management) below.
 
 ### Basic Index
 
@@ -107,6 +107,8 @@ Fluree uses a default English analyzer that applies:
 The analyzer is not configurable — it always uses the English pipeline for consistency.
 
 ## Querying BM25 Indexes
+
+BM25 search is expressed with the `f:` namespace predicates in a query's `where` clause. It is a **JSON-LD (FQL) feature** and executes over the standard query endpoint — `POST /v1/fluree/query` — so search hits can be joined with ledger data in a single query. It is **not** available via SPARQL: the SPARQL parser does not recognize the `f:` search block, so those predicates would be matched as ordinary triples and return nothing.
 
 ### JSON-LD Query Syntax
 
@@ -315,11 +317,28 @@ The storage format is selected automatically based on the storage backend:
 - **File storage**: V3 single-blob format (optimized for local filesystem)
 - **Memory / S3 / object store**: V4 chunked format (enables selective loading and caching)
 
+## CLI Management
+
+The `fluree bm25` command group manages indexes without writing Rust. Each command runs in-process against local storage (no server round-trip), so it works under `docker exec` against a running server's data directory (native storage uses per-file locks, so this is safe alongside a running server).
+
+| Command | Description |
+|---------|-------------|
+| `fluree bm25 create --name <n> --ledger <l> -f <index-query.json>` | Build a BM25 index over a source ledger from an indexing query |
+| `fluree bm25 list [--stale]` | List indexes with their source ledger, `INDEX_T`/`LEDGER_T`, and staleness. `--stale` prints `name:branch` per line for scripting |
+| `fluree bm25 sync --index <gs>` | Incrementally sync an index up to its source ledger's head (prints the watermark `old -> new` and upserted/removed counts) |
+| `fluree bm25 drop --index <gs>` | Retract the index and delete its snapshot blobs |
+
+A maintenance loop syncs every stale index:
+
+```bash
+for i in $(fluree bm25 list --stale); do fluree bm25 sync --index "$i"; done
+```
+
 ## Deployment Modes
 
 ### Embedded Mode (Default)
 
-In embedded mode, the BM25 index is loaded and searched within the same process as Fluree. This is the default behavior.
+In embedded mode, the BM25 index is loaded and searched within the same process as Fluree. This is the default behavior, and it is what serves an `f:searchText` query over the main server's `POST /v1/fluree/query` route — the query execution context wires a local index provider, so no separate search service is required.
 
 ### Remote Mode
 

--- a/fluree-db-api/src/graph_query_builder.rs
+++ b/fluree-db-api/src/graph_query_builder.rs
@@ -102,12 +102,6 @@ impl<'a, 'g> GraphQueryBuilder<'a, 'g> {
         self
     }
 
-    /// Enable BM25/Vector index providers for graph source queries.
-    pub fn with_index_providers(mut self) -> Self {
-        self.core.set_index_providers();
-        self
-    }
-
     /// Enable R2RML/Iceberg support (feature-gated).
     ///
     /// Attaches actual R2RML provider objects so that GRAPH patterns
@@ -427,12 +421,6 @@ impl<'a: 'v, 'v> GraphSnapshotQueryBuilder<'a, 'v> {
     /// Set query execution controls.
     pub fn execution_options(mut self, options: QueryExecutionOptions) -> Self {
         self.core.set_execution_options(options);
-        self
-    }
-
-    /// Enable BM25/Vector index providers for graph source queries.
-    pub fn with_index_providers(mut self) -> Self {
-        self.core.set_index_providers();
         self
     }
 

--- a/fluree-db-api/src/query/builder.rs
+++ b/fluree-db-api/src/query/builder.rs
@@ -37,8 +37,6 @@ pub enum GraphSourceMode {
     /// No graph source integration (default).
     #[default]
     None,
-    /// Enable BM25/Vector index providers.
-    IndexProviders,
     /// Enable R2RML/Iceberg support (feature-gated).
     #[cfg(feature = "iceberg")]
     R2rml,
@@ -124,10 +122,6 @@ impl<'a> QueryCore<'a> {
         self.execution = options;
     }
 
-    pub(crate) fn set_index_providers(&mut self) {
-        self.graph_sources = GraphSourceMode::IndexProviders;
-    }
-
     #[cfg(feature = "iceberg")]
     pub(crate) fn set_r2rml(&mut self) {
         self.graph_sources = GraphSourceMode::R2rml;
@@ -145,12 +139,6 @@ impl<'a> QueryCore<'a> {
 
         match self.graph_sources {
             GraphSourceMode::None => {}
-            GraphSourceMode::IndexProviders => {
-                errs.push(BuilderError::Invalid {
-                    field: "graph_sources",
-                    message: "Index provider mode (.with_index_providers()) is not yet supported by query builders; use fluree.query_connection_with_bm25() or fluree.query_dataset_with_bm25() instead".into(),
-                });
-            }
             #[cfg(feature = "iceberg")]
             GraphSourceMode::R2rml => {
                 if self.r2rml.is_none() {
@@ -247,12 +235,6 @@ impl<'a> ViewQueryBuilder<'a> {
     /// Set query execution controls.
     pub fn execution_options(mut self, options: QueryExecutionOptions) -> Self {
         self.core.set_execution_options(options);
-        self
-    }
-
-    /// Enable BM25/Vector index providers for graph source queries.
-    pub fn with_index_providers(mut self) -> Self {
-        self.core.set_index_providers();
         self
     }
 
@@ -533,12 +515,6 @@ impl<'a> DatasetQueryBuilder<'a> {
     /// Set query execution controls.
     pub fn execution_options(mut self, options: QueryExecutionOptions) -> Self {
         self.core.set_execution_options(options);
-        self
-    }
-
-    /// Enable BM25/Vector index providers.
-    pub fn with_index_providers(mut self) -> Self {
-        self.core.set_index_providers();
         self
     }
 
@@ -881,12 +857,6 @@ impl<'a> FromQueryBuilder<'a> {
     /// Set query execution controls.
     pub fn execution_options(mut self, options: QueryExecutionOptions) -> Self {
         self.core.set_execution_options(options);
-        self
-    }
-
-    /// Enable BM25/Vector index providers.
-    pub fn with_index_providers(mut self) -> Self {
-        self.core.set_index_providers();
         self
     }
 

--- a/fluree-db-api/src/view/dataset_query.rs
+++ b/fluree-db-api/src/view/dataset_query.rs
@@ -678,6 +678,13 @@ impl Fluree {
                 (None, None, None, None, None)
             };
 
+        // Wire the BM25 index provider so embedded `f:searchText` graph-source
+        // queries execute in-process (parity with `query_dataset_with_bm25`).
+        // It is a zero-cost `&Fluree` wrapper and is only consulted by the
+        // `IndexSearch` operator, so non-search queries are unaffected. Declared
+        // before `config` so it outlives the borrow held by the context.
+        let index_provider = crate::FlureeIndexProvider::new(self);
+
         let config = ContextConfig {
             tracker: if tracker.is_enabled() {
                 Some(tracker)
@@ -688,6 +695,7 @@ impl Fluree {
             dataset: Some(&runtime_dataset),
             policy_enforcer: primary.policy_enforcer().cloned(),
             r2rml: Some((r2rml.provider, r2rml.table_provider)),
+            bm25_provider: Some(&index_provider),
             binary_g_id: primary.graph_id,
             binary_store,
             dict_novelty,
@@ -818,12 +826,19 @@ impl Fluree {
                 (None, None, None, None, None)
             };
 
+        // Wire the BM25 index provider so embedded `f:searchText` graph-source
+        // queries execute in-process (parity with `query_dataset_with_bm25`).
+        // Zero-cost `&Fluree` wrapper, only consulted by the `IndexSearch`
+        // operator; declared before `config` so it outlives the context borrow.
+        let index_provider = crate::FlureeIndexProvider::new(self);
+
         let config = ContextConfig {
             tracker: Some(tracker),
             cancellation: options.cancellation.clone(),
             dataset: Some(&runtime_dataset),
             policy_enforcer: primary.policy_enforcer().cloned(),
             r2rml: Some((r2rml.provider, r2rml.table_provider)),
+            bm25_provider: Some(&index_provider),
             binary_g_id: primary.graph_id,
             binary_store,
             dict_novelty,

--- a/fluree-db-api/src/view/dataset_query.rs
+++ b/fluree-db-api/src/view/dataset_query.rs
@@ -679,10 +679,17 @@ impl Fluree {
             };
 
         // Wire the BM25 index provider so embedded `f:searchText` graph-source
-        // queries execute in-process (parity with `query_dataset_with_bm25`).
+        // queries execute in-process over the standard query route.
         // It is a zero-cost `&Fluree` wrapper and is only consulted by the
         // `IndexSearch` operator, so non-search queries are unaffected. Declared
         // before `config` so it outlives the borrow held by the context.
+        //
+        // `bm25_provider` (the "legacy" index-provider slot), NOT the
+        // "preferred" `bm25_search_provider` that `ContextConfig` steers you
+        // toward: view-policy enforcement on a hit only works in index-provider
+        // mode. Search-provider mode has no local flakes and fails closed
+        // (`operator.rs`), so it would return zero rows for every
+        // policy-enforced query. Do not "upgrade" this.
         let index_provider = crate::FlureeIndexProvider::new(self);
 
         let config = ContextConfig {
@@ -827,9 +834,16 @@ impl Fluree {
             };
 
         // Wire the BM25 index provider so embedded `f:searchText` graph-source
-        // queries execute in-process (parity with `query_dataset_with_bm25`).
+        // queries execute in-process over the standard query route.
         // Zero-cost `&Fluree` wrapper, only consulted by the `IndexSearch`
         // operator; declared before `config` so it outlives the context borrow.
+        //
+        // `bm25_provider` (the "legacy" index-provider slot), NOT the
+        // "preferred" `bm25_search_provider` that `ContextConfig` steers you
+        // toward: view-policy enforcement on a hit only works in index-provider
+        // mode. Search-provider mode has no local flakes and fails closed
+        // (`operator.rs`), so it would return zero rows for every
+        // policy-enforced query. Do not "upgrade" this.
         let index_provider = crate::FlureeIndexProvider::new(self);
 
         let config = ContextConfig {

--- a/fluree-db-api/src/view/mod.rs
+++ b/fluree-db-api/src/view/mod.rs
@@ -93,11 +93,17 @@ macro_rules! view_context_config {
             None
         };
         // Wire the BM25 index provider so embedded `f:searchText` graph-source
-        // queries execute in-process on the single-graph view path too (parity
-        // with `query_dataset_with_bm25` and the dataset path). Zero-cost
-        // `&Fluree` wrapper, only consulted by the `IndexSearch` operator, so
-        // non-search queries are unaffected. Declared before `$cfg` so it
-        // outlives the borrow the context holds.
+        // queries execute in-process on the single-graph view path too.
+        // Zero-cost `&Fluree` wrapper, only consulted by the `IndexSearch`
+        // operator, so non-search queries are unaffected. Declared before `$cfg`
+        // so it outlives the borrow the context holds.
+        //
+        // `bm25_provider` (the "legacy" index-provider slot), NOT the
+        // "preferred" `bm25_search_provider` that `ContextConfig` steers you
+        // toward: view-policy enforcement on a hit only works in index-provider
+        // mode. Search-provider mode has no local flakes and fails closed
+        // (`operator.rs`), so it would return zero rows for every
+        // policy-enforced query. Do not "upgrade" this.
         let __index_provider = $crate::FlureeIndexProvider::new($self);
         let $cfg = ContextConfig {
             tracker: Some($tracker),

--- a/fluree-db-api/src/view/mod.rs
+++ b/fluree-db-api/src/view/mod.rs
@@ -92,11 +92,19 @@ macro_rules! view_context_config {
         } else {
             None
         };
+        // Wire the BM25 index provider so embedded `f:searchText` graph-source
+        // queries execute in-process on the single-graph view path too (parity
+        // with `query_dataset_with_bm25` and the dataset path). Zero-cost
+        // `&Fluree` wrapper, only consulted by the `IndexSearch` operator, so
+        // non-search queries are unaffected. Declared before `$cfg` so it
+        // outlives the borrow the context holds.
+        let __index_provider = $crate::FlureeIndexProvider::new($self);
         let $cfg = ContextConfig {
             tracker: Some($tracker),
             cancellation: $options.cancellation.clone(),
             policy_enforcer: __db.policy_enforcer().cloned(),
             r2rml: $r2rml,
+            bm25_provider: Some(&__index_provider),
             binary_store: __db.binary_store.clone(),
             binary_g_id: __db.graph_id,
             dict_novelty: __db.dict_novelty.clone(),

--- a/fluree-db-api/tests/it_graph_source_bm25.rs
+++ b/fluree-db-api/tests/it_graph_source_bm25.rs
@@ -728,6 +728,74 @@ async fn bm25_query_connection_with_idx_pattern() {
     );
 }
 
+/// Regression: embedded `f:searchText` must resolve through the STANDARD query
+/// path (`query_connection`), not only the dedicated `query_connection_with_bm25`.
+///
+/// This is exactly what the HTTP `POST /v1/fluree/query` route executes (via
+/// `query_from()`). Before the dataset/view execution context wired a
+/// `FlureeIndexProvider` as `bm25_provider`, this returned
+/// `InvalidQuery("BM25 IndexSearch requires ExecutionContext.bm25_search_provider
+/// or bm25_provider (not configured)")`. It must now succeed.
+#[tokio::test]
+async fn bm25_embedded_search_via_plain_query_connection() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let ledger_id = "bm25/plain-qc:main";
+    let ledger0 = support::genesis_ledger(&fluree, ledger_id);
+    let tx = json!({
+        "@context": { "ex":"http://example.org/" },
+        "@graph": [
+            { "@id":"ex:doc1", "@type":"ex:Doc", "ex:title":"Rust programming guide", "ex:author":"Alice" },
+            { "@id":"ex:doc2", "@type":"ex:Doc", "ex:title":"Rust and WebAssembly", "ex:author":"Bob" },
+            { "@id":"ex:doc3", "@type":"ex:Doc", "ex:title":"Python for beginners", "ex:author":"Charlie" }
+        ]
+    });
+    let _ledger = fluree.insert(ledger0, &tx).await.expect("insert failed");
+
+    let index_query = json!({
+        "@context": { "ex":"http://example.org/" },
+        "where": [{ "@id":"?x", "@type":"ex:Doc", "ex:title":"?title" }],
+        "select": { "?x": ["@id", "ex:title"] }
+    });
+    let cfg = Bm25CreateConfig::new("plain-qc-search", ledger_id, index_query);
+    let created = fluree
+        .create_full_text_index(cfg)
+        .await
+        .expect("create index failed");
+
+    let idx_query = json!({
+        "@context": { "ex":"http://example.org/", "f": "https://ns.flur.ee/db#" },
+        "from": ledger_id,
+        "where": [
+            {
+                "f:graphSource": &created.graph_source_id,
+                "f:searchText": "rust",
+                "f:searchLimit": 10,
+                "f:searchResult": {"f:resultId": "?doc", "f:resultScore": "?score"}
+            },
+            { "@id": "?doc", "ex:author": "?author" }
+        ],
+        "select": ["?doc", "?score", "?author"]
+    });
+
+    // The PLAIN connection path — NOT `_with_bm25`. This mirrors the HTTP query
+    // route; it must now serve the embedded BM25 search rather than error.
+    let result = fluree
+        .query_connection(&idx_query)
+        .await
+        .expect("plain query_connection must serve f:searchText (bm25 provider wired into the query context)");
+
+    let total: usize = result.batches.iter().map(fluree_db_api::Batch::len).sum();
+    assert!(
+        total >= 2,
+        "expected >=2 rust docs via plain query_connection, got {total}"
+    );
+    assert!(
+        result.vars.get("?score").is_some(),
+        "expected ?score binding from the embedded BM25 search"
+    );
+}
+
 /// Test BM25 federated query with aggregation: search + join + groupBy/count
 ///
 /// Scenario: federated BM25 aggregation scenarios.

--- a/fluree-db-api/tests/it_graph_source_bm25.rs
+++ b/fluree-db-api/tests/it_graph_source_bm25.rs
@@ -990,3 +990,287 @@ async fn bm25_search_enforces_view_policy_on_indexed_flake() {
         "doc2 (hidden title) must not leak through inline BM25 search; got: {jsonld:#?}"
     );
 }
+
+/// Regression: embedded `f:searchText` must also resolve through the **dataset**
+/// execution path (`execute_dataset_*`), not only the single-graph view path.
+///
+/// A multi-ledger `from` is what routes a query to the dataset path; the plain
+/// single-graph test above exercises the `view/mod.rs` macro site instead. The
+/// two dataset sites are the bulk of this change and are what
+/// `POST /v1/fluree/query` takes for a multi-ledger query, so they need their own
+/// guard: the fix is a struct-field initializer, the easiest thing for a future
+/// refactor of `dataset_query.rs` to drop while CI stays green. Reverting either
+/// site to `bm25_provider: None` must turn this red.
+#[tokio::test]
+async fn bm25_embedded_search_via_dataset_path() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    // Two ledgers so `from` is a dataset, forcing the dataset execution path.
+    let l1 = "bm25/dataset-a:main";
+    let l2 = "bm25/dataset-b:main";
+    let a0 = support::genesis_ledger(&fluree, l1);
+    let _ = fluree
+        .insert(
+            a0,
+            &json!({
+                "@context": { "ex":"http://example.org/" },
+                "@graph": [
+                    { "@id":"ex:doc1", "@type":"ex:Doc", "ex:title":"Rust programming guide" },
+                    { "@id":"ex:doc2", "@type":"ex:Doc", "ex:title":"Rust and WebAssembly" },
+                    { "@id":"ex:doc3", "@type":"ex:Doc", "ex:title":"Python for beginners" }
+                ]
+            }),
+        )
+        .await
+        .expect("insert a");
+
+    let b0 = support::genesis_ledger(&fluree, l2);
+    let _ = fluree
+        .insert(
+            b0,
+            &json!({
+                "@context": { "ex":"http://example.org/" },
+                "@graph": [{ "@id":"ex:other1", "@type":"ex:Note", "ex:title":"Unrelated note" }]
+            }),
+        )
+        .await
+        .expect("insert b");
+
+    let index_query = json!({
+        "@context": { "ex":"http://example.org/" },
+        "where": [{ "@id":"?x", "@type":"ex:Doc", "ex:title":"?title" }],
+        "select": { "?x": ["@id", "ex:title"] }
+    });
+    let created = fluree
+        .create_full_text_index(Bm25CreateConfig::new("dataset-search", l1, index_query))
+        .await
+        .expect("create index");
+
+    let idx_query = json!({
+        "@context": { "ex":"http://example.org/", "f": "https://ns.flur.ee/db#" },
+        "from": [l1, l2],
+        "where": [{
+            "f:graphSource": &created.graph_source_id,
+            "f:searchText": "rust",
+            "f:searchLimit": 10,
+            "f:searchResult": {"f:resultId": "?doc", "f:resultScore": "?score"}
+        }],
+        "select": ["?doc", "?score"]
+    });
+
+    let result = fluree.query_connection(&idx_query).await.expect(
+        "DATASET path must serve f:searchText (bm25 provider wired into the dataset context)",
+    );
+
+    let total: usize = result.batches.iter().map(fluree_db_api::Batch::len).sum();
+    assert_eq!(
+        total, 2,
+        "expected both rust docs via the dataset path, got {total}"
+    );
+    assert!(
+        result.vars.get("?score").is_some(),
+        "expected ?score binding from the embedded BM25 search"
+    );
+}
+
+/// A view policy must still hide unreadable hits on the path this PR opens.
+///
+/// The suite's other policy test drives `query_connection_with_bm25`, which was
+/// reachable before this change. This drives the plain `query_connection` — the
+/// standard, policy-enforced route the HTTP endpoint uses — because that is the
+/// surface being widened, and the failure mode of a gap here is returning
+/// documents a policy says the caller cannot read.
+#[tokio::test]
+async fn bm25_embedded_search_enforces_policy_via_plain_query_connection() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let ledger_id = "bm25/plain-policy:main";
+    let ledger0 = support::genesis_ledger(&fluree, ledger_id);
+    let _ = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": { "ex": "http://example.org/" },
+                "@graph": [
+                    { "@id": "ex:doc1", "@type": "ex:Doc", "ex:title": "Rust programming guide", "ex:author": "Alice" },
+                    { "@id": "ex:doc2", "@type": "ex:Doc", "ex:title": "Rust and WebAssembly", "ex:author": "Bob" }
+                ]
+            }),
+        )
+        .await
+        .expect("insert");
+
+    let index_query = json!({
+        "@context": { "ex": "http://example.org/" },
+        "where": [{ "@id": "?x", "@type": "ex:Doc", "ex:title": "?title" }],
+        "select": { "?x": ["@id", "ex:title"] }
+    });
+    let created = fluree
+        .create_full_text_index(Bm25CreateConfig::new(
+            "plain-policy-search",
+            ledger_id,
+            index_query,
+        ))
+        .await
+        .expect("create index");
+
+    // Bare search, no constraining BGP — the shape that leaked in the C3 regression.
+    let search_where = json!([{
+        "f:graphSource": &created.graph_source_id,
+        "f:searchText": "rust",
+        "f:searchLimit": 10,
+        "f:searchResult": { "f:resultId": "?doc" }
+    }]);
+
+    // Control: no policy, over the plain route => both rust docs match.
+    let control_res = fluree
+        .query_connection(&json!({
+            "@context": { "ex": "http://example.org/", "f": "https://ns.flur.ee/db#" },
+            "from": ledger_id,
+            "where": search_where.clone(),
+            "select": ["?doc"]
+        }))
+        .await
+        .expect("control query");
+    let control_total: usize = control_res
+        .batches
+        .iter()
+        .map(fluree_db_api::Batch::len)
+        .sum();
+    assert_eq!(control_total, 2, "control: both rust docs should match");
+
+    // ex:title is viewable only on Alice-authored docs, so doc2's indexed text
+    // is unreadable and its hit must be dropped.
+    let policy = json!([{
+        "@id": "ex:titlePolicy",
+        "@type": "f:AccessPolicy",
+        "f:action": "f:view",
+        "f:onProperty": [{ "@id": "http://example.org/title" }],
+        "f:query": {
+            "@type": "@json",
+            "@value": {
+                "@context": { "ex": "http://example.org/" },
+                "where": [{ "@id": "?$this", "ex:author": "Alice" }]
+            }
+        }
+    }]);
+    let result = fluree
+        .query_connection(&json!({
+            "@context": { "ex": "http://example.org/", "f": "https://ns.flur.ee/db#" },
+            "from": ledger_id,
+            "opts": { "policy": policy, "default-allow": false },
+            "where": search_where,
+            "select": ["?doc"]
+        }))
+        .await
+        .expect("policy query");
+
+    let ledger = fluree.ledger(ledger_id).await.expect("ledger");
+    let rendered = result
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld")
+        .to_string();
+
+    assert!(
+        !rendered.contains("doc2"),
+        "doc2 (hidden title) must not leak through embedded BM25 search on the \
+         standard query route; got: {rendered}"
+    );
+    assert!(
+        rendered.contains("doc1"),
+        "doc1 (viewable title) must remain; got: {rendered}"
+    );
+}
+
+/// Regression: the **tracked** dataset site must be wired too.
+///
+/// There are two dataset wiring sites and a multi-ledger `from` alone does not
+/// reach both — which builder method you call decides it:
+///
+/// - `query_connection` / `query_from().execute_formatted()` land in
+///   `execute_dataset_internal_with_r2rml` → `execute_dataset_into_with_r2rml`;
+/// - `query_from().execute_tracked()` lands in `execute_dataset_tracked` →
+///   `execute_dataset_tracked_with_r2rml`.
+///
+/// Per-site mutation proves the split: reverting only the tracked site leaves
+/// the plain dataset test above green, and reverting only the other leaves this
+/// one green. Each site needs its own test.
+#[tokio::test]
+async fn bm25_embedded_search_via_tracked_dataset_path() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let l1 = "bm25/tracked-a:main";
+    let l2 = "bm25/tracked-b:main";
+    let a0 = support::genesis_ledger(&fluree, l1);
+    let _ = fluree
+        .insert(
+            a0,
+            &json!({
+                "@context": { "ex":"http://example.org/" },
+                "@graph": [
+                    { "@id":"ex:doc1", "@type":"ex:Doc", "ex:title":"Rust programming guide" },
+                    { "@id":"ex:doc2", "@type":"ex:Doc", "ex:title":"Rust and WebAssembly" },
+                    { "@id":"ex:doc3", "@type":"ex:Doc", "ex:title":"Python for beginners" }
+                ]
+            }),
+        )
+        .await
+        .expect("insert a");
+
+    let b0 = support::genesis_ledger(&fluree, l2);
+    let _ = fluree
+        .insert(
+            b0,
+            &json!({
+                "@context": { "ex":"http://example.org/" },
+                "@graph": [{ "@id":"ex:other1", "@type":"ex:Note", "ex:title":"Unrelated note" }]
+            }),
+        )
+        .await
+        .expect("insert b");
+
+    let index_query = json!({
+        "@context": { "ex":"http://example.org/" },
+        "where": [{ "@id":"?x", "@type":"ex:Doc", "ex:title":"?title" }],
+        "select": { "?x": ["@id", "ex:title"] }
+    });
+    let created = fluree
+        .create_full_text_index(Bm25CreateConfig::new(
+            "tracked-dataset-search",
+            l1,
+            index_query,
+        ))
+        .await
+        .expect("create index");
+
+    let idx_query = json!({
+        "@context": { "ex":"http://example.org/", "f": "https://ns.flur.ee/db#" },
+        "from": [l1, l2],
+        "where": [{
+            "f:graphSource": &created.graph_source_id,
+            "f:searchText": "rust",
+            "f:searchLimit": 10,
+            "f:searchResult": {"f:resultId": "?doc", "f:resultScore": "?score"}
+        }],
+        "select": ["?doc", "?score"]
+    });
+
+    // `execute_tracked()` — NOT `execute_formatted()`, which routes to
+    // `execute_dataset_internal_with_r2rml` and lands on the *other* dataset
+    // site. Only the tracked builder path reaches
+    // `execute_dataset_tracked_with_r2rml`.
+    let result = fluree
+        .query_from()
+        .jsonld(&idx_query)
+        .execute_tracked()
+        .await
+        .expect("TRACKED dataset path must serve f:searchText");
+
+    let rendered = serde_json::to_value(&result.result)
+        .expect("serialize tracked result")
+        .to_string();
+    assert!(
+        rendered.contains("doc1") && rendered.contains("doc2"),
+        "expected both rust docs via the tracked dataset path; got: {rendered}"
+    );
+}

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -400,6 +400,26 @@ pub enum Commands {
         action: GraphAction,
     },
 
+    /// Create, list, sync, or drop BM25 full-text search indexes (graph sources).
+    ///
+    /// BM25 index creation has no HTTP endpoint today — it is a Rust-API-only
+    /// operation (`Bm25CreateConfig` + `create_full_text_index`). These commands
+    /// expose it: they run in-process against local storage (no server
+    /// round-trip), so they work under `docker exec` against a running server's
+    /// data directory. Querying the resulting index is done either through the
+    /// standalone `fluree-search-httpd` service (`POST /v1/search`) or, embedded,
+    /// via an FQL `f:searchText` query.
+    ///
+    /// Examples:
+    ///   fluree bm25 create --name silver-search --ledger silver:main -f index-query.json
+    ///   fluree bm25 list --stale
+    ///   fluree bm25 sync --index silver-search:main
+    ///   fluree bm25 drop --index silver-search:main
+    Bm25 {
+        #[command(subcommand)]
+        action: Bm25Action,
+    },
+
     /// Insert data into a ledger
     ///
     /// Examples:
@@ -1122,6 +1142,84 @@ pub enum Commands {
     Iceberg {
         #[command(subcommand)]
         action: IcebergAction,
+    },
+}
+
+/// BM25 full-text index subcommands.
+#[derive(Subcommand)]
+pub enum Bm25Action {
+    /// Create a BM25 full-text search index over a ledger.
+    ///
+    /// The indexing query (FQL / JSON-LD) selects the documents and the text
+    /// properties to index; it MUST select `@id`. Example indexing query:
+    ///   {"@context":{"as":"https://www.w3.org/ns/activitystreams#"},
+    ///    "where":{"@id":"?s"},
+    ///    "select":{"?s":["@id","as:content","as:name","as:summary"]}}
+    Create {
+        /// Graph-source name for the index (no ':'). The alias is
+        /// `<name>:<branch>` (e.g. `silver-search:main`).
+        #[arg(long)]
+        name: String,
+
+        /// Source ledger alias to index (e.g. "silver:main").
+        #[arg(long)]
+        ledger: String,
+
+        /// Branch for the index graph source (default "main").
+        #[arg(long, default_value = "main")]
+        branch: String,
+
+        /// Inline indexing query (FQL / JSON-LD).
+        #[arg(short = 'e', long = "query")]
+        query: Option<String>,
+
+        /// Read the indexing query from a file (`-` for stdin).
+        #[arg(short = 'f', long = "query-file")]
+        query_file: Option<PathBuf>,
+
+        /// BM25 k1 (term-frequency saturation). Default 1.2.
+        #[arg(long)]
+        k1: Option<f64>,
+
+        /// BM25 b (document-length normalization, 0..=1). Default 0.75.
+        #[arg(long)]
+        b: Option<f64>,
+    },
+
+    /// Drop (retract) a BM25 full-text index and delete its snapshots.
+    Drop {
+        /// Index graph-source alias to drop (e.g. "silver-search:main").
+        #[arg(long)]
+        index: String,
+    },
+
+    /// Sync a BM25 full-text index up to its source ledger's latest state.
+    ///
+    /// Incremental when possible — only re-indexes the subjects changed since
+    /// the index's stored watermark — falling back to a full rebuild if needed.
+    /// A no-op when the index is already current. Run this from a maintenance
+    /// job (once per index) to keep search fresh as the source ledger is
+    /// materialized/updated; it runs in-process against local storage, so it
+    /// works under `docker exec` against a running server's data directory
+    /// (same as `create`/`drop`).
+    Sync {
+        /// Index graph-source alias to sync (e.g. "silver-search:main").
+        #[arg(long)]
+        index: String,
+    },
+
+    /// List BM25 full-text indexes with their source ledger and staleness.
+    ///
+    /// For each index: its alias, the source ledger it covers, the index
+    /// watermark (`index_t`), the source ledger's current `t`, and whether the
+    /// index is STALE (source advanced past the index). This is what a
+    /// maintenance job enumerates to decide which indexes to `sync` — unlike
+    /// `fluree list`, it shows the source ledger and staleness. With `--stale`,
+    /// print only stale indexes (one alias per line, for scripting a sync loop).
+    List {
+        /// Print only stale indexes, one alias per line (script-friendly).
+        #[arg(long)]
+        stale: bool,
     },
 }
 

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -1173,7 +1173,7 @@ pub enum Bm25Action {
         #[arg(short = 'e', long = "query")]
         query: Option<String>,
 
-        /// Read the indexing query from a file (`-` for stdin).
+        /// Read the indexing query from a file (or pipe it via stdin).
         #[arg(short = 'f', long = "query-file")]
         query_file: Option<PathBuf>,
 
@@ -1191,6 +1191,10 @@ pub enum Bm25Action {
         /// Index graph-source alias to drop (e.g. "silver-search:main").
         #[arg(long)]
         index: String,
+
+        /// Required flag to confirm deletion
+        #[arg(long)]
+        force: bool,
     },
 
     /// Sync a BM25 full-text index up to its source ledger's latest state.

--- a/fluree-db-cli/src/commands/bm25.rs
+++ b/fluree-db-cli/src/commands/bm25.rs
@@ -1,0 +1,253 @@
+//! BM25 full-text search index commands.
+//!
+//! BM25 is a Fluree *graph source* (like Iceberg/R2RML). Index **creation** and
+//! **sync** have no HTTP route or other shipped entrypoint today — they are
+//! Rust-API-only operations (`create_full_text_index` / `sync_bm25_index`).
+//! These commands expose that API so an index can be built and kept fresh
+//! reproducibly, running **in-process** against local storage via
+//! [`build_fluree`]. Native file storage coordinates writers with a per-file
+//! advisory flock (not an exclusive whole-store lock), so `create`/`drop`/`sync`
+//! work under `docker exec` against a directory a server is already serving:
+//! each writes new content-addressed snapshots plus/against a graph-source
+//! nameservice record (no key the server writes). `sync` is incremental
+//! (watermark-based) and lets a maintenance job keep an index current as its
+//! source ledger is materialized — there is no HTTP `sync`, and the standalone
+//! `fluree-search-httpd` is read-only, so this CLI is the way to advance an
+//! index. Querying the resulting index is done separately — through
+//! `fluree-search-httpd` (`POST /v1/search`, reading the same storage), or
+//! embedded via an FQL `f:searchText` query.
+
+use crate::cli::Bm25Action;
+use crate::context::build_fluree;
+use crate::error::{CliError, CliResult};
+use crate::input;
+use colored::Colorize;
+use fluree_db_api::server_defaults::FlureeDir;
+use fluree_db_api::Bm25CreateConfig;
+use std::path::Path;
+
+pub async fn run(action: Bm25Action, dirs: &FlureeDir) -> CliResult<()> {
+    match action {
+        Bm25Action::Create {
+            name,
+            ledger,
+            branch,
+            query,
+            query_file,
+            k1,
+            b,
+        } => {
+            run_create(
+                &name,
+                &ledger,
+                &branch,
+                query.as_deref(),
+                query_file.as_deref(),
+                k1,
+                b,
+                dirs,
+            )
+            .await
+        }
+        Bm25Action::Drop { index } => run_drop(&index, dirs).await,
+        Bm25Action::Sync { index } => run_sync(&index, dirs).await,
+        Bm25Action::List { stale } => run_list(stale, dirs).await,
+    }
+}
+
+/// List BM25 indexes with their source ledger and staleness — what a maintenance
+/// job enumerates to decide which to `sync`. An index is STALE when its source
+/// ledger's commit `t` has advanced past the index's watermark (`index_t`).
+async fn run_list(stale_only: bool, dirs: &FlureeDir) -> CliResult<()> {
+    use comfy_table::{ContentArrangement, Table};
+    use std::collections::HashMap;
+
+    let fluree = build_fluree(dirs)?;
+    let ledgers = fluree.nameservice().all_records().await?;
+    let sources = fluree.nameservice().all_graph_source_records().await?;
+
+    // Source-ledger alias -> current commit t (skip retracted).
+    let commit_t: HashMap<String, i64> = ledgers
+        .iter()
+        .filter(|r| !r.retracted)
+        .map(|r| (format!("{}:{}", r.name, r.branch), r.commit_t))
+        .collect();
+
+    // (name, branch, source ledger, index_t, source commit_t?, stale)
+    let mut rows: Vec<(String, String, String, i64, Option<i64>, bool)> = sources
+        .iter()
+        .filter(|r| r.is_bm25() && !r.retracted)
+        .map(|gs| {
+            let source = gs.dependencies.first().cloned().unwrap_or_default();
+            // A stored dependency alias may omit the branch (a bare `name` means
+            // `name:main` to Fluree), while ledger records are keyed `name:branch`
+            // — so try the alias as-is, then with an implicit `:main`.
+            let ledger_t = commit_t
+                .get(&source)
+                .or_else(|| commit_t.get(&format!("{source}:main")))
+                .copied();
+            let stale = ledger_t.is_some_and(|lt| gs.index_t < lt);
+            (
+                gs.name.clone(),
+                gs.branch.clone(),
+                source,
+                gs.index_t,
+                ledger_t,
+                stale,
+            )
+        })
+        .collect();
+    rows.sort();
+
+    // Script-friendly mode: just the stale indexes, one alias per line, so a
+    // maintenance loop can do: `for i in $(fluree bm25 list --stale); do
+    // fluree bm25 sync --index "$i"; done`.
+    if stale_only {
+        for (name, branch, ..) in rows.iter().filter(|r| r.5) {
+            println!("{name}:{branch}");
+        }
+        return Ok(());
+    }
+
+    if rows.is_empty() {
+        println!("No BM25 full-text indexes found. Run 'fluree bm25 create ...' to add one.");
+        return Ok(());
+    }
+
+    // Same look and feel as `fluree list` (comfy_table, dynamic arrangement).
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec![
+        "NAME",
+        "BRANCH",
+        "SOURCE LEDGER",
+        "INDEX_T",
+        "LEDGER_T",
+        "STALE",
+    ]);
+    for (name, branch, source, index_t, ledger_t, stale) in &rows {
+        let index_t_str = if *index_t > 0 {
+            index_t.to_string()
+        } else {
+            "-".to_string()
+        };
+        let ledger_t_str = ledger_t.map_or_else(|| "-".to_string(), |v| v.to_string());
+        table.add_row(vec![
+            name.clone(),
+            branch.clone(),
+            source.clone(),
+            index_t_str,
+            ledger_t_str,
+            if *stale { "YES" } else { "no" }.to_string(),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_create(
+    name: &str,
+    ledger: &str,
+    branch: &str,
+    query_inline: Option<&str>,
+    query_file: Option<&Path>,
+    k1: Option<f64>,
+    b: Option<f64>,
+    dirs: &FlureeDir,
+) -> CliResult<()> {
+    // Resolve the indexing query: -e inline > -f file > stdin.
+    let source = input::resolve_input(query_inline, None, query_file, None)?;
+    let content = input::read_input(&source)?;
+    let query: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| CliError::Input(format!("indexing query must be valid JSON: {e}")))?;
+
+    let mut config = Bm25CreateConfig::new(name, ledger, query).with_branch(branch);
+    if let Some(k1) = k1 {
+        config = config.with_k1(k1);
+    }
+    if let Some(b) = b {
+        config = config.with_b(b);
+    }
+    config.validate().map_err(CliError::Api)?;
+
+    eprintln!(
+        "  {} indexing {} -> {}:{}...",
+        "bm25:".cyan().bold(),
+        ledger,
+        name,
+        branch
+    );
+
+    let fluree = build_fluree(dirs)?;
+    let result = fluree
+        .create_full_text_index(config)
+        .await
+        .map_err(CliError::Api)?;
+
+    println!(
+        "Created full-text index {} (docs={}, terms={}, index_t={}).",
+        result.graph_source_id, result.doc_count, result.term_count, result.index_t
+    );
+    Ok(())
+}
+
+async fn run_sync(index: &str, dirs: &FlureeDir) -> CliResult<()> {
+    eprintln!("  {} syncing {}...", "bm25:".cyan().bold(), index);
+
+    let fluree = build_fluree(dirs)?;
+    let result = fluree.sync_bm25_index(index).await.map_err(CliError::Api)?;
+
+    if result.old_watermark == result.new_watermark && result.upserted == 0 && result.removed == 0 {
+        println!(
+            "Full-text index {} already up to date (watermark {}).",
+            result.graph_source_id, result.new_watermark
+        );
+    } else {
+        println!(
+            "Synced full-text index {} ({} upserted, {} removed, {} subject{}; \
+             watermark {} -> {}{}).",
+            result.graph_source_id,
+            result.upserted,
+            result.removed,
+            result.affected_subjects,
+            if result.affected_subjects == 1 {
+                ""
+            } else {
+                "s"
+            },
+            result.old_watermark,
+            result.new_watermark,
+            if result.was_full_resync {
+                ", full resync"
+            } else {
+                ""
+            }
+        );
+    }
+    Ok(())
+}
+
+async fn run_drop(index: &str, dirs: &FlureeDir) -> CliResult<()> {
+    let fluree = build_fluree(dirs)?;
+    let result = fluree
+        .drop_full_text_index(index)
+        .await
+        .map_err(CliError::Api)?;
+
+    if result.was_already_retracted {
+        println!("Full-text index {index} was already retracted.");
+    } else {
+        println!(
+            "Dropped full-text index {} (deleted {} snapshot{}).",
+            result.graph_source_id,
+            result.deleted_snapshots,
+            if result.deleted_snapshots == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
+    }
+    Ok(())
+}

--- a/fluree-db-cli/src/commands/bm25.rs
+++ b/fluree-db-cli/src/commands/bm25.rs
@@ -49,7 +49,7 @@ pub async fn run(action: Bm25Action, dirs: &FlureeDir) -> CliResult<()> {
             )
             .await
         }
-        Bm25Action::Drop { index } => run_drop(&index, dirs).await,
+        Bm25Action::Drop { index, force } => run_drop(&index, force, dirs).await,
         Bm25Action::Sync { index } => run_sync(&index, dirs).await,
         Bm25Action::List { stale } => run_list(stale, dirs).await,
     }
@@ -228,7 +228,18 @@ async fn run_sync(index: &str, dirs: &FlureeDir) -> CliResult<()> {
     Ok(())
 }
 
-async fn run_drop(index: &str, dirs: &FlureeDir) -> CliResult<()> {
+/// Drop is destructive — it retracts the nameservice record *and* deletes the
+/// snapshot blobs — so it gates behind `--force` like every other destructive
+/// command here (`fluree drop` for a ledger, `fluree iceberg drop` for the
+/// adjacent graph-source family). Rebuilding an index over a large corpus is
+/// expensive enough that the confirmation earns its keep.
+async fn run_drop(index: &str, force: bool, dirs: &FlureeDir) -> CliResult<()> {
+    if !force {
+        return Err(CliError::Usage(format!(
+            "use --force to confirm deletion of '{index}'"
+        )));
+    }
+
     let fluree = build_fluree(dirs)?;
     let result = fluree
         .drop_full_text_index(index)

--- a/fluree-db-cli/src/commands/mod.rs
+++ b/fluree-db-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod bm25;
 pub mod branch;
 pub mod cache;
 #[cfg(feature = "server")]
@@ -10,7 +11,6 @@ pub mod create;
 pub mod docs;
 pub mod drop;
 pub mod export;
-pub mod bm25;
 pub mod graph;
 pub mod history;
 pub mod iceberg;

--- a/fluree-db-cli/src/commands/mod.rs
+++ b/fluree-db-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod create;
 pub mod docs;
 pub mod drop;
 pub mod export;
+pub mod bm25;
 pub mod graph;
 pub mod history;
 pub mod iceberg;

--- a/fluree-db-cli/src/lib.rs
+++ b/fluree-db-cli/src/lib.rs
@@ -201,6 +201,11 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             commands::graph::run(action, &fluree_dir, direct).await
         }
 
+        Commands::Bm25 { action } => {
+            let fluree_dir = config::require_fluree_dir(config_path)?;
+            commands::bm25::run(action, &fluree_dir).await
+        }
+
         Commands::Insert {
             args,
             ledger,

--- a/fluree-db-cli/tests/integration.rs
+++ b/fluree-db-cli/tests/integration.rs
@@ -3100,3 +3100,234 @@ fn load_requires_a_template_flag() {
         .failure()
         .stderr(predicate::str::contains("--cypher").or(predicate::str::contains("--jsonld")));
 }
+
+// ============================================================================
+// bm25 (full-text index management)
+// ============================================================================
+
+/// Indexes every `ex:Doc`'s `ex:title`. MUST select `@id`.
+const BM25_INDEX_QUERY: &str = r#"{"@context":{"ex":"http://example.org/"},"where":[{"@id":"?x","@type":"ex:Doc","ex:title":"?t"}],"select":{"?x":["@id","ex:title"]}}"#;
+
+/// `init` + a `docs` ledger holding one `ex:Doc`.
+fn bm25_fixture() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+    fluree_cmd(&tmp).args(["create", "docs"]).assert().success();
+    fluree_cmd(&tmp)
+        .args([
+            "insert",
+            "-e",
+            r#"{"@context":{"ex":"http://example.org/"},"@id":"ex:doc1","@type":"ex:Doc","ex:title":"Rust programming guide"}"#,
+        ])
+        .assert()
+        .success();
+    tmp
+}
+
+fn bm25_create_index(tmp: &TempDir, name: &str, ledger: &str) {
+    fluree_cmd(tmp)
+        .args([
+            "bm25",
+            "create",
+            "--name",
+            name,
+            "--ledger",
+            ledger,
+            "-e",
+            BM25_INDEX_QUERY,
+        ])
+        .assert()
+        .success();
+}
+
+fn bm25_insert_second_doc(tmp: &TempDir) {
+    fluree_cmd(tmp)
+        .args([
+            "insert",
+            "-e",
+            r#"{"@context":{"ex":"http://example.org/"},"@id":"ex:doc2","@type":"ex:Doc","ex:title":"Rust and WebAssembly"}"#,
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn bm25_list_empty_reports_no_indexes() {
+    let tmp = bm25_fixture();
+    fluree_cmd(&tmp)
+        .args(["bm25", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No BM25 full-text indexes found"));
+}
+
+#[test]
+fn bm25_create_then_list_shows_a_fresh_index() {
+    let tmp = bm25_fixture();
+    fluree_cmd(&tmp)
+        .args([
+            "bm25",
+            "create",
+            "--name",
+            "docsearch",
+            "--ledger",
+            "docs:main",
+            "-e",
+            BM25_INDEX_QUERY,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Created full-text index docsearch:main",
+        ));
+
+    // Built over the current head => listed, and not stale.
+    fluree_cmd(&tmp)
+        .args(["bm25", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("docsearch"))
+        .stdout(predicate::str::contains("docs:main"))
+        .stdout(predicate::str::contains("YES").not());
+
+    // Script mode prints nothing when nothing is stale.
+    fluree_cmd(&tmp)
+        .args(["bm25", "list", "--stale"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// A commit after the index was built must make `list` report it stale, and
+/// `--stale` must emit the alias a maintenance loop feeds back to `sync`.
+#[test]
+fn bm25_list_reports_staleness_after_a_new_commit() {
+    let tmp = bm25_fixture();
+    bm25_create_index(&tmp, "docsearch", "docs:main");
+    bm25_insert_second_doc(&tmp);
+
+    fluree_cmd(&tmp)
+        .args(["bm25", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("YES"));
+
+    fluree_cmd(&tmp)
+        .args(["bm25", "list", "--stale"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("docsearch:main"));
+
+    // ...and syncing clears it.
+    fluree_cmd(&tmp)
+        .args(["bm25", "sync", "--index", "docsearch:main"])
+        .assert()
+        .success();
+
+    fluree_cmd(&tmp)
+        .args(["bm25", "list", "--stale"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+/// A dependency alias stored WITHOUT a branch must still resolve.
+///
+/// `bm25 create --ledger docs` persists the dependency verbatim as `docs`, while
+/// ledger records are keyed `docs:main`, so the staleness lookup only matches via
+/// the implicit-`:main` retry. Without that fallback the source ledger's `t` is
+/// unknown, `LEDGER_T` renders `-`, and the index silently reports itself
+/// never-stale — a maintenance loop driven off `--stale` would skip it forever.
+#[test]
+fn bm25_list_resolves_a_branchless_dependency_alias() {
+    let tmp = bm25_fixture();
+    // No `:main` — this is what lands in the record's dependencies.
+    bm25_create_index(&tmp, "baresearch", "docs");
+    bm25_insert_second_doc(&tmp);
+
+    // The load-bearing assertion: staleness is computed despite the bare alias.
+    fluree_cmd(&tmp)
+        .args(["bm25", "list", "--stale"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("baresearch:main"));
+
+    fluree_cmd(&tmp)
+        .args(["bm25", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("YES"));
+}
+
+#[test]
+fn bm25_drop_requires_force() {
+    let tmp = bm25_fixture();
+    bm25_create_index(&tmp, "docsearch", "docs:main");
+
+    fluree_cmd(&tmp)
+        .args(["bm25", "drop", "--index", "docsearch:main"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "use --force to confirm deletion of 'docsearch:main'",
+        ));
+
+    // Still there.
+    fluree_cmd(&tmp)
+        .args(["bm25", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("docsearch"));
+
+    fluree_cmd(&tmp)
+        .args(["bm25", "drop", "--index", "docsearch:main", "--force"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dropped full-text index"));
+
+    fluree_cmd(&tmp)
+        .args(["bm25", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No BM25 full-text indexes found"));
+}
+
+#[test]
+fn bm25_create_rejects_a_name_with_a_colon() {
+    let tmp = bm25_fixture();
+    fluree_cmd(&tmp)
+        .args([
+            "bm25",
+            "create",
+            "--name",
+            "bad:name",
+            "--ledger",
+            "docs:main",
+            "-e",
+            BM25_INDEX_QUERY,
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot contain ':'"));
+}
+
+#[test]
+fn bm25_create_rejects_invalid_json() {
+    let tmp = bm25_fixture();
+    fluree_cmd(&tmp)
+        .args([
+            "bm25",
+            "create",
+            "--name",
+            "docsearch",
+            "--ledger",
+            "docs:main",
+            "-e",
+            "{not json",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "indexing query must be valid JSON",
+        ));
+}


### PR DESCRIPTION
## Summary

Two related, independent changes that make Fluree's BM25 full-text search usable without a second process or the Rust API:

1. **Embedded `f:searchText` now executes over the normal query route** (`POST /v1/fluree/query`), not only via the dedicated `query_connection_with_bm25` API method or the standalone `fluree-search-httpd` service.
2. **A `fluree bm25` CLI** to create, list, sync, and drop BM25 indexes (the only management surface that ships today is the Rust API — there is no HTTP endpoint for index management).

Both are self-contained and could land independently; they are grouped here because they are the two halves of "use BM25 from a running Fluree server."

---

## 1. Embedded BM25 over `/v1/fluree/query`

A query with an `f:searchText` / `f:graphSource` where-clause parses correctly (the JSON-LD parser lowers it to a `Pattern::IndexSearch`) but, on the standard query route, failed at execution with `BM25 IndexSearch requires ExecutionContext.bm25_search_provider or bm25_provider (not configured)`. The query is valid; the execution context that route builds simply never wired a BM25 provider. The only code that wired one was `query_connection_with_bm25` / `query_dataset_with_bm25`, whose sole callers were tests — the server never called them — so embedded search was unreachable over HTTP. (The docs describe embedded search as the default deployment mode and flag the missing in-server wiring as a "near-term gap".)

**Fix.** Wire `FlureeIndexProvider` as the `bm25_provider` on the `ExecutionContext` at the sites the HTTP route funnels through: `execute_dataset_into_with_r2rml` and `execute_dataset_tracked_with_r2rml` (the dataset path used by `POST /v1/fluree/query`), and the shared `view_context_config!` macro (the single-graph view path), for parity. Each creates a `FlureeIndexProvider::new(self)` — a zero-cost `&Fluree` wrapper — declared before the context so it outlives the borrow, mirroring exactly how the R2RML providers are already threaded through those same sites. The provider is only consulted by the `IndexSearch` operator, so non-search queries are unaffected; this is the same provider `query_dataset_with_bm25` already used, just made available on the standard path.

**Verified end-to-end.** `POST /v1/fluree/query` with a BM25 search block now returns ranked `?doc`/`?score` bindings instead of a 400 — confirmed on a real index (`"nature"` → two profiles, scored 3.78 and 2.68). A new integration test, `bm25_embedded_search_via_plain_query_connection`, runs `f:searchText` through the plain `query_connection` (the path the HTTP route uses) and asserts scored results — it would have returned the "not configured" error before this change.

**Not covered (deliberately):** SPARQL. The `f:` search block is recognized only by the JSON-LD parser (`parse/node_map.rs`); the SPARQL parser never constructs a `Pattern::IndexSearch`, so a SPARQL query with those predicates matches them as ordinary triples and silently returns nothing. Adding SPARQL search is a separate parser/lowering change in `fluree-db-sparql`. Vector (`f:queryVector`) is also out of scope here: its provider impl is `#[cfg(feature = "vector")]` and not in the default server build, so wiring it would be dead code in the shipped binary — a one-line follow-up once that feature is enabled.

---

## 2. `fluree bm25` CLI

BM25 index management is Rust-API-only (`Bm25CreateConfig` + `create_full_text_index`, `sync_bm25_index`, `drop_full_text_index`) with no HTTP route. This adds a thin CLI wrapper that runs in-process against local storage, so it works under `docker exec` against a running server's data directory (native storage uses per-file locks, not a whole-store exclusive lock).

- **`fluree bm25 create --name <n> --ledger <l> -f <index-query.json>`** — build a BM25 index over a source ledger from an indexing query.
- **`fluree bm25 list [--stale]`** — tabular view (NAME / BRANCH / SOURCE LEDGER / INDEX_T / LEDGER_T / STALE), the same look-and-feel as `fluree list`. `--stale` prints `name:branch` per line so a maintenance loop can be scripted: `for i in $(fluree bm25 list --stale); do fluree bm25 sync --index "$i"; done`.
- **`fluree bm25 sync --index <gs>`** — incremental sync up to the source ledger's head; prints the watermark `old -> new` and upserted/removed counts (falls back to a full resync when no affected subjects are detected).
- **`fluree bm25 drop --index <gs>`** — retract the index in the nameservice and delete its snapshot blobs.

---

## Tests

Full BM25 integration suite green (`fluree-db-api --test grp_graphsource`, incl. the new `bm25_embedded_search_via_plain_query_connection`); `cargo fmt --check` and `clippy -D warnings` clean on both `fluree-db-api` and `fluree-db-cli`. The branch is based on current `main` and compiles + tests against it (not just the fork's older base).