### PR TITLE
bench: baseline host/corpus identity, phase-share gating, and noise floors

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,6 +12,16 @@ on:
   schedule:
     - cron: "0 7 * * *" # 07:00 UTC daily
   workflow_dispatch:
+    inputs:
+      capture_samples:
+        description: >-
+          Repeat runs to fold into the captured baseline. 1 is a single
+          measurement with no noise estimate; >= 5 records a median + MAD, which
+          is what a baseline intended to GATE on shared runners needs — the
+          compare gate widens each budget to 3*MAD/median, and ubuntu-latest
+          flap is the whole reason the per-PR compare is advisory today.
+        required: false
+        default: "1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -39,9 +49,10 @@ jobs:
     env:
       FLUREE_BENCH_PROFILE: quick
       FLUREE_BENCH_SCALE: tiny
-      # Baseline is runner_class=local, so the nightly compare enforces memory and
-      # treats time as advisory until a ci-* baseline is committed (bench-capture).
-      FLUREE_BENCH_RUNNER_CLASS: ci-ubuntu-latest
+      # Baseline is host_class=local, so the nightly compare treats time and
+      # memory as advisory until a ci-* baseline is committed (bench-capture).
+      # (FLUREE_BENCH_RUNNER_CLASS is still read as the pre-rename spelling.)
+      FLUREE_BENCH_HOST_CLASS: ci-ubuntu-latest
     steps:
       - name: Free disk space
         run: |
@@ -85,11 +96,12 @@ jobs:
       - name: Compare captured subset against committed baseline
         if: always()
         run: |
-          rm -rf target/fluree-bench-mem
+          rm -rf target/fluree-bench-mem target/fluree-bench-meta
           cargo bench -p fluree-db-api --bench query_overlay_matrix
           cargo bench -p fluree-db-api --bench query_hot_bsbm
           cargo run -p fluree-bench-support --bin bench-baseline -- \
-            compare --baseline bench-baselines/guardrails-pre.json
+            compare --baseline bench-baselines/guardrails-pre.json \
+            --allow-host-mismatch
 
   bench-capture:
     # On-demand CI-class baseline capture (review item 1c). Captures the cheap
@@ -104,7 +116,7 @@ jobs:
     env:
       FLUREE_BENCH_PROFILE: quick
       FLUREE_BENCH_SCALE: tiny
-      FLUREE_BENCH_RUNNER_CLASS: ci-ubuntu-latest
+      FLUREE_BENCH_HOST_CLASS: ci-ubuntu-latest
     steps:
       - name: Free disk space
         run: |
@@ -123,15 +135,27 @@ jobs:
 
       # Same cheap subset and scales (tiny+small) as the committed baseline, so
       # the artifact is a drop-in ci-* replacement once a human commits it.
+      #
+      # Each pass reruns the benches and folds the fresh criterion means into the
+      # same file with --accumulate, which is what turns N runs into one median +
+      # MAD. Passes must NOT be parallelised and the sidecars are cleared each
+      # time: a sample has to be an independent measurement of the same thing.
       - name: Capture cheap subset (CI-class)
         run: |
-          rm -rf target/fluree-bench-mem
-          for scale in tiny small; do
-            FLUREE_BENCH_SCALE=$scale cargo bench -p fluree-db-api --bench query_overlay_matrix
-            FLUREE_BENCH_SCALE=$scale cargo bench -p fluree-db-api --bench query_hot_bsbm
+          samples="${{ github.event.inputs.capture_samples || '1' }}"
+          rm -f bench-baselines/guardrails-pre-ci.json
+          for pass in $(seq 1 "$samples"); do
+            echo "::group::capture pass $pass/$samples"
+            rm -rf target/fluree-bench-mem target/fluree-bench-meta
+            for scale in tiny small; do
+              FLUREE_BENCH_SCALE=$scale cargo bench -p fluree-db-api --bench query_overlay_matrix
+              FLUREE_BENCH_SCALE=$scale cargo bench -p fluree-db-api --bench query_hot_bsbm
+            done
+            cargo run -p fluree-bench-support --bin bench-baseline -- \
+              capture --label guardrails-pre-ci --out bench-baselines/guardrails-pre-ci.json \
+              --accumulate
+            echo "::endgroup::"
           done
-          cargo run -p fluree-bench-support --bin bench-baseline -- \
-            capture --label guardrails-pre-ci --out bench-baselines/guardrails-pre-ci.json
 
       - name: Upload CI-class baseline artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -143,6 +143,14 @@ jobs:
       - name: Capture cheap subset (CI-class)
         run: |
           samples="${{ github.event.inputs.capture_samples || '1' }}"
+          # `seq 1 0` runs zero passes, so a 0 (or any non-number) would produce
+          # no baseline at all while the job still reported success. Fail loudly
+          # instead — a capture job that captures nothing is worse than one that
+          # errors, because the artifact step would then upload nothing quietly.
+          if ! [[ "$samples" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::capture_samples must be a positive integer, got '$samples'"
+            exit 1
+          fi
           rm -f bench-baselines/guardrails-pre-ci.json
           for pass in $(seq 1 "$samples"); do
             echo "::group::capture pass $pass/$samples"
@@ -162,3 +170,6 @@ jobs:
         with:
           name: guardrails-pre-ci-baseline
           path: bench-baselines/guardrails-pre-ci.json
+          # Default is `warn`, which lets the job go green having produced no
+          # artifact — the exact silent success this job exists to avoid.
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,13 @@ jobs:
     # Cheap per-PR perf gate. Runs the two cheapest benches at tiny/quick and
     # compares against the committed baseline.
     #
-    # Both metrics enforce ONLY when the baseline's runner_class matches this
+    # Both metrics enforce ONLY when the baseline's host_class matches this
     # runner's. It currently does not — the committed baseline is
-    # runner_class=local — so on every PR today both wall-clock TIME and
+    # host_class=local — so on every PR today both wall-clock TIME and
     # PEAK_MEM breaches print as ::warning:: annotations and the job exits 0.
+    # That downgrade is now explicit (`--allow-host-mismatch`) rather than
+    # implicit: comparing absolute numbers across host classes is a refusal by
+    # default, and a job that wants the annotations has to say so.
     #
     # Why not gate on memory now: shared ubuntu-latest runners flap, and a
     # tracking allocator's peak moves with allocator behaviour, page size, and
@@ -184,9 +187,10 @@ jobs:
     env:
       FLUREE_BENCH_PROFILE: quick
       FLUREE_BENCH_SCALE: tiny
-      # CI-class marker. The committed baseline is runner_class=local, so this
+      # CI-class marker. The committed baseline is host_class=local, so this
       # mismatch is what makes both metrics advisory today.
-      FLUREE_BENCH_RUNNER_CLASS: ci-ubuntu-latest
+      # (FLUREE_BENCH_RUNNER_CLASS is still read as the pre-rename spelling.)
+      FLUREE_BENCH_HOST_CLASS: ci-ubuntu-latest
     steps:
       - name: Free disk space
         run: |
@@ -203,21 +207,28 @@ jobs:
         with:
           cache-on-failure: true
 
-      # Clear stale memory sidecars first: rust-cache persists target/ across
-      # runs, and compare must not merge a mem number from a bench not rerun
-      # this session (review item 10). Then run the two cheap benches (writes
-      # criterion timings + fresh memory sidecars).
+      # Clear stale sidecars first: rust-cache persists target/ across runs, and
+      # compare must not merge a mem number from a bench not rerun this session
+      # (review item 10), nor a corpus block from a run that never read that
+      # corpus. Then run the two cheap benches (writes criterion timings + fresh
+      # sidecars).
       - name: Run cheap benches (tiny, quick)
         run: |
-          rm -rf target/fluree-bench-mem
+          rm -rf target/fluree-bench-mem target/fluree-bench-meta
           cargo bench -p fluree-db-api --bench query_overlay_matrix
           cargo bench -p fluree-db-api --bench query_hot_bsbm
 
       # Compare against the committed baseline. Exit 1 on any breach of a metric
-      # the runner-class match makes enforcing; against a cross-class baseline
-      # (today's state) every breach prints as a ::warning:: annotation and the
-      # step exits 0.
+      # the host-class match makes enforcing, 2 on a refusal to compare.
+      #
+      # --allow-host-mismatch is the phase-1 posture and nothing else: the
+      # committed baseline is host_class=local, this runner is
+      # ci-ubuntu-latest, and without the flag the job would refuse outright.
+      # DROP THIS FLAG once a ci-ubuntu-latest baseline is committed (bench.yml's
+      # bench-capture job) — the flag is what stands between annotations and a
+      # real gate. Phase-share drift enforces either way.
       - name: Compare against committed baseline
         run: |
           cargo run -p fluree-bench-support --bin bench-baseline -- \
-            compare --baseline bench-baselines/guardrails-pre.json
+            compare --baseline bench-baselines/guardrails-pre.json \
+            --allow-host-mismatch

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -187,9 +187,12 @@ captured at the branch's **merge-base** (see `bench-baselines/README.md`).
 **Compare** — after a change, rerun the benches and compare:
 
 ```bash
+# --allow-host-mismatch is required against the committed baseline, which is
+# host_class=local; without it compare refuses (exit 2) rather than compare
+# absolute numbers across machines. Drop it once you have a same-class baseline.
 cargo run -p fluree-bench-support --bin bench-baseline -- \
-    compare --baseline bench-baselines/guardrails-pre.json \
-    [--only <substr>] [--share-drift-pp 5] [--allow-host-mismatch] [--advisory]
+    compare --baseline bench-baselines/guardrails-pre.json --allow-host-mismatch \
+    [--only <substr>] [--share-drift-pp 5] [--advisory]
 ```
 
 Each scenario present in both runs is checked against `baseline × (1 +
@@ -208,12 +211,30 @@ share.
 — exit 2, no verdict — unless `--allow-host-mismatch` downgrades them to
 `::warning::` annotations. `--advisory` forces the downgrade even on a match.
 
+> **No bench emits phases yet.** The `meta` sidecar and everything below about
+> phases is Tier-1 scaffolding for the `fluree rdf` conversion lane: the schema,
+> the recorder, and the gate are in place, but no bench in the workspace calls
+> `meta::record_scenario` today, so no phase or corpus row appears in any current
+> report. The share gate goes live with the first producer. Corpus identity is in
+> the same state — the refusal rules are real, they simply have nothing to check
+> until a bench declares what it read.
+
 **Share drift always enforces**, because a share is a ratio within a single run:
 the machine cancels. Only share *growth* gates; shares sum to 100, so gating both
 directions would fail a clean improvement twice, once for the phase that got
 better and once for its complement. This is the metric that catches the
 regression an aggregate number hides — a scenario 2% slower overall whose parse
 share moved 60% → 75% has a parse regression masked by a write improvement.
+
+**A phase that appears or disappears is gated on its share alone.** Comparing
+only same-named phases is how a regression hides: move work into a phase the
+baseline never had and the old phase's share *falls*, reading as an improvement,
+while the new phase carrying the cost produces no row. So a phase new in the
+current run breaches when it claims more than the drift threshold, and a phase
+that has vanished from the current run breaches when it *used to* claim more than
+the threshold — work that large did not evaporate, it moved somewhere unmeasured.
+Such rows are marked `(NEW)` / `(VANISHED)` and carry no `phase_time` row, since
+there is no ratio to report against a missing side.
 
 **A corpus mismatch is always a refusal, with no override.** Benches that read an
 input record its SHA-256, byte length, element count, input/output syntax, and
@@ -244,10 +265,25 @@ done
 ```
 
 With ≥ 5 samples the baseline records a median and a MAD, the gate compares
-medians instead of single-run means, and each budget widens to
-`max(budget_pct, 3 × MAD / median)`. The floor only ever *widens* an envelope: a
-quiet scenario keeps its declared budget. MAD rather than standard deviation
-because one outlier run is the common failure here and barely moves it.
+medians instead of single-run means, and the wall-clock budget widens to
+`max(budget_pct, 3 × MAD / median)`. MAD rather than standard deviation because
+one outlier run is the common failure here and barely moves it.
+
+Three bounds on that, each of which exists because dropping it inverts the gate:
+
+- **Widening only.** A budget tighter than the measured noise can only produce
+  false alarms; a quiet scenario keeps its declared budget.
+- **Wall-clock only.** The floor applies to `time` and `phase_time`, never to
+  `peak_mem`. A tracking allocator's peak is near-deterministic for a given
+  workload, so widening the memory budget by a *timing* MAD would let a real
+  allocation regression through on the strength of a noisy clock.
+- **Baseline only.** The current run's own spread never widens its own budget.
+  Otherwise the worse a run behaves, the more it is forgiven.
+
+`capture --accumulate` refuses to pool samples across host classes or across
+corpora. Blending two populations into one median and MAD destroys the evidence
+that they were ever different, and the accumulated file inherits the fresh run's
+provenance — so there would be nothing left for a later `compare` to catch.
 
 ### Why the gate has two phases
 

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -317,11 +317,24 @@ whose numbers are meant to gate should set `FLUREE_BENCH_HOST_CLASS` explicitly
 
 Two ways to reach phase 2:
 
-1. **Committed CI-class baseline (implemented).** Run `bench.yml`'s
-   `workflow_dispatch` `bench-capture` job with `capture_samples: 5`, download
-   the artifact, commit it, and remove `--allow-host-mismatch` from `ci.yml`'s
-   compare step. Its `host_class=ci-ubuntu-latest` matches CI and its noise floor
-   absorbs runner flap, so both metrics enforce.
+1. **Committed CI-class baseline (implemented).** Note the **filename change** —
+   the capture job writes `guardrails-pre-ci.json`, but both compare jobs read
+   `guardrails-pre.json`. Committing the artifact under its own name leaves CI
+   reading the old `host_class=local` file, which without
+   `--allow-host-mismatch` refuses every run. So:
+
+   ```bash
+   # 1. Run bench.yml's workflow_dispatch `bench-capture` job with
+   #    capture_samples: 5, and download the artifact.
+   # 2. REPLACE the committed baseline — do not add it alongside:
+   mv guardrails-pre-ci.json bench-baselines/guardrails-pre.json
+   # 3. Drop `--allow-host-mismatch` from ci.yml's and bench.yml's compare steps.
+   ```
+
+   The replaced file's `host_class=ci-ubuntu-latest` then matches CI and its
+   noise floor absorbs runner flap, so both metrics enforce. (Keeping the
+   `-ci` suffix instead would work only if you also repoint every
+   `--baseline` path; one rename is the smaller change.)
 2. **Same-runner interleaved base-vs-HEAD (documented future option).** Measure
    merge-base and HEAD in the *same* job on the *same* runner and compare those,
    instead of any committed cross-machine file — the only design that survives

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -40,13 +40,24 @@ FLUREE_BENCH_TRACING=1 cargo bench -p fluree-db-api --bench insert_formats
 |---|---|---|---|
 | `FLUREE_BENCH_PROFILE` | `quick` \| `full` | `quick` | sample-count + warmup discipline |
 | `FLUREE_BENCH_SCALE` | `tiny` \| `small` \| `medium` \| `large` | `small` | per-bench input size |
+| `FLUREE_BENCH_HOST_CLASS` | any name | `{os}-{arch}` | comparability class for baseline capture/compare |
+| `FLUREE_BENCH_HOST` | any name | `$HOSTNAME` | host name recorded as provenance |
 | `FLUREE_BENCH_TRACING` | `1` (or unset) | unset | install a stderr tracing subscriber |
 | `FLUREE_BENCH_RUNTIME` | `multi` (or unset) | single-threaded | tokio runtime shape |
 | `RUST_LOG` | tracing-subscriber filter | `info` when `FLUREE_BENCH_TRACING=1` | tracing levels per crate |
 
+Those defaults are what a bare `cargo bench` on a laptop uses. **Both CI jobs
+pin `FLUREE_BENCH_PROFILE=quick` and `FLUREE_BENCH_SCALE=tiny`** — including the
+nightly, which is quick-profile despite the name — so a nightly number is not a
+`full`-profile number. `FLUREE_BENCH_RUNNER_CLASS` is still read as the
+pre-rename spelling of `FLUREE_BENCH_HOST_CLASS`.
+
 ## Current benches
 
-Hand-maintained; add new entries when introducing a bench file.
+Hand-maintained, and reconciled against the `[[bench]]` declarations plus
+`regression-budget.json` — `cargo test -p fluree-bench-support --test
+workspace_reconcile` enforces those two against each other, but nothing enforces
+this table, so it is the one that rots. Add a row when you add a bench file.
 
 | Crate | Bench file | Topic |
 |---|---|---|
@@ -60,6 +71,12 @@ Hand-maintained; add new entries when introducing a bench file.
 | `fluree-db-api` | `reindex_incremental.rs` | Orchestrator's incremental path via `Fluree::trigger_index(...)` over delta novelty |
 | `fluree-db-api` | `novelty_replay.rs` | Cold reload with `without_indexing()` so populate stays in novelty; scaled by commit count |
 | `fluree-db-api` | `query_hot_bsbm.rs` | Warm-cache SPARQL: BSBM-shape Q3/Q5/Q9 against a reindexed ledger |
+| `fluree-db-api` | `query_hot_bsbm_bi.rs` | BSBM Business-Intelligence "bowtie" (BI-1 F2): join-ordering tie-break between two equally-selective anchors |
+| `fluree-db-api` | `query_hot_property_path.rs` | Hot-cache SPARQL property paths, one scenario per execution mode of the operator (`*` closure, sequence, `?`, …) |
+| `fluree-db-api` | `query_hot_whole_graph_agg.rs` | Cypher aggregate folds from `fast_whole_graph_agg` (whole-graph + class scalars, histograms) against a linear-cost pipeline baseline |
+| `fluree-db-api` | `query_overlay_matrix.rs` | The same query shapes at three ledger conditions — base / overlay / novelty — so the columnar+novelty merge lane has coverage |
+| `fluree-db-api` | `annotation_hydration.rs` | `inject_annotations` hydration cost: index scan vs sealed annotation arena |
+| `fluree-db-api` | `annotation_planner.rs` | Planner direction for `f:reifies*` edge-annotation queries: arena-informed row counts vs HLL-only stats |
 | `fluree-db-query` | `vector_math.rs` | SIMD vs scalar dot/L2/cosine micro-bench |
 | `fluree-db-spatial` | `spatial_bench.rs` | S2 covering build + within/intersects/radius latency |
 
@@ -103,12 +120,13 @@ on-demand):
      at runtime (bad SPARQL, broken setup, missing API surface).
 2. **Per-PR compare (`ci.yml` `bench-compare`).** Runs the cheap subset
    (`query_overlay_matrix` + `query_hot_bsbm`) at `tiny`/`quick` and compares
-   against the committed baseline via the `bench-baseline` bin. **Both metrics
-   enforce only when the baseline's `runner_class` matches the runner's; against
-   a cross-class baseline both are advisory** (see
-   [Baselines](#baselines-capture--compare) for why). Today's committed baseline
-   is `runner_class=local`, so on `ubuntu-latest` the job currently annotates and
-   exits 0. The nightly `bench-gate` runs the same compare over a larger sample.
+   against the committed baseline via the `bench-baseline` bin. **Time and peak
+   memory enforce only when the baseline's `host_class` matches the runner's**
+   (see [Baselines](#baselines-capture--compare) for why). Today's committed
+   baseline is `host_class=local` and the runner is `ci-ubuntu-latest`, so the
+   step passes `--allow-host-mismatch` and both metrics annotate rather than
+   gate; **phase-share drift enforces regardless of host class.** The nightly
+   `bench-gate` runs the same compare over a larger sample.
 
    The job costs ~30 minutes, so it is gated on a `bench-paths` job that skips it
    when a PR touches nothing perf-relevant (engine crates, bench crates,
@@ -117,9 +135,12 @@ on-demand):
    run, a false negative lets a regression through.
 
 3. **CI-class capture (`bench.yml` `bench-capture`, `workflow_dispatch`).**
-   Captures the cheap subset on `ubuntu-latest` (`runner_class=ci-ubuntu-latest`)
-   and uploads it as an artifact; committing it lands a CI-class baseline that
-   flips **both** metrics to enforcing, with no code change.
+   Captures the cheap subset on `ubuntu-latest` (`host_class=ci-ubuntu-latest`)
+   and uploads it as an artifact. Committing it plus dropping
+   `--allow-host-mismatch` from the compare step lands a real per-PR gate. The
+   `capture_samples` dispatch input controls how many repeat runs are folded into
+   one median + MAD — use ≥ 5 for a baseline meant to gate, since without a noise
+   estimate the budget has to absorb shared-runner flap on its own.
 
 > **Visibility gap (documented; fix is a follow-up).** The per-PR gate only
 > *compiles* benches — `clippy --all --all-features --all-targets` in `ci.yml`
@@ -150,7 +171,7 @@ reference (`guardrails-pre.json`, …), captured and compared by the
 scheme — it is now a directory plus a bin.)
 
 **Capture** — run the benches, then snapshot criterion's estimates plus the
-memory sidecars into a git-stamped baseline:
+memory and meta sidecars into a git-stamped baseline:
 
 ```bash
 cargo bench -p fluree-db-api --bench query_overlay_matrix
@@ -159,29 +180,74 @@ cargo run -p fluree-bench-support --bin bench-baseline -- \
 ```
 
 The baseline records provenance: `git_sha`, `captured_at`, `profile`, `scale`,
-and — load-bearing for the gate — `runner_class` (env
-`FLUREE_BENCH_RUNNER_CLASS`, default `local`) and `host`. The `"pre"` reference
-for a phase is captured at the branch's **merge-base** (see
-`bench-baselines/README.md`).
+and a `host` block — os, arch, cpu model, physical/logical cores, and,
+load-bearing for the gate, `host.class`. The `"pre"` reference for a phase is
+captured at the branch's **merge-base** (see `bench-baselines/README.md`).
 
 **Compare** — after a change, rerun the benches and compare:
 
 ```bash
 cargo run -p fluree-bench-support --bin bench-baseline -- \
-    compare --baseline bench-baselines/guardrails-pre.json [--only <substr>] [--advisory]
+    compare --baseline bench-baselines/guardrails-pre.json \
+    [--only <substr>] [--share-drift-pp 5] [--allow-host-mismatch] [--advisory]
 ```
 
 Each scenario present in both runs is checked against `baseline × (1 +
-budget_pct/100)` from `regression-budget.json`, for both wall-clock time
-(criterion `mean`) and peak memory (`peak_bytes`). **One rule covers both
-metrics:** they enforce when the baseline's `runner_class` matches the comparing
-runner's, and are **advisory** (`::warning::` annotations, non-gating) when it
-doesn't. `--advisory` forces advisory for both.
+budget_pct/100)` from `regression-budget.json`, for wall-clock time, peak memory
+(`peak_bytes`), and — for benches that record them — per-phase time and per-phase
+share.
 
-| baseline vs runner class | time breach | peak_mem breach | exit |
-| --- | --- | --- | --- |
-| matched | fails the gate | fails the gate | 1 |
-| mismatched | `::warning::` | `::warning::` | 0 |
+| metric | units | gated across host classes? |
+| --- | --- | --- |
+| `time` | ns | no |
+| `peak_mem` | bytes | no |
+| `phase_time` | ns | no |
+| `phase_share` | percentage points | **yes** |
+
+**Absolute metrics enforce only within a host class.** A mismatch is a *refusal*
+— exit 2, no verdict — unless `--allow-host-mismatch` downgrades them to
+`::warning::` annotations. `--advisory` forces the downgrade even on a match.
+
+**Share drift always enforces**, because a share is a ratio within a single run:
+the machine cancels. Only share *growth* gates; shares sum to 100, so gating both
+directions would fail a clean improvement twice, once for the phase that got
+better and once for its complement. This is the metric that catches the
+regression an aggregate number hides — a scenario 2% slower overall whose parse
+share moved 60% → 75% has a parse regression masked by a write improvement.
+
+**A corpus mismatch is always a refusal, with no override.** Benches that read an
+input record its SHA-256, byte length, element count, input/output syntax, and
+thread count; comparing a run over one input against a baseline captured over
+another is the most expensive silent failure this gate can produce, because the
+output is indistinguishable from a real regression.
+
+| condition | outcome | exit |
+| --- | --- | --- |
+| within budget | pass | 0 |
+| enforced breach | fail | 1 |
+| host class differs, no `--allow-host-mismatch` | refuse | 2 |
+| corpus sha256 / syntax / thread count differs | refuse | 2 |
+| baseline `schema_version` newer than the binary | refuse | 2 |
+
+### Noise floors
+
+`ubuntu-latest` flap is not a regression, and criterion's confidence interval
+does not measure it — it describes iterations *within* one run. Accumulate
+several independent runs instead:
+
+```bash
+for i in 1 2 3 4 5; do
+  cargo bench -p fluree-db-api --bench query_overlay_matrix
+  cargo run -p fluree-bench-support --bin bench-baseline -- \
+      capture --label ci-pre --out bench-baselines/ci-pre.json --accumulate
+done
+```
+
+With ≥ 5 samples the baseline records a median and a MAD, the gate compares
+medians instead of single-run means, and each budget widens to
+`max(budget_pct, 3 × MAD / median)`. The floor only ever *widens* an envelope: a
+quiet scenario keeps its declared budget. MAD rather than standard deviation
+because one outlier run is the common failure here and barely moves it.
 
 ### Why the gate has two phases
 
@@ -197,21 +263,29 @@ portable of the two signals in the blocking position.
 
 So the gate runs in two phases:
 
-- **Phase 1 (today).** The committed `guardrails-pre.json` is
-  `runner_class=local`, CI runs as `ci-ubuntu-latest`, the classes don't match,
-  and both metrics annotate without gating. The job still earns its keep: the
-  annotations surface real movement on the PR that caused it, and the compare
-  itself exercises the capture/compare machinery.
-- **Phase 2.** Commit a CI-class baseline and both metrics start gating on the
-  next PR, automatically — the rule reads the baseline's `runner_class`, so
-  there is no code or workflow change to make.
+- **Phase 1 (today).** The committed `guardrails-pre.json` is `host_class=local`,
+  CI runs as `ci-ubuntu-latest`, the classes don't match, and the compare step
+  passes `--allow-host-mismatch` so both absolute metrics annotate without
+  gating. The job still earns its keep: the annotations surface real movement on
+  the PR that caused it, share drift gates for any bench that records phases, and
+  the compare itself exercises the capture/compare machinery.
+- **Phase 2.** Commit a CI-class baseline and drop `--allow-host-mismatch`, and
+  both absolute metrics gate from the next PR on.
+
+A note on `host_class` values. The derived default is `{os}-{arch}`, which is
+deliberately coarse and deliberately not a promise: an M1 and an M4 both derive
+`macos-aarch64` and their absolute numbers are not interchangeable. A class is a
+claim *a human makes* that two machines' numbers may be compared, so any host
+whose numbers are meant to gate should set `FLUREE_BENCH_HOST_CLASS` explicitly
+(`ci-ubuntu-latest`, `bench-m8gd`, …) rather than inherit the default.
 
 Two ways to reach phase 2:
 
 1. **Committed CI-class baseline (implemented).** Run `bench.yml`'s
-   `workflow_dispatch` `bench-capture` job, download the artifact, and commit it
-   — its `runner_class=ci-ubuntu-latest` matches CI, so both metrics enforce
-   automatically.
+   `workflow_dispatch` `bench-capture` job with `capture_samples: 5`, download
+   the artifact, commit it, and remove `--allow-host-mismatch` from `ci.yml`'s
+   compare step. Its `host_class=ci-ubuntu-latest` matches CI and its noise floor
+   absorbs runner flap, so both metrics enforce.
 2. **Same-runner interleaved base-vs-HEAD (documented future option).** Measure
    merge-base and HEAD in the *same* job on the *same* runner and compare those,
    instead of any committed cross-machine file — the only design that survives
@@ -268,10 +342,15 @@ For tracing conventions inside the database itself (where to put
 
 ```
 fluree-bench-support/        # chassis (helpers, generators, templates, fixtures)
+fluree-bench-alloc/          # tracking allocator behind the peak_mem metric
 <crate>/benches/<name>.rs    # one file per bench; criterion harness=false
-regression-budget.json       # per-bench gate at the workspace root
-.github/workflows/ci.yml     # gated bench job (per-PR, lands in bench-5)
-.github/workflows/bench-nightly.yml   # full sweep (lands in bench-nightly PR)
+regression-budget.json       # per-bench, per-scale budgets at the workspace root
+bench-baselines/             # committed reference points (see its README)
+.github/workflows/ci.yml     # bench-paths + bench-compare (per-PR, cheap subset)
+.github/workflows/bench.yml  # bench-gate (nightly) + bench-capture (on demand)
+target/criterion/            # criterion estimates — what `capture` reads
+target/fluree-bench-mem/     # peak/total allocation sidecars
+target/fluree-bench-meta/    # corpus identity + phase timing sidecars
 ```
 
 ## Troubleshooting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 1.0.69",
  "tokio",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-bench-virtual"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/bench-baselines/README.md
+++ b/bench-baselines/README.md
@@ -18,15 +18,28 @@ Conventions:
 - Ad-hoc local baselines (validation runs, experiments) should live
   outside the repo or be cleaned up before merge — only phase reference
   points belong here.
-- Each baseline records its `runner_class` (env `FLUREE_BENCH_RUNNER_CLASS`,
-  default `local`) and `host`. `compare` enforces **memory** across any runner
-  class but treats **wall-clock time** as advisory when the baseline's runner
-  class differs from the comparing runner's (cross-machine time can't gate).
-  Commit a CI-class baseline (`runner_class=ci-*`, via `bench.yml`'s
-  `bench-capture` job) to make the per-PR time half enforce.
+- Each baseline records a `host` block (`class`, name, os, arch, cpu model,
+  cores). `host.class` names a *comparability set*, from
+  `FLUREE_BENCH_HOST_CLASS` or the derived `{os}-{arch}` default. `compare`
+  **refuses** (exit 2) when the baseline's class differs from the comparing
+  host's, since neither wall-clock time nor a tracking allocator's peak survives
+  a machine change; `--allow-host-mismatch` downgrades those to non-gating
+  annotations. Per-phase **share** drift gates either way — it is a ratio within
+  one run, so the machine cancels.
+- A baseline that also carries a corpus block (sha256, byte length, element
+  count, input/output syntax, thread count) makes `compare` refuse outright on a
+  corpus change. There is no override: comparing different inputs is never
+  meaningful, and the result would look exactly like a real regression.
+- Baselines built with `capture --accumulate` over ≥ 5 runs carry a median + MAD
+  per scenario, and the gate widens each budget to `3 × MAD / median` when that
+  exceeds the declared budget. Prefer this for any baseline meant to gate on
+  shared CI runners.
 
 `guardrails-pre.json` is the PR-1 (guardrails net) reference — captured at the
-merge-base engine, quick profile, tiny+small, `runner_class=local`.
+merge-base engine, quick profile, tiny+small, schema 1. It predates the host
+block, so its `runner_class: "local"` is read as `host.class = "local"`: an
+honest "some developer machine, unspecified". That is why the per-PR compare
+still runs with `--allow-host-mismatch`.
 
 Capture (the `--label`/`--out` name the phase reference; capture at the
 merge-base commit):

--- a/fluree-bench-support/Cargo.toml
+++ b/fluree-bench-support/Cargo.toml
@@ -29,6 +29,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
+# Corpus identity hashing for baseline entries (`meta::CorpusInfo`). Already a
+# workspace dependency — BLAKE3 would hash faster but is not in the tree, and a
+# corpus is hashed once per capture.
+sha2 = { workspace = true }
+
 [dev-dependencies]
 # Bench helpers are themselves trivially testable; small criterion dep is OK
 # but we keep the surface tiny so this crate doesn't pull criterion into

--- a/fluree-bench-support/README.md
+++ b/fluree-bench-support/README.md
@@ -72,6 +72,30 @@ library function.
 end-of-run tables. Useful when criterion's HTML output doesn't surface the
 domain-specific cross-scenario comparison a bench wants.
 
+### `mem` and `meta` modules — sidecars
+
+Criterion records one number per scenario: wall-clock. Anything else a bench
+knows has to be written down beside it, keyed by the same
+`<group>/<function>/<scale>` ID criterion uses, so that
+`bench-baseline capture` can join the rows.
+
+| Module | Sidecar dir | Carries |
+|---|---|---|
+| `mem` | `target/fluree-bench-mem/` | `MemMetrics` — scenario-attributable peak and total allocated bytes (needs `fluree-bench-alloc` installed in the bench binary) |
+| `meta` | `target/fluree-bench-meta/` | `CorpusInfo` — what the scenario read (sha256, byte length, element count, input/output syntax, thread count) — and `PhaseTiming` per pipeline phase |
+
+Both are best-effort: a bench must not fail because a sidecar write did.
+Build phase timings with `ScenarioMeta::with_phase_ns`, which derives each
+`share_pct` from the nanoseconds so the two can't disagree.
+
+### `baseline` module
+
+`BaselineFile` capture/compare behind the `bench-baseline` bin, including the
+host block, the refusal rules (host class, corpus identity, schema version),
+share-drift gating, and `NoiseStats` median + MAD accumulation. See
+[`BENCHMARKING.md`](../BENCHMARKING.md) ("Baselines: capture & compare") for
+the operator-facing workflow.
+
 ## Templates
 
 `templates/BENCH_TEMPLATE.rs` is a working bench skeleton with `// TODO`
@@ -86,10 +110,11 @@ without hiding them behind macros.
 cargo test -p fluree-bench-support --lib
 ```
 
-44 unit tests cover the determinism contract on every generator, env-var
-parsing, budget loading, alias uniqueness, and tracing init idempotence.
-A separate integration test (`tests/workspace_reconcile.rs`) reconciles
-workspace `[[bench]]` entries with `regression-budget.json`.
+102 unit tests cover the determinism contract on every generator, env-var
+parsing, budget loading, alias uniqueness, tracing init idempotence, corpus
+hashing, and every rule the compare gate applies. A separate integration test
+(`tests/workspace_reconcile.rs`) reconciles workspace `[[bench]]` entries with
+`regression-budget.json`.
 
 ## Adding to your crate
 

--- a/fluree-bench-support/src/baseline.rs
+++ b/fluree-bench-support/src/baseline.rs
@@ -7,9 +7,11 @@
 //! 1. Run benches (`cargo bench ...`). Criterion writes per-scenario
 //!    estimates under `target/criterion/<group>/<fn>/<param>/new/estimates.json`;
 //!    memory-aware benches additionally write sidecars under
-//!    `target/fluree-bench-mem/` (see [`crate::mem`]).
+//!    `target/fluree-bench-mem/` (see [`crate::mem`]), and pipeline benches
+//!    write corpus identity + phase timings under `target/fluree-bench-meta/`
+//!    (see [`crate::meta`]).
 //! 2. `bench-baseline capture --label phase-1-pre --out bench-baselines/phase-1-pre.json`
-//!    walks both outputs into one git-stamped [`BaselineFile`].
+//!    walks all three outputs into one git-stamped [`BaselineFile`].
 //! 3. After a change, rerun the benches and
 //!    `bench-baseline compare --baseline bench-baselines/phase-1-pre.json`.
 //!    Each scenario present in both runs is compared against
@@ -22,6 +24,21 @@
 //! `"<group>/<function>/<parameter>"` — and benches put the scale in the
 //! parameter slot (`BenchScale::as_str()`), so budget lookup can recover
 //! `(bench, scale)` from the ID's first and last segments.
+//!
+//! ## What the gate refuses to do
+//!
+//! Two comparisons produce a number that *looks* like a result but means
+//! nothing, so they are hard errors rather than budget breaches — [`compare`]
+//! reports them in [`CompareReport::fatal`] and the bin exits `2`:
+//!
+//! - **Different host class.** Absolute nanoseconds and a tracking allocator's
+//!   peak are both properties of the machine. `--allow-host-mismatch` downgrades
+//!   this to the advisory posture (absolute metrics annotate, share drift still
+//!   gates), which is what the per-PR CI job runs today.
+//! - **Different corpus.** Comparing a run over one input against a baseline
+//!   captured over another is the most expensive silent failure available here,
+//!   because the output is indistinguishable from a real regression. There is no
+//!   override.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -30,9 +47,270 @@ use serde::{Deserialize, Serialize};
 
 use crate::budget::RegressionBudget;
 use crate::mem::MemMetrics;
+use crate::meta::{short_hash, CorpusInfo, PhaseTiming, ScenarioMeta, DEFAULT_SHARE_DRIFT_PP};
 use crate::runtime::BenchScale;
 
-pub const BASELINE_SCHEMA_VERSION: u32 = 1;
+/// Bumped from 1 when the host block, corpus identity, phase shares, and noise
+/// stats landed. Version 1 files still read (see [`RawBaselineFile`]); a file
+/// claiming a *newer* version than this is a fatal compare error, because
+/// silently ignoring fields we don't understand is how a gate stops gating.
+pub const BASELINE_SCHEMA_VERSION: u32 = 2;
+
+/// Samples required before [`NoiseStats`] widens a budget. Below this the
+/// median and MAD are too unstable to be a noise estimate, so the entry is
+/// gated on its declared budget alone.
+pub const MIN_NOISE_SAMPLES: u32 = 5;
+
+/// Host class recorded by schema-1 baselines that predate the host block and
+/// carried no `runner_class` either.
+const LEGACY_DEFAULT_HOST_CLASS: &str = "local";
+
+// ---------------------------------------------------------------------------
+// Host
+// ---------------------------------------------------------------------------
+
+/// The machine a baseline was captured on.
+///
+/// `class` is the load-bearing field: it names a *comparability set*, not a
+/// machine. Two hosts share a class when their absolute numbers are meant to be
+/// compared against each other — which is a claim only a human can make. The
+/// derived default (`{os}-{arch}`) is deliberately coarse and deliberately not
+/// a promise: an M1 and an M4 both derive `macos-aarch64` and are not
+/// interchangeable. Any host whose numbers are meant to *gate* should set
+/// `FLUREE_BENCH_HOST_CLASS` explicitly (`ci-ubuntu-latest`, `bench-m8gd`, …).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostBlock {
+    /// Comparability set. Required — a baseline without one is unusable, so
+    /// legacy files inherit `runner_class` or `"local"`.
+    pub class: String,
+    /// Host name — informational provenance.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub name: String,
+    /// `std::env::consts::OS` at capture time.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub os: String,
+    /// `std::env::consts::ARCH` at capture time.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub arch: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub cpu_model: String,
+    /// Physical cores, when the platform probe succeeds. Distinct from
+    /// `logical_cores` because thread-scaling curves are read against physical
+    /// cores and SMT siblings flatten them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub physical_cores: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logical_cores: Option<u32>,
+}
+
+impl HostBlock {
+    /// Probe the current machine.
+    pub fn detect() -> Self {
+        Self {
+            class: host_class(),
+            name: host_name(),
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            cpu_model: cpu_model(),
+            physical_cores: physical_cores(),
+            logical_cores: std::thread::available_parallelism()
+                .ok()
+                .map(|n| n.get() as u32),
+        }
+    }
+
+    /// A class-only block, for tests and for legacy files with no host data.
+    pub fn of_class(class: impl Into<String>) -> Self {
+        Self {
+            class: class.into(),
+            name: String::new(),
+            os: String::new(),
+            arch: String::new(),
+            cpu_model: String::new(),
+            physical_cores: None,
+            logical_cores: None,
+        }
+    }
+
+    /// One-line description for report headers.
+    pub fn describe(&self) -> String {
+        let mut parts = vec![self.class.clone()];
+        if !self.name.is_empty() {
+            parts.push(self.name.clone());
+        }
+        let platform = match (self.os.as_str(), self.arch.as_str()) {
+            ("", "") => String::new(),
+            (os, "") => os.to_string(),
+            ("", arch) => arch.to_string(),
+            (os, arch) => format!("{os}/{arch}"),
+        };
+        if !platform.is_empty() {
+            parts.push(platform);
+        }
+        if !self.cpu_model.is_empty() {
+            parts.push(self.cpu_model.clone());
+        }
+        if let Some(cores) = self.physical_cores {
+            parts.push(format!("{cores}c"));
+        }
+        parts.join(", ")
+    }
+}
+
+/// The host class of the current environment.
+///
+/// `FLUREE_BENCH_HOST_CLASS` wins; `FLUREE_BENCH_RUNNER_CLASS` is accepted as
+/// the pre-rename spelling so existing workflow files keep working; otherwise
+/// it derives `{os}-{arch}`.
+pub fn host_class() -> String {
+    std::env::var("FLUREE_BENCH_HOST_CLASS")
+        .or_else(|_| std::env::var("FLUREE_BENCH_RUNNER_CLASS"))
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(derived_host_class)
+}
+
+/// `{os}-{arch}`, e.g. `macos-aarch64`, `linux-x86_64`.
+pub fn derived_host_class() -> String {
+    format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+}
+
+fn host_name() -> String {
+    std::env::var("FLUREE_BENCH_HOST")
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+/// Best-effort CPU model string. Empty when the platform has no cheap probe —
+/// this is provenance, never a gate input, so a miss costs nothing.
+fn cpu_model() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(s) = sysctl("machdep.cpu.brand_string") {
+            return s;
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(raw) = std::fs::read_to_string("/proc/cpuinfo") {
+            for line in raw.lines() {
+                if let Some((key, value)) = line.split_once(':') {
+                    let key = key.trim();
+                    if key == "model name" || key == "Model" {
+                        return value.trim().to_string();
+                    }
+                }
+            }
+        }
+    }
+    String::new()
+}
+
+/// Physical (not logical) core count.
+///
+/// `available_parallelism()` reports logical CPUs and is also cgroup-clamped on
+/// CI, so it is the wrong number for a thread-scaling curve. Probe the platform
+/// first and fall back to it only so the field is rarely empty.
+fn physical_cores() -> Option<u32> {
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(n) = sysctl("hw.physicalcpu").and_then(|s| s.parse().ok()) {
+            return Some(n);
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(raw) = std::fs::read_to_string("/proc/cpuinfo") {
+            // (physical id, core id) pairs — the standard way to collapse SMT
+            // siblings. Single-socket VMs often omit both, hence the fallback.
+            let mut seen = std::collections::BTreeSet::new();
+            let mut physical_id = None;
+            for line in raw.lines() {
+                if let Some((key, value)) = line.split_once(':') {
+                    match key.trim() {
+                        "physical id" => physical_id = Some(value.trim().to_string()),
+                        "core id" => {
+                            seen.insert((physical_id.clone(), value.trim().to_string()));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            if !seen.is_empty() {
+                return Some(seen.len() as u32);
+            }
+        }
+    }
+    std::thread::available_parallelism()
+        .ok()
+        .map(|n| n.get() as u32)
+}
+
+#[cfg(target_os = "macos")]
+fn sysctl(key: &str) -> Option<String> {
+    let out = std::process::Command::new("sysctl")
+        .args(["-n", key])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    (!s.is_empty()).then_some(s)
+}
+
+// ---------------------------------------------------------------------------
+// Entries
+// ---------------------------------------------------------------------------
+
+/// Repeat-run statistics for one scenario's wall-clock.
+///
+/// Criterion's own confidence interval describes iterations *within* one run;
+/// it says nothing about the run-to-run spread that a shared runner, a thermal
+/// event, or a noisy neighbour produces. This is that spread, accumulated by
+/// `bench-baseline capture --accumulate` across ≥ [`MIN_NOISE_SAMPLES`] separate
+/// bench invocations, and it is what stops a gate from flagging noise.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NoiseStats {
+    pub n: u32,
+    pub median_ns: f64,
+    /// Median absolute deviation — the robust spread estimator. Chosen over
+    /// stddev because a single outlier run (a CI hiccup) moves stddev a lot and
+    /// MAD barely at all, and outlier runs are the common case here.
+    pub mad_ns: f64,
+    /// Every accumulated sample, so `--accumulate` can recompute from scratch
+    /// and a human can audit what the floor was derived from.
+    #[serde(default)]
+    pub samples_ns: Vec<f64>,
+}
+
+impl NoiseStats {
+    /// Build from raw per-run means. `samples` need not be sorted.
+    pub fn from_samples(mut samples: Vec<f64>) -> Self {
+        samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let median_ns = median_of_sorted(&samples);
+        let mut deviations: Vec<f64> = samples.iter().map(|s| (s - median_ns).abs()).collect();
+        deviations.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        Self {
+            n: samples.len() as u32,
+            median_ns,
+            mad_ns: median_of_sorted(&deviations),
+            samples_ns: samples,
+        }
+    }
+
+    fn is_usable(&self) -> bool {
+        self.n >= MIN_NOISE_SAMPLES && self.median_ns > 0.0
+    }
+}
+
+fn median_of_sorted(sorted: &[f64]) -> f64 {
+    match sorted.len() {
+        0 => 0.0,
+        n if n % 2 == 1 => sorted[n / 2],
+        n => (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0,
+    }
+}
 
 /// One scenario's captured measurements.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -44,10 +322,57 @@ pub struct BaselineEntry {
     /// Allocation metrics, when the bench records them.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mem: Option<MemMetrics>,
+    /// Repeat-run spread, when the baseline was accumulated over several runs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub noise: Option<NoiseStats>,
+    /// What this scenario read. Falls back to [`BaselineFile::corpus`] when
+    /// absent, so a single-corpus run declares it once at file level.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corpus: Option<CorpusInfo>,
+    /// Per-phase timings and shares, when the bench records them.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub phases: BTreeMap<String, PhaseTiming>,
 }
+
+impl BaselineEntry {
+    /// A bare time measurement — the shape criterion alone produces.
+    pub fn from_ns(mean_ns: f64, median_ns: f64) -> Self {
+        Self {
+            mean_ns,
+            median_ns,
+            mem: None,
+            noise: None,
+            corpus: None,
+            phases: BTreeMap::new(),
+        }
+    }
+
+    /// The wall-clock figure the gate compares: the repeat-run median when
+    /// enough samples exist, criterion's single-run mean otherwise.
+    pub fn effective_ns(&self) -> f64 {
+        match &self.noise {
+            Some(n) if n.is_usable() => n.median_ns,
+            _ => self.mean_ns,
+        }
+    }
+
+    /// The noise floor this entry contributes, as a percentage: `3 × MAD /
+    /// median`. Zero when there aren't enough samples to estimate one.
+    pub fn noise_floor_pct(&self) -> f64 {
+        match &self.noise {
+            Some(n) if n.is_usable() => 3.0 * n.mad_ns / n.median_ns * 100.0,
+            _ => 0.0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// File
+// ---------------------------------------------------------------------------
 
 /// A captured baseline: scenario ID → measurements, plus provenance.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "RawBaselineFile")]
 pub struct BaselineFile {
     pub schema_version: u32,
     /// Human label, e.g. `phase-1-pre`.
@@ -62,42 +387,102 @@ pub struct BaselineFile {
     /// knobs.
     pub profile: String,
     pub scale: String,
-    /// Runner class the baseline was captured on (env `FLUREE_BENCH_RUNNER_CLASS`,
-    /// default `"local"`). Load-bearing for the gate: NEITHER metric is
-    /// comparable across machine classes. Wall-clock time obviously isn't
-    /// (shared CI runners flap; local silicon differs), and a tracking
-    /// allocator's peak isn't either — allocator behaviour, page size, and
-    /// background load move it too. The one ±2.2% cross-machine memory
-    /// measurement this gate was originally built on is a single pair of
-    /// machines, not a portability result. So when this differs from the
-    /// comparing runner's class, `compare` reports BOTH time and peak_mem
-    /// breaches as ADVISORY and gates on neither; when the classes match, both
-    /// enforce. `#[serde(default)]` so pre-field baselines still load (treated
-    /// as `"local"`).
-    #[serde(default = "default_runner_class")]
-    pub runner_class: String,
-    /// Host the baseline was captured on — informational provenance.
-    #[serde(default)]
-    pub host: String,
+    /// The machine, and above all its comparability class. A class mismatch is
+    /// a hard compare error unless the caller opts into the advisory posture.
+    pub host: HostBlock,
+    /// File-level corpus, inherited by every entry that declares none. Lets a
+    /// single-corpus capture state its input once.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corpus: Option<CorpusInfo>,
     pub entries: BTreeMap<String, BaselineEntry>,
 }
 
-fn default_runner_class() -> String {
-    "local".to_string()
+impl BaselineFile {
+    /// The corpus that governs `id`: the entry's own, else the file's.
+    pub fn corpus_for(&self, id: &str) -> Option<&CorpusInfo> {
+        self.entries
+            .get(id)
+            .and_then(|e| e.corpus.as_ref())
+            .or(self.corpus.as_ref())
+    }
 }
 
-/// The runner class of the current environment, from `FLUREE_BENCH_RUNNER_CLASS`
-/// (default `"local"`). CI capture/compare jobs set it (e.g.
-/// `ci-ubuntu-latest`); a match between baseline and current enables
-/// enforcement of both metrics, a mismatch makes both advisory.
-pub fn runner_class() -> String {
-    std::env::var("FLUREE_BENCH_RUNNER_CLASS").unwrap_or_else(|_| default_runner_class())
+/// Deserialization mirror, so schema-1 files keep loading.
+///
+/// Two shapes have to survive: `runner_class: "local"` + `host: "some-hostname"`
+/// (schema 1), and the `host: { class, … }` block (schema 2). Serde field
+/// attributes can't reconcile the two because the legacy class lives in a
+/// *sibling* field, so the fixup happens in `From`.
+#[derive(Deserialize)]
+struct RawBaselineFile {
+    #[serde(default = "one")]
+    schema_version: u32,
+    #[serde(default)]
+    label: String,
+    #[serde(default)]
+    git_sha: Option<String>,
+    #[serde(default)]
+    captured_at: String,
+    #[serde(default)]
+    profile: String,
+    #[serde(default)]
+    scale: String,
+    /// Schema-1 spelling of `host.class`.
+    #[serde(default)]
+    runner_class: Option<String>,
+    #[serde(default)]
+    host: Option<HostField>,
+    #[serde(default)]
+    corpus: Option<CorpusInfo>,
+    #[serde(default)]
+    entries: BTreeMap<String, BaselineEntry>,
 }
 
-fn host() -> String {
-    std::env::var("FLUREE_BENCH_HOST")
-        .or_else(|_| std::env::var("HOSTNAME"))
-        .unwrap_or_else(|_| "unknown".to_string())
+fn one() -> u32 {
+    1
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum HostField {
+    /// Schema 1: a bare host name.
+    Name(String),
+    Block(HostBlock),
+}
+
+impl From<RawBaselineFile> for BaselineFile {
+    fn from(raw: RawBaselineFile) -> Self {
+        let legacy_class = || {
+            raw.runner_class
+                .clone()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| LEGACY_DEFAULT_HOST_CLASS.to_string())
+        };
+        let host = match raw.host {
+            Some(HostField::Block(mut block)) => {
+                if block.class.trim().is_empty() {
+                    block.class = legacy_class();
+                }
+                block
+            }
+            Some(HostField::Name(name)) => HostBlock {
+                name,
+                ..HostBlock::of_class(legacy_class())
+            },
+            None => HostBlock::of_class(legacy_class()),
+        };
+        BaselineFile {
+            schema_version: raw.schema_version,
+            label: raw.label,
+            git_sha: raw.git_sha,
+            captured_at: raw.captured_at,
+            profile: raw.profile,
+            scale: raw.scale,
+            host,
+            corpus: raw.corpus,
+            entries: raw.entries,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -148,18 +533,19 @@ fn parse_estimates(path: &Path) -> Option<BaselineEntry> {
     let raw = std::fs::read_to_string(path).ok()?;
     let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
     let point = |stat: &str| -> Option<f64> { v.get(stat)?.get("point_estimate")?.as_f64() };
-    Some(BaselineEntry {
-        mean_ns: point("mean")?,
-        median_ns: point("median").or_else(|| point("mean"))?,
-        mem: None,
-    })
+    let mean = point("mean")?;
+    Some(BaselineEntry::from_ns(
+        mean,
+        point("median").unwrap_or(mean),
+    ))
 }
 
-/// Capture a baseline from criterion output plus memory sidecars.
+/// Capture a baseline from criterion output plus memory and meta sidecars.
 pub fn capture(
     label: &str,
     criterion_dir: &Path,
     mem_dir: &Path,
+    meta_dir: &Path,
     git_sha: Option<String>,
     captured_at: String,
 ) -> BaselineFile {
@@ -167,12 +553,16 @@ pub fn capture(
     for (id, metrics) in crate::mem::read_all_sidecars(mem_dir) {
         entries
             .entry(id)
-            .and_modify(|e| e.mem = Some(metrics))
-            .or_insert(BaselineEntry {
-                mean_ns: 0.0,
-                median_ns: 0.0,
-                mem: Some(metrics),
-            });
+            .or_insert_with(|| BaselineEntry::from_ns(0.0, 0.0))
+            .mem = Some(metrics);
+    }
+    for (id, meta) in crate::meta::read_all_sidecars(meta_dir) {
+        let ScenarioMeta { corpus, phases } = meta;
+        let entry = entries
+            .entry(id)
+            .or_insert_with(|| BaselineEntry::from_ns(0.0, 0.0));
+        entry.corpus = corpus;
+        entry.phases = phases;
     }
     BaselineFile {
         schema_version: BASELINE_SCHEMA_VERSION,
@@ -181,10 +571,55 @@ pub fn capture(
         captured_at,
         profile: std::env::var("FLUREE_BENCH_PROFILE").unwrap_or_else(|_| "quick".into()),
         scale: std::env::var("FLUREE_BENCH_SCALE").unwrap_or_else(|_| "small".into()),
-        runner_class: runner_class(),
-        host: host(),
+        host: HostBlock::detect(),
+        corpus: None,
         entries,
     }
+}
+
+/// Fold a fresh capture into an existing baseline as one more sample.
+///
+/// This is how a baseline reaches [`MIN_NOISE_SAMPLES`]: run the benches, run
+/// `capture --accumulate`, repeat. Each pass appends the fresh criterion mean to
+/// the entry's sample vector and recomputes median + MAD, so the recorded floor
+/// always matches the samples stored beside it.
+///
+/// Scenarios absent from `fresh` keep their prior stats untouched — a subset
+/// rerun tops up only what it measured. Scenarios new in `fresh` start their own
+/// sample series. `prev`'s provenance (label, sha, host) is replaced by
+/// `fresh`'s: the accumulated file describes the run that finished last, and a
+/// host change mid-accumulation is exactly the thing the host gate should catch
+/// on the next compare rather than something to average over.
+pub fn accumulate(prev: &BaselineFile, fresh: &BaselineFile) -> BaselineFile {
+    let mut out = fresh.clone();
+    for (id, prev_entry) in &prev.entries {
+        let prior: Vec<f64> = prev_entry
+            .noise
+            .as_ref()
+            .map(|n| n.samples_ns.clone())
+            .unwrap_or_else(|| {
+                // A pre-accumulation baseline holds one measurement and no
+                // sample vector; seed the series with it so the first
+                // --accumulate pass yields n=2 rather than discarding history.
+                if prev_entry.mean_ns > 0.0 {
+                    vec![prev_entry.mean_ns]
+                } else {
+                    Vec::new()
+                }
+            });
+        match out.entries.get_mut(id) {
+            Some(entry) if entry.mean_ns > 0.0 => {
+                let mut samples = prior;
+                samples.push(entry.mean_ns);
+                entry.noise = Some(NoiseStats::from_samples(samples));
+            }
+            // Not rerun this pass: carry the previous entry forward whole.
+            _ => {
+                out.entries.insert(id.clone(), prev_entry.clone());
+            }
+        }
+    }
+    out
 }
 
 pub fn load_baseline(path: &Path) -> Result<BaselineFile, String> {
@@ -207,7 +642,8 @@ pub fn save_baseline(file: &BaselineFile, path: &Path) -> Result<(), String> {
 /// Outcome of one scenario × one metric comparison.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompareStatus {
-    /// Faster / smaller than baseline by more than 1%.
+    /// Faster / smaller than baseline by more than 1% (for share metrics: by
+    /// more than the drift threshold).
     Improved,
     /// Within the budget envelope.
     Within,
@@ -215,20 +651,130 @@ pub enum CompareStatus {
     Exceeded,
 }
 
+/// What a comparison measured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Metric {
+    /// Wall-clock, whole scenario.
+    Time,
+    /// Tracking-allocator peak, whole scenario.
+    PeakMem,
+    /// Wall-clock of one pipeline phase, absolute nanoseconds.
+    PhaseTime,
+    /// One phase's share of the scenario's measured phases, in percentage
+    /// points. Dimensionless, so it survives a host change.
+    PhaseShare,
+}
+
+impl Metric {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Metric::Time => "time",
+            Metric::PeakMem => "peak_mem",
+            Metric::PhaseTime => "phase_time",
+            Metric::PhaseShare => "phase_share",
+        }
+    }
+
+    /// Whether this metric is comparable across host classes. Only shares are:
+    /// they are ratios within a single run, so the machine cancels.
+    pub fn is_host_portable(self) -> bool {
+        matches!(self, Metric::PhaseShare)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Comparison {
     pub id: String,
-    /// `"time"` or `"peak_mem"`.
-    pub metric: &'static str,
+    pub metric: Metric,
+    /// Phase name for the per-phase metrics.
+    pub phase: Option<String>,
     pub baseline: f64,
     pub observed: f64,
+    /// Percent change for time/memory metrics; **percentage points** of
+    /// movement for [`Metric::PhaseShare`].
     pub change_pct: f64,
+    /// The threshold applied: percent for time/memory (budget, widened by any
+    /// noise floor), percentage points for share drift.
     pub budget_pct: f64,
     pub status: CompareStatus,
-    /// Whether an `Exceeded` here fails the gate. Symmetric across metrics:
-    /// both time and peak_mem enforce when the baseline and the comparing
-    /// runner share a runner class, and both are advisory when they don't.
+    /// Whether an `Exceeded` here fails the gate. Absolute metrics enforce only
+    /// when the host classes match; share drift always enforces.
     pub enforced: bool,
+}
+
+impl Comparison {
+    /// `"<id> [<metric>]"`, with the phase folded in for per-phase rows.
+    pub fn label(&self) -> String {
+        match &self.phase {
+            Some(phase) => format!("{}::{} [{}]", self.id, phase, self.metric.as_str()),
+            None => format!("{} [{}]", self.id, self.metric.as_str()),
+        }
+    }
+}
+
+/// A comparison the gate refuses to make.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MismatchKind {
+    /// Baseline and current ran on different comparability classes.
+    HostClass,
+    /// Baseline and current measured different inputs.
+    Corpus,
+    /// The baseline file is newer than this binary understands.
+    SchemaVersion,
+}
+
+impl MismatchKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MismatchKind::HostClass => "host-class",
+            MismatchKind::Corpus => "corpus",
+            MismatchKind::SchemaVersion => "schema-version",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FatalMismatch {
+    pub kind: MismatchKind,
+    /// Scenario the mismatch applies to; `None` for file-level mismatches.
+    pub id: Option<String>,
+    pub detail: String,
+    /// What the operator can do about it.
+    pub remedy: String,
+}
+
+/// What [`compare`] does when the host classes differ.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HostMismatchPolicy {
+    /// Refuse to compare (default): absolute numbers from different machines
+    /// are not evidence.
+    #[default]
+    Fatal,
+    /// Compare anyway, with every absolute metric advisory. Share drift still
+    /// gates, which is the whole reason this posture is useful.
+    Advise,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompareOptions {
+    /// Restrict to scenario IDs containing this substring (PR-scoped subsets).
+    pub only: Option<String>,
+    pub host_mismatch: HostMismatchPolicy,
+    /// Percentage points of share movement that count as drift.
+    pub share_drift_pp: f64,
+    /// Force every absolute metric advisory regardless of host class.
+    pub force_advisory: bool,
+}
+
+impl Default for CompareOptions {
+    fn default() -> Self {
+        Self {
+            only: None,
+            host_mismatch: HostMismatchPolicy::default(),
+            share_drift_pp: DEFAULT_SHARE_DRIFT_PP,
+            force_advisory: false,
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -239,26 +785,35 @@ pub struct CompareReport {
     pub missing: Vec<String>,
     /// Scenario IDs measured now but absent from the baseline.
     pub new_scenarios: Vec<String>,
+    /// Comparisons the gate refused to make. Any entry here fails the gate,
+    /// distinctly from a budget breach.
+    pub fatal: Vec<FatalMismatch>,
+    /// Why absolute metrics are advisory, when they are.
+    pub advisory_reason: Option<String>,
 }
 
 impl CompareReport {
     /// Enforced breaches — an `Exceeded` on an enforced metric. These fail the
-    /// gate (nonzero exit).
+    /// gate.
     pub fn breaches(&self) -> impl Iterator<Item = &Comparison> {
         self.comparisons
             .iter()
             .filter(|c| c.status == CompareStatus::Exceeded && c.enforced)
     }
     /// Advisory breaches — an `Exceeded` measured against a baseline from a
-    /// different runner class. Reported as annotations; they do NOT fail the
+    /// different host class. Reported as annotations; they do NOT fail the
     /// gate.
     pub fn advisories(&self) -> impl Iterator<Item = &Comparison> {
         self.comparisons
             .iter()
             .filter(|c| c.status == CompareStatus::Exceeded && !c.enforced)
     }
+    /// True when the gate refused to produce a verdict at all.
+    pub fn is_fatal(&self) -> bool {
+        !self.fatal.is_empty()
+    }
     pub fn passed(&self) -> bool {
-        self.breaches().next().is_none()
+        !self.is_fatal() && self.breaches().next().is_none()
     }
 }
 
@@ -310,32 +865,91 @@ fn classify(baseline: f64, observed: f64, budget_pct: f64) -> (f64, CompareStatu
     (change_pct, status)
 }
 
-/// Compare current entries against a baseline under the given budgets.
+/// Share drift is measured in percentage points, and only *growth* gates.
 ///
-/// `only` restricts the comparison to scenario IDs containing the given
-/// substring (PR-scoped subset runs).
+/// Shares sum to 100, so every phase that grows forces others to shrink. Gating
+/// both directions would fail a clean improvement twice — once for the phase
+/// that got better and once for its complement. Growth is the regression;
+/// shrink is reported as an improvement so the report still shows the whole
+/// picture.
+fn classify_share(baseline_pct: f64, observed_pct: f64, drift_pp: f64) -> (f64, CompareStatus) {
+    let delta_pp = observed_pct - baseline_pct;
+    let status = if delta_pp > drift_pp {
+        CompareStatus::Exceeded
+    } else if delta_pp < -drift_pp {
+        CompareStatus::Improved
+    } else {
+        CompareStatus::Within
+    };
+    (delta_pp, status)
+}
+
+/// Compare a current capture against a baseline under the given budgets.
 ///
-/// `advisory` marks EVERY comparison as non-enforced (breaches reported but not
-/// gate-failing). Callers set it when the baseline's runner class differs from
-/// the comparing runner's, or via an explicit override. It is deliberately not
-/// per-metric: a cross-machine baseline is untrustworthy for wall-clock time
-/// and for a tracking allocator's peak alike, and gating on the less portable
-/// of the two while merely warning on the other is the wrong way round.
+/// Returns a report rather than a `Result`: a refusal to compare
+/// ([`CompareReport::fatal`]) still carries the provenance a reader needs to fix
+/// it, and the caller decides the exit code.
 pub fn compare(
     baseline: &BaselineFile,
-    current: &BTreeMap<String, BaselineEntry>,
+    current: &BaselineFile,
     budget: &RegressionBudget,
-    only: Option<&str>,
-    advisory: bool,
+    opts: &CompareOptions,
 ) -> CompareReport {
-    let selected = |id: &str| only.is_none_or(|f| id.contains(f));
     let mut report = CompareReport::default();
+
+    if baseline.schema_version > BASELINE_SCHEMA_VERSION {
+        report.fatal.push(FatalMismatch {
+            kind: MismatchKind::SchemaVersion,
+            id: None,
+            detail: format!(
+                "baseline schema_version {} is newer than this binary understands ({BASELINE_SCHEMA_VERSION})",
+                baseline.schema_version
+            ),
+            remedy: "rebuild bench-baseline from the commit that wrote the baseline, or recapture"
+                .to_string(),
+        });
+        return report;
+    }
+
+    let host_differs = baseline.host.class != current.host.class;
+    if host_differs && opts.host_mismatch == HostMismatchPolicy::Fatal {
+        report.fatal.push(FatalMismatch {
+            kind: MismatchKind::HostClass,
+            id: None,
+            detail: format!(
+                "baseline host_class '{}' ({}) != current '{}' ({})",
+                baseline.host.class,
+                baseline.host.describe(),
+                current.host.class,
+                current.host.describe(),
+            ),
+            remedy: "recapture on this host class, set FLUREE_BENCH_HOST_CLASS / --host-class to \
+                     the class the baseline was captured on, or pass --allow-host-mismatch to \
+                     compare share drift only (absolute time and memory become advisory)"
+                .to_string(),
+        });
+        return report;
+    }
+
+    let advisory = opts.force_advisory || host_differs;
+    report.advisory_reason = if opts.force_advisory {
+        Some("--advisory was passed".to_string())
+    } else if host_differs {
+        Some(format!(
+            "baseline host_class '{}' != current '{}'",
+            baseline.host.class, current.host.class
+        ))
+    } else {
+        None
+    };
+
+    let selected = |id: &str| opts.only.as_deref().is_none_or(|f| id.contains(f));
 
     for (id, base) in &baseline.entries {
         if !selected(id) {
             continue;
         }
-        let Some(cur) = current.get(id) else {
+        let Some(cur) = current.entries.get(id) else {
             report.missing.push(id.clone());
             continue;
         };
@@ -349,15 +963,42 @@ pub fn compare(
             report.missing.push(id.clone());
             continue;
         }
-        let budget_pct = budget_for_id(budget, id);
 
-        if base.mean_ns > 0.0 {
-            let (change_pct, status) = classify(base.mean_ns, cur.mean_ns, budget_pct);
+        // Corpus identity gates everything else about this scenario: if the two
+        // runs read different inputs, none of their numbers are comparable and
+        // emitting rows for them would be worse than emitting nothing.
+        if let (Some(base_corpus), Some(cur_corpus)) =
+            (baseline.corpus_for(id), current.corpus_for(id))
+        {
+            if let Some(detail) = base_corpus.identity_mismatch(cur_corpus) {
+                report.fatal.push(FatalMismatch {
+                    kind: MismatchKind::Corpus,
+                    id: Some(id.clone()),
+                    detail,
+                    remedy: "rerun against the corpus the baseline recorded, or recapture the \
+                             baseline against the corpus you intend to gate on"
+                        .to_string(),
+                });
+                continue;
+            }
+        }
+
+        let declared_budget = budget_for_id(budget, id);
+        // A noise floor only ever *widens* the envelope: it is a statement about
+        // how much run-to-run movement this scenario shows on this machine, and
+        // a budget tighter than the noise can only produce false alarms.
+        let noise_floor = base.noise_floor_pct().max(cur.noise_floor_pct());
+        let budget_pct = declared_budget.max(noise_floor);
+
+        if base.effective_ns() > 0.0 {
+            let (change_pct, status) =
+                classify(base.effective_ns(), cur.effective_ns(), budget_pct);
             report.comparisons.push(Comparison {
                 id: id.clone(),
-                metric: "time",
-                baseline: base.mean_ns,
-                observed: cur.mean_ns,
+                metric: Metric::Time,
+                phase: None,
+                baseline: base.effective_ns(),
+                observed: cur.effective_ns(),
                 change_pct,
                 budget_pct,
                 status,
@@ -369,7 +1010,8 @@ pub fn compare(
                 classify(bm.peak_bytes as f64, cm.peak_bytes as f64, budget_pct);
             report.comparisons.push(Comparison {
                 id: id.clone(),
-                metric: "peak_mem",
+                metric: Metric::PeakMem,
+                phase: None,
                 baseline: bm.peak_bytes as f64,
                 observed: cm.peak_bytes as f64,
                 change_pct,
@@ -380,14 +1022,71 @@ pub fn compare(
                 enforced: !advisory,
             });
         }
+
+        for (phase, base_phase) in &base.phases {
+            let Some(cur_phase) = cur.phases.get(phase) else {
+                continue;
+            };
+            let (change_pct, status) = classify(base_phase.ns, cur_phase.ns, budget_pct);
+            report.comparisons.push(Comparison {
+                id: id.clone(),
+                metric: Metric::PhaseTime,
+                phase: Some(phase.clone()),
+                baseline: base_phase.ns,
+                observed: cur_phase.ns,
+                change_pct,
+                budget_pct,
+                status,
+                enforced: !advisory,
+            });
+
+            let (delta_pp, status) = classify_share(
+                base_phase.share_pct,
+                cur_phase.share_pct,
+                opts.share_drift_pp,
+            );
+            report.comparisons.push(Comparison {
+                id: id.clone(),
+                metric: Metric::PhaseShare,
+                phase: Some(phase.clone()),
+                baseline: base_phase.share_pct,
+                observed: cur_phase.share_pct,
+                change_pct: delta_pp,
+                budget_pct: opts.share_drift_pp,
+                status,
+                // Shares are ratios within one run, so the machine cancels.
+                // This is the one signal a cross-host comparison keeps, and
+                // making it advisory alongside the absolute metrics would throw
+                // away the entire reason to compare across hosts at all.
+                enforced: true,
+            });
+        }
     }
 
-    for id in current.keys() {
+    for id in current.entries.keys() {
         if selected(id) && !baseline.entries.contains_key(id) {
             report.new_scenarios.push(id.clone());
         }
     }
     report
+}
+
+/// One-line summary of a corpus, for report headers.
+pub fn describe_corpus(corpus: &CorpusInfo) -> String {
+    let mut s = format!(
+        "{} sha256:{} {} bytes",
+        corpus.name,
+        short_hash(&corpus.sha256),
+        corpus.byte_len
+    );
+    if corpus.element_count > 0 {
+        s.push_str(&format!(", {} elements", corpus.element_count));
+    }
+    s.push_str(&format!(
+        ", {}→{}, {} thread(s)",
+        corpus.input_syntax, corpus.output_syntax, corpus.thread_count
+    ));
+    s
 }
 
 /// Default locations, resolved from the workspace root.
@@ -403,14 +1102,20 @@ mod tests {
     use super::*;
 
     fn entry(mean: f64) -> BaselineEntry {
+        BaselineEntry::from_ns(mean, mean)
+    }
+
+    fn mem_entry(mean: f64, peak: u64) -> BaselineEntry {
         BaselineEntry {
-            mean_ns: mean,
-            median_ns: mean,
-            mem: None,
+            mem: Some(MemMetrics {
+                peak_bytes: peak,
+                total_allocated_bytes: peak * 2,
+            }),
+            ..entry(mean)
         }
     }
 
-    fn baseline_with(entries: Vec<(&str, BaselineEntry)>) -> BaselineFile {
+    fn file_of(class: &str, entries: Vec<(&str, BaselineEntry)>) -> BaselineFile {
         BaselineFile {
             schema_version: BASELINE_SCHEMA_VERSION,
             label: "test".into(),
@@ -418,8 +1123,8 @@ mod tests {
             captured_at: "2026-01-01T00:00:00Z".into(),
             profile: "quick".into(),
             scale: "small".into(),
-            runner_class: "local".into(),
-            host: "test".into(),
+            host: HostBlock::of_class(class),
+            corpus: None,
             entries: entries
                 .into_iter()
                 .map(|(k, v)| (k.to_string(), v))
@@ -427,14 +1132,27 @@ mod tests {
         }
     }
 
-    fn mem_entry(mean: f64, peak: u64) -> BaselineEntry {
-        BaselineEntry {
-            mean_ns: mean,
-            median_ns: mean,
-            mem: Some(MemMetrics {
-                peak_bytes: peak,
-                total_allocated_bytes: peak * 2,
-            }),
+    fn baseline_with(entries: Vec<(&str, BaselineEntry)>) -> BaselineFile {
+        file_of("local", entries)
+    }
+
+    /// Same host class as `baseline_with`, so absolute metrics enforce.
+    fn current_with(entries: Vec<(&str, BaselineEntry)>) -> BaselineFile {
+        file_of("local", entries)
+    }
+
+    fn corpus(bytes: &[u8]) -> CorpusInfo {
+        CorpusInfo::from_bytes("dblp.ttl", bytes, "turtle", "nquads", 8)
+    }
+
+    fn opts() -> CompareOptions {
+        CompareOptions::default()
+    }
+
+    fn allow_mismatch() -> CompareOptions {
+        CompareOptions {
+            host_mismatch: HostMismatchPolicy::Advise,
+            ..CompareOptions::default()
         }
     }
 
@@ -470,13 +1188,14 @@ mod tests {
             ("g/q2/small", entry(1000.0)),
             ("g/q3/small", entry(1000.0)),
         ]);
-        let mut current = BTreeMap::new();
-        current.insert("g/q1/small".to_string(), entry(900.0)); // -10%
-        current.insert("g/q2/small".to_string(), entry(1030.0)); // +3%
-        current.insert("g/q3/small".to_string(), entry(1100.0)); // +10%
+        let current = current_with(vec![
+            ("g/q1/small", entry(900.0)),  // -10%
+            ("g/q2/small", entry(1030.0)), // +3%
+            ("g/q3/small", entry(1100.0)), // +10%
+        ]);
         let budget = RegressionBudget::empty(5.0);
 
-        let report = compare(&base, &current, &budget, None, false);
+        let report = compare(&base, &current, &budget, &opts());
         assert!(!report.passed());
         let by_id = |id: &str| {
             report
@@ -497,56 +1216,684 @@ mod tests {
             ("g/q1/small", entry(1000.0)),
             ("h/q1/small", entry(1000.0)),
         ]);
-        let mut current = BTreeMap::new();
-        current.insert("g/q1/small".to_string(), entry(1000.0));
+        let current = current_with(vec![("g/q1/small", entry(1000.0))]);
         let budget = RegressionBudget::empty(5.0);
 
         // Unfiltered: h/q1 is missing (informational, not a failure).
-        let report = compare(&base, &current, &budget, None, false);
+        let report = compare(&base, &current, &budget, &opts());
         assert!(report.passed());
         assert_eq!(report.missing, vec!["h/q1/small".to_string()]);
 
         // Filtered to g/: nothing missing.
-        let report = compare(&base, &current, &budget, Some("g/"), false);
+        let filtered = CompareOptions {
+            only: Some("g/".into()),
+            ..opts()
+        };
+        let report = compare(&base, &current, &budget, &filtered);
         assert!(report.missing.is_empty());
         assert_eq!(report.comparisons.len(), 1);
     }
 
     #[test]
     fn compare_includes_memory_metric() {
-        let mem = |peak: u64| MemMetrics {
-            peak_bytes: peak,
-            total_allocated_bytes: peak * 2,
-        };
-        let mut base_entry = entry(1000.0);
-        base_entry.mem = Some(mem(1_000_000));
-        let base = baseline_with(vec![("g/q1/small", base_entry)]);
-
-        let mut cur_entry = entry(1000.0);
-        cur_entry.mem = Some(mem(2_000_000)); // +100% peak
-        let mut current = BTreeMap::new();
-        current.insert("g/q1/small".to_string(), cur_entry);
-
+        let base = baseline_with(vec![("g/q1/small", mem_entry(1000.0, 1_000_000))]);
+        let current = current_with(vec![("g/q1/small", mem_entry(1000.0, 2_000_000))]);
         let budget = RegressionBudget::empty(5.0);
-        let report = compare(&base, &current, &budget, None, false);
+        let report = compare(&base, &current, &budget, &opts());
         assert!(!report.passed());
         let breach = report.breaches().next().unwrap();
-        assert_eq!(breach.metric, "peak_mem");
+        assert_eq!(breach.metric, Metric::PeakMem);
+    }
+
+    // -----------------------------------------------------------------------
+    // Host class
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn host_class_mismatch_is_fatal_by_default() {
+        let base = file_of("bench-m8gd", vec![("g/q1/small", entry(1000.0))]);
+        let current = file_of("macos-aarch64", vec![("g/q1/small", entry(1000.0))]);
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(report.is_fatal());
+        assert!(!report.passed());
+        assert_eq!(report.fatal[0].kind, MismatchKind::HostClass);
+        // No verdict at all — not even a clean one.
+        assert!(report.comparisons.is_empty());
+        assert!(
+            report.fatal[0].detail.contains("bench-m8gd")
+                && report.fatal[0].detail.contains("macos-aarch64"),
+            "message must name both classes: {}",
+            report.fatal[0].detail
+        );
+        assert!(report.fatal[0].remedy.contains("--allow-host-mismatch"));
+    }
+
+    #[test]
+    fn allow_host_mismatch_makes_absolute_metrics_advisory() {
+        let base = file_of(
+            "bench-m8gd",
+            vec![("g/q1/small", mem_entry(1000.0, 1_000_000))],
+        );
+        let current = file_of(
+            "macos-aarch64",
+            vec![("g/q1/small", mem_entry(5000.0, 9_000_000))],
+        );
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &allow_mismatch());
+        assert!(!report.is_fatal());
+        assert!(
+            report.passed(),
+            "cross-host absolute breaches must not gate"
+        );
+        assert_eq!(report.advisories().count(), 2);
+        assert!(report.advisory_reason.unwrap().contains("bench-m8gd"));
+    }
+
+    #[test]
+    fn matching_host_class_enforces_absolute_metrics() {
+        let base = file_of("ci-ubuntu-latest", vec![("g/q1/small", entry(1000.0))]);
+        let current = file_of("ci-ubuntu-latest", vec![("g/q1/small", entry(2000.0))]);
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(!report.passed());
+        assert_eq!(report.breaches().count(), 1);
+        assert!(report.advisory_reason.is_none());
+    }
+
+    #[test]
+    fn force_advisory_downgrades_even_on_matching_hosts() {
+        let base = baseline_with(vec![("g/q1/small", entry(1000.0))]);
+        let current = current_with(vec![("g/q1/small", entry(2000.0))]);
+        let budget = RegressionBudget::empty(5.0);
+        let forced = CompareOptions {
+            force_advisory: true,
+            ..opts()
+        };
+
+        let report = compare(&base, &current, &budget, &forced);
+        assert!(report.passed());
+        assert_eq!(report.advisories().count(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Corpus identity
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn corpus_hash_mismatch_is_fatal_and_drops_the_scenario() {
+        let mut base_entry = entry(1000.0);
+        base_entry.corpus = Some(corpus(b"one"));
+        let mut cur_entry = entry(1000.0);
+        cur_entry.corpus = Some(corpus(b"two"));
+
+        let base = baseline_with(vec![("g/q1/small", base_entry)]);
+        let current = current_with(vec![("g/q1/small", cur_entry)]);
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(report.is_fatal());
+        assert!(!report.passed());
+        assert_eq!(report.fatal[0].kind, MismatchKind::Corpus);
+        assert_eq!(report.fatal[0].id.as_deref(), Some("g/q1/small"));
+        assert!(report.fatal[0].detail.starts_with("sha256:"));
+        assert!(
+            report.comparisons.is_empty(),
+            "a scenario with a corpus mismatch must produce no rows"
+        );
+    }
+
+    #[test]
+    fn corpus_mismatch_has_no_override() {
+        // Unlike a host mismatch, --allow-host-mismatch does not rescue this:
+        // there is no posture in which comparing different inputs is meaningful.
+        let mut base_entry = entry(1000.0);
+        base_entry.corpus = Some(corpus(b"one"));
+        let mut cur_entry = entry(1000.0);
+        cur_entry.corpus = Some(corpus(b"two"));
+        let base = baseline_with(vec![("g/q1/small", base_entry)]);
+        let current = current_with(vec![("g/q1/small", cur_entry)]);
+        let budget = RegressionBudget::empty(5.0);
+
+        let forced = CompareOptions {
+            force_advisory: true,
+            ..allow_mismatch()
+        };
+        assert!(compare(&base, &current, &budget, &forced).is_fatal());
+    }
+
+    #[test]
+    fn matching_corpus_compares_normally() {
+        let mut base_entry = entry(1000.0);
+        base_entry.corpus = Some(corpus(b"same"));
+        let mut cur_entry = entry(1030.0);
+        cur_entry.corpus = Some(corpus(b"same"));
+
+        let base = baseline_with(vec![("g/q1/small", base_entry)]);
+        let current = current_with(vec![("g/q1/small", cur_entry)]);
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(report.passed());
+        assert_eq!(report.comparisons.len(), 1);
+    }
+
+    #[test]
+    fn file_level_corpus_is_inherited_by_entries() {
+        let mut base = baseline_with(vec![("g/q1/small", entry(1000.0))]);
+        base.corpus = Some(corpus(b"one"));
+        let mut current = current_with(vec![("g/q1/small", entry(1000.0))]);
+        current.corpus = Some(corpus(b"two"));
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(report.is_fatal(), "file-level corpus must gate too");
+        assert_eq!(report.fatal[0].kind, MismatchKind::Corpus);
+    }
+
+    #[test]
+    fn entry_corpus_overrides_file_corpus() {
+        let mut base = baseline_with(vec![("g/q1/small", {
+            let mut e = entry(1000.0);
+            e.corpus = Some(corpus(b"same"));
+            e
+        })]);
+        base.corpus = Some(corpus(b"file-level-differs"));
+        let mut current = current_with(vec![("g/q1/small", {
+            let mut e = entry(1000.0);
+            e.corpus = Some(corpus(b"same"));
+            e
+        })]);
+        current.corpus = Some(corpus(b"and-differs-here-too"));
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(
+            report.passed(),
+            "entry-level corpus agreement must win over file-level disagreement"
+        );
+    }
+
+    #[test]
+    fn one_sided_corpus_declaration_does_not_gate() {
+        // An old baseline with no corpus block compared against a run that has
+        // one: nothing to check, so compare normally rather than inventing a
+        // mismatch.
+        let base = baseline_with(vec![("g/q1/small", entry(1000.0))]);
+        let current = current_with(vec![("g/q1/small", {
+            let mut e = entry(1000.0);
+            e.corpus = Some(corpus(b"one"));
+            e
+        })]);
+        let budget = RegressionBudget::empty(5.0);
+        assert!(compare(&base, &current, &budget, &opts()).passed());
+    }
+
+    // -----------------------------------------------------------------------
+    // Phases and share drift
+    // -----------------------------------------------------------------------
+
+    fn phased(mean: f64, phases: &[(&str, f64)]) -> BaselineEntry {
+        BaselineEntry {
+            phases: ScenarioMeta::new()
+                .with_phase_ns(phases.iter().map(|(n, ns)| (n.to_string(), *ns)))
+                .phases,
+            ..entry(mean)
+        }
+    }
+
+    #[test]
+    fn share_drift_gates_even_across_host_classes() {
+        // Whole-scenario time is identical; the work moved from write to parse.
+        let base = file_of(
+            "bench-m8gd",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 60.0), ("write", 40.0)]),
+            )],
+        );
+        let current = file_of(
+            "macos-aarch64",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 80.0), ("write", 20.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &allow_mismatch());
+        let share_breaches: Vec<_> = report
+            .breaches()
+            .filter(|c| c.metric == Metric::PhaseShare)
+            .collect();
+        assert_eq!(share_breaches.len(), 1, "only the grown phase gates");
+        assert_eq!(share_breaches[0].phase.as_deref(), Some("parse"));
+        assert!((share_breaches[0].change_pct - 20.0).abs() < 1e-9, "20pp");
+        assert!(!report.passed(), "share drift must fail the gate");
+    }
+
+    #[test]
+    fn share_shrink_is_reported_as_improvement_not_a_breach() {
+        let base = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 60.0), ("write", 40.0)]),
+            )],
+        );
+        let current = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 80.0), ("write", 20.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(5.0);
+        let report = compare(&base, &current, &budget, &opts());
+
+        let write = report
+            .comparisons
+            .iter()
+            .find(|c| c.metric == Metric::PhaseShare && c.phase.as_deref() == Some("write"))
+            .unwrap();
+        assert_eq!(write.status, CompareStatus::Improved);
+    }
+
+    #[test]
+    fn share_within_threshold_does_not_gate() {
+        let base = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 60.0), ("write", 40.0)]),
+            )],
+        );
+        let current = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 62.0), ("write", 38.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(5.0);
+        assert!(compare(&base, &current, &budget, &opts()).passed());
+    }
+
+    #[test]
+    fn share_drift_threshold_is_configurable() {
+        let base = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 60.0), ("write", 40.0)]),
+            )],
+        );
+        let current = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 63.0), ("write", 37.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(500.0);
+        let tight = CompareOptions {
+            share_drift_pp: 1.0,
+            ..opts()
+        };
+        assert!(!compare(&base, &current, &budget, &tight).passed());
+        assert!(compare(&base, &current, &budget, &opts()).passed());
+    }
+
+    #[test]
+    fn absolute_phase_time_is_advisory_across_host_classes() {
+        // Same shares, 10x the absolute phase cost: a machine change, not a
+        // regression. The share rows stay clean and the phase_time rows only
+        // annotate.
+        let base = file_of(
+            "bench-m8gd",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 60.0), ("write", 40.0)]),
+            )],
+        );
+        let current = file_of(
+            "macos-aarch64",
+            vec![(
+                "g/q1/small",
+                phased(10000.0, &[("parse", 600.0), ("write", 400.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &allow_mismatch());
+        assert!(report.passed());
+        assert!(report
+            .advisories()
+            .any(|c| c.metric == Metric::PhaseTime && c.phase.as_deref() == Some("parse")));
+        assert!(report
+            .comparisons
+            .iter()
+            .filter(|c| c.metric == Metric::PhaseShare)
+            .all(|c| c.status == CompareStatus::Within));
+    }
+
+    #[test]
+    fn phases_only_in_one_side_are_skipped() {
+        let base = file_of(
+            "local",
+            vec![("g/q1/small", phased(1000.0, &[("parse", 100.0)]))],
+        );
+        let current = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("lex", 50.0), ("parse", 50.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(5.0);
+        let report = compare(&base, &current, &budget, &opts());
+        // parse: share 100 -> 50 (improved), plus phase_time. lex has no
+        // baseline counterpart and produces nothing.
+        assert!(report
+            .comparisons
+            .iter()
+            .all(|c| c.phase.as_deref() != Some("lex")));
+    }
+
+    // -----------------------------------------------------------------------
+    // Noise floor
+    // -----------------------------------------------------------------------
+
+    fn noisy(samples: &[f64]) -> BaselineEntry {
+        let stats = NoiseStats::from_samples(samples.to_vec());
+        BaselineEntry {
+            noise: Some(stats.clone()),
+            ..entry(stats.median_ns)
+        }
+    }
+
+    #[test]
+    fn mad_and_median_are_computed_from_samples() {
+        let stats = NoiseStats::from_samples(vec![100.0, 102.0, 98.0, 101.0, 99.0]);
+        assert_eq!(stats.n, 5);
+        assert_eq!(stats.median_ns, 100.0);
+        // deviations 0,1,1,2,2 -> median 1
+        assert_eq!(stats.mad_ns, 1.0);
+        assert_eq!(stats.samples_ns, vec![98.0, 99.0, 100.0, 101.0, 102.0]);
+    }
+
+    #[test]
+    fn even_sample_count_medians_the_middle_pair() {
+        let stats = NoiseStats::from_samples(vec![10.0, 20.0, 30.0, 40.0]);
+        assert_eq!(stats.median_ns, 25.0);
+    }
+
+    /// Deviations from the median of 1000 are 20/10/0/10/20, so MAD = 10 and
+    /// the floor is `3 × 10 / 1000 = 3%`.
+    const MAD_10_SAMPLES: [f64; 5] = [980.0, 990.0, 1000.0, 1010.0, 1020.0];
+
+    #[test]
+    fn noise_floor_widens_a_tight_budget() {
+        let base = file_of("local", vec![("g/q1/small", noisy(&MAD_10_SAMPLES))]);
+        // +2.5%: inside the 3% noise floor, outside the declared 1% budget.
+        let current = current_with(vec![("g/q1/small", entry(1025.0))]);
+        let budget = RegressionBudget::empty(1.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(report.passed(), "2.5% move must not flag under a 3% floor");
+        let c = &report.comparisons[0];
+        assert_eq!(c.budget_pct, 3.0, "budget widened to the floor: {c:?}");
+    }
+
+    #[test]
+    fn noise_floor_does_not_hide_a_move_beyond_it() {
+        let base = file_of("local", vec![("g/q1/small", noisy(&MAD_10_SAMPLES))]);
+        let current = current_with(vec![("g/q1/small", entry(1200.0))]); // +20%
+        let budget = RegressionBudget::empty(1.0);
+        assert!(!compare(&base, &current, &budget, &opts()).passed());
+    }
+
+    #[test]
+    fn a_noisy_current_run_widens_the_budget_too() {
+        // The floor is a property of the environment, not of the baseline: a
+        // quiet baseline compared against a run that measured wide must take
+        // the wider of the two floors, or every noisy PR run false-flags.
+        let base = file_of("local", vec![("g/q1/small", entry(1000.0))]);
+        let current = current_with(vec![("g/q1/small", noisy(&MAD_10_SAMPLES))]);
+        let budget = RegressionBudget::empty(1.0);
+        assert_eq!(
+            compare(&base, &current, &budget, &opts()).comparisons[0].budget_pct,
+            3.0
+        );
+    }
+
+    #[test]
+    fn noise_floor_never_tightens_a_looser_budget() {
+        // A quiet scenario (MAD 0) must not drag a 10% budget down to 0%.
+        let base = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                noisy(&[1000.0, 1000.0, 1000.0, 1000.0, 1000.0]),
+            )],
+        );
+        let current = current_with(vec![("g/q1/small", entry(1080.0))]); // +8%
+        let budget = RegressionBudget::empty(10.0);
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(report.passed());
+        assert_eq!(report.comparisons[0].budget_pct, 10.0);
+    }
+
+    #[test]
+    fn too_few_samples_do_not_widen_anything() {
+        let base = file_of(
+            "local",
+            vec![("g/q1/small", noisy(&[900.0, 1000.0, 1100.0]))],
+        );
+        let current = current_with(vec![("g/q1/small", entry(1100.0))]);
+        let budget = RegressionBudget::empty(1.0);
+        let report = compare(&base, &current, &budget, &opts());
+        assert_eq!(
+            report.comparisons[0].budget_pct, 1.0,
+            "n=3 < MIN_NOISE_SAMPLES"
+        );
+        assert!(!report.passed());
+    }
+
+    #[test]
+    fn noise_median_replaces_the_single_run_mean() {
+        // The entry's mean_ns is a wild outlier; the accumulated median is what
+        // the gate must compare against.
+        let mut base_entry = noisy(&[1000.0, 1000.0, 1000.0, 1000.0, 1000.0]);
+        base_entry.mean_ns = 50_000.0;
+        let base = file_of("local", vec![("g/q1/small", base_entry)]);
+        let current = current_with(vec![("g/q1/small", entry(1000.0))]);
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert_eq!(report.comparisons[0].baseline, 1000.0);
+        assert!(report.passed());
+    }
+
+    #[test]
+    fn accumulate_grows_the_sample_series() {
+        let mut acc = file_of("local", vec![("g/q1/small", entry(1000.0))]);
+        for mean in [1010.0, 990.0, 1005.0, 995.0] {
+            let fresh = file_of("local", vec![("g/q1/small", entry(mean))]);
+            acc = accumulate(&acc, &fresh);
+        }
+        let noise = acc.entries["g/q1/small"].noise.as_ref().unwrap();
+        assert_eq!(noise.n, 5, "seed run plus four accumulations");
+        assert_eq!(noise.median_ns, 1000.0);
+        assert!(noise.samples_ns.contains(&1010.0));
+    }
+
+    #[test]
+    fn accumulate_carries_forward_scenarios_not_rerun() {
+        let acc = file_of(
+            "local",
+            vec![("g/q1/small", entry(1000.0)), ("g/q2/small", entry(2000.0))],
+        );
+        let fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
+        let merged = accumulate(&acc, &fresh);
+        assert_eq!(merged.entries.len(), 2);
+        assert_eq!(merged.entries["g/q2/small"].mean_ns, 2000.0);
+        assert!(merged.entries["g/q2/small"].noise.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Schema
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn schema_1_baseline_loads_with_host_class_from_runner_class() {
+        let json = r#"{"schema_version":1,"label":"old","captured_at":"2026-01-01T00:00:00Z",
+            "profile":"quick","scale":"small","runner_class":"ci-ubuntu-latest",
+            "host":"runner-7","entries":{"g/q1/small":{"mean_ns":10.0,"median_ns":10.0}}}"#;
+        let read: BaselineFile = serde_json::from_str(json).unwrap();
+        assert_eq!(read.host.class, "ci-ubuntu-latest");
+        assert_eq!(read.host.name, "runner-7");
+        assert_eq!(read.host.os, "");
+        assert_eq!(read.entries["g/q1/small"].mean_ns, 10.0);
+        assert!(read.entries["g/q1/small"].phases.is_empty());
+        assert!(read.entries["g/q1/small"].corpus.is_none());
+    }
+
+    #[test]
+    fn schema_1_baseline_without_runner_class_defaults_to_local() {
+        let json = r#"{"schema_version":1,"label":"old","captured_at":"2026-01-01T00:00:00Z","profile":"quick","scale":"small","entries":{}}"#;
+        let read: BaselineFile = serde_json::from_str(json).unwrap();
+        assert_eq!(read.host.class, LEGACY_DEFAULT_HOST_CLASS);
+        assert_eq!(read.host.name, "");
+    }
+
+    #[test]
+    fn committed_schema_1_baseline_shape_still_loads() {
+        // The exact shape of bench-baselines/guardrails-pre.json, which stays on
+        // disk unchanged: the legacy reader is what keeps it comparable.
+        let json = r#"{"schema_version":1,"label":"guardrails-pre","git_sha":"2c5162014",
+            "captured_at":"2026-07-11T23:50:43.824907+00:00","profile":"quick","scale":"small",
+            "runner_class":"local","host":"MacBook-Pro-8-applesilicon",
+            "entries":{"query_overlay_matrix/count_base/small":{"mean_ns":15669.9,"median_ns":15670.4,
+            "mem":{"peak_bytes":4820445,"total_allocated_bytes":33717125336}}}}"#;
+        let read: BaselineFile = serde_json::from_str(json).unwrap();
+        assert_eq!(read.host.class, "local");
+        assert_eq!(read.host.name, "MacBook-Pro-8-applesilicon");
+        assert_eq!(
+            read.entries["query_overlay_matrix/count_base/small"]
+                .mem
+                .unwrap()
+                .peak_bytes,
+            4_820_445
+        );
+    }
+
+    #[test]
+    fn newer_schema_version_is_fatal() {
+        let mut base = baseline_with(vec![("g/q1/small", entry(1000.0))]);
+        base.schema_version = BASELINE_SCHEMA_VERSION + 1;
+        let current = current_with(vec![("g/q1/small", entry(1000.0))]);
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(report.is_fatal());
+        assert_eq!(report.fatal[0].kind, MismatchKind::SchemaVersion);
+    }
+
+    #[test]
+    fn baseline_file_round_trips_through_schema_2() {
+        let mut base = baseline_with(vec![("g/q1/small", {
+            let mut e = phased(42.0, &[("parse", 10.0), ("write", 30.0)]);
+            e.corpus = Some(corpus(b"bytes"));
+            e.noise = Some(NoiseStats::from_samples(vec![40.0, 42.0, 44.0, 41.0, 43.0]));
+            e
+        })]);
+        base.host = HostBlock {
+            class: "bench-m8gd".into(),
+            name: "ip-10-0-0-1".into(),
+            os: "linux".into(),
+            arch: "x86_64".into(),
+            cpu_model: "AMD EPYC 9R14".into(),
+            physical_cores: Some(16),
+            logical_cores: Some(32),
+        };
+        base.corpus = Some(corpus(b"file-level"));
+
+        let json = serde_json::to_string(&base).unwrap();
+        let read: BaselineFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(read.host, base.host);
+        assert_eq!(read.corpus, base.corpus);
+        let e = &read.entries["g/q1/small"];
+        assert_eq!(e.mean_ns, 42.0);
+        assert_eq!(e.phases["parse"].share_pct, 25.0);
+        assert_eq!(e.noise.as_ref().unwrap().n, 5);
+        assert_eq!(e.corpus.as_ref().unwrap().sha256, corpus(b"bytes").sha256);
+    }
+
+    #[test]
+    fn derived_host_class_is_os_dash_arch() {
+        assert_eq!(
+            derived_host_class(),
+            format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+        );
+    }
+
+    #[test]
+    fn budget_lookup_recovers_bench_and_scale() {
+        let mut budget = RegressionBudget::empty(5.0);
+        budget
+            .crates
+            .entry("fluree-db-api".into())
+            .or_default()
+            .entry("query_overlay_matrix".into())
+            .or_default()
+            .insert("tiny".into(), 12.0);
+        assert_eq!(
+            budget_for_id(&budget, "query_overlay_matrix/count_base/tiny"),
+            12.0
+        );
+        // Unknown bench falls back to default.
+        assert_eq!(budget_for_id(&budget, "nope/x/small"), 5.0);
+    }
+
+    #[test]
+    fn stale_sidecar_only_entry_is_not_compared() {
+        // Current has ONLY a mem sidecar (mean_ns == 0): the bench was not rerun
+        // this session, so its mem is stale and must not be compared (item 10);
+        // it counts as missing.
+        let base = baseline_with(vec![("g/q1/small", mem_entry(1000.0, 1_000_000))]);
+        let stale = BaselineEntry {
+            mem: Some(MemMetrics {
+                peak_bytes: 9_000_000,
+                total_allocated_bytes: 0,
+            }),
+            ..entry(0.0)
+        };
+        let current = current_with(vec![("g/q1/small", stale)]);
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(
+            report.comparisons.is_empty(),
+            "stale sidecar must not be compared"
+        );
+        assert_eq!(report.missing, vec!["g/q1/small".to_string()]);
     }
 
     /// The whole gate rule, as a truth table over
-    /// (runner class matched?) × (which metric breached).
+    /// (host class matched?) × (which metric breached).
     ///
-    /// Matched → both metrics enforce. Mismatched → both are advisory, so the
-    /// gate passes while still annotating. The mismatched+memory row is the one
-    /// that used to fail: memory gated on a `runner_class=local` baseline, which
-    /// meant every PR compared a shared `ubuntu-latest` peak against a number
-    /// captured on somebody's laptop.
+    /// Matched → both metrics enforce. Mismatched *under
+    /// `--allow-host-mismatch`* → both are advisory, so the gate passes while
+    /// still annotating. Without the flag a mismatch never reaches this table at
+    /// all — it is fatal.
     #[test]
-    fn gate_truth_table_over_runner_class_match() {
+    fn gate_truth_table_over_host_class_match() {
         let budget = RegressionBudget::empty(5.0);
-        let base = baseline_with(vec![("g/q1/small", mem_entry(1000.0, 1_000_000))]);
-        // (label, current entry, mismatched?, expect_pass, expect_breaches, expect_advisories)
+        // (label, current entry, mismatched?, expect_pass, breaches, advisories)
         let cases = [
             (
                 "matched + clean",
@@ -613,10 +1960,16 @@ mod tests {
                 2,
             ),
         ];
-        for (label, cur, advisory, expect_pass, breaches, advisories) in cases {
-            let mut current = BTreeMap::new();
-            current.insert("g/q1/small".to_string(), cur);
-            let report = compare(&base, &current, &budget, None, advisory);
+        for (label, cur, mismatched, expect_pass, breaches, advisories) in cases {
+            let base = file_of(
+                "class-a",
+                vec![("g/q1/small", mem_entry(1000.0, 1_000_000))],
+            );
+            let current = file_of(
+                if mismatched { "class-b" } else { "class-a" },
+                vec![("g/q1/small", cur)],
+            );
+            let report = compare(&base, &current, &budget, &allow_mismatch());
             assert_eq!(report.passed(), expect_pass, "{label}: gate outcome");
             assert_eq!(report.breaches().count(), breaches, "{label}: breach count");
             assert_eq!(
@@ -625,85 +1978,5 @@ mod tests {
                 "{label}: advisory count"
             );
         }
-    }
-
-    #[test]
-    fn mismatched_runner_class_never_gates_on_memory() {
-        // The asymmetry bplatz flagged, pinned directly: a memory-only breach
-        // against a cross-class baseline must annotate, not fail.
-        let base = baseline_with(vec![("g/q1/small", mem_entry(1000.0, 1_000_000))]);
-        let mut current = BTreeMap::new();
-        current.insert("g/q1/small".to_string(), mem_entry(1000.0, 5_000_000));
-        let budget = RegressionBudget::empty(5.0);
-
-        let report = compare(&base, &current, &budget, None, true);
-        assert!(
-            report.passed(),
-            "cross-class memory breach must not fail the gate"
-        );
-        let advisory = report.advisories().next().unwrap();
-        assert_eq!(advisory.metric, "peak_mem");
-        assert!(!advisory.enforced);
-    }
-
-    #[test]
-    fn stale_sidecar_only_entry_is_not_compared() {
-        // Current has ONLY a mem sidecar (mean_ns == 0): the bench was not rerun
-        // this session, so its mem is stale and must not be compared (item 10);
-        // it counts as missing.
-        let base = baseline_with(vec![("g/q1/small", mem_entry(1000.0, 1_000_000))]);
-        let stale = BaselineEntry {
-            mean_ns: 0.0,
-            median_ns: 0.0,
-            mem: Some(MemMetrics {
-                peak_bytes: 9_000_000,
-                total_allocated_bytes: 0,
-            }),
-        };
-        let mut current = BTreeMap::new();
-        current.insert("g/q1/small".to_string(), stale);
-        let budget = RegressionBudget::empty(5.0);
-
-        let report = compare(&base, &current, &budget, None, false);
-        assert!(
-            report.comparisons.is_empty(),
-            "stale sidecar must not be compared"
-        );
-        assert_eq!(report.missing, vec!["g/q1/small".to_string()]);
-    }
-
-    #[test]
-    fn baseline_without_provenance_fields_loads() {
-        // Pre-field baselines must still parse (serde default → "local").
-        let json = r#"{"schema_version":1,"label":"old","captured_at":"2026-01-01T00:00:00Z","profile":"quick","scale":"small","entries":{}}"#;
-        let read: BaselineFile = serde_json::from_str(json).unwrap();
-        assert_eq!(read.runner_class, "local");
-        assert_eq!(read.host, "");
-    }
-
-    #[test]
-    fn budget_lookup_recovers_bench_and_scale() {
-        let mut budget = RegressionBudget::empty(5.0);
-        budget
-            .crates
-            .entry("fluree-db-api".into())
-            .or_default()
-            .entry("query_overlay_matrix".into())
-            .or_default()
-            .insert("tiny".into(), 12.0);
-        assert_eq!(
-            budget_for_id(&budget, "query_overlay_matrix/count_base/tiny"),
-            12.0
-        );
-        // Unknown bench falls back to default.
-        assert_eq!(budget_for_id(&budget, "nope/x/small"), 5.0);
-    }
-
-    #[test]
-    fn baseline_file_round_trips() {
-        let base = baseline_with(vec![("g/q1/small", entry(42.0))]);
-        let json = serde_json::to_string(&base).unwrap();
-        let read: BaselineFile = serde_json::from_str(&json).unwrap();
-        assert_eq!(read.entries["g/q1/small"].mean_ns, 42.0);
     }
 }

--- a/fluree-bench-support/src/baseline.rs
+++ b/fluree-bench-support/src/baseline.rs
@@ -303,8 +303,40 @@ impl NoiseStats {
         }
     }
 
+    /// Recompute `n`, `median_ns`, and `mad_ns` from `samples_ns`, which is the
+    /// only field a reader can verify.
+    ///
+    /// A baseline file is untrusted input, and these four fields are
+    /// independently settable: a stale or hand-edited file could claim `n = 5`
+    /// beside an arbitrary median and MAD, moving the comparison baseline and
+    /// widening the budget on the strength of numbers nothing derived. Applied
+    /// at load, so every later reader sees stats that match their own samples.
+    ///
+    /// A set with no samples, too few samples, or any non-finite / non-positive
+    /// sample cannot be recomputed, so it is returned unusable rather than
+    /// trusted — the floor only ever widens, and losing it is the safe
+    /// direction.
+    fn revalidated(self) -> Self {
+        let usable_samples = self.samples_ns.len() >= MIN_NOISE_SAMPLES as usize
+            && self.samples_ns.iter().all(|s| s.is_finite() && *s > 0.0);
+        if !usable_samples {
+            return Self {
+                n: self.samples_ns.len() as u32,
+                median_ns: 0.0,
+                mad_ns: 0.0,
+                samples_ns: self.samples_ns,
+            };
+        }
+        Self::from_samples(self.samples_ns)
+    }
+
     fn is_usable(&self) -> bool {
-        self.n >= MIN_NOISE_SAMPLES && self.median_ns > 0.0
+        self.n >= MIN_NOISE_SAMPLES
+            && self.n as usize == self.samples_ns.len()
+            && self.median_ns > 0.0
+            && self.median_ns.is_finite()
+            && self.mad_ns.is_finite()
+            && self.mad_ns >= 0.0
     }
 }
 
@@ -475,6 +507,16 @@ impl From<RawBaselineFile> for BaselineFile {
             },
             None => HostBlock::of_class(legacy_class()),
         };
+        // Noise stats are recomputed from their own samples at the boundary, so
+        // no later reader has to wonder whether they were derived or asserted.
+        let entries = raw
+            .entries
+            .into_iter()
+            .map(|(id, mut entry)| {
+                entry.noise = entry.noise.map(NoiseStats::revalidated);
+                (id, entry)
+            })
+            .collect();
         BaselineFile {
             schema_version: raw.schema_version,
             label: raw.label,
@@ -484,8 +526,30 @@ impl From<RawBaselineFile> for BaselineFile {
             scale: raw.scale,
             host,
             corpus: raw.corpus,
-            entries: raw.entries,
+            entries,
         }
+    }
+}
+
+impl BaselineFile {
+    /// Reject a document that parsed but is not a usable baseline.
+    ///
+    /// Every top-level field carries a serde default so schema-1 files keep
+    /// loading, which means `{}` also deserializes "successfully" — and an
+    /// empty baseline compares against nothing, reports every current scenario
+    /// as new, breaches no metric, and exits 0. A gate that passes because it
+    /// had no reference points is worse than one that fails.
+    fn validate_structure(&self, source: &str) -> Result<(), String> {
+        if self.schema_version == 0 {
+            return Err(format!("{source}: schema_version must be >= 1"));
+        }
+        if self.entries.is_empty() {
+            return Err(format!(
+                "{source}: baseline contains no scenarios — an empty baseline compares against \
+                 nothing and would pass every gate vacuously"
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -581,6 +645,14 @@ pub fn capture(
     }
 }
 
+/// Policy knobs for [`accumulate`]. Defaults refuse everything questionable.
+#[derive(Debug, Clone, Default)]
+pub struct AccumulateOptions {
+    /// Permit pooling samples captured at different `git_sha`s. Off by default:
+    /// samples from different revisions are different populations.
+    pub allow_revision_drift: bool,
+}
+
 /// Fold a fresh capture into an existing baseline as one more sample.
 ///
 /// This is how a baseline reaches [`MIN_NOISE_SAMPLES`]: run the benches, run
@@ -605,10 +677,33 @@ pub fn capture(
 /// happens to call it — a bench harness or script calling `accumulate` directly
 /// gets the same protection:
 ///
+/// - **schema version** — `prev` must not be newer than this binary
+///   understands. An older binary can deserialize an additive future schema,
+///   clone a fresh capture over it, and write it back having silently dropped
+///   every field it did not recognise.
 /// - **host class** must match between `prev` and `fresh`.
+/// - **revision** — differing non-empty `git_sha`s refuse unless
+///   [`AccumulateOptions::allow_revision_drift`]. Accumulating across a code
+///   change pools pre- and post-change populations, relabels every sample as
+///   the new revision, and can widen the MAD enough to hide the very change
+///   being measured.
 /// - **corpus identity** must match for every scenario present in both,
-///   resolved entry-then-file exactly as [`compare`] resolves it.
-pub fn accumulate(prev: &BaselineFile, fresh: &BaselineFile) -> Result<BaselineFile, String> {
+///   resolved entry-then-file exactly as [`compare`] resolves it — and, as in
+///   `compare`, a `prev` that declares a corpus against a `fresh` that declares
+///   none is a refusal, not a pass.
+pub fn accumulate(
+    prev: &BaselineFile,
+    fresh: &BaselineFile,
+    opts: &AccumulateOptions,
+) -> Result<BaselineFile, String> {
+    if prev.schema_version > BASELINE_SCHEMA_VERSION {
+        return Err(format!(
+            "refusing to accumulate: existing baseline schema_version {} is newer than this binary \
+             understands ({BASELINE_SCHEMA_VERSION}). Merging would write it back with every \
+             unrecognised field silently dropped.",
+            prev.schema_version
+        ));
+    }
     if prev.host.class != fresh.host.class {
         return Err(format!(
             "refusing to accumulate across host classes: existing baseline is '{}' ({}), this run \
@@ -619,18 +714,28 @@ pub fn accumulate(prev: &BaselineFile, fresh: &BaselineFile) -> Result<BaselineF
             fresh.host.describe(),
         ));
     }
+    if !opts.allow_revision_drift {
+        if let (Some(prev_sha), Some(fresh_sha)) = (&prev.git_sha, &fresh.git_sha) {
+            if !prev_sha.is_empty() && !fresh_sha.is_empty() && prev_sha != fresh_sha {
+                return Err(format!(
+                    "refusing to accumulate across revisions: existing samples were captured at \
+                     {prev_sha}, this run at {fresh_sha}. Pooling them mixes pre- and \
+                     post-change populations, relabels every sample as {fresh_sha}, and can widen \
+                     the MAD enough to hide the change being measured. Pass \
+                     --allow-revision-drift if the difference is genuinely irrelevant."
+                ));
+            }
+        }
+    }
     for id in prev.entries.keys() {
         if !fresh.entries.contains_key(id) {
             continue;
         }
-        if let (Some(prev_corpus), Some(fresh_corpus)) = (prev.corpus_for(id), fresh.corpus_for(id))
-        {
-            if let Some(detail) = prev_corpus.identity_mismatch(fresh_corpus) {
-                return Err(format!(
-                    "refusing to accumulate across corpora for {id}: {detail}. Samples over \
-                     different inputs cannot be pooled into one median/MAD."
-                ));
-            }
+        if let Some(detail) = corpus_refusal(prev.corpus_for(id), fresh.corpus_for(id)) {
+            return Err(format!(
+                "refusing to accumulate for {id}: {detail}. Samples over different inputs cannot \
+                 be pooled into one median/MAD."
+            ));
         }
     }
 
@@ -667,7 +772,10 @@ pub fn accumulate(prev: &BaselineFile, fresh: &BaselineFile) -> Result<BaselineF
 
 pub fn load_baseline(path: &Path) -> Result<BaselineFile, String> {
     let raw = std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
-    serde_json::from_str(&raw).map_err(|e| format!("parse {}: {e}", path.display()))
+    let file: BaselineFile =
+        serde_json::from_str(&raw).map_err(|e| format!("parse {}: {e}", path.display()))?;
+    file.validate_structure(&path.display().to_string())?;
+    Ok(file)
 }
 
 pub fn save_baseline(file: &BaselineFile, path: &Path) -> Result<(), String> {
@@ -789,6 +897,9 @@ pub enum MismatchKind {
     Corpus,
     /// The baseline file is newer than this binary understands.
     SchemaVersion,
+    /// A phase-share set that could not have been produced by the constructor,
+    /// and so cannot be gated on.
+    PhaseShares,
 }
 
 impl MismatchKind {
@@ -797,6 +908,7 @@ impl MismatchKind {
             MismatchKind::HostClass => "host-class",
             MismatchKind::Corpus => "corpus",
             MismatchKind::SchemaVersion => "schema-version",
+            MismatchKind::PhaseShares => "phase-shares",
         }
     }
 }
@@ -856,9 +968,6 @@ pub struct CompareReport {
     /// Comparisons the gate refused to make. Any entry here fails the gate,
     /// distinctly from a budget breach.
     pub fatal: Vec<FatalMismatch>,
-    /// Data that looks wrong but does not invalidate the comparison — reported,
-    /// never gating. Today: phase shares that don't sum to 100%.
-    pub anomalies: Vec<String>,
     /// Why absolute metrics are advisory, when they are.
     pub advisory_reason: Option<String>,
 }
@@ -1059,30 +1168,82 @@ fn compare_phases(
     }
 }
 
+/// Decide whether two resolved corpus blocks make the scenario comparable.
+///
+/// The asymmetry matters and is not symmetric on purpose:
+///
+/// - **baseline has one, current does not** → refuse. A producer that stopped
+///   emitting its sidecar, or a sidecar write that failed, would otherwise slip
+///   past the identity gate entirely and exit 0. Absence of evidence is not
+///   evidence of the same input.
+/// - **current has one, baseline does not** → compare. This is the legacy case:
+///   a schema-1 baseline predates corpus blocks, and there is nothing to check
+///   against. Refusing here would make every old baseline unusable.
+fn corpus_refusal(base: Option<&CorpusInfo>, cur: Option<&CorpusInfo>) -> Option<String> {
+    match (base, cur) {
+        (Some(base_corpus), Some(cur_corpus)) => {
+            if let Err(e) = base_corpus.validate() {
+                return Some(format!("baseline {e}"));
+            }
+            if let Err(e) = cur_corpus.validate() {
+                return Some(format!("current {e}"));
+            }
+            base_corpus.identity_mismatch(cur_corpus)
+        }
+        (Some(base_corpus), None) => Some(format!(
+            "baseline declares corpus '{}' (sha256:{}) but this run recorded none — a missing \
+             sidecar cannot be assumed to be the same input",
+            base_corpus.name,
+            short_hash(&base_corpus.sha256),
+        )),
+        (None, _) => None,
+    }
+}
+
+/// Reject a phase-share set that cannot be trusted to gate.
+///
 /// Shares are constructed to sum to 100 across a scenario's measured phases,
 /// but that is a property of [`crate::meta::ScenarioMeta::with_phase_ns`], not
-/// an invariant — the fields are public and a baseline file is untrusted input.
-/// A sum far from 100 means the shares were hand-written or assembled by
-/// something other than the constructor, which makes every drift number on that
-/// scenario suspect. Report it; do not gate on it, since the drift comparison
-/// is still internally consistent and failing here would block on a cosmetic
-/// defect.
-fn note_share_sum_anomaly(
-    report: &mut CompareReport,
-    id: &str,
-    side: &str,
-    phases: &BTreeMap<String, PhaseTiming>,
-) {
-    if phases.is_empty() {
-        return;
+/// an invariant of the type — the fields are public and a baseline file is
+/// untrusted input. This is emphatically not cosmetic: `phase_share` is the
+/// ONLY metric that still enforces across a host mismatch, so a current sidecar
+/// with every share at 0.0 would mark every phase "improved" and exit 0 while
+/// the absolute metrics were merely advisory. A share set that the constructor
+/// could not have produced therefore refuses rather than gates.
+fn share_refusal(
+    base: &BTreeMap<String, PhaseTiming>,
+    cur: &BTreeMap<String, PhaseTiming>,
+) -> Option<String> {
+    for (side, phases) in [("baseline", base), ("current", cur)] {
+        if phases.is_empty() {
+            continue;
+        }
+        for (name, timing) in phases {
+            if !timing.share_pct.is_finite() || timing.share_pct < 0.0 {
+                return Some(format!(
+                    "{side} phase '{name}' has share_pct {} — shares must be finite and \
+                     non-negative",
+                    timing.share_pct
+                ));
+            }
+            if !timing.ns.is_finite() || timing.ns < 0.0 {
+                return Some(format!(
+                    "{side} phase '{name}' has ns {} — phase timings must be finite and \
+                     non-negative",
+                    timing.ns
+                ));
+            }
+        }
+        let sum: f64 = phases.values().map(|p| p.share_pct).sum();
+        if (sum - 100.0).abs() > SHARE_SUM_TOLERANCE_PP {
+            return Some(format!(
+                "{side} phase shares sum to {sum:.1}%, not 100% (±{SHARE_SUM_TOLERANCE_PP}) — the \
+                 share set was not derived from its own nanoseconds, so drift numbers computed \
+                 from it mean nothing"
+            ));
+        }
     }
-    let sum: f64 = phases.values().map(|p| p.share_pct).sum();
-    if (sum - 100.0).abs() > SHARE_SUM_TOLERANCE_PP {
-        report.anomalies.push(format!(
-            "{id}: {side} phase shares sum to {sum:.1}%, not 100% — drift numbers for this \
-             scenario are only as trustworthy as the shares they came from"
-        ));
-    }
+    None
 }
 
 /// Compare a current capture against a baseline under the given budgets.
@@ -1172,20 +1333,32 @@ pub fn compare(
         // Corpus identity gates everything else about this scenario: if the two
         // runs read different inputs, none of their numbers are comparable and
         // emitting rows for them would be worse than emitting nothing.
-        if let (Some(base_corpus), Some(cur_corpus)) =
-            (baseline.corpus_for(id), current.corpus_for(id))
-        {
-            if let Some(detail) = base_corpus.identity_mismatch(cur_corpus) {
-                report.fatal.push(FatalMismatch {
-                    kind: MismatchKind::Corpus,
-                    id: Some(id.clone()),
-                    detail,
-                    remedy: "rerun against the corpus the baseline recorded, or recapture the \
-                             baseline against the corpus you intend to gate on"
-                        .to_string(),
-                });
-                continue;
-            }
+        if let Some(detail) = corpus_refusal(baseline.corpus_for(id), current.corpus_for(id)) {
+            report.fatal.push(FatalMismatch {
+                kind: MismatchKind::Corpus,
+                id: Some(id.clone()),
+                detail,
+                remedy: "rerun against the corpus the baseline recorded, or recapture the \
+                         baseline against the corpus you intend to gate on"
+                    .to_string(),
+            });
+            continue;
+        }
+
+        // Phase shares are the only signal that still enforces across host
+        // classes, so a malformed share set is not cosmetic: all-zero shares
+        // make every phase look improved. Validate before any gating decision
+        // reads them.
+        if let Some(detail) = share_refusal(&base.phases, &cur.phases) {
+            report.fatal.push(FatalMismatch {
+                kind: MismatchKind::PhaseShares,
+                id: Some(id.clone()),
+                detail,
+                remedy: "regenerate the phase block through ScenarioMeta::with_phase_ns, which \
+                         derives every share from its nanoseconds"
+                    .to_string(),
+            });
+            continue;
         }
 
         let declared_budget = budget_for_id(budget, id);
@@ -1250,8 +1423,6 @@ pub fn compare(
             opts.share_drift_pp,
             advisory,
         );
-        note_share_sum_anomaly(&mut report, id, "baseline", &base.phases);
-        note_share_sum_anomaly(&mut report, id, "current", &cur.phases);
     }
 
     for id in current.entries.keys() {
@@ -2125,7 +2296,7 @@ mod tests {
         let mut acc = file_of("local", vec![("g/q1/small", entry(1000.0))]);
         for mean in [1010.0, 990.0, 1005.0, 995.0] {
             let fresh = file_of("local", vec![("g/q1/small", entry(mean))]);
-            acc = accumulate(&acc, &fresh).unwrap();
+            acc = accumulate(&acc, &fresh, &AccumulateOptions::default()).unwrap();
         }
         let noise = acc.entries["g/q1/small"].noise.as_ref().unwrap();
         assert_eq!(noise.n, 5, "seed run plus four accumulations");
@@ -2140,7 +2311,7 @@ mod tests {
             vec![("g/q1/small", entry(1000.0)), ("g/q2/small", entry(2000.0))],
         );
         let fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
-        let merged = accumulate(&acc, &fresh).unwrap();
+        let merged = accumulate(&acc, &fresh, &AccumulateOptions::default()).unwrap();
         assert_eq!(merged.entries.len(), 2);
         assert_eq!(merged.entries["g/q2/small"].mean_ns, 2000.0);
         assert!(merged.entries["g/q2/small"].noise.is_none());
@@ -2155,7 +2326,7 @@ mod tests {
     fn accumulate_refuses_across_host_classes() {
         let prev = file_of("bench-m8gd", vec![("g/q1/small", entry(1000.0))]);
         let fresh = file_of("macos-aarch64", vec![("g/q1/small", entry(1010.0))]);
-        let err = accumulate(&prev, &fresh).unwrap_err();
+        let err = accumulate(&prev, &fresh, &AccumulateOptions::default()).unwrap_err();
         assert!(
             err.contains("bench-m8gd") && err.contains("macos-aarch64"),
             "{err}"
@@ -2172,7 +2343,7 @@ mod tests {
         let prev = file_of("local", vec![("g/q1/small", prev_entry)]);
         let fresh = file_of("local", vec![("g/q1/small", fresh_entry)]);
 
-        let err = accumulate(&prev, &fresh).unwrap_err();
+        let err = accumulate(&prev, &fresh, &AccumulateOptions::default()).unwrap_err();
         assert!(err.contains("g/q1/small"), "{err}");
         assert!(err.contains("sha256"), "{err}");
     }
@@ -2183,7 +2354,63 @@ mod tests {
         prev.corpus = Some(corpus(b"one"));
         let mut fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
         fresh.corpus = Some(corpus(b"two"));
-        assert!(accumulate(&prev, &fresh).is_err());
+        assert!(accumulate(&prev, &fresh, &AccumulateOptions::default()).is_err());
+    }
+
+    /// bplatz review item 1, accumulate half. `fresh.clone()` would otherwise
+    /// erase the prior corpus identity while still pooling the sample.
+    #[test]
+    fn accumulate_refuses_when_fresh_drops_the_corpus() {
+        let mut prev_entry = entry(1000.0);
+        prev_entry.corpus = Some(corpus(b"one"));
+        let prev = file_of("local", vec![("g/q1/small", prev_entry)]);
+        let fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
+
+        let err = accumulate(&prev, &fresh, &AccumulateOptions::default()).unwrap_err();
+        assert!(err.contains("recorded none"), "{err}");
+        assert!(err.contains("g/q1/small"), "{err}");
+    }
+
+    /// bplatz review item 3.
+    #[test]
+    fn accumulate_refuses_a_newer_schema() {
+        let mut prev = file_of("local", vec![("g/q1/small", entry(1000.0))]);
+        prev.schema_version = BASELINE_SCHEMA_VERSION + 1;
+        let fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
+
+        let err = accumulate(&prev, &fresh, &AccumulateOptions::default()).unwrap_err();
+        assert!(err.contains("newer than this binary"), "{err}");
+    }
+
+    /// bplatz review item 4.
+    #[test]
+    fn accumulate_refuses_across_revisions_unless_overridden() {
+        let mut prev = file_of("local", vec![("g/q1/small", entry(1000.0))]);
+        prev.git_sha = Some("aaaaaaa".into());
+        let mut fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
+        fresh.git_sha = Some("bbbbbbb".into());
+
+        let err = accumulate(&prev, &fresh, &AccumulateOptions::default()).unwrap_err();
+        assert!(err.contains("aaaaaaa") && err.contains("bbbbbbb"), "{err}");
+        assert!(err.contains("--allow-revision-drift"), "{err}");
+
+        let allowed = AccumulateOptions {
+            allow_revision_drift: true,
+        };
+        assert!(accumulate(&prev, &fresh, &allowed).is_ok());
+    }
+
+    #[test]
+    fn accumulate_allows_a_matching_or_absent_revision() {
+        // Same sha: normal loop. Absent sha (no git): nothing to compare.
+        let mut prev = file_of("local", vec![("g/q1/small", entry(1000.0))]);
+        let mut fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
+        prev.git_sha = Some("aaaaaaa".into());
+        fresh.git_sha = Some("aaaaaaa".into());
+        assert!(accumulate(&prev, &fresh, &AccumulateOptions::default()).is_ok());
+
+        prev.git_sha = None;
+        assert!(accumulate(&prev, &fresh, &AccumulateOptions::default()).is_ok());
     }
 
     #[test]
@@ -2194,7 +2421,7 @@ mod tests {
         fresh_entry.corpus = Some(corpus(b"same"));
         let prev = file_of("local", vec![("g/q1/small", prev_entry)]);
         let fresh = file_of("local", vec![("g/q1/small", fresh_entry)]);
-        assert!(accumulate(&prev, &fresh).is_ok());
+        assert!(accumulate(&prev, &fresh, &AccumulateOptions::default()).is_ok());
     }
 
     #[test]
@@ -2213,7 +2440,7 @@ mod tests {
         let mut fresh_a = entry(1010.0);
         fresh_a.corpus = Some(corpus(b"one"));
         let fresh = file_of("local", vec![("g/q1/small", fresh_a)]);
-        assert!(accumulate(&prev, &fresh).is_ok());
+        assert!(accumulate(&prev, &fresh, &AccumulateOptions::default()).is_ok());
     }
 
     /// The remedy must not suggest relabelling this host to the baseline's
@@ -2234,44 +2461,115 @@ mod tests {
         );
     }
 
+    fn with_raw_phases(mean: f64, phases: &[(&str, f64, f64)]) -> BaselineEntry {
+        BaselineEntry {
+            phases: phases
+                .iter()
+                .map(|(n, ns, share)| {
+                    (
+                        n.to_string(),
+                        PhaseTiming {
+                            ns: *ns,
+                            share_pct: *share,
+                        },
+                    )
+                })
+                .collect(),
+            ..entry(mean)
+        }
+    }
+
+    /// bplatz review item 2. A malformed share set is NOT cosmetic: on a host
+    /// mismatch `phase_share` is the only enforcing metric, so all-zero shares
+    /// would mark every phase "improved" and exit 0 while the absolute metrics
+    /// were merely advisory.
     #[test]
-    fn shares_that_do_not_sum_to_100_are_reported_but_do_not_gate() {
-        // Hand-assembled or hand-edited shares: the drift comparison is still
-        // internally consistent, so report rather than fail.
-        let mut skewed = entry(1000.0);
-        skewed.phases = [
-            (
-                "parse".to_string(),
-                PhaseTiming {
-                    ns: 10.0,
-                    share_pct: 30.0,
-                },
-            ),
-            (
-                "write".to_string(),
-                PhaseTiming {
-                    ns: 10.0,
-                    share_pct: 30.0,
-                },
-            ),
-        ]
-        .into_iter()
-        .collect();
+    fn all_zero_current_shares_refuse_instead_of_gating_as_improved() {
+        let base = file_of(
+            "bench-m8gd",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 600.0), ("write", 400.0)]),
+            )],
+        );
+        let current = file_of(
+            "macos-aarch64",
+            vec![(
+                "g/q1/small",
+                with_raw_phases(1000.0, &[("parse", 600.0, 0.0), ("write", 400.0, 0.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &allow_mismatch());
+        assert!(report.is_fatal(), "must refuse, not gate");
+        assert_eq!(report.fatal[0].kind, MismatchKind::PhaseShares);
+        assert!(!report.passed());
+        assert!(
+            !report
+                .comparisons
+                .iter()
+                .any(|c| c.status == CompareStatus::Improved),
+            "must not report a bogus improvement"
+        );
+    }
+
+    #[test]
+    fn non_finite_and_negative_shares_refuse() {
+        for bad in [f64::NAN, f64::INFINITY, -10.0] {
+            let base = file_of(
+                "local",
+                vec![("g/q1/small", phased(1000.0, &[("parse", 1000.0)]))],
+            );
+            let current = file_of(
+                "local",
+                vec![(
+                    "g/q1/small",
+                    with_raw_phases(1000.0, &[("parse", 1.0, bad)]),
+                )],
+            );
+            let budget = RegressionBudget::empty(5.0);
+            let report = compare(&base, &current, &budget, &opts());
+            assert!(report.is_fatal(), "share_pct {bad} must refuse");
+            assert_eq!(report.fatal[0].kind, MismatchKind::PhaseShares);
+        }
+    }
+
+    #[test]
+    fn non_finite_phase_ns_refuses() {
+        let base = file_of(
+            "local",
+            vec![("g/q1/small", phased(1000.0, &[("parse", 1000.0)]))],
+        );
+        let current = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                with_raw_phases(1000.0, &[("parse", f64::NAN, 100.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(5.0);
+        assert!(compare(&base, &current, &budget, &opts()).is_fatal());
+    }
+
+    #[test]
+    fn shares_that_do_not_sum_to_100_refuse() {
+        let skewed = with_raw_phases(1000.0, &[("parse", 10.0, 30.0), ("write", 10.0, 30.0)]);
         let base = file_of("local", vec![("g/q1/small", skewed.clone())]);
         let current = file_of("local", vec![("g/q1/small", skewed)]);
         let budget = RegressionBudget::empty(5.0);
 
         let report = compare(&base, &current, &budget, &opts());
-        assert!(report.passed(), "a cosmetic share defect must not gate");
+        assert!(report.is_fatal());
         assert!(
-            report.anomalies.iter().any(|a| a.contains("60.0%")),
+            report.fatal[0].detail.contains("60.0%"),
             "{:?}",
-            report.anomalies
+            report.fatal
         );
     }
 
     #[test]
-    fn well_formed_shares_produce_no_anomaly() {
+    fn well_formed_shares_do_not_refuse() {
         let base = file_of(
             "local",
             vec![(
@@ -2281,9 +2579,52 @@ mod tests {
         );
         let current = base.clone();
         let budget = RegressionBudget::empty(5.0);
-        assert!(compare(&base, &current, &budget, &opts())
-            .anomalies
-            .is_empty());
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(!report.is_fatal());
+        assert!(report.passed());
+    }
+
+    /// bplatz review item 1. A producer that stops emitting its sidecar, or a
+    /// sidecar write that fails, must not slip past the identity gate.
+    #[test]
+    fn baseline_corpus_with_no_current_corpus_refuses() {
+        let mut base_entry = entry(1000.0);
+        base_entry.corpus = Some(corpus(b"one"));
+        let base = baseline_with(vec![("g/q1/small", base_entry)]);
+        let current = current_with(vec![("g/q1/small", entry(1000.0))]);
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(report.is_fatal(), "missing current corpus must refuse");
+        assert_eq!(report.fatal[0].kind, MismatchKind::Corpus);
+        assert!(report.fatal[0].detail.contains("recorded none"));
+        assert!(report.comparisons.is_empty());
+    }
+
+    #[test]
+    fn malformed_sha256_refuses_rather_than_panicking() {
+        // Untrusted input: a multibyte hash used to panic the report path when
+        // sliced at byte 12, turning a refusal into exit 101.
+        for bad in [
+            "\u{fc}nicode-hash-not-hex-but-plenty-long-enough-to-slice-at-twelve",
+            "",
+            "ABC123",
+            "zz",
+        ] {
+            let mut c = corpus(b"one");
+            c.sha256 = bad.to_string();
+            let mut base_entry = entry(1000.0);
+            base_entry.corpus = Some(c.clone());
+            let mut cur_entry = entry(1000.0);
+            cur_entry.corpus = Some(c);
+            let base = baseline_with(vec![("g/q1/small", base_entry)]);
+            let current = current_with(vec![("g/q1/small", cur_entry)]);
+            let budget = RegressionBudget::empty(5.0);
+
+            let report = compare(&base, &current, &budget, &opts());
+            assert!(report.is_fatal(), "malformed sha256 {bad:?} must refuse");
+            assert_eq!(report.fatal[0].kind, MismatchKind::Corpus);
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -2331,6 +2672,91 @@ mod tests {
                 .peak_bytes,
             4_820_445
         );
+    }
+
+    /// bplatz review item 5. `n`/`median_ns`/`mad_ns` were trusted
+    /// independently of the samples they claim to summarise.
+    #[test]
+    fn noise_stats_are_recomputed_from_their_own_samples_at_load() {
+        // Claims n=5 with a fabricated median and MAD beside real samples.
+        let json = r#"{"schema_version":2,"label":"x","captured_at":"t","profile":"quick",
+            "scale":"small","host":{"class":"local"},
+            "entries":{"g/q1/small":{"mean_ns":1000.0,"median_ns":1000.0,
+              "noise":{"n":5,"median_ns":99999.0,"mad_ns":88888.0,
+                       "samples_ns":[980.0,990.0,1000.0,1010.0,1020.0]}}}}"#;
+        let read: BaselineFile = serde_json::from_str(json).unwrap();
+        let noise = read.entries["g/q1/small"].noise.as_ref().unwrap();
+        assert_eq!(noise.median_ns, 1000.0, "median recomputed from samples");
+        assert_eq!(noise.mad_ns, 10.0, "MAD recomputed from samples");
+    }
+
+    #[test]
+    fn fabricated_noise_without_samples_is_unusable() {
+        // No samples to verify against: the floor is dropped rather than
+        // trusted. Losing a floor is the safe direction — it only widens.
+        let json = r#"{"schema_version":2,"label":"x","captured_at":"t","profile":"quick",
+            "scale":"small","host":{"class":"local"},
+            "entries":{"g/q1/small":{"mean_ns":1000.0,"median_ns":1000.0,
+              "noise":{"n":5,"median_ns":1000.0,"mad_ns":900.0,"samples_ns":[]}}}}"#;
+        let read: BaselineFile = serde_json::from_str(json).unwrap();
+        let entry = &read.entries["g/q1/small"];
+        assert_eq!(entry.noise_floor_pct(), 0.0, "no samples -> no floor");
+        assert_eq!(entry.effective_ns(), 1000.0, "falls back to the mean");
+    }
+
+    #[test]
+    fn non_positive_samples_are_rejected_as_a_floor() {
+        for bad in [
+            vec![0.0, 1.0, 1.0, 1.0, 1.0],
+            vec![-5.0, 1.0, 1.0, 1.0, 1.0],
+        ] {
+            let stats = NoiseStats {
+                n: 5,
+                median_ns: 1000.0,
+                mad_ns: 500.0,
+                samples_ns: bad,
+            }
+            .revalidated();
+            let e = BaselineEntry {
+                noise: Some(stats),
+                ..entry(1000.0)
+            };
+            assert_eq!(e.noise_floor_pct(), 0.0);
+        }
+    }
+
+    /// bplatz review item 6. `{}` deserialized as a valid schema-1 baseline; an
+    /// empty baseline breaches no metric and exits 0.
+    #[test]
+    fn empty_document_is_rejected_at_load() {
+        let dir = std::env::temp_dir().join(format!(
+            "fluree-baseline-empty-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("empty.json");
+
+        for doc in ["{}", r#"{"schema_version":2,"label":"x","entries":{}}"#] {
+            std::fs::write(&path, doc).unwrap();
+            let err = load_baseline(&path).unwrap_err();
+            assert!(err.contains("no scenarios"), "{doc} -> {err}");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_baseline_with_scenarios_still_loads() {
+        let dir = std::env::temp_dir().join(format!(
+            "fluree-baseline-ok-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("ok.json");
+        save_baseline(&baseline_with(vec![("g/q1/small", entry(1.0))]), &path).unwrap();
+        assert!(load_baseline(&path).is_ok());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/fluree-bench-support/src/baseline.rs
+++ b/fluree-bench-support/src/baseline.rs
@@ -40,7 +40,7 @@
 //!   because the output is indistinguishable from a real regression. There is no
 //!   override.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -64,6 +64,10 @@ pub const MIN_NOISE_SAMPLES: u32 = 5;
 /// Host class recorded by schema-1 baselines that predate the host block and
 /// carried no `runner_class` either.
 const LEGACY_DEFAULT_HOST_CLASS: &str = "local";
+
+/// How far a scenario's phase shares may sum from 100% before `compare` says so.
+/// Generous, because this catches hand-assembled data, not rounding.
+const SHARE_SUM_TOLERANCE_PP: f64 = 1.0;
 
 // ---------------------------------------------------------------------------
 // Host
@@ -586,11 +590,50 @@ pub fn capture(
 ///
 /// Scenarios absent from `fresh` keep their prior stats untouched — a subset
 /// rerun tops up only what it measured. Scenarios new in `fresh` start their own
-/// sample series. `prev`'s provenance (label, sha, host) is replaced by
-/// `fresh`'s: the accumulated file describes the run that finished last, and a
-/// host change mid-accumulation is exactly the thing the host gate should catch
-/// on the next compare rather than something to average over.
-pub fn accumulate(prev: &BaselineFile, fresh: &BaselineFile) -> BaselineFile {
+/// sample series.
+///
+/// # Refusals
+///
+/// Accumulation is the one operation that *destroys* the evidence of a mismatch
+/// rather than reporting it: fold a run from another machine, or over another
+/// corpus, into the sample vector and the resulting median and MAD are a blend
+/// of two populations that no later `compare` can unpick. The provenance it
+/// would have been caught by is overwritten in the same breath, because the
+/// accumulated file takes `fresh`'s label, sha, and host.
+///
+/// So both guards live here, in the library, rather than in the CLI that
+/// happens to call it — a bench harness or script calling `accumulate` directly
+/// gets the same protection:
+///
+/// - **host class** must match between `prev` and `fresh`.
+/// - **corpus identity** must match for every scenario present in both,
+///   resolved entry-then-file exactly as [`compare`] resolves it.
+pub fn accumulate(prev: &BaselineFile, fresh: &BaselineFile) -> Result<BaselineFile, String> {
+    if prev.host.class != fresh.host.class {
+        return Err(format!(
+            "refusing to accumulate across host classes: existing baseline is '{}' ({}), this run \
+             is '{}' ({}). Samples from different machines cannot be pooled into one median/MAD.",
+            prev.host.class,
+            prev.host.describe(),
+            fresh.host.class,
+            fresh.host.describe(),
+        ));
+    }
+    for id in prev.entries.keys() {
+        if !fresh.entries.contains_key(id) {
+            continue;
+        }
+        if let (Some(prev_corpus), Some(fresh_corpus)) = (prev.corpus_for(id), fresh.corpus_for(id))
+        {
+            if let Some(detail) = prev_corpus.identity_mismatch(fresh_corpus) {
+                return Err(format!(
+                    "refusing to accumulate across corpora for {id}: {detail}. Samples over \
+                     different inputs cannot be pooled into one median/MAD."
+                ));
+            }
+        }
+    }
+
     let mut out = fresh.clone();
     for (id, prev_entry) in &prev.entries {
         let prior: Vec<f64> = prev_entry
@@ -619,7 +662,7 @@ pub fn accumulate(prev: &BaselineFile, fresh: &BaselineFile) -> BaselineFile {
             }
         }
     }
-    out
+    Ok(out)
 }
 
 pub fn load_baseline(path: &Path) -> Result<BaselineFile, String> {
@@ -682,12 +725,31 @@ impl Metric {
     }
 }
 
+/// Whether a phase exists on both sides of a comparison, or only one.
+///
+/// A phase appearing or disappearing is a change in the *shape* of the
+/// pipeline, and it is invisible to a same-name comparison. Tracking it is what
+/// stops work relocating into an unmeasured phase from reading as an
+/// improvement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PhasePresence {
+    #[default]
+    Both,
+    /// New in this run — no baseline counterpart.
+    AddedInCurrent,
+    /// In the baseline but gone from this run.
+    MissingFromCurrent,
+}
+
 #[derive(Debug, Clone)]
 pub struct Comparison {
     pub id: String,
     pub metric: Metric,
     /// Phase name for the per-phase metrics.
     pub phase: Option<String>,
+    /// Whether this phase existed on both sides. Always [`PhasePresence::Both`]
+    /// for whole-scenario metrics.
+    pub presence: PhasePresence,
     pub baseline: f64,
     pub observed: f64,
     /// Percent change for time/memory metrics; **percentage points** of
@@ -703,12 +765,18 @@ pub struct Comparison {
 }
 
 impl Comparison {
-    /// `"<id> [<metric>]"`, with the phase folded in for per-phase rows.
+    /// `"<id> [<metric>]"`, with the phase folded in for per-phase rows and
+    /// one-sided phases marked, since a bare name would hide the shape change.
     pub fn label(&self) -> String {
-        match &self.phase {
-            Some(phase) => format!("{}::{} [{}]", self.id, phase, self.metric.as_str()),
-            None => format!("{} [{}]", self.id, self.metric.as_str()),
-        }
+        let Some(phase) = &self.phase else {
+            return format!("{} [{}]", self.id, self.metric.as_str());
+        };
+        let mark = match self.presence {
+            PhasePresence::Both => "",
+            PhasePresence::AddedInCurrent => " (NEW)",
+            PhasePresence::MissingFromCurrent => " (VANISHED)",
+        };
+        format!("{}::{}{} [{}]", self.id, phase, mark, self.metric.as_str())
     }
 }
 
@@ -788,6 +856,9 @@ pub struct CompareReport {
     /// Comparisons the gate refused to make. Any entry here fails the gate,
     /// distinctly from a budget breach.
     pub fatal: Vec<FatalMismatch>,
+    /// Data that looks wrong but does not invalidate the comparison — reported,
+    /// never gating. Today: phase shares that don't sum to 100%.
+    pub anomalies: Vec<String>,
     /// Why absolute metrics are advisory, when they are.
     pub advisory_reason: Option<String>,
 }
@@ -884,6 +955,136 @@ fn classify_share(baseline_pct: f64, observed_pct: f64, drift_pp: f64) -> (f64, 
     (delta_pp, status)
 }
 
+/// Emit the per-phase rows for one scenario, over the UNION of the two sides'
+/// phase names.
+///
+/// Walking only the baseline's phases is how a regression hides: move work into
+/// a phase the baseline never had and the old phase's share *falls*, which
+/// reads as an improvement, while the new phase — carrying the cost — produces
+/// no row at all. So a one-sided phase is gated on its share alone:
+///
+/// - **new in current**: breach when the phase claims more than the drift
+///   threshold of the run. It has no baseline, so its whole share is drift.
+/// - **gone from current**: breach when it *used* to claim more than the
+///   threshold. Work that large did not evaporate; it moved somewhere, and the
+///   somewhere is not being measured.
+///
+/// Neither one-sided case emits a `phase_time` row: with nothing on one side
+/// there is no ratio to report, and a row reading "ok" against a zero baseline
+/// would be worse than no row.
+fn compare_phases(
+    report: &mut CompareReport,
+    id: &str,
+    base: &BaselineEntry,
+    cur: &BaselineEntry,
+    time_budget_pct: f64,
+    share_drift_pp: f64,
+    advisory: bool,
+) {
+    let names: BTreeSet<&String> = base.phases.keys().chain(cur.phases.keys()).collect();
+    for phase in names {
+        let share_row =
+            |presence, baseline: f64, observed: f64, delta_pp: f64, status| Comparison {
+                id: id.to_string(),
+                metric: Metric::PhaseShare,
+                phase: Some(phase.clone()),
+                presence,
+                baseline,
+                observed,
+                change_pct: delta_pp,
+                budget_pct: share_drift_pp,
+                status,
+                // Shares are ratios within one run, so the machine cancels. This is
+                // the one signal a cross-host comparison keeps, and making it
+                // advisory alongside the absolute metrics would throw away the
+                // entire reason to compare across hosts at all.
+                enforced: true,
+            };
+
+        match (base.phases.get(phase), cur.phases.get(phase)) {
+            (Some(base_phase), Some(cur_phase)) => {
+                let (change_pct, status) = classify(base_phase.ns, cur_phase.ns, time_budget_pct);
+                report.comparisons.push(Comparison {
+                    id: id.to_string(),
+                    metric: Metric::PhaseTime,
+                    phase: Some(phase.clone()),
+                    presence: PhasePresence::Both,
+                    baseline: base_phase.ns,
+                    observed: cur_phase.ns,
+                    change_pct,
+                    budget_pct: time_budget_pct,
+                    status,
+                    enforced: !advisory,
+                });
+                let (delta_pp, status) =
+                    classify_share(base_phase.share_pct, cur_phase.share_pct, share_drift_pp);
+                report.comparisons.push(share_row(
+                    PhasePresence::Both,
+                    base_phase.share_pct,
+                    cur_phase.share_pct,
+                    delta_pp,
+                    status,
+                ));
+            }
+            (None, Some(cur_phase)) => {
+                let status = if cur_phase.share_pct > share_drift_pp {
+                    CompareStatus::Exceeded
+                } else {
+                    CompareStatus::Within
+                };
+                report.comparisons.push(share_row(
+                    PhasePresence::AddedInCurrent,
+                    0.0,
+                    cur_phase.share_pct,
+                    cur_phase.share_pct,
+                    status,
+                ));
+            }
+            (Some(base_phase), None) => {
+                let status = if base_phase.share_pct > share_drift_pp {
+                    CompareStatus::Exceeded
+                } else {
+                    CompareStatus::Within
+                };
+                report.comparisons.push(share_row(
+                    PhasePresence::MissingFromCurrent,
+                    base_phase.share_pct,
+                    0.0,
+                    -base_phase.share_pct,
+                    status,
+                ));
+            }
+            (None, None) => unreachable!("phase name came from one of the two maps"),
+        }
+    }
+}
+
+/// Shares are constructed to sum to 100 across a scenario's measured phases,
+/// but that is a property of [`crate::meta::ScenarioMeta::with_phase_ns`], not
+/// an invariant — the fields are public and a baseline file is untrusted input.
+/// A sum far from 100 means the shares were hand-written or assembled by
+/// something other than the constructor, which makes every drift number on that
+/// scenario suspect. Report it; do not gate on it, since the drift comparison
+/// is still internally consistent and failing here would block on a cosmetic
+/// defect.
+fn note_share_sum_anomaly(
+    report: &mut CompareReport,
+    id: &str,
+    side: &str,
+    phases: &BTreeMap<String, PhaseTiming>,
+) {
+    if phases.is_empty() {
+        return;
+    }
+    let sum: f64 = phases.values().map(|p| p.share_pct).sum();
+    if (sum - 100.0).abs() > SHARE_SUM_TOLERANCE_PP {
+        report.anomalies.push(format!(
+            "{id}: {side} phase shares sum to {sum:.1}%, not 100% — drift numbers for this \
+             scenario are only as trustworthy as the shares they came from"
+        ));
+    }
+}
+
 /// Compare a current capture against a baseline under the given budgets.
 ///
 /// Returns a report rather than a `Result`: a refusal to compare
@@ -923,9 +1124,13 @@ pub fn compare(
                 current.host.class,
                 current.host.describe(),
             ),
-            remedy: "recapture on this host class, set FLUREE_BENCH_HOST_CLASS / --host-class to \
-                     the class the baseline was captured on, or pass --allow-host-mismatch to \
-                     compare share drift only (absolute time and memory become advisory)"
+            // Deliberately does NOT suggest relabelling this host to the
+            // baseline's class. Renaming a machine does not make its numbers
+            // comparable — it converts this refusal into a silent, confident
+            // ENFORCEMENT against a baseline from different hardware, which is
+            // the exact failure the refusal exists to prevent.
+            remedy: "pass --allow-host-mismatch to compare share drift only (absolute time and \
+                     memory become advisory), or recapture the baseline on this host class"
                 .to_string(),
         });
         return report;
@@ -984,83 +1189,69 @@ pub fn compare(
         }
 
         let declared_budget = budget_for_id(budget, id);
-        // A noise floor only ever *widens* the envelope: it is a statement about
-        // how much run-to-run movement this scenario shows on this machine, and
-        // a budget tighter than the noise can only produce false alarms.
-        let noise_floor = base.noise_floor_pct().max(cur.noise_floor_pct());
-        let budget_pct = declared_budget.max(noise_floor);
+        // The noise floor is a WALL-CLOCK statement, and it comes from the
+        // BASELINE only. Two halves, both load-bearing:
+        //
+        // - Wall-clock only. A tracking allocator's peak is near-deterministic
+        //   for a given workload; widening the memory budget by a *timing* MAD
+        //   would let a real allocation regression through on the strength of a
+        //   noisy clock. `time_budget_pct` therefore never reaches peak_mem.
+        // - Baseline only. The floor says "this is how much this scenario
+        //   moves on a quiet machine". Taking the current run's floor too lets
+        //   an erratic run widen its own budget — the worse the run behaves,
+        //   the more it is forgiven, which inverts the gate.
+        //
+        // Within those bounds the floor only ever *widens*: a budget tighter
+        // than the measured noise can only produce false alarms.
+        let time_budget_pct = declared_budget.max(base.noise_floor_pct());
 
         if base.effective_ns() > 0.0 {
             let (change_pct, status) =
-                classify(base.effective_ns(), cur.effective_ns(), budget_pct);
+                classify(base.effective_ns(), cur.effective_ns(), time_budget_pct);
             report.comparisons.push(Comparison {
                 id: id.clone(),
                 metric: Metric::Time,
                 phase: None,
+                presence: PhasePresence::Both,
                 baseline: base.effective_ns(),
                 observed: cur.effective_ns(),
                 change_pct,
-                budget_pct,
+                budget_pct: time_budget_pct,
                 status,
                 enforced: !advisory,
             });
         }
         if let (Some(bm), Some(cm)) = (base.mem, cur.mem) {
             let (change_pct, status) =
-                classify(bm.peak_bytes as f64, cm.peak_bytes as f64, budget_pct);
+                classify(bm.peak_bytes as f64, cm.peak_bytes as f64, declared_budget);
             report.comparisons.push(Comparison {
                 id: id.clone(),
                 metric: Metric::PeakMem,
                 phase: None,
+                presence: PhasePresence::Both,
                 baseline: bm.peak_bytes as f64,
                 observed: cm.peak_bytes as f64,
                 change_pct,
-                budget_pct,
+                // Declared budget, NOT the timing-derived floor.
+                budget_pct: declared_budget,
                 status,
-                // Same rule as time: a tracking allocator's peak is no more
+                // Same host rule as time: a tracking allocator's peak is no more
                 // portable across machine classes than wall clock is.
                 enforced: !advisory,
             });
         }
 
-        for (phase, base_phase) in &base.phases {
-            let Some(cur_phase) = cur.phases.get(phase) else {
-                continue;
-            };
-            let (change_pct, status) = classify(base_phase.ns, cur_phase.ns, budget_pct);
-            report.comparisons.push(Comparison {
-                id: id.clone(),
-                metric: Metric::PhaseTime,
-                phase: Some(phase.clone()),
-                baseline: base_phase.ns,
-                observed: cur_phase.ns,
-                change_pct,
-                budget_pct,
-                status,
-                enforced: !advisory,
-            });
-
-            let (delta_pp, status) = classify_share(
-                base_phase.share_pct,
-                cur_phase.share_pct,
-                opts.share_drift_pp,
-            );
-            report.comparisons.push(Comparison {
-                id: id.clone(),
-                metric: Metric::PhaseShare,
-                phase: Some(phase.clone()),
-                baseline: base_phase.share_pct,
-                observed: cur_phase.share_pct,
-                change_pct: delta_pp,
-                budget_pct: opts.share_drift_pp,
-                status,
-                // Shares are ratios within one run, so the machine cancels.
-                // This is the one signal a cross-host comparison keeps, and
-                // making it advisory alongside the absolute metrics would throw
-                // away the entire reason to compare across hosts at all.
-                enforced: true,
-            });
-        }
+        compare_phases(
+            &mut report,
+            id,
+            base,
+            cur,
+            time_budget_pct,
+            opts.share_drift_pp,
+            advisory,
+        );
+        note_share_sum_anomaly(&mut report, id, "baseline", &base.phases);
+        note_share_sum_anomaly(&mut report, id, "current", &cur.phases);
     }
 
     for id in current.entries.keys() {
@@ -1580,8 +1771,15 @@ mod tests {
             .all(|c| c.status == CompareStatus::Within));
     }
 
+    /// reproA, from review-prbench. The defect this pins: walking only the
+    /// baseline's phases made a doubling regression report as an IMPROVEMENT.
+    ///
+    /// Baseline is one 100%-share `parse` phase. The current run is 2x slower
+    /// overall and has moved 75% of its work into a brand-new `validate` phase.
+    /// Before the fix, `parse` fell 100% → 25% and printed "improved", while
+    /// `validate` — carrying the regression — produced no row at all.
     #[test]
-    fn phases_only_in_one_side_are_skipped() {
+    fn work_moved_into_a_new_phase_is_a_breach_not_an_improvement() {
         let base = file_of(
             "local",
             vec![("g/q1/small", phased(1000.0, &[("parse", 100.0)]))],
@@ -1590,17 +1788,148 @@ mod tests {
             "local",
             vec![(
                 "g/q1/small",
-                phased(1000.0, &[("lex", 50.0), ("parse", 50.0)]),
+                phased(2000.0, &[("parse", 50.0), ("validate", 150.0)]),
             )],
         );
-        let budget = RegressionBudget::empty(5.0);
+        // Wide budget so only the phase rules can fail this.
+        let budget = RegressionBudget::empty(500.0);
         let report = compare(&base, &current, &budget, &opts());
-        // parse: share 100 -> 50 (improved), plus phase_time. lex has no
-        // baseline counterpart and produces nothing.
-        assert!(report
+
+        let validate = report
             .comparisons
             .iter()
-            .all(|c| c.phase.as_deref() != Some("lex")));
+            .find(|c| c.phase.as_deref() == Some("validate"))
+            .expect("a new phase must produce a row");
+        assert_eq!(validate.metric, Metric::PhaseShare);
+        assert_eq!(validate.presence, PhasePresence::AddedInCurrent);
+        assert_eq!(validate.status, CompareStatus::Exceeded);
+        assert!(validate.enforced);
+        assert_eq!(validate.baseline, 0.0);
+        assert_eq!(validate.observed, 75.0);
+        assert!(validate.label().contains("(NEW)"), "{}", validate.label());
+        assert!(!report.passed(), "the gate must fail on the new phase");
+    }
+
+    #[test]
+    fn a_small_new_phase_within_the_drift_threshold_does_not_gate() {
+        // Splitting 2% of the work into its own phase is bookkeeping, not a
+        // regression — the threshold is what separates the two.
+        let base = file_of(
+            "local",
+            vec![("g/q1/small", phased(1000.0, &[("parse", 100.0)]))],
+        );
+        let current = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 98.0), ("flush", 2.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(500.0);
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(report.passed());
+        let flush = report
+            .comparisons
+            .iter()
+            .find(|c| c.phase.as_deref() == Some("flush"))
+            .unwrap();
+        assert_eq!(flush.presence, PhasePresence::AddedInCurrent);
+        assert_eq!(flush.status, CompareStatus::Within);
+    }
+
+    #[test]
+    fn a_phase_vanishing_from_the_current_run_is_a_breach() {
+        // The mirror hazard: a phase carrying 40% of the baseline is simply
+        // absent now. Under growth-only share gating its -40pp would read as an
+        // improvement, but work that large moved somewhere unmeasured.
+        let base = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 60.0), ("write", 40.0)]),
+            )],
+        );
+        let current = file_of(
+            "local",
+            vec![("g/q1/small", phased(1000.0, &[("parse", 100.0)]))],
+        );
+        let budget = RegressionBudget::empty(500.0);
+        let report = compare(&base, &current, &budget, &opts());
+
+        let write = report
+            .comparisons
+            .iter()
+            .find(|c| c.phase.as_deref() == Some("write"))
+            .expect("a vanished phase must produce a row");
+        assert_eq!(write.presence, PhasePresence::MissingFromCurrent);
+        assert_eq!(write.status, CompareStatus::Exceeded);
+        assert_eq!(write.observed, 0.0);
+        assert!((write.change_pct + 40.0).abs() < 1e-9, "-40pp");
+        assert!(write.label().contains("(VANISHED)"));
+        assert!(!report.passed());
+    }
+
+    #[test]
+    fn a_tiny_vanished_phase_does_not_gate() {
+        let base = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 98.0), ("flush", 2.0)]),
+            )],
+        );
+        let current = file_of(
+            "local",
+            vec![("g/q1/small", phased(1000.0, &[("parse", 100.0)]))],
+        );
+        let budget = RegressionBudget::empty(500.0);
+        assert!(compare(&base, &current, &budget, &opts()).passed());
+    }
+
+    #[test]
+    fn one_sided_phases_emit_no_phase_time_row() {
+        // There is no ratio to report against a missing side, and a row reading
+        // "ok" versus a zero baseline would be worse than no row.
+        let base = file_of(
+            "local",
+            vec![("g/q1/small", phased(1000.0, &[("parse", 100.0)]))],
+        );
+        let current = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 50.0), ("lex", 50.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(500.0);
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(!report
+            .comparisons
+            .iter()
+            .any(|c| c.phase.as_deref() == Some("lex") && c.metric == Metric::PhaseTime));
+    }
+
+    #[test]
+    fn new_phase_gating_survives_a_cross_host_comparison() {
+        // The whole point of the share metric: absolute numbers are advisory
+        // across hosts, but a pipeline reshaping still has to fail.
+        let base = file_of(
+            "bench-m8gd",
+            vec![("g/q1/small", phased(1000.0, &[("parse", 100.0)]))],
+        );
+        let current = file_of(
+            "macos-aarch64",
+            vec![(
+                "g/q1/small",
+                phased(9000.0, &[("parse", 50.0), ("validate", 150.0)]),
+            )],
+        );
+        let budget = RegressionBudget::empty(500.0);
+        let report = compare(&base, &current, &budget, &allow_mismatch());
+        assert!(!report.passed());
+        assert!(report
+            .breaches()
+            .any(|c| c.phase.as_deref() == Some("validate")));
     }
 
     // -----------------------------------------------------------------------
@@ -1656,17 +1985,90 @@ mod tests {
         assert!(!compare(&base, &current, &budget, &opts()).passed());
     }
 
+    /// Review decision: the floor is BASELINE-ONLY.
+    ///
+    /// Taking the wider of the two floors — which this originally did — lets an
+    /// erratic run widen its own budget, so the worse a run behaves the more it
+    /// is forgiven. That inverts the gate. The baseline is the controlled
+    /// measurement; it alone gets to say how much this scenario moves.
     #[test]
-    fn a_noisy_current_run_widens_the_budget_too() {
-        // The floor is a property of the environment, not of the baseline: a
-        // quiet baseline compared against a run that measured wide must take
-        // the wider of the two floors, or every noisy PR run false-flags.
+    fn a_noisy_current_run_does_not_widen_the_budget() {
         let base = file_of("local", vec![("g/q1/small", entry(1000.0))]);
         let current = current_with(vec![("g/q1/small", noisy(&MAD_10_SAMPLES))]);
         let budget = RegressionBudget::empty(1.0);
         assert_eq!(
             compare(&base, &current, &budget, &opts()).comparisons[0].budget_pct,
-            3.0
+            1.0,
+            "current-side noise must not widen the declared budget"
+        );
+    }
+
+    /// reproC, from review-prbench. A wall-clock MAD was widening the MEMORY
+    /// budget: baseline MAD 100 on a median of 1000 gave a 30% floor, and a
+    /// +25% peak_bytes regression sailed through a 5% memory budget.
+    ///
+    /// A tracking allocator's peak is near-deterministic for a given workload,
+    /// so a noisy clock is no reason at all to forgive it.
+    #[test]
+    fn timing_noise_never_widens_the_memory_budget() {
+        let mut base_entry = mem_entry(1000.0, 1_000_000);
+        base_entry.noise = Some(NoiseStats::from_samples(vec![
+            800.0, 900.0, 1000.0, 1100.0, 1200.0,
+        ]));
+        assert_eq!(base_entry.noise_floor_pct(), 30.0, "MAD 100 / median 1000");
+
+        let base = file_of("local", vec![("g/q1/small", base_entry)]);
+        // Same wall clock, +25% peak memory.
+        let current = current_with(vec![("g/q1/small", mem_entry(1000.0, 1_250_000))]);
+        let budget = RegressionBudget::empty(5.0);
+        let report = compare(&base, &current, &budget, &opts());
+
+        let mem = report
+            .comparisons
+            .iter()
+            .find(|c| c.metric == Metric::PeakMem)
+            .unwrap();
+        assert_eq!(mem.budget_pct, 5.0, "declared budget, not the timing floor");
+        assert_eq!(mem.status, CompareStatus::Exceeded);
+        assert!(!report.passed());
+
+        // The time row still gets the widened envelope — the split is the point.
+        let time = report
+            .comparisons
+            .iter()
+            .find(|c| c.metric == Metric::Time)
+            .unwrap();
+        assert_eq!(time.budget_pct, 30.0);
+    }
+
+    #[test]
+    fn timing_noise_widens_phase_time_but_not_share() {
+        let mut base_entry = phased(1000.0, &[("parse", 600.0), ("write", 400.0)]);
+        base_entry.noise = Some(NoiseStats::from_samples(vec![
+            800.0, 900.0, 1000.0, 1100.0, 1200.0,
+        ]));
+        let base = file_of("local", vec![("g/q1/small", base_entry)]);
+        let current = current_with(vec![(
+            "g/q1/small",
+            phased(1000.0, &[("parse", 600.0), ("write", 400.0)]),
+        )]);
+        let budget = RegressionBudget::empty(5.0);
+        let report = compare(&base, &current, &budget, &opts());
+
+        let phase_time = report
+            .comparisons
+            .iter()
+            .find(|c| c.metric == Metric::PhaseTime)
+            .unwrap();
+        assert_eq!(phase_time.budget_pct, 30.0, "phase ns is wall clock");
+        let share = report
+            .comparisons
+            .iter()
+            .find(|c| c.metric == Metric::PhaseShare)
+            .unwrap();
+        assert_eq!(
+            share.budget_pct, DEFAULT_SHARE_DRIFT_PP,
+            "share drift has its own threshold in pp"
         );
     }
 
@@ -1723,7 +2125,7 @@ mod tests {
         let mut acc = file_of("local", vec![("g/q1/small", entry(1000.0))]);
         for mean in [1010.0, 990.0, 1005.0, 995.0] {
             let fresh = file_of("local", vec![("g/q1/small", entry(mean))]);
-            acc = accumulate(&acc, &fresh);
+            acc = accumulate(&acc, &fresh).unwrap();
         }
         let noise = acc.entries["g/q1/small"].noise.as_ref().unwrap();
         assert_eq!(noise.n, 5, "seed run plus four accumulations");
@@ -1738,10 +2140,150 @@ mod tests {
             vec![("g/q1/small", entry(1000.0)), ("g/q2/small", entry(2000.0))],
         );
         let fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
-        let merged = accumulate(&acc, &fresh);
+        let merged = accumulate(&acc, &fresh).unwrap();
         assert_eq!(merged.entries.len(), 2);
         assert_eq!(merged.entries["g/q2/small"].mean_ns, 2000.0);
         assert!(merged.entries["g/q2/small"].noise.is_none());
+    }
+
+    /// reproB, from review-prbench. Both accumulate guards live in the library,
+    /// not in the CLI that happens to call it — accumulation is the one
+    /// operation that DESTROYS the evidence of a mismatch (two populations
+    /// blended into one median/MAD, with the provenance overwritten in the same
+    /// breath), so a direct caller must not be able to skip them.
+    #[test]
+    fn accumulate_refuses_across_host_classes() {
+        let prev = file_of("bench-m8gd", vec![("g/q1/small", entry(1000.0))]);
+        let fresh = file_of("macos-aarch64", vec![("g/q1/small", entry(1010.0))]);
+        let err = accumulate(&prev, &fresh).unwrap_err();
+        assert!(
+            err.contains("bench-m8gd") && err.contains("macos-aarch64"),
+            "{err}"
+        );
+        assert!(err.contains("host class"), "{err}");
+    }
+
+    #[test]
+    fn accumulate_refuses_across_corpora() {
+        let mut prev_entry = entry(1000.0);
+        prev_entry.corpus = Some(corpus(b"one"));
+        let mut fresh_entry = entry(1010.0);
+        fresh_entry.corpus = Some(corpus(b"two"));
+        let prev = file_of("local", vec![("g/q1/small", prev_entry)]);
+        let fresh = file_of("local", vec![("g/q1/small", fresh_entry)]);
+
+        let err = accumulate(&prev, &fresh).unwrap_err();
+        assert!(err.contains("g/q1/small"), "{err}");
+        assert!(err.contains("sha256"), "{err}");
+    }
+
+    #[test]
+    fn accumulate_refuses_across_file_level_corpora() {
+        let mut prev = file_of("local", vec![("g/q1/small", entry(1000.0))]);
+        prev.corpus = Some(corpus(b"one"));
+        let mut fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
+        fresh.corpus = Some(corpus(b"two"));
+        assert!(accumulate(&prev, &fresh).is_err());
+    }
+
+    #[test]
+    fn accumulate_allows_a_matching_corpus() {
+        let mut prev_entry = entry(1000.0);
+        prev_entry.corpus = Some(corpus(b"same"));
+        let mut fresh_entry = entry(1010.0);
+        fresh_entry.corpus = Some(corpus(b"same"));
+        let prev = file_of("local", vec![("g/q1/small", prev_entry)]);
+        let fresh = file_of("local", vec![("g/q1/small", fresh_entry)]);
+        assert!(accumulate(&prev, &fresh).is_ok());
+    }
+
+    #[test]
+    fn accumulate_ignores_corpora_for_scenarios_not_in_both() {
+        // A subset rerun tops up only what it measured; a scenario absent from
+        // the fresh run has no corpus to disagree about.
+        let mut prev_a = entry(1000.0);
+        prev_a.corpus = Some(corpus(b"one"));
+        let mut prev_b = entry(2000.0);
+        prev_b.corpus = Some(corpus(b"other"));
+        let prev = file_of(
+            "local",
+            vec![("g/q1/small", prev_a), ("g/q2/small", prev_b)],
+        );
+
+        let mut fresh_a = entry(1010.0);
+        fresh_a.corpus = Some(corpus(b"one"));
+        let fresh = file_of("local", vec![("g/q1/small", fresh_a)]);
+        assert!(accumulate(&prev, &fresh).is_ok());
+    }
+
+    /// The remedy must not suggest relabelling this host to the baseline's
+    /// class: that converts a refusal into a confident ENFORCEMENT against
+    /// hardware the baseline never ran on — the exact failure the refusal
+    /// exists to prevent.
+    #[test]
+    fn host_mismatch_remedy_does_not_suggest_relabelling_the_host() {
+        let base = file_of("bench-m8gd", vec![("g/q1/small", entry(1000.0))]);
+        let current = file_of("macos-aarch64", vec![("g/q1/small", entry(1000.0))]);
+        let budget = RegressionBudget::empty(5.0);
+        let remedy = &compare(&base, &current, &budget, &opts()).fatal[0].remedy;
+
+        assert!(remedy.contains("--allow-host-mismatch"), "{remedy}");
+        assert!(
+            !remedy.contains("--host-class") && !remedy.contains("FLUREE_BENCH_HOST_CLASS"),
+            "remedy must not offer relabelling as a fix: {remedy}"
+        );
+    }
+
+    #[test]
+    fn shares_that_do_not_sum_to_100_are_reported_but_do_not_gate() {
+        // Hand-assembled or hand-edited shares: the drift comparison is still
+        // internally consistent, so report rather than fail.
+        let mut skewed = entry(1000.0);
+        skewed.phases = [
+            (
+                "parse".to_string(),
+                PhaseTiming {
+                    ns: 10.0,
+                    share_pct: 30.0,
+                },
+            ),
+            (
+                "write".to_string(),
+                PhaseTiming {
+                    ns: 10.0,
+                    share_pct: 30.0,
+                },
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let base = file_of("local", vec![("g/q1/small", skewed.clone())]);
+        let current = file_of("local", vec![("g/q1/small", skewed)]);
+        let budget = RegressionBudget::empty(5.0);
+
+        let report = compare(&base, &current, &budget, &opts());
+        assert!(report.passed(), "a cosmetic share defect must not gate");
+        assert!(
+            report.anomalies.iter().any(|a| a.contains("60.0%")),
+            "{:?}",
+            report.anomalies
+        );
+    }
+
+    #[test]
+    fn well_formed_shares_produce_no_anomaly() {
+        let base = file_of(
+            "local",
+            vec![(
+                "g/q1/small",
+                phased(1000.0, &[("parse", 600.0), ("write", 400.0)]),
+            )],
+        );
+        let current = base.clone();
+        let budget = RegressionBudget::empty(5.0);
+        assert!(compare(&base, &current, &budget, &opts())
+            .anomalies
+            .is_empty());
     }
 
     // -----------------------------------------------------------------------

--- a/fluree-bench-support/src/baseline.rs
+++ b/fluree-bench-support/src/baseline.rs
@@ -714,28 +714,72 @@ pub fn accumulate(
             fresh.host.describe(),
         ));
     }
+    // Revision identity is compared as a whole, INCLUDING absence. Requiring
+    // both sides `Some` left a two-step laundering path: one pass with no git
+    // reset the accumulator's sha to `None`, and the next pass at any revision
+    // then sailed through a guard that needed two `Some`s to fire. A sample
+    // whose revision is unknowable is precisely the one that cannot be pooled
+    // safely, so `None` vs `Some` is drift like any other. Both-absent stays
+    // fine — a tarball or container build has nothing to disagree about.
     if !opts.allow_revision_drift {
-        if let (Some(prev_sha), Some(fresh_sha)) = (&prev.git_sha, &fresh.git_sha) {
-            if !prev_sha.is_empty() && !fresh_sha.is_empty() && prev_sha != fresh_sha {
-                return Err(format!(
-                    "refusing to accumulate across revisions: existing samples were captured at \
-                     {prev_sha}, this run at {fresh_sha}. Pooling them mixes pre- and \
-                     post-change populations, relabels every sample as {fresh_sha}, and can widen \
-                     the MAD enough to hide the change being measured. Pass \
-                     --allow-revision-drift if the difference is genuinely irrelevant."
-                ));
-            }
+        let norm = |s: &Option<String>| s.clone().filter(|v| !v.is_empty());
+        let (prev_sha, fresh_sha) = (norm(&prev.git_sha), norm(&fresh.git_sha));
+        if prev_sha != fresh_sha {
+            let describe = |s: &Option<String>| {
+                s.clone()
+                    .unwrap_or_else(|| "an unknown revision (no git)".to_string())
+            };
+            return Err(format!(
+                "refusing to accumulate across revisions: existing samples were captured at {}, \
+                 this run at {}. Pooling them mixes populations, relabels every sample as the \
+                 latter, and can widen the MAD enough to hide the change being measured. Pass \
+                 --allow-revision-drift if the difference is genuinely irrelevant.",
+                describe(&prev_sha),
+                describe(&fresh_sha),
+            ));
         }
     }
-    for id in prev.entries.keys() {
-        if !fresh.entries.contains_key(id) {
-            continue;
-        }
-        if let Some(detail) = corpus_refusal(prev.corpus_for(id), fresh.corpus_for(id)) {
-            return Err(format!(
-                "refusing to accumulate for {id}: {detail}. Samples over different inputs cannot \
-                 be pooled into one median/MAD."
-            ));
+
+    // Corpus identity is checked over the UNION of scenario ids, not the
+    // intersection. Checking only the overlap left the carry-forward path
+    // below free to re-insert a prev-only entry into a file whose file-level
+    // corpus is `fresh`'s — silently relabelling samples that were measured
+    // against something else. Same defect class as `(Some, None)`, one path
+    // over.
+    let ids: BTreeSet<&String> = prev.entries.keys().chain(fresh.entries.keys()).collect();
+    let mut carried_corpus: BTreeMap<String, CorpusInfo> = BTreeMap::new();
+    for id in ids {
+        let prev_resolved = prev.corpus_for(id);
+        let fresh_resolved = fresh.corpus_for(id);
+        if prev.entries.contains_key(id) && fresh.entries.contains_key(id) {
+            if let Some(detail) = corpus_refusal(prev_resolved, fresh_resolved) {
+                return Err(format!(
+                    "refusing to accumulate for {id}: {detail}. Samples over different inputs \
+                     cannot be pooled into one median/MAD."
+                ));
+            }
+        } else if prev.entries.contains_key(id) {
+            // Carried forward, not re-measured. Preserve the identity it had
+            // rather than letting it inherit the new file-level corpus.
+            match (prev_resolved, fresh_resolved) {
+                (Some(p), f) if Some(&p.sha256) != f.map(|c| &c.sha256) => {
+                    carried_corpus.insert(id.clone(), p.clone());
+                }
+                (None, Some(f)) => {
+                    // Nothing to stamp: "explicitly no corpus" cannot be
+                    // expressed through inheritance, so the entry would claim
+                    // an identity its samples never had.
+                    return Err(format!(
+                        "refusing to accumulate: {id} is carried forward with no recorded corpus, \
+                         but this run declares a file-level corpus '{}' (sha256:{}) that it would \
+                         silently inherit. Start a new accumulation instead of retro-labelling \
+                         existing samples.",
+                        f.name,
+                        short_hash(&f.sha256),
+                    ));
+                }
+                _ => {}
+            }
         }
     }
 
@@ -761,9 +805,15 @@ pub fn accumulate(
                 samples.push(entry.mean_ns);
                 entry.noise = Some(NoiseStats::from_samples(samples));
             }
-            // Not rerun this pass: carry the previous entry forward whole.
+            // Not rerun this pass: carry the previous entry forward whole,
+            // stamping the corpus it actually resolved to so the new
+            // file-level block can't relabel it.
             _ => {
-                out.entries.insert(id.clone(), prev_entry.clone());
+                let mut carried = prev_entry.clone();
+                if let Some(c) = carried_corpus.get(id) {
+                    carried.corpus = Some(c.clone());
+                }
+                out.entries.insert(id.clone(), carried);
             }
         }
     }
@@ -2401,16 +2451,30 @@ mod tests {
     }
 
     #[test]
-    fn accumulate_allows_a_matching_or_absent_revision() {
-        // Same sha: normal loop. Absent sha (no git): nothing to compare.
+    fn accumulate_allows_a_matching_revision() {
         let mut prev = file_of("local", vec![("g/q1/small", entry(1000.0))]);
         let mut fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
         prev.git_sha = Some("aaaaaaa".into());
         fresh.git_sha = Some("aaaaaaa".into());
         assert!(accumulate(&prev, &fresh, &AccumulateOptions::default()).is_ok());
+    }
 
+    /// Revision identity now includes ABSENCE (R2). One-sided `None` used to be
+    /// waved through, and that is the laundering step: a no-git pass reset the
+    /// accumulator's sha and reopened the gate for every pass after it.
+    #[test]
+    fn one_sided_missing_revision_is_drift() {
+        let mut prev = file_of("local", vec![("g/q1/small", entry(1000.0))]);
+        let mut fresh = file_of("local", vec![("g/q1/small", entry(1010.0))]);
+        prev.git_sha = Some("aaaaaaa".into());
+        fresh.git_sha = None;
+        let err = accumulate(&prev, &fresh, &AccumulateOptions::default()).unwrap_err();
+        assert!(err.contains("unknown revision"), "{err}");
+
+        // ...and the mirror direction.
         prev.git_sha = None;
-        assert!(accumulate(&prev, &fresh, &AccumulateOptions::default()).is_ok());
+        fresh.git_sha = Some("aaaaaaa".into());
+        assert!(accumulate(&prev, &fresh, &AccumulateOptions::default()).is_err());
     }
 
     #[test]
@@ -2422,6 +2486,111 @@ mod tests {
         let prev = file_of("local", vec![("g/q1/small", prev_entry)]);
         let fresh = file_of("local", vec![("g/q1/small", fresh_entry)]);
         assert!(accumulate(&prev, &fresh, &AccumulateOptions::default()).is_ok());
+    }
+
+    /// bplatz residual R1. The corpus guard only walked the INTERSECTION, but
+    /// the carry-forward arm re-inserts prev-only entries into a file whose
+    /// file-level corpus is `fresh`'s — so an entry that was inheriting prev's
+    /// corpus silently resolves against a different one, samples unchanged.
+    ///
+    /// His repro: prev = {q1, q2} under file-level corpus A, a pass that reran
+    /// only q3 under corpus B.
+    #[test]
+    fn carried_forward_entries_keep_their_own_corpus() {
+        let mut prev = file_of(
+            "local",
+            vec![("g/q1/small", entry(1000.0)), ("g/q2/small", entry(2000.0))],
+        );
+        prev.corpus = Some(corpus(b"A"));
+        let mut fresh = file_of("local", vec![("g/q3/small", entry(3000.0))]);
+        fresh.corpus = Some(corpus(b"B"));
+
+        let merged = accumulate(&prev, &fresh, &AccumulateOptions::default()).unwrap();
+
+        // q2 was measured under A and must still resolve to A, not to the new
+        // file-level B it would otherwise inherit.
+        assert_eq!(
+            merged.corpus_for("g/q2/small").map(|c| &c.sha256),
+            prev.corpus_for("g/q2/small").map(|c| &c.sha256),
+            "carried-forward entry was relabelled to the fresh corpus"
+        );
+        assert_eq!(merged.entries["g/q2/small"].mean_ns, 2000.0, "same samples");
+        // The scenario the fresh pass actually measured keeps B.
+        assert_eq!(
+            merged.corpus_for("g/q3/small").map(|c| &c.sha256),
+            fresh.corpus.as_ref().map(|c| &c.sha256)
+        );
+    }
+
+    #[test]
+    fn carrying_forward_into_a_newly_declared_corpus_refuses() {
+        // prev declared no corpus anywhere; fresh introduces a file-level one.
+        // The carried entries would inherit an identity their samples never
+        // had, and "explicitly none" is not expressible via inheritance — so
+        // there is nothing to stamp and the merge must refuse.
+        let prev = file_of(
+            "local",
+            vec![("g/q1/small", entry(1000.0)), ("g/q2/small", entry(2000.0))],
+        );
+        let mut fresh = file_of("local", vec![("g/q3/small", entry(3000.0))]);
+        fresh.corpus = Some(corpus(b"B"));
+
+        let err = accumulate(&prev, &fresh, &AccumulateOptions::default()).unwrap_err();
+        assert!(
+            err.contains("g/q1/small") || err.contains("g/q2/small"),
+            "{err}"
+        );
+    }
+
+    /// bplatz residual R2. The guard required both sides `Some` and the merge
+    /// took `fresh`'s `git_sha`, so ONE no-git pass reset the accumulator and
+    /// reopened the gate for every pass after it — the MAD-widening case the
+    /// guard exists for, reached in two steps instead of one.
+    #[test]
+    fn a_no_git_pass_cannot_launder_a_revision_change() {
+        let mut p1 = file_of("local", vec![("g/q1/small", entry(1000.0))]);
+        p1.git_sha = Some("aaaaaaa".into());
+
+        // Pass 2: no git available.
+        let mut p2 = file_of("local", vec![("g/q1/small", entry(1010.0))]);
+        p2.git_sha = None;
+        let after_no_git = accumulate(&p1, &p2, &AccumulateOptions::default());
+        // Pass 3: a different revision, with a wildly different measurement.
+        let mut p3 = file_of("local", vec![("g/q1/small", entry(5000.0))]);
+        p3.git_sha = Some("ccccccc".into());
+
+        match after_no_git {
+            // Either the no-git pass itself refuses...
+            Err(e) => assert!(e.contains("revision"), "{e}"),
+            // ...or it is accepted, in which case the NEXT pass at a different
+            // revision must not be.
+            Ok(merged) => {
+                let err = accumulate(&merged, &p3, &AccumulateOptions::default()).unwrap_err();
+                assert!(err.contains("revision"), "{err}");
+            }
+        }
+    }
+
+    #[test]
+    fn an_all_no_git_accumulation_still_works() {
+        // No git anywhere (tarball, container): nothing to disagree about.
+        let mut p1 = file_of("local", vec![("g/q1/small", entry(1000.0))]);
+        let mut p2 = file_of("local", vec![("g/q1/small", entry(1010.0))]);
+        p1.git_sha = None;
+        p2.git_sha = None;
+        assert!(accumulate(&p1, &p2, &AccumulateOptions::default()).is_ok());
+    }
+
+    #[test]
+    fn revision_drift_override_still_covers_the_none_case() {
+        let mut p1 = file_of("local", vec![("g/q1/small", entry(1000.0))]);
+        p1.git_sha = Some("aaaaaaa".into());
+        let mut p2 = file_of("local", vec![("g/q1/small", entry(1010.0))]);
+        p2.git_sha = None;
+        let allowed = AccumulateOptions {
+            allow_revision_drift: true,
+        };
+        assert!(accumulate(&p1, &p2, &allowed).is_ok());
     }
 
     #[test]

--- a/fluree-bench-support/src/bin/bench_baseline.rs
+++ b/fluree-bench-support/src/bin/bench_baseline.rs
@@ -39,8 +39,8 @@ use std::process::ExitCode;
 
 use fluree_bench_support::baseline::{
     accumulate, capture, compare, default_criterion_dir, describe_corpus, host_class,
-    load_baseline, save_baseline, CompareOptions, CompareStatus, Comparison, HostMismatchPolicy,
-    Metric,
+    load_baseline, save_baseline, AccumulateOptions, CompareOptions, CompareStatus, Comparison,
+    HostMismatchPolicy, Metric,
 };
 use fluree_bench_support::budget;
 use fluree_bench_support::mem;
@@ -76,7 +76,8 @@ fn print_usage() {
         "bench-baseline — capture and compare performance baselines\n\n\
          USAGE:\n  \
          bench-baseline capture --label <name> --out <file> [--criterion-dir <dir>] [--mem-dir <dir>]\n                          \
-         [--meta-dir <dir>] [--host-class <name>] [--accumulate] [--clean-sidecars]\n  \
+         [--meta-dir <dir>] [--host-class <name>] [--accumulate] [--allow-revision-drift]\n                          \
+         [--clean-sidecars]\n  \
          bench-baseline compare --baseline <file> [--criterion-dir <dir>] [--mem-dir <dir>]\n                          \
          [--meta-dir <dir>] [--budget <file>] [--only <substr>] [--host-class <name>]\n                          \
          [--share-drift-pp <pp>] [--allow-host-mismatch] [--advisory]\n\n\
@@ -185,7 +186,12 @@ fn run_capture(args: &[String]) -> ExitCode {
             "--meta-dir",
             "--host-class",
         ],
-        &["--clean-mem", "--clean-sidecars", "--accumulate"],
+        &[
+            "--clean-mem",
+            "--clean-sidecars",
+            "--accumulate",
+            "--allow-revision-drift",
+        ],
     ) {
         Ok(f) => f,
         Err(e) => {
@@ -232,7 +238,13 @@ fn run_capture(args: &[String]) -> ExitCode {
         match load_baseline(&out_path) {
             // `accumulate` enforces the host-class and corpus guards itself, so
             // the CLI has no policy of its own to apply here.
-            Ok(prev) => match accumulate(&prev, &file) {
+            Ok(prev) => match accumulate(
+                &prev,
+                &file,
+                &AccumulateOptions {
+                    allow_revision_drift: flags.contains_key("--allow-revision-drift"),
+                },
+            ) {
                 Ok(merged) => file = merged,
                 Err(e) => {
                     eprintln!("{e}");
@@ -431,9 +443,6 @@ fn run_compare(args: &[String]) -> ExitCode {
             "new scenarios (no baseline entry): {}",
             report.new_scenarios.join(", ")
         );
-    }
-    for anomaly in &report.anomalies {
-        println!("::warning::{anomaly}");
     }
 
     let advisories: Vec<_> = report.advisories().collect();

--- a/fluree-bench-support/src/bin/bench_baseline.rs
+++ b/fluree-bench-support/src/bin/bench_baseline.rs
@@ -86,10 +86,16 @@ fn print_usage() {
          else {{os}}-{{arch}}). A mismatch is a REFUSAL (exit {EXIT_REFUSED}) unless\n  \
          --allow-host-mismatch downgrades those metrics to advisory.\n  \
          phase_share drift enforces regardless of host class — shares are ratios\n  \
-         within one run, so the machine cancels.\n  \
+         within one run, so the machine cancels; a phase that appears or\n  \
+         disappears is gated on its share alone.\n  \
          A corpus mismatch (sha256 / syntax / thread count) is always a refusal:\n  \
          there is no posture in which comparing different inputs is meaningful.\n  \
          --advisory forces every absolute metric advisory.\n\n\
+         --host-class LABELS this host; it does not make it comparable. Use it to\n  \
+         declare a class you genuinely are (CI pinning its runner class), never to\n  \
+         silence a refusal — that turns a refusal into a false ENFORCEMENT against\n  \
+         hardware the baseline never ran on. To compare anyway, use\n  \
+         --allow-host-mismatch.\n\n\
          EXIT CODES\n  \
          0 within budget   {EXIT_BREACH} enforced budget breach   {EXIT_REFUSED} refused to compare\n\n\
          Run the benches first (`cargo bench ...`); this tool reads criterion's\n\
@@ -224,16 +230,15 @@ fn run_capture(args: &[String]) -> ExitCode {
 
     if flags.contains_key("--accumulate") {
         match load_baseline(&out_path) {
-            Ok(prev) => {
-                if prev.host.class != file.host.class {
-                    eprintln!(
-                        "refusing to accumulate: existing baseline host_class '{}' != this run's '{}'",
-                        prev.host.class, file.host.class
-                    );
+            // `accumulate` enforces the host-class and corpus guards itself, so
+            // the CLI has no policy of its own to apply here.
+            Ok(prev) => match accumulate(&prev, &file) {
+                Ok(merged) => file = merged,
+                Err(e) => {
+                    eprintln!("{e}");
                     return ExitCode::from(EXIT_REFUSED);
                 }
-                file = accumulate(&prev, &file);
-            }
+            },
             // First pass of an accumulation loop: nothing to merge yet.
             Err(_) if !out_path.exists() => {}
             Err(e) => {
@@ -426,6 +431,9 @@ fn run_compare(args: &[String]) -> ExitCode {
             "new scenarios (no baseline entry): {}",
             report.new_scenarios.join(", ")
         );
+    }
+    for anomaly in &report.anomalies {
+        println!("::warning::{anomaly}");
     }
 
     let advisories: Vec<_> = report.advisories().collect();

--- a/fluree-bench-support/src/bin/bench_baseline.rs
+++ b/fluree-bench-support/src/bin/bench_baseline.rs
@@ -12,9 +12,16 @@
 //! cargo run -p fluree-bench-support --bin bench-baseline -- \
 //!     capture --label phase-1-pre --out bench-baselines/phase-1-pre.json
 //!
+//! # 2b. ...or accumulate repeat runs into one noise-aware baseline:
+//! for i in 1 2 3 4 5; do
+//!   cargo bench -p fluree-db-api --bench query_overlay_matrix
+//!   cargo run -p fluree-bench-support --bin bench-baseline -- \
+//!       capture --label phase-1-pre --out bench-baselines/phase-1-pre.json --accumulate
+//! done
+//!
 //! # 3. ...make changes, rerun the benches...
 //!
-//! # 4. Compare (exit 1 on any budget breach):
+//! # 4. Compare (exit 1 on a budget breach, 2 on a refusal to compare):
 //! cargo run -p fluree-bench-support --bin bench-baseline -- \
 //!     compare --baseline bench-baselines/phase-1-pre.json
 //!
@@ -31,11 +38,21 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use fluree_bench_support::baseline::{
-    capture, compare, default_criterion_dir, load_baseline, runner_class, save_baseline,
-    BaselineEntry, CompareStatus,
+    accumulate, capture, compare, default_criterion_dir, describe_corpus, host_class,
+    load_baseline, save_baseline, CompareOptions, CompareStatus, Comparison, HostMismatchPolicy,
+    Metric,
 };
 use fluree_bench_support::budget;
 use fluree_bench_support::mem;
+use fluree_bench_support::meta;
+use fluree_bench_support::meta::DEFAULT_SHARE_DRIFT_PP;
+
+/// Budget breach on an enforced metric.
+const EXIT_BREACH: u8 = 1;
+/// Refusal to compare (host class, corpus identity, schema version). Distinct
+/// from a breach because the two demand different responses: a breach means
+/// "your change is slower", a refusal means "this comparison is meaningless".
+const EXIT_REFUSED: u8 = 2;
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -58,15 +75,27 @@ fn print_usage() {
     eprintln!(
         "bench-baseline — capture and compare performance baselines\n\n\
          USAGE:\n  \
-         bench-baseline capture --label <name> --out <file> [--criterion-dir <dir>] [--mem-dir <dir>] [--clean-mem]\n  \
-         bench-baseline compare --baseline <file> [--criterion-dir <dir>] [--mem-dir <dir>] [--budget <file>] [--only <substr>] [--advisory]\n\n\
-         TIME and PEAK_MEM both enforce only when the baseline's runner_class\n\
-         matches this runner's (env FLUREE_BENCH_RUNNER_CLASS, default\n\
-         \"local\"); on a mismatch both are advisory and the gate passes.\n\
-         --advisory forces advisory for both.\n\n\
+         bench-baseline capture --label <name> --out <file> [--criterion-dir <dir>] [--mem-dir <dir>]\n                          \
+         [--meta-dir <dir>] [--host-class <name>] [--accumulate] [--clean-sidecars]\n  \
+         bench-baseline compare --baseline <file> [--criterion-dir <dir>] [--mem-dir <dir>]\n                          \
+         [--meta-dir <dir>] [--budget <file>] [--only <substr>] [--host-class <name>]\n                          \
+         [--share-drift-pp <pp>] [--allow-host-mismatch] [--advisory]\n\n\
+         GATE\n  \
+         time and peak_mem enforce only when the baseline's host_class matches\n  \
+         this host's (env FLUREE_BENCH_HOST_CLASS, else FLUREE_BENCH_RUNNER_CLASS,\n  \
+         else {{os}}-{{arch}}). A mismatch is a REFUSAL (exit {EXIT_REFUSED}) unless\n  \
+         --allow-host-mismatch downgrades those metrics to advisory.\n  \
+         phase_share drift enforces regardless of host class — shares are ratios\n  \
+         within one run, so the machine cancels.\n  \
+         A corpus mismatch (sha256 / syntax / thread count) is always a refusal:\n  \
+         there is no posture in which comparing different inputs is meaningful.\n  \
+         --advisory forces every absolute metric advisory.\n\n\
+         EXIT CODES\n  \
+         0 within budget   {EXIT_BREACH} enforced budget breach   {EXIT_REFUSED} refused to compare\n\n\
          Run the benches first (`cargo bench ...`); this tool reads criterion's\n\
-         output from target/criterion and memory sidecars from\n\
-         target/fluree-bench-mem. See BENCHMARKING.md (\"Baselines\")."
+         output from target/criterion, memory sidecars from target/fluree-bench-mem,\n\
+         and corpus/phase sidecars from target/fluree-bench-meta.\n\
+         See BENCHMARKING.md (\"Baselines\")."
     );
 }
 
@@ -111,6 +140,22 @@ fn mem_dir(flags: &BTreeMap<String, String>) -> PathBuf {
         .unwrap_or_else(mem::sidecar_dir)
 }
 
+fn meta_dir(flags: &BTreeMap<String, String>) -> PathBuf {
+    flags
+        .get("--meta-dir")
+        .map(PathBuf::from)
+        .unwrap_or_else(meta::sidecar_dir)
+}
+
+/// `--host-class` is applied by setting the env var the library reads, so there
+/// is exactly one resolution path for the class and the flag can't disagree
+/// with `HostBlock::detect()`.
+fn apply_host_class_override(flags: &BTreeMap<String, String>) {
+    if let Some(class) = flags.get("--host-class") {
+        std::env::set_var("FLUREE_BENCH_HOST_CLASS", class);
+    }
+}
+
 fn git_short_sha() -> Option<String> {
     let out = std::process::Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
@@ -126,8 +171,15 @@ fn git_short_sha() -> Option<String> {
 fn run_capture(args: &[String]) -> ExitCode {
     let flags = match parse_flags(
         args,
-        &["--label", "--out", "--criterion-dir", "--mem-dir"],
-        &["--clean-mem"],
+        &[
+            "--label",
+            "--out",
+            "--criterion-dir",
+            "--mem-dir",
+            "--meta-dir",
+            "--host-class",
+        ],
+        &["--clean-mem", "--clean-sidecars", "--accumulate"],
     ) {
         Ok(f) => f,
         Err(e) => {
@@ -144,9 +196,11 @@ fn run_capture(args: &[String]) -> ExitCode {
         eprintln!("capture requires --out <file>");
         return ExitCode::FAILURE;
     };
+    apply_host_class_override(&flags);
 
     let crit = criterion_dir(&flags);
     let mem_d = mem_dir(&flags);
+    let meta_d = meta_dir(&flags);
     if !crit.is_dir() {
         eprintln!(
             "criterion dir {} not found — run `cargo bench ...` first",
@@ -155,10 +209,11 @@ fn run_capture(args: &[String]) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    let file = capture(
+    let mut file = capture(
         label,
         &crit,
         &mem_d,
+        &meta_d,
         git_short_sha(),
         chrono::Utc::now().to_rfc3339(),
     );
@@ -166,25 +221,63 @@ fn run_capture(args: &[String]) -> ExitCode {
         eprintln!("no scenarios found under {}", crit.display());
         return ExitCode::FAILURE;
     }
+
+    if flags.contains_key("--accumulate") {
+        match load_baseline(&out_path) {
+            Ok(prev) => {
+                if prev.host.class != file.host.class {
+                    eprintln!(
+                        "refusing to accumulate: existing baseline host_class '{}' != this run's '{}'",
+                        prev.host.class, file.host.class
+                    );
+                    return ExitCode::from(EXIT_REFUSED);
+                }
+                file = accumulate(&prev, &file);
+            }
+            // First pass of an accumulation loop: nothing to merge yet.
+            Err(_) if !out_path.exists() => {}
+            Err(e) => {
+                eprintln!("--accumulate could not read {}: {e}", out_path.display());
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
     if let Err(e) = save_baseline(&file, &out_path) {
         eprintln!("{e}");
         return ExitCode::FAILURE;
     }
     let with_mem = file.entries.values().filter(|e| e.mem.is_some()).count();
+    let with_corpus = file.entries.values().filter(|e| e.corpus.is_some()).count();
+    let with_phases = file
+        .entries
+        .values()
+        .filter(|e| !e.phases.is_empty())
+        .count();
+    let sampled = file
+        .entries
+        .values()
+        .filter_map(|e| e.noise.as_ref())
+        .map(|n| n.n)
+        .min();
     println!(
-        "captured {} scenarios ({} with memory metrics) → {} [label={} sha={} profile={} scale={} runner_class={} host={}]",
+        "captured {} scenarios ({with_mem} with memory, {with_corpus} with corpus, {with_phases} with phases) → {} [label={} sha={} profile={} scale={}]",
         file.entries.len(),
-        with_mem,
         out_path.display(),
         file.label,
         file.git_sha.as_deref().unwrap_or("?"),
         file.profile,
         file.scale,
-        file.runner_class,
-        file.host,
     );
-    if flags.contains_key("--clean-mem") {
+    println!("host: {}", file.host.describe());
+    if let Some(n) = sampled {
+        println!("noise samples: {n} (min across entries)");
+    }
+    // `--clean-mem` is the pre-meta spelling; both clear every sidecar dir so a
+    // stale corpus block can't outlive the run that wrote it.
+    if flags.contains_key("--clean-sidecars") || flags.contains_key("--clean-mem") {
         mem::clear_sidecars(&mem_d);
+        meta::clear_sidecars(&meta_d);
     }
     ExitCode::SUCCESS
 }
@@ -196,10 +289,13 @@ fn run_compare(args: &[String]) -> ExitCode {
             "--baseline",
             "--criterion-dir",
             "--mem-dir",
+            "--meta-dir",
             "--budget",
             "--only",
+            "--host-class",
+            "--share-drift-pp",
         ],
-        &["--advisory"],
+        &["--advisory", "--allow-host-mismatch"],
     ) {
         Ok(f) => f,
         Err(e) => {
@@ -212,6 +308,16 @@ fn run_compare(args: &[String]) -> ExitCode {
         eprintln!("compare requires --baseline <file>");
         return ExitCode::FAILURE;
     };
+    apply_host_class_override(&flags);
+
+    let share_drift_pp = match flags.get("--share-drift-pp").map(|s| s.parse::<f64>()) {
+        Some(Ok(pp)) if pp >= 0.0 => pp,
+        Some(_) => {
+            eprintln!("--share-drift-pp requires a non-negative number");
+            return ExitCode::FAILURE;
+        }
+        None => DEFAULT_SHARE_DRIFT_PP,
+    };
 
     let baseline = match load_baseline(&baseline_path) {
         Ok(b) => b,
@@ -221,13 +327,6 @@ fn run_compare(args: &[String]) -> ExitCode {
         }
     };
 
-    // Neither metric is comparable across machine classes, so BOTH enforce only
-    // when the baseline and this runner share a runner class; on a mismatch both
-    // are advisory. `--advisory` forces advisory regardless. Committing a
-    // baseline captured under the CI runner class is what flips them to
-    // enforcing — no code change needed.
-    let current_rc = runner_class();
-    let advisory = flags.contains_key("--advisory") || baseline.runner_class != current_rc;
     let budgets = match flags.get("--budget") {
         Some(p) => budget::load_from(PathBuf::from(p).as_path()),
         None => budget::load(),
@@ -243,40 +342,60 @@ fn run_compare(args: &[String]) -> ExitCode {
     // Collect current measurements the same way capture does.
     let crit = criterion_dir(&flags);
     let mem_d = mem_dir(&flags);
-    let current_file = capture("current", &crit, &mem_d, None, String::new());
-    let current: BTreeMap<String, BaselineEntry> = current_file.entries;
+    let meta_d = meta_dir(&flags);
+    let current = capture("current", &crit, &mem_d, &meta_d, None, String::new());
 
-    let report = compare(
-        &baseline,
-        &current,
-        &budgets,
-        flags.get("--only").map(String::as_str),
-        advisory,
-    );
+    let opts = CompareOptions {
+        only: flags.get("--only").cloned(),
+        host_mismatch: if flags.contains_key("--allow-host-mismatch") {
+            HostMismatchPolicy::Advise
+        } else {
+            HostMismatchPolicy::Fatal
+        },
+        share_drift_pp,
+        force_advisory: flags.contains_key("--advisory"),
+    };
+    let report = compare(&baseline, &current, &budgets, &opts);
 
     println!(
-        "comparing against '{}' (sha={} captured={} profile={} scale={} runner_class={})",
+        "comparing against '{}' (sha={} captured={} profile={} scale={})",
         baseline.label,
         baseline.git_sha.as_deref().unwrap_or("?"),
         baseline.captured_at,
         baseline.profile,
         baseline.scale,
-        baseline.runner_class,
     );
-    println!(
-        "runner_class: baseline={} current={} → time + peak_mem {}",
-        baseline.runner_class,
-        current_rc,
-        if advisory {
-            "ADVISORY (cross-machine or overridden; not gating)"
-        } else {
-            "ENFORCED"
-        },
-    );
+    println!("  baseline host: {}", baseline.host.describe());
+    println!("  current  host: {}", current.host.describe());
+    if let Some(corpus) = &baseline.corpus {
+        println!("  baseline corpus: {}", describe_corpus(corpus));
+    }
+
+    if report.is_fatal() {
+        eprintln!("\nREFUSED to compare:");
+        for f in &report.fatal {
+            match &f.id {
+                Some(id) => eprintln!("  [{}] {id}: {}", f.kind.as_str(), f.detail),
+                None => eprintln!("  [{}] {}", f.kind.as_str(), f.detail),
+            }
+            eprintln!("      → {}", f.remedy);
+        }
+        eprintln!(
+            "\n::error::bench-baseline refused {} comparison(s); current host_class={}",
+            report.fatal.len(),
+            host_class(),
+        );
+        return ExitCode::from(EXIT_REFUSED);
+    }
+
+    match &report.advisory_reason {
+        Some(reason) => println!("\ntime + peak_mem: ADVISORY ({reason}); phase_share: ENFORCED"),
+        None => println!("\ntime + peak_mem + phase_share: ENFORCED"),
+    }
     println!();
     println!(
-        "{:<55} {:>9} {:>14} {:>14} {:>8} {:>8}",
-        "scenario [metric]", "status", "baseline", "observed", "Δ%", "budget%"
+        "{:<62} {:>9} {:>14} {:>14} {:>9} {:>8}",
+        "scenario [metric]", "status", "baseline", "observed", "Δ", "budget"
     );
     for c in &report.comparisons {
         let status = match c.status {
@@ -285,19 +404,15 @@ fn run_compare(args: &[String]) -> ExitCode {
             CompareStatus::Exceeded if c.enforced => "EXCEEDED",
             CompareStatus::Exceeded => "advisory",
         };
-        let (baseline_s, observed_s) = if c.metric == "time" {
-            (format_ns(c.baseline), format_ns(c.observed))
-        } else {
-            (format_bytes(c.baseline), format_bytes(c.observed))
-        };
+        let (baseline_s, observed_s, delta_s, budget_s) = render(c);
         println!(
-            "{:<55} {:>9} {:>14} {:>14} {:>+8.2} {:>8.1}",
-            format!("{} [{}]", c.id, c.metric),
+            "{:<62} {:>9} {:>14} {:>14} {:>9} {:>8}",
+            c.label(),
             status,
             baseline_s,
             observed_s,
-            c.change_pct,
-            c.budget_pct,
+            delta_s,
+            budget_s,
         );
     }
     if !report.missing.is_empty() {
@@ -315,19 +430,15 @@ fn run_compare(args: &[String]) -> ExitCode {
 
     let advisories: Vec<_> = report.advisories().collect();
     if !advisories.is_empty() {
-        let reason = if baseline.runner_class != current_rc {
-            format!(
-                "baseline runner_class {} != {}; commit a {}-class baseline to make these enforce",
-                baseline.runner_class, current_rc, current_rc
-            )
-        } else {
-            "--advisory was passed".to_string()
-        };
+        let reason = report
+            .advisory_reason
+            .as_deref()
+            .unwrap_or("advisory metrics");
         println!(
             "\n::warning::advisory regressions (not gating — {reason}): {}",
             advisories
                 .iter()
-                .map(|c| format!("{} [{}] {:+.1}%", c.id, c.metric, c.change_pct))
+                .map(|c| format!("{} {}", c.label(), render(c).2))
                 .collect::<Vec<_>>()
                 .join(", ")
         );
@@ -353,7 +464,33 @@ fn run_compare(args: &[String]) -> ExitCode {
             "FAIL: enforced budget exceeded for {} scenario metric(s)",
             breaches.len()
         );
-        ExitCode::FAILURE
+        ExitCode::from(EXIT_BREACH)
+    }
+}
+
+/// `(baseline, observed, delta, budget)` rendered in the metric's own units.
+/// Share rows are percentages moving in percentage points; everything else is a
+/// magnitude moving in percent.
+fn render(c: &Comparison) -> (String, String, String, String) {
+    match c.metric {
+        Metric::PeakMem => (
+            format_bytes(c.baseline),
+            format_bytes(c.observed),
+            format!("{:+.2}%", c.change_pct),
+            format!("{:.1}%", c.budget_pct),
+        ),
+        Metric::PhaseShare => (
+            format!("{:.1}%", c.baseline),
+            format!("{:.1}%", c.observed),
+            format!("{:+.1}pp", c.change_pct),
+            format!("{:.1}pp", c.budget_pct),
+        ),
+        Metric::Time | Metric::PhaseTime => (
+            format_ns(c.baseline),
+            format_ns(c.observed),
+            format!("{:+.2}%", c.change_pct),
+            format!("{:.1}%", c.budget_pct),
+        ),
     }
 }
 

--- a/fluree-bench-support/src/lib.rs
+++ b/fluree-bench-support/src/lib.rs
@@ -25,6 +25,8 @@
 //! - [`gen`] — deterministic data generators reused across benches.
 //! - [`fixtures`] — vendored / fetched fixture loaders.
 //! - [`budget`] — regression-budget loader and validator.
+//! - [`mem`], [`meta`] — per-scenario sidecars (allocation metrics; corpus
+//!   identity and phase timings) that `bench-baseline` merges into a baseline.
 //! - [`report`] — opt-in human-readable end-of-run summary tables.
 
 #![forbid(unsafe_code)]
@@ -35,6 +37,7 @@ pub mod fixtures;
 pub mod gen;
 pub mod ledger;
 pub mod mem;
+pub mod meta;
 pub mod normalize;
 pub mod report;
 pub mod runtime;

--- a/fluree-bench-support/src/meta.rs
+++ b/fluree-bench-support/src/meta.rs
@@ -139,6 +139,23 @@ impl CorpusInfo {
         self
     }
 
+    /// Reject a corpus block whose hash could not have been written by this
+    /// crate. A malformed `sha256` cannot establish identity — comparing
+    /// against it would assert "same input" on the strength of a field nothing
+    /// validated — so the caller must refuse rather than proceed.
+    pub fn validate(&self) -> Result<(), String> {
+        if !is_well_formed_sha256(&self.sha256) {
+            return Err(format!(
+                "corpus '{}' has a malformed sha256 ({:?}): expected 64 lowercase hex digits, got \
+                 {} character(s). A hash that cannot be parsed cannot establish corpus identity.",
+                self.name,
+                short_hash(&self.sha256),
+                self.sha256.chars().count(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Describe how this corpus differs from `other` in a way that makes the
     /// two measurements incomparable, or `None` when they are the same
     /// measurement. Order the checks cheapest-signal-first so the message names
@@ -344,10 +361,26 @@ fn hex_encode(bytes: &[u8]) -> String {
     out
 }
 
-/// First 12 hex chars, for report lines. Never used for comparison.
+/// First 12 characters, for report lines. Never used for comparison.
+///
+/// Slices on a CHARACTER boundary, not a byte offset. A baseline file is
+/// untrusted input, so a `sha256` field can hold anything — and this is called
+/// from the refusal path, where a panic would turn a documented exit-2 refusal
+/// into an exit-101 crash. [`CorpusInfo::validate`] rejects such a hash outright;
+/// this is the second line of defence for the report line that names it.
 pub(crate) fn short_hash(hash: &str) -> &str {
-    let end = hash.len().min(12);
-    &hash[..end]
+    match hash.char_indices().nth(12) {
+        Some((byte_idx, _)) => &hash[..byte_idx],
+        None => hash,
+    }
+}
+
+/// A SHA-256 as this crate writes it: exactly 64 lowercase ASCII hex digits.
+fn is_well_formed_sha256(hash: &str) -> bool {
+    hash.len() == 64
+        && hash
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
 #[cfg(test)]
@@ -492,6 +525,48 @@ mod tests {
         clear_sidecars(&dir);
         assert!(read_all_sidecars(&dir).is_empty());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// bplatz review item 7. `short_hash` sliced at byte 12, which panics when
+    /// byte 12 is not a UTF-8 boundary — turning a documented exit-2 refusal
+    /// into an exit-101 crash on untrusted input.
+    #[test]
+    fn short_hash_never_panics_on_multibyte_input() {
+        for s in [
+            "üüüüüüüüüüüüüüüü",
+            "日本語のハッシュ値です",
+            "",
+            "abc",
+            "🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥",
+        ] {
+            let out = short_hash(s);
+            assert!(s.starts_with(out), "{s:?} -> {out:?}");
+            assert!(out.chars().count() <= 12);
+        }
+    }
+
+    #[test]
+    fn validate_accepts_a_real_sha256() {
+        assert!(corpus().validate().is_ok());
+        assert_eq!(corpus().sha256.len(), 64);
+    }
+
+    #[test]
+    fn validate_rejects_malformed_hashes() {
+        let cases = [
+            ("", "empty"),
+            ("abc", "too short"),
+            (&"a".repeat(63), "63 chars"),
+            (&"a".repeat(65), "65 chars"),
+            (&"A".repeat(64), "uppercase"),
+            (&"g".repeat(64), "non-hex letter"),
+            (&"ü".repeat(64), "multibyte"),
+        ];
+        for (hash, why) in cases {
+            let mut c = corpus();
+            c.sha256 = hash.to_string();
+            assert!(c.validate().is_err(), "should reject {why}: {hash:?}");
+        }
     }
 
     #[test]

--- a/fluree-bench-support/src/meta.rs
+++ b/fluree-bench-support/src/meta.rs
@@ -1,0 +1,465 @@
+//! Per-scenario corpus identity and phase timings.
+//!
+//! Criterion measures one number per scenario: wall-clock. Two other facts
+//! decide whether that number *means* anything, and neither is recoverable
+//! after the fact:
+//!
+//! - **What was measured.** A conversion bench reads a corpus off disk. Compare
+//!   a run over `dblp.ttl` against a baseline captured over `dblp.nt` and the
+//!   gate reports a 40% "regression" that is really a different file. This is
+//!   the most expensive silent failure the baseline gate has, because the output
+//!   looks exactly like a real result.
+//! - **Where the time went.** A pipeline that gets 5% slower overall while its
+//!   parse share moves from 60% to 75% has a parse regression masked by a write
+//!   improvement. Absolute per-phase nanoseconds don't survive a machine change;
+//!   the *share* does, which makes share drift the one per-phase signal that
+//!   still gates across host classes.
+//!
+//! Both travel the same route as [`crate::mem`]: the bench records them into a
+//! JSON sidecar under `target/fluree-bench-meta/<bench>.json`, keyed by the same
+//! `<group>/<function>/<scale>` ID criterion uses, and `bench-baseline capture`
+//! merges them into the captured [`crate::baseline::BaselineFile`].
+//!
+//! ```no_run
+//! use fluree_bench_support::meta::{CorpusInfo, ScenarioMeta};
+//!
+//! let corpus = CorpusInfo::from_path("corpora/dblp.ttl", "turtle", "nquads", 8)?
+//!     .with_element_count(561_500_000);
+//! let meta = ScenarioMeta::new()
+//!     .with_corpus(corpus)
+//!     .with_phase_ns([("read", 1.2e9), ("parse", 8.0e9), ("write", 2.8e9)]);
+//! fluree_bench_support::meta::record_scenario("convert", "convert/ttl_to_nq/small", &meta);
+//! # Ok::<(), std::io::Error>(())
+//! ```
+//!
+//! Hashing is SHA-256 (`sha2`, already a workspace dependency). BLAKE3 would be
+//! faster, but it is not in the tree and a corpus is hashed once per capture —
+//! the strategy note's preference for "no new deps" wins over the throughput
+//! difference.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Minimum share movement, in percentage points, that the default gate treats
+/// as drift. Overridable per compare run (`--share-drift-pp`).
+pub const DEFAULT_SHARE_DRIFT_PP: f64 = 5.0;
+
+/// Identity of the input a scenario measured.
+///
+/// Every field is part of "is this the same measurement?" except
+/// `byte_len`/`element_count`, which are implied by the hash and kept for
+/// human-readable reports (throughput needs a denominator).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusInfo {
+    /// Human name — a file name, a generator spec (`bsbm:pc=1000`), whatever
+    /// identifies the input to a reader. Not part of the identity check: two
+    /// paths to identical bytes are the same corpus.
+    pub name: String,
+    /// Lowercase hex SHA-256 of the input bytes.
+    pub sha256: String,
+    pub byte_len: u64,
+    /// Triples/quads/rows in the input, when the bench knows it. `0` = unknown.
+    #[serde(default)]
+    pub element_count: u64,
+    /// Syntax read, e.g. `"turtle"`, `"ntriples"`, `"jsonld"`.
+    pub input_syntax: String,
+    /// Syntax written, e.g. `"nquads"`. `"none"` for parse-only scenarios.
+    pub output_syntax: String,
+    /// Worker threads the scenario ran with. A K=8 number is not comparable to
+    /// a K=16 baseline, so this is part of the identity.
+    pub thread_count: u32,
+}
+
+impl CorpusInfo {
+    /// Hash `bytes` and describe them as a corpus.
+    pub fn from_bytes(
+        name: impl Into<String>,
+        bytes: &[u8],
+        input_syntax: impl Into<String>,
+        output_syntax: impl Into<String>,
+        thread_count: u32,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            sha256: sha256_hex(bytes),
+            byte_len: bytes.len() as u64,
+            element_count: 0,
+            input_syntax: input_syntax.into(),
+            output_syntax: output_syntax.into(),
+            thread_count,
+        }
+    }
+
+    /// Hash a file on disk, streaming so a multi-GB corpus doesn't have to be
+    /// resident. `name` defaults to the path's file name.
+    pub fn from_path(
+        path: impl AsRef<Path>,
+        input_syntax: impl Into<String>,
+        output_syntax: impl Into<String>,
+        thread_count: u32,
+    ) -> std::io::Result<Self> {
+        use std::io::Read;
+        let path = path.as_ref();
+        let mut file = std::fs::File::open(path)?;
+        let mut hasher = Sha256::new();
+        let mut buf = vec![0u8; 1 << 20];
+        let mut byte_len = 0u64;
+        loop {
+            let n = file.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+            byte_len += n as u64;
+        }
+        Ok(Self {
+            name: path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.display().to_string()),
+            sha256: hex_encode(&hasher.finalize()),
+            byte_len,
+            element_count: 0,
+            input_syntax: input_syntax.into(),
+            output_syntax: output_syntax.into(),
+            thread_count,
+        })
+    }
+
+    pub fn with_element_count(mut self, count: u64) -> Self {
+        self.element_count = count;
+        self
+    }
+
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Describe how this corpus differs from `other` in a way that makes the
+    /// two measurements incomparable, or `None` when they are the same
+    /// measurement. Order the checks cheapest-signal-first so the message names
+    /// the *cause* a reader can act on (a syntax swap reads very differently
+    /// from a corpus refresh, even though both change the hash).
+    pub fn identity_mismatch(&self, other: &Self) -> Option<String> {
+        if self.input_syntax != other.input_syntax || self.output_syntax != other.output_syntax {
+            return Some(format!(
+                "syntax: baseline {}→{}, current {}→{}",
+                self.input_syntax, self.output_syntax, other.input_syntax, other.output_syntax
+            ));
+        }
+        if self.thread_count != other.thread_count {
+            return Some(format!(
+                "thread_count: baseline {}, current {}",
+                self.thread_count, other.thread_count
+            ));
+        }
+        if self.sha256 != other.sha256 {
+            return Some(format!(
+                "sha256: baseline {} ({}, {} bytes), current {} ({}, {} bytes)",
+                short_hash(&self.sha256),
+                self.name,
+                self.byte_len,
+                short_hash(&other.sha256),
+                other.name,
+                other.byte_len,
+            ));
+        }
+        None
+    }
+}
+
+/// One phase of a pipeline: how long it took, and what fraction of the
+/// scenario's measured phases it was.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PhaseTiming {
+    pub ns: f64,
+    /// `ns / Σns × 100`, computed once at record time by
+    /// [`ScenarioMeta::with_phase_ns`] so the share can never disagree with the
+    /// nanoseconds beside it.
+    pub share_pct: f64,
+}
+
+/// Corpus identity plus phase timings for one scenario.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ScenarioMeta {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corpus: Option<CorpusInfo>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub phases: BTreeMap<String, PhaseTiming>,
+}
+
+impl ScenarioMeta {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_corpus(mut self, corpus: CorpusInfo) -> Self {
+        self.corpus = Some(corpus);
+        self
+    }
+
+    /// Record phases from their raw nanosecond costs, deriving each share from
+    /// the total. Phases need not cover the whole scenario — shares are of the
+    /// *measured* phases, which is what makes derived-by-subtraction phases
+    /// (per the `cypher_phase_profile.rs` model) safe to include.
+    ///
+    /// A zero total leaves every share at 0.0 rather than dividing by zero.
+    pub fn with_phase_ns<I, S>(mut self, phases: I) -> Self
+    where
+        I: IntoIterator<Item = (S, f64)>,
+        S: Into<String>,
+    {
+        let collected: Vec<(String, f64)> = phases
+            .into_iter()
+            .map(|(name, ns)| (name.into(), ns))
+            .collect();
+        let total: f64 = collected.iter().map(|(_, ns)| *ns).sum();
+        self.phases = collected
+            .into_iter()
+            .map(|(name, ns)| {
+                let share_pct = if total > 0.0 { ns / total * 100.0 } else { 0.0 };
+                (name, PhaseTiming { ns, share_pct })
+            })
+            .collect();
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.corpus.is_none() && self.phases.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar IO — same shape as `crate::mem`, different directory.
+// ---------------------------------------------------------------------------
+
+/// Sidecar directory under the cargo target dir.
+pub fn sidecar_dir() -> PathBuf {
+    crate::budget::workspace_root()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("target")
+        .join("fluree-bench-meta")
+}
+
+/// Record meta for one scenario of `bench`, merging into the bench's sidecar
+/// file. `scenario_id` must match the criterion ID path —
+/// `"<group>/<function>/<scale>"` — so baseline capture can join the rows.
+///
+/// Best-effort, like [`crate::mem::record_scenario`]: a bench must not fail
+/// because a sidecar write did.
+pub fn record_scenario(bench: &str, scenario_id: &str, meta: &ScenarioMeta) {
+    let dir = sidecar_dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("  [bench-meta] create {}: {e}", dir.display());
+        return;
+    }
+    let path = dir.join(format!("{bench}.json"));
+    let mut entries = read_sidecar(&path).unwrap_or_default();
+    entries.insert(scenario_id.to_string(), meta.clone());
+    match serde_json::to_string_pretty(&entries) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(&path, json) {
+                eprintln!("  [bench-meta] write {}: {e}", path.display());
+            }
+        }
+        Err(e) => eprintln!("  [bench-meta] serialize {}: {e}", path.display()),
+    }
+}
+
+/// Read one sidecar file. Returns `None` when missing or unparsable.
+pub fn read_sidecar(path: &Path) -> Option<BTreeMap<String, ScenarioMeta>> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Read every sidecar in [`sidecar_dir`] (or the given dir), merged into a
+/// single scenario-ID → meta map. Used by `bench-baseline capture`.
+pub fn read_all_sidecars(dir: &Path) -> BTreeMap<String, ScenarioMeta> {
+    let mut merged = BTreeMap::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return merged;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            if let Some(map) = read_sidecar(&path) {
+                merged.extend(map);
+            }
+        }
+    }
+    merged
+}
+
+/// Remove all sidecars so a fresh bench run starts clean. Stale meta from an
+/// earlier run would otherwise be merged into a new baseline — and stale
+/// *corpus* meta is worse than stale timings, since it would assert the wrong
+/// input identity for a run that never read that input.
+pub fn clear_sidecars(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hashing
+// ---------------------------------------------------------------------------
+
+/// Lowercase hex SHA-256 of `bytes`.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex_encode(&hasher.finalize())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        use std::fmt::Write;
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// First 12 hex chars, for report lines. Never used for comparison.
+pub(crate) fn short_hash(hash: &str) -> &str {
+    let end = hash.len().min(12);
+    &hash[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn corpus() -> CorpusInfo {
+        CorpusInfo::from_bytes("dblp.ttl", b"<a> <b> <c> .\n", "turtle", "nquads", 8)
+    }
+
+    #[test]
+    fn sha256_matches_known_vector() {
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn from_path_matches_from_bytes() {
+        let dir = std::env::temp_dir().join(format!(
+            "fluree-bench-meta-hash-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("corpus.ttl");
+        let bytes = b"<a> <b> <c> .\n".repeat(100_000);
+        std::fs::write(&path, &bytes).unwrap();
+
+        let from_path = CorpusInfo::from_path(&path, "turtle", "nquads", 8).unwrap();
+        let from_bytes = CorpusInfo::from_bytes("corpus.ttl", &bytes, "turtle", "nquads", 8);
+        // Streams across many 1MiB reads — the chunk boundary must not change
+        // the digest.
+        assert!(from_path.byte_len > (1 << 20));
+        assert_eq!(from_path, from_bytes);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn identical_corpora_do_not_mismatch() {
+        assert!(corpus().identity_mismatch(&corpus()).is_none());
+    }
+
+    #[test]
+    fn differing_bytes_mismatch_on_hash() {
+        let other = CorpusInfo::from_bytes("dblp.ttl", b"<a> <b> <d> .\n", "turtle", "nquads", 8);
+        let msg = corpus().identity_mismatch(&other).unwrap();
+        assert!(msg.starts_with("sha256:"), "{msg}");
+    }
+
+    #[test]
+    fn differing_syntax_mismatches_before_hash() {
+        let mut other = corpus();
+        other.input_syntax = "ntriples".into();
+        let msg = corpus().identity_mismatch(&other).unwrap();
+        assert!(msg.starts_with("syntax:"), "{msg}");
+    }
+
+    #[test]
+    fn differing_thread_count_mismatches() {
+        let mut other = corpus();
+        other.thread_count = 16;
+        let msg = corpus().identity_mismatch(&other).unwrap();
+        assert!(msg.starts_with("thread_count:"), "{msg}");
+    }
+
+    #[test]
+    fn name_and_element_count_are_not_identity() {
+        let other = corpus().with_name("renamed.ttl").with_element_count(1);
+        assert!(corpus().identity_mismatch(&other).is_none());
+    }
+
+    #[test]
+    fn shares_are_derived_from_ns_and_sum_to_100() {
+        let meta = ScenarioMeta::new().with_phase_ns([("read", 1.0e9), ("parse", 3.0e9)]);
+        assert_eq!(meta.phases["read"].share_pct, 25.0);
+        assert_eq!(meta.phases["parse"].share_pct, 75.0);
+        let total: f64 = meta.phases.values().map(|p| p.share_pct).sum();
+        assert!((total - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn zero_total_phases_do_not_divide_by_zero() {
+        let meta = ScenarioMeta::new().with_phase_ns([("read", 0.0), ("parse", 0.0)]);
+        assert!(meta.phases.values().all(|p| p.share_pct == 0.0));
+    }
+
+    #[test]
+    fn sidecar_round_trip() {
+        let dir = std::env::temp_dir().join(format!(
+            "fluree-bench-meta-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("convert.json");
+
+        let mut entries: BTreeMap<String, ScenarioMeta> = BTreeMap::new();
+        entries.insert(
+            "convert/ttl_to_nq/small".into(),
+            ScenarioMeta::new()
+                .with_corpus(corpus())
+                .with_phase_ns([("parse", 2.0e9)]),
+        );
+        std::fs::write(&path, serde_json::to_string(&entries).unwrap()).unwrap();
+
+        let read = read_sidecar(&path).unwrap();
+        assert_eq!(
+            read["convert/ttl_to_nq/small"].corpus.as_ref().unwrap(),
+            &corpus()
+        );
+        assert_eq!(read_all_sidecars(&dir).len(), 1);
+
+        clear_sidecars(&dir);
+        assert!(read_all_sidecars(&dir).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn empty_meta_serializes_without_null_fields() {
+        let json = serde_json::to_string(&ScenarioMeta::new()).unwrap();
+        assert_eq!(json, "{}");
+    }
+}

--- a/fluree-bench-support/src/meta.rs
+++ b/fluree-bench-support/src/meta.rs
@@ -177,9 +177,15 @@ impl CorpusInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct PhaseTiming {
     pub ns: f64,
-    /// `ns / Σns × 100`, computed once at record time by
-    /// [`ScenarioMeta::with_phase_ns`] so the share can never disagree with the
-    /// nanoseconds beside it.
+    /// `ns / Σns × 100` across the scenario's measured phases.
+    ///
+    /// [`ScenarioMeta::with_phase_ns`] computes this from the nanoseconds, so
+    /// anything built through that constructor is self-consistent. That is a
+    /// property of the constructor, **not an invariant of the type**: both
+    /// fields are public, and a `PhaseTiming` deserialized from a baseline file
+    /// is untrusted input that can say whatever the file says. `compare`
+    /// therefore reports a scenario whose shares don't sum to 100% instead of
+    /// assuming they do.
     pub share_pct: f64,
 }
 
@@ -207,24 +213,32 @@ impl ScenarioMeta {
     /// *measured* phases, which is what makes derived-by-subtraction phases
     /// (per the `cypher_phase_profile.rs` model) safe to include.
     ///
+    /// **Merges** into any phases already recorded, and recomputes every share
+    /// over the combined total, so a bench that reports its phases in more than
+    /// one call still ends up with one consistent set. A repeated phase name
+    /// overwrites its previous nanoseconds. Replacing instead of merging would
+    /// silently discard the earlier call's phases while leaving the shares
+    /// looking perfectly well-formed — the failure would be invisible in the
+    /// output.
+    ///
     /// A zero total leaves every share at 0.0 rather than dividing by zero.
     pub fn with_phase_ns<I, S>(mut self, phases: I) -> Self
     where
         I: IntoIterator<Item = (S, f64)>,
         S: Into<String>,
     {
-        let collected: Vec<(String, f64)> = phases
-            .into_iter()
-            .map(|(name, ns)| (name.into(), ns))
-            .collect();
-        let total: f64 = collected.iter().map(|(_, ns)| *ns).sum();
-        self.phases = collected
-            .into_iter()
-            .map(|(name, ns)| {
-                let share_pct = if total > 0.0 { ns / total * 100.0 } else { 0.0 };
-                (name, PhaseTiming { ns, share_pct })
-            })
-            .collect();
+        for (name, ns) in phases {
+            self.phases
+                .insert(name.into(), PhaseTiming { ns, share_pct: 0.0 });
+        }
+        let total: f64 = self.phases.values().map(|p| p.ns).sum();
+        for timing in self.phases.values_mut() {
+            timing.share_pct = if total > 0.0 {
+                timing.ns / total * 100.0
+            } else {
+                0.0
+            };
+        }
         self
     }
 
@@ -418,6 +432,29 @@ mod tests {
         assert_eq!(meta.phases["parse"].share_pct, 75.0);
         let total: f64 = meta.phases.values().map(|p| p.share_pct).sum();
         assert!((total - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn with_phase_ns_merges_and_recomputes_shares_over_the_union() {
+        // A bench that reports phases in two calls must end up with one
+        // consistent set. Replacing would drop `read` while leaving the
+        // remaining shares looking perfectly well-formed — invisible in output.
+        let meta = ScenarioMeta::new()
+            .with_phase_ns([("read", 1.0e9)])
+            .with_phase_ns([("parse", 3.0e9)]);
+        assert_eq!(meta.phases.len(), 2);
+        assert_eq!(meta.phases["read"].share_pct, 25.0);
+        assert_eq!(meta.phases["parse"].share_pct, 75.0);
+    }
+
+    #[test]
+    fn with_phase_ns_overwrites_a_repeated_phase_name() {
+        let meta = ScenarioMeta::new()
+            .with_phase_ns([("parse", 1.0e9), ("write", 1.0e9)])
+            .with_phase_ns([("parse", 3.0e9)]);
+        assert_eq!(meta.phases["parse"].ns, 3.0e9);
+        assert_eq!(meta.phases["parse"].share_pct, 75.0);
+        assert_eq!(meta.phases["write"].share_pct, 25.0);
     }
 
     #[test]

--- a/fluree-bench-support/src/runtime.rs
+++ b/fluree-bench-support/src/runtime.rs
@@ -5,15 +5,20 @@
 //!
 //! | Env var | Type | Default | Effect |
 //! |---|---|---|---|
-//! | `FLUREE_BENCH_PROFILE` | `Quick` \| `Full` | `Quick` (local), `Full` (CI) | sample-count + warmup discipline |
+//! | `FLUREE_BENCH_PROFILE` | `Quick` \| `Full` | `Quick` | sample-count + warmup discipline |
 //! | `FLUREE_BENCH_SCALE` | `Tiny` \| `Small` \| `Medium` \| `Large` | `Small` | per-bench input size |
 //!
 //! ## Profile semantics
 //!
 //! - **`Quick`** — fewer samples, no warmup, target wall-time ≤ 2s per bench.
-//!   Used by `cargo bench` on a developer's machine and by the PR-gated CI job.
 //! - **`Full`** — full criterion sample counts, full warmup, multi-size matrix.
-//!   Used by the nightly job in `bench-nightly`.
+//!
+//! No job in CI runs `Full` today: both `ci.yml`'s `bench-compare` and
+//! `bench.yml`'s nightly `bench-gate` pin `FLUREE_BENCH_PROFILE=quick` and
+//! `FLUREE_BENCH_SCALE=tiny` to stay inside their wall-clock budgets. `Full` is
+//! a local knob for widening a distribution when a bench looks flaky. Run-to-run
+//! spread is measured separately, by accumulating repeat captures into a
+//! median + MAD (see [`crate::baseline::NoiseStats`]).
 //!
 //! Benches read the profile via [`current_profile()`] and choose
 //! `group.sample_size(...)` accordingly. The chassis does **not** override
@@ -41,21 +46,18 @@ use std::sync::OnceLock;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BenchProfile {
     /// Few samples, no warmup, target wall-time ≤ 2s per bench. Local
-    /// development and PR-gated CI.
+    /// development and every CI job, nightly included.
     Quick,
-    /// Full criterion sample counts, full warmup. Nightly CI.
+    /// Full criterion sample counts, full warmup. Local use only today.
     Full,
 }
 
 impl BenchProfile {
     /// Suggested criterion `sample_size`. Benches may override.
     ///
-    /// `Quick` (PR-gated) keeps the sample tight (10) so the gate stays
-    /// under its wall-clock budget; `Full` uses criterion's default
-    /// (100) for a wider distribution suitable for the nightly. Both
-    /// are starting points — once `bench-nightly` lands and we have
-    /// flap data from real CI runs, we may need to bump `Full` higher
-    /// (200+) to bring noise within the regression-budget thresholds.
+    /// `Quick` — what every CI job runs — keeps the sample tight (10) so the
+    /// gate stays under its wall-clock budget; `Full` uses criterion's default
+    /// (100) for a wider distribution. Both are starting points.
     pub fn sample_size(self) -> usize {
         match self {
             BenchProfile::Quick => 10,


### PR DESCRIPTION
# PR-bench: baseline extensions (host class, corpus identity, phase shares, noise floor)

> Builds on the `BaselineFile` introduced by **#1477**, which has now merged —
> this branch is rebased onto `06f1c10cf` (#1477's merge-reconcile head), which is
> in `main`'s history, so it merges cleanly with no rebase outstanding.
>
> The last commit is a **disclosed rider**, deliberately separable: a one-line
> `Cargo.lock` refresh (`fluree-bench-virtual` 4.1.3 → 4.1.4). That entry was
> stale on `main` itself — any plain `cargo build` on a main-derived branch
> rewrites it — and building this branch is what surfaced it. Drop or cherry-pick
> it independently; it carries no dependency-resolution change.

## Why

#1477 gave the workspace a real baseline capture/compare tool. This PR closes the
four gaps between that tool and what the `fluree rdf` conversion effort needs from
it (`riot-analog-bench-strategy.md` §6b, F5/F6), and corrects a doc that had
drifted from the workflows it describes.

The gaps share a theme: **a compare run that emits a number which looks like a
result and is not one.** Today the tool will happily compare a laptop against a CI
runner, a Turtle corpus against an N-Triples one, or a single flaky sample against
another, and print a tidy Δ% table either way.

## What changed

### 1. Host block, and a refusal instead of a silent downgrade

`runner_class` becomes `host.class` inside a block that also records os, arch,
cpu model, and physical/logical cores (probed via `sysctl` on Darwin,
`/proc/cpuinfo` on Linux, falling back to `available_parallelism`).

A class names a **comparability set**, not a machine — two hosts share one when a
human has decided their absolute numbers may be compared. A mismatch is now a
**refusal (exit 2)**, not a quiet flip to advisory. `--allow-host-mismatch` opts
back into the advisory posture.

The derived default is `{os}-{arch}`, and the docs say plainly that it is coarse
and not a promise: an M1 and an M4 both derive `macos-aarch64`. Any host whose
numbers are meant to gate should set `FLUREE_BENCH_HOST_CLASS` explicitly.
`FLUREE_BENCH_RUNNER_CLASS` is still read as the pre-rename spelling, so no
existing workflow breaks.

### 2. Corpus identity — the expensive silent failure

A new `meta` sidecar (`target/fluree-bench-meta/`, same shape as #1477's `mem`
sidecar) carries per scenario: `sha256`, `byte_len`, `element_count`,
`input_syntax`, `output_syntax`, `thread_count`. Declarable per entry, or once at
file level and inherited.

A mismatch in hash, syntax, or thread count is a **refusal with no override**.
Unlike the host check there is no posture in which comparing different inputs is
meaningful, and the resulting table is indistinguishable from a real regression.
`name` and `element_count` are deliberately *not* part of the identity — two paths
to identical bytes are the same corpus.

**SHA-256, not BLAKE3.** blake3 is not in the workspace; `sha2` already is. A
corpus is hashed once per capture (streamed in 1 MiB chunks), so the throughput
difference does not pay for a new dependency. **No new workspace dependencies.**

> **Nothing produces phases or corpus blocks yet.** `meta.rs` is Tier-1
> scaffolding for the conversion lane: schema, recorder, and gate are in place,
> but no bench in the workspace calls `meta::record_scenario`, so no phase or
> corpus row appears in any report this PR produces. The share gate and the
> corpus refusal go live with the first producer. That is deliberate — the gate
> has to exist before the benches that depend on it, and it ships with full test
> coverage rather than waiting.

### 3. Per-phase timings and share drift

Per-entry `{phase: {ns, share_pct}}`, with the share derived from the ns at record
time (`ScenarioMeta::with_phase_ns`) so the two can never disagree.

- **Absolute `phase_time`** gates only within a host class, like `time` and
  `peak_mem`.
- **`phase_share` gates regardless of host class.** A share is a ratio within one
  run, so the machine cancels. This is the only signal a cross-host comparison
  keeps, and it is the one that catches a regression an aggregate number hides.

Only share *growth* gates. Shares sum to 100, so gating both directions would fail
a clean improvement twice — once for the phase that got better, once for its
complement. Shrink is reported as `improved` so the whole picture stays visible.

**One-sided phases are gated on share alone.** Comparing only same-named phases
is itself a hiding place: move work into a phase the baseline never had and the
old phase's share falls — reading as an improvement — while the new phase
carrying the cost produces no row. So a phase new in the current run breaches
when it claims more than the drift threshold, and a phase that has vanished
breaches when it *used to*. Rows are marked `(NEW)` / `(VANISHED)`.

Here is the case that motivates the whole feature, from the end-to-end smoke run —
whole-scenario time is inside its noise floor and clean, while the phase breakdown
localizes a 28% parse regression masked by a write improvement:

```
scenario [metric]                                    status     baseline     observed        Δ   budget
convert/ttl_to_nq/small [time]                           ok     1.000 ms     1.025 ms   +2.50%     3.0%
convert/ttl_to_nq/small::parse [phase_time]        EXCEEDED   600.000 µs   768.750 µs  +28.12%     3.0%
convert/ttl_to_nq/small::parse [phase_share]       EXCEEDED        60.0%        75.0%  +15.0pp    5.0pp
convert/ttl_to_nq/small::read  [phase_time]              ok   100.000 µs   102.500 µs   +2.50%     3.0%
convert/ttl_to_nq/small::read  [phase_share]             ok        10.0%        10.0%   +0.0pp    5.0pp
convert/ttl_to_nq/small::write [phase_time]        improved   300.000 µs   153.750 µs  -48.75%     3.0%
convert/ttl_to_nq/small::write [phase_share]       improved        30.0%        15.0%  -15.0pp    5.0pp
```

### 4. Noise floor

`capture --accumulate` folds repeat runs into one file: each pass appends the fresh
criterion mean to a per-scenario sample vector and recomputes median + MAD. At
n ≥ 5 the gate compares **medians** instead of single-run means, and widens the
wall-clock budget to `max(budget_pct, 3 × MAD / median)`.

Criterion's own confidence interval describes iterations *within* one run and says
nothing about run-to-run spread — which is exactly what shared-runner flap is. MAD
rather than standard deviation because one outlier run is the common failure here
and barely moves MAD.

Three bounds, each of which inverts the gate if dropped: the floor **only widens**
(a tighter-than-noise budget can only false-alarm); it is **wall-clock only**,
never touching `peak_mem` (an allocator peak is near-deterministic, so a noisy
clock is no reason to forgive an allocation regression); and it is **baseline
only** (otherwise the worse a run behaves, the more it is forgiven).

`accumulate` itself refuses to pool samples across host classes or corpora, and
both guards live in the library rather than the CLI. Accumulation is the one
operation that *destroys* the evidence of a mismatch — two populations blended
into one median/MAD, with the provenance overwritten in the same breath — so a
direct caller must not be able to skip the check.

### 5. BENCHMARKING.md corrections

Every claim checked against the merged main + #1477 tree. Five were wrong:

| Claim | Reality |
|---|---|
| `.github/workflows/bench-nightly.yml` (in "Where benches live") | Never existed; the file is `bench.yml` |
| "lands in bench-5" / "lands in bench-nightly PR" | Both landed |
| Bench table lists 12 benches | 18 `[[bench]]` entries are registered — six missing |
| `BenchProfile::Full` = "Nightly CI" (`runtime.rs`) | Every CI job pins `quick`/`tiny`, nightly included |
| `bench-baselines/README.md`: "enforces memory across any runner class, time advisory" | False since 5d9d69513 made the gate symmetric — stale on #1477's own branch |

Note on the "runs on every PR" and "dedicated 4-core runners" claims from the
original brief: **#1477 already removed both** in its rewrite of the CI-gate
section. They are gone from the merged result; nothing to do.

The six missing bench rows are `query_overlay_matrix`, `query_hot_bsbm_bi`,
`query_hot_property_path`, `query_hot_whole_graph_agg`, `annotation_hydration`,
`annotation_planner` (five are missing on main; #1477 adds the first). Each row is
written from the bench's own module docs. The table now also states outright that
nothing enforces it — unlike the `[[bench]]` ↔ budget reconcile — which is why it
rots.

## Sample baseline (schema 2)

```json
{
  "schema_version": 2,
  "label": "convert-pre",
  "git_sha": "c7d82614d",
  "captured_at": "2026-07-28T23:54:15Z",
  "profile": "quick",
  "scale": "small",
  "host": {
    "class": "bench-m8gd",
    "name": "ip-10-0-3-7",
    "os": "linux",
    "arch": "x86_64",
    "cpu_model": "AMD EPYC 9R14",
    "physical_cores": 16,
    "logical_cores": 32
  },
  "entries": {
    "convert/ttl_to_nq/small": {
      "mean_ns": 990000.0,
      "median_ns": 990000.0,
      "mem": { "peak_bytes": 24117248, "total_allocated_bytes": 310378496 },
      "noise": {
        "n": 5,
        "median_ns": 1000000.0,
        "mad_ns": 10000.0,
        "samples_ns": [980000.0, 990000.0, 1000000.0, 1010000.0, 1020000.0]
      },
      "corpus": {
        "name": "dblp.ttl",
        "sha256": "aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa7777bbbb8888",
        "byte_len": 1048576,
        "element_count": 40000,
        "input_syntax": "turtle",
        "output_syntax": "nquads",
        "thread_count": 8
      },
      "phases": {
        "read":  { "ns": 100000.0, "share_pct": 10.0 },
        "parse": { "ns": 600000.0, "share_pct": 60.0 },
        "write": { "ns": 300000.0, "share_pct": 30.0 }
      }
    }
  }
}
```

Every added block is optional. A schema-1 file still loads: `runner_class` maps to
`host.class`, a bare `host` string maps to `host.name`, and missing
`noise`/`corpus`/`phases` simply switch off their respective rules. The committed
`bench-baselines/guardrails-pre.json` is **unmodified** and still compares. A
baseline claiming a *newer* schema version is a refusal — silently ignoring fields
we don't understand is how a gate stops gating.

## Gating semantics, complete

| metric | units | noise floor applies | enforced within host class | enforced across host classes |
|---|---|---|---|---|
| `time` | ns | yes | yes | no (advisory) |
| `peak_mem` | bytes | **no** | yes | no (advisory) |
| `phase_time` | ns | yes | yes | no (advisory) |
| `phase_share` | percentage points | no | yes | **yes** |

The noise floor is wall-clock-only and baseline-only. It never touches
`peak_mem` — an allocator peak is near-deterministic, so a noisy clock is no
reason to forgive an allocation regression — and the current run's own spread
never widens its own budget, or the worse a run behaves the more it is forgiven.

Phase rows also carry a presence marker. A phase present on both sides compares
normally; one new in the current run breaches when its share exceeds the drift
threshold (`(NEW)`); one that has vanished breaches when it *used to*
(`(VANISHED)`). Neither one-sided case emits a `phase_time` row.

| condition | outcome | exit |
|---|---|---|
| within budget | pass | 0 |
| enforced breach | fail | 1 |
| host class differs, no `--allow-host-mismatch` | refuse | 2 |
| corpus sha256 / syntax / thread count differs | refuse | 2 |
| baseline `schema_version` newer than the binary | refuse | 2 |

## CI impact: none, by construction

The per-PR `bench-compare` and nightly `bench-gate` compare a `host_class=local`
baseline on `ci-ubuntu-latest`, which the new default would refuse. Both steps now
pass `--allow-host-mismatch` explicitly, reproducing #1477's exact behaviour
(annotations, exit 0). The change is that the downgrade is written down, with a
comment naming the condition for removing the flag.

`bench-capture` gains a `capture_samples` dispatch input (default `1`, unchanged
behaviour). At `≥ 5` it reruns the subset and accumulates, producing the median +
MAD a baseline needs before it can gate through runner flap.

## Files

| File | What |
|---|---|
| `fluree-bench-support/src/meta.rs` | **new** — `CorpusInfo`, `PhaseTiming`, `ScenarioMeta`, sidecar IO, SHA-256 |
| `fluree-bench-support/src/baseline.rs` | `HostBlock`, `NoiseStats`, `CompareOptions`, `FatalMismatch`, `Metric`, refusal + share + noise gating, schema-1 read path |
| `fluree-bench-support/src/bin/bench_baseline.rs` | `--host-class`, `--allow-host-mismatch`, `--share-drift-pp`, `--accumulate`, `--clean-sidecars`; exit code 2; per-metric rendering |
| `fluree-bench-support/src/runtime.rs` | corrected profile docs (`Full` is not the CI profile) |
| `fluree-bench-support/src/lib.rs`, `Cargo.toml` | `meta` module; `sha2` (existing workspace dep) |
| `.github/workflows/{ci,bench}.yml` | explicit `--allow-host-mismatch`; `capture_samples`; clear the meta sidecar dir |
| `BENCHMARKING.md`, `bench-baselines/README.md`, `fluree-bench-support/README.md` | corrections + new semantics |

## Verification

```
cargo nextest run -p fluree-bench-support                    122 passed, 0 skipped
cargo test -p fluree-bench-support --test workspace_reconcile  1 passed
cargo clippy -p fluree-bench-support --all-targets --no-deps   clean, 0 warnings
cargo fmt --check                                              clean
```

**57 of the 121 lib tests are new** (measured against this branch's base at
`06f1c10cf`, which has 64). Every gating rule has one: host mismatch fatal /
allowed / matched / forced-advisory, corpus mismatch by hash, by syntax, by thread
count, file-level vs entry-level precedence, one-sided declaration, share growth /
shrink / within-threshold / configurable-threshold / cross-host enforcement, MAD
arithmetic, floor widening, floor not tightening, floor not hiding a real move,
sub-threshold sample counts, accumulate arithmetic, and the schema-1 read path
including the exact shape of the committed `guardrails-pre.json`.

Also exercised end-to-end against the real binary: the committed schema-1 baseline
(refusal, then advisory under the flag), a captured schema-2 baseline accumulated
to n=5, a share-drift breach under a passing aggregate, a corpus swap, and
cross-host share enforcement.

## Deviations from the §6b spec

1. **SHA-256 instead of BLAKE3** — blake3 is not in the tree; `sha2` is. The spec
   permits this ("prefer no new deps").
2. **Share drift gates growth only, not absolute movement.** Gating `|Δ|` would
   double-flag every real improvement, since shares sum to 100. Both directions are
   still reported.
3. **`--allow-host-mismatch` exists at all.** The spec says compare hard-errors on
   host mismatch; making that unconditional would red every PR today, since the
   only committed baseline is cross-class. The refusal is the default and the
   escape hatch is explicit, per-invocation, and documented — strictly louder than
   #1477's silent downgrade.
4. **`thread_count` is part of corpus identity**, though the spec listed it as a
   recorded field. A K=8 run compared against a K=16 baseline is the same class of
   silent failure as a corpus swap. Its refusal message is distinct so a reader can
   tell a config mismatch from a data mismatch.

## Open questions

1. **Should `guardrails-pre.json` be re-stamped to a specific host class?** It was
   captured on Apple silicon but records `host_class=local`. Re-stamping it
   `macos-aarch64` would make a Mac dev's local compare *enforce* — but would also
   assert that any two Macs are comparable, which is false. Left as `local`
   deliberately; it is the honest value.
2. **What `host_class` string does the official publication locus use?** H-10
   approved `m8gd.4xlarge`; the strategy's F7 wants publication tooling to refuse
   non-official classes. This PR provides the field; the allowlist is not
   implemented and needs the canonical string.
3. **Where should milestone convert baselines live** — `bench-baselines/convert/`
   per §6b, with rolling per-change baselines gitignored? Not created here (no
   convert benches exist yet).
