### PR TITLE
perf: eliminate per-flake staging cost in bulk upserts

### DIFF
--- a/fluree-db-api/tests/grp_transact.rs
+++ b/fluree-db-api/tests/grp_transact.rs
@@ -31,6 +31,8 @@ mod it_transact_update;
 mod it_transact_update_indexed;
 #[path = "it_transact_upsert.rs"]
 mod it_transact_upsert;
+#[path = "it_transact_upsert_indexed.rs"]
+mod it_transact_upsert_indexed;
 #[path = "it_txn_meta.rs"]
 mod it_txn_meta;
 #[path = "it_update_wildcard_delete_indexed.rs"]

--- a/fluree-db-api/tests/it_transact_upsert_indexed.rs
+++ b/fluree-db-api/tests/it_transact_upsert_indexed.rs
@@ -39,6 +39,38 @@ async fn name_values(
     normalize_rows(&rows)
 }
 
+const GRAPH_ALPHA: &str = "http://example.org/graphs/alpha";
+const GRAPH_BETA: &str = "http://example.org/graphs/beta";
+const GRAPH_GAMMA: &str = "http://example.org/graphs/gamma";
+
+async fn graph_name_values(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &fluree_db_api::LedgerState,
+    ledger_id: &str,
+    graph_iri: &str,
+    subject: &str,
+) -> Vec<String> {
+    let query = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}#{graph_iri}"),
+        "where": {"@id": subject, "ex:name": "?n"},
+        "select": "?n"
+    });
+    let results = fluree
+        .query_connection(&query)
+        .await
+        .expect("named-graph query");
+    let results = results.to_jsonld(&ledger.snapshot).expect("to_jsonld");
+    let mut vals: Vec<String> = results
+        .as_array()
+        .expect("array")
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_string))
+        .collect();
+    vals.sort();
+    vals
+}
+
 /// One upsert touching a persisted subject, a novelty-only subject, and a
 /// brand-new subject must replace values for the first two and plainly insert
 /// the third — before and after the next index build.
@@ -157,6 +189,109 @@ async fn upsert_mixed_persisted_novelty_new_subjects() {
             assert_eq!(name_values(&fluree, &ledger, "ex:b").await, expect("B1"));
             assert_eq!(name_values(&fluree, &ledger, "ex:c").await, expect("C2"));
             assert_eq!(name_values(&fluree, &ledger, "ex:d").await, expect("D1"));
+        })
+        .await;
+}
+
+/// Post-index named-graph upsert. The subject pre-check keys its novelty set
+/// per ledger graph while `subject_in_base` is graph-agnostic, and the
+/// txn-graph → ledger-graph translation is hoisted out of the subject loop —
+/// this pins that restructuring against a real binary index: the same subject
+/// IRI upserted into two named graphs is replaced independently with no
+/// cross-graph leakage, alongside a brand-new subject (skip path) and a graph
+/// not yet in the ledger registry (nothing-to-retract path) in the same
+/// transaction.
+#[tokio::test]
+async fn upsert_indexed_named_graphs_replace_independently() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let index_cfg = IndexConfig {
+        reindex_min_bytes: 0,
+        reindex_max_bytes: 1_000_000,
+    };
+
+    let mut fluree = FlureeBuilder::file(path).build().expect("build");
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .publisher_arc()
+            .expect("test setup requires ReadWrite nameservice mode"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/upsert-indexed-named-graphs:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            // Same subject IRI in two named graphs, different values.
+            let trig1 = r#"
+                @prefix ex: <http://example.org/ns/> .
+                GRAPH <http://example.org/graphs/alpha> { ex:s ex:name "A1" . }
+                GRAPH <http://example.org/graphs/beta>  { ex:s ex:name "B1" . }
+            "#;
+            let r1 = fluree
+                .stage_owned(ledger)
+                .upsert_turtle(trig1)
+                .index_config(index_cfg.clone())
+                .execute()
+                .await
+                .unwrap();
+
+            // Index + reload so both graphs live in the binary index.
+            trigger_index_and_wait_outcome(&handle, ledger_id, r1.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(ledger.snapshot.range_provider.is_some());
+
+            // One post-index upsert: ex:s replaced in alpha AND beta with
+            // different values, a brand-new subject in beta, and ex:s in
+            // gamma — a graph the ledger registry has never seen.
+            let trig2 = r#"
+                @prefix ex: <http://example.org/ns/> .
+                GRAPH <http://example.org/graphs/alpha> { ex:s ex:name "A2" . }
+                GRAPH <http://example.org/graphs/beta>  { ex:s ex:name "B2" . ex:t ex:name "T1" . }
+                GRAPH <http://example.org/graphs/gamma> { ex:s ex:name "G1" . }
+            "#;
+            let r2 = fluree
+                .stage_owned(ledger)
+                .upsert_turtle(trig2)
+                .index_config(index_cfg.clone())
+                .execute()
+                .await
+                .unwrap();
+
+            let expect = |v: &str| vec![v.to_string()];
+            for stage in ["pre-index", "post-index"] {
+                let ledger = if stage == "pre-index" {
+                    r2.ledger.clone()
+                } else {
+                    trigger_index_and_wait_outcome(&handle, ledger_id, r2.receipt.t).await;
+                    fluree.ledger(ledger_id).await.unwrap()
+                };
+                assert_eq!(
+                    graph_name_values(&fluree, &ledger, ledger_id, GRAPH_ALPHA, "ex:s").await,
+                    expect("A2"),
+                    "{stage}: alpha value replaced, no leakage from beta/gamma"
+                );
+                assert_eq!(
+                    graph_name_values(&fluree, &ledger, ledger_id, GRAPH_BETA, "ex:s").await,
+                    expect("B2"),
+                    "{stage}: beta value replaced, no leakage from alpha/gamma"
+                );
+                assert_eq!(
+                    graph_name_values(&fluree, &ledger, ledger_id, GRAPH_BETA, "ex:t").await,
+                    expect("T1"),
+                    "{stage}: brand-new subject inserted in beta"
+                );
+                assert_eq!(
+                    graph_name_values(&fluree, &ledger, ledger_id, GRAPH_GAMMA, "ex:s").await,
+                    expect("G1"),
+                    "{stage}: new graph gets its value, nothing retracted"
+                );
+            }
         })
         .await;
 }

--- a/fluree-db-api/tests/it_transact_upsert_indexed.rs
+++ b/fluree-db-api/tests/it_transact_upsert_indexed.rs
@@ -1,0 +1,162 @@
+//! Upsert replace-semantics against an indexed ledger.
+//!
+//! Regression coverage for the upsert-deletion subject pre-check in
+//! `generate_upsert_deletions`: subjects absent from both the persisted
+//! subject dictionary and novelty skip their existing-value lookups entirely
+//! (a bound-subject scan for an unresolvable subject degrades to a full PSOT
+//! predicate-partition walk — ~8 ms/flake on real ledgers). These tests pin
+//! that the skip never drops retractions for subjects that DO exist:
+//! persisted (base index), novelty-only (committed after the last index), and
+//! brand-new subjects all in one transaction.
+
+#![cfg(feature = "native")]
+
+use crate::support::{
+    normalize_rows, query_jsonld_formatted, start_background_indexer_local,
+    trigger_index_and_wait_outcome,
+};
+use fluree_db_api::{FlureeBuilder, IndexConfig};
+use fluree_db_transact::{CommitOpts, TxnOpts};
+use serde_json::json;
+
+fn ctx() -> serde_json::Value {
+    json!({"ex": "http://example.org/ns/"})
+}
+
+async fn name_values(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &fluree_db_api::LedgerState,
+    subject: &str,
+) -> Vec<serde_json::Value> {
+    let query = json!({
+        "@context": ctx(),
+        "where": {"@id": subject, "ex:name": "?n"},
+        "select": ["?n"]
+    });
+    let rows = query_jsonld_formatted(fluree, ledger, &query)
+        .await
+        .expect("query");
+    normalize_rows(&rows)
+}
+
+/// One upsert touching a persisted subject, a novelty-only subject, and a
+/// brand-new subject must replace values for the first two and plainly insert
+/// the third — before and after the next index build.
+#[tokio::test]
+async fn upsert_mixed_persisted_novelty_new_subjects() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let index_cfg = IndexConfig {
+        reindex_min_bytes: 0,
+        reindex_max_bytes: 1_000_000,
+    };
+
+    let mut fluree = FlureeBuilder::file(path).build().expect("build");
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .publisher_arc()
+            .expect("test setup requires ReadWrite nameservice mode"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/upsert-indexed-mixed:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            // Persisted subject with a multi-valued property (all values must
+            // be retracted on upsert, not just one).
+            let r1 = fluree
+                .upsert_with_opts(
+                    ledger,
+                    &json!({
+                        "@context": ctx(),
+                        "@graph": [
+                            {"@id": "ex:a", "ex:name": ["A1a", "A1b"]},
+                            {"@id": "ex:b", "ex:name": "B1"}
+                        ]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .unwrap();
+
+            // Index + reload so ex:a / ex:b live in the binary index.
+            trigger_index_and_wait_outcome(&handle, ledger_id, r1.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(ledger.snapshot.range_provider.is_some());
+
+            // Novelty-only subject: committed after the index build.
+            let r2 = fluree
+                .upsert_with_opts(
+                    ledger,
+                    &json!({
+                        "@context": ctx(),
+                        "@id": "ex:c",
+                        "ex:name": "C1"
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .unwrap();
+
+            // One upsert across all three subject classes.
+            let r3 = fluree
+                .upsert_with_opts(
+                    r2.ledger,
+                    &json!({
+                        "@context": ctx(),
+                        "@graph": [
+                            {"@id": "ex:a", "ex:name": "A2"},
+                            {"@id": "ex:c", "ex:name": "C2"},
+                            {"@id": "ex:d", "ex:name": "D1"}
+                        ]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .unwrap();
+
+            let expect = |v: &str| vec![json!([v])];
+            assert_eq!(
+                name_values(&fluree, &r3.ledger, "ex:a").await,
+                expect("A2"),
+                "persisted subject: both old values replaced"
+            );
+            assert_eq!(
+                name_values(&fluree, &r3.ledger, "ex:b").await,
+                expect("B1"),
+                "untouched subject keeps its value"
+            );
+            assert_eq!(
+                name_values(&fluree, &r3.ledger, "ex:c").await,
+                expect("C2"),
+                "novelty-only subject: old value replaced"
+            );
+            assert_eq!(
+                name_values(&fluree, &r3.ledger, "ex:d").await,
+                expect("D1"),
+                "new subject inserted"
+            );
+
+            // Same assertions after the next index build (retractions must
+            // have been staged, not merely masked by novelty).
+            trigger_index_and_wait_outcome(&handle, ledger_id, r3.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(name_values(&fluree, &ledger, "ex:a").await, expect("A2"));
+            assert_eq!(name_values(&fluree, &ledger, "ex:b").await, expect("B1"));
+            assert_eq!(name_values(&fluree, &ledger, "ex:c").await, expect("C2"));
+            assert_eq!(name_values(&fluree, &ledger, "ex:d").await, expect("D1"));
+        })
+        .await;
+}

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -258,6 +258,11 @@ pub struct BinaryIndexStore {
     ns_split_mode: NsSplitMode,
     /// Whether `set_ns_split_mode` was called. Debug-asserted on first encode.
     ns_split_mode_set: bool,
+    /// Lazily-built persisted `p_id → Sid` table, shared by scan operators.
+    /// Initialized on first query use — always after load-time `&mut`
+    /// configuration (`set_ns_split_mode`, namespace augmentation), which
+    /// cannot occur once the store is behind `Arc`.
+    p_sid_table: std::sync::OnceLock<Arc<[Sid]>>,
 }
 
 impl BinaryIndexStore {
@@ -382,6 +387,7 @@ impl BinaryIndexStore {
             lex_sorted_string_ids: root.lex_sorted_string_ids,
             ns_split_mode: root.ns_split_mode,
             ns_split_mode_set: true,
+            p_sid_table: std::sync::OnceLock::new(),
         })
     }
 
@@ -1447,6 +1453,25 @@ impl BinaryIndexStore {
     /// Resolve a predicate ID to its IRI.
     pub fn resolve_predicate_iri(&self, p_id: u32) -> Option<&str> {
         self.dicts.predicates.resolve(p_id)
+    }
+
+    /// Shared persisted `p_id → Sid` table, built once per store on first use.
+    ///
+    /// Scan opens previously rebuilt this table (one dictionary resolve +
+    /// namespace encode per predicate) on every call — a fixed cost
+    /// proportional to the ledger's predicate count that dominated
+    /// bound-subject point lookups.
+    pub fn p_sid_table(&self) -> &Arc<[Sid]> {
+        self.p_sid_table.get_or_init(|| {
+            let mut table = Vec::new();
+            for p_id in 0u32.. {
+                match self.resolve_predicate_iri(p_id) {
+                    Some(iri) => table.push(self.encode_iri(iri)),
+                    None => break,
+                }
+            }
+            table.into()
+        })
     }
 
     /// Lookup a predicate IRI → p_id.
@@ -3039,6 +3064,7 @@ mod tests {
             lex_sorted_string_ids: false,
             ns_split_mode: NsSplitMode::default(),
             ns_split_mode_set: true,
+            p_sid_table: std::sync::OnceLock::new(),
         }
     }
 

--- a/fluree-db-query/src/binary_range.rs
+++ b/fluree-db-query/src/binary_range.rs
@@ -717,9 +717,9 @@ fn binary_range_eq_v3(
                 Some(sid) => sid.clone(),
                 None => resolve_sid(s_id, &view)?,
             };
-            // Resolve predicate: persisted dict first, then ephemeral overlay map.
-            let p_sid = match store.resolve_predicate_iri(p_id) {
-                Some(iri) => store.encode_iri(iri),
+            // Resolve predicate: persisted table first, then ephemeral overlay map.
+            let p_sid = match store.p_sid_table().get(p_id as usize) {
+                Some(sid) => sid.clone(),
                 None => match ephemeral_p_id_to_sid.get(&p_id) {
                     Some(sid) => sid.clone(),
                     None => continue, // truly unknown — shouldn't happen
@@ -1361,9 +1361,9 @@ fn binary_range_bounded_v3(
                 }
             }
 
-            // Resolve predicate: persisted dict first, then ephemeral overlay map.
-            let p_sid = match store.resolve_predicate_iri(p_id) {
-                Some(iri) => store.encode_iri(iri),
+            // Resolve predicate: persisted table first, then ephemeral overlay map.
+            let p_sid = match store.p_sid_table().get(p_id as usize) {
+                Some(sid) => sid.clone(),
                 None => match ephemeral_p_id_to_sid.get(&p_id) {
                     Some(sid) => sid.clone(),
                     None => continue, // truly unknown — shouldn't happen

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -185,8 +185,11 @@ pub struct BinaryScanOperator {
     store: Option<Arc<BinaryIndexStore>>,
     g_id: GraphId,
     cursor: Option<BinaryCursor>,
-    /// Pre-computed p_id → Sid (all predicates, done once at open).
-    p_sids: Vec<Sid>,
+    /// Persisted p_id → Sid table, shared from the store's per-instance cache.
+    p_sids: Arc<[Sid]>,
+    /// Novelty-only predicate overrides keyed by ephemeral p_id, populated
+    /// during overlay translation (ephemeral ids sit above the persisted range).
+    p_sids_ephemeral: HashMap<u32, Sid>,
     /// Cached s_id → Sid for amortized IRI resolution.
     sid_cache: HashMap<u64, Sid>,
     /// Whether predicate is a variable (for internal predicate filtering).
@@ -723,7 +726,8 @@ impl BinaryScanOperator {
             store: None,
             g_id: 0,
             cursor: None,
-            p_sids: Vec::new(),
+            p_sids: Vec::new().into(),
+            p_sids_ephemeral: HashMap::new(),
             sid_cache: HashMap::new(),
             p_is_var,
             include_system_facts: false,
@@ -1138,6 +1142,9 @@ impl BinaryScanOperator {
     /// Resolve p_id → Sid (pre-computed, O(1)).
     #[inline]
     fn resolve_p_id(&self, p_id: u32) -> Sid {
+        if let Some(sid) = self.p_sids_ephemeral.get(&p_id) {
+            return sid.clone();
+        }
         self.p_sids
             .get(p_id as usize)
             .cloned()
@@ -1170,8 +1177,12 @@ impl BinaryScanOperator {
         if self.include_system_facts {
             return false;
         }
-        let Some(sid) = self.p_sids.get(p_id as usize) else {
-            return false;
+        let sid = match self.p_sids_ephemeral.get(&p_id) {
+            Some(sid) => sid,
+            None => match self.p_sids.get(p_id as usize) {
+                Some(sid) => sid,
+                None => return false,
+            },
         };
         // Always hide `f:reifies*` regardless of graph.
         if fluree_db_core::is_reserved_reifies_predicate(sid) {
@@ -1774,21 +1785,14 @@ impl Operator for BinaryScanOperator {
             return self.open_range_fallback(ctx).await;
         }
 
-        // Pre-compute p_id → Sid table.
-        let mut p_sids = Vec::new();
         let store = self.store.as_ref().ok_or_else(|| {
             QueryError::Internal(
                 "BinaryScanOperator::open: no binary_store on ExecutionContext".into(),
             )
         })?;
         let store_ref = store.as_ref();
-        for p_id in 0u32.. {
-            match store_ref.resolve_predicate_iri(p_id) {
-                Some(iri) => p_sids.push(store_ref.encode_iri(iri)),
-                None => break,
-            }
-        }
-        self.p_sids = p_sids;
+        // Persisted p_id → Sid table, built once per store instance.
+        self.p_sids = Arc::clone(store_ref.p_sid_table());
 
         // Extract bound terms in snapshot namespace space and build the persisted-ID filter
         // by translating through full IRIs into store namespace space.
@@ -2204,14 +2208,10 @@ impl Operator for BinaryScanOperator {
                 }
             };
 
-            // Extend p_sids table with novelty-only predicates so that ephemeral
-            // p_ids from overlay ops can be decoded back to Sids during row binding.
+            // Record novelty-only predicates so that ephemeral p_ids from
+            // overlay ops can be decoded back to Sids during row binding.
             for (sid, ep_id) in &translated.ephemeral_preds {
-                let idx = *ep_id as usize;
-                if idx >= self.p_sids.len() {
-                    self.p_sids.resize(idx + 1, Sid::new(0, ""));
-                }
-                self.p_sids[idx] = sid.clone();
+                self.p_sids_ephemeral.insert(*ep_id, sid.clone());
             }
 
             if !translated.ops.is_empty() {
@@ -2394,7 +2394,8 @@ impl Operator for BinaryScanOperator {
         self.range_iter = None;
         self.store = None;
         self.sid_cache.clear();
-        self.p_sids.clear();
+        self.p_sids = Vec::new().into();
+        self.p_sids_ephemeral.clear();
         self.unresolved_bound_subject_iri = None;
         self.state = OperatorState::Closed;
     }
@@ -2751,8 +2752,8 @@ pub(crate) fn translate_one_flake_v3_pub(
     // Predicate: persisted → ephemeral (keyed by Sid to avoid namespace decode issues).
     //
     // For novelty-only predicates (not present in the persisted predicate dictionary),
-    // we allocate ephemeral p_ids and later extend `p_sids` so decode produces the
-    // original Sid (in snapshot namespace space).
+    // we allocate ephemeral p_ids and later record them in `p_sids_ephemeral` so
+    // decode produces the original Sid (in snapshot namespace space).
     let p_id = match store.sid_to_p_id(&flake.p) {
         Some(id) => id,
         None => runtime_small_dicts

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -2579,8 +2579,16 @@ fn inline_values_to_pattern(values: &InlineValues) -> Result<Pattern> {
 /// query existing values and generate retractions for them. This implements the
 /// "replace mode" semantics of Upsert.
 ///
-/// Named graph support: retractions are created in the same graph as the insert templates
-/// to ensure proper cancellation with assertions.
+/// Subjects absent from both the persisted subject dictionary and novelty are
+/// skipped without any index query: they cannot have existing values. This
+/// matters because a bound-subject scan for a subject the dictionaries can't
+/// resolve degrades to a full PSOT predicate-partition walk with per-row IRI
+/// decoding (`unresolved_bound_subject_iri` in `BinaryScanOperator`) — for bulk
+/// upserts of new entities that turned staging into minutes of work producing
+/// zero retractions.
+///
+/// Named graph support: retractions are created in the same graph as the insert
+/// templates to ensure proper cancellation with assertions.
 async fn generate_upsert_deletions(
     ledger: &LedgerState,
     txn: &Txn,
@@ -2588,23 +2596,30 @@ async fn generate_upsert_deletions(
     graph_sids: &std::collections::HashMap<u16, Sid>,
 ) -> Result<Vec<fluree_db_core::Flake>> {
     use fluree_db_binary_index::BinaryGraphView;
-    use fluree_db_core::Flake;
+    use fluree_db_core::{Flake, IndexType};
     use fluree_db_query::materializer::JoinKeyMode;
     use fluree_db_query::{BinaryRangeProvider, Materializer};
 
-    // Collect unique (subject, predicate, graph_id) tuples from insert templates
-    // Include graph_id to ensure retractions are created in the correct graph
-    let mut spg_tuples: HashSet<(Sid, Sid, Option<u16>)> = HashSet::new();
+    // Group deduplicated predicates by (subject, graph_id) so subject existence
+    // is resolved once per subject rather than once per (subject, predicate).
+    let mut subject_groups: HashMap<(Sid, Option<u16>), Vec<Sid>> = HashMap::new();
     for template in &txn.insert_templates {
         if let (TemplateTerm::Sid(s), TemplateTerm::Sid(p)) =
             (&template.subject, &template.predicate)
         {
-            spg_tuples.insert((s.clone(), p.clone(), template.graph_id));
+            subject_groups
+                .entry((s.clone(), template.graph_id))
+                .or_default()
+                .push(p.clone());
         }
         // Variables and blank nodes are skipped - we can't query for them
     }
+    for predicates in subject_groups.values_mut() {
+        predicates.sort_unstable();
+        predicates.dedup();
+    }
 
-    if spg_tuples.is_empty() {
+    if subject_groups.is_empty() {
         return Ok(Vec::new());
     }
 
@@ -2618,65 +2633,99 @@ async fn generate_upsert_deletions(
     let binary_store = brp_ref.map(|brp| Arc::clone(brp.store()));
     let dict_novelty = brp_ref.map(|brp| Arc::clone(brp.dict_novelty()));
 
+    // IMPORTANT: `TripleTemplate.graph_id` is a transaction-local ID.
+    // It must be translated to a ledger-stable GraphId before we can query
+    // the correct per-graph index partition.
+    //
+    // txn_local_g_id -> graph IRI (txn.graph_delta) -> ledger g_id (GraphRegistry)
+    // None in the value position means the graph is not yet in the ledger
+    // registry (new graph in this txn), so there cannot be existing values.
+    let ledger_g_for_txn_g: HashMap<Option<u16>, Option<u16>> = subject_groups
+        .keys()
+        .map(|(_, txn_g)| *txn_g)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .map(|txn_g| {
+            let ledger_g = match txn_g {
+                None => Some(0),
+                Some(tg) => txn
+                    .graph_delta
+                    .get(&tg)
+                    .and_then(|iri| ledger.snapshot.graph_registry.graph_id_for_iri(iri)),
+            };
+            (txn_g, ledger_g)
+        })
+        .collect();
+
+    // Novelty presence: one overlay walk per referenced graph, collecting which
+    // of this transaction's subjects have any novelty flakes. Novelty is
+    // in-memory and small (bounded by reindex backpressure), so a filtered full
+    // walk per graph is cheap — and it is authoritative in Sid space, needing
+    // no dictionary translation.
+    let mut novelty_present: HashMap<u16, HashSet<Sid>> = HashMap::new();
+    if binary_store.is_some() {
+        let mut per_g_subjects: HashMap<u16, HashSet<&Sid>> = HashMap::new();
+        for (subject, txn_g) in subject_groups.keys() {
+            if let Some(Some(ledger_g)) = ledger_g_for_txn_g.get(txn_g) {
+                per_g_subjects.entry(*ledger_g).or_default().insert(subject);
+            }
+        }
+        for (g, subjects) in per_g_subjects {
+            let present = novelty_present.entry(g).or_default();
+            ledger.novelty.for_each_overlay_flake(
+                g,
+                IndexType::Spot,
+                None,
+                None,
+                true,
+                ledger.t(),
+                &mut |flake| {
+                    if subjects.contains(&flake.s) && !present.contains(&flake.s) {
+                        present.insert(flake.s.clone());
+                    }
+                },
+            );
+        }
+    }
+
+    // Persisted presence: the subject reverse dictionary is authoritative under
+    // canonical namespace encoding (see `fluree_db_core::ns_encoding`) — a miss
+    // on both the (ns_code, suffix) key and the full-IRI key means the subject
+    // has no rows in the base index. Lookup errors fall back to "present" so the
+    // per-predicate query surfaces the real failure.
+    let subject_in_base = |subject: &Sid| -> bool {
+        let Some(store) = binary_store.as_deref() else {
+            return true;
+        };
+        if matches!(
+            store.find_subject_id_by_parts(subject.namespace_code, &subject.name),
+            Ok(Some(_))
+        ) {
+            return true;
+        }
+        match ledger.snapshot.decode_sid(subject) {
+            Some(iri) => !matches!(store.find_subject_id(&iri), Ok(None)),
+            None => true,
+        }
+    };
+
     let mut retractions = Vec::new();
+    let mut skipped_subjects = 0usize;
 
     // Query existing values for each (subject, predicate, graph) tuple
     let mut query_vars = VarRegistry::new();
     let o_var = query_vars.get_or_insert("?o");
 
-    for (subject, predicate, graph_id) in spg_tuples {
-        // IMPORTANT: `TripleTemplate.graph_id` is a transaction-local ID.
-        // It must be translated to a ledger-stable GraphId before we can query
-        // the correct per-graph index partition.
-        //
-        // txn_local_g_id -> graph IRI (txn.graph_delta) -> ledger g_id (GraphRegistry)
-        let ledger_g_id: Option<u16> = graph_id.and_then(|txn_g_id| {
-            txn.graph_delta
-                .get(&txn_g_id)
-                .and_then(|iri| ledger.snapshot.graph_registry.graph_id_for_iri(iri))
-        });
+    for ((subject, graph_id), predicates) in &subject_groups {
+        let ledger_g_id: Option<u16> = ledger_g_for_txn_g.get(graph_id).copied().flatten();
 
-        // Query: <subject> <predicate> ?o
-        let pattern = TriplePattern::new(
-            Ref::Sid(subject.clone()),
-            Ref::Sid(predicate.clone()),
-            Term::Var(o_var),
-        );
-
-        let batches = if graph_id.is_some() {
-            // Named graph: translate txn-local g_id to ledger g_id before querying.
-            match ledger_g_id {
-                None => {
-                    // Graph is not yet in the ledger registry (new graph in this txn),
-                    // so there cannot be existing values to retract.
-                    Vec::new()
-                }
-                Some(g_id) => {
-                    if ledger.snapshot.range_provider.is_some() {
-                        fluree_db_query::execute_pattern(
-                            ledger.as_graph_db_ref(g_id),
-                            &query_vars,
-                            pattern,
-                        )
-                        .await?
-                    } else {
-                        // No binary store available (genesis / not indexed): scan novelty directly.
-                        query_novelty_for_graph(ledger, &subject, &predicate, g_id, o_var)
-                    }
-                }
-            }
-        } else {
-            // Default graph: use standard query path through range_provider
-            fluree_db_query::execute_pattern(ledger.as_graph_db_ref(0), &query_vars, pattern)
-                .await?
-        };
-
-        // Convert each result to a retraction flake in the appropriate graph.
-        // Here we use the txn-local g_id to look up the graph Sid (flake.g).
+        // Retraction flakes carry the graph Sid (flake.g), looked up by the
+        // txn-local g_id. Resolved before any skip so broken graph delta/sid
+        // wiring still surfaces as an error.
         let graph_sid: Option<Sid> = match graph_id {
             None => None,
             Some(txn_g_id) => Some(
-                graph_sids.get(&txn_g_id).cloned().ok_or_else(|| {
+                graph_sids.get(txn_g_id).cloned().ok_or_else(|| {
                     TransactError::FlakeGeneration(format!(
                         "upsert deletion generation references graph_id {txn_g_id} but no graph Sid was provided; \
                          this indicates a bug in graph delta/sid wiring"
@@ -2685,10 +2734,26 @@ async fn generate_upsert_deletions(
             ),
         };
 
+        // Named graph not yet in the ledger registry: nothing to retract.
+        if graph_id.is_some() && ledger_g_id.is_none() {
+            continue;
+        }
+        let effective_g_id = ledger_g_id.unwrap_or(0);
+
+        // Skip subjects with no persisted or novelty presence entirely.
+        if binary_store.is_some()
+            && !novelty_present
+                .get(&effective_g_id)
+                .is_some_and(|s| s.contains(subject))
+            && !subject_in_base(subject)
+        {
+            skipped_subjects += 1;
+            continue;
+        }
+
         // Create a materializer for this graph context if a binary store exists.
         // BinaryGraphView::with_novelty handles watermark routing internally,
         // so novelty-only string/subject IDs resolve correctly.
-        let effective_g_id = ledger_g_id.unwrap_or(0);
         let mut materializer = binary_store.as_ref().map(|store| {
             let view = BinaryGraphView::with_novelty(
                 Arc::clone(store),
@@ -2698,38 +2763,71 @@ async fn generate_upsert_deletions(
             Materializer::new(view, JoinKeyMode::SingleLedger)
         });
 
-        for batch in &batches {
-            for row in 0..batch.len() {
-                let flake_obj = batch
-                    .get(row, o_var)
-                    .and_then(|b| binding_to_flake_object(b, materializer.as_mut()));
-                if let Some((o, dt)) = flake_obj {
-                    let flake = match graph_sid.clone() {
-                        Some(g) => Flake::new_in_graph(
-                            g,
-                            subject.clone(),
-                            predicate.clone(),
-                            o,
-                            dt,
-                            new_t,
-                            false, // retraction
-                            None,
-                        ),
-                        None => Flake::new(
-                            subject.clone(),
-                            predicate.clone(),
-                            o,
-                            dt,
-                            new_t,
-                            false, // retraction
-                            None,
-                        ),
-                    };
-                    retractions.push(flake);
+        for predicate in predicates {
+            // Query: <subject> <predicate> ?o
+            let pattern = TriplePattern::new(
+                Ref::Sid(subject.clone()),
+                Ref::Sid(predicate.clone()),
+                Term::Var(o_var),
+            );
+
+            let batches = if graph_id.is_some() {
+                if ledger.snapshot.range_provider.is_some() {
+                    fluree_db_query::execute_pattern(
+                        ledger.as_graph_db_ref(effective_g_id),
+                        &query_vars,
+                        pattern,
+                    )
+                    .await?
+                } else {
+                    // No binary store available (genesis / not indexed): scan novelty directly.
+                    query_novelty_for_graph(ledger, subject, predicate, effective_g_id, o_var)
+                }
+            } else {
+                // Default graph: use standard query path through range_provider
+                fluree_db_query::execute_pattern(ledger.as_graph_db_ref(0), &query_vars, pattern)
+                    .await?
+            };
+
+            for batch in &batches {
+                for row in 0..batch.len() {
+                    let flake_obj = batch
+                        .get(row, o_var)
+                        .and_then(|b| binding_to_flake_object(b, materializer.as_mut()));
+                    if let Some((o, dt)) = flake_obj {
+                        let flake = match graph_sid.clone() {
+                            Some(g) => Flake::new_in_graph(
+                                g,
+                                subject.clone(),
+                                predicate.clone(),
+                                o,
+                                dt,
+                                new_t,
+                                false, // retraction
+                                None,
+                            ),
+                            None => Flake::new(
+                                subject.clone(),
+                                predicate.clone(),
+                                o,
+                                dt,
+                                new_t,
+                                false, // retraction
+                                None,
+                            ),
+                        };
+                        retractions.push(flake);
+                    }
                 }
             }
         }
     }
+
+    tracing::debug!(
+        subject_count = subject_groups.len(),
+        skipped_subjects,
+        "upsert deletion subject pre-check"
+    );
 
     Ok(retractions)
 }

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -2657,36 +2657,23 @@ async fn generate_upsert_deletions(
         })
         .collect();
 
-    // Novelty presence: one overlay walk per referenced graph, collecting which
-    // of this transaction's subjects have any novelty flakes. Novelty is
-    // in-memory and small (bounded by reindex backpressure), so a filtered full
-    // walk per graph is cheap — and it is authoritative in Sid space, needing
+    // Novelty presence, resolved lazily: the per-graph set is built by a
+    // filtered overlay walk only when a subject misses the base dictionary
+    // (see the skip below), so upserts whose subjects all resolve in the
+    // persisted dictionary never pay it. The walk is O(novelty flakes in the
+    // graph), and novelty is bounded by `reindex_max_bytes` — up to 20% of
+    // system RAM when indexing lags — which is why it runs at most once per
+    // graph, and only on demand. It is authoritative in Sid space, needing
     // no dictionary translation.
-    let mut novelty_present: HashMap<u16, HashSet<Sid>> = HashMap::new();
+    let mut per_g_subjects: HashMap<u16, HashSet<&Sid>> = HashMap::new();
     if binary_store.is_some() {
-        let mut per_g_subjects: HashMap<u16, HashSet<&Sid>> = HashMap::new();
         for (subject, txn_g) in subject_groups.keys() {
             if let Some(Some(ledger_g)) = ledger_g_for_txn_g.get(txn_g) {
                 per_g_subjects.entry(*ledger_g).or_default().insert(subject);
             }
         }
-        for (g, subjects) in per_g_subjects {
-            let present = novelty_present.entry(g).or_default();
-            ledger.novelty.for_each_overlay_flake(
-                g,
-                IndexType::Spot,
-                None,
-                None,
-                true,
-                ledger.t(),
-                &mut |flake| {
-                    if subjects.contains(&flake.s) && !present.contains(&flake.s) {
-                        present.insert(flake.s.clone());
-                    }
-                },
-            );
-        }
     }
+    let mut novelty_present: HashMap<u16, HashSet<Sid>> = HashMap::new();
 
     // Persisted presence: the subject reverse dictionary is authoritative under
     // canonical namespace encoding (see `fluree_db_core::ns_encoding`) — a miss
@@ -2740,15 +2727,33 @@ async fn generate_upsert_deletions(
         }
         let effective_g_id = ledger_g_id.unwrap_or(0);
 
-        // Skip subjects with no persisted or novelty presence entirely.
-        if binary_store.is_some()
-            && !novelty_present
-                .get(&effective_g_id)
-                .is_some_and(|s| s.contains(subject))
-            && !subject_in_base(subject)
-        {
-            skipped_subjects += 1;
-            continue;
+        // Skip subjects with no persisted or novelty presence entirely. The
+        // base dictionary is a point probe, so it is consulted first; the
+        // per-graph novelty set is built on the first dictionary miss only.
+        if binary_store.is_some() && !subject_in_base(subject) {
+            let present = novelty_present.entry(effective_g_id).or_insert_with(|| {
+                let mut set = HashSet::new();
+                if let Some(subjects) = per_g_subjects.get(&effective_g_id) {
+                    ledger.novelty.for_each_overlay_flake(
+                        effective_g_id,
+                        IndexType::Spot,
+                        None,
+                        None,
+                        true,
+                        ledger.t(),
+                        &mut |flake| {
+                            if subjects.contains(&flake.s) && !set.contains(&flake.s) {
+                                set.insert(flake.s.clone());
+                            }
+                        },
+                    );
+                }
+                set
+            });
+            if !present.contains(subject) {
+                skipped_subjects += 1;
+                continue;
+            }
         }
 
         // Create a materializer for this graph context if a binary store exists.


### PR DESCRIPTION
## Problem

Bulk JSON-LD upserts staged at ~8 ms/flake (STAGING-PERF-BUG report: 35–70 s per ~6k-flake transaction against a 5 MB / 451k-flake ledger, with essentially all time inside `stage()` and `retractions ≈ 0`).

## Root cause

`generate_upsert_deletions` issues one bound-subject point query per (subject, predicate) tuple to find existing values to retract. For subjects **not yet in the persisted subject dictionary** — the dominant case when bulk-upserting new entities — `BinaryScanOperator` cannot resolve an `s_id`, sets `unresolved_bound_subject_iri`, and degrades to a **full PSOT predicate-partition scan with per-row subject-IRI decoding**. On the repro ledger that's ~56k row-decodes per subject for `rdf:type` and the multi-valued `blockingKey` alone; a 600-subject upsert spent 13.27 s of 13.29 s staging in this loop, producing zero retractions.

Resolved subjects were never the problem: the same 3,000-tuple loop over existing subjects runs in ~40 ms (~13 µs per point probe).

## Fix

**Commit 1 — subject-existence pre-check in `generate_upsert_deletions`:** group predicates by subject and resolve existence once per subject:
- persisted presence via the subject reverse dictionary (`find_subject_id_by_parts` + full-IRI `find_subject_id`), authoritative under the canonical namespace-encoding invariants;
- novelty presence via one Sid-space overlay walk per referenced graph (no dictionary translation, works even when dict-novelty is uninitialized).

Subjects present in neither cannot have values to retract and skip their per-predicate queries entirely. Everything else keeps the existing query path.

**Commit 2 — cache the persisted `p_id → Sid` table on `BinaryIndexStore`:** every scan `open()` rebuilt the full predicate table (one dict resolve + namespace encode per predicate in the ledger), and the `binary_range` materialization loops re-resolved the predicate per emitted row. The table is now built once per store instance (`OnceLock<Arc<[Sid]>>`; stores are immutable once shared behind `Arc`) and shared; novelty-only predicates keep their ephemeral p_ids in a per-operator overlay map. Removes an O(predicate-count) fixed cost per scan open that becomes significant for wide-schema ledgers.

## Results (repro clone, 600 subjects / 6,600 flakes)

| scenario | deletion phase | staging total |
|---|---:|---:|
| new subjects, before | 13,270 ms | 13,292 ms |
| new subjects, after | **0.9 ms** | **3.5 ms** |
| existing subjects (values changed) | ~40 ms | ~43 ms |

Verified on the repro ledger that all three subject classes retract correctly: persisted subjects (values replaced, no duplicates), novelty-only subjects, and new subjects (skipped, `skipped_subjects` debug field added for prod diagnosis).

## Tests

New `it_transact_upsert_indexed.rs` pins replace-semantics across persisted + novelty-only + new subjects in a single upsert against a file-backed indexed ledger, re-checked after the next index build. Existing transact/query/index/history integration groups and unit tests pass.