### PR TITLE
fix: gate WHERE-level early dedup on aggregate duplicate-insensitivity

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -2309,6 +2309,24 @@ mem:constraint-01kv3h37ky6wpm8c8jdvpnamjk a mem:Constraint ;
     mem:createdAt "2026-06-14T16:58:01.214124+00:00"^^xsd:dateTime ;
     mem:rationale "Non-obvious behavior change: distinguishing \"WHERE matched nothing\" (no-op) from \"no WHERE clause\" (fire once) and the OPTIONAL=1-row subtlety prevents future regressions or confusion when touching stage.rs." .
 
+mem:constraint-01kyke812e1np5c9ag45ac7580 a mem:Constraint ;
+    mem:content "The WHERE early-dedup gate (`where_dedup_safe`) must check BOTH that every aggregate is `duplicate_insensitive()` AND that every var in `VariableDeps::required_aggregate_vars` is a GROUP BY key or an aggregate output. A non-key var surviving the grouping stage is emitted as `Binding::Grouped` — a per-group LIST (JSON-LD-only feature; SPARQL rejects the shape) that observes row multiplicity. Note `aggregates()` is EMPTY for a dedup-only `GROUP BY ?g`, so the aggregate check alone is vacuously true there." ;
+    mem:tag "aggregates" ;
+    mem:tag "correctness" ;
+    mem:tag "dedup" ;
+    mem:tag "grouping" ;
+    mem:tag "jsonld" ;
+    mem:tag "planner" ;
+    mem:scope mem:repo ;
+    mem:severity "must" ;
+    mem:artifactRef "fluree-db-api/tests/it_query_grouping.rs" ;
+    mem:artifactRef "fluree-db-query/src/execute/dependency.rs" ;
+    mem:artifactRef "fluree-db-query/src/execute/operator_tree.rs" ;
+    mem:artifactRef "fluree-db-query/src/groupby.rs" ;
+    mem:branch "fix/where-early-dedup-aggregate-gate" ;
+    mem:createdAt "2026-07-28T04:03:09.006298+00:00"^^xsd:dateTime ;
+    mem:rationale "Using required_aggregate_vars (rather than checking the projection directly) folds in projection, HAVING, post-binds and ORDER BY in one check — a post-bind whose EXPRESSION reads a non-key var still reads a grouped list, which a bind-output whitelist would miss. Regression tests need a fan-in fixture; the pinned grouped-list test has none and cannot catch dedup." .
+
 mem:constraint-01kjte29y3cp8mae56xy6yfv2n a mem:Constraint ;
     mem:content "SPARQL↔JSON-LD Parity: both compile to the same IR (fluree-db-query/src/ir.rs) and share the entire execution engine. When adding SPARQL features: (1) shared IR changes already affect JSON-LD — verify JSON-LD tests pass, (2) if expressible in JSON-LD, add parallel tests, (3) execution path missing in JSON-LD lower → track follow-up.\n\nSPARQL tests: it_query_sparql.rs | JSON-LD tests: it_query.rs, it_query_analytical.rs, it_query_grouping.rs\nValidate: `cd testsuite-sparql && make test-eval-cat CAT=<cat>` then `cargo test -p fluree-db-api --test it_query`" ;
     mem:tag "compliance" ;
@@ -2577,7 +2595,7 @@ mem:fact-01kxtfwy7tzh5vebpny7sayycv a mem:Fact ;
     mem:createdAt "2026-07-18T11:31:02.010277+00:00"^^xsd:dateTime .
 
 mem:fact-01kye0dqrnn5ffnwnwwnk9f0bp a mem:Fact ;
-    mem:content "WHERE-level early dedup (project dead vars + DistinctOperator between joins) is gated by `where_dedup_safe`, computed in build_operator_tree_inner: grouping present → ALL aggregates must be AggregateFn::duplicate_insensitive() (DISTINCT-marked or MIN/MAX/SAMPLE); no grouping → SELECT DISTINCT. The old gate was `query.output.is_distinct()` alone, which (1) never fired for COUNT(DISTINCT) chains — the PrimeKG q66 2,490×-redundancy/404×-slowdown bug — and (2) was UNSOUND for `SELECT DISTINCT (COUNT(?x))`: it collapsed pre-aggregation rows and halved counts. Outer DISTINCT never licenses pre-aggregation dedup." ;
+    mem:content "WHERE-level early dedup (project dead vars + DistinctOperator between joins) is gated by `where_dedup_safe`, computed in build_operator_tree_inner: grouping present → ALL aggregates duplicate_insensitive() (DISTINCT-marked or MIN/MAX/SAMPLE) AND no raw non-key var passes through grouping; no grouping → SELECT DISTINCT. The old gate was `query.output.is_distinct()` alone, which (1) never fired for COUNT(DISTINCT) chains — the PrimeKG q66 2,490×-redundancy/404×-slowdown bug — and (2) was UNSOUND for `SELECT DISTINCT (COUNT(?x))`: it collapsed pre-aggregation rows and halved counts. Outer DISTINCT never licenses pre-aggregation dedup." ;
     mem:tag "aggregates" ;
     mem:tag "correctness" ;
     mem:tag "dedup" ;

--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -2576,6 +2576,33 @@ mem:fact-01kxtfwy7tzh5vebpny7sayycv a mem:Fact ;
     mem:branch "main" ;
     mem:createdAt "2026-07-18T11:31:02.010277+00:00"^^xsd:dateTime .
 
+mem:fact-01kye0dqrnn5ffnwnwwnk9f0bp a mem:Fact ;
+    mem:content "WHERE-level early dedup (project dead vars + DistinctOperator between joins) is gated by `where_dedup_safe`, computed in build_operator_tree_inner: grouping present → ALL aggregates must be AggregateFn::duplicate_insensitive() (DISTINCT-marked or MIN/MAX/SAMPLE); no grouping → SELECT DISTINCT. The old gate was `query.output.is_distinct()` alone, which (1) never fired for COUNT(DISTINCT) chains — the PrimeKG q66 2,490×-redundancy/404×-slowdown bug — and (2) was UNSOUND for `SELECT DISTINCT (COUNT(?x))`: it collapsed pre-aggregation rows and halved counts. Outer DISTINCT never licenses pre-aggregation dedup." ;
+    mem:tag "aggregates" ;
+    mem:tag "correctness" ;
+    mem:tag "dedup" ;
+    mem:tag "distinct" ;
+    mem:tag "planner" ;
+    mem:tag "query-perf" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-query/src/execute/operator_tree.rs" ;
+    mem:artifactRef "fluree-db-query/src/execute/where_plan.rs" ;
+    mem:artifactRef "fluree-db-query/src/ir/grouping.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-07-26T01:25:23.861334+00:00"^^xsd:dateTime ;
+    mem:rationale "Any future change to the dedup gate or aggregate variants must preserve both directions: fire for duplicate-insensitive aggregate chains (perf) and never fire under a duplicate-sensitive aggregate (correctness). Plan-shape guards live in it_query_explain.rs (explain_chain_* tests)." .
+
+mem:fact-01kye0e6kqs8q712xrcvdednee a mem:Fact ;
+    mem:content "hash-join-reason \"subject-driven-forward-join\" is an intentional structural short-circuit, not a costing bug: HashJoinOperator only implements object→subject joins (build keyed on the probe's OBJECT var, one PSOT partition scan). object_hash_shape() classifies subject-bound/object-new patterns as SubjectDriven and explain_object_hash_join returns chosen=false before any cost gate. Forward joins use the batched-SUBJECT SPOT galloping path, cheap per probe — a forward join with driving-est ≫ probe-count usually signals duplicate multiplicity feeding it (see early-dedup gate), not a wrong join choice. No subject-keyed/build-on-right hash join variant exists." ;
+    mem:tag "explain" ;
+    mem:tag "hash-join" ;
+    mem:tag "planner" ;
+    mem:tag "query-perf" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-query/src/hash_join.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-07-26T01:25:39.063758+00:00"^^xsd:dateTime .
+
 mem:constraint-01kp8yczz09ndt54ztchbheeyb a mem:Constraint ;
     mem:content "JSON-LD transaction parsing does NOT auto-promote bare string values to IRI references. User data becomes an IRI only when wrapped in `{\"@id\": \"...\"}` or when the property has `@type: \"@id\"` in `@context`. The former `looks_like_iri` heuristic (three sites in parse/jsonld.rs) was removed — it silently promoted strings starting with `http://`/`https://`/`did:`/`fluree:`/`urn:` to IRIs, which violated the JSON-LD spec (especially for `{\"@value\": \"...\"}`, explicitly a literal)." ;
     mem:tag "iri" ;

--- a/docs/design/query-execution.md
+++ b/docs/design/query-execution.md
@@ -162,12 +162,24 @@ streaming `DistinctOperator` so duplicates collapse before the next join.
 `build_operator_tree_inner`): collapsing duplicate rows is only legal when
 downstream cannot observe WHERE-output multiplicity —
 
-- **grouping present** → every aggregate must be *duplicate-insensitive*:
-  `AggregateFn::duplicate_insensitive()` = any `DISTINCT`-marked aggregate
-  (`COUNT/SUM/AVG/MEDIAN/VARIANCE/STDDEV/GROUP_CONCAT/collect DISTINCT`) plus
-  `MIN`/`MAX`/`SAMPLE`. A single plain `COUNT`/`SUM`/… blocks dedup for the
-  whole WHERE.
+- **grouping present** → *both* of:
+  - every aggregate must be *duplicate-insensitive*:
+    `AggregateFn::duplicate_insensitive()` = any `DISTINCT`-marked aggregate
+    (`COUNT/SUM/AVG/MEDIAN/VARIANCE/STDDEV/GROUP_CONCAT/collect DISTINCT`) plus
+    `MIN`/`MAX`/`SAMPLE`. A single plain `COUNT`/`SUM`/… blocks dedup for the
+    whole WHERE.
+  - no variable may pass through the grouping stage *raw*: every var in
+    `VariableDeps::required_aggregate_vars` must be a `GROUP BY` key or an
+    aggregate output. A non-key variable that survives grouping is emitted as
+    a per-group **list** (`Binding::Grouped`, the JSON-LD grouped-projection
+    feature — SPARQL rejects the shape), and that list observes row
+    multiplicity. This clause also covers the `GROUP BY ?g` case with *no*
+    aggregation stage, where the aggregate check alone is vacuously true.
 - **no grouping** → the query itself must be `SELECT DISTINCT`.
+
+Both clauses are checked against `variable_deps`; when it is `None`
+(wildcard/boolean/construct) dedup is off anyway, since projection pushdown —
+and therefore the live-var trimming that triggers dedup — is disabled.
 
 An outer `SELECT DISTINCT` over an aggregate query does **not** license WHERE
 dedup — it dedups *result* rows after aggregation, while a plain `COUNT` under
@@ -176,7 +188,11 @@ correctness bug fixed alongside the aggregate-aware gate).
 
 The dedup is inserted only at steps where trimming actually dropped a dead
 variable, so queries whose variables all stay live (e.g. same-subject stars
-feeding the projection) pay nothing. Subqueries dedup at their own boundary
+feeding the projection) pay nothing. Note the memory trade: `DistinctOperator`
+holds an uncapped, non-spilling hash set of the distinct rows seen at each
+insertion point, so an aggregate query that previously streamed (e.g. a
+`MAX`-only chain whose intermediates are large and already near-distinct)
+becomes resident-memory-bound for no gain. The gate errs toward the speed win. Subqueries dedup at their own boundary
 (`apply_solution_modifiers` applies the subquery's `DISTINCT`) rather than
 per-step.
 

--- a/docs/design/query-execution.md
+++ b/docs/design/query-execution.md
@@ -141,3 +141,42 @@ needs the history sidecar, defers). Two lanes split on whether novelty is presen
   materialized through a novelty-aware graph view (the persisted-dict
   `encoded_sid` form would not resolve them).
 
+## WHERE-level early dedup (projection + distinct between joins)
+
+Deep existential chains (`?a p1 ?b . ?b p2 ?c . ?c p3 ?x` where only `?x` is
+projected/aggregated) can carry compounding duplicate multiplicity: once `?a`
+is dead, every distinct `?b` is repeated once per `?a` that produced it, and
+each join multiplies the redundancy into the next hop. On a real 6-hop
+biomedical query this reached 10.17M intermediate rows carrying 4,086 distinct
+values (2,490× redundancy, ~400× slowdown).
+
+The WHERE planner (`fluree-db-query/src/execute/where_plan.rs`,
+`build_sequential_join_block` / `build_sequential_triple_chain`) counters this
+with **early dedup**: at each join step it computes the live-variable set
+(post-WHERE required vars ∪ vars referenced by not-yet-executed
+patterns/filters/binds), trims dead columns from the join output
+(`with_out_schema`), and — when dedup is licensed — wraps the step in a
+streaming `DistinctOperator` so duplicates collapse before the next join.
+
+**Soundness gate** (`where_dedup_safe`, computed in
+`build_operator_tree_inner`): collapsing duplicate rows is only legal when
+downstream cannot observe WHERE-output multiplicity —
+
+- **grouping present** → every aggregate must be *duplicate-insensitive*:
+  `AggregateFn::duplicate_insensitive()` = any `DISTINCT`-marked aggregate
+  (`COUNT/SUM/AVG/MEDIAN/VARIANCE/STDDEV/GROUP_CONCAT/collect DISTINCT`) plus
+  `MIN`/`MAX`/`SAMPLE`. A single plain `COUNT`/`SUM`/… blocks dedup for the
+  whole WHERE.
+- **no grouping** → the query itself must be `SELECT DISTINCT`.
+
+An outer `SELECT DISTINCT` over an aggregate query does **not** license WHERE
+dedup — it dedups *result* rows after aggregation, while a plain `COUNT` under
+it still observes pre-aggregation multiplicity (this exact miswiring was a
+correctness bug fixed alongside the aggregate-aware gate).
+
+The dedup is inserted only at steps where trimming actually dropped a dead
+variable, so queries whose variables all stay live (e.g. same-subject stars
+feeding the projection) pay nothing. Subqueries dedup at their own boundary
+(`apply_solution_modifiers` applies the subquery's `DISTINCT`) rather than
+per-step.
+

--- a/fluree-db-api/tests/it_query_aggregates.rs
+++ b/fluree-db-api/tests/it_query_aggregates.rs
@@ -715,3 +715,78 @@ async fn aggregates_arithmetic_over_min_max_jsonld() {
         normalize_rows(&json!([["sup:partA", 4], ["sup:partB", 4]]))
     );
 }
+
+/// JSON-LD parity for WHERE-level early-dedup semantics (see the SPARQL
+/// twins in `it_query_sparql.rs`): a fan-in chain where two subjects reach
+/// the same intermediate node, so the intermediate relation carries
+/// duplicate rows once the head var is projected away.
+///
+///   a1 --p1--> b1 --p2--> {10, 20}
+///   a2 --p1--> b1
+async fn seed_chain_fan_in(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    let insert = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [
+            {"@id": "ex:a1", "ex:p1": {"@id": "ex:b1"}},
+            {"@id": "ex:a2", "ex:p1": {"@id": "ex:b1"}},
+            {"@id": "ex:b1", "ex:p2": [10, 20]}
+        ]
+    });
+    fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert chain fixture")
+        .ledger
+}
+
+/// `count-distinct` over the fan-in chain: 2 distinct ?x values. The
+/// duplicate-insensitive aggregate licenses WHERE-level early dedup; the
+/// result must be identical either way.
+#[tokio::test]
+async fn count_distinct_chain_fan_in_jsonld() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_chain_fan_in(&fluree, "agg/dedup-cd:main").await;
+
+    let query = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "select": ["(as (count-distinct ?x) ?c)"],
+        "where": [
+            {"@id": "?a", "ex:p1": "?b"},
+            {"@id": "?b", "ex:p2": "?x"}
+        ]
+    });
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+    assert_eq!(rows, json!([[2]]), "2 distinct ?x values: {rows}");
+}
+
+/// `selectDistinct` + plain `count` over the fan-in chain: the outer DISTINCT
+/// dedups result rows after aggregation and must not collapse the
+/// intermediate (?b) relation before the count — all 4 chain rows count.
+#[tokio::test]
+async fn select_distinct_plain_count_keeps_multiplicity_jsonld() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_chain_fan_in(&fluree, "agg/dedup-c:main").await;
+
+    let query = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "selectDistinct": ["(as (count ?x) ?c)"],
+        "where": [
+            {"@id": "?a", "ex:p1": "?b"},
+            {"@id": "?b", "ex:p2": "?x"}
+        ]
+    });
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+    assert_eq!(
+        rows,
+        json!([[4]]),
+        "COUNT(?x) must count all 4 chain rows — early dedup of the \
+         intermediate (?b) relation would wrongly halve it: {rows}"
+    );
+}

--- a/fluree-db-api/tests/it_query_explain.rs
+++ b/fluree-db-api/tests/it_query_explain.rs
@@ -448,3 +448,141 @@ async fn explain_logical_plan_preserves_compound_structure() {
         .expect("required triple present");
     assert_eq!(triple["category"], "source");
 }
+
+/// Count `"op": "DistinctOperator"` nodes in a physical plan tree.
+fn count_distinct_nodes(node: &serde_json::Value) -> usize {
+    let mut n = usize::from(node["op"] == "DistinctOperator");
+    if let Some(children) = node["children"].as_array() {
+        n += children
+            .iter()
+            .map(|e| count_distinct_nodes(&e["node"]))
+            .sum::<usize>();
+    }
+    n
+}
+
+/// Seed a 3-hop chain so `ex:` predicates are encodable, then return the
+/// physical plan for `sparql`.
+async fn chain_physical_plan(sparql: &str) -> serde_json::Value {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "dedup-plan:main");
+    let ledger = fluree
+        .insert(
+            ledger0,
+            &json!({
+                "@context": {"ex":"http://example.org/"},
+                "@graph": [
+                    {"@id":"ex:a1","ex:p1":{"@id":"ex:b1"}},
+                    {"@id":"ex:b1","ex:p2":{"@id":"ex:m1"}},
+                    {"@id":"ex:m1","ex:p3":"v"}
+                ]
+            }),
+        )
+        .await
+        .expect("seed")
+        .ledger;
+
+    let db = graphdb_from_ledger(&ledger);
+    let resp = fluree
+        .explain_sparql(&db, sparql)
+        .await
+        .expect("explain_sparql");
+    let physical = resp["plan"]["physical"].clone();
+    assert!(physical.is_object(), "plan.physical present: {resp}");
+    physical
+}
+
+/// A chain query whose only aggregate is duplicate-insensitive
+/// (`COUNT(DISTINCT ?x)`) gets WHERE-level early dedup: `DistinctOperator`
+/// nodes are inserted where projection trimming drops a dead variable, so
+/// duplicate multiplicity cannot compound through the join chain. There is no
+/// outer `SELECT DISTINCT` here, so every `DistinctOperator` in the plan is
+/// the early-dedup insertion.
+#[tokio::test]
+async fn explain_chain_count_distinct_inserts_early_dedup() {
+    let _env = HashJoinEnv::acquire();
+    let physical = chain_physical_plan(
+        "PREFIX ex: <http://example.org/>\n\
+         SELECT (COUNT(DISTINCT ?x) AS ?c)\n\
+         WHERE { ?a ex:p1 ?b . ?b ex:p2 ?m . ?m ex:p3 ?x }",
+    )
+    .await;
+    assert!(
+        count_distinct_nodes(&physical) >= 1,
+        "early dedup must fire for an all-duplicate-insensitive aggregate chain: {physical}"
+    );
+}
+
+/// `MIN`/`MAX` are duplicate-insensitive without a DISTINCT modifier, so the
+/// same early dedup applies.
+#[tokio::test]
+async fn explain_chain_max_inserts_early_dedup() {
+    let _env = HashJoinEnv::acquire();
+    let physical = chain_physical_plan(
+        "PREFIX ex: <http://example.org/>\n\
+         SELECT (MAX(?x) AS ?mx)\n\
+         WHERE { ?a ex:p1 ?b . ?b ex:p2 ?m . ?m ex:p3 ?x }",
+    )
+    .await;
+    assert!(
+        count_distinct_nodes(&physical) >= 1,
+        "early dedup must fire for MIN/MAX aggregates: {physical}"
+    );
+}
+
+/// A plain `COUNT(?x)` observes row multiplicity — no early dedup may be
+/// inserted anywhere in the chain.
+#[tokio::test]
+async fn explain_chain_plain_count_no_early_dedup() {
+    let _env = HashJoinEnv::acquire();
+    let physical = chain_physical_plan(
+        "PREFIX ex: <http://example.org/>\n\
+         SELECT (COUNT(?x) AS ?c)\n\
+         WHERE { ?a ex:p1 ?b . ?b ex:p2 ?m . ?m ex:p3 ?x }",
+    )
+    .await;
+    assert_eq!(
+        count_distinct_nodes(&physical),
+        0,
+        "plain COUNT is duplicate-sensitive; early dedup would change it: {physical}"
+    );
+}
+
+/// A mix of duplicate-insensitive and duplicate-sensitive aggregates blocks
+/// early dedup (the sensitive one still observes multiplicity).
+#[tokio::test]
+async fn explain_chain_mixed_aggregates_no_early_dedup() {
+    let _env = HashJoinEnv::acquire();
+    let physical = chain_physical_plan(
+        "PREFIX ex: <http://example.org/>\n\
+         SELECT (COUNT(DISTINCT ?x) AS ?c) (COUNT(?x) AS ?n)\n\
+         WHERE { ?a ex:p1 ?b . ?b ex:p2 ?m . ?m ex:p3 ?x }",
+    )
+    .await;
+    assert_eq!(
+        count_distinct_nodes(&physical),
+        0,
+        "a duplicate-sensitive aggregate in the mix must block early dedup: {physical}"
+    );
+}
+
+/// `SELECT DISTINCT` over a plain `COUNT`: the outer DISTINCT dedups *result*
+/// rows after aggregation and must NOT license WHERE-level dedup (that was the
+/// bug — the intermediate relation was collapsed before the count). Exactly
+/// one `DistinctOperator` may appear: the outer one above the aggregation.
+#[tokio::test]
+async fn explain_select_distinct_plain_count_only_outer_distinct() {
+    let _env = HashJoinEnv::acquire();
+    let physical = chain_physical_plan(
+        "PREFIX ex: <http://example.org/>\n\
+         SELECT DISTINCT (COUNT(?x) AS ?c)\n\
+         WHERE { ?a ex:p1 ?b . ?b ex:p2 ?m . ?m ex:p3 ?x }",
+    )
+    .await;
+    assert_eq!(
+        count_distinct_nodes(&physical),
+        1,
+        "only the outer result-row DISTINCT is allowed; WHERE-level dedup \
+         under a plain COUNT is unsound: {physical}"
+    );
+}

--- a/fluree-db-api/tests/it_query_grouping.rs
+++ b/fluree-db-api/tests/it_query_grouping.rs
@@ -315,3 +315,72 @@ async fn sparql_12_syntax_checks_rejected() {
         "unexpected error: {err}"
     );
 }
+
+/// Fan-in fixture for the grouped-list dedup regression: three `?a`s collapse
+/// onto one `?b`, so `?a` dying mid-chain is what WHERE-level early dedup
+/// would otherwise use to collapse rows.
+async fn seed_fanin(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    let ctx = context_ex_schema();
+    let insert = json!({
+        "@context": ctx,
+        "@graph": [
+            {"@id": "ex:a1", "ex:p1": {"@id": "ex:b1"}},
+            {"@id": "ex:a2", "ex:p1": {"@id": "ex:b1"}},
+            {"@id": "ex:a3", "ex:p1": {"@id": "ex:b1"}},
+            {"@id": "ex:a4", "ex:p1": {"@id": "ex:b2"}},
+            {"@id": "ex:b1", "ex:p2": 10},
+            {"@id": "ex:b2", "ex:p2": [20, 30]}
+        ]
+    });
+    fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("seed insert should succeed")
+        .ledger
+}
+
+/// The grouped list is a duplicate-SENSITIVE consumer: a duplicate-insensitive
+/// aggregate (`max`) licenses WHERE-level early dedup for itself, but a
+/// non-key variable projected alongside it still comes back as a per-group
+/// multiset. Companion to `jsonld_groupby_ungrouped_select_projects_grouped_list`,
+/// which has no fan-in and so cannot catch this.
+#[tokio::test]
+async fn jsonld_grouped_list_keeps_duplicates_under_insensitive_aggregate() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_fanin(&fluree, "query/grouped-list-dedup:main").await;
+    let ctx = context_ex_schema();
+
+    let query = json!({
+        "@context": ctx,
+        "select": ["?x", "(as (max ?x) ?m)"],
+        "where": [{"@id": "?a", "ex:p1": "?b"}, {"@id": "?b", "ex:p2": "?x"}]
+    });
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+    assert_eq!(rows, json!([[[10, 10, 10, 20, 30], 30]]));
+}
+
+/// A dedup-only `GROUP BY` has an EMPTY aggregate set, so an
+/// "all aggregates are duplicate-insensitive" check passes vacuously. The
+/// grouped list must still keep its duplicates.
+#[tokio::test]
+async fn jsonld_grouped_list_keeps_duplicates_without_aggregation() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_fanin(&fluree, "query/grouped-list-no-agg:main").await;
+    let ctx = context_ex_schema();
+
+    let query = json!({
+        "@context": ctx,
+        "select": ["?b", "?x"],
+        "where": [{"@id": "?a", "ex:p1": "?b"}, {"@id": "?b", "ex:p2": "?x"}],
+        "groupBy": ["?b"]
+    });
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+    assert_eq!(rows, json!([["ex:b1", [10, 10, 10]], ["ex:b2", [20, 30]]]));
+}

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -6535,3 +6535,74 @@ async fn sparql_no_base_keeps_relative_iris_verbatim() {
         "without BASE, relative IRIs match verbatim: {j}"
     );
 }
+
+/// Fixture for WHERE-level early-dedup semantics: a 2-hop chain where the
+/// first hop fans in (two ?a rows reach the same ?b), so the intermediate
+/// relation carries duplicate ?b rows once ?a is projected away.
+///
+///   a1 --p1--> b1 --p2--> {10, 20}
+///   a2 --p1--> b1
+///
+/// Chain rows for `?a :p1 ?b . ?b :p2 ?x`: (a1,b1,10) (a1,b1,20) (a2,b1,10)
+/// (a2,b1,20) — COUNT(?x) = 4, COUNT(DISTINCT ?x) = 2.
+async fn seed_chain_fan_in(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    let insert = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "@graph": [
+            {"@id": "ex:a1", "ex:p1": {"@id": "ex:b1"}},
+            {"@id": "ex:a2", "ex:p1": {"@id": "ex:b1"}},
+            {"@id": "ex:b1", "ex:p2": [10, 20]}
+        ]
+    });
+    fluree
+        .insert(ledger0, &insert)
+        .await
+        .expect("insert chain fixture")
+        .ledger
+}
+
+/// A duplicate-sensitive aggregate (`COUNT` without DISTINCT) must see full
+/// row multiplicity even when the query is `SELECT DISTINCT` and a WHERE var
+/// (?a) dies mid-chain. The WHERE-level early-dedup optimization must NOT
+/// fire here: outer DISTINCT dedups *result* rows after aggregation and says
+/// nothing about pre-aggregation multiplicity.
+#[tokio::test]
+async fn sparql_select_distinct_with_plain_count_keeps_multiplicity() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_chain_fan_in(&fluree, "it/sparql:dedup-count").await;
+
+    let q = r"PREFIX ex: <http://example.org/ns/>
+        SELECT DISTINCT (COUNT(?x) AS ?c)
+        WHERE { ?a ex:p1 ?b . ?b ex:p2 ?x }";
+    let r = support::query_sparql(&fluree, &ledger, q)
+        .await
+        .expect("distinct + plain count");
+    let j = r.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    assert_eq!(
+        j,
+        json!([[4]]),
+        "COUNT(?x) must count all 4 chain rows — early dedup of the \
+         intermediate (?b) relation would wrongly halve it: {j}"
+    );
+}
+
+/// COUNT(DISTINCT ?x) over the same fan-in chain: 2 distinct values. This is
+/// the shape where WHERE-level early dedup IS sound (every aggregate is
+/// duplicate-insensitive) and collapses the duplicate ?b intermediate rows.
+#[tokio::test]
+async fn sparql_count_distinct_chain_fan_in() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_chain_fan_in(&fluree, "it/sparql:dedup-count-distinct").await;
+
+    let q = r"PREFIX ex: <http://example.org/ns/>
+        SELECT (COUNT(DISTINCT ?x) AS ?c)
+        WHERE { ?a ex:p1 ?b . ?b ex:p2 ?x }";
+    let r = support::query_sparql(&fluree, &ledger, q)
+        .await
+        .expect("count distinct over chain");
+    let j = r.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    assert_eq!(j, json!([[2]]), "2 distinct ?x values: {j}");
+}

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2940,16 +2940,34 @@ fn build_operator_tree_inner(
 
     // WHERE-level early dedup (project away dead vars, collapse duplicate rows
     // between joins) is sound only when downstream cannot observe row
-    // multiplicity. With a grouping phase, that is decided by the aggregates
-    // alone: every one must be duplicate-insensitive (COUNT/SUM/AVG/… DISTINCT,
-    // or MIN/MAX/SAMPLE). An outer SELECT DISTINCT does NOT license it — it
-    // dedups result rows *after* aggregation, so a plain COUNT under it still
-    // observes pre-aggregation multiplicity. Without grouping, SELECT DISTINCT
-    // is exactly the license.
+    // multiplicity. With a grouping phase there are two consumers to clear:
+    // every aggregate must be duplicate-insensitive (COUNT/SUM/AVG/… DISTINCT,
+    // or MIN/MAX/SAMPLE), AND nothing may read a non-key variable raw. A
+    // non-key variable surviving the grouping stage comes out as a per-group
+    // LIST (the JSON-LD grouped projection), which observes multiplicity —
+    // note `aggregates()` is empty for a dedup-only `GROUP BY ?g`, where the
+    // aggregate check alone is vacuously true. An outer SELECT DISTINCT does
+    // NOT license dedup — it dedups result rows *after* aggregation, so a
+    // plain COUNT under it still observes pre-aggregation multiplicity.
+    // Without grouping, SELECT DISTINCT is exactly the license.
     let where_dedup_safe = match query.grouping.as_ref() {
-        Some(g) => g
-            .aggregates()
-            .all(|spec| spec.function.duplicate_insensitive()),
+        Some(g) => {
+            let aggregates_ok = g
+                .aggregates()
+                .all(|spec| spec.function.duplicate_insensitive());
+            // `required_aggregate_vars` is what the grouping stage's OUTPUT must
+            // carry, so it already folds in projection, HAVING, post-binds and
+            // ORDER BY. Anything in it that is not a GROUP BY key or an
+            // aggregate output passes through raw as a grouped list.
+            let keys: HashSet<VarId> = g.group_by_vars().collect();
+            let agg_outputs: HashSet<VarId> = g.aggregates().map(|s| s.output_var).collect();
+            let no_raw_passthrough = variable_deps.as_ref().is_some_and(|d| {
+                d.required_aggregate_vars
+                    .iter()
+                    .all(|v| keys.contains(v) || agg_outputs.contains(v))
+            });
+            aggregates_ok && no_raw_passthrough
+        }
         None => query.output.is_distinct(),
     };
 

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2938,12 +2938,27 @@ fn build_operator_tree_inner(
         .flat_map(Grouping::group_by_vars)
         .collect();
 
+    // WHERE-level early dedup (project away dead vars, collapse duplicate rows
+    // between joins) is sound only when downstream cannot observe row
+    // multiplicity. With a grouping phase, that is decided by the aggregates
+    // alone: every one must be duplicate-insensitive (COUNT/SUM/AVG/… DISTINCT,
+    // or MIN/MAX/SAMPLE). An outer SELECT DISTINCT does NOT license it — it
+    // dedups result rows *after* aggregation, so a plain COUNT under it still
+    // observes pre-aggregation multiplicity. Without grouping, SELECT DISTINCT
+    // is exactly the license.
+    let where_dedup_safe = match query.grouping.as_ref() {
+        Some(g) => g
+            .aggregates()
+            .all(|spec| spec.function.duplicate_insensitive()),
+        None => query.output.is_distinct(),
+    };
+
     let mut operator = build_where_operators_with_needed(
         &query.patterns,
         stats,
         &needed_where_vars,
         &group_by_vec,
-        query.output.is_distinct(),
+        where_dedup_safe,
         required_where_vars,
         planning,
     )?;

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1408,7 +1408,7 @@ pub(crate) struct TriplePlanContext<'a> {
     var_counts: &'a HashMap<VarId, usize>,
     protected_vars: &'a HashSet<VarId>,
     group_by: &'a [VarId],
-    distinct_query: bool,
+    where_dedup_safe: bool,
     planning: &'a PlanningContext,
     stats: Option<&'a StatsView>,
 }
@@ -1488,7 +1488,7 @@ fn build_sequential_join_block(
             live.into_iter().collect::<Vec<VarId>>()
         });
 
-        let pruned_vars: Option<HashSet<VarId>> = if ctx.distinct_query {
+        let pruned_vars: Option<HashSet<VarId>> = if ctx.where_dedup_safe {
             live_vars.as_ref().map(|live| {
                 let live_set: HashSet<VarId> = live.iter().copied().collect();
                 vars_after
@@ -1527,12 +1527,12 @@ fn build_sequential_join_block(
             );
             pending_binds = new_binds;
             pending_filters = new_filters;
-            operator = if ctx.distinct_query && pruned_vars.as_ref().is_some_and(|s| !s.is_empty())
-            {
-                Some(Box::new(DistinctOperator::new(child)))
-            } else {
-                Some(child)
-            };
+            operator =
+                if ctx.where_dedup_safe && pruned_vars.as_ref().is_some_and(|s| !s.is_empty()) {
+                    Some(Box::new(DistinctOperator::new(child)))
+                } else {
+                    Some(child)
+                };
         }
     }
 
@@ -1579,12 +1579,20 @@ pub fn build_where_operators(
 ///
 /// `needed_vars` are the variables that must survive the WHERE stage (because they
 /// are used by GROUP BY, aggregates, HAVING, ORDER BY, projection, etc.).
+///
+/// `where_dedup_safe` asserts that downstream cannot observe WHERE-output row
+/// multiplicity (a non-grouped `SELECT DISTINCT`, or a grouping phase whose
+/// aggregates are all duplicate-insensitive — the caller owns that analysis;
+/// see `build_operator_tree_inner`). When set, the join chain collapses
+/// duplicate rows with a `DistinctOperator` at every step where projection
+/// trimming dropped a dead variable, preventing duplicate multiplicity from
+/// compounding through deep existential chains.
 pub fn build_where_operators_with_needed(
     patterns: &[Pattern],
     stats: Option<Arc<StatsView>>,
     needed_vars: &HashSet<VarId>,
     group_by: &[VarId],
-    distinct_query: bool,
+    where_dedup_safe: bool,
     required_where_vars: Option<&[VarId]>,
     planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
@@ -1594,7 +1602,7 @@ pub fn build_where_operators_with_needed(
         stats,
         needed_vars,
         group_by,
-        distinct_query,
+        where_dedup_safe,
         required_where_vars,
         planning,
     )
@@ -1798,7 +1806,7 @@ pub fn build_where_operators_seeded_with_needed(
     stats: Option<Arc<StatsView>>,
     needed_vars: &HashSet<VarId>,
     group_by: &[VarId],
-    distinct_query: bool,
+    where_dedup_safe: bool,
     required_where_vars: Option<&[VarId]>,
     planning: &PlanningContext,
 ) -> Result<BoxedOperator> {
@@ -1949,7 +1957,7 @@ pub fn build_where_operators_seeded_with_needed(
                         var_counts: &var_counts,
                         protected_vars: &protected_vars,
                         group_by,
-                        distinct_query,
+                        where_dedup_safe,
                         planning,
                         stats: stats.as_deref(),
                     };
@@ -2157,7 +2165,7 @@ pub fn build_where_operators_seeded_with_needed(
                         var_counts: &var_counts,
                         protected_vars: &protected_vars,
                         group_by,
-                        distinct_query,
+                        where_dedup_safe,
                         planning,
                         stats: stats.as_deref(),
                     };
@@ -2762,9 +2770,10 @@ fn build_sequential_triple_chain(
             &hash_planner,
         ));
 
-        // DISTINCT query optimization: if any variables seen so far are no longer live,
-        // collapse duplicates early to avoid downstream join blowups.
-        if ctx.distinct_query {
+        // Early dedup (sound because downstream is multiplicity-insensitive —
+        // see `where_dedup_safe`): if any variables seen so far are no longer
+        // live, collapse duplicates early to avoid downstream join blowups.
+        if ctx.where_dedup_safe {
             if let Some(live) = live_vars.as_ref() {
                 let live_set: HashSet<VarId> = live.iter().copied().collect();
                 let dead = seen_vars
@@ -2912,7 +2921,7 @@ mod tests {
             var_counts: &counts,
             protected_vars: &protected,
             group_by: &[],
-            distinct_query: false,
+            where_dedup_safe: false,
             planning: &crate::temporal_mode::PlanningContext::current(),
             stats: None,
         };

--- a/fluree-db-query/src/ir/grouping.rs
+++ b/fluree-db-query/src/ir/grouping.rs
@@ -125,8 +125,23 @@ impl AggregateFn {
     /// planner may project away dead variables and collapse duplicate rows
     /// between joins without changing results (see
     /// `where_plan::build_sequential_join_block`).
+    /// Matched exhaustively on purpose: this is a soundness-critical
+    /// partition, so a new variant must be classified deliberately rather
+    /// than defaulting (silently to `false` — safe, but it would lose the
+    /// optimization with no signal).
     pub fn duplicate_insensitive(&self) -> bool {
-        matches!(self, Self::Min(_) | Self::Max(_) | Self::Sample(_)) || self.is_distinct()
+        match self {
+            Self::Min(_) | Self::Max(_) | Self::Sample(_) => true,
+            Self::CountAll | Self::Count(_) => false,
+            Self::CountDistinct(_)
+            | Self::Sum(..)
+            | Self::Avg(..)
+            | Self::Median(..)
+            | Self::Variance(..)
+            | Self::Stddev(..)
+            | Self::Collect(..)
+            | Self::GroupConcat { .. } => self.is_distinct(),
+        }
     }
 }
 

--- a/fluree-db-query/src/ir/grouping.rs
+++ b/fluree-db-query/src/ir/grouping.rs
@@ -114,6 +114,20 @@ impl AggregateFn {
                 | Self::Collect(_, InputSemantics::Set)
         )
     }
+
+    /// Whether the aggregate's result is unchanged when duplicate input ROWS
+    /// are collapsed to one — i.e. it observes only the *set* of values, not
+    /// their multiplicity. True for every `DISTINCT`-marked variant plus
+    /// `Min`/`Max`/`Sample` (order statistics / arbitrary pick).
+    ///
+    /// This is the soundness condition for WHERE-level early dedup: when
+    /// every aggregate in the grouping phase is duplicate-insensitive, the
+    /// planner may project away dead variables and collapse duplicate rows
+    /// between joins without changing results (see
+    /// `where_plan::build_sequential_join_block`).
+    pub fn duplicate_insensitive(&self) -> bool {
+        matches!(self, Self::Min(_) | Self::Max(_) | Self::Sample(_)) || self.is_distinct()
+    }
 }
 
 impl AggregateFn {
@@ -326,6 +340,56 @@ impl Grouping {
         }
         if let Some(expr) = having {
             expr.substitute_var(old, new);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::var_registry::VarId;
+
+    #[test]
+    fn duplicate_insensitive_partitions_aggregates() {
+        let v = VarId(0);
+        // Insensitive: every DISTINCT-marked variant plus MIN/MAX/SAMPLE.
+        for f in [
+            AggregateFn::CountDistinct(v),
+            AggregateFn::Sum(v, InputSemantics::Set),
+            AggregateFn::Avg(v, InputSemantics::Set),
+            AggregateFn::Median(v, InputSemantics::Set),
+            AggregateFn::Variance(v, InputSemantics::Set),
+            AggregateFn::Stddev(v, InputSemantics::Set),
+            AggregateFn::GroupConcat {
+                input: v,
+                semantics: InputSemantics::Set,
+                separator: ",".into(),
+            },
+            AggregateFn::Collect(v, InputSemantics::Set),
+            AggregateFn::Min(v),
+            AggregateFn::Max(v),
+            AggregateFn::Sample(v),
+        ] {
+            assert!(f.duplicate_insensitive(), "{f:?} must be insensitive");
+        }
+        // Sensitive: multiplicity-observing variants — WHERE-level early dedup
+        // must be blocked when any of these is present.
+        for f in [
+            AggregateFn::Count(v),
+            AggregateFn::CountAll,
+            AggregateFn::Sum(v, InputSemantics::List),
+            AggregateFn::Avg(v, InputSemantics::List),
+            AggregateFn::Median(v, InputSemantics::List),
+            AggregateFn::Variance(v, InputSemantics::List),
+            AggregateFn::Stddev(v, InputSemantics::List),
+            AggregateFn::GroupConcat {
+                input: v,
+                semantics: InputSemantics::List,
+                separator: ",".into(),
+            },
+            AggregateFn::Collect(v, InputSemantics::List),
+        ] {
+            assert!(!f.duplicate_insensitive(), "{f:?} must be sensitive");
         }
     }
 }


### PR DESCRIPTION
## Problem

On a 6-hop existential chain (every intermediate variable bound but never projected), the pipeline carries full duplicate multiplicity through every join. On PrimeKG (8.7M flakes):

```sparql
SELECT (COUNT(DISTINCT ?p3) AS ?n) WHERE {
  ?dis pkg:diseaseName "epilepsy" ; pkg:associatedWithProtein ?p1 .
  ?p1  pkg:participatesInPathway ?pw .
  ?pw  pkg:hasPathwayProtein ?p2 .
  ?p2  pkg:targetedByDrug ?d1 .
  ?d1  pkg:interactsWithDrug ?d2 .
  ?d2  pkg:targetsProtein ?p3 .
}
```

The final join consumed a **10.17M-row intermediate carrying only 4,086 distinct `?d2` values** (2,490× redundancy) — 74.7s, while a hand-rewritten nested `SELECT DISTINCT` version returned the identical answer in 185ms. Join order was already optimal; the problem was purely that nothing collapsed duplicates once a variable went dead.

## Root cause

The WHERE planner already has per-step early dedup (trim dead columns via live-var analysis, then insert a streaming `DistinctOperator`), but it was gated on `query.output.is_distinct()` — i.e. `SELECT DISTINCT` only. That gate is wrong in **both** directions:

1. **Too narrow:** an aggregate query whose aggregates are all duplicate-insensitive (`COUNT(DISTINCT …)`, `MIN`, `MAX`, `SAMPLE`, any `DISTINCT`-marked aggregate) can't observe WHERE-output multiplicity either, but never got the dedup.
2. **Unsound:** `SELECT DISTINCT (COUNT(?x) AS ?c)` *did* fire the dedup and returned wrong counts — confirmed on main with a failing test before the fix (returned 2 where the correct count is 4). The outer DISTINCT dedups *result* rows after aggregation; it does not license pre-aggregation dedup.

## Fix

`build_operator_tree_inner` now computes `where_dedup_safe`:

- **grouping present** → every aggregate must satisfy the new `AggregateFn::duplicate_insensitive()` (any `DISTINCT`-marked variant, plus `MIN`/`MAX`/`SAMPLE`)
- **no grouping** → `SELECT DISTINCT`, as before

The flag is threaded through the WHERE planner under that name (renamed from `distinct_query`). No change to the dedup mechanism itself, subquery planning, fast paths, or the hash-join planner.

## Results (PrimeKG, release build)

| Query | Before | After | Result |
|---|---|---|---|
| Chain as written | 74,660 ms | **188.1 ms** | 2341 ✓ |
| Hand-dedup rewrite | 184.9 ms | 188.3 ms | 2341 ✓ |

The plan now shows a `DistinctOperator` after each join, collapsing every intermediate to its distinct live tuples (193 → 464 → 5,790 → 4,949 → 4,086 rows instead of 1 → 17 → 85 → 1,700 → 15,300 → 10.17M).

Dedup is only inserted at steps where trimming actually dropped a dead variable, so star shapes and queries whose variables stay live are untouched, as are all plain-`COUNT`/`SUM` aggregates.

## Testing

- Plan-shape guards (`it_query_explain.rs`): dedup fires for `COUNT(DISTINCT)`/`MAX` chains; blocked for plain `COUNT`, mixed aggregates, and `SELECT DISTINCT` + plain `COUNT` (exactly one outer `DistinctOperator`)
- Correctness fixtures in `it_query_sparql.rs` (fan-in chain: plain count keeps multiplicity, distinct count unchanged) with JSON-LD twins in `it_query_aggregates.rs`
- Unit test partitioning every `AggregateFn` variant by duplicate-insensitivity
- Full W3C SPARQL compliance suite: 36/36 suites pass (aggregates + grouping included)
- 1,213 `fluree-db-query` unit tests, `grp_query` (380), `grp_query_sparql` (290), `grp_query_reason` (100), `it_query_cypher` (228), `it_query_sparql_indexed` (85) — all green
- clippy `--all-features --all-targets -D warnings` clean

Design doc updated: `docs/design/query-execution.md` § "WHERE-level early dedup".