### PR TITLE
Limit recursion depth on turtle imports

### DIFF
--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -148,6 +148,10 @@ Fluree parses Turtle 1.1:
 - Collections
 - Blank nodes
 
+Resource limits: recursive constructs (property lists, collections, reified
+triples) may nest at most 128 levels deep, and a single parse accepts at most
+4 GiB of input; either limit produces a clean parse error.
+
 **Specification:** https://www.w3.org/TR/turtle/
 
 ### JSON Web Signature (JWS)

--- a/docs/transactions/turtle.md
+++ b/docs/transactions/turtle.md
@@ -329,6 +329,18 @@ riot --validate data.ttl
 }
 ```
 
+### Parser Limits
+
+The parser enforces two resource limits; input past either is rejected with a
+parse error rather than ingested:
+
+- Blank-node property lists (`[ ... ]`), collections (`( ... )`), and reified
+  triples (`<< ... >>`) may nest at most 128 levels deep. Wide structures are
+  unaffected — a flat list of any length counts as one level; only the nesting
+  chain is limited.
+- A single parse call accepts at most 4 GiB (`u32::MAX` bytes) of input. Bulk
+  import splits files into chunks well below this automatically.
+
 ## Performance Tips
 
 ### 1. Use Batch Import

--- a/fluree-graph-turtle/src/error.rs
+++ b/fluree-graph-turtle/src/error.rs
@@ -54,6 +54,14 @@ impl TurtleError {
 /// wrapped offset that would later panic when slicing the source.
 pub const MAX_INPUT_BYTES: usize = u32::MAX as usize;
 
+/// Maximum nesting depth for the recursive Turtle constructs — blank-node
+/// property lists (`[ … ]`), collections (`( … )`), and reified triples
+/// (`<< … >>`). Each level recurses through the parser, so unbounded nesting
+/// lets a small adversarial document overflow the stack and abort the
+/// process; past this ceiling parsing fails with a clean parse error. The
+/// three constructs share one counter, so mixed nesting is bounded too.
+pub const MAX_NESTING_DEPTH: u32 = 128;
+
 /// Reject input too large for `u32` token-span offsets.
 ///
 /// Called at every lexer/parser entry point. Compares via `u64` so the check is

--- a/fluree-graph-turtle/src/lib.rs
+++ b/fluree-graph-turtle/src/lib.rs
@@ -23,6 +23,13 @@
 //! // Option 2: Parse directly to transaction JSON
 //! let json = parse_to_json(turtle).unwrap();
 //! ```
+//!
+//! # Limits
+//!
+//! Input is bounded by [`error::MAX_INPUT_BYTES`] per parse call, and
+//! recursive constructs (property lists, collections, reified triples) by
+//! [`error::MAX_NESTING_DEPTH`] nesting levels; exceeding either produces a
+//! parse error.
 
 pub mod adapter;
 pub mod error;

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -2027,47 +2027,32 @@ mod tests {
 
     /// `[ ex:p [ ex:p … ex:o … ] ] .` nested `depth` levels.
     fn nested_property_lists(depth: usize) -> String {
-        let mut input = String::from("@prefix ex: <http://example.org/> .\n");
-        for _ in 0..depth {
-            input.push_str("[ ex:p ");
-        }
-        input.push_str("ex:o");
-        for _ in 0..depth {
-            input.push_str(" ]");
-        }
-        input.push_str(" .");
-        input
+        format!(
+            "@prefix ex: <http://example.org/> .\n{}ex:o{} .",
+            "[ ex:p ".repeat(depth),
+            " ]".repeat(depth)
+        )
     }
 
     /// `ex:s ex:p ( ( … ( ex:o ) … ) ) .` nested `depth` levels. The
     /// innermost collection holds a real item — a bare `()` lexes as a
     /// single `Nil` token and would not count as a nesting level.
     fn nested_collections(depth: usize) -> String {
-        let mut input = String::from("@prefix ex: <http://example.org/> .\nex:s ex:p ");
-        for _ in 0..depth {
-            input.push_str("( ");
-        }
-        input.push_str("ex:o");
-        for _ in 0..depth {
-            input.push_str(" )");
-        }
-        input.push_str(" .");
-        input
+        format!(
+            "@prefix ex: <http://example.org/> .\nex:s ex:p {}ex:o{} .",
+            "( ".repeat(depth),
+            " )".repeat(depth)
+        )
     }
 
     /// `<< … << ex:s ex:p ex:o >> … ex:p ex:o >> ex:p ex:o .` nested
     /// `depth` levels via the reified-triple subject position.
     fn nested_reified_triples(depth: usize) -> String {
-        let mut input = String::from("@prefix ex: <http://example.org/> .\n");
-        for _ in 0..depth {
-            input.push_str("<< ");
-        }
-        input.push_str("ex:s ex:p ex:o");
-        for _ in 0..depth {
-            input.push_str(" >> ex:p ex:o");
-        }
-        input.push_str(" .");
-        input
+        format!(
+            "@prefix ex: <http://example.org/> .\n{}ex:s ex:p ex:o{} .",
+            "<< ".repeat(depth),
+            " >> ex:p ex:o".repeat(depth)
+        )
     }
 
     fn assert_depth_err(err: TurtleError) {
@@ -2077,9 +2062,11 @@ mod tests {
         );
     }
 
+    /// The ceiling is inclusive: depth == MAX_NESTING_DEPTH parses, pinning
+    /// the boundary against a stricter-by-one guard regression.
     #[test]
-    fn nesting_below_the_ceiling_parses() {
-        let depth = (crate::error::MAX_NESTING_DEPTH - 1) as usize;
+    fn nesting_at_the_ceiling_parses() {
+        let depth = crate::error::MAX_NESTING_DEPTH as usize;
         parse_to_graph(&nested_property_lists(depth)).expect("property lists");
         parse_to_graph(&nested_collections(depth)).expect("collections");
         parse_star(&nested_reified_triples(depth));

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -60,6 +60,11 @@ pub struct Parser<'a, 'input, S> {
     /// deferred v1 shapes — mirrors the JSON-LD `@annotation` lowering,
     /// which rejects the same nesting.
     annotation_depth: u32,
+    /// Combined nesting depth of the recursive constructs (property lists,
+    /// collections, reified triples), bounded by
+    /// [`crate::error::MAX_NESTING_DEPTH`] so adversarial nesting errors
+    /// instead of overflowing the stack.
+    nesting_depth: u32,
 }
 
 impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
@@ -97,7 +102,29 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             prefixes: FxHashMap::default(),
             base: None,
             annotation_depth: 0,
+            nesting_depth: 0,
         })
+    }
+
+    /// Run `f` one nesting level deeper, erroring past
+    /// [`crate::error::MAX_NESTING_DEPTH`]. Owns both sides of the depth
+    /// bookkeeping so call sites cannot increment without the matching
+    /// decrement.
+    fn with_nesting<T>(&mut self, f: impl FnOnce(&mut Self) -> Result<T>) -> Result<T> {
+        if self.nesting_depth >= crate::error::MAX_NESTING_DEPTH {
+            return Err(TurtleError::parse(
+                self.current().start as usize,
+                format!(
+                    "nesting of property lists, collections, and reified triples \
+                     exceeds the maximum depth of {}",
+                    crate::error::MAX_NESTING_DEPTH
+                ),
+            ));
+        }
+        self.nesting_depth += 1;
+        let result = f(self);
+        self.nesting_depth -= 1;
+        result
     }
 
     /// Parse the entire Turtle document.
@@ -617,15 +644,17 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
     /// Parse a collection in object position as indexed list items.
     fn parse_collection_as_list(&mut self, subject: TermId, predicate: TermId) -> Result<()> {
-        self.expect(&TokenKind::LParen)?;
-        let mut index: i32 = 0;
-        while !matches!(self.current().kind, TokenKind::RParen) {
-            let item = self.parse_object()?;
-            self.sink_emit_list_item(subject, predicate, item, index);
-            index += 1;
-        }
-        self.expect(&TokenKind::RParen)?;
-        Ok(())
+        self.with_nesting(|p| {
+            p.expect(&TokenKind::LParen)?;
+            let mut index: i32 = 0;
+            while !matches!(p.current().kind, TokenKind::RParen) {
+                let item = p.parse_object()?;
+                p.sink_emit_list_item(subject, predicate, item, index);
+                index += 1;
+            }
+            p.expect(&TokenKind::RParen)?;
+            Ok(())
+        })
     }
 
     /// Parse an object term.
@@ -840,51 +869,55 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
     /// Parse a blank node property list: `[ predicate object ; ... ]`
     fn parse_blank_node_property_list(&mut self) -> Result<TermId> {
-        self.expect(&TokenKind::LBracket)?;
+        self.with_nesting(|p| {
+            p.expect(&TokenKind::LBracket)?;
 
-        let bnode = self.sink_term_blank(None);
+            let bnode = p.sink_term_blank(None);
 
-        if !matches!(self.current().kind, TokenKind::RBracket) {
-            self.parse_predicate_object_list(bnode)?;
-        }
+            if !matches!(p.current().kind, TokenKind::RBracket) {
+                p.parse_predicate_object_list(bnode)?;
+            }
 
-        self.expect(&TokenKind::RBracket)?;
+            p.expect(&TokenKind::RBracket)?;
 
-        Ok(bnode)
+            Ok(bnode)
+        })
     }
 
     /// Parse a collection (RDF list): `( item1 item2 ... )`
     fn parse_collection(&mut self) -> Result<TermId> {
-        self.expect(&TokenKind::LParen)?;
+        self.with_nesting(|p| {
+            p.expect(&TokenKind::LParen)?;
 
-        if matches!(self.current().kind, TokenKind::RParen) {
-            self.advance()?;
-            return Ok(self.rdf_nil());
-        }
-
-        let rdf_first = self.rdf_first();
-        let rdf_rest = self.rdf_rest();
-        let rdf_nil = self.rdf_nil();
-
-        let first_node = self.sink_term_blank(None);
-        let mut current_node = first_node;
-
-        loop {
-            let item = self.parse_object()?;
-            self.sink_emit_triple(current_node, rdf_first, item);
-
-            if matches!(self.current().kind, TokenKind::RParen) {
-                self.sink_emit_triple(current_node, rdf_rest, rdf_nil);
-                break;
+            if matches!(p.current().kind, TokenKind::RParen) {
+                p.advance()?;
+                return Ok(p.rdf_nil());
             }
-            let next_node = self.sink_term_blank(None);
-            self.sink_emit_triple(current_node, rdf_rest, next_node);
-            current_node = next_node;
-        }
 
-        self.expect(&TokenKind::RParen)?;
+            let rdf_first = p.rdf_first();
+            let rdf_rest = p.rdf_rest();
+            let rdf_nil = p.rdf_nil();
 
-        Ok(first_node)
+            let first_node = p.sink_term_blank(None);
+            let mut current_node = first_node;
+
+            loop {
+                let item = p.parse_object()?;
+                p.sink_emit_triple(current_node, rdf_first, item);
+
+                if matches!(p.current().kind, TokenKind::RParen) {
+                    p.sink_emit_triple(current_node, rdf_rest, rdf_nil);
+                    break;
+                }
+                let next_node = p.sink_term_blank(None);
+                p.sink_emit_triple(current_node, rdf_rest, next_node);
+                current_node = next_node;
+            }
+
+            p.expect(&TokenKind::RParen)?;
+
+            Ok(first_node)
+        })
     }
 
     // =========================================================================
@@ -970,32 +1003,34 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
     /// reifier (mirrors the JSON-LD `_:fluree_ann_N` minting; W3C
     /// eval-triple-terms `pattern-3-nomatch` depends on this).
     fn parse_reified_triple(&mut self) -> Result<TermId> {
-        self.check_star_allowed("reified triple ('<< … >>')")?;
-        self.expect(&TokenKind::ReifiedTripleStart)?;
+        self.with_nesting(|p| {
+            p.check_star_allowed("reified triple ('<< … >>')")?;
+            p.expect(&TokenKind::ReifiedTripleStart)?;
 
-        let subject = self.parse_rt_subject()?;
-        let predicate = self.parse_predicate()?;
-        let object = self.parse_rt_object()?;
+            let subject = p.parse_rt_subject()?;
+            let predicate = p.parse_predicate()?;
+            let object = p.parse_rt_object()?;
 
-        // Optional reifier: `~` (iri | BlankNode)? — bare `~` mints fresh.
-        let reifier = if matches!(self.current().kind, TokenKind::Tilde) {
-            self.advance()?;
-            self.parse_reifier_term()?
-        } else {
-            self.sink_term_blank(None)
-        };
+            // Optional reifier: `~` (iri | BlankNode)? — bare `~` mints fresh.
+            let reifier = if matches!(p.current().kind, TokenKind::Tilde) {
+                p.advance()?;
+                p.parse_reifier_term()?
+            } else {
+                p.sink_term_blank(None)
+            };
 
-        self.expect(&TokenKind::ReifiedTripleEnd)?;
+            p.expect(&TokenKind::ReifiedTripleEnd)?;
 
-        // Fluree's edge-annotation model reifies an asserted edge: emit the
-        // base triple, then the reifier attachment (documented divergence
-        // from RDF 1.2's non-asserting `<< >>`; see the roadmap's construct
-        // inventory).
-        self.sink_emit_triple(subject, predicate, object);
-        self.sink
-            .emit_reified_triple(subject, predicate, object, reifier);
+            // Fluree's edge-annotation model reifies an asserted edge: emit the
+            // base triple, then the reifier attachment (documented divergence
+            // from RDF 1.2's non-asserting `<< >>`; see the roadmap's construct
+            // inventory).
+            p.sink_emit_triple(subject, predicate, object);
+            p.sink
+                .emit_reified_triple(subject, predicate, object, reifier);
 
-        Ok(reifier)
+            Ok(reifier)
+        })
     }
 
     /// rtSubject ::= iri | BlankNode | reifiedTriple
@@ -1985,5 +2020,95 @@ mod tests {
             .map(|(s, _, _)| s.clone())
             .expect(":b2 a2 triple");
         assert_ne!(b2_object, b2_subject, "pattern-3-nomatch must stay empty");
+    }
+    // =========================================================================
+    // Recursion depth ceiling (issue #1480)
+    // =========================================================================
+
+    /// `[ ex:p [ ex:p … ex:o … ] ] .` nested `depth` levels.
+    fn nested_property_lists(depth: usize) -> String {
+        let mut input = String::from("@prefix ex: <http://example.org/> .\n");
+        for _ in 0..depth {
+            input.push_str("[ ex:p ");
+        }
+        input.push_str("ex:o");
+        for _ in 0..depth {
+            input.push_str(" ]");
+        }
+        input.push_str(" .");
+        input
+    }
+
+    /// `ex:s ex:p ( ( … ( ex:o ) … ) ) .` nested `depth` levels. The
+    /// innermost collection holds a real item — a bare `()` lexes as a
+    /// single `Nil` token and would not count as a nesting level.
+    fn nested_collections(depth: usize) -> String {
+        let mut input = String::from("@prefix ex: <http://example.org/> .\nex:s ex:p ");
+        for _ in 0..depth {
+            input.push_str("( ");
+        }
+        input.push_str("ex:o");
+        for _ in 0..depth {
+            input.push_str(" )");
+        }
+        input.push_str(" .");
+        input
+    }
+
+    /// `<< … << ex:s ex:p ex:o >> … ex:p ex:o >> ex:p ex:o .` nested
+    /// `depth` levels via the reified-triple subject position.
+    fn nested_reified_triples(depth: usize) -> String {
+        let mut input = String::from("@prefix ex: <http://example.org/> .\n");
+        for _ in 0..depth {
+            input.push_str("<< ");
+        }
+        input.push_str("ex:s ex:p ex:o");
+        for _ in 0..depth {
+            input.push_str(" >> ex:p ex:o");
+        }
+        input.push_str(" .");
+        input
+    }
+
+    fn assert_depth_err(err: TurtleError) {
+        assert!(
+            err.to_string().contains("maximum depth"),
+            "expected the nesting-depth error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn nesting_below_the_ceiling_parses() {
+        let depth = (crate::error::MAX_NESTING_DEPTH - 1) as usize;
+        parse_to_graph(&nested_property_lists(depth)).expect("property lists");
+        parse_to_graph(&nested_collections(depth)).expect("collections");
+        parse_star(&nested_reified_triples(depth));
+    }
+
+    #[test]
+    fn nesting_past_the_ceiling_errors_cleanly() {
+        let depth = (crate::error::MAX_NESTING_DEPTH + 1) as usize;
+        assert_depth_err(parse_to_graph(&nested_property_lists(depth)).expect_err("lists"));
+        assert_depth_err(parse_to_graph(&nested_collections(depth)).expect_err("collections"));
+        let mut sink = StarSink::default();
+        assert_depth_err(parse(&nested_reified_triples(depth), &mut sink).expect_err("reified"));
+    }
+
+    /// The original DoS shape: a small document with adversarial nesting
+    /// depth must fail with a clean parse error, not a stack overflow.
+    #[test]
+    fn deeply_nested_property_lists_do_not_overflow_the_stack() {
+        assert_depth_err(parse_to_graph(&nested_property_lists(100_000)).expect_err("deep"));
+    }
+
+    /// Siblings at the same level do not accumulate depth: only the nesting
+    /// chain counts, so wide-but-shallow documents stay parseable.
+    #[test]
+    fn sibling_nesting_does_not_accumulate_depth() {
+        let mut input = String::from("@prefix ex: <http://example.org/> .\n");
+        for i in 0..(crate::error::MAX_NESTING_DEPTH as usize * 4) {
+            input.push_str(&format!("ex:s{i} ex:p [ ex:q ( ex:o ) ] .\n"));
+        }
+        parse_to_graph(&input).expect("sibling nesting must not accumulate");
     }
 }


### PR DESCRIPTION
Issue #1480 reported that the Turtle parser's recursive constructs — blank-node property lists (`[ … ]`), collections (`( … )`), and reified triples (`<< … >>`) — recurse without a depth limit, so a small adversarial document can overflow the stack. A Rust stack overflow is uncatchable and aborts the whole process, making this a denial-of-service vector on any surface that parses untrusted Turtle. The bug was confirmed by reproduction before the fix: a ~1MB document of 100,000 nested property lists aborted the test process with SIGABRT.

## Changes

- `fluree-graph-turtle/src/error.rs`: new `pub const MAX_NESTING_DEPTH: u32 = 128`, documented alongside the existing `MAX_INPUT_BYTES` input bound. The three constructs share one counter, so mixed nesting is bounded too. 128 matches common practice (serde_json's default recursion limit) and is far beyond real-world Turtle nesting.
- `fluree-graph-turtle/src/parser.rs`: a `nesting_depth` field and a `with_nesting` closure wrapper that owns the entire invariant in one place — the ceiling check (erroring with a positioned parse error past the limit), the increment, and an unconditional decrement — so call sites cannot increment without the matching decrement, and the counter stays correct even if parse-error recovery is ever added. Applied at all four recursion entry points: `parse_blank_node_property_list`, `parse_collection`, `parse_collection_as_list` (the object-position indexed-list variant, a fourth entry beyond the issue's list of three — caught because an unguarded outer level let collections nest one past the ceiling), and `parse_reified_triple`. Guarding these four bounds every recursion cycle: reified-triple nesting through the subject/object positions loops back through `parse_reified_triple`, and annotation bodies are already capped at one level by the star gate.
- Documentation: a `### Parser Limits` subsection in `docs/transactions/turtle.md` covering both the nesting ceiling and the pre-existing 4 GiB input bound, a resource-limits note under the Turtle entry in `docs/reference/compatibility.md`, and a `# Limits` section in the crate docs with intra-doc links to the two constants.

## Tests

Five cases in the parser's test module, with single-`format!`/`str::repeat` input generators matching the Cypher crate's recursion-test idiom:

- `nesting_at_the_ceiling_parses` — all three constructs parse at exactly depth 128, pinning the inclusive boundary against a stricter-by-one guard regression.
- `nesting_past_the_ceiling_errors_cleanly` — all three constructs fail at depth 129 with the "maximum depth" parse error (the reified case runs through the star-capable `StarSink`, since the default sink rejects star forms outright).
- `deeply_nested_property_lists_do_not_overflow_the_stack` — the original 100k DoS shape returns the clean error. This is not redundant with the depth-129 case: under a regression where the ceiling check stops short-circuiting before the recursive descent, 129 frames still parse or error cleanly while only the 100k input reproduces the overflow.
- `sibling_nesting_does_not_accumulate_depth` — 512 sibling nestings (deliberately more than the 128 ceiling) parse fine, proving only the nesting chain counts.
- One lexer subtlety the generators encode: bare `()` lexes as a single `Nil` token, so nested collections must carry a real innermost item to count levels correctly.

Fixes #1480