### PR TITLE
fix(import): document-scoped blank node identity, and skolem ids SPARQL can write

### DIFF
--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -32,6 +32,7 @@ fluree create <LEDGER> [OPTIONS]
 
 - `--memory-budget-mb <MB>` — Memory budget in MB (0 = auto: 60% of system RAM). Drives chunk size, concurrency, and indexer run budget. Set this to cap how much memory the import uses; auto-detected thread count shrinks to fit it.
 - `--parallelism <N>` — Number of parallel parse threads (0 = auto: most logical cores, capped to fit the memory budget; explicit values honored as-is, floored at 1).
+- `--skolem-namespace <id>` — Namespace salting the blank-node ids this import mints (default: the ledger id). See [Blank nodes](#blank-nodes).
 
 ## Description
 
@@ -40,6 +41,63 @@ Creates a new empty ledger with the given name and sets it as the active ledger.
 Use `--from` to create a ledger pre-populated with data from a Turtle, N-Triples, N-Quads, TriG, or JSON-LD file (or a directory of same-format files). Any input may be gzip- or zstd-compressed and is decoded transparently (`data.ttl.gz`, `dump.nq.zst`, mixed directories — the underlying RDF extension classifies the file). N-Triples (`.nt`) is a strict subset of Turtle and is parsed by the same parser. N-Quads (`.nq`) and TriG (`.trig`) support named graphs — queryable after import via the `#<graph-iri>` fragment. For large Turtle/N-Triples files (including `.ttl.gz`/`.nt.gz`), the CLI splits work into chunks and runs parallel parse threads — though compressed inputs decode single-threaded; TriG/N-Quads/JSON-LD use a serial path. Tune with `--memory-budget-mb` and `--parallelism` if needed.
 
 **Directory imports (`.ttl`/`.nt`)** are *rechunked by bytes* rather than one-chunk-per-file: large files are sub-split at statement boundaries and many small files are coalesced into `~chunk_size` work items. This keeps the import fully parallel and bounds the number of commits and sorted index runs regardless of how the data is packaged — so a directory of one big file, or of hundreds of tiny shards, both import at full speed. Coalescing engages automatically once a directory holds more than 64 sub-`chunk_size` files; a file containing a labeled blank node (`_:`) or an `@base` directive is never coalesced (it would change RDF document scope) and is imported as its own chunk. Set `FLUREE_IMPORT_COALESCE_THRESHOLD=<n>` to change the gate (`0` disables coalescing — every file becomes its own commit, the legacy behavior). Directories containing any `.trig`/`.nq`/`.jsonld` continue to use the per-file serial path.
+
+### Blank nodes
+
+Import skolemizes every blank node in its source into the reserved `_:fdb-…`
+label space, and queries return those labels as the node's `@id`. The minted id
+is `_:fdb-d<scope>-<label>`, where `<label>` is the label as written in the
+source and `<scope>` identifies the **document** it came from. Only `[0-9a-z-]`
+appears in it, so the id can be written back in SPARQL, Turtle, or JSON-LD to
+edit the node in place — see
+[Editing blank-node structures](../transactions/update-where-delete-insert.md#editing-blank-node-structures-stable-_fdb--ids).
+
+A label unifies across its whole document and stays distinct between documents,
+so `_:x` in two files is two nodes no matter how the importer chunks them. What
+counts as a document:
+
+| source | document |
+|---|---|
+| `.ttl`/`.nt`/`.trig`/`.nq`/`.jsonld` | one file |
+| `.jsonl`/`.ndjson` | one **context segment** (see below) |
+
+The scope is derived from the document's path relative to the import root, so
+importing the same tree from `/tmp/x` and from `/data/x` mints the same ids, and
+adding a file to the directory does not renumber anything.
+
+**ndjson context segments.** A lone `{"@context": …}` line replaces the shared
+context for the lines that follow, which is what makes `cat a.jsonl b.jsonl >
+combined.jsonl` work. Each such switch ends one document and starts the next, so
+`a.jsonl`'s `_:x` and `b.jsonl`'s `_:x` stay distinct through the seam. Within a
+segment a label unifies across every chunk.
+
+> **Caveat.** If you write ndjson in the "every line is an independent document"
+> style — an inline `@context` on *every* line — Fluree treats those lines as
+> ordinary nodes in one `@graph`, which is one document. A `_:x` reused across
+> such lines therefore resolves to **one** node. That is correct JSON-LD (node
+> objects carrying local contexts inside a shared graph are co-document), but it
+> is not what the NDJSON-of-independent-documents convention would suggest. Use
+> a lone context line to separate them, or give the nodes real `@id`s.
+
+**Cross-ledger identity.** The ledger id salts the mint, so importing one source
+tree into two ledgers gives them disjoint blank nodes. Pass the same
+`--skolem-namespace <id>` to both to make them mint *identical* ids instead —
+for a rebuild-and-diff, a sharded load of one logical dataset, or a
+staging/production pair you want to compare node for node.
+
+**Tracing an id back to its file.** Each source document contributes one triple
+to the ledger's `txn-meta` graph:
+
+```sparql
+SELECT ?source WHERE {
+  GRAPH <urn:fluree:mydb:main#txn-meta> {
+    _:fdb-d1t3k9x0abcdef <https://ns.flur.ee/db#importSource> ?source
+  }
+}
+```
+
+The subject is the first 19 characters of the id (`_:fdb-` plus the 14-character
+scope).
 
 ### Property-graph imports (CSV & Cypher)
 

--- a/docs/transactions/update-where-delete-insert.md
+++ b/docs/transactions/update-where-delete-insert.md
@@ -638,7 +638,10 @@ Notes:
   `--skolem-namespace` on `fluree create --from` controls the other half of
   the id: by default the ledger id salts the mint, so two ledgers loaded from
   one source tree hold different blank nodes; passing the same namespace to
-  both makes them mint identical ids instead.
+  both makes them mint identical ids instead. See
+  [Blank nodes](../cli/create.md#blank-nodes) for what counts as a document —
+  in particular for `.jsonl`/`.ndjson`, where a `@context` switch ends one
+  document and starts the next.
 
 ## Error Handling
 

--- a/docs/transactions/update-where-delete-insert.md
+++ b/docs/transactions/update-where-delete-insert.md
@@ -610,10 +610,35 @@ Notes:
   treats WHERE-pattern labels as variables; accepting `_:fdb-` ids as
   constants is a deliberate Fluree extension (the same one Virtuoso's
   `nodeID://` refs and Jena's `<_:label>` syntax provide).
-- Some stable ids minted by bulk import embed `:` characters (e.g.
-  `_:fdb-lubm:main-1-genid10`). These are addressable from JSON-LD, but the
-  SPARQL grammar does not allow `:` inside blank-node labels, so such ids
-  cannot be written in SPARQL syntax.
+- Bulk import mints the same way, into the same reserved space, with the same
+  editability. Its ids carry a document scope — `_:fdb-d<14 chars>-<label>`,
+  where the scope identifies the source file and `<label>` is the label as
+  written in it (`_:fdb-d1t3k9x0abcdef-genid10`). They are `[0-9a-z-]` only,
+  so they are writable in SPARQL, Turtle and JSON-LD without escaping.
+- Ledgers imported by Fluree **4.1.4 or earlier** hold the older import format, which
+  embedded the ledger id and therefore `:` and `/` (`_:fdb-lubm:main-1-genid10`).
+  Those ids are still addressable from JSON-LD, but the SPARQL grammar does
+  not allow `:` inside a blank-node label, so they cannot be written in SPARQL
+  syntax. Re-importing the source produces ids in the current format. There is
+  no mixed-format ledger: import requires a fresh ledger, so a ledger's import
+  ids are all of one format.
+- To find out which document an import id came from, look it up in the
+  ledger's `txn-meta` graph. Each source document contributes one triple whose
+  subject is its scope — the first 19 characters of the id, `_:fdb-` plus the
+  14-character scope:
+
+  ```sparql
+  SELECT ?source WHERE {
+    GRAPH <urn:fluree:my/ledger:main#txn-meta> {
+      _:fdb-d1t3k9x0abcdef <https://ns.flur.ee/db#importSource> ?source
+    }
+  }
+  ```
+
+  `--skolem-namespace` on `fluree create --from` controls the other half of
+  the id: by default the ledger id salts the mint, so two ledgers loaded from
+  one source tree hold different blank nodes; passing the same namespace to
+  both makes them mint identical ids instead.
 
 ## Error Handling
 

--- a/fluree-db-api/src/export.rs
+++ b/fluree-db-api/src/export.rs
@@ -489,6 +489,18 @@ pub fn write_turtle_iri<W: Write>(w: &mut W, iri: &str, prefixes: &PrefixMap) ->
 }
 
 /// Write a subject term as Turtle (prefixed name, `<iri>`, or `_:bnode`).
+///
+/// Blank-node labels are written verbatim, deliberately: an export has to
+/// round-trip, and rewriting a label to fit the Turtle grammar would merge two
+/// distinct nodes onto one id (contrast `crate::validate`, whose report output
+/// sanitizes because it does not round-trip).
+///
+/// Current blank-node ids are all writable as-is: import mints `[0-9a-z-]`
+/// (see `fluree_db_core::skolem`), staged transactions mint hex, `BNODE()`
+/// mints a UUID. Ledgers imported by Fluree 4.1.4 or earlier hold ids that
+/// embedded the ledger id, so they contain `/` and `:` and an export of such a
+/// ledger emits Turtle that strict parsers reject — the identity is preserved,
+/// the syntax is not. Re-importing the source fixes it.
 fn write_turtle_iri_or_bnode<W: Write>(
     w: &mut W,
     iri: &str,

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -809,10 +809,14 @@ type RemoteChunk = (usize, DocChunk, Vec<u8>);
 ///
 #[derive(Debug)]
 pub(crate) struct DocIds {
+    /// Salt for every id in this import — the normalized ledger id unless the
+    /// caller overrode it. Retained because the ndjson arm discovers extra
+    /// documents (context segments) mid-read, after this table is built.
+    namespace: String,
     /// Document keys in source order — paths relative to the import root, or
     /// remote addresses relative to the listing prefix.
     keys: Vec<String>,
-    /// `skolem::doc_id` of each key, same order.
+    /// `skolem::doc_id` of each key at segment 0, same order.
     ids: Vec<u64>,
 }
 
@@ -831,7 +835,7 @@ impl DocIds {
         let mut ids = Vec::with_capacity(keys.len());
         let mut seen: HashMap<u64, usize> = HashMap::with_capacity(keys.len());
         for (idx, key) in keys.iter().enumerate() {
-            let id = fluree_db_core::skolem::doc_id(namespace, key);
+            let id = fluree_db_core::skolem::doc_id(namespace, key, 0);
             if let Some(&first) = seen.get(&id) {
                 return Err(ImportError::Source(format!(
                     "two import documents share the blank-node scope \
@@ -846,7 +850,11 @@ impl DocIds {
             seen.insert(id, idx);
             ids.push(id);
         }
-        Ok(Self { keys, ids })
+        Ok(Self {
+            namespace: namespace.to_string(),
+            keys,
+            ids,
+        })
     }
 
     /// Hashed id of document `idx`.
@@ -863,6 +871,12 @@ impl DocIds {
         self.ids.clone()
     }
 
+    /// Document keys in source order, for the ndjson producers, which hash
+    /// their own per-segment ids.
+    fn keys(&self) -> Vec<String> {
+        self.keys.clone()
+    }
+
     /// The import manifest: `(blank-node local name of the scope, document
     /// key)` for every document.
     ///
@@ -870,21 +884,41 @@ impl DocIds {
     /// every id minted from that document shares — so a reader holding an
     /// opaque `_:fdb-d…-label` recovers the source with
     /// `fluree_db_core::skolem::split_doc_scope` and one lookup.
-    fn manifest(&self) -> Vec<(String, String)> {
-        self.ids
+    ///
+    /// `extra_segments` names `(document index, segment ordinal)` pairs beyond
+    /// segment 0 — the ndjson arm cuts one file into several documents at its
+    /// `@context` switches, and which ones exist is only known once the file
+    /// has been read. Each gets its own row against the same document key, so
+    /// every minted scope resolves even though the manifest does not say which
+    /// segment of the file it was.
+    fn manifest(&self, extra_segments: &[(usize, u32)]) -> Vec<(String, String)> {
+        let scope_row = |id: u64, key: &str| {
+            (
+                format!(
+                    "{}{}",
+                    fluree_db_core::ns_encoding::STABLE_BLANK_NODE_LABEL_PREFIX,
+                    fluree_db_core::skolem::doc_scope(id)
+                ),
+                key.to_string(),
+            )
+        };
+        let mut rows: Vec<(String, String)> = self
+            .ids
             .iter()
             .zip(&self.keys)
-            .map(|(&id, key)| {
-                (
-                    format!(
-                        "{}{}",
-                        fluree_db_core::ns_encoding::STABLE_BLANK_NODE_LABEL_PREFIX,
-                        fluree_db_core::skolem::doc_scope(id)
-                    ),
-                    key.clone(),
-                )
-            })
-            .collect()
+            .map(|(&id, key)| scope_row(id, key))
+            .collect();
+        for &(idx, segment) in extra_segments {
+            if segment == 0 {
+                continue; // already covered above
+            }
+            let Some(key) = self.keys.get(idx) else {
+                continue;
+            };
+            let id = fluree_db_core::skolem::doc_id(&self.namespace, key, segment);
+            rows.push(scope_row(id, key));
+        }
+        rows
     }
 }
 
@@ -918,6 +952,13 @@ type RemoteChunkRx = Arc<std::sync::Mutex<std::sync::mpsc::Receiver<RemoteChunk>
 /// exit to distinguish clean completion from producer failure.
 pub struct RemoteChunkProducer {
     pub(crate) rx: RemoteChunkRx,
+    /// `(document index, segment ordinal)` for every context segment an ndjson
+    /// source actually opened, filled by the producer as it reads. Empty for
+    /// whole-object sources, which are one document each.
+    ///
+    /// Read after the producer thread is joined; that is the only point at
+    /// which it is known to be complete.
+    pub(crate) segments: Arc<std::sync::Mutex<Vec<(usize, u32)>>>,
     /// Take-once handles, accessible through `&self` via Mutex<Option<_>>.
     /// `error_rx` carries `Some(err)` on producer failure, `None` on success.
     pub(crate) error_rx:
@@ -1343,7 +1384,8 @@ fn resolve_chunk_source(
             let channel_capacity = config.effective_max_inflight();
             let producer = spawn_local_ndjson_producer(
                 files,
-                doc_ids.ids(),
+                doc_ids.keys(),
+                skolem_namespace.to_string(),
                 config.ndjson_first_line_context,
                 chunk_size_bytes,
                 channel_capacity,
@@ -1412,7 +1454,8 @@ fn resolve_chunk_source(
         let doc_ids = single_file_docs(path)?;
         let producer = spawn_local_ndjson_producer(
             vec![path.to_path_buf()],
-            doc_ids.ids(),
+            doc_ids.keys(),
+            skolem_namespace.to_string(),
             config.ndjson_first_line_context,
             chunk_size_bytes,
             channel_capacity,
@@ -1701,6 +1744,8 @@ fn spawn_remote_producer(
 
     RemoteChunkProducer {
         rx: Arc::new(std::sync::Mutex::new(std_rx)),
+        // One whole object is one document; nothing segments it.
+        segments: Arc::default(),
         error_rx: std::sync::Mutex::new(Some(error_rx)),
         bridge_handle: std::sync::Mutex::new(Some(bridge_handle)),
         estimated_count,
@@ -1813,21 +1858,37 @@ fn estimate_ndjson_chunks(total_bytes: u64, chunk_size_bytes: u64) -> usize {
     total_bytes.div_ceil(chunk_size_bytes.max(1)).max(1) as usize
 }
 
-/// Spawn a producer that streams ndjson from a sequence of `(label, factory)`
-/// byte sources, chaining one [`NdjsonReader`] per source and forwarding their
-/// JSON-LD chunks into a shared channel with a global chunk index. The readers
-/// are independent, so each source's own leading `@context` is honored.
+/// One ndjson byte source for [`spawn_chained_ndjson_producer`].
+struct NdjsonSource {
+    /// Human-readable name — a path or remote address — for error text.
+    label: String,
+    /// Position of this source in the import's document list.
+    doc_idx: usize,
+    /// The key this source's documents hash under (see [`DocIds`]). Each of
+    /// its context segments is a document in its own right, so the id is
+    /// derived per chunk rather than precomputed.
+    doc_key: String,
+    factory: NdjsonSourceFactory,
+}
+
+/// Spawn a producer that streams ndjson from a sequence of byte sources,
+/// chaining one [`NdjsonReader`] per source and forwarding their JSON-LD chunks
+/// into a shared channel with a global chunk index. The readers are
+/// independent, so each source's own leading `@context` is honored.
 /// Reuses [`RemoteChunkProducer`]'s channel + `error_rx` machinery;
 /// `per_chunk_format` is empty because the chunks ride the
 /// [`ChunkSource::JsonLdStream`] path, which always parses them as JSON-LD.
 fn spawn_chained_ndjson_producer(
-    sources: Vec<(String, u64, NdjsonSourceFactory)>,
+    sources: Vec<NdjsonSource>,
+    skolem_namespace: String,
     policy: FirstLineContextPolicy,
     chunk_size_bytes: u64,
     in_flight: usize,
     estimated_count: usize,
 ) -> RemoteChunkProducer {
     let in_flight = in_flight.max(1);
+    let segments: Arc<std::sync::Mutex<Vec<(usize, u32)>>> = Arc::default();
+    let segment_log = Arc::clone(&segments);
     let (std_tx, std_rx) = std::sync::mpsc::sync_channel::<RemoteChunk>(in_flight);
     let (error_tx, error_rx) = tokio::sync::oneshot::channel::<Option<ImportError>>();
 
@@ -1838,7 +1899,14 @@ fn spawn_chained_ndjson_producer(
         .name("ndjson-producer".into())
         .spawn(move || {
             let mut global_idx = 0usize;
-            for (label, doc_id, factory) in sources {
+            for source in sources {
+                let NdjsonSource {
+                    label,
+                    doc_idx,
+                    doc_key,
+                    factory,
+                } = source;
+                let mut last_segment: Option<u32> = None;
                 let byte_source = match factory() {
                     Ok(r) => r,
                     Err(e) => {
@@ -1864,16 +1932,32 @@ fn spawn_chained_ndjson_producer(
                     };
                 loop {
                     match reader.recv_chunk() {
-                        Ok(Some((local_idx, bytes))) => {
-                            // One ndjson SOURCE is one document. `NdjsonReader`
-                            // applies the source's leading `@context` to every
-                            // chunk it cuts, so the file — not the chunk, and
-                            // not the line — is the unit Fluree already treats
-                            // as one JSON-LD document. `local_idx` is the
-                            // reader's own 0-based counter, so it is the
-                            // sub-chunk index this document needs.
+                        Ok(Some((local_idx, segment, bytes))) => {
+                            // One CONTEXT SEGMENT is one document. Within a
+                            // segment the nodes share an `@context` and are
+                            // emitted as members of one `@graph`, which is
+                            // what makes them co-document; a `@context` switch
+                            // seals that document and opens the next, so
+                            // `cat a.jsonl b.jsonl` keeps the two files' `_:x`
+                            // labels apart. Neither the chunk nor the line is
+                            // the unit: a chunk is a cut of a segment, and a
+                            // line is a node.
+                            //
+                            // `local_idx` is the reader's own chunk counter,
+                            // monotonic across the whole file and never reset
+                            // at a switch, so it is distinct within every
+                            // segment — which is all the sub-chunk index has
+                            // to be.
+                            if last_segment != Some(segment) {
+                                last_segment = Some(segment);
+                                segment_log.lock().unwrap().push((doc_idx, segment));
+                            }
                             let doc = DocChunk {
-                                doc: doc_id,
+                                doc: fluree_db_core::skolem::doc_id(
+                                    &skolem_namespace,
+                                    &doc_key,
+                                    segment,
+                                ),
                                 sub_chunk: u32::try_from(local_idx).unwrap_or(u32::MAX),
                             };
                             if std_tx.send((global_idx, doc, bytes)).is_err() {
@@ -1907,6 +1991,7 @@ fn spawn_chained_ndjson_producer(
 
     RemoteChunkProducer {
         rx: Arc::new(std::sync::Mutex::new(std_rx)),
+        segments,
         error_rx: std::sync::Mutex::new(Some(error_rx)),
         bridge_handle: std::sync::Mutex::new(Some(producer_handle)),
         estimated_count,
@@ -1925,7 +2010,8 @@ fn spawn_chained_ndjson_producer(
 fn spawn_remote_ndjson_producer(
     storage: Arc<dyn StorageRead>,
     objects: Vec<RemoteObject>,
-    doc_ids: Vec<u64>,
+    doc_keys: Vec<String>,
+    skolem_namespace: String,
     policy: FirstLineContextPolicy,
     chunk_size_bytes: u64,
     in_flight: usize,
@@ -1934,11 +2020,11 @@ fn spawn_remote_ndjson_producer(
     let ranged = storage.supports_ranged_reads();
     let total_bytes: u64 = objects.iter().map(|o| o.size_bytes).sum();
     let estimated_count = estimate_ndjson_chunks(total_bytes, chunk_size_bytes);
-    let sources: Vec<(String, u64, NdjsonSourceFactory)> = objects
+    let sources: Vec<NdjsonSource> = objects
         .into_iter()
         .enumerate()
         .map(|(idx, obj)| {
-            let doc_id = doc_ids.get(idx).copied().unwrap_or(0);
+            let doc_key = doc_keys.get(idx).cloned().unwrap_or_default();
             let storage = Arc::clone(&storage);
             let handle = handle.clone();
             let label = obj.address.clone();
@@ -1969,11 +2055,17 @@ fn spawn_remote_ndjson_producer(
                     decode_buffered(comp, Box::new(std::io::Cursor::new(bytes)))
                 })
             };
-            (label, doc_id, factory)
+            NdjsonSource {
+                label,
+                doc_idx: idx,
+                doc_key,
+                factory,
+            }
         })
         .collect();
     spawn_chained_ndjson_producer(
         sources,
+        skolem_namespace,
         policy,
         chunk_size_bytes,
         in_flight,
@@ -1985,7 +2077,8 @@ fn spawn_remote_ndjson_producer(
 /// `open_decoded` handles `.gz`/`.zst` transparently.
 fn spawn_local_ndjson_producer(
     files: Vec<PathBuf>,
-    doc_ids: Vec<u64>,
+    doc_keys: Vec<String>,
+    skolem_namespace: String,
     policy: FirstLineContextPolicy,
     chunk_size_bytes: u64,
     in_flight: usize,
@@ -1998,18 +2091,24 @@ fn spawn_local_ndjson_producer(
         .map(|m| m.len())
         .sum();
     let estimated_count = estimate_ndjson_chunks(total_bytes, chunk_size_bytes);
-    let sources: Vec<(String, u64, NdjsonSourceFactory)> = files
+    let sources: Vec<NdjsonSource> = files
         .into_iter()
         .enumerate()
         .map(|(idx, f)| {
-            let doc_id = doc_ids.get(idx).copied().unwrap_or(0);
+            let doc_key = doc_keys.get(idx).cloned().unwrap_or_default();
             let label = f.display().to_string();
             let factory: NdjsonSourceFactory = Box::new(move || open_decoded(&f));
-            (label, doc_id, factory)
+            NdjsonSource {
+                label,
+                doc_idx: idx,
+                doc_key,
+                factory,
+            }
         })
         .collect();
     spawn_chained_ndjson_producer(
         sources,
+        skolem_namespace,
         policy,
         chunk_size_bytes,
         in_flight,
@@ -3327,7 +3426,8 @@ where
                     let producer = spawn_remote_ndjson_producer(
                         Arc::clone(storage),
                         objects,
-                        doc_ids.ids(),
+                        doc_ids.keys(),
+                        skolem_namespace.clone(),
                         config.ndjson_first_line_context,
                         chunk_size_bytes,
                         in_flight,
@@ -5166,7 +5266,16 @@ where
         let p_import_source = spool_config
             .predicate_alloc
             .get_or_insert_parts(fluree::DB, db::IMPORT_SOURCE);
-        let manifest = doc_ids.manifest();
+        // The ndjson producer discovers documents as it reads (a `@context`
+        // switch opens a new one), and it has been joined by now, so its log
+        // is complete.
+        let observed_segments = match &**chunk_source {
+            ChunkSource::Remote(producer) | ChunkSource::JsonLdStream(producer) => {
+                producer.segments.lock().unwrap().clone()
+            }
+            _ => Vec::new(),
+        };
+        let manifest = doc_ids.manifest(&observed_segments);
 
         // txn-meta is always pre-seeded as dict_id=0 in the graph allocator
         // (via SharedDictAllocator::new_graph), so g_id = dict_id + 1 = 1.

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -707,8 +707,32 @@ pub(crate) enum RemoteFormat {
     Ndjson,
 }
 
-/// `(chunk_index, raw_bytes)` payload sent from the remote producer to parser workers.
-type RemoteChunk = (usize, Vec<u8>);
+/// `(chunk_index, doc_index, raw_bytes)` payload sent from a chunk producer to
+/// the parser workers.
+///
+/// `doc_index` names the **source document** the bytes were cut from. RDF
+/// scopes blank-node labels to a document, and only the producer knows how
+/// chunks map onto input files — a large file is sub-split into many chunks,
+/// several small files can share one chunk. Workers turn it into the parser's
+/// `doc_scope` so `_:x` unifies across every chunk of one file and stays
+/// distinct between files. Producers that emit exactly one whole document per
+/// chunk set it equal to `chunk_index`.
+type RemoteChunk = (usize, usize, Vec<u8>);
+
+/// Document index used by the single-file streaming arm.
+///
+/// [`ChunkSource::Streaming`] always reads exactly one local file, so every
+/// chunk it emits belongs to the same document.
+const STREAMING_DOC_IDX: usize = 0;
+
+/// Render a document index as a parser `doc_scope` key.
+///
+/// The `d` prefix keeps these keys disjoint from the commit-ordinal keys used
+/// by the serial TriG/JSON-LD paths, so no two documents in one import can
+/// collide on a skolemization base.
+fn doc_scope(doc_idx: usize) -> String {
+    format!("d{doc_idx}")
+}
 
 type RemoteChunkRx = Arc<std::sync::Mutex<std::sync::mpsc::Receiver<RemoteChunk>>>;
 
@@ -1397,10 +1421,10 @@ fn spawn_remote_producer(
     let in_flight = in_flight.max(1);
 
     // tokio mpsc — async producer side.
-    let (tokio_tx, mut tokio_rx) = tokio::sync::mpsc::channel::<(usize, Vec<u8>)>(in_flight);
+    let (tokio_tx, mut tokio_rx) = tokio::sync::mpsc::channel::<RemoteChunk>(in_flight);
     // std mpsc — sync worker side. Capacity 2 (small handoff buffer; tokio
     // channel is the real backpressure knob).
-    let (std_tx, std_rx) = std::sync::mpsc::sync_channel::<(usize, Vec<u8>)>(2);
+    let (std_tx, std_rx) = std::sync::mpsc::sync_channel::<RemoteChunk>(2);
     let (error_tx, error_rx) = tokio::sync::oneshot::channel::<Option<ImportError>>();
 
     // Producer task — async on tokio.
@@ -1425,7 +1449,8 @@ fn spawn_remote_producer(
                     "remote object size differs from listing metadata"
                 );
             }
-            if tokio_tx.send((idx, bytes)).await.is_err() {
+            // One remote object == one whole document, so doc_index == idx.
+            if tokio_tx.send((idx, idx, bytes)).await.is_err() {
                 // Bridge dropped — pipeline aborted upstream. Exit cleanly.
                 let _ = error_tx.send(None);
                 return;
@@ -1576,7 +1601,7 @@ fn spawn_chained_ndjson_producer(
     estimated_count: usize,
 ) -> RemoteChunkProducer {
     let in_flight = in_flight.max(1);
-    let (std_tx, std_rx) = std::sync::mpsc::sync_channel::<(usize, Vec<u8>)>(in_flight);
+    let (std_tx, std_rx) = std::sync::mpsc::sync_channel::<RemoteChunk>(in_flight);
     let (error_tx, error_rx) = tokio::sync::oneshot::channel::<Option<ImportError>>();
 
     // A dedicated std thread: each NdjsonReader spawns its own reader thread,
@@ -1613,7 +1638,9 @@ fn spawn_chained_ndjson_producer(
                 loop {
                     match reader.recv_chunk() {
                         Ok(Some((_local_idx, bytes))) => {
-                            if std_tx.send((global_idx, bytes)).is_err() {
+                            // Each ndjson chunk is rewritten into a standalone
+                            // JSON-LD document, so doc_index == global_idx.
+                            if std_tx.send((global_idx, global_idx, bytes)).is_err() {
                                 // Consumer aborted upstream — exit cleanly.
                                 let _ = error_tx.send(None);
                                 return;
@@ -1838,9 +1865,15 @@ fn should_stream_split(path: &Path, on_disk: u64, chunk_size_bytes: u64) -> bool
 }
 
 /// Background rechunk loop for a local directory of plain Turtle/N-Triples
-/// files. Walks `files` in order, emitting contiguous `(idx, bytes)` chunks:
-/// large files are sub-split at statement boundaries; small files are read
-/// whole and (when `coalesce_enabled`) concatenated up to ~`chunk_size`.
+/// files. Walks `files` in order, emitting contiguous `(idx, doc, bytes)`
+/// chunks: large files are sub-split at statement boundaries; small files are
+/// read whole and (when `coalesce_enabled`) concatenated up to ~`chunk_size`.
+///
+/// Every chunk carries the index of the file it came from, so the parse workers
+/// can scope blank-node labels to their source document (see [`RemoteChunk`]).
+/// A coalesced payload reports its *first* file — sound because
+/// [`coalesce_unsafe`] refuses to coalesce any file containing a `_:` label, so
+/// a coalesced payload has no labeled blank nodes to scope.
 ///
 /// Returns `Ok(())` on completion **or** on a closed receiver (consumer aborted
 /// upstream — not this producer's error). Returns `Err` only for an actual
@@ -1850,18 +1883,20 @@ fn local_rechunk_loop(
     sizes: &[u64],
     chunk_size_bytes: u64,
     coalesce_enabled: bool,
-    tx: &std::sync::mpsc::SyncSender<(usize, Vec<u8>)>,
+    tx: &std::sync::mpsc::SyncSender<RemoteChunk>,
 ) -> std::result::Result<(), ImportError> {
     let mut next_idx = 0usize;
-    // Accumulated self-contained TTL text for coalesced small files.
+    // Accumulated self-contained TTL text for coalesced small files, and the
+    // index of the first file that contributed to it.
     let mut buf: Vec<u8> = Vec::new();
+    let mut buf_doc = 0usize;
 
     macro_rules! emit {
-        ($payload:expr) => {{
+        ($doc:expr, $payload:expr) => {{
             let payload = $payload;
             let payload_len = payload.len();
             let send_start = Instant::now();
-            if tx.send((next_idx, payload)).is_err() {
+            if tx.send((next_idx, $doc, payload)).is_err() {
                 // Consumer dropped the receiver — pipeline aborted upstream.
                 return Ok(());
             }
@@ -1893,7 +1928,7 @@ fn local_rechunk_loop(
             // at statement boundaries. ----
             // Flush any pending coalesce buffer first to preserve ordering.
             if !buf.is_empty() {
-                emit!(std::mem::take(&mut buf));
+                emit!(buf_doc, std::mem::take(&mut buf));
             }
 
             let mut reader = if matches!(comp, Compression::None) {
@@ -1949,7 +1984,9 @@ fn local_rechunk_loop(
                                 "local rechunk built split-file payload"
                             );
                         }
-                        emit!(payload);
+                        // Every sub-chunk of this file shares its document
+                        // scope — that is the whole point of `doc`.
+                        emit!(fi, payload);
                     }
                     Ok(None) => break,
                     Err(e) => {
@@ -1989,20 +2026,22 @@ fn local_rechunk_loop(
             if !coalesce_enabled || coalesce_unsafe(&bytes) {
                 // Emit standalone (flush any pending buffer first).
                 if !buf.is_empty() {
-                    emit!(std::mem::take(&mut buf));
+                    emit!(buf_doc, std::mem::take(&mut buf));
                 }
-                emit!(bytes);
+                emit!(fi, bytes);
             } else {
                 // Coalesce: flush first if adding would overflow the target.
                 if !buf.is_empty() && (buf.len() + 1 + bytes.len()) as u64 > chunk_size_bytes {
-                    emit!(std::mem::take(&mut buf));
+                    emit!(buf_doc, std::mem::take(&mut buf));
                 }
-                if !buf.is_empty() {
+                if buf.is_empty() {
+                    buf_doc = fi;
+                } else {
                     buf.push(b'\n');
                 }
                 buf.extend_from_slice(&bytes);
                 if buf.len() as u64 >= chunk_size_bytes {
-                    emit!(std::mem::take(&mut buf));
+                    emit!(buf_doc, std::mem::take(&mut buf));
                 }
             }
         }
@@ -2013,7 +2052,7 @@ fn local_rechunk_loop(
         let payload = std::mem::take(&mut buf);
         let payload_len = payload.len();
         let send_start = Instant::now();
-        if tx.send((next_idx, payload)).is_err() {
+        if tx.send((next_idx, buf_doc, payload)).is_err() {
             // Consumer dropped the receiver — pipeline aborted upstream.
             return Ok(());
         }
@@ -2174,14 +2213,15 @@ fn process_local_rechunk_job(
 }
 
 fn emit_local_rechunk_payload(
-    tx: &std::sync::mpsc::SyncSender<(usize, Vec<u8>)>,
+    tx: &std::sync::mpsc::SyncSender<RemoteChunk>,
     next_idx: &mut usize,
+    doc_idx: usize,
     payload: Vec<u8>,
 ) -> bool {
     let payload_len = payload.len();
     let chunk_idx = *next_idx;
     let send_start = Instant::now();
-    if tx.send((chunk_idx, payload)).is_err() {
+    if tx.send((chunk_idx, doc_idx, payload)).is_err() {
         // Consumer dropped the receiver — pipeline aborted upstream.
         return false;
     }
@@ -2209,7 +2249,7 @@ fn local_rechunk_loop_parallel(
     sizes: Vec<u64>,
     chunk_size_bytes: u64,
     coalesce_enabled: bool,
-    tx: &std::sync::mpsc::SyncSender<(usize, Vec<u8>)>,
+    tx: &std::sync::mpsc::SyncSender<RemoteChunk>,
     rechunk_threads: usize,
 ) -> std::result::Result<(), ImportError> {
     let worker_count = rechunk_threads.min(files.len()).max(1);
@@ -2276,7 +2316,11 @@ fn local_rechunk_loop_parallel(
     let mut result: std::result::Result<(), ImportError> = Ok(());
     let mut output_open = true;
     let mut next_idx = 0usize;
+    // Coalesce buffer plus the index of the first file that contributed to it,
+    // so a flushed payload reports the document it started in (see
+    // `local_rechunk_loop` for why that is sound for coalesced payloads).
     let mut buf: Vec<u8> = Vec::new();
+    let mut buf_doc = 0usize;
 
     while let Some((file_idx, event_rx)) = event_rxs.pop_front() {
         loop {
@@ -2298,12 +2342,14 @@ fn local_rechunk_loop_parallel(
                     if output_open && result.is_ok() {
                         if !buf.is_empty() {
                             let pending = std::mem::take(&mut buf);
-                            if !emit_local_rechunk_payload(tx, &mut next_idx, pending) {
+                            if !emit_local_rechunk_payload(tx, &mut next_idx, buf_doc, pending) {
                                 output_open = false;
                                 buf.clear();
                             }
                         }
-                        if output_open && !emit_local_rechunk_payload(tx, &mut next_idx, payload) {
+                        if output_open
+                            && !emit_local_rechunk_payload(tx, &mut next_idx, file_idx, payload)
+                        {
                             output_open = false;
                             buf.clear();
                         }
@@ -2317,12 +2363,14 @@ fn local_rechunk_loop_parallel(
                         if !coalesce_enabled || unsafe_to_coalesce {
                             if !buf.is_empty() {
                                 let pending = std::mem::take(&mut buf);
-                                if !emit_local_rechunk_payload(tx, &mut next_idx, pending) {
+                                if !emit_local_rechunk_payload(tx, &mut next_idx, buf_doc, pending)
+                                {
                                     output_open = false;
                                     buf.clear();
                                 }
                             }
-                            if output_open && !emit_local_rechunk_payload(tx, &mut next_idx, bytes)
+                            if output_open
+                                && !emit_local_rechunk_payload(tx, &mut next_idx, file_idx, bytes)
                             {
                                 output_open = false;
                                 buf.clear();
@@ -2332,19 +2380,27 @@ fn local_rechunk_loop_parallel(
                                 && (buf.len() + 1 + bytes.len()) as u64 > chunk_size_bytes
                             {
                                 let pending = std::mem::take(&mut buf);
-                                if !emit_local_rechunk_payload(tx, &mut next_idx, pending) {
+                                if !emit_local_rechunk_payload(tx, &mut next_idx, buf_doc, pending)
+                                {
                                     output_open = false;
                                     buf.clear();
                                 }
                             }
                             if output_open {
-                                if !buf.is_empty() {
+                                if buf.is_empty() {
+                                    buf_doc = file_idx;
+                                } else {
                                     buf.push(b'\n');
                                 }
                                 buf.extend_from_slice(&bytes);
                                 if buf.len() as u64 >= chunk_size_bytes {
                                     let pending = std::mem::take(&mut buf);
-                                    if !emit_local_rechunk_payload(tx, &mut next_idx, pending) {
+                                    if !emit_local_rechunk_payload(
+                                        tx,
+                                        &mut next_idx,
+                                        buf_doc,
+                                        pending,
+                                    ) {
                                         output_open = false;
                                         buf.clear();
                                     }
@@ -2382,7 +2438,7 @@ fn local_rechunk_loop_parallel(
 
     if output_open && result.is_ok() && !buf.is_empty() {
         let pending = std::mem::take(&mut buf);
-        if !emit_local_rechunk_payload(tx, &mut next_idx, pending) {
+        if !emit_local_rechunk_payload(tx, &mut next_idx, buf_doc, pending) {
             return Ok(());
         }
     }
@@ -2435,7 +2491,7 @@ fn spawn_local_producer(
         "local directory rechunk producer"
     );
 
-    let (tx, rx) = std::sync::mpsc::sync_channel::<(usize, Vec<u8>)>(channel_capacity);
+    let (tx, rx) = std::sync::mpsc::sync_channel::<RemoteChunk>(channel_capacity);
     let (error_tx, error_rx) = tokio::sync::oneshot::channel::<Option<ImportError>>();
 
     let producer_handle = std::thread::Builder::new()
@@ -3806,12 +3862,18 @@ where
         spool_config: &'a Arc<SpoolConfig>,
     }
 
+    /// `doc` is the index of the source document this chunk was cut from; it
+    /// scopes blank-node labels (see [`RemoteChunk`]). It is deliberately a
+    /// separate argument from `idx`/`t`: the two coincide only when a chunk is
+    /// a whole document.
     fn parse_ttl_chunk(
         ttl: &str,
         ctx: &ParseChunkContext<'_>,
         t: i64,
         idx: usize,
+        doc: usize,
     ) -> std::result::Result<ParsedChunk, String> {
+        let scope = doc_scope(doc);
         let parsed = if let Some(prelude) = ctx.prelude {
             parse_chunk_with_prelude(
                 ttl,
@@ -3819,6 +3881,7 @@ where
                 prelude,
                 t,
                 ctx.ledger,
+                &scope,
                 ctx.compress,
                 Some(ctx.spool_dir),
                 Some(ctx.spool_config),
@@ -3830,6 +3893,7 @@ where
                 ctx.shared_alloc,
                 t,
                 ctx.ledger,
+                &scope,
                 ctx.compress,
                 Some(ctx.spool_dir),
                 Some(ctx.spool_config),
@@ -3941,7 +4005,9 @@ where
                             starts_with = &ttl[..ttl.len().min(200)],
                             "about to parse chunk"
                         );
-                        match parse_ttl_chunk(&ttl, &ctx, t, idx) {
+                        // This arm streams a SINGLE local file, so every chunk
+                        // belongs to document 0 and shares one label scope.
+                        match parse_ttl_chunk(&ttl, &ctx, t, idx, STREAMING_DOC_IDX) {
                             Ok(parsed) => {
                                 if result_tx.send(Ok((idx, parsed))).is_err() {
                                     break;
@@ -4194,7 +4260,7 @@ where
                     };
                     loop {
                         let recv_start = Instant::now();
-                        let (idx, raw_bytes) = match work_rx.lock().unwrap().recv() {
+                        let (idx, doc, raw_bytes) = match work_rx.lock().unwrap().recv() {
                             Ok(payload) => payload,
                             Err(_) => break, // Bridge dropped — channel closed.
                         };
@@ -4220,7 +4286,7 @@ where
 
                         let t = (idx + 1) as i64;
                         let parse_start = Instant::now();
-                        match parse_ttl_chunk(&ttl, &ctx, t, idx) {
+                        match parse_ttl_chunk(&ttl, &ctx, t, idx, doc) {
                             Ok(parsed) => {
                                 let parse_ms = parse_start.elapsed().as_millis();
                                 let send_start = Instant::now();
@@ -4345,7 +4411,7 @@ where
                         ImportError::Transact(format!("chunk receive task panicked: {e}"))
                     })?
             };
-            let (idx, raw_bytes) = match payload {
+            let (idx, doc, raw_bytes) = match payload {
                 Ok(payload) => payload,
                 Err(_) => break, // Channel closed — producer thread exited.
             };
@@ -4399,6 +4465,7 @@ where
                         &shared_alloc,
                         t,
                         alias,
+                        &doc_scope(doc),
                         compress,
                         Some(&spool_dir),
                         Some(&spool_config),
@@ -4551,8 +4618,9 @@ where
                                 }
                             };
 
+                            // `Files` reads one whole file per chunk.
                             let t = (idx + 1) as i64;
-                            match parse_ttl_chunk(&ttl, &ctx, t, idx) {
+                            match parse_ttl_chunk(&ttl, &ctx, t, idx, idx) {
                                 Ok(parsed) => {
                                     let _ = permit_tx_ref.send(());
                                     if result_tx.send(Ok((idx, parsed))).is_err() {
@@ -4648,11 +4716,13 @@ where
                             i,
                         )
                     } else {
+                        // `Files` reads one whole file per chunk.
                         parse_chunk(
                             &content,
                             &shared_alloc,
                             t,
                             alias,
+                            &doc_scope(i),
                             compress,
                             Some(&spool_dir),
                             Some(&spool_config),

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -184,6 +184,20 @@ pub struct ImportConfig {
     /// the provider + graph-source id; `None` for every file/remote import, so
     /// those paths are unaffected.
     pub(crate) virtual_source: Option<VirtualSource>,
+    /// Namespace that salts blank-node ids minted by this import.
+    ///
+    /// `None` (the default) salts with the normalized ledger id, so importing
+    /// one source tree into two ledgers mints two disjoint sets of ids —
+    /// blank nodes are local to the graph that holds them, and nothing should
+    /// make them look shared across ledgers by accident.
+    ///
+    /// Set it to make that sharing deliberate: two ledgers imported from the
+    /// same tree under the same namespace mint *identical* ids, so a blank
+    /// node can be matched across them (a rebuild-and-diff, a sharded load of
+    /// one logical dataset, a staging/production pair). It is a plain string
+    /// with no interpretation — any two imports that agree on it, agree on
+    /// their ids.
+    pub skolem_namespace: Option<String>,
 }
 
 /// A virtual (R2RML-over-Iceberg) graph source to materialize into a native
@@ -235,6 +249,7 @@ impl Default for ImportConfig {
             tracker: Tracker::disabled(),
             ndjson_first_line_context: FirstLineContextPolicy::Auto,
             virtual_source: None,
+            skolem_namespace: None,
         }
     }
 }
@@ -707,31 +722,154 @@ pub(crate) enum RemoteFormat {
     Ndjson,
 }
 
-/// `(chunk_index, doc_index, raw_bytes)` payload sent from a chunk producer to
-/// the parser workers.
+/// Which document a chunk came from, and where inside it.
 ///
-/// `doc_index` names the **source document** the bytes were cut from. RDF
-/// scopes blank-node labels to a document, and only the producer knows how
+/// RDF scopes blank-node labels to a document, and only the producer knows how
 /// chunks map onto input files — a large file is sub-split into many chunks,
-/// several small files can share one chunk. Workers turn it into the parser's
-/// `doc_scope` so `_:x` unifies across every chunk of one file and stays
-/// distinct between files. Producers that emit exactly one whole document per
-/// chunk set it equal to `chunk_index`.
-type RemoteChunk = (usize, usize, Vec<u8>);
-
-/// Document index used by the single-file streaming arm.
+/// several small files can share one chunk. This travels with every chunk so
+/// the parse worker can scope labels to their source document.
 ///
-/// [`ChunkSource::Streaming`] always reads exactly one local file, so every
-/// chunk it emits belongs to the same document.
-const STREAMING_DOC_IDX: usize = 0;
+/// `Copy` and two scalars wide on purpose: it rides the chunk channel, which
+/// stays allocation-free (the skolem base is rendered once per chunk in the
+/// worker, not once per document in the producer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DocChunk {
+    /// Hashed identity of the source document — see [`fluree_db_core::skolem`].
+    /// Every chunk cut from one document carries the same value, and no two
+    /// documents in an import share one (enforced by [`DocIds::new`]).
+    doc: u64,
+    /// Index of this chunk within its source document, from 0.
+    ///
+    /// Labeled blank nodes ignore it (they unify across the whole document);
+    /// *anonymous* nodes need it, because their mint counter restarts in every
+    /// sink. See `ImportSink::term_blank`.
+    sub_chunk: u32,
+}
 
-/// Render a document index as a parser `doc_scope` key.
+impl DocChunk {
+    /// A chunk that is a whole document by itself.
+    fn whole(doc: u64) -> Self {
+        Self { doc, sub_chunk: 0 }
+    }
+
+    /// The `{base}` in the parser's `fdb-{base}-{label}` skolem key.
+    fn skolem_base(self) -> String {
+        fluree_db_core::skolem::doc_scope(self.doc)
+    }
+}
+
+/// Assigns each payload its sub-chunk index within its source document.
 ///
-/// The `d` prefix keeps these keys disjoint from the commit-ordinal keys used
-/// by the serial TriG/JSON-LD paths, so no two documents in one import can
-/// collide on a skolemization base.
-fn doc_scope(doc_idx: usize) -> String {
-    format!("d{doc_idx}")
+/// Producers emit a document's chunks contiguously and in document order, so a
+/// counter that resets whenever the document changes is enough to make
+/// `(doc, sub_chunk)` unique across the import. `next_for` debug-asserts that
+/// contiguity rather than trusting it silently — a producer that interleaved
+/// documents would otherwise re-issue sub-chunk 0 and merge two documents'
+/// anonymous nodes.
+#[derive(Default)]
+struct SubChunkCounter {
+    current: Option<u64>,
+    next: u32,
+    #[cfg(debug_assertions)]
+    seen: std::collections::HashSet<u64>,
+}
+
+impl SubChunkCounter {
+    fn next_for(&mut self, doc: u64) -> DocChunk {
+        if self.current != Some(doc) {
+            #[cfg(debug_assertions)]
+            debug_assert!(
+                self.seen.insert(doc),
+                "producer emitted document {doc:x} in two separate runs; \
+                 sub-chunk indexes would repeat"
+            );
+            self.current = Some(doc);
+            self.next = 0;
+        }
+        let sub_chunk = self.next;
+        self.next += 1;
+        DocChunk { doc, sub_chunk }
+    }
+}
+
+/// `(chunk_index, doc_chunk, raw_bytes)` payload sent from a chunk producer to
+/// the parser workers.
+type RemoteChunk = (usize, DocChunk, Vec<u8>);
+
+/// Every document in one import, in source order: its key and its hashed id.
+///
+/// Built at the two places where the document set and the import root are both
+/// in scope — [`discover_chunks`] for local sources, [`resolve_remote_objects`]
+/// for remote ones — so every arm agrees on what a document key is. Indexed the
+/// same way `per_chunk_format` and the rechunk `sizes` are.
+///
+#[derive(Debug)]
+pub(crate) struct DocIds {
+    /// `skolem::doc_id` of each document key, in source order.
+    ids: Vec<u64>,
+}
+
+impl DocIds {
+    /// Hash every key under `namespace`, refusing an import whose documents do
+    /// not have distinct ids.
+    ///
+    /// A duplicate is nearly always a duplicate *key* — the `Remote`
+    /// `OrderedObjects` arm takes a caller-supplied list, which can name one
+    /// address twice — and much more rarely an `xxh64` collision between two
+    /// genuinely different keys. Both are fatal for the same reason: two
+    /// documents sharing a scope silently merge their `_:x` nodes into one
+    /// subject. Aborting up front costs nothing; discovering it after a
+    /// multi-hour import costs the whole import.
+    fn new(namespace: &str, keys: Vec<String>) -> std::result::Result<Self, ImportError> {
+        let mut ids = Vec::with_capacity(keys.len());
+        let mut seen: HashMap<u64, usize> = HashMap::with_capacity(keys.len());
+        for (idx, key) in keys.iter().enumerate() {
+            let id = fluree_db_core::skolem::doc_id(namespace, key);
+            if let Some(&first) = seen.get(&id) {
+                return Err(ImportError::Source(format!(
+                    "two import documents share the blank-node scope \
+                     '{}': {:?} and {:?}. Blank-node labels in the two would \
+                     merge into one subject. Remove the duplicate, or import \
+                     them separately.",
+                    fluree_db_core::skolem::doc_scope(id),
+                    keys[first],
+                    key,
+                )));
+            }
+            seen.insert(id, idx);
+            ids.push(id);
+        }
+        Ok(Self { ids })
+    }
+
+    /// Hashed id of document `idx`.
+    ///
+    /// Out-of-range indexes fall back to `0`: the caller has already sized its
+    /// document list, so this is unreachable, and a wrong-but-stable scope is a
+    /// better failure than a panic mid-import.
+    fn id(&self, idx: usize) -> u64 {
+        self.ids.get(idx).copied().unwrap_or(0)
+    }
+
+    /// Hashed ids in source order, for handing to a producer thread.
+    fn ids(&self) -> Vec<u64> {
+        self.ids.clone()
+    }
+}
+
+/// Derive a document key for a local path: its location relative to the import
+/// root, or its file name when the root *is* the file.
+///
+/// Relative rather than absolute so that ids depend on the shape of the import,
+/// not on where the tree happens to be mounted — the same directory imported
+/// from `/tmp/x` and `/data/x` mints the same ids.
+fn local_doc_key(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .ok()
+        .or_else(|| path.file_name().map(Path::new))
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
 }
 
 type RemoteChunkRx = Arc<std::sync::Mutex<std::sync::mpsc::Receiver<RemoteChunk>>>;
@@ -1128,12 +1266,33 @@ fn read_decoded_to_string(path: &Path) -> std::io::Result<String> {
 /// - If `path` is a single large `.ttl` file: auto-split using `StreamingTurtleReader`.
 /// - If `path` is a single small `.ttl`/`.nt`/`.nq`/`.trig`/`.jsonld` file: treat as a single-element `Files` source.
 /// - All extensions above also accept `.gz` and `.zst` suffixes (e.g. `data.ttl.gz`).
+///
+/// Returns the source alongside its document identity table.
+/// `skolem_namespace` salts the document ids (see [`DocIds`]); it is the
+/// normalized ledger id unless the caller overrode it.
 fn resolve_chunk_source(
     path: &Path,
     config: &ImportConfig,
-) -> std::result::Result<ChunkSource, ImportError> {
+    skolem_namespace: &str,
+) -> std::result::Result<(ChunkSource, DocIds), ImportError> {
+    // Single-file sources key on the file name: a lone file is the import root
+    // *and* its only document, so a path relative to the root would be empty.
+    let single_file_docs = |p: &Path| -> std::result::Result<DocIds, ImportError> {
+        DocIds::new(
+            skolem_namespace,
+            vec![p.file_name().map_or_else(
+                || p.to_string_lossy().into_owned(),
+                |n| n.to_string_lossy().into_owned(),
+            )],
+        )
+    };
+
     if path.is_dir() {
         let files = discover_chunks(path)?;
+        let doc_ids = DocIds::new(
+            skolem_namespace,
+            files.iter().map(|f| local_doc_key(path, f)).collect(),
+        )?;
 
         // A directory of newline-delimited JSON-LD streams via chained
         // NdjsonReaders (one file → many JSON-LD chunks). `.jsonl`/`.ndjson`
@@ -1149,11 +1308,12 @@ fn resolve_chunk_source(
             let channel_capacity = config.effective_max_inflight();
             let producer = spawn_local_ndjson_producer(
                 files,
+                doc_ids.ids(),
                 config.ndjson_first_line_context,
                 chunk_size_bytes,
                 channel_capacity,
             );
-            return Ok(ChunkSource::JsonLdStream(producer));
+            return Ok((ChunkSource::JsonLdStream(producer), doc_ids));
         }
 
         // A directory of purely Turtle/N-Triples files can be rechunked through
@@ -1171,15 +1331,16 @@ fn resolve_chunk_source(
             let rechunk_threads = config.effective_rechunk_threads();
             let producer = spawn_local_producer(
                 files,
+                doc_ids.ids(),
                 chunk_size_bytes,
                 channel_capacity,
                 coalesce_threshold,
                 rechunk_threads,
             );
-            return Ok(ChunkSource::LocalRechunk(producer));
+            return Ok((ChunkSource::LocalRechunk(producer), doc_ids));
         }
 
-        return Ok(ChunkSource::Files(files));
+        return Ok((ChunkSource::Files(files), doc_ids));
     }
 
     if !path.exists() {
@@ -1213,13 +1374,15 @@ fn resolve_chunk_source(
     if is_ndjson_ext(inner_ext.as_deref()) {
         let chunk_size_bytes = config.effective_chunk_size_mb() as u64 * 1024 * 1024;
         let channel_capacity = config.effective_max_inflight();
+        let doc_ids = single_file_docs(path)?;
         let producer = spawn_local_ndjson_producer(
             vec![path.to_path_buf()],
+            doc_ids.ids(),
             config.ndjson_first_line_context,
             chunk_size_bytes,
             channel_capacity,
         );
-        return Ok(ChunkSource::JsonLdStream(producer));
+        return Ok((ChunkSource::JsonLdStream(producer), doc_ids));
     }
 
     let is_ttl = matches!(inner_ext.as_deref(), Some("ttl" | "nt"));
@@ -1279,24 +1442,37 @@ fn resolve_chunk_source(
             compression = ?compression,
             "streaming large Turtle file (no pre-scan)"
         );
-        Ok(ChunkSource::Streaming(reader))
+        Ok((ChunkSource::Streaming(reader), single_file_docs(path)?))
     } else {
         // Small file or non-TTL: treat as a single-element source. The Files
         // variant's `read_chunk` transparently decodes `.gz` / `.zst`.
-        Ok(ChunkSource::Files(vec![path.to_path_buf()]))
+        Ok((
+            ChunkSource::Files(vec![path.to_path_buf()]),
+            single_file_docs(path)?,
+        ))
     }
 }
 
 /// Resolve a remote source (`OrderedObjects` or `Prefix`) into a list of
 /// `RemoteObject`s, sorted lex by address for `Prefix` mode.
 ///
-/// Returns the accepted objects and their per-chunk formats (parallel to
-/// the objects vec). Rejects mixing Turtle (`.ttl`/`.trig`) with JSON-LD
-/// (`.jsonld`), mirroring the local `scan_directory_format` rule.
+/// Returns the accepted objects, their per-chunk formats (parallel to the
+/// objects vec), and their document identity table. Rejects mixing Turtle
+/// (`.ttl`/`.trig`) with JSON-LD (`.jsonld`), mirroring the local
+/// `scan_directory_format` rule.
+///
+/// Document keys are addresses relative to the listing prefix, so a prefix
+/// import mints the same ids wherever the bucket layout puts it — the local
+/// arms' relative-path rule, transposed. `OrderedObjects` supplies no prefix,
+/// so its keys are the full addresses. Note that `RemoteObject::address` is
+/// backend-opaque by contract (see `fluree_db_core::storage`), so hashing it
+/// pins the minted ids to whatever address encoding that backend uses: the
+/// same objects re-imported through a different backend mint different ids.
 async fn resolve_remote_objects(
     storage: &Arc<dyn StorageRead>,
     source: &RemoteSource,
-) -> std::result::Result<(Vec<RemoteObject>, Vec<RemoteFormat>), ImportError> {
+    skolem_namespace: &str,
+) -> std::result::Result<(Vec<RemoteObject>, Vec<RemoteFormat>, DocIds), ImportError> {
     let all_objects = match source {
         RemoteSource::OrderedObjects(objs) => objs.clone(),
         RemoteSource::Prefix { prefix } => {
@@ -1397,7 +1573,20 @@ async fn resolve_remote_objects(
     // and named graphs are queryable via the `#<graph-iri>` fragment. See the
     // named-graph spool wiring in `import_trig_commit` (fluree-db-transact).
 
-    Ok((accepted, extensions))
+    let doc_keys = accepted
+        .iter()
+        .map(|o| match source {
+            RemoteSource::Prefix { prefix } => o
+                .address
+                .strip_prefix(prefix.as_str())
+                .unwrap_or(&o.address)
+                .to_string(),
+            RemoteSource::OrderedObjects(_) => o.address.clone(),
+        })
+        .collect();
+    let doc_ids = DocIds::new(skolem_namespace, doc_keys)?;
+
+    Ok((accepted, extensions, doc_ids))
 }
 
 /// Spawn the async producer task + bridge thread for a remote source.
@@ -1414,10 +1603,12 @@ fn spawn_remote_producer(
     storage: Arc<dyn StorageRead>,
     objects: Vec<RemoteObject>,
     per_chunk_format: Vec<RemoteFormat>,
+    doc_ids: Vec<u64>,
     in_flight: usize,
 ) -> RemoteChunkProducer {
     let estimated_count = objects.len();
     debug_assert_eq!(estimated_count, per_chunk_format.len());
+    debug_assert_eq!(estimated_count, doc_ids.len());
     let in_flight = in_flight.max(1);
 
     // tokio mpsc — async producer side.
@@ -1449,8 +1640,9 @@ fn spawn_remote_producer(
                     "remote object size differs from listing metadata"
                 );
             }
-            // One remote object == one whole document, so doc_index == idx.
-            if tokio_tx.send((idx, idx, bytes)).await.is_err() {
+            // One remote object == one whole document.
+            let doc = DocChunk::whole(doc_ids.get(idx).copied().unwrap_or(0));
+            if tokio_tx.send((idx, doc, bytes)).await.is_err() {
                 // Bridge dropped — pipeline aborted upstream. Exit cleanly.
                 let _ = error_tx.send(None);
                 return;
@@ -1594,7 +1786,7 @@ fn estimate_ndjson_chunks(total_bytes: u64, chunk_size_bytes: u64) -> usize {
 /// `per_chunk_format` is empty because the chunks ride the
 /// [`ChunkSource::JsonLdStream`] path, which always parses them as JSON-LD.
 fn spawn_chained_ndjson_producer(
-    sources: Vec<(String, NdjsonSourceFactory)>,
+    sources: Vec<(String, u64, NdjsonSourceFactory)>,
     policy: FirstLineContextPolicy,
     chunk_size_bytes: u64,
     in_flight: usize,
@@ -1611,7 +1803,7 @@ fn spawn_chained_ndjson_producer(
         .name("ndjson-producer".into())
         .spawn(move || {
             let mut global_idx = 0usize;
-            for (label, factory) in sources {
+            for (label, doc_id, factory) in sources {
                 let byte_source = match factory() {
                     Ok(r) => r,
                     Err(e) => {
@@ -1637,10 +1829,19 @@ fn spawn_chained_ndjson_producer(
                     };
                 loop {
                     match reader.recv_chunk() {
-                        Ok(Some((_local_idx, bytes))) => {
-                            // Each ndjson chunk is rewritten into a standalone
-                            // JSON-LD document, so doc_index == global_idx.
-                            if std_tx.send((global_idx, global_idx, bytes)).is_err() {
+                        Ok(Some((local_idx, bytes))) => {
+                            // One ndjson SOURCE is one document. `NdjsonReader`
+                            // applies the source's leading `@context` to every
+                            // chunk it cuts, so the file — not the chunk, and
+                            // not the line — is the unit Fluree already treats
+                            // as one JSON-LD document. `local_idx` is the
+                            // reader's own 0-based counter, so it is the
+                            // sub-chunk index this document needs.
+                            let doc = DocChunk {
+                                doc: doc_id,
+                                sub_chunk: u32::try_from(local_idx).unwrap_or(u32::MAX),
+                            };
+                            if std_tx.send((global_idx, doc, bytes)).is_err() {
                                 // Consumer aborted upstream — exit cleanly.
                                 let _ = error_tx.send(None);
                                 return;
@@ -1689,6 +1890,7 @@ fn spawn_chained_ndjson_producer(
 fn spawn_remote_ndjson_producer(
     storage: Arc<dyn StorageRead>,
     objects: Vec<RemoteObject>,
+    doc_ids: Vec<u64>,
     policy: FirstLineContextPolicy,
     chunk_size_bytes: u64,
     in_flight: usize,
@@ -1697,9 +1899,11 @@ fn spawn_remote_ndjson_producer(
     let ranged = storage.supports_ranged_reads();
     let total_bytes: u64 = objects.iter().map(|o| o.size_bytes).sum();
     let estimated_count = estimate_ndjson_chunks(total_bytes, chunk_size_bytes);
-    let sources: Vec<(String, NdjsonSourceFactory)> = objects
+    let sources: Vec<(String, u64, NdjsonSourceFactory)> = objects
         .into_iter()
-        .map(|obj| {
+        .enumerate()
+        .map(|(idx, obj)| {
+            let doc_id = doc_ids.get(idx).copied().unwrap_or(0);
             let storage = Arc::clone(&storage);
             let handle = handle.clone();
             let label = obj.address.clone();
@@ -1730,7 +1934,7 @@ fn spawn_remote_ndjson_producer(
                     decode_buffered(comp, Box::new(std::io::Cursor::new(bytes)))
                 })
             };
-            (label, factory)
+            (label, doc_id, factory)
         })
         .collect();
     spawn_chained_ndjson_producer(
@@ -1746,6 +1950,7 @@ fn spawn_remote_ndjson_producer(
 /// `open_decoded` handles `.gz`/`.zst` transparently.
 fn spawn_local_ndjson_producer(
     files: Vec<PathBuf>,
+    doc_ids: Vec<u64>,
     policy: FirstLineContextPolicy,
     chunk_size_bytes: u64,
     in_flight: usize,
@@ -1758,12 +1963,14 @@ fn spawn_local_ndjson_producer(
         .map(|m| m.len())
         .sum();
     let estimated_count = estimate_ndjson_chunks(total_bytes, chunk_size_bytes);
-    let sources: Vec<(String, NdjsonSourceFactory)> = files
+    let sources: Vec<(String, u64, NdjsonSourceFactory)> = files
         .into_iter()
-        .map(|f| {
+        .enumerate()
+        .map(|(idx, f)| {
+            let doc_id = doc_ids.get(idx).copied().unwrap_or(0);
             let label = f.display().to_string();
             let factory: NdjsonSourceFactory = Box::new(move || open_decoded(&f));
-            (label, factory)
+            (label, doc_id, factory)
         })
         .collect();
     spawn_chained_ndjson_producer(
@@ -1869,9 +2076,9 @@ fn should_stream_split(path: &Path, on_disk: u64, chunk_size_bytes: u64) -> bool
 /// chunks: large files are sub-split at statement boundaries; small files are
 /// read whole and (when `coalesce_enabled`) concatenated up to ~`chunk_size`.
 ///
-/// Every chunk carries the index of the file it came from, so the parse workers
-/// can scope blank-node labels to their source document (see [`RemoteChunk`]).
-/// A coalesced payload reports its *first* file — sound because
+/// Every chunk carries the identity of the file it came from, so the parse
+/// workers can scope blank-node labels to their source document (see
+/// [`DocChunk`]). A coalesced payload reports its *first* file — sound because
 /// [`coalesce_unsafe`] refuses to coalesce any file containing a `_:` label, so
 /// a coalesced payload has no labeled blank nodes to scope.
 ///
@@ -1881,6 +2088,7 @@ fn should_stream_split(path: &Path, on_disk: u64, chunk_size_bytes: u64) -> bool
 fn local_rechunk_loop(
     files: &[PathBuf],
     sizes: &[u64],
+    doc_ids: &[u64],
     chunk_size_bytes: u64,
     coalesce_enabled: bool,
     tx: &std::sync::mpsc::SyncSender<RemoteChunk>,
@@ -1890,13 +2098,15 @@ fn local_rechunk_loop(
     // index of the first file that contributed to it.
     let mut buf: Vec<u8> = Vec::new();
     let mut buf_doc = 0usize;
+    let mut sub_chunks = SubChunkCounter::default();
 
     macro_rules! emit {
         ($doc:expr, $payload:expr) => {{
             let payload = $payload;
             let payload_len = payload.len();
             let send_start = Instant::now();
-            if tx.send((next_idx, $doc, payload)).is_err() {
+            let doc = sub_chunks.next_for(doc_ids.get($doc).copied().unwrap_or(0));
+            if tx.send((next_idx, doc, payload)).is_err() {
                 // Consumer dropped the receiver — pipeline aborted upstream.
                 return Ok(());
             }
@@ -2052,7 +2262,8 @@ fn local_rechunk_loop(
         let payload = std::mem::take(&mut buf);
         let payload_len = payload.len();
         let send_start = Instant::now();
-        if tx.send((next_idx, buf_doc, payload)).is_err() {
+        let doc = sub_chunks.next_for(doc_ids.get(buf_doc).copied().unwrap_or(0));
+        if tx.send((next_idx, doc, payload)).is_err() {
             // Consumer dropped the receiver — pipeline aborted upstream.
             return Ok(());
         }
@@ -2215,13 +2426,13 @@ fn process_local_rechunk_job(
 fn emit_local_rechunk_payload(
     tx: &std::sync::mpsc::SyncSender<RemoteChunk>,
     next_idx: &mut usize,
-    doc_idx: usize,
+    doc: DocChunk,
     payload: Vec<u8>,
 ) -> bool {
     let payload_len = payload.len();
     let chunk_idx = *next_idx;
     let send_start = Instant::now();
-    if tx.send((chunk_idx, doc_idx, payload)).is_err() {
+    if tx.send((chunk_idx, doc, payload)).is_err() {
         // Consumer dropped the receiver — pipeline aborted upstream.
         return false;
     }
@@ -2247,6 +2458,7 @@ fn emit_local_rechunk_payload(
 fn local_rechunk_loop_parallel(
     files: Vec<PathBuf>,
     sizes: Vec<u64>,
+    doc_ids: Vec<u64>,
     chunk_size_bytes: u64,
     coalesce_enabled: bool,
     tx: &std::sync::mpsc::SyncSender<RemoteChunk>,
@@ -2254,7 +2466,14 @@ fn local_rechunk_loop_parallel(
 ) -> std::result::Result<(), ImportError> {
     let worker_count = rechunk_threads.min(files.len()).max(1);
     if worker_count <= 1 {
-        return local_rechunk_loop(&files, &sizes, chunk_size_bytes, coalesce_enabled, tx);
+        return local_rechunk_loop(
+            &files,
+            &sizes,
+            &doc_ids,
+            chunk_size_bytes,
+            coalesce_enabled,
+            tx,
+        );
     }
 
     let (job_tx, job_rx) = std::sync::mpsc::sync_channel::<LocalRechunkJob>(worker_count);
@@ -2321,6 +2540,10 @@ fn local_rechunk_loop_parallel(
     // `local_rechunk_loop` for why that is sound for coalesced payloads).
     let mut buf: Vec<u8> = Vec::new();
     let mut buf_doc = 0usize;
+    let mut sub_chunks = SubChunkCounter::default();
+    let doc_chunk = |sub_chunks: &mut SubChunkCounter, file_idx: usize| {
+        sub_chunks.next_for(doc_ids.get(file_idx).copied().unwrap_or(0))
+    };
 
     while let Some((file_idx, event_rx)) = event_rxs.pop_front() {
         loop {
@@ -2342,13 +2565,23 @@ fn local_rechunk_loop_parallel(
                     if output_open && result.is_ok() {
                         if !buf.is_empty() {
                             let pending = std::mem::take(&mut buf);
-                            if !emit_local_rechunk_payload(tx, &mut next_idx, buf_doc, pending) {
+                            if !emit_local_rechunk_payload(
+                                tx,
+                                &mut next_idx,
+                                doc_chunk(&mut sub_chunks, buf_doc),
+                                pending,
+                            ) {
                                 output_open = false;
                                 buf.clear();
                             }
                         }
                         if output_open
-                            && !emit_local_rechunk_payload(tx, &mut next_idx, file_idx, payload)
+                            && !emit_local_rechunk_payload(
+                                tx,
+                                &mut next_idx,
+                                doc_chunk(&mut sub_chunks, file_idx),
+                                payload,
+                            )
                         {
                             output_open = false;
                             buf.clear();
@@ -2363,14 +2596,23 @@ fn local_rechunk_loop_parallel(
                         if !coalesce_enabled || unsafe_to_coalesce {
                             if !buf.is_empty() {
                                 let pending = std::mem::take(&mut buf);
-                                if !emit_local_rechunk_payload(tx, &mut next_idx, buf_doc, pending)
-                                {
+                                if !emit_local_rechunk_payload(
+                                    tx,
+                                    &mut next_idx,
+                                    doc_chunk(&mut sub_chunks, buf_doc),
+                                    pending,
+                                ) {
                                     output_open = false;
                                     buf.clear();
                                 }
                             }
                             if output_open
-                                && !emit_local_rechunk_payload(tx, &mut next_idx, file_idx, bytes)
+                                && !emit_local_rechunk_payload(
+                                    tx,
+                                    &mut next_idx,
+                                    doc_chunk(&mut sub_chunks, file_idx),
+                                    bytes,
+                                )
                             {
                                 output_open = false;
                                 buf.clear();
@@ -2380,8 +2622,12 @@ fn local_rechunk_loop_parallel(
                                 && (buf.len() + 1 + bytes.len()) as u64 > chunk_size_bytes
                             {
                                 let pending = std::mem::take(&mut buf);
-                                if !emit_local_rechunk_payload(tx, &mut next_idx, buf_doc, pending)
-                                {
+                                if !emit_local_rechunk_payload(
+                                    tx,
+                                    &mut next_idx,
+                                    doc_chunk(&mut sub_chunks, buf_doc),
+                                    pending,
+                                ) {
                                     output_open = false;
                                     buf.clear();
                                 }
@@ -2398,7 +2644,7 @@ fn local_rechunk_loop_parallel(
                                     if !emit_local_rechunk_payload(
                                         tx,
                                         &mut next_idx,
-                                        buf_doc,
+                                        doc_chunk(&mut sub_chunks, buf_doc),
                                         pending,
                                     ) {
                                         output_open = false;
@@ -2438,7 +2684,12 @@ fn local_rechunk_loop_parallel(
 
     if output_open && result.is_ok() && !buf.is_empty() {
         let pending = std::mem::take(&mut buf);
-        if !emit_local_rechunk_payload(tx, &mut next_idx, buf_doc, pending) {
+        if !emit_local_rechunk_payload(
+            tx,
+            &mut next_idx,
+            doc_chunk(&mut sub_chunks, buf_doc),
+            pending,
+        ) {
             return Ok(());
         }
     }
@@ -2455,6 +2706,7 @@ fn local_rechunk_loop_parallel(
 /// files (`0` disables it).
 fn spawn_local_producer(
     files: Vec<PathBuf>,
+    doc_ids: Vec<u64>,
     chunk_size_bytes: u64,
     channel_capacity: usize,
     coalesce_threshold: usize,
@@ -2500,6 +2752,7 @@ fn spawn_local_producer(
             let result = local_rechunk_loop_parallel(
                 files,
                 sizes,
+                doc_ids,
                 chunk_size_bytes,
                 coalesce_enabled,
                 &tx,
@@ -2685,6 +2938,17 @@ impl<'a> ImportBuilder<'a> {
     /// First-line interpretation for ndjson/jsonl sources: whether line 1 is a
     /// shared `@context` map or the first node. No effect on other formats.
     /// Default: [`FirstLineContextPolicy::Auto`].
+    /// Salt this import's blank-node ids with `namespace` instead of the
+    /// ledger id.
+    ///
+    /// Two imports of the same source tree mint identical blank-node ids iff
+    /// they agree on this value. See [`ImportConfig::skolem_namespace`].
+    #[must_use]
+    pub fn skolem_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.config.skolem_namespace = Some(namespace.into());
+        self
+    }
+
     pub fn ndjson_first_line_context(mut self, policy: FirstLineContextPolicy) -> Self {
         self.config.ndjson_first_line_context = policy;
         self
@@ -2984,19 +3248,33 @@ where
     async {
         // ---- Log effective settings and resolve chunk source ----
         config.log_effective_settings();
-        let chunk_source = match &import_source {
+
+        // Normalize before anything derives an identity from the alias.
+        // `create my/ledger --import` and `create my/ledger:main --import` name
+        // the SAME ledger, so they must salt blank-node ids identically —
+        // otherwise re-importing under the other spelling would mint a
+        // different id for every blank node in the source.
+        let normalized_alias = fluree_db_core::ledger_id::normalize_ledger_id(alias)
+            .unwrap_or_else(|_| alias.to_string());
+        let skolem_namespace = config
+            .skolem_namespace
+            .clone()
+            .unwrap_or_else(|| normalized_alias.clone());
+
+        let (chunk_source, doc_ids) = match &import_source {
             ImportSource::Local(path) => {
-                let cs = resolve_chunk_source(path, config)?;
+                let (cs, doc_ids) = resolve_chunk_source(path, config, &skolem_namespace)?;
                 tracing::info!(
                     estimated_chunks = cs.estimated_len(),
                     streaming = cs.is_streaming(),
                     path = %path.display(),
                     "resolved import chunks"
                 );
-                cs
+                (cs, doc_ids)
             }
             ImportSource::Remote { storage, source } => {
-                let (objects, per_chunk_format) = resolve_remote_objects(storage, source).await?;
+                let (objects, per_chunk_format, doc_ids) =
+                    resolve_remote_objects(storage, source, &skolem_namespace).await?;
                 let count = objects.len();
                 let total_bytes: u64 = objects.iter().map(|o| o.size_bytes).sum();
                 let in_flight = config.effective_max_inflight();
@@ -3014,6 +3292,7 @@ where
                     let producer = spawn_remote_ndjson_producer(
                         Arc::clone(storage),
                         objects,
+                        doc_ids.ids(),
                         config.ndjson_first_line_context,
                         chunk_size_bytes,
                         in_flight,
@@ -3024,7 +3303,7 @@ where
                         in_flight,
                         "resolved remote ndjson import (streamed)"
                     );
-                    ChunkSource::JsonLdStream(producer)
+                    (ChunkSource::JsonLdStream(producer), doc_ids)
                 } else {
                     // Each remote object is fetched whole into memory by the
                     // producer. Warn if any object exceeds the configured chunk
@@ -3048,6 +3327,7 @@ where
                         Arc::clone(storage),
                         objects,
                         per_chunk_format,
+                        doc_ids.ids(),
                         in_flight,
                     );
                     tracing::info!(
@@ -3056,20 +3336,27 @@ where
                         in_flight,
                         "resolved remote import chunks"
                     );
-                    ChunkSource::Remote(producer)
+                    (ChunkSource::Remote(producer), doc_ids)
                 }
             }
             // Virtual (R2RML) source: the provider rides on
             // `config.virtual_source`; the chunk source is an empty placeholder
             // and `run_import_chunks` routes to the virtual producer arm when
             // `config.virtual_source` is set.
-            ImportSource::Virtual => ChunkSource::Files(Vec::new()),
+            //
+            // A virtual source has no source *documents* — it scans a mapped
+            // table, not a tree of files — so its document table is empty. That
+            // is the honest value, not a placeholder: the manifest it feeds
+            // gains no `importSource` rows (there is no file to name), and any
+            // `DocIds::id` call on this path would be indexing a document list
+            // that was never populated, which the `debug_assert` there reports.
+            ImportSource::Virtual => (
+                ChunkSource::Files(Vec::new()),
+                DocIds::new(&skolem_namespace, Vec::new())?,
+            ),
         };
 
         // ---- Phase 1: Create ledger (init nameservice) ----
-        let normalized_alias = fluree_db_core::ledger_id::normalize_ledger_id(alias)
-            .unwrap_or_else(|_| alias.to_string());
-
         // Check if ledger already exists
         let ns_record = nameservice
             .lookup(&normalized_alias)
@@ -3133,6 +3420,7 @@ where
             nameservice,
             &normalized_alias,
             &chunk_source,
+            &doc_ids,
             paths,
             config,
             pipeline_start,
@@ -3241,11 +3529,13 @@ struct IndexBuildInput<'a> {
 ///
 /// Separated from `run_import_pipeline` to enable clean error-path handling:
 /// on failure, the caller keeps the session dir for debugging.
+#[allow(clippy::too_many_arguments)]
 async fn run_pipeline_phases<S>(
     storage: &S,
     nameservice: &dyn crate::NameServicePublisher,
     alias: &str,
     chunk_source: &std::sync::Arc<ChunkSource>,
+    doc_ids: &DocIds,
     paths: PipelinePaths<'_>,
     config: &ImportConfig,
     pipeline_start: Instant,
@@ -3259,6 +3549,7 @@ where
         nameservice,
         alias,
         chunk_source,
+        doc_ids,
         paths.run_dir,
         config,
     )
@@ -3411,11 +3702,13 @@ struct ChunkImportResult {
 }
 
 /// Import all TTL chunks: parallel parse + serial commit + streaming runs.
+#[allow(clippy::too_many_arguments)]
 async fn run_import_chunks<S>(
     storage: &S,
     nameservice: &dyn crate::NameServicePublisher,
     alias: &str,
     chunk_source: &std::sync::Arc<ChunkSource>,
+    doc_ids: &DocIds,
     run_dir: &Path,
     config: &ImportConfig,
 ) -> std::result::Result<ChunkImportResult, ImportError>
@@ -3856,32 +4149,30 @@ where
     struct ParseChunkContext<'a> {
         shared_alloc: &'a Arc<SharedNamespaceAllocator>,
         prelude: Option<&'a fluree_graph_turtle::splitter::TurtlePrelude>,
-        ledger: &'a str,
         compress: bool,
         spool_dir: &'a Path,
         spool_config: &'a Arc<SpoolConfig>,
     }
 
-    /// `doc` is the index of the source document this chunk was cut from; it
-    /// scopes blank-node labels (see [`RemoteChunk`]). It is deliberately a
-    /// separate argument from `idx`/`t`: the two coincide only when a chunk is
-    /// a whole document.
+    /// `doc` says which source document this chunk was cut from and where
+    /// inside it (see [`DocChunk`]). It is deliberately a separate argument
+    /// from `idx`/`t`: the two coincide only when a chunk is a whole document.
     fn parse_ttl_chunk(
         ttl: &str,
         ctx: &ParseChunkContext<'_>,
         t: i64,
         idx: usize,
-        doc: usize,
+        doc: DocChunk,
     ) -> std::result::Result<ParsedChunk, String> {
-        let scope = doc_scope(doc);
+        let base = doc.skolem_base();
         let parsed = if let Some(prelude) = ctx.prelude {
             parse_chunk_with_prelude(
                 ttl,
                 ctx.shared_alloc,
                 prelude,
                 t,
-                ctx.ledger,
-                &scope,
+                &base,
+                doc.sub_chunk,
                 ctx.compress,
                 Some(ctx.spool_dir),
                 Some(ctx.spool_config),
@@ -3892,8 +4183,8 @@ where
                 ttl,
                 ctx.shared_alloc,
                 t,
-                ctx.ledger,
-                &scope,
+                &base,
+                doc.sub_chunk,
                 ctx.compress,
                 Some(ctx.spool_dir),
                 Some(ctx.spool_config),
@@ -3929,8 +4220,6 @@ where
         // Streaming path: workers receive chunk data from the reader thread's
         // channel. No worker I/O — the reader is the only entity reading from disk.
         // This avoids double I/O that would kill throughput on external drives.
-        let ledger = alias.to_string();
-
         let (reader_rx, prelude, ns_preflight_cell) = match &**chunk_source {
             ChunkSource::Streaming(reader) => (
                 reader.shared_receiver(),
@@ -3960,12 +4249,14 @@ where
             std::result::Result<(usize, ParsedChunk), String>,
         >(num_threads);
 
+        // One streamed file is one document; every chunk shares its scope.
+        let streaming_doc = doc_ids.id(0);
+
         let mut parse_handles = Vec::with_capacity(num_threads);
         for thread_idx in 0..num_threads {
             let work_rx = Arc::clone(&work_rx);
             let result_tx = result_tx.clone();
             let shared_alloc = Arc::clone(&shared_alloc);
-            let ledger = ledger.clone();
             let prelude = prelude.clone();
             let spool_dir = spool_dir.clone();
             let spool_config = Arc::clone(&spool_config);
@@ -3976,7 +4267,6 @@ where
                     let ctx = ParseChunkContext {
                         shared_alloc: &shared_alloc,
                         prelude: Some(&prelude),
-                        ledger: &ledger,
                         compress,
                         spool_dir: &spool_dir,
                         spool_config: &spool_config,
@@ -4006,8 +4296,13 @@ where
                             "about to parse chunk"
                         );
                         // This arm streams a SINGLE local file, so every chunk
-                        // belongs to document 0 and shares one label scope.
-                        match parse_ttl_chunk(&ttl, &ctx, t, idx, STREAMING_DOC_IDX) {
+                        // belongs to the same document; `idx` is its sub-chunk
+                        // index inside that document.
+                        let doc = DocChunk {
+                            doc: streaming_doc,
+                            sub_chunk: u32::try_from(idx).unwrap_or(u32::MAX),
+                        };
+                        match parse_ttl_chunk(&ttl, &ctx, t, idx, doc) {
                             Ok(parsed) => {
                                 if result_tx.send(Ok((idx, parsed))).is_err() {
                                     break;
@@ -4203,7 +4498,6 @@ where
         // throttle). At least one worker is always used — zero would deadlock the
         // producer sending into an unread channel.
         let num_threads = num_threads.max(1);
-        let ledger = alias.to_string();
 
         // Both producers expose `(rx, error_rx, join_handle)` with identical EOF
         // semantics: the channel closing is not "success" on its own — we must
@@ -4241,7 +4535,6 @@ where
             let work_rx = Arc::clone(&remote_rx);
             let result_tx = result_tx.clone();
             let shared_alloc = Arc::clone(&shared_alloc);
-            let ledger = ledger.clone();
             let spool_dir = spool_dir.clone();
             let spool_config = Arc::clone(&spool_config);
 
@@ -4253,7 +4546,6 @@ where
                         // Remote objects are whole files with embedded preludes —
                         // parse_chunk extracts prelude per-chunk.
                         prelude: None,
-                        ledger: &ledger,
                         compress,
                         spool_dir: &spool_dir,
                         spool_config: &spool_config,
@@ -4435,6 +4727,7 @@ where
                     trig_content,
                     storage,
                     alias,
+                    &doc.skolem_base(),
                     compress,
                     Some(&spool_dir),
                     Some(&spool_config),
@@ -4448,12 +4741,14 @@ where
                 published_codes.extend(state.ns_registry.all_codes());
                 r
             } else {
+                let skolem_base = doc.skolem_base();
                 let parsed = if chunk_source.is_jsonld(idx) {
                     parse_jsonld_chunk(
                         &content,
                         &shared_alloc,
                         t,
-                        alias,
+                        &skolem_base,
+                        doc.sub_chunk,
                         compress,
                         Some(&spool_dir),
                         Some(&spool_config),
@@ -4464,8 +4759,8 @@ where
                         &content,
                         &shared_alloc,
                         t,
-                        alias,
-                        &doc_scope(doc),
+                        &skolem_base,
+                        doc.sub_chunk,
                         compress,
                         Some(&spool_dir),
                         Some(&spool_config),
@@ -4561,9 +4856,9 @@ where
         let has_nquads = chunk_source.has_nquads();
         let has_jsonld = chunk_source.has_jsonld();
         if estimated_total > 0 && num_threads > 0 && !has_trig && !has_nquads && !has_jsonld {
-            let ledger = alias.to_string();
-
             let next_chunk = Arc::new(AtomicUsize::new(0));
+            // One whole file per chunk, so chunk index == document index.
+            let file_doc_ids: Arc<Vec<u64>> = Arc::new(doc_ids.ids());
             let (result_tx, result_rx) = std::sync::mpsc::sync_channel::<
                 std::result::Result<(usize, ParsedChunk), String>,
             >(num_threads);
@@ -4577,7 +4872,7 @@ where
                 let next_chunk = Arc::clone(&next_chunk);
                 let result_tx = result_tx.clone();
                 let shared_alloc = Arc::clone(&shared_alloc);
-                let ledger = ledger.clone();
+                let file_doc_ids = Arc::clone(&file_doc_ids);
                 let chunk_source = Arc::clone(chunk_source);
                 let permit_rx_ref = Arc::clone(&permit_rx);
                 let permit_tx_ref = permit_tx.clone();
@@ -4591,7 +4886,6 @@ where
                         let ctx = ParseChunkContext {
                             shared_alloc: &shared_alloc,
                             prelude: None,
-                            ledger: &ledger,
                             compress,
                             spool_dir: &spool_dir,
                             spool_config: &spool_config,
@@ -4620,7 +4914,8 @@ where
 
                             // `Files` reads one whole file per chunk.
                             let t = (idx + 1) as i64;
-                            match parse_ttl_chunk(&ttl, &ctx, t, idx, idx) {
+                            let doc = DocChunk::whole(file_doc_ids[idx]);
+                            match parse_ttl_chunk(&ttl, &ctx, t, idx, doc) {
                                 Ok(parsed) => {
                                     let _ = permit_tx_ref.send(());
                                     if result_tx.send(Ok((idx, parsed))).is_err() {
@@ -4688,6 +4983,7 @@ where
                         trig_content,
                         storage,
                         alias,
+                        &DocChunk::whole(doc_ids.id(i)).skolem_base(),
                         compress,
                         Some(&spool_dir),
                         Some(&spool_config),
@@ -4703,26 +4999,28 @@ where
                     published_codes.extend(state.ns_registry.all_codes());
                     r
                 } else {
-                    // TTL and JSON-LD: parse via shared allocator, then finalize.
+                    // TTL and JSON-LD: parse via shared allocator, then
+                    // finalize. `Files` reads one whole file per chunk.
+                    let skolem_base = DocChunk::whole(doc_ids.id(i)).skolem_base();
                     let parsed = if chunk_source.is_jsonld(i) {
                         parse_jsonld_chunk(
                             &content,
                             &shared_alloc,
                             t,
-                            alias,
+                            &skolem_base,
+                            0,
                             compress,
                             Some(&spool_dir),
                             Some(&spool_config),
                             i,
                         )
                     } else {
-                        // `Files` reads one whole file per chunk.
                         parse_chunk(
                             &content,
                             &shared_alloc,
                             t,
-                            alias,
-                            &doc_scope(i),
+                            &skolem_base,
+                            0,
                             compress,
                             Some(&spool_dir),
                             Some(&spool_config),
@@ -6605,6 +6903,88 @@ mod resource_model_tests {
         }
     }
 
+    // A duplicate document key is unreachable through `discover_chunks`
+    // (`read_dir` yields each entry once), so exercise the guard directly. The
+    // one arm that CAN produce it — caller-supplied `OrderedObjects` — is
+    // covered end-to-end by `duplicate_remote_addresses_abort_the_import`.
+    #[test]
+    fn duplicate_document_keys_are_refused_by_name() {
+        let err = DocIds::new(
+            "l:main",
+            vec!["a.ttl".into(), "sub/b.ttl".into(), "a.ttl".into()],
+        )
+        .expect_err("two documents with one key must not build a DocIds");
+        let msg = err.to_string();
+        assert!(msg.contains("a.ttl"), "must name the colliding key: {msg}");
+        assert!(
+            !msg.contains("sub/b.ttl"),
+            "must not implicate the innocent document: {msg}"
+        );
+    }
+
+    #[test]
+    fn distinct_document_keys_build_distinct_ids() {
+        let docs =
+            DocIds::new("l:main", vec!["a.ttl".into(), "sub/a.ttl".into()]).expect("distinct keys");
+        assert_ne!(
+            docs.id(0),
+            docs.id(1),
+            "the same file name under a different directory is a different document"
+        );
+    }
+
+    // Anonymous-node ids are `(doc, sub_chunk, counter)`; the producer supplies
+    // the first two. A counter that reset outside its document's run would
+    // re-issue sub-chunk 0 and merge two documents' anonymous nodes.
+    #[test]
+    fn sub_chunk_indexes_restart_per_document() {
+        let mut counter = SubChunkCounter::default();
+        assert_eq!(
+            counter.next_for(7),
+            DocChunk {
+                doc: 7,
+                sub_chunk: 0
+            }
+        );
+        assert_eq!(
+            counter.next_for(7),
+            DocChunk {
+                doc: 7,
+                sub_chunk: 1
+            }
+        );
+        assert_eq!(
+            counter.next_for(9),
+            DocChunk {
+                doc: 9,
+                sub_chunk: 0
+            }
+        );
+        assert_eq!(
+            counter.next_for(9),
+            DocChunk {
+                doc: 9,
+                sub_chunk: 1
+            }
+        );
+    }
+
+    #[test]
+    fn local_doc_key_is_relative_to_the_import_root() {
+        let root = Path::new("/data/corpus");
+        assert_eq!(
+            local_doc_key(root, Path::new("/data/corpus/a.ttl")),
+            "a.ttl"
+        );
+        assert_eq!(
+            local_doc_key(root, Path::new("/data/corpus/sub/a.ttl")),
+            format!("sub{}a.ttl", std::path::MAIN_SEPARATOR)
+        );
+        // Outside the root (never produced by discovery) falls back to the
+        // file name rather than leaking an absolute path into the id.
+        assert_eq!(local_doc_key(root, Path::new("/elsewhere/a.ttl")), "a.ttl");
+    }
+
     #[test]
     fn explicit_thread_count_is_honored_uncapped() {
         let _env = EnvGuard::clear_overrides();
@@ -6749,6 +7129,7 @@ mod resource_model_tests {
             .iter()
             .map(|p| std::fs::metadata(p).expect("metadata").len())
             .collect();
+        let doc_ids: Vec<u64> = (0..files.len() as u64).map(|i| i + 1).collect();
         let chunk_size_bytes = 1024;
         let coalesce_enabled = true;
 
@@ -6756,6 +7137,7 @@ mod resource_model_tests {
         local_rechunk_loop(
             &files,
             &sizes,
+            &doc_ids,
             chunk_size_bytes,
             coalesce_enabled,
             &serial_tx,
@@ -6768,6 +7150,7 @@ mod resource_model_tests {
         local_rechunk_loop_parallel(
             files,
             sizes,
+            doc_ids,
             chunk_size_bytes,
             coalesce_enabled,
             &parallel_tx,

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -862,7 +862,19 @@ impl DocIds {
     /// Out-of-range indexes fall back to `0`: the caller has already sized its
     /// document list, so this is unreachable, and a wrong-but-stable scope is a
     /// better failure than a panic mid-import.
+    ///
+    /// The fallback is nonetheless the one silent way this table can go wrong:
+    /// *several* out-of-range documents would all land on scope `0` and merge
+    /// their `_:x` nodes — the failure `DocIds::new` refuses up front, arriving
+    /// through the back door. The assertion turns that into a test failure and
+    /// costs nothing in release.
     fn id(&self, idx: usize) -> u64 {
+        debug_assert!(
+            idx < self.ids.len(),
+            "document index {idx} is out of range ({} documents); every \
+             out-of-range index shares scope 0",
+            self.ids.len()
+        );
         self.ids.get(idx).copied().unwrap_or(0)
     }
 

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -803,9 +803,16 @@ type RemoteChunk = (usize, DocChunk, Vec<u8>);
 /// for remote ones — so every arm agrees on what a document key is. Indexed the
 /// same way `per_chunk_format` and the rechunk `sizes` are.
 ///
+/// Doubles as the import manifest: [`DocIds::manifest`] hands the
+/// `scope → key` mapping to the `txn-meta` graph builder, which is what makes a
+/// minted `_:fdb-d…` id traceable back to the document it came from.
+///
 #[derive(Debug)]
 pub(crate) struct DocIds {
-    /// `skolem::doc_id` of each document key, in source order.
+    /// Document keys in source order — paths relative to the import root, or
+    /// remote addresses relative to the listing prefix.
+    keys: Vec<String>,
+    /// `skolem::doc_id` of each key, same order.
     ids: Vec<u64>,
 }
 
@@ -839,7 +846,7 @@ impl DocIds {
             seen.insert(id, idx);
             ids.push(id);
         }
-        Ok(Self { ids })
+        Ok(Self { keys, ids })
     }
 
     /// Hashed id of document `idx`.
@@ -855,6 +862,30 @@ impl DocIds {
     fn ids(&self) -> Vec<u64> {
         self.ids.clone()
     }
+
+    /// The import manifest: `(blank-node local name of the scope, document
+    /// key)` for every document.
+    ///
+    /// The subject is the scope's own blank node — `fdb-d<scope>`, the prefix
+    /// every id minted from that document shares — so a reader holding an
+    /// opaque `_:fdb-d…-label` recovers the source with
+    /// `fluree_db_core::skolem::split_doc_scope` and one lookup.
+    fn manifest(&self) -> Vec<(String, String)> {
+        self.ids
+            .iter()
+            .zip(&self.keys)
+            .map(|(&id, key)| {
+                (
+                    format!(
+                        "{}{}",
+                        fluree_db_core::ns_encoding::STABLE_BLANK_NODE_LABEL_PREFIX,
+                        fluree_db_core::skolem::doc_scope(id)
+                    ),
+                    key.clone(),
+                )
+            })
+            .collect()
+    }
 }
 
 /// Derive a document key for a local path: its location relative to the import
@@ -863,6 +894,10 @@ impl DocIds {
 /// Relative rather than absolute so that ids depend on the shape of the import,
 /// not on where the tree happens to be mounted — the same directory imported
 /// from `/tmp/x` and `/data/x` mints the same ids.
+///
+/// [`discover_chunks`] does not recurse, so a local key is a bare file name in
+/// practice; the relative form is what remote `Prefix` listings need, and what
+/// keeps the two arms describing documents the same way.
 fn local_doc_key(root: &Path, path: &Path) -> String {
     path.strip_prefix(root)
         .ok()
@@ -4120,6 +4155,7 @@ where
             (fluree::DB, db::ASSERTS),
             (fluree::DB, db::RETRACTS),
             (fluree::DB, db::PREVIOUS),
+            (fluree::DB, db::IMPORT_SOURCE),
         ] {
             spool_config
                 .predicate_alloc
@@ -5127,6 +5163,10 @@ where
         let p_previous = spool_config
             .predicate_alloc
             .get_or_insert_parts(fluree::DB, db::PREVIOUS);
+        let p_import_source = spool_config
+            .predicate_alloc
+            .get_or_insert_parts(fluree::DB, db::IMPORT_SOURCE);
+        let manifest = doc_ids.manifest();
 
         // txn-meta is always pre-seeded as dict_id=0 in the graph allocator
         // (via SharedDictAllocator::new_graph), so g_id = dict_id + 1 = 1.
@@ -5154,6 +5194,24 @@ where
             let mut meta_strings = ChunkStringDict::new();
             let mut records: Vec<RunRecord> = Vec::with_capacity(commit_metas.len() * 8);
 
+            let record = |s_id: u64,
+                          p_id: u32,
+                          o_kind: ObjKind,
+                          o_key: ObjKey,
+                          dt: DatatypeDictId,
+                          t: u32| RunRecord {
+                g_id,
+                s_id: SubjectId::from_u64(s_id),
+                p_id,
+                dt: dt.as_u16(),
+                o_kind: o_kind.as_u8(),
+                op: 1, // assert
+                o_key: o_key.as_u64(),
+                t,
+                lang_id: 0,
+                i: LIST_INDEX_NONE,
+            };
+
             for cm in &commit_metas {
                 let commit_s = meta_subjects
                     .get_or_insert(namespaces::FLUREE_COMMIT, cm.commit_hash_hex.as_bytes());
@@ -5161,18 +5219,7 @@ where
 
                 let mut push =
                     |s_id: u64, p_id: u32, o_kind: ObjKind, o_key: ObjKey, dt: DatatypeDictId| {
-                        records.push(RunRecord {
-                            g_id,
-                            s_id: SubjectId::from_u64(s_id),
-                            p_id,
-                            dt: dt.as_u16(),
-                            o_kind: o_kind.as_u8(),
-                            op: 1, // assert
-                            o_key: o_key.as_u64(),
-                            t,
-                            lang_id: 0,
-                            i: LIST_INDEX_NONE,
-                        });
+                        records.push(record(s_id, p_id, o_kind, o_key, dt, t));
                     };
 
                 // db:address — commit hash hex as LEX_ID string
@@ -5246,6 +5293,29 @@ where
                 }
             }
 
+            // Import manifest: one triple per source document, mapping the
+            // blank-node scope every id from that document shares back to the
+            // document itself. Without it a minted `_:fdb-d…` is unresolvable
+            // — the scope is a hash, and nothing else in the ledger records
+            // what was hashed.
+            //
+            // Stamped at t=1: the manifest describes the import as a whole,
+            // and t=1 is the first commit any reader of the ledger can see.
+            let manifest_count = manifest.len();
+            for (scope_label, doc_key) in &manifest {
+                let scope_s =
+                    meta_subjects.get_or_insert(namespaces::BLANK_NODE, scope_label.as_bytes());
+                let key_str_id = meta_strings.get_or_insert(doc_key.as_bytes());
+                records.push(record(
+                    scope_s,
+                    p_import_source,
+                    ObjKind::LEX_ID,
+                    ObjKey::encode_u32_id(key_str_id),
+                    DatatypeDictId::STRING,
+                    1,
+                ));
+            }
+
             let meta_records_count = records.len();
             let commit_count = commit_metas.len();
 
@@ -5280,6 +5350,7 @@ where
             tracing::info!(
                 meta_chunk_idx,
                 commit_count,
+                manifest_count,
                 meta_records_count,
                 "txn-meta meta chunk built"
             );

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -766,6 +766,16 @@ impl DocChunk {
 /// contiguity rather than trusting it silently — a producer that interleaved
 /// documents would otherwise re-issue sub-chunk 0 and merge two documents'
 /// anonymous nodes.
+///
+/// Debug-only, unlike the analogous guard in [`DocIds::new`], because the two
+/// watch different things. `DocIds::new` validates *caller-supplied input* — a
+/// `Remote` `OrderedObjects` list names the addresses, and a caller can repeat
+/// one — so no amount of testing this crate rules it out and the check has to
+/// hold in release. This one guards an invariant of an internal producer loop,
+/// which no external input can perturb: whether a producer walks its documents
+/// contiguously is fixed by the code, so a violation is a bug in this file that
+/// a debug build catches before it ships, not a condition to re-check per chunk
+/// on the hot path.
 #[derive(Default)]
 struct SubChunkCounter {
     current: Option<u64>,

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -7168,6 +7168,98 @@ mod resource_model_tests {
         assert_eq!(c.effective_rechunk_threads(), 1);
     }
 
+    // The sub-chunk index a chunk carries only separates anonymous nodes if a
+    // document's chunks are emitted as one contiguous run — otherwise the
+    // counter resets mid-document and re-issues 0. The mixed shape is where
+    // that could break: a split file's sub-chunks interleaving with coalesce
+    // buffer flushes. Runs in debug, so `SubChunkCounter`'s contiguity
+    // assertion is live, and compares the two producers payload-for-payload
+    // (the comparison includes the `DocChunk`).
+    #[test]
+    fn rechunk_scopes_survive_split_and_coalesced_files_interleaved() {
+        let _env = EnvGuard::clear_overrides();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let chunk_size_bytes = 64 * 1024;
+
+        // 000/001 coalesce, 002 splits into several sub-chunks, 003/004
+        // coalesce again behind it.
+        let big: String = (0..5_000)
+            .map(|i| format!("<http://example/big{i}> <http://example/p> <http://example/o> .\n"))
+            .collect();
+        let small =
+            |i: usize| format!("<http://example/s{i}> <http://example/p> <http://example/o> .\n");
+        let inputs: Vec<(String, String)> = vec![
+            ("000.nt".into(), small(0)),
+            ("001.nt".into(), small(1)),
+            ("002.nt".into(), big),
+            ("003.nt".into(), small(3)),
+            ("004.nt".into(), small(4)),
+        ];
+
+        let files: Vec<PathBuf> = inputs
+            .iter()
+            .map(|(name, contents)| {
+                let path = dir.path().join(name);
+                std::fs::write(&path, contents).expect("write fixture");
+                path
+            })
+            .collect();
+        let sizes: Vec<u64> = files
+            .iter()
+            .map(|p| std::fs::metadata(p).expect("metadata").len())
+            .collect();
+        assert!(
+            sizes[2] > chunk_size_bytes,
+            "fixture must force the split arm"
+        );
+        let doc_ids: Vec<u64> = (0..files.len() as u64).map(|i| i + 1).collect();
+
+        let (serial_tx, serial_rx) = std::sync::mpsc::sync_channel(64);
+        local_rechunk_loop(&files, &sizes, &doc_ids, chunk_size_bytes, true, &serial_tx)
+            .expect("serial rechunk");
+        drop(serial_tx);
+        let serial: Vec<RemoteChunk> = serial_rx.into_iter().collect();
+
+        let (parallel_tx, parallel_rx) = std::sync::mpsc::sync_channel(256);
+        local_rechunk_loop_parallel(
+            files,
+            sizes,
+            doc_ids,
+            chunk_size_bytes,
+            true,
+            &parallel_tx,
+            4,
+        )
+        .expect("parallel rechunk");
+        drop(parallel_tx);
+        let parallel: Vec<RemoteChunk> = parallel_rx.into_iter().collect();
+
+        assert_eq!(parallel, serial);
+
+        // Both loops buffer their whole output here (nothing drains
+        // concurrently), so the channel must outrun the chunk count.
+        //
+        // Note the 64 KB chunk size: `StreamingTurtleReader` does not
+        // terminate on a sub-KB chunk size, so the split arm cannot be
+        // exercised at the 1 KB the coalescing-only test above uses. That is
+        // pre-existing and unreachable in production — `chunk_size_mb` is
+        // megabytes — but it is why this fixture is sized the way it is.
+
+        // Every (document, sub-chunk) pair is used once — the invariant the
+        // anonymous-node mint rests on.
+        let mut seen: Vec<DocChunk> = serial.iter().map(|(_, doc, _)| *doc).collect();
+        let total = seen.len();
+        seen.sort_by_key(|d| (d.doc, d.sub_chunk));
+        seen.dedup();
+        assert_eq!(seen.len(), total, "a (doc, sub_chunk) pair was reused");
+
+        let split_chunks = serial.iter().filter(|(_, d, _)| d.doc == 3).count();
+        assert!(
+            split_chunks > 1,
+            "test is vacuous unless 002.nt was sub-split: {split_chunks} chunk(s)"
+        );
+    }
+
     #[test]
     fn parallel_local_rechunk_matches_serial_order_and_coalescing() {
         let _env = EnvGuard::clear_overrides();

--- a/fluree-db-api/src/materialize.rs
+++ b/fluree-db-api/src/materialize.rs
@@ -312,7 +312,11 @@ pub fn build_stamp_chunk(
 ) -> Result<ParsedChunk, MaterializeError> {
     let txn_id = format!("{}-{}", ctx.ledger_id, t);
     let mut worker_cache = WorkerCache::new(Arc::clone(ctx.shared_alloc));
-    let mut sink = ImportSink::new_cached(&mut worker_cache, t, txn_id, ctx.compress)
+    // Sub-chunk 0: the sink's sub-chunk ordinal only separates ANONYMOUS blank
+    // nodes minted by two sinks that share a skolem base, and this base already
+    // carries `t`, so it is unique per chunk. (The twin never mints an anonymous
+    // node in any case — every materialized blank node is labeled.)
+    let mut sink = ImportSink::new_cached(&mut worker_cache, t, txn_id, 0, ctx.compress)
         .map_err(|e| R2rmlError::Materialization(format!("import sink create: {e}")))?;
 
     if let Some(config) = ctx.spool_config {
@@ -825,10 +829,13 @@ fn spawn_produce_workers(
                         // and the chunk is cut on the running byte estimate at batch
                         // boundaries (one batch of overshoot at most).
                         let mut worker_cache = WorkerCache::new(Arc::clone(&shared_alloc));
+                        // Sub-chunk 0 for the same reason as `build_stamp_chunk`:
+                        // the base carries `t`, so it is already unique per chunk.
                         let mut sink = ImportSink::new_cached(
                             &mut worker_cache,
                             t,
                             format!("{ledger}-{t}"),
+                            0,
                             compress,
                         )
                         .map_err(|e| format!("import sink create: {e}"))?;

--- a/fluree-db-api/src/validate.rs
+++ b/fluree-db-api/src/validate.rs
@@ -215,9 +215,20 @@ impl ValidateReport {
 
 /// Render an IRI or blank-node label as a Turtle term.
 ///
-/// Skolemized blank-node labels may carry characters that are invalid in a
-/// Turtle BLANK_NODE_LABEL (e.g. `/` and `:` from embedded ledger ids) —
-/// sanitize them so the emitted document always parses.
+/// A blank-node label may carry characters that are invalid in a Turtle
+/// BLANK_NODE_LABEL — map them to `-` so the emitted report always parses.
+///
+/// Two label shapes still need it. Ledgers imported by Fluree 4.1.4 or earlier
+/// hold ids that embedded the ledger id, so they contain `/` and `:`
+/// (`fdb-lubm:main-1-genid10`); current import ids are `[0-9a-z-]` only (see
+/// `fluree_db_core::skolem`) and pass through unchanged. Client-authored
+/// labels can also carry characters JSON-LD accepts and Turtle does not.
+///
+/// The rewrite is **lossy**: two labels differing only in sanitized characters
+/// collapse onto one. That is acceptable here — a validation report is
+/// human-facing output, not a round-trippable serialization of the graph — and
+/// it is why the same rewrite is deliberately NOT applied on the export path
+/// (`crate::export`), where identity has to survive.
 fn turtle_term(iri_or_bnode: &str) -> String {
     match iri_or_bnode.strip_prefix("_:") {
         Some(label) => {

--- a/fluree-db-api/tests/grp_import.rs
+++ b/fluree-db-api/tests/grp_import.rs
@@ -13,6 +13,8 @@ mod it_import_ndjson;
 mod it_import_ns_split_mode;
 #[path = "it_import_remote.rs"]
 mod it_import_remote;
+#[path = "it_import_skolem.rs"]
+mod it_import_skolem;
 #[path = "it_import_v3.rs"]
 mod it_import_v3;
 #[path = "it_namespace_new_after_index.rs"]

--- a/fluree-db-api/tests/it_import.rs
+++ b/fluree-db-api/tests/it_import.rs
@@ -1564,6 +1564,287 @@ GRAPH <http://example.org/graphs/g2> {
 }
 
 // ============================================================================
+// Turtle blank-node label scoping across CHUNK boundaries
+//
+// Same contract as the TriG test above, applied to the chunked bulk-import
+// path: bulk import cuts one Turtle document into many chunks (one commit
+// each), so a labeled blank node must still resolve to ONE subject across all
+// of them, and must stay distinct between input files.
+// ============================================================================
+
+/// Build a Turtle document large enough to be split across import chunks, with
+/// `_:shared` referenced in the FIRST statement and again in the LAST.
+///
+/// `marker` distinguishes documents; the filler is sized so a 1 MB chunk cannot
+/// hold the whole file.
+fn multi_chunk_ttl(marker: &str, filler_triples: usize) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(filler_triples * 128 + 256);
+    s.push_str("@prefix ex: <http://example.org/> .\n");
+    s.push_str("@prefix schema: <http://schema.org/> .\n\n");
+    let _ = writeln!(s, "_:shared schema:name \"{marker}\" .");
+    for i in 0..filler_triples {
+        let _ = writeln!(
+            s,
+            "ex:{marker}-filler{i} schema:description \"padding that pushes the two _:shared statements into different import chunks\" ."
+        );
+    }
+    let _ = writeln!(s, "_:shared schema:jobTitle \"{marker}\" .");
+    s
+}
+
+/// Like [`multi_chunk_ttl`], but the first and last statements each contain an
+/// ANONYMOUS blank node (`[ … ]`) rather than a labeled one.
+///
+/// Both land at the same ordinal within their respective chunks (the filler
+/// mints none), which is exactly the case where a per-chunk mint counter under
+/// a document-shared skolem base collides.
+fn multi_chunk_anon_ttl(filler_triples: usize) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(filler_triples * 128 + 256);
+    s.push_str("@prefix ex: <http://example.org/> .\n");
+    s.push_str("@prefix schema: <http://schema.org/> .\n\n");
+    s.push_str("ex:doc ex:first [ schema:name \"anon-first\" ] .\n");
+    for i in 0..filler_triples {
+        let _ = writeln!(
+            s,
+            "ex:anon-filler{i} schema:description \"padding that pushes the two anonymous nodes into different import chunks\" ."
+        );
+    }
+    s.push_str("ex:doc ex:last [ schema:name \"anon-last\" ] .\n");
+    s
+}
+
+/// Resolve the single subject carrying `predicate` = `marker`.
+async fn sole_subject_for(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &fluree_db_api::LedgerState,
+    predicate: &str,
+    marker: &str,
+) -> String {
+    let qr = support::query_jsonld(
+        fluree,
+        ledger,
+        &json!({"select": ["?s"], "where": {"@id": "?s", predicate: marker}}),
+    )
+    .await
+    .expect("subject query");
+    let rows = qr.to_jsonld(&ledger.snapshot).expect("jsonld");
+    let subjects: Vec<String> = rows
+        .as_array()
+        .expect("array result")
+        .iter()
+        .filter_map(|r| match r {
+            serde_json::Value::Array(cols) => cols[0].as_str(),
+            other => other.as_str(),
+        })
+        .map(str::to_string)
+        .collect();
+    assert_eq!(
+        subjects.len(),
+        1,
+        "expected exactly one subject for {predicate} = {marker}: {rows}"
+    );
+    let subject = subjects.into_iter().next().unwrap();
+    assert!(
+        subject.starts_with("_:fdb-"),
+        "expected a skolemized blank node, got {subject}"
+    );
+    subject
+}
+
+// Regression: `parse_chunk` used to derive the skolemization key from the
+// per-chunk commit `t`, so `_:shared` in chunk 0 and `_:shared` in chunk 1 of
+// ONE file became two different subjects — the chunked-Turtle sibling of the
+// TriG bug fixed in #1432. Runs with 2 parse threads: the two occurrences are
+// skolemized on different workers with no shared state between them.
+#[tokio::test]
+async fn import_ttl_blank_label_scoped_across_chunks() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    // ~1.5 MB against a 1 MB chunk size — at least two chunks.
+    let ttl = multi_chunk_ttl("solo", 12_000);
+    assert!(ttl.len() > 1024 * 1024, "fixture must exceed one chunk");
+    let path = write_ttl(data_dir.path(), "big.ttl", &ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let result = fluree
+        .create("test/ttl-bnode-chunks:main")
+        .import(&path)
+        .threads(2)
+        .chunk_size_mb(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("chunked import should succeed");
+    assert!(
+        result.t > 1,
+        "test is vacuous unless the file was split: {} chunk(s)",
+        result.t
+    );
+
+    let ledger = fluree
+        .ledger("test/ttl-bnode-chunks:main")
+        .await
+        .expect("load ledger");
+
+    let first = sole_subject_for(&fluree, &ledger, "http://schema.org/name", "solo").await;
+    let last = sole_subject_for(&fluree, &ledger, "http://schema.org/jobTitle", "solo").await;
+    assert_eq!(
+        first, last,
+        "a labeled blank node is scoped to its document, not to the chunk it lands in"
+    );
+}
+
+// The counterpart constraint, and the one a document-scoped skolem base can
+// easily break: ANONYMOUS nodes carry no label to unify on, so two of them must
+// stay distinct even when they sit at the same ordinal in different chunks of
+// one document. The mint counter is per-sink (per chunk), so it only separates
+// them if the minted label also carries something chunk-unique.
+#[tokio::test]
+async fn import_ttl_anonymous_nodes_distinct_across_chunks() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    let ttl = multi_chunk_anon_ttl(12_000);
+    assert!(ttl.len() > 1024 * 1024, "fixture must exceed one chunk");
+    let path = write_ttl(data_dir.path(), "anon.ttl", &ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let result = fluree
+        .create("test/ttl-anon-chunks:main")
+        .import(&path)
+        .threads(2)
+        .chunk_size_mb(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("chunked import should succeed");
+    assert!(
+        result.t > 1,
+        "test is vacuous unless the file was split: {} chunk(s)",
+        result.t
+    );
+
+    let ledger = fluree
+        .ledger("test/ttl-anon-chunks:main")
+        .await
+        .expect("load ledger");
+
+    let first = sole_subject_for(&fluree, &ledger, "http://schema.org/name", "anon-first").await;
+    let last = sole_subject_for(&fluree, &ledger, "http://schema.org/name", "anon-last").await;
+    assert_ne!(
+        first, last,
+        "two anonymous nodes are two nodes, however the chunker happens to cut the file"
+    );
+}
+
+// The other half of the contract: chunk boundaries must not merge labels
+// ACROSS files. Two multi-chunk files in one directory take the local-rechunk
+// arm, so each is sub-split *and* interleaved with the other in the same
+// import session.
+#[tokio::test]
+async fn import_ttl_blank_labels_distinct_across_files() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    write_ttl(data_dir.path(), "a.ttl", &multi_chunk_ttl("alpha", 12_000));
+    write_ttl(data_dir.path(), "b.ttl", &multi_chunk_ttl("beta", 12_000));
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let result = fluree
+        .create("test/ttl-bnode-files:main")
+        .import(data_dir.path())
+        .threads(2)
+        .chunk_size_mb(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("directory import should succeed");
+    assert!(
+        result.t > 2,
+        "test is vacuous unless both files were split: {} chunk(s)",
+        result.t
+    );
+
+    let ledger = fluree
+        .ledger("test/ttl-bnode-files:main")
+        .await
+        .expect("load ledger");
+
+    let alpha_first = sole_subject_for(&fluree, &ledger, "http://schema.org/name", "alpha").await;
+    let alpha_last =
+        sole_subject_for(&fluree, &ledger, "http://schema.org/jobTitle", "alpha").await;
+    let beta_first = sole_subject_for(&fluree, &ledger, "http://schema.org/name", "beta").await;
+    let beta_last = sole_subject_for(&fluree, &ledger, "http://schema.org/jobTitle", "beta").await;
+
+    assert_eq!(
+        alpha_first, alpha_last,
+        "a.ttl's label spans its own chunks"
+    );
+    assert_eq!(beta_first, beta_last, "b.ttl's label spans its own chunks");
+    assert_ne!(
+        alpha_first, beta_first,
+        "the same label in two files denotes two different nodes"
+    );
+}
+
+// Small files never reach the splitter, but they can be *coalesced* into one
+// chunk — which would merge their labels just as wrongly. `coalesce_unsafe`
+// refuses to coalesce any file containing `_:`; this pins that guarantee.
+#[tokio::test]
+async fn import_ttl_blank_labels_distinct_across_small_files() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    let doc = |marker: &str| {
+        format!("@prefix schema: <http://schema.org/> .\n\n_:shared schema:name \"{marker}\" .\n")
+    };
+    write_ttl(data_dir.path(), "a.ttl", &doc("small-a"));
+    write_ttl(data_dir.path(), "b.ttl", &doc("small-b"));
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    fluree
+        .create("test/ttl-bnode-small:main")
+        .import(data_dir.path())
+        .threads(1)
+        // Coalescing only engages above this threshold, and the default (64)
+        // would leave two files well under it — the test would pass without
+        // ever reaching the code path it exists to cover.
+        .coalesce_small_files_threshold(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("directory import should succeed");
+
+    let ledger = fluree
+        .ledger("test/ttl-bnode-small:main")
+        .await
+        .expect("load ledger");
+
+    let a = sole_subject_for(&fluree, &ledger, "http://schema.org/name", "small-a").await;
+    let b = sole_subject_for(&fluree, &ledger, "http://schema.org/name", "small-b").await;
+    assert_ne!(a, b, "each file is its own document");
+}
+
+// ============================================================================
 // N-Quads (.nq) import
 //
 // N-Quads is converted to TriG and dispatched through the named-graph-aware
@@ -2072,20 +2353,35 @@ async fn import_directory_blank_nodes_not_coalesced() {
         &ledger,
         &json!({
             "@context": {"schema": "http://schema.org/"},
-            "select": ["?name"],
-            "where": {"schema:name": "?name"}
+            "select": ["?s", "?name"],
+            "where": {"@id": "?s", "schema:name": "?name"}
         }),
     )
     .await
     .expect("query names");
-    let names = extract_sorted_strings(&qr.to_jsonld(&ledger.snapshot).unwrap());
+    let rows = qr.to_jsonld(&ledger.snapshot).expect("jsonld");
+    let rows = rows.as_array().expect("array result");
+
+    // Distinct SUBJECTS is the assertion that actually pins `coalesce_unsafe`.
+    // Counting names does not: if two files' `_:b1` merged, the merged subject
+    // would simply carry both names and the name count would be unchanged.
+    let subjects: std::collections::BTreeSet<&str> = rows
+        .iter()
+        .filter_map(|r| r.as_array().and_then(|row| row[0].as_str()))
+        .collect();
     assert_eq!(
-        names.len(),
+        subjects.len(),
         N,
         "every file's blank node must stay distinct (no cross-file merge)"
     );
-    assert!(names.contains(&"blank-0".to_string()));
-    assert!(names.contains(&"blank-79".to_string()));
+
+    let names: std::collections::BTreeSet<&str> = rows
+        .iter()
+        .filter_map(|r| r.as_array().and_then(|row| row[1].as_str()))
+        .collect();
+    assert_eq!(names.len(), N, "no name may be lost");
+    assert!(names.contains("blank-0"));
+    assert!(names.contains("blank-79"));
 }
 
 /// `coalesce_small_files_threshold(0)` disables coalescing: every small file

--- a/fluree-db-api/tests/it_import_skolem.rs
+++ b/fluree-db-api/tests/it_import_skolem.rs
@@ -1,0 +1,474 @@
+//! Identity of blank nodes minted by bulk import.
+//!
+//! Import skolemizes every blank node in its source into the reserved
+//! `_:fdb-...` label space. These tests pin what that id *is* — not its exact
+//! bytes, which are an implementation detail, but the four properties callers
+//! actually depend on:
+//!
+//! - it can be written back in SPARQL, so an imported blank-node structure is
+//!   editable in place the same way a transacted one is
+//!   ([`it_stable_blank_nodes`](super::it_stable_blank_nodes));
+//! - it depends on the document, not on the shape of the import — adding a file
+//!   to the directory does not renumber anything;
+//! - it depends on the ledger, so two ledgers loaded from one tree do not look
+//!   like they share nodes;
+//! - unless the caller says otherwise, in which case they do.
+
+#![cfg(feature = "native")]
+
+use crate::support;
+use fluree_db_api::{FlureeBuilder, LedgerState};
+use serde_json::json;
+
+/// A document with one labeled blank node (referenced twice, so a merge failure
+/// is visible as two subjects) and one anonymous node.
+const DOC: &str = r#"@prefix ex: <http://example.org/> .
+@prefix schema: <http://schema.org/> .
+
+ex:alice ex:knows _:shared .
+_:shared schema:name "Shared" .
+ex:bob ex:knows _:shared .
+ex:carol ex:owns [ schema:name "Anonymous" ] .
+"#;
+
+fn write(dir: &std::path::Path, name: &str, content: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, content).expect("write fixture");
+    path
+}
+
+/// Every `_:fdb-` id in the ledger that carries `schema:name` `name`.
+async fn blank_ids_named(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &LedgerState,
+    name: &str,
+) -> Vec<String> {
+    let qr = support::query_jsonld(
+        fluree,
+        ledger,
+        &json!({
+            "select": ["?s"],
+            "where": {"@id": "?s", "http://schema.org/name": name}
+        }),
+    )
+    .await
+    .expect("query");
+    let json = qr.to_jsonld(&ledger.snapshot).expect("jsonld");
+    let mut ids: Vec<String> = json
+        .as_array()
+        .expect("array result")
+        .iter()
+        .filter_map(|row| match row {
+            serde_json::Value::Array(cols) => cols.first().and_then(|v| v.as_str()),
+            other => other.as_str(),
+        })
+        .filter(|s| s.starts_with("_:fdb-"))
+        .map(str::to_string)
+        .collect();
+    ids.sort();
+    ids
+}
+
+/// The sole `_:fdb-` id carrying `schema:name` `name`.
+async fn sole_blank_id(fluree: &fluree_db_api::Fluree, ledger: &LedgerState, name: &str) -> String {
+    let ids = blank_ids_named(fluree, ledger, name).await;
+    assert_eq!(
+        ids.len(),
+        1,
+        "expected exactly one node named {name}: {ids:?}"
+    );
+    ids.into_iter().next().unwrap()
+}
+
+/// Import `DOC` (plus any extra files) into a fresh ledger and hand back the
+/// live handle.
+async fn import_doc(
+    db_dir: &std::path::Path,
+    data_dir: &std::path::Path,
+    alias: &str,
+    namespace: Option<&str>,
+) -> (fluree_db_api::Fluree, LedgerState) {
+    let fluree = FlureeBuilder::file(db_dir.to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    let mut builder = fluree
+        .create(alias)
+        .import(data_dir)
+        .threads(1)
+        .memory_budget_mb(256)
+        .cleanup(false);
+    if let Some(ns) = namespace {
+        builder = builder.skolem_namespace(ns);
+    }
+    builder.execute().await.expect("import should succeed");
+    let ledger = fluree.ledger(alias).await.expect("load ledger");
+    (fluree, ledger)
+}
+
+// ============================================================================
+// SPARQL writability — the reason the format changed
+// ============================================================================
+
+/// The headline property. Import used to build its skolem key out of the ledger
+/// id, so a minted id looked like `_:fdb-test/skolem-sparql:main-d0-shared`.
+/// SPARQL's `BLANK_NODE_LABEL` production admits neither `/` nor `:`, so that
+/// id could be read out of a query result and never written back — a
+/// bulk-imported blank-node structure was, uniquely, uneditable from SPARQL.
+///
+/// Fails before the hashed format: `parse_sparql` rejects the DELETE template.
+#[tokio::test]
+async fn imported_blank_node_id_is_writable_in_sparql() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    write(data_dir.path(), "doc.ttl", DOC);
+
+    // A ledger id with both offenders in it: `/` in the name, `:` before the
+    // branch.
+    let (fluree, ledger) = import_doc(
+        db_dir.path(),
+        data_dir.path(),
+        "test/skolem-sparql:main",
+        None,
+    )
+    .await;
+    let bnode = sole_blank_id(&fluree, &ledger, "Shared").await;
+
+    let sparql = format!(
+        "PREFIX schema: <http://schema.org/>\n\
+         DELETE {{ {bnode} schema:name ?old }}\n\
+         INSERT {{ {bnode} schema:name \"Renamed\" }}\n\
+         WHERE  {{ {bnode} schema:name ?old }}"
+    );
+    let parsed = fluree_db_sparql::parse_sparql(&sparql);
+    assert!(
+        !parsed.has_errors(),
+        "a minted import id must lex as a SPARQL BLANK_NODE_LABEL; \
+         id was {bnode}, diagnostics: {:?}",
+        parsed.diagnostics
+    );
+    let ast = parsed.ast.expect("SPARQL AST");
+    let mut ns = fluree_db_transact::NamespaceRegistry::from_db(&ledger.snapshot);
+    let txn = fluree_db_transact::lower_sparql_update_ast(
+        &ast,
+        &mut ns,
+        fluree_db_transact::TxnOpts::default(),
+    )
+    .expect("lower SPARQL UPDATE");
+    let ledger = fluree
+        .stage_owned(ledger)
+        .txn(txn)
+        .execute()
+        .await
+        .expect("stage SPARQL UPDATE")
+        .ledger;
+
+    // The edit landed on the stored node, rather than minting a fresh one.
+    assert!(
+        blank_ids_named(&fluree, &ledger, "Shared").await.is_empty(),
+        "the old name should be retracted"
+    );
+    assert_eq!(
+        sole_blank_id(&fluree, &ledger, "Renamed").await,
+        bnode,
+        "the SPARQL update must address the stored node, not mint a new one"
+    );
+}
+
+// ============================================================================
+// What the id depends on
+// ============================================================================
+
+/// Blank-node ids must not depend on what else happens to be in the import.
+///
+/// Before the hashed format the document scope was the file's *position* in the
+/// sorted directory listing, and anonymous nodes carried the global chunk
+/// ordinal on top of that — so dropping one more file into the directory
+/// renumbered every id behind it. Nothing about `doc.ttl`'s content changed;
+/// its ids did.
+///
+/// Fails before: `doc.ttl` is file 0 in the first import and file 1 in the
+/// second, so both the labeled and the anonymous id come out different.
+#[tokio::test]
+async fn minted_ids_do_not_depend_on_the_rest_of_the_directory() {
+    let alone_db = tempfile::tempdir().expect("db tmpdir");
+    let alone_data = tempfile::tempdir().expect("data tmpdir");
+    write(alone_data.path(), "02-doc.ttl", DOC);
+
+    // Same file, but now preceded by another document in listing order.
+    let together_db = tempfile::tempdir().expect("db tmpdir");
+    let together_data = tempfile::tempdir().expect("data tmpdir");
+    write(
+        together_data.path(),
+        "01-other.ttl",
+        "<http://example.org/x> <http://example.org/p> <http://example.org/y> .\n",
+    );
+    write(together_data.path(), "02-doc.ttl", DOC);
+
+    // Same ledger id on both sides, in separate stores, so the ONLY thing that
+    // differs between the two imports is the extra file.
+    let (f1, l1) = import_doc(
+        alone_db.path(),
+        alone_data.path(),
+        "test/skolem-shape:main",
+        None,
+    )
+    .await;
+    let (f2, l2) = import_doc(
+        together_db.path(),
+        together_data.path(),
+        "test/skolem-shape:main",
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        sole_blank_id(&f1, &l1, "Shared").await,
+        sole_blank_id(&f2, &l2, "Shared").await,
+        "a labeled blank node's id depends on its document, not on the import"
+    );
+    assert_eq!(
+        sole_blank_id(&f1, &l1, "Anonymous").await,
+        sole_blank_id(&f2, &l2, "Anonymous").await,
+        "an anonymous node's id depends on its document, not on the import"
+    );
+}
+
+/// Two ledgers loaded from one tree hold *different* blank nodes. Blank nodes
+/// are local to the graph that contains them; nothing should make two ledgers
+/// look like they share one by accident.
+#[tokio::test]
+async fn different_ledgers_mint_different_ids() {
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    write(data_dir.path(), "doc.ttl", DOC);
+    let db_a = tempfile::tempdir().expect("db tmpdir");
+    let db_b = tempfile::tempdir().expect("db tmpdir");
+
+    let (fa, la) = import_doc(db_a.path(), data_dir.path(), "test/skolem-one:main", None).await;
+    let (fb, lb) = import_doc(db_b.path(), data_dir.path(), "test/skolem-two:main", None).await;
+
+    assert_ne!(
+        sole_blank_id(&fa, &la, "Shared").await,
+        sole_blank_id(&fb, &lb, "Shared").await,
+        "the ledger id salts the mint"
+    );
+}
+
+/// …but the two spellings of ONE ledger id are one ledger, so they must salt
+/// identically. `create my/ledger --import` and `create my/ledger:main --import`
+/// both land on `my/ledger:main`.
+#[tokio::test]
+async fn ledger_id_spelling_does_not_change_minted_ids() {
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    write(data_dir.path(), "doc.ttl", DOC);
+    let db_bare = tempfile::tempdir().expect("db tmpdir");
+    let db_branch = tempfile::tempdir().expect("db tmpdir");
+
+    let (f1, l1) = import_doc(db_bare.path(), data_dir.path(), "test/skolem-spell", None).await;
+    let (f2, l2) = import_doc(
+        db_branch.path(),
+        data_dir.path(),
+        "test/skolem-spell:main",
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        sole_blank_id(&f1, &l1, "Shared").await,
+        sole_blank_id(&f2, &l2, "Shared").await,
+        "'name' and 'name:main' are the same ledger and must salt the same"
+    );
+}
+
+/// `--skolem-namespace` makes the cross-ledger sharing deliberate: two ledgers
+/// imported from one tree under one namespace mint identical ids, so a blank
+/// node can be matched across them.
+#[tokio::test]
+async fn explicit_skolem_namespace_shares_ids_across_ledgers() {
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    write(data_dir.path(), "doc.ttl", DOC);
+    let db_a = tempfile::tempdir().expect("db tmpdir");
+    let db_b = tempfile::tempdir().expect("db tmpdir");
+
+    let (fa, la) = import_doc(
+        db_a.path(),
+        data_dir.path(),
+        "test/skolem-ns-a:main",
+        Some("shared-corpus"),
+    )
+    .await;
+    let (fb, lb) = import_doc(
+        db_b.path(),
+        data_dir.path(),
+        "test/skolem-ns-b:main",
+        Some("shared-corpus"),
+    )
+    .await;
+
+    assert_eq!(
+        sole_blank_id(&fa, &la, "Shared").await,
+        sole_blank_id(&fb, &lb, "Shared").await,
+        "an explicit namespace overrides the ledger id on both sides"
+    );
+}
+
+/// Two files sitting at the same relative path in *different* trees are two
+/// documents of one import only if their keys differ — here they do not clash,
+/// but their labels must still stay apart, which is the invariant a shared
+/// scope would break.
+#[tokio::test]
+async fn labels_stay_distinct_between_documents() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    write(data_dir.path(), "a.ttl", DOC);
+    write(
+        data_dir.path(),
+        "b.ttl",
+        "@prefix schema: <http://schema.org/> .\n\
+         _:shared schema:name \"Other document\" .\n",
+    );
+
+    let (fluree, ledger) = import_doc(
+        db_dir.path(),
+        data_dir.path(),
+        "test/skolem-distinct:main",
+        None,
+    )
+    .await;
+
+    assert_ne!(
+        sole_blank_id(&fluree, &ledger, "Shared").await,
+        sole_blank_id(&fluree, &ledger, "Other document").await,
+        "`_:shared` in two documents is two nodes"
+    );
+}
+
+// ============================================================================
+// ndjson: one source is one document
+// ============================================================================
+
+/// `NdjsonReader` cuts one `.jsonl` source into many JSON-LD chunks, applying
+/// the source's leading `@context` to each. The document scope has to follow
+/// the source, not the cut: before this change the scope was the chunk, so
+/// `_:shared` near the top of a file and `_:shared` near the bottom became two
+/// subjects the moment the file grew past one chunk — and the boundary that
+/// decided it was `chunk_size_mb`, not anything in the data.
+///
+/// Fails before: the reference and the named node land in different chunks and
+/// resolve to different subjects.
+#[tokio::test]
+async fn ndjson_blank_label_is_scoped_to_its_source_not_its_chunk() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    let mut lines = String::from(
+        "{\"@context\":{\"ex\":\"http://example.org/ns/\",\"schema\":\"http://schema.org/\"}}\n\
+         {\"@id\":\"_:shared\",\"schema:name\":\"Shared\"}\n",
+    );
+    // Pad past one 1 MB chunk so the last line is cut into a different chunk.
+    for i in 0..12_000 {
+        lines.push_str(&format!(
+            "{{\"@id\":\"ex:filler{i}\",\"schema:description\":\"padding that pushes the reference into a later import chunk\"}}\n"
+        ));
+    }
+    lines.push_str("{\"@id\":\"ex:alice\",\"ex:knows\":{\"@id\":\"_:shared\"}}\n");
+    assert!(lines.len() > 1024 * 1024, "fixture must exceed one chunk");
+    write(data_dir.path(), "people.jsonl", &lines);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    let result = fluree
+        .create("test/skolem-ndjson:main")
+        .import(data_dir.path())
+        .threads(1)
+        .chunk_size_mb(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("ndjson import should succeed");
+    assert!(
+        result.t > 1,
+        "test is vacuous unless the source was split: {} chunk(s)",
+        result.t
+    );
+    let ledger = fluree
+        .ledger("test/skolem-ndjson:main")
+        .await
+        .expect("load ledger");
+
+    let named = sole_blank_id(&fluree, &ledger, "Shared").await;
+
+    let qr = support::query_jsonld(
+        &fluree,
+        &ledger,
+        &json!({
+            "select": ["?o"],
+            "where": {"@id": "http://example.org/ns/alice", "http://example.org/ns/knows": "?o"}
+        }),
+    )
+    .await
+    .expect("query");
+    let json = qr.to_jsonld(&ledger.snapshot).expect("jsonld");
+    let referenced = json
+        .as_array()
+        .and_then(|rows| rows.first())
+        .and_then(|row| match row {
+            serde_json::Value::Array(cols) => cols.first().and_then(|v| v.as_str()),
+            other => other.as_str(),
+        })
+        .expect("alice must reference a node")
+        .to_string();
+
+    assert_eq!(
+        referenced, named,
+        "`_:shared` unifies across one ndjson source however the chunker cuts it"
+    );
+}
+
+// ============================================================================
+// Duplicate document keys
+// ============================================================================
+
+/// The local arms cannot produce a duplicate key — `read_dir` yields each entry
+/// once — but `RemoteSource::OrderedObjects` takes a caller-supplied list, and
+/// nothing stops that list naming one address twice. Two documents sharing a
+/// scope silently merge their `_:x` nodes, so the import refuses to start.
+#[tokio::test]
+async fn duplicate_remote_addresses_abort_the_import() {
+    use fluree_db_core::{MemoryStorage, StorageRead, StorageWrite};
+    use std::sync::Arc;
+
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let storage = Arc::new(MemoryStorage::new());
+    storage
+        .write_bytes("remote/doc.ttl", DOC.as_bytes())
+        .await
+        .expect("seed remote object");
+    let object = fluree_db_api::RemoteObject {
+        address: "remote/doc.ttl".to_string(),
+        size_bytes: DOC.len() as u64,
+    };
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    let storage_dyn: Arc<dyn StorageRead> = storage.clone();
+    let err = fluree
+        .create("test/skolem-dup:main")
+        .import_from_storage(
+            storage_dyn,
+            fluree_db_api::RemoteSource::OrderedObjects(vec![object.clone(), object]),
+        )
+        .threads(1)
+        .memory_budget_mb(256)
+        .execute()
+        .await
+        .expect_err("an import naming one object twice must not run");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("share the blank-node scope") && msg.contains("remote/doc.ttl"),
+        "the error must name the colliding documents, got: {msg}"
+    );
+}

--- a/fluree-db-api/tests/it_import_skolem.rs
+++ b/fluree-db-api/tests/it_import_skolem.rs
@@ -346,17 +346,18 @@ async fn labels_stay_distinct_between_documents() {
 // ndjson: one source is one document
 // ============================================================================
 
-/// `NdjsonReader` cuts one `.jsonl` source into many JSON-LD chunks, applying
-/// the source's leading `@context` to each. The document scope has to follow
-/// the source, not the cut: before this change the scope was the chunk, so
-/// `_:shared` near the top of a file and `_:shared` near the bottom became two
-/// subjects the moment the file grew past one chunk — and the boundary that
-/// decided it was `chunk_size_mb`, not anything in the data.
+/// `NdjsonReader` cuts one context segment into many JSON-LD chunks, applying
+/// the segment's `@context` to each and emitting each as one `@graph`. The
+/// document scope has to follow the segment, not the cut: before this change
+/// the scope was the chunk, so `_:shared` near the top of a file and
+/// `_:shared` near the bottom became two subjects the moment the file grew
+/// past one chunk — and the boundary that decided it was `chunk_size_mb`, not
+/// anything in the data.
 ///
 /// Fails before: the reference and the named node land in different chunks and
 /// resolve to different subjects.
 #[tokio::test]
-async fn ndjson_blank_label_is_scoped_to_its_source_not_its_chunk() {
+async fn ndjson_blank_label_is_scoped_to_its_segment_not_its_chunk() {
     let db_dir = tempfile::tempdir().expect("db tmpdir");
     let data_dir = tempfile::tempdir().expect("data tmpdir");
 
@@ -603,4 +604,137 @@ async fn trig_fast_path_delegation_keeps_the_document_key() {
         "the pure-Turtle fast path must reuse the caller's document key, \
          not rebuild one"
     );
+}
+
+/// `cat a.jsonl b.jsonl > combined.jsonl` is a first-class NDJSON workflow —
+/// the format is defined to be concatenable — and Fluree handles it by letting
+/// a mid-stream lone `{"@context": …}` line replace the shared context for
+/// everything after it. That seam is a document boundary: the reader seals the
+/// outgoing chunk and emits what follows as a separate `@graph` under a
+/// different context.
+///
+/// So the two halves must not share a blank-node scope. Scoping the whole file
+/// as one document would silently merge `a.jsonl`'s `_:shared` with
+/// `b.jsonl`'s — the over-merge failure class this whole change exists to
+/// avoid.
+#[tokio::test]
+async fn ndjson_context_switch_starts_a_new_blank_node_scope() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    // Two independently-written sources, concatenated. Both use `_:shared`,
+    // and they mean different things by it.
+    let combined = concat!(
+        "{\"@context\":{\"schema\":\"http://schema.org/\"}}\n",
+        "{\"@id\":\"_:shared\",\"schema:name\":\"From A\"}\n",
+        "{\"@context\":{\"schema\":\"http://schema.org/\",\"b\":\"http://b.example/\"}}\n",
+        "{\"@id\":\"_:shared\",\"schema:name\":\"From B\"}\n",
+    );
+    write(data_dir.path(), "combined.jsonl", combined);
+
+    let (fluree, ledger) = {
+        let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+            .build()
+            .expect("build file-backed Fluree");
+        fluree
+            .create("test/skolem-ndjson-seam:main")
+            .import(data_dir.path())
+            .threads(1)
+            .memory_budget_mb(256)
+            .cleanup(false)
+            .execute()
+            .await
+            .expect("ndjson import should succeed");
+        let ledger = fluree
+            .ledger("test/skolem-ndjson-seam:main")
+            .await
+            .expect("load ledger");
+        (fluree, ledger)
+    };
+
+    assert_ne!(
+        sole_blank_id(&fluree, &ledger, "From A").await,
+        sole_blank_id(&fluree, &ledger, "From B").await,
+        "a `@context` switch ends one ndjson document and starts the next"
+    );
+}
+
+/// Every scope an import mints has to resolve, including the ones the ndjson
+/// arm discovers mid-read. A segment past the first is a document the manifest
+/// did not know about when it was built, so it has to be added once the
+/// producer reports it.
+#[tokio::test]
+async fn import_manifest_covers_ndjson_context_segments() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    let combined = concat!(
+        "{\"@context\":{\"schema\":\"http://schema.org/\"}}\n",
+        "{\"@id\":\"_:shared\",\"schema:name\":\"From A\"}\n",
+        "{\"@context\":{\"schema\":\"http://schema.org/\",\"b\":\"http://b.example/\"}}\n",
+        "{\"@id\":\"_:shared\",\"schema:name\":\"From B\"}\n",
+    );
+    write(data_dir.path(), "combined.jsonl", combined);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    fluree
+        .create("test/skolem-ndjson-manifest:main")
+        .import(data_dir.path())
+        .threads(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("ndjson import should succeed");
+    let ledger = fluree
+        .ledger("test/skolem-ndjson-manifest:main")
+        .await
+        .expect("load ledger");
+
+    let manifest = fluree
+        .query_connection(&json!({
+            "from": "test/skolem-ndjson-manifest:main#txn-meta",
+            "select": ["?doc", "?source"],
+            "where": {"@id": "?doc", "https://ns.flur.ee/db#importSource": "?source"}
+        }))
+        .await
+        .expect("txn-meta query");
+    let rows = manifest.to_jsonld(&ledger.snapshot).expect("jsonld");
+    let entries: Vec<(String, String)> = rows
+        .as_array()
+        .expect("array result")
+        .iter()
+        .filter_map(|row| {
+            let cols = row.as_array()?;
+            Some((
+                cols.first()?.as_str()?.into(),
+                cols.get(1)?.as_str()?.into(),
+            ))
+        })
+        .collect();
+
+    assert_eq!(
+        entries.len(),
+        2,
+        "one row per context segment, both naming the file: {entries:?}"
+    );
+    assert!(
+        entries.iter().all(|(_, src)| src == "combined.jsonl"),
+        "both segments came from one file: {entries:?}"
+    );
+
+    // Both minted scopes resolve.
+    for name in ["From A", "From B"] {
+        let bnode = sole_blank_id(&fluree, &ledger, name).await;
+        let local = bnode.strip_prefix("_:").expect("blank-node id");
+        let (scope, _) = fluree_db_core::skolem::split_doc_scope(local)
+            .expect("minted id must carry a doc scope");
+        assert!(
+            entries
+                .iter()
+                .any(|(doc, _)| doc.strip_prefix("_:fdb-") == Some(scope)),
+            "manifest must resolve {bnode} ({name}); entries: {entries:?}"
+        );
+    }
 }

--- a/fluree-db-api/tests/it_import_skolem.rs
+++ b/fluree-db-api/tests/it_import_skolem.rs
@@ -472,3 +472,79 @@ async fn duplicate_remote_addresses_abort_the_import() {
         "the error must name the colliding documents, got: {msg}"
     );
 }
+
+// ============================================================================
+// Import manifest
+// ============================================================================
+
+/// A minted id is a hash, so on its own it says nothing about where it came
+/// from. The import records the mapping in the `txn-meta` graph: one
+/// `db:importSource` triple per document, subject = the blank-node scope every
+/// id from that document shares. Together with `skolem::split_doc_scope`, that
+/// turns an opaque `_:fdb-d…-label` back into a file name.
+#[tokio::test]
+async fn import_manifest_maps_blank_node_scopes_back_to_documents() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    write(data_dir.path(), "a.ttl", DOC);
+    write(
+        data_dir.path(),
+        "b.ttl",
+        "@prefix schema: <http://schema.org/> .\n\
+         _:shared schema:name \"Other document\" .\n",
+    );
+
+    let (fluree, ledger) = import_doc(
+        db_dir.path(),
+        data_dir.path(),
+        "test/skolem-manifest:main",
+        None,
+    )
+    .await;
+
+    let manifest = fluree
+        .query_connection(&json!({
+            "from": "test/skolem-manifest:main#txn-meta",
+            "select": ["?doc", "?source"],
+            "where": {"@id": "?doc", "https://ns.flur.ee/db#importSource": "?source"}
+        }))
+        .await
+        .expect("txn-meta query");
+    let rows = manifest.to_jsonld(&ledger.snapshot).expect("jsonld");
+    let entries: Vec<(String, String)> = rows
+        .as_array()
+        .expect("array result")
+        .iter()
+        .filter_map(|row| {
+            let cols = row.as_array()?;
+            Some((
+                cols.first()?.as_str()?.into(),
+                cols.get(1)?.as_str()?.into(),
+            ))
+        })
+        .collect();
+
+    let sources: std::collections::BTreeSet<&str> =
+        entries.iter().map(|(_, src)| src.as_str()).collect();
+    assert_eq!(
+        sources,
+        ["a.ttl", "b.ttl"].into_iter().collect(),
+        "every source document must appear, keyed relative to the import root"
+    );
+
+    // The round trip a reader actually makes: minted id → scope → document.
+    let bnode = sole_blank_id(&fluree, &ledger, "Shared").await;
+    let local = bnode.strip_prefix("_:").expect("blank-node id");
+    let (scope, label) =
+        fluree_db_core::skolem::split_doc_scope(local).expect("minted id must carry a doc scope");
+    assert_eq!(label, "shared", "the source label survives the mint");
+    let source = entries
+        .iter()
+        .find(|(doc, _)| doc.strip_prefix("_:fdb-") == Some(scope))
+        .map(|(_, src)| src.as_str());
+    assert_eq!(
+        source,
+        Some("a.ttl"),
+        "the manifest must resolve {bnode} back to its document; entries: {entries:?}"
+    );
+}

--- a/fluree-db-api/tests/it_import_skolem.rs
+++ b/fluree-db-api/tests/it_import_skolem.rs
@@ -548,3 +548,59 @@ async fn import_manifest_maps_blank_node_scopes_back_to_documents() {
         "the manifest must resolve {bnode} back to its document; entries: {entries:?}"
     );
 }
+
+// ============================================================================
+// Entry points into the serial commit paths
+// ============================================================================
+
+/// `import_trig_commit` hands a TriG document with no named graphs and no
+/// txn-meta straight to `import_commit` — the pure-Turtle fast path. The
+/// skolem base has to travel through that delegation rather than being rebuilt
+/// on the far side, or one document would get two identities depending on
+/// which branch its *content* happened to take. Nothing about a file's blank
+/// nodes should depend on whether it also contains a `GRAPH` block.
+///
+/// Same file name and same namespace on both sides, so the document key is
+/// identical by construction and only the entry point differs.
+#[tokio::test]
+async fn trig_fast_path_delegation_keeps_the_document_key() {
+    let plain = "@prefix schema: <http://schema.org/> .\n\
+                 _:shared schema:name \"Shared\" .\n";
+    // Same triple, plus a named graph — enough to keep `import_trig_commit`
+    // from delegating.
+    let with_graph = "@prefix schema: <http://schema.org/> .\n\
+                      _:shared schema:name \"Shared\" .\n\
+                      GRAPH <http://example.org/g> {\n\
+                        <http://example.org/a> <http://example.org/p> \"x\" .\n\
+                      }\n";
+
+    let delegated_db = tempfile::tempdir().expect("db tmpdir");
+    let delegated_data = tempfile::tempdir().expect("data tmpdir");
+    write(delegated_data.path(), "doc.trig", plain);
+
+    let direct_db = tempfile::tempdir().expect("db tmpdir");
+    let direct_data = tempfile::tempdir().expect("data tmpdir");
+    write(direct_data.path(), "doc.trig", with_graph);
+
+    let (f1, l1) = import_doc(
+        delegated_db.path(),
+        delegated_data.path(),
+        "test/skolem-trig-fast:main",
+        Some("fixed"),
+    )
+    .await;
+    let (f2, l2) = import_doc(
+        direct_db.path(),
+        direct_data.path(),
+        "test/skolem-trig-graph:main",
+        Some("fixed"),
+    )
+    .await;
+
+    assert_eq!(
+        sole_blank_id(&f1, &l1, "Shared").await,
+        sole_blank_id(&f2, &l2, "Shared").await,
+        "the pure-Turtle fast path must reuse the caller's document key, \
+         not rebuild one"
+    );
+}

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -319,6 +319,16 @@ pub enum Commands {
         #[arg(long, default_value_t = 0)]
         parallelism: usize,
 
+        /// Namespace that salts the blank-node ids this import mints.
+        /// Defaults to the ledger id, so importing one source tree into two
+        /// ledgers gives them disjoint blank nodes. Pass the same value to
+        /// both to make them mint IDENTICAL ids instead — for a
+        /// rebuild-and-diff, a sharded load of one logical dataset, or a
+        /// staging/production pair you want to compare node-for-node.
+        /// Any string; two imports match iff they agree on it.
+        #[arg(long)]
+        skolem_namespace: Option<String>,
+
         /// Records per leaflet in index files. Default: 25000.
         /// Larger values produce fewer, bigger leaflets (less I/O, more memory per read).
         #[arg(long, default_value_t = 25_000)]

--- a/fluree-db-cli/src/commands/create.rs
+++ b/fluree-db-cli/src/commands/create.rs
@@ -11,6 +11,8 @@ pub struct ImportOpts {
     pub memory_budget_mb: usize,
     pub parallelism: usize,
     pub chunk_size_mb: usize,
+    /// Namespace salting minted blank-node ids. `None` = the ledger id.
+    pub skolem_namespace: Option<String>,
     pub leaflet_rows: usize,
     pub leaflets_per_leaf: usize,
     /// CSV/Cypher import: how relationship (edge) properties are encoded.
@@ -537,6 +539,9 @@ async fn run_bulk_import(
     }
     if import_opts.chunk_size_mb > 0 {
         builder = builder.chunk_size_mb(import_opts.chunk_size_mb);
+    }
+    if let Some(ns) = import_opts.skolem_namespace.as_deref() {
+        builder = builder.skolem_namespace(ns);
     }
     if import_opts.leaflet_rows != 25_000 {
         builder = builder.leaflet_rows(import_opts.leaflet_rows);

--- a/fluree-db-cli/src/lib.rs
+++ b/fluree-db-cli/src/lib.rs
@@ -51,6 +51,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
             chunk_size_mb,
             memory_budget_mb,
             parallelism,
+            skolem_namespace,
             leaflet_rows,
             leaflets_per_leaf,
             remote,
@@ -137,6 +138,7 @@ pub async fn run(cli: Cli) -> error::CliResult<()> {
                     cli.parallelism
                 },
                 chunk_size_mb,
+                skolem_namespace,
                 leaflet_rows,
                 leaflets_per_leaf,
                 edge_policy,

--- a/fluree-db-cli/tests/integration.rs
+++ b/fluree-db-cli/tests/integration.rs
@@ -3331,3 +3331,70 @@ fn bm25_create_rejects_invalid_json() {
             "indexing query must be valid JSON",
         ));
 }
+
+// ============================================================================
+// `create --from … --skolem-namespace`
+// ============================================================================
+
+/// Import `doc.ttl` into `ledger` and return the `@id` of its labeled blank
+/// node, as the CLI reports it.
+fn import_and_read_blank_id(tmp: &TempDir, ledger: &str, namespace: Option<&str>) -> String {
+    let data = tmp.path().join(format!("{ledger}-src"));
+    std::fs::create_dir_all(&data).unwrap();
+    std::fs::write(
+        data.join("doc.ttl"),
+        "@prefix schema: <http://schema.org/> .\n_:shared schema:name \"Shared\" .\n",
+    )
+    .unwrap();
+
+    let mut cmd = fluree_cmd(tmp);
+    cmd.args(["create", ledger, "--from"]).arg(&data);
+    if let Some(ns) = namespace {
+        cmd.args(["--skolem-namespace", ns]);
+    }
+    cmd.assert().success();
+
+    let out = fluree_cmd(tmp)
+        .args([
+            "query",
+            "--ledger",
+            ledger,
+            "-e",
+            r#"{"select": ["?s"], "where": {"@id": "?s", "http://schema.org/name": "Shared"}}"#,
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let out = String::from_utf8(out).unwrap();
+    let id = out
+        .split(|c: char| c.is_whitespace() || c == '"' || c == '[' || c == ']')
+        .find(|tok| tok.starts_with("_:fdb-"))
+        .unwrap_or_else(|| panic!("no minted blank-node id in query output: {out}"))
+        .to_string();
+    id
+}
+
+/// The default salt is the ledger id, so two ledgers loaded from equivalent
+/// sources hold different blank nodes; `--skolem-namespace` overrides that on
+/// both sides so they line up.
+#[test]
+fn skolem_namespace_flag_controls_cross_ledger_blank_node_identity() {
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+
+    let default_a = import_and_read_blank_id(&tmp, "salt-default-a", None);
+    let default_b = import_and_read_blank_id(&tmp, "salt-default-b", None);
+    assert_ne!(
+        default_a, default_b,
+        "without the flag the ledger id salts the mint"
+    );
+
+    let shared_a = import_and_read_blank_id(&tmp, "salt-shared-a", Some("one-corpus"));
+    let shared_b = import_and_read_blank_id(&tmp, "salt-shared-b", Some("one-corpus"));
+    assert_eq!(
+        shared_a, shared_b,
+        "--skolem-namespace must reach the import builder on both sides"
+    );
+}

--- a/fluree-db-core/src/lib.rs
+++ b/fluree-db-core/src/lib.rs
@@ -69,6 +69,7 @@ pub mod runtime_small_dicts;
 pub mod schema_hierarchy;
 pub mod serde;
 pub mod sid;
+pub mod skolem;
 pub mod stats_view;
 pub mod stats_wire;
 pub mod storage;

--- a/fluree-db-core/src/ns_encoding.rs
+++ b/fluree-db-core/src/ns_encoding.rs
@@ -124,8 +124,10 @@ pub const BLANK_NODE_PREFIX: &str = "_:";
 /// Label prefix reserved for Fluree-minted stable blank-node identifiers.
 ///
 /// Every skolemized blank node the system mints has a local name beginning
-/// with `fdb-` (e.g. `fdb-<ulid>`, `fdb-<txn>-<label>`), rendered as
-/// `_:fdb-...` in query results. Labels with this prefix are reserved: when
+/// with `fdb-` (e.g. `fdb-<uuid>` from `BNODE()`, `fdb-<txn>-<label>` from a
+/// staged transaction, `fdb-d<doc-scope>-<label>` from bulk import — see
+/// [`crate::skolem`]), rendered as `_:fdb-...` in query results. Labels with
+/// this prefix are reserved: when
 /// they appear in incoming queries or transactions they denote the *existing*
 /// stored node rather than minting a fresh one (RDF 1.1 §3.5 skolemization,
 /// kept in blank-node syntax). Client-chosen labels never collide because
@@ -164,9 +166,14 @@ pub fn stable_blank_node_local(iri: &str) -> Option<&str> {
 /// check built-ins because they have no standard IRI delimiters.
 pub fn canonical_split(iri: &str, mode: NsSplitMode) -> (&str, &str) {
     // Blank nodes always use the well-known `_:` prefix. Split it off first and
-    // unconditionally: the skolemized local part can contain colons (e.g.
-    // `_:fdb-<ledger>:<branch>-...`), which would otherwise make the generic
-    // opaque-IRI splitter cut at an embedded colon and drop the `_:` prefix,
+    // unconditionally: the skolemized local part can contain colons.
+    //
+    // Bulk import no longer mints them — its ids are `fdb-d<base36>-<label>`
+    // (see [`crate::skolem`]) — but ledgers imported before that change hold
+    // `_:fdb-<ledger>:<branch>-<t>-<label>`, and a user-authored label can
+    // carry a colon on any surface that admits one (JSON-LD does; SPARQL does
+    // not). Without this branch the generic opaque-IRI splitter would cut at
+    // the embedded colon and drop the `_:` prefix,
     // re-encoding the blank node into the EMPTY namespace (code 0). That breaks
     // round-tripping: a blank node written via the dedicated blank-node code (10)
     // would read back as a different Sid, so subject-bounded index lookups miss.

--- a/fluree-db-core/src/skolem.rs
+++ b/fluree-db-core/src/skolem.rs
@@ -12,7 +12,8 @@
 //! fdb-d<13 lowercase base36 digits>-<label>
 //!     ^ ^                          ^
 //!     | |                          `- the label as written in the source
-//!     | `- xxh64(namespace ‖ 0x00 ‖ doc_key), zero-padded to a fixed width
+//!     | `- xxh64(namespace ‖ 0x00 ‖ doc_key ‖ 0x00 ‖ segment), zero-padded
+//!     |    to a fixed width
 //!     `- the document-scope marker
 //! ```
 //!

--- a/fluree-db-core/src/skolem.rs
+++ b/fluree-db-core/src/skolem.rs
@@ -1,0 +1,240 @@
+//! Document-scoped skolemization keys for bulk import.
+//!
+//! RDF scopes a blank-node label to the document that contains it. Bulk import
+//! cuts a document into many chunks and commits each separately, so the
+//! skolemization key cannot be derived from the commit — it has to name the
+//! *document*. This module defines the key format and is the only place that
+//! builds one.
+//!
+//! # Format
+//!
+//! ```text
+//! fdb-d<13 lowercase base36 digits>-<label>
+//!     ^ ^                          ^
+//!     | |                          `- the label as written in the source
+//!     | `- xxh64(namespace ‖ 0x00 ‖ doc_key), zero-padded to a fixed width
+//!     `- the document-scope marker
+//! ```
+//!
+//! Everything after `fdb-` up to the first `-` is the **document scope**: a
+//! [`doc_scope`] rendering of [`doc_id`]. The whole label is what
+//! `_:fdb-…` renders as in query results.
+//!
+//! ## Why a hash and not the ledger id
+//!
+//! The obvious key — `{ledger_id}-{document}` — embeds a ledger id, which
+//! contains `/` and `:`. Neither is legal inside a SPARQL `BLANK_NODE_LABEL`,
+//! so ids minted that way could be read out of a query but never written back
+//! into a SPARQL `DELETE`/`INSERT`. Hashing produces `[0-9a-z]` only, which is
+//! writable in every surface Fluree exposes (SPARQL, Turtle, JSON-LD) with no
+//! escaping.
+//!
+//! The ledger id does not disappear — it becomes the hash **namespace**, so two
+//! ledgers importing the same file still mint different ids. Callers that
+//! deliberately want them to agree pass an explicit shared namespace.
+//!
+//! ## Why a fixed width
+//!
+//! 13 base36 digits hold any `u64` (`36^13 > 2^64`), so the rendering is
+//! lossless and the document scope is always exactly [`DOC_SCOPE_LEN`] bytes.
+//! Fixed width is what makes the scope recoverable from a minted id: the first
+//! [`DOC_SCOPE_LEN`] bytes of the local name are the scope, and the rest —
+//! after one `-` — is the source label, however many `-` it contains itself.
+//! [`split_doc_scope`] does that, and the import manifest in the `txn-meta`
+//! graph maps the scope back to the file it came from.
+//!
+//! ## Disjointness from the other `fdb-` minters
+//!
+//! Three subsystems mint `fdb-` labels, and they must not collide:
+//!
+//! | minter | shape | first `-` after `fdb-` |
+//! |---|---|---|
+//! | bulk import (here) | `d` + 13 base36 + `-` + label | offset 14 |
+//! | staged transaction | `{nanos:x}` + `-` + solution + `-` + label | offset 16 |
+//! | SPARQL `BNODE()` | hyphenated UUIDv4 | offset 8 |
+//!
+//! The offsets are structural, not coincidental: `BNODE()` emits RFC-4122 text,
+//! whose first hyphen is always at offset 8; the staged-transaction key is
+//! nanoseconds-since-epoch in hex, which is 16 digits for every wall clock
+//! between 2004-11 and 2154-07. A staged key could only reach offset 14 on a
+//! host whose clock reads within about four days of 1970-01-01.
+
+use xxhash_rust::xxh64::Xxh64;
+
+/// Marker character that opens an import document scope, immediately after the
+/// `fdb-` stable-label prefix.
+pub const DOC_SCOPE_MARKER: char = 'd';
+
+/// Number of base36 digits in a rendered document scope.
+///
+/// `36^13 ≈ 1.7e20 > u64::MAX`, so 13 digits render any `u64` losslessly.
+pub const DOC_SCOPE_DIGITS: usize = 13;
+
+/// Byte length of a rendered document scope (`DOC_SCOPE_MARKER` + digits).
+pub const DOC_SCOPE_LEN: usize = 1 + DOC_SCOPE_DIGITS;
+
+/// Byte separating the namespace from the document key in the hash input.
+///
+/// A key cannot contain NUL (paths and object addresses are UTF-8 text), so no
+/// `(namespace, doc_key)` pair can be re-cut at a different boundary to produce
+/// the same hash input. Without it, namespace `"a"` + key `"b/c"` and namespace
+/// `"a/b"` + key `"c"` would hash identically.
+const NAMESPACE_SEPARATOR: u8 = 0;
+
+const BASE36: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+
+/// Hash a document key into its import-stable document id.
+///
+/// `namespace` is the ledger id by default (see the module docs); `doc_key`
+/// identifies the document within the import — a path relative to the import
+/// root, a remote address relative to its listing prefix, or a file's basename.
+///
+/// Pure and allocation-free: parse workers on different threads derive the same
+/// id for the same document with no coordination.
+#[must_use]
+pub fn doc_id(namespace: &str, doc_key: &str) -> u64 {
+    let mut hasher = Xxh64::new(0);
+    hasher.update(namespace.as_bytes());
+    hasher.update(&[NAMESPACE_SEPARATOR]);
+    hasher.update(doc_key.as_bytes());
+    hasher.digest()
+}
+
+/// Render a document id as its fixed-width document scope.
+#[must_use]
+pub fn doc_scope(id: u64) -> String {
+    let mut buf = [b'0'; DOC_SCOPE_LEN];
+    buf[0] = DOC_SCOPE_MARKER as u8;
+    let mut rest = id;
+    let mut i = DOC_SCOPE_LEN;
+    while rest > 0 {
+        i -= 1;
+        buf[i] = BASE36[(rest % 36) as usize];
+        rest /= 36;
+    }
+    // Every byte is ASCII by construction.
+    String::from_utf8(buf.to_vec()).expect("base36 rendering is ASCII")
+}
+
+/// Build the skolem base for a document: [`doc_id`] then [`doc_scope`].
+///
+/// The result is the `{base}` in `fdb-{base}-{label}`.
+#[must_use]
+pub fn skolem_base(namespace: &str, doc_key: &str) -> String {
+    doc_scope(doc_id(namespace, doc_key))
+}
+
+/// Split a stable blank-node local name minted by bulk import into its
+/// `(document scope, source label)` halves.
+///
+/// `local` is the name *after* `_:` — e.g. `fdb-d0000000000abc-shared`, which
+/// splits into `("d0000000000abc", "shared")`. Returns `None` for any local
+/// name not minted by this module (a staged-transaction key, a `BNODE()` uuid,
+/// or an id minted before this format existed).
+#[must_use]
+pub fn split_doc_scope(local: &str) -> Option<(&str, &str)> {
+    let rest = local.strip_prefix(crate::ns_encoding::STABLE_BLANK_NODE_LABEL_PREFIX)?;
+    let (scope, label) = rest.split_at_checked(DOC_SCOPE_LEN)?;
+    let mut chars = scope.chars();
+    if chars.next() != Some(DOC_SCOPE_MARKER)
+        || !chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    {
+        return None;
+    }
+    Some((scope, label.strip_prefix('-')?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doc_scope_is_fixed_width_lowercase_base36() {
+        for id in [0u64, 1, 35, 36, u64::MAX, 0x0123_4567_89ab_cdef] {
+            let rendered = doc_scope(id);
+            assert_eq!(rendered.len(), DOC_SCOPE_LEN, "{id}");
+            assert!(rendered.starts_with(DOC_SCOPE_MARKER), "{rendered}");
+            assert!(
+                rendered[1..]
+                    .bytes()
+                    .all(|b| b.is_ascii_digit() || b.is_ascii_lowercase()),
+                "{rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn doc_scope_renders_u64_max_losslessly() {
+        // If 13 digits were not enough, u64::MAX would wrap onto some smaller
+        // id's rendering. Decode and compare.
+        let rendered = doc_scope(u64::MAX);
+        let decoded = rendered[1..].bytes().fold(0u128, |acc, b| {
+            acc * 36 + u128::from(BASE36.iter().position(|&c| c == b).unwrap() as u32)
+        });
+        assert_eq!(decoded, u128::from(u64::MAX));
+    }
+
+    // The whole point of hashing: a minted id must be writable as a SPARQL
+    // BLANK_NODE_LABEL, which admits neither `/` nor `:`.
+    #[test]
+    fn skolem_base_is_free_of_characters_sparql_forbids() {
+        let base = skolem_base("my/ledger:main", "sub dir/data (1).ttl");
+        assert!(
+            base.bytes()
+                .all(|b| b.is_ascii_digit() || b.is_ascii_lowercase()),
+            "{base}"
+        );
+    }
+
+    #[test]
+    fn namespace_separates_ledger_from_document() {
+        // Without the NUL, ("a", "b/c") and ("a/b", "c") would collide.
+        assert_ne!(doc_id("a", "b/c"), doc_id("a/b", "c"));
+    }
+
+    #[test]
+    fn different_ledgers_mint_different_scopes_for_one_file() {
+        assert_ne!(
+            skolem_base("one:main", "data.ttl"),
+            skolem_base("two:main", "data.ttl")
+        );
+    }
+
+    #[test]
+    fn split_doc_scope_recovers_labels_containing_hyphens() {
+        let base = skolem_base("l:main", "data.ttl");
+        let local = format!("fdb-{base}-my-label-with-hyphens");
+        assert_eq!(
+            split_doc_scope(&local),
+            Some((base.as_str(), "my-label-with-hyphens"))
+        );
+    }
+
+    #[test]
+    fn split_doc_scope_rejects_the_other_minters() {
+        // Staged transaction: `fdb-{nanos:x}-{solution}-{label}`.
+        assert_eq!(split_doc_scope("fdb-1857f4a2b9c3d0e1-0-b0"), None);
+        // SPARQL BNODE(): `fdb-{uuid}`.
+        assert_eq!(
+            split_doc_scope("fdb-67e55044-10b1-426f-9247-bb680e5fe0c8"),
+            None
+        );
+        // Pre-C2 import id: `fdb-{ledger}:{branch}-{t}-{label}`.
+        assert_eq!(split_doc_scope("fdb-lubm:main-1-genid10"), None);
+    }
+
+    // Structural disjointness from the other two `fdb-` minters, expressed as
+    // the offset of the first `-` after the `fdb-` prefix (see module docs).
+    #[test]
+    fn first_hyphen_offset_distinguishes_the_minters() {
+        let import = skolem_base("l:main", "data.ttl");
+        assert_eq!(import.find('-'), None, "a scope contains no hyphen");
+        assert_eq!(import.len(), 14, "so the first hyphen lands at offset 14");
+
+        let staged = format!("{:x}", 1_750_000_000_000_000_000u64);
+        assert_eq!(staged.len(), 16, "nanos-since-epoch is 16 hex digits");
+
+        let bnode = "67e55044-10b1-426f-9247-bb680e5fe0c8";
+        assert_eq!(bnode.find('-'), Some(8), "uuid hyphen is at offset 8");
+    }
+}

--- a/fluree-db-core/src/skolem.rs
+++ b/fluree-db-core/src/skolem.rs
@@ -73,12 +73,14 @@ pub const DOC_SCOPE_DIGITS: usize = 13;
 /// Byte length of a rendered document scope (`DOC_SCOPE_MARKER` + digits).
 pub const DOC_SCOPE_LEN: usize = 1 + DOC_SCOPE_DIGITS;
 
-/// Byte separating the namespace from the document key in the hash input.
+/// Byte separating the three hash-input fields: `namespace ‖ 0 ‖ doc_key ‖ 0 ‖
+/// segment` (the segment is four little-endian bytes and is always last, so it
+/// needs no terminator).
 ///
-/// A key cannot contain NUL (paths and object addresses are UTF-8 text), so no
-/// `(namespace, doc_key)` pair can be re-cut at a different boundary to produce
-/// the same hash input. Without it, namespace `"a"` + key `"b/c"` and namespace
-/// `"a/b"` + key `"c"` would hash identically.
+/// Neither a namespace nor a key can contain NUL (both are UTF-8 text: ledger
+/// ids, paths, object addresses), so no two field triples can be re-cut at a
+/// different boundary to produce the same input. Without it, namespace `"a"` +
+/// key `"b/c"` and namespace `"a/b"` + key `"c"` would hash identically.
 const NAMESPACE_SEPARATOR: u8 = 0;
 
 const BASE36: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
@@ -89,14 +91,23 @@ const BASE36: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
 /// identifies the document within the import — a path relative to the import
 /// root, a remote address relative to its listing prefix, or a file's basename.
 ///
+/// `segment` distinguishes several documents carried by one source. Every arm
+/// passes `0` except ndjson, where a mid-stream `@context` line ends one
+/// document and starts the next inside a single file. It is an **ordinal** —
+/// how many context switches precede this segment — deliberately not the chunk
+/// index the segment starts at, which would vary with `chunk_size_mb` and
+/// reintroduce the dependence on import shape this module exists to remove.
+///
 /// Pure and allocation-free: parse workers on different threads derive the same
 /// id for the same document with no coordination.
 #[must_use]
-pub fn doc_id(namespace: &str, doc_key: &str) -> u64 {
+pub fn doc_id(namespace: &str, doc_key: &str, segment: u32) -> u64 {
     let mut hasher = Xxh64::new(0);
     hasher.update(namespace.as_bytes());
     hasher.update(&[NAMESPACE_SEPARATOR]);
     hasher.update(doc_key.as_bytes());
+    hasher.update(&[NAMESPACE_SEPARATOR]);
+    hasher.update(&segment.to_le_bytes());
     hasher.digest()
 }
 
@@ -120,8 +131,8 @@ pub fn doc_scope(id: u64) -> String {
 ///
 /// The result is the `{base}` in `fdb-{base}-{label}`.
 #[must_use]
-pub fn skolem_base(namespace: &str, doc_key: &str) -> String {
-    doc_scope(doc_id(namespace, doc_key))
+pub fn skolem_base(namespace: &str, doc_key: &str, segment: u32) -> String {
+    doc_scope(doc_id(namespace, doc_key, segment))
 }
 
 /// Split a stable blank-node local name minted by bulk import into its
@@ -178,7 +189,7 @@ mod tests {
     // BLANK_NODE_LABEL, which admits neither `/` nor `:`.
     #[test]
     fn skolem_base_is_free_of_characters_sparql_forbids() {
-        let base = skolem_base("my/ledger:main", "sub dir/data (1).ttl");
+        let base = skolem_base("my/ledger:main", "sub dir/data (1).ttl", 0);
         assert!(
             base.bytes()
                 .all(|b| b.is_ascii_digit() || b.is_ascii_lowercase()),
@@ -189,20 +200,40 @@ mod tests {
     #[test]
     fn namespace_separates_ledger_from_document() {
         // Without the NUL, ("a", "b/c") and ("a/b", "c") would collide.
-        assert_ne!(doc_id("a", "b/c"), doc_id("a/b", "c"));
+        assert_ne!(doc_id("a", "b/c", 0), doc_id("a/b", "c", 0));
+    }
+
+    // A mid-stream `@context` line ends one ndjson document and starts the
+    // next; the segments must not share a scope.
+    #[test]
+    fn segments_of_one_source_are_distinct_documents() {
+        let a = skolem_base("l:main", "combined.jsonl", 0);
+        let b = skolem_base("l:main", "combined.jsonl", 1);
+        assert_ne!(a, b);
+        assert_eq!(a, skolem_base("l:main", "combined.jsonl", 0), "and stable");
+    }
+
+    // The segment rides its own field, so it cannot be confused with a key
+    // that merely ends in digits.
+    #[test]
+    fn segment_is_not_absorbed_into_the_document_key() {
+        assert_ne!(
+            doc_id("l:main", "a.jsonl", 1),
+            doc_id("l:main", "a.jsonl\u{0}\u{1}", 0)
+        );
     }
 
     #[test]
     fn different_ledgers_mint_different_scopes_for_one_file() {
         assert_ne!(
-            skolem_base("one:main", "data.ttl"),
-            skolem_base("two:main", "data.ttl")
+            skolem_base("one:main", "data.ttl", 0),
+            skolem_base("two:main", "data.ttl", 0)
         );
     }
 
     #[test]
     fn split_doc_scope_recovers_labels_containing_hyphens() {
-        let base = skolem_base("l:main", "data.ttl");
+        let base = skolem_base("l:main", "data.ttl", 0);
         let local = format!("fdb-{base}-my-label-with-hyphens");
         assert_eq!(
             split_doc_scope(&local),
@@ -227,7 +258,7 @@ mod tests {
     // the offset of the first `-` after the `fdb-` prefix (see module docs).
     #[test]
     fn first_hyphen_offset_distinguishes_the_minters() {
-        let import = skolem_base("l:main", "data.ttl");
+        let import = skolem_base("l:main", "data.ttl", 0);
         assert_eq!(import.find('-'), None, "a scope contains no hyphen");
         assert_eq!(import.len(), 14, "so the first hyphen lands at offset 14");
 

--- a/fluree-db-core/src/skolem.rs
+++ b/fluree-db-core/src/skolem.rs
@@ -142,6 +142,21 @@ pub fn skolem_base(namespace: &str, doc_key: &str, segment: u32) -> String {
 /// splits into `("d0000000000abc", "shared")`. Returns `None` for any local
 /// name not minted by this module (a staged-transaction key, a `BNODE()` uuid,
 /// or an id minted before this format existed).
+///
+/// Rejecting a pre-C2 import id rests on one fact: those ids open with a
+/// **normalized** ledger id, `{name}:{branch}`, so a `:` always sits at index
+/// `name.len()`. Each of the three positions it can take trips a different
+/// check:
+///
+/// - `name.len() < DOC_SCOPE_LEN` — the colon is inside the scanned scope and
+///   fails the base36 charset test;
+/// - `name.len() == DOC_SCOPE_LEN` — the colon is the byte after the scope,
+///   where the label's leading `-` has to be;
+/// - `name.len() > DOC_SCOPE_LEN` — that byte is an ordinary name character,
+///   likewise not `-`.
+///
+/// So no pre-C2 id reads as a document scope however long its ledger name is,
+/// including one shaped exactly like a scope (`d` plus 13 alphanumerics).
 #[must_use]
 pub fn split_doc_scope(local: &str) -> Option<(&str, &str)> {
     let rest = local.strip_prefix(crate::ns_encoding::STABLE_BLANK_NODE_LABEL_PREFIX)?;
@@ -252,6 +267,35 @@ mod tests {
         );
         // Pre-C2 import id: `fdb-{ledger}:{branch}-{t}-{label}`.
         assert_eq!(split_doc_scope("fdb-lubm:main-1-genid10"), None);
+    }
+
+    // The pre-C2 rejection rests on the normalized ledger id always carrying a
+    // `:` at `name.len()`, which trips a different check at each of the three
+    // positions it can occupy. Worst case is a ledger name shaped exactly like
+    // a document scope, so walk the boundary with one.
+    #[test]
+    fn split_doc_scope_rejects_pre_c2_ids_at_every_colon_position() {
+        let scope_shaped = format!("d{}", "0".repeat(DOC_SCOPE_DIGITS));
+        assert_eq!(scope_shaped.len(), DOC_SCOPE_LEN);
+
+        for name_len in [DOC_SCOPE_LEN - 1, DOC_SCOPE_LEN, DOC_SCOPE_LEN + 1] {
+            let name = if name_len <= scope_shaped.len() {
+                scope_shaped[..name_len].to_string()
+            } else {
+                format!(
+                    "{scope_shaped}{}",
+                    "0".repeat(name_len - scope_shaped.len())
+                )
+            };
+            assert_eq!(name.len(), name_len);
+            let local = format!("fdb-{name}:main-1-genid10");
+            assert_eq!(
+                split_doc_scope(&local),
+                None,
+                "pre-C2 id with a {name_len}-char ledger name must not read as \
+                 a document scope: {local}"
+            );
+        }
     }
 
     // Structural disjointness from the other two `fdb-` minters, expressed as

--- a/fluree-db-transact/src/import.rs
+++ b/fluree-db-transact/src/import.rs
@@ -144,7 +144,7 @@ mod inner {
         // One serial commit == one whole document, so the commit ordinal is
         // a valid document scope here. See `skolem_base` for why the chunked
         // parallel path cannot use it.
-        let skolem_base = format!("{ledger_id}-{new_t}");
+        let skolem_base = skolem_base(ledger_id, &new_t.to_string());
 
         // 1. Create ImportSink + parse TTL
         let ns_codes_before = state.ns_registry.code_count();
@@ -306,7 +306,7 @@ mod inner {
         // One serial commit == one whole document, so the commit ordinal is
         // a valid document scope here. See `skolem_base` for why the chunked
         // parallel path cannot use it.
-        let skolem_base = format!("{ledger_id}-{new_t}");
+        let skolem_base = skolem_base(ledger_id, &new_t.to_string());
 
         let ns_codes_before = state.ns_registry.code_count();
         let _parse_span = tracing::debug_span!(
@@ -464,7 +464,7 @@ mod inner {
         // One serial commit == one whole document, so the commit ordinal is
         // a valid document scope here. See `skolem_base` for why the chunked
         // parallel path cannot use it.
-        let skolem_base = format!("{ledger_id}-{new_t}");
+        let skolem_base = skolem_base(ledger_id, &new_t.to_string());
 
         // 1. Parse TriG to extract GRAPH blocks
         let phase1 = parse_trig_phase1(trig)?;
@@ -865,6 +865,12 @@ mod inner {
     /// cross-worker coordination is needed: `blank_node_sid` is a pure function
     /// of the key, so two threads parsing chunk 1 and chunk 7 independently
     /// derive the same Sid for the same label.
+    ///
+    /// This is the **only** place an import skolem base is built. Every entry
+    /// point routes through it — the three serial commit paths and
+    /// `parse_jsonld_chunk` pass the commit ordinal (one serial call is one
+    /// whole document, so the ordinal is a valid scope); `parse_chunk` and
+    /// `parse_chunk_with_prelude` pass the caller's document scope.
     fn skolem_base(ledger_id: &str, doc_scope: &str) -> String {
         format!("{ledger_id}-{doc_scope}")
     }
@@ -1077,7 +1083,7 @@ mod inner {
         // split across chunks. That predates document scoping and is left alone
         // deliberately — deciding whether an ndjson line is its own RDF
         // document is a JSON-LD question, not a Turtle-chunking one.
-        let skolem_base = format!("{ledger_id}-{t}");
+        let skolem_base = skolem_base(ledger_id, &t.to_string());
 
         let _parse_span =
             tracing::debug_span!("parse_jsonld_chunk", t, jsonld_bytes = jsonld.len(),).entered();

--- a/fluree-db-transact/src/import.rs
+++ b/fluree-db-transact/src/import.rs
@@ -125,6 +125,8 @@ mod inner {
     /// * `ttl` — Turtle input text
     /// * `storage` — storage backend for writing commit blobs
     /// * `ledger_id` — ledger name for storage path construction
+    /// * `skolem_base` — document-scoped blank-node key, built by the caller
+    ///   via `fluree_db_core::skolem::skolem_base`
     /// * `compress` — whether to zstd-compress the ops stream
     #[allow(clippy::too_many_arguments)]
     pub async fn import_commit<S>(
@@ -132,6 +134,7 @@ mod inner {
         ttl: &str,
         storage: &S,
         ledger_id: &str,
+        skolem_base: &str,
         compress: bool,
         spool_dir: Option<&std::path::Path>,
         spool_config: Option<&crate::import_sink::SpoolConfig>,
@@ -141,10 +144,6 @@ mod inner {
         S: ContentAddressedWrite,
     {
         let new_t = state.t + 1;
-        // One serial commit == one whole document, so the commit ordinal is
-        // a valid document scope here. See `skolem_base` for why the chunked
-        // parallel path cannot use it.
-        let skolem_base = skolem_base(ledger_id, &new_t.to_string());
 
         // 1. Create ImportSink + parse TTL
         let ns_codes_before = state.ns_registry.code_count();
@@ -165,8 +164,14 @@ mod inner {
             None => Arc::new(SharedNamespaceAllocator::from_registry(&state.ns_registry)),
         };
         let mut worker_cache = WorkerCache::new(Arc::clone(&shared_ns));
-        let mut sink = ImportSink::new_cached(&mut worker_cache, new_t, skolem_base, compress)
-            .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
+        let mut sink = ImportSink::new_cached(
+            &mut worker_cache,
+            new_t,
+            skolem_base.to_string(),
+            0,
+            compress,
+        )
+        .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
             let spool_path = dir.join(format!("chunk_{chunk_idx}.spool"));
@@ -284,6 +289,7 @@ mod inner {
         prelude: &TurtlePrelude,
         storage: &S,
         ledger_id: &str,
+        skolem_base: &str,
         compress: bool,
         spool_dir: Option<&std::path::Path>,
         spool_config: Option<&crate::import_sink::SpoolConfig>,
@@ -303,10 +309,6 @@ mod inner {
         }
 
         let new_t = state.t + 1;
-        // One serial commit == one whole document, so the commit ordinal is
-        // a valid document scope here. See `skolem_base` for why the chunked
-        // parallel path cannot use it.
-        let skolem_base = skolem_base(ledger_id, &new_t.to_string());
 
         let ns_codes_before = state.ns_registry.code_count();
         let _parse_span = tracing::debug_span!(
@@ -323,8 +325,14 @@ mod inner {
             None => Arc::new(SharedNamespaceAllocator::from_registry(&state.ns_registry)),
         };
         let mut worker_cache = WorkerCache::new(Arc::clone(&shared_ns));
-        let mut sink = ImportSink::new_cached(&mut worker_cache, new_t, skolem_base, compress)
-            .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
+        let mut sink = ImportSink::new_cached(
+            &mut worker_cache,
+            new_t,
+            skolem_base.to_string(),
+            0,
+            compress,
+        )
+        .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
             let spool_path = dir.join(format!("chunk_{chunk_idx}.spool"));
@@ -445,6 +453,8 @@ mod inner {
     /// * `trig` — TriG input text (Turtle-compatible if no GRAPH blocks)
     /// * `storage` — storage backend for writing commit blobs
     /// * `ledger_id` — ledger name for storage path construction
+    /// * `skolem_base` — document-scoped blank-node key, built by the caller
+    ///   via `fluree_db_core::skolem::skolem_base`
     /// * `compress` — whether to zstd-compress the ops stream
     #[allow(clippy::too_many_arguments)]
     pub async fn import_trig_commit<S>(
@@ -452,6 +462,7 @@ mod inner {
         trig: &str,
         storage: &S,
         ledger_id: &str,
+        skolem_base: &str,
         compress: bool,
         spool_dir: Option<&std::path::Path>,
         spool_config: Option<&crate::import_sink::SpoolConfig>,
@@ -461,10 +472,6 @@ mod inner {
         S: ContentAddressedWrite,
     {
         let new_t = state.t + 1;
-        // One serial commit == one whole document, so the commit ordinal is
-        // a valid document scope here. See `skolem_base` for why the chunked
-        // parallel path cannot use it.
-        let skolem_base = skolem_base(ledger_id, &new_t.to_string());
 
         // 1. Parse TriG to extract GRAPH blocks
         let phase1 = parse_trig_phase1(trig)?;
@@ -476,6 +483,7 @@ mod inner {
                 trig,
                 storage,
                 ledger_id,
+                skolem_base,
                 compress,
                 spool_dir,
                 spool_config,
@@ -508,9 +516,14 @@ mod inner {
             None => Arc::new(SharedNamespaceAllocator::from_registry(&state.ns_registry)),
         };
         let mut worker_cache = WorkerCache::new(Arc::clone(&shared_ns));
-        let mut sink =
-            ImportSink::new_cached(&mut worker_cache, new_t, skolem_base.clone(), compress)
-                .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
+        let mut sink = ImportSink::new_cached(
+            &mut worker_cache,
+            new_t,
+            skolem_base.to_string(),
+            0,
+            compress,
+        )
+        .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
             let spool_path = dir.join(format!("chunk_{chunk_idx}.spool"));
@@ -574,17 +587,17 @@ mod inner {
                     TransactError::Parse("named graph triple missing subject".to_string())
                 })?;
 
-                let s = expand_term(subject, &block.prefixes, &mut worker_cache, &skolem_base)?;
+                let s = expand_term(subject, &block.prefixes, &mut worker_cache, skolem_base)?;
                 let p = expand_term(
                     &triple.predicate,
                     &block.prefixes,
                     &mut worker_cache,
-                    &skolem_base,
+                    skolem_base,
                 )?;
 
                 for obj in &triple.objects {
                     let (o, dt, lang) =
-                        expand_object(obj, &block.prefixes, &mut worker_cache, &skolem_base)?;
+                        expand_object(obj, &block.prefixes, &mut worker_cache, skolem_base)?;
 
                     // Spool the named-graph flake under its g_id (so it enters
                     // the index), then encode it into the commit blob.
@@ -851,30 +864,6 @@ mod inner {
         pub txn_meta: Vec<TxnMetaEntry>,
     }
 
-    /// Blank-node skolemization key for one import *document*.
-    ///
-    /// RDF scopes blank-node labels to the document that contains them, so
-    /// `_:x` must resolve to one subject everywhere in a document and to a
-    /// different subject in the next one. Bulk import cuts a document into many
-    /// chunks — each its own commit — so the commit `t` is the wrong key: it
-    /// splits one document's labels across chunk boundaries.
-    ///
-    /// `doc_scope` is therefore supplied by the caller, which is the only layer
-    /// that knows which chunks came from which source file. It must be stable
-    /// across every chunk of a document and distinct between documents. No
-    /// cross-worker coordination is needed: `blank_node_sid` is a pure function
-    /// of the key, so two threads parsing chunk 1 and chunk 7 independently
-    /// derive the same Sid for the same label.
-    ///
-    /// This is the **only** place an import skolem base is built. Every entry
-    /// point routes through it — the three serial commit paths and
-    /// `parse_jsonld_chunk` pass the commit ordinal (one serial call is one
-    /// whole document, so the ordinal is a valid scope); `parse_chunk` and
-    /// `parse_chunk_with_prelude` pass the caller's document scope.
-    fn skolem_base(ledger_id: &str, doc_scope: &str) -> String {
-        format!("{ledger_id}-{doc_scope}")
-    }
-
     /// Parse a TTL chunk into a `StreamingCommitWriter`. Thread-safe.
     ///
     /// Uses a [`WorkerCache`] backed by the shared allocator for lock-free
@@ -892,20 +881,24 @@ mod inner {
         ttl: &str,
         alloc: &Arc<SharedNamespaceAllocator>,
         t: i64,
-        ledger_id: &str,
-        doc_scope: &str,
+        skolem_base: &str,
+        sub_chunk: u32,
         compress: bool,
         spool_dir: Option<&std::path::Path>,
         spool_config: Option<&crate::import_sink::SpoolConfig>,
         chunk_idx: usize,
     ) -> Result<ParsedChunk> {
-        let skolem_base = skolem_base(ledger_id, doc_scope);
-
         let _parse_span = tracing::debug_span!("parse_chunk", t, ttl_bytes = ttl.len(),).entered();
 
         let mut worker_cache = WorkerCache::new(Arc::clone(alloc));
-        let mut sink = ImportSink::new_cached(&mut worker_cache, t, skolem_base, compress)
-            .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
+        let mut sink = ImportSink::new_cached(
+            &mut worker_cache,
+            t,
+            skolem_base.to_string(),
+            sub_chunk,
+            compress,
+        )
+        .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
             let spool_path = dir.join(format!("chunk_{chunk_idx}.spool"));
@@ -952,14 +945,13 @@ mod inner {
         alloc: &Arc<SharedNamespaceAllocator>,
         prelude: &TurtlePrelude,
         t: i64,
-        ledger_id: &str,
-        doc_scope: &str,
+        skolem_base: &str,
+        sub_chunk: u32,
         compress: bool,
         spool_dir: Option<&std::path::Path>,
         spool_config: Option<&crate::import_sink::SpoolConfig>,
         chunk_idx: usize,
     ) -> Result<ParsedChunk> {
-        let skolem_base = skolem_base(ledger_id, doc_scope);
         let _parse_span = tracing::debug_span!("parse_chunk", t, ttl_bytes = ttl.len(),).entered();
 
         let mut worker_cache = WorkerCache::new(Arc::clone(alloc));
@@ -969,8 +961,14 @@ mod inner {
             worker_cache.get_or_allocate(ns_iri);
         }
 
-        let mut sink = ImportSink::new_cached(&mut worker_cache, t, skolem_base, compress)
-            .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
+        let mut sink = ImportSink::new_cached(
+            &mut worker_cache,
+            t,
+            skolem_base.to_string(),
+            sub_chunk,
+            compress,
+        )
+        .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
             let spool_path = dir.join(format!("chunk_{chunk_idx}.spool"));
@@ -1069,7 +1067,8 @@ mod inner {
         jsonld: &str,
         alloc: &Arc<SharedNamespaceAllocator>,
         t: i64,
-        ledger_id: &str,
+        skolem_base: &str,
+        sub_chunk: u32,
         compress: bool,
         spool_dir: Option<&std::path::Path>,
         spool_config: Option<&crate::import_sink::SpoolConfig>,
@@ -1083,14 +1082,19 @@ mod inner {
         // split across chunks. That predates document scoping and is left alone
         // deliberately — deciding whether an ndjson line is its own RDF
         // document is a JSON-LD question, not a Turtle-chunking one.
-        let skolem_base = skolem_base(ledger_id, &t.to_string());
 
         let _parse_span =
             tracing::debug_span!("parse_jsonld_chunk", t, jsonld_bytes = jsonld.len(),).entered();
 
         let mut worker_cache = WorkerCache::new(Arc::clone(alloc));
-        let mut sink = ImportSink::new_cached(&mut worker_cache, t, skolem_base, compress)
-            .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
+        let mut sink = ImportSink::new_cached(
+            &mut worker_cache,
+            t,
+            skolem_base.to_string(),
+            sub_chunk,
+            compress,
+        )
+        .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
             let spool_path = dir.join(format!("chunk_{chunk_idx}.spool"));

--- a/fluree-db-transact/src/import.rs
+++ b/fluree-db-transact/src/import.rs
@@ -141,7 +141,10 @@ mod inner {
         S: ContentAddressedWrite,
     {
         let new_t = state.t + 1;
-        let txn_id = format!("{ledger_id}-{new_t}");
+        // One serial commit == one whole document, so the commit ordinal is
+        // a valid document scope here. See `skolem_base` for why the chunked
+        // parallel path cannot use it.
+        let skolem_base = format!("{ledger_id}-{new_t}");
 
         // 1. Create ImportSink + parse TTL
         let ns_codes_before = state.ns_registry.code_count();
@@ -162,7 +165,7 @@ mod inner {
             None => Arc::new(SharedNamespaceAllocator::from_registry(&state.ns_registry)),
         };
         let mut worker_cache = WorkerCache::new(Arc::clone(&shared_ns));
-        let mut sink = ImportSink::new_cached(&mut worker_cache, new_t, txn_id, compress)
+        let mut sink = ImportSink::new_cached(&mut worker_cache, new_t, skolem_base, compress)
             .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
@@ -300,7 +303,10 @@ mod inner {
         }
 
         let new_t = state.t + 1;
-        let txn_id = format!("{ledger_id}-{new_t}");
+        // One serial commit == one whole document, so the commit ordinal is
+        // a valid document scope here. See `skolem_base` for why the chunked
+        // parallel path cannot use it.
+        let skolem_base = format!("{ledger_id}-{new_t}");
 
         let ns_codes_before = state.ns_registry.code_count();
         let _parse_span = tracing::debug_span!(
@@ -317,7 +323,7 @@ mod inner {
             None => Arc::new(SharedNamespaceAllocator::from_registry(&state.ns_registry)),
         };
         let mut worker_cache = WorkerCache::new(Arc::clone(&shared_ns));
-        let mut sink = ImportSink::new_cached(&mut worker_cache, new_t, txn_id, compress)
+        let mut sink = ImportSink::new_cached(&mut worker_cache, new_t, skolem_base, compress)
             .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
@@ -455,7 +461,10 @@ mod inner {
         S: ContentAddressedWrite,
     {
         let new_t = state.t + 1;
-        let txn_id = format!("{ledger_id}-{new_t}");
+        // One serial commit == one whole document, so the commit ordinal is
+        // a valid document scope here. See `skolem_base` for why the chunked
+        // parallel path cannot use it.
+        let skolem_base = format!("{ledger_id}-{new_t}");
 
         // 1. Parse TriG to extract GRAPH blocks
         let phase1 = parse_trig_phase1(trig)?;
@@ -500,7 +509,7 @@ mod inner {
         };
         let mut worker_cache = WorkerCache::new(Arc::clone(&shared_ns));
         let mut sink =
-            ImportSink::new_cached(&mut worker_cache, new_t, txn_id.clone(), compress)
+            ImportSink::new_cached(&mut worker_cache, new_t, skolem_base.clone(), compress)
                 .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
@@ -565,17 +574,17 @@ mod inner {
                     TransactError::Parse("named graph triple missing subject".to_string())
                 })?;
 
-                let s = expand_term(subject, &block.prefixes, &mut worker_cache, &txn_id)?;
+                let s = expand_term(subject, &block.prefixes, &mut worker_cache, &skolem_base)?;
                 let p = expand_term(
                     &triple.predicate,
                     &block.prefixes,
                     &mut worker_cache,
-                    &txn_id,
+                    &skolem_base,
                 )?;
 
                 for obj in &triple.objects {
                     let (o, dt, lang) =
-                        expand_object(obj, &block.prefixes, &mut worker_cache, &txn_id)?;
+                        expand_object(obj, &block.prefixes, &mut worker_cache, &skolem_base)?;
 
                     // Spool the named-graph flake under its g_id (so it enters
                     // the index), then encode it into the commit blob.
@@ -720,7 +729,7 @@ mod inner {
     /// the spool's prefix lookups see codes the moment they're allocated (see
     /// the comment in `import_trig_commit`).
     ///
-    /// Blank-node labels are skolemized with the same `{txn_id}-{label}` key
+    /// Blank-node labels are skolemized with the same `{skolem_base}-{label}` key
     /// as `ImportSink::skolemize`, so a label shared between the default graph
     /// and a named-graph block of one TriG document resolves to one node
     /// (TriG scopes labels to the whole document), while the same label in a
@@ -729,12 +738,12 @@ mod inner {
         term: &RawTerm,
         prefixes: &rustc_hash::FxHashMap<String, String>,
         ns: &mut WorkerCache,
-        txn_id: &str,
+        skolem_base: &str,
     ) -> Result<Sid> {
         match term {
             RawTerm::Iri(iri) => {
                 if let Some(local) = iri.strip_prefix("_:") {
-                    Ok(ns.blank_node_sid(&format!("{txn_id}-{local}")))
+                    Ok(ns.blank_node_sid(&format!("{skolem_base}-{local}")))
                 } else {
                     Ok(ns.sid_for_iri(iri))
                 }
@@ -754,13 +763,13 @@ mod inner {
         obj: &RawObject,
         prefixes: &rustc_hash::FxHashMap<String, String>,
         ns: &mut WorkerCache,
-        txn_id: &str,
+        skolem_base: &str,
     ) -> Result<(FlakeValue, Sid, Option<String>)> {
         match obj {
             RawObject::Iri(iri) => {
                 // Blank labels use the ImportSink skolem key; see expand_term.
                 let sid = if let Some(local) = iri.strip_prefix("_:") {
-                    ns.blank_node_sid(&format!("{txn_id}-{local}"))
+                    ns.blank_node_sid(&format!("{skolem_base}-{local}"))
                 } else {
                     ns.sid_for_iri(iri)
                 };
@@ -842,13 +851,33 @@ mod inner {
         pub txn_meta: Vec<TxnMetaEntry>,
     }
 
+    /// Blank-node skolemization key for one import *document*.
+    ///
+    /// RDF scopes blank-node labels to the document that contains them, so
+    /// `_:x` must resolve to one subject everywhere in a document and to a
+    /// different subject in the next one. Bulk import cuts a document into many
+    /// chunks — each its own commit — so the commit `t` is the wrong key: it
+    /// splits one document's labels across chunk boundaries.
+    ///
+    /// `doc_scope` is therefore supplied by the caller, which is the only layer
+    /// that knows which chunks came from which source file. It must be stable
+    /// across every chunk of a document and distinct between documents. No
+    /// cross-worker coordination is needed: `blank_node_sid` is a pure function
+    /// of the key, so two threads parsing chunk 1 and chunk 7 independently
+    /// derive the same Sid for the same label.
+    fn skolem_base(ledger_id: &str, doc_scope: &str) -> String {
+        format!("{ledger_id}-{doc_scope}")
+    }
+
     /// Parse a TTL chunk into a `StreamingCommitWriter`. Thread-safe.
     ///
     /// Uses a [`WorkerCache`] backed by the shared allocator for lock-free
     /// namespace lookups. New prefix allocations are tracked in the worker's
     /// `new_codes` set for commit-order publication by the serial finalizer.
     ///
-    /// The `t` value is pre-assigned by the caller (chunk_index + 1).
+    /// The `t` value is pre-assigned by the caller (chunk_index + 1);
+    /// `doc_scope` identifies the source document this chunk was cut from (see
+    /// [`skolem_base`]).
     ///
     /// If `spool_dir` is `Some`, a spool file is written alongside the commit
     /// blob for Phase A validation of the spool format.
@@ -858,17 +887,18 @@ mod inner {
         alloc: &Arc<SharedNamespaceAllocator>,
         t: i64,
         ledger_id: &str,
+        doc_scope: &str,
         compress: bool,
         spool_dir: Option<&std::path::Path>,
         spool_config: Option<&crate::import_sink::SpoolConfig>,
         chunk_idx: usize,
     ) -> Result<ParsedChunk> {
-        let txn_id = format!("{ledger_id}-{t}");
+        let skolem_base = skolem_base(ledger_id, doc_scope);
 
         let _parse_span = tracing::debug_span!("parse_chunk", t, ttl_bytes = ttl.len(),).entered();
 
         let mut worker_cache = WorkerCache::new(Arc::clone(alloc));
-        let mut sink = ImportSink::new_cached(&mut worker_cache, t, txn_id, compress)
+        let mut sink = ImportSink::new_cached(&mut worker_cache, t, skolem_base, compress)
             .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
@@ -905,6 +935,9 @@ mod inner {
     /// Like `parse_chunk`, but does not require the prefix block text to be
     /// prepended onto `ttl`. Uses a [`WorkerCache`] for lock-free lookups.
     ///
+    /// `doc_scope` carries the same document-scoping contract as in
+    /// [`parse_chunk`] — see [`skolem_base`].
+    ///
     /// If `spool_dir` is `Some`, a spool file is written alongside the commit
     /// blob for Phase A validation of the spool format.
     #[allow(clippy::too_many_arguments)]
@@ -914,12 +947,13 @@ mod inner {
         prelude: &TurtlePrelude,
         t: i64,
         ledger_id: &str,
+        doc_scope: &str,
         compress: bool,
         spool_dir: Option<&std::path::Path>,
         spool_config: Option<&crate::import_sink::SpoolConfig>,
         chunk_idx: usize,
     ) -> Result<ParsedChunk> {
-        let txn_id = format!("{ledger_id}-{t}");
+        let skolem_base = skolem_base(ledger_id, doc_scope);
         let _parse_span = tracing::debug_span!("parse_chunk", t, ttl_bytes = ttl.len(),).entered();
 
         let mut worker_cache = WorkerCache::new(Arc::clone(alloc));
@@ -929,7 +963,7 @@ mod inner {
             worker_cache.get_or_allocate(ns_iri);
         }
 
-        let mut sink = ImportSink::new_cached(&mut worker_cache, t, txn_id, compress)
+        let mut sink = ImportSink::new_cached(&mut worker_cache, t, skolem_base, compress)
             .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {
@@ -1035,13 +1069,21 @@ mod inner {
         spool_config: Option<&crate::import_sink::SpoolConfig>,
         chunk_idx: usize,
     ) -> Result<ParsedChunk> {
-        let txn_id = format!("{ledger_id}-{t}");
+        // Chunk-scoped, matching the behavior before document scoping existed.
+        // For the `Files` and remote arms that is also document-scoped, because
+        // one chunk is one whole `.jsonld` file. It is NOT for the ndjson
+        // stream, where `NdjsonReader` packs many lines into one synthetic
+        // `@graph` document: labels there merge across lines within a chunk and
+        // split across chunks. That predates document scoping and is left alone
+        // deliberately — deciding whether an ndjson line is its own RDF
+        // document is a JSON-LD question, not a Turtle-chunking one.
+        let skolem_base = format!("{ledger_id}-{t}");
 
         let _parse_span =
             tracing::debug_span!("parse_jsonld_chunk", t, jsonld_bytes = jsonld.len(),).entered();
 
         let mut worker_cache = WorkerCache::new(Arc::clone(alloc));
-        let mut sink = ImportSink::new_cached(&mut worker_cache, t, txn_id, compress)
+        let mut sink = ImportSink::new_cached(&mut worker_cache, t, skolem_base, compress)
             .map_err(|e| TransactError::Parse(format!("failed to create import sink: {e}")))?;
 
         if let Some((dir, config)) = spool_dir.zip(spool_config) {

--- a/fluree-db-transact/src/import_sink.rs
+++ b/fluree-db-transact/src/import_sink.rs
@@ -540,8 +540,14 @@ mod inner {
         /// `fdb-{skolem_base}-{label}`, so this value must be identical for
         /// every chunk cut from one source document and distinct between
         /// documents. It is deliberately NOT the commit id: bulk import splits
-        /// one document across many commits.
+        /// one document across many commits. Built by
+        /// `fluree_db_core::skolem::skolem_base`.
         skolem_base: String,
+        /// Index of this chunk within its source document, from 0.
+        ///
+        /// Separates *anonymous* nodes, which `skolem_base` alone cannot — see
+        /// `term_blank`.
+        sub_chunk: u32,
         writer: StreamingCommitWriter,
         /// First encoding error encountered (checked after parse).
         encode_error: Option<CommitCodecError>,
@@ -559,11 +565,13 @@ mod inner {
         /// * `ns_registry` — namespace registry (seeded from predefined codes)
         /// * `t` — transaction time
         /// * `skolem_base` — document-scoped blank-node skolemization key
+        /// * `sub_chunk` — index of this chunk within its source document
         /// * `compress` — whether to zstd-compress the ops stream
         pub fn new(
             ns_registry: &'a mut NamespaceRegistry,
             t: i64,
             skolem_base: String,
+            sub_chunk: u32,
             compress: bool,
         ) -> Result<Self, CommitCodecError> {
             Ok(Self {
@@ -573,6 +581,7 @@ mod inner {
                 ns: NsAllocator::Exclusive(ns_registry),
                 t,
                 skolem_base,
+                sub_chunk,
                 writer: StreamingCommitWriter::new(compress)?,
                 encode_error: None,
                 prefix_map: HashMap::new(),
@@ -585,6 +594,7 @@ mod inner {
             worker_cache: &'a mut WorkerCache,
             t: i64,
             skolem_base: String,
+            sub_chunk: u32,
             compress: bool,
         ) -> Result<Self, CommitCodecError> {
             Ok(Self {
@@ -594,6 +604,7 @@ mod inner {
                 ns: NsAllocator::Cached(worker_cache),
                 t,
                 skolem_base,
+                sub_chunk,
                 writer: StreamingCommitWriter::new(compress)?,
                 encode_error: None,
                 prefix_map: HashMap::new(),
@@ -781,20 +792,27 @@ mod inner {
                     // Anonymous mint: leading '-' keeps the namespace
                     // disjoint from every lexable user label (labels cannot
                     // start with '-'), while the full skolemized
-                    // `fdb-{skolem_base}--b{t}-{N}` stays serializable — see
-                    // `FlakeSink::term_blank` for the full rationale.
+                    // `fdb-{skolem_base}--b{sub_chunk}-{N}` stays
+                    // serializable — see `FlakeSink::term_blank` for the full
+                    // rationale.
                     //
-                    // `t` is in the label because the counter alone is NOT
-                    // enough: it restarts at 0 in every sink (one per chunk)
-                    // while `skolem_base` is deliberately shared by all
+                    // `sub_chunk` is in the label because the counter alone is
+                    // NOT enough: it restarts at 0 in every sink (one per
+                    // chunk) while `skolem_base` is deliberately shared by all
                     // chunks of a document, so `-b{N}` alone would make
-                    // chunk 0's Nth anonymous node and chunk 1's Nth the
-                    // same subject. Being statement-local means nothing can
+                    // chunk 0's Nth anonymous node and chunk 1's Nth the same
+                    // subject. Being statement-local means nothing can
                     // *reference* an anonymous node from elsewhere; it does
-                    // not stop two of them from colliding on an id. `t` is
-                    // unique per chunk, which restores that.
+                    // not stop two of them from colliding on an id.
+                    //
+                    // The three parts are jointly unique: `skolem_base` per
+                    // document, `sub_chunk` per chunk within a document, `N`
+                    // per anonymous node within a chunk. It is deliberately
+                    // NOT the commit ordinal — that is a property of the whole
+                    // import, so adding one file to the front of a directory
+                    // would renumber every anonymous node behind it.
                     self.blank_counter += 1;
-                    let label = format!("-b{}-{}", self.t, self.blank_counter);
+                    let label = format!("-b{}-{}", self.sub_chunk, self.blank_counter);
                     let sid = self.skolemize(&label);
                     self.add_term(ResolvedTerm::Sid(sid))
                 }
@@ -937,7 +955,7 @@ mod inner {
             ns: &mut NamespaceRegistry,
             t: i64,
         ) -> Result<ImportSink<'_>, CommitCodecError> {
-            ImportSink::new(ns, t, "test-txn".to_string(), true)
+            ImportSink::new(ns, t, "test-txn".to_string(), 0, true)
         }
 
         fn make_envelope(t: i64) -> crate::commit_v2::CodecEnvelope {
@@ -1167,7 +1185,7 @@ mod inner {
             // wiring) so spool prefix lookups resolve mid-parse.
             let mut cache = WorkerCache::new(Arc::clone(&config.ns_alloc));
             let mut sink =
-                ImportSink::new_cached(&mut cache, 1, "test-txn".to_string(), true).unwrap();
+                ImportSink::new_cached(&mut cache, 1, "test-txn".to_string(), 0, true).unwrap();
 
             // Attach spool context
             let spool_path = dir.join("chunk_0.spool");
@@ -1239,7 +1257,7 @@ mod inner {
             // wiring) so spool prefix lookups resolve mid-parse.
             let mut cache = WorkerCache::new(Arc::clone(&config.ns_alloc));
             let mut sink =
-                ImportSink::new_cached(&mut cache, 1, "test-txn".to_string(), true).unwrap();
+                ImportSink::new_cached(&mut cache, 1, "test-txn".to_string(), 0, true).unwrap();
 
             let spool_path = dir.join("chunk_0.spool");
             let spool_ctx = SpoolContext::new(&spool_path, 0, 0, &config).unwrap();
@@ -1291,7 +1309,7 @@ mod inner {
             // wiring) so spool prefix lookups resolve mid-parse.
             let mut cache = WorkerCache::new(Arc::clone(&config.ns_alloc));
             let mut sink =
-                ImportSink::new_cached(&mut cache, 1, "test-txn".to_string(), true).unwrap();
+                ImportSink::new_cached(&mut cache, 1, "test-txn".to_string(), 0, true).unwrap();
 
             let spool_path = dir.join("chunk_0.spool");
             let spool_ctx = SpoolContext::new(&spool_path, 0, 0, &config).unwrap();

--- a/fluree-db-transact/src/import_sink.rs
+++ b/fluree-db-transact/src/import_sink.rs
@@ -523,7 +523,7 @@ mod inner {
     /// # Example
     ///
     /// ```ignore
-    /// let mut sink = ImportSink::new(&mut ns, t, skolem_base, true)?;
+    /// let mut sink = ImportSink::new(&mut ns, t, skolem_base, 0, true)?;
     /// fluree_graph_turtle::parse(ttl, &mut sink)?;
     /// let writer = sink.into_parts();
     /// let result = writer.finish(&envelope)?;

--- a/fluree-db-transact/src/import_sink.rs
+++ b/fluree-db-transact/src/import_sink.rs
@@ -523,7 +523,7 @@ mod inner {
     /// # Example
     ///
     /// ```ignore
-    /// let mut sink = ImportSink::new(&mut ns, t, txn_id, true)?;
+    /// let mut sink = ImportSink::new(&mut ns, t, skolem_base, true)?;
     /// fluree_graph_turtle::parse(ttl, &mut sink)?;
     /// let writer = sink.into_parts();
     /// let result = writer.finish(&envelope)?;
@@ -534,7 +534,14 @@ mod inner {
         blank_counter: u32,
         ns: NsAllocator<'a>,
         t: i64,
-        txn_id: String,
+        /// Blank-node skolemization key for the RDF *document* being parsed.
+        ///
+        /// Every labeled blank node in the document resolves to
+        /// `fdb-{skolem_base}-{label}`, so this value must be identical for
+        /// every chunk cut from one source document and distinct between
+        /// documents. It is deliberately NOT the commit id: bulk import splits
+        /// one document across many commits.
+        skolem_base: String,
         writer: StreamingCommitWriter,
         /// First encoding error encountered (checked after parse).
         encode_error: Option<CommitCodecError>,
@@ -551,12 +558,12 @@ mod inner {
         /// # Arguments
         /// * `ns_registry` — namespace registry (seeded from predefined codes)
         /// * `t` — transaction time
-        /// * `txn_id` — unique ID for blank node skolemization
+        /// * `skolem_base` — document-scoped blank-node skolemization key
         /// * `compress` — whether to zstd-compress the ops stream
         pub fn new(
             ns_registry: &'a mut NamespaceRegistry,
             t: i64,
-            txn_id: String,
+            skolem_base: String,
             compress: bool,
         ) -> Result<Self, CommitCodecError> {
             Ok(Self {
@@ -565,7 +572,7 @@ mod inner {
                 blank_counter: 0,
                 ns: NsAllocator::Exclusive(ns_registry),
                 t,
-                txn_id,
+                skolem_base,
                 writer: StreamingCommitWriter::new(compress)?,
                 encode_error: None,
                 prefix_map: HashMap::new(),
@@ -577,7 +584,7 @@ mod inner {
         pub fn new_cached(
             worker_cache: &'a mut WorkerCache,
             t: i64,
-            txn_id: String,
+            skolem_base: String,
             compress: bool,
         ) -> Result<Self, CommitCodecError> {
             Ok(Self {
@@ -586,7 +593,7 @@ mod inner {
                 blank_counter: 0,
                 ns: NsAllocator::Cached(worker_cache),
                 t,
-                txn_id,
+                skolem_base,
                 writer: StreamingCommitWriter::new(compress)?,
                 encode_error: None,
                 prefix_map: HashMap::new(),
@@ -645,7 +652,7 @@ mod inner {
         }
 
         fn skolemize(&mut self, local: &str) -> Sid {
-            let unique_id = format!("{}-{}", self.txn_id, local);
+            let unique_id = format!("{}-{}", self.skolem_base, local);
             self.ns.blank_node_sid(&unique_id)
         }
 
@@ -774,10 +781,20 @@ mod inner {
                     // Anonymous mint: leading '-' keeps the namespace
                     // disjoint from every lexable user label (labels cannot
                     // start with '-'), while the full skolemized
-                    // `fdb-{txn}--b{N}` stays serializable — see
+                    // `fdb-{skolem_base}--b{t}-{N}` stays serializable — see
                     // `FlakeSink::term_blank` for the full rationale.
+                    //
+                    // `t` is in the label because the counter alone is NOT
+                    // enough: it restarts at 0 in every sink (one per chunk)
+                    // while `skolem_base` is deliberately shared by all
+                    // chunks of a document, so `-b{N}` alone would make
+                    // chunk 0's Nth anonymous node and chunk 1's Nth the
+                    // same subject. Being statement-local means nothing can
+                    // *reference* an anonymous node from elsewhere; it does
+                    // not stop two of them from colliding on an id. `t` is
+                    // unique per chunk, which restores that.
                     self.blank_counter += 1;
-                    let label = format!("-b{}", self.blank_counter);
+                    let label = format!("-b{}-{}", self.t, self.blank_counter);
                     let sid = self.skolemize(&label);
                     self.add_term(ResolvedTerm::Sid(sid))
                 }

--- a/fluree-graph-json-ld/src/lib.rs
+++ b/fluree-graph-json-ld/src/lib.rs
@@ -51,7 +51,7 @@ pub use compact::ContextCompactor;
 pub use context::{Container, ContextEntry, ParsedContext, TypeValue};
 pub use error::{JsonLdError, Result};
 pub use iri::UnresolvedIriDisposition;
-pub use ndjson_splitter::{FirstLineContextPolicy, NdjsonReader};
+pub use ndjson_splitter::{FirstLineContextPolicy, NdjsonChunkPayload, NdjsonReader};
 pub use normalize::{Algorithm, Format, NormalizeOptions};
 
 use serde_json::Value as JsonValue;

--- a/fluree-graph-json-ld/src/ndjson_splitter.rs
+++ b/fluree-graph-json-ld/src/ndjson_splitter.rs
@@ -33,6 +33,20 @@
 //! everywhere, never switches. Nodes carrying an inline `@context` alongside
 //! other keys remain ordinary nodes anywhere.
 //!
+//! # Segments are documents
+//!
+//! Every chunk carries the ordinal of the **context segment** it belongs to,
+//! counting switches from 0. A segment is the unit consumers must treat as one
+//! RDF document: the nodes inside one share a `@context` and are emitted as
+//! members of a single `@graph`, and nodes on either side of a switch are
+//! emitted as separate `@graph` documents under different contexts. Bulk
+//! import uses it to scope blank-node labels, so `_:x` unifies across a
+//! segment (however the chunker cuts it) and stays distinct across the
+//! `cat a.jsonl b.jsonl` seam.
+//!
+//! It is an ordinal, not the chunk index the segment starts at, so it does not
+//! move when `chunk_size_bytes` changes.
+//!
 //! # Streaming
 //!
 //! The reader is driven by any [`BufRead`] (not a `Path`), so it streams local
@@ -59,7 +73,7 @@ use serde::de::IgnoredAny;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
-use crate::splitter::{ChunkPayload, JsonLdPrelude, SplitError};
+use crate::splitter::{JsonLdPrelude, SplitError};
 
 /// Policy for interpreting the first non-blank line of an ndjson/jsonl source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -81,9 +95,16 @@ pub enum FirstLineContextPolicy {
 /// Streams a newline-delimited JSON-LD source as standalone JSON-LD chunks.
 pub struct NdjsonReader {
     prelude: JsonLdPrelude,
-    rx: Mutex<mpsc::Receiver<ChunkPayload>>,
+    rx: Mutex<mpsc::Receiver<NdjsonChunkPayload>>,
     reader_handle: Option<JoinHandle<Result<usize, SplitError>>>,
 }
+
+/// `(chunk_index, segment_ordinal, chunk_bytes)` — what [`NdjsonReader`] emits.
+///
+/// Deliberately NOT [`crate::splitter::ChunkPayload`]: that type is shared with
+/// the structured JSON-LD splitter, which has no notion of segments, and
+/// widening it would ripple into a reader this has nothing to do with.
+pub type NdjsonChunkPayload = (usize, u32, Vec<u8>);
 
 impl NdjsonReader {
     /// Create a reader over any byte stream (local file, S3 object range
@@ -129,7 +150,7 @@ impl NdjsonReader {
     /// Receive the next chunk, blocking until available. `Ok(None)` once all
     /// chunks have been emitted (call [`join`](Self::join) afterwards to
     /// observe any reader-thread error).
-    pub fn recv_chunk(&self) -> Result<Option<ChunkPayload>, SplitError> {
+    pub fn recv_chunk(&self) -> Result<Option<NdjsonChunkPayload>, SplitError> {
         let rx = self.rx.lock().unwrap();
         match rx.recv() {
             Ok(payload) => Ok(Some(payload)),
@@ -295,7 +316,7 @@ fn reader_thread(
     lines_consumed: usize,
     chunk_size: u64,
     policy: FirstLineContextPolicy,
-    tx: mpsc::SyncSender<ChunkPayload>,
+    tx: mpsc::SyncSender<NdjsonChunkPayload>,
 ) -> Result<usize, SplitError> {
     let mut prefix = build_prefix(&context)?;
     let suffix: &[u8] = b"]}";
@@ -307,6 +328,10 @@ fn reader_thread(
     let mut chunk_buf = seeded_buf(&prefix, chunk_size);
     let mut element_count: usize = 0;
     let mut chunk_idx: usize = 0;
+    // Which context segment the chunks being built belong to. Bumped once per
+    // switch; see the module docs for why it is an ordinal rather than the
+    // chunk index the segment starts at.
+    let mut segment: u32 = 0;
     // Continue the prelude's numbering so errors report true file lines.
     let mut line_no: usize = lines_consumed;
     let mut line_buf: Vec<u8> = Vec::new();
@@ -333,9 +358,13 @@ fn reader_thread(
         // hatch) lone contexts remain data nodes, as on line 1.
         if policy != FirstLineContextPolicy::Entity {
             if let Some(new_ctx) = lone_context_line(trimmed) {
+                // Seal the outgoing segment before the switch: a segment
+                // boundary is always a chunk boundary, so no chunk ever spans
+                // two contexts (or two documents).
                 if element_count > 0 {
-                    emit(&tx, &mut chunk_idx, &mut chunk_buf, suffix)?;
+                    emit(&tx, &mut chunk_idx, segment, &mut chunk_buf, suffix)?;
                 }
+                segment = segment.saturating_add(1);
                 tracing::warn!(
                     line = line_no,
                     "ndjson: lone {{\"@context\":…}} line replaces the shared \
@@ -350,14 +379,14 @@ fn reader_thread(
         push_node(&mut chunk_buf, &mut element_count, trimmed);
 
         if chunk_buf.len() as u64 >= chunk_size {
-            emit(&tx, &mut chunk_idx, &mut chunk_buf, suffix)?;
+            emit(&tx, &mut chunk_idx, segment, &mut chunk_buf, suffix)?;
             chunk_buf = seeded_buf(&prefix, chunk_size);
             element_count = 0;
         }
     }
 
     if element_count > 0 {
-        emit(&tx, &mut chunk_idx, &mut chunk_buf, suffix)?;
+        emit(&tx, &mut chunk_idx, segment, &mut chunk_buf, suffix)?;
     }
 
     Ok(chunk_idx)
@@ -380,14 +409,15 @@ fn push_node(chunk_buf: &mut Vec<u8>, element_count: &mut usize, node: &[u8]) {
 
 /// Seal `chunk_buf` with the suffix and send it, leaving the buffer empty.
 fn emit(
-    tx: &mpsc::SyncSender<ChunkPayload>,
+    tx: &mpsc::SyncSender<NdjsonChunkPayload>,
     chunk_idx: &mut usize,
+    segment: u32,
     chunk_buf: &mut Vec<u8>,
     suffix: &[u8],
 ) -> Result<(), SplitError> {
     chunk_buf.extend_from_slice(suffix);
     let doc = std::mem::take(chunk_buf);
-    tx.send((*chunk_idx, doc))
+    tx.send((*chunk_idx, segment, doc))
         .map_err(|_| SplitError::ChannelClosed)?;
     *chunk_idx += 1;
     Ok(())
@@ -458,11 +488,27 @@ mod tests {
         let mut reader = NdjsonReader::new_from_reader(reader_for(input), chunk_size, 4, policy)?;
         let ctx = reader.prelude().context.clone();
         let mut chunks = Vec::new();
-        while let Some((_idx, bytes)) = reader.recv_chunk()? {
+        while let Some((_idx, _segment, bytes)) = reader.recv_chunk()? {
             chunks.push(serde_json::from_slice::<JsonValue>(&bytes).unwrap());
         }
         reader.join()?;
         Ok((ctx, chunks))
+    }
+
+    /// Drive a reader to completion, returning `(segment, node_count)` per chunk.
+    fn read_segments(
+        input: &str,
+        chunk_size: u64,
+        policy: FirstLineContextPolicy,
+    ) -> Result<Vec<(u32, usize)>, SplitError> {
+        let mut reader = NdjsonReader::new_from_reader(reader_for(input), chunk_size, 4, policy)?;
+        let mut out = Vec::new();
+        while let Some((_idx, segment, bytes)) = reader.recv_chunk()? {
+            let doc: JsonValue = serde_json::from_slice(&bytes).unwrap();
+            out.push((segment, doc["@graph"].as_array().unwrap().len()));
+        }
+        reader.join()?;
+        Ok(out)
     }
 
     /// Total `@graph` nodes across all chunks.
@@ -471,6 +517,68 @@ mod tests {
             .iter()
             .map(|c| c["@graph"].as_array().unwrap().len())
             .sum()
+    }
+
+    // A `cat a.jsonl b.jsonl` seam. Everything before the second lone context
+    // is one document, everything after is another, and consumers need to be
+    // able to tell which is which.
+    #[test]
+    fn segment_ordinal_counts_context_switches() {
+        let input = "{\"@context\":{\"a\":\"http://a.example/\"}}\n\
+                     {\"@id\":\"a:1\"}\n\
+                     {\"@id\":\"a:2\"}\n\
+                     {\"@context\":{\"b\":\"http://b.example/\"}}\n\
+                     {\"@id\":\"b:1\"}\n";
+        let segments = read_segments(input, 1_000_000, FirstLineContextPolicy::Auto).unwrap();
+        assert_eq!(segments, vec![(0, 2), (1, 1)]);
+    }
+
+    // The ordinal names the segment, so it must not move when the chunker
+    // cuts differently — the whole reason it is not "the chunk index the
+    // segment started at".
+    #[test]
+    fn segment_ordinal_is_independent_of_chunk_size() {
+        let mut input = String::from("{\"@context\":{\"a\":\"http://a.example/\"}}\n");
+        for i in 0..40 {
+            input.push_str(&format!("{{\"@id\":\"a:{i}\"}}\n"));
+        }
+        input.push_str("{\"@context\":{\"b\":\"http://b.example/\"}}\n");
+        input.push_str("{\"@id\":\"b:1\"}\n");
+
+        let coarse = read_segments(&input, 1_000_000, FirstLineContextPolicy::Auto).unwrap();
+        let fine = read_segments(&input, 64, FirstLineContextPolicy::Auto).unwrap();
+        assert_eq!(
+            coarse.len(),
+            2,
+            "one chunk per segment when chunks are large"
+        );
+        assert!(
+            fine.len() > coarse.len(),
+            "small chunks must split segment 0"
+        );
+
+        let ordinals = |v: &[(u32, usize)]| -> Vec<u32> {
+            let mut o: Vec<u32> = v.iter().map(|(s, _)| *s).collect();
+            o.dedup();
+            o
+        };
+        assert_eq!(ordinals(&coarse), vec![0, 1]);
+        assert_eq!(ordinals(&fine), vec![0, 1]);
+    }
+
+    // Under `Entity` a lone context line is data, never a switch, so the file
+    // is one segment throughout.
+    #[test]
+    fn entity_policy_never_opens_a_new_segment() {
+        let input = "{\"@context\":{\"a\":\"http://a.example/\"}}\n\
+                     {\"@id\":\"http://a.example/1\"}\n\
+                     {\"@context\":{\"b\":\"http://b.example/\"}}\n\
+                     {\"@id\":\"http://b.example/1\"}\n";
+        let segments = read_segments(input, 1_000_000, FirstLineContextPolicy::Entity).unwrap();
+        assert!(
+            segments.iter().all(|(s, _)| *s == 0),
+            "Entity policy has no switches: {segments:?}"
+        );
     }
 
     #[test]

--- a/fluree-vocab/src/lib.rs
+++ b/fluree-vocab/src/lib.rs
@@ -1804,6 +1804,17 @@ pub mod db {
     /// db:ledgerIndex - nameservice field: pointer to latest ledger index root
     pub const LEDGER_INDEX: &str = "ledgerIndex";
 
+    /// db:importSource - bulk-import manifest: the document a blank-node scope
+    /// was minted from, as a path relative to the import root (or a remote
+    /// address relative to its listing prefix).
+    ///
+    /// Written into the `txn-meta` graph, one triple per source document, with
+    /// the scope's blank node as subject:
+    /// `_:fdb-d<scope> db:importSource "sub/dir/data.ttl"`. Every id minted
+    /// from that document starts with that scope, so it is what turns an
+    /// opaque `_:fdb-…` back into the file it came from.
+    pub const IMPORT_SOURCE: &str = "importSource";
+
     // ========================================================================
     // Edge-annotation system predicates (durable attachment encoding)
     // ========================================================================


### PR DESCRIPTION
# Scope blank-node labels to the document, and make the ids writable

Two bugs with one root. Bulk import derived a blank node's identity from *where the chunker happened to cut*, and rendered that identity in a form no SPARQL parser accepts.

## What was wrong

**Labels split across chunk boundaries.** Import skolemized labeled blank nodes from the per-chunk commit id, so `_:x` in chunk 1 and `_:x` in chunk 7 of one Turtle file became two different subjects. RDF scopes a blank-node label to the document containing it; one `.ttl` file is one document. This is the chunked-Turtle sibling of the TriG bug fixed in #1432, which established the rule that a label unifies across one document and stays distinct across documents — #1432 fixed the named-graph half, the shipping parallel Turtle path still split labels the other way. Nothing surfaced it: the labels come out as opaque `_:fdb-…` ids, so the data simply arrived silently un-joined.

**The ids could not be written back.** The skolem key was `{ledger_id}-{scope}`, and a ledger id contains `/` and `:`. So a minted id looked like `_:fdb-lubm/bench:main-d3-genid10`, and SPARQL's `BLANK_NODE_LABEL` production admits neither character. Those ids came out of a query and could never go back in — a bulk-imported blank-node structure was the one kind Fluree could not edit in place from SPARQL, and `docs/transactions/update-where-delete-insert.md` said so out loud as a standing caveat.

**And the identity moved when the import did.** The document scope was the file's *position* in the sorted directory listing, and anonymous nodes carried the global chunk ordinal on top of that. Dropping one more file into the directory renumbered every id behind it, for data whose bytes had not changed.

## The format

```
fdb-d<13 lowercase base36 digits>-<label>
    ^ ^                          ^
    | |                          `- the label as written in the source
    | `- xxh64(namespace ‖ 0x00 ‖ document key), zero-padded
    `- the document-scope marker
```

`fluree_db_core::skolem` is the single definition. `[0-9a-z-]` only, so the ids are writable in SPARQL, Turtle and JSON-LD with no escaping — which is the headline, and the thing the PR exists to deliver.

Three properties are load-bearing:

**The namespace replaces the ledger id, it does not drop it.** Two ledgers loaded from one source tree still mint disjoint blank nodes, because the ledger id salts the hash. It is the *normalized* id, so `my/ledger` and `my/ledger:main` — one ledger, two spellings — agree. `--skolem-namespace <id>` overrides it for the cases where identical ids across ledgers are the point: a rebuild-and-diff, a sharded load of one logical dataset, a staging/production pair.

**The document key is relative.** A path relative to the import root; for remote sources, the address relative to the listing prefix. So the same tree mints the same ids whether it is mounted at `/tmp/x` or `/data/x`. `RemoteSource::OrderedObjects` supplies no prefix, so its keys are whole addresses — and since `RemoteObject::address` is backend-opaque by contract, hashing it pins those ids to that backend's address encoding. That is called out at the code.

**The width is fixed.** 13 base36 digits hold any `u64` (`36^13 > 2^64`), so the scope is always exactly 14 bytes and splits off a minted id cleanly — even from a label that contains any number of `-` itself. That is what makes the manifest (below) usable, and it is what gives structural disjointness from the other two `fdb-` minters: import's first hyphen falls at offset 14, a staged transaction's at 16 (nanoseconds-since-epoch is 16 hex digits for every clock between 2004 and 2154), `BNODE()`'s at 8 (RFC-4122 text). Pinned by a unit test.

**Anonymous nodes** now carry the sub-chunk index within their document rather than the global chunk ordinal, so they stop depending on the rest of the file set too. `(document, sub-chunk, counter)` is jointly unique: the base per document, the sub-chunk per chunk within a document, the counter per node within a chunk. Being statement-local means nothing can *reference* an anonymous node from elsewhere; it does not stop two of them from colliding on an id, which is why the mint needs all three.

## The ndjson arm

Previously chunk-scoped, so labels merged across lines within a chunk and split across chunks — a boundary set by `chunk_size_mb`, not by anything in the data. An ndjson document is now one **context segment**: the run of lines sharing one `@context`.

Not the file, and not the line. Three facts in our own code fix it there. `ndjson_splitter`'s module doc says each line is one complete JSON-LD *node*, not document. A line cannot be read standalone anyway — it resolves against a `@context` declared on a different line. And the emitter wraps a run of nodes as members of one `@graph`, which is what co-document means. The NDJSON convention that each line is an independent JSON *value* is satisfied by that and says nothing about the JSON-LD document boundary.

The boundary is the `@context` switch: a mid-stream lone `{"@context": …}` line replaces the shared context, and the reader seals the outgoing chunk before rebuilding the prefix, so nodes on either side become different `@graph` documents under different contexts. That is the `cat a.jsonl b.jsonl > combined.jsonl` seam — a first-class NDJSON workflow, and the case where per-file scoping would have silently merged `a.jsonl`'s `_:x` with `b.jsonl`'s.

The key gains the segment ordinal: `xxh64(namespace ‖ 0 ‖ doc_key ‖ 0 ‖ segment)`, segment 0 everywhere else. It is an **ordinal** — how many switches precede the segment — deliberately not the chunk index the segment starts at, which would move with `chunk_size_mb` and put back exactly the import-shape dependence this change removes. The reader gets its own `NdjsonChunkPayload` rather than widening the shared `ChunkPayload`, which the structured JSON-LD splitter also uses and which has no notion of segments.

## Fail-loud on duplicate documents

`DocIds::new` hashes the whole document set up front and refuses an import whose documents do not hash apart, naming both. A duplicate is nearly always a duplicate *key* — `RemoteSource::OrderedObjects` takes a caller-supplied list, and nothing stops it naming one address twice — and much more rarely an `xxh64` collision between two different keys. Both are fatal the same way: two documents sharing a scope silently merge their `_:x` nodes. Refusing up front costs nothing; discovering it after a multi-hour import costs the import.

The local arms cannot produce a duplicate (`read_dir` yields each entry once), so the guard is unit-tested directly and the reachable arm is covered end to end.

## Provenance

A hash carries no provenance, so the import now writes the mapping into the `txn-meta` graph it already builds: one `db:importSource` triple per source document, subject = the scope's own blank node, object = the document key. Records ride the existing meta chunk — no extra pass, no extra file. The ndjson arm discovers documents as it reads (a `@context` switch opens one), so its producer logs the segments it actually opens and the meta chunk adds a row for each against the same file name — every minted scope resolves, even though the manifest does not say *which* segment of the file it was.

```sparql
SELECT ?source WHERE {
  GRAPH <urn:fluree:my/ledger:main#txn-meta> {
    _:fdb-d1t3k9x0abcdef <https://ns.flur.ee/db#importSource> ?source
  }
}
```

`skolem::split_doc_scope` takes a minted id to its scope; the manifest takes the scope to the file.

## Migration

There is no mixed-format ledger to migrate. Import requires a fresh ledger (`import.rs`, the `already has commits` guard), so a ledger's import ids are all of one format. Nothing parses a minted label apart, either — the only structural reader is `stable_blank_node_local`, which just checks the `fdb-` prefix.

Existing ledgers are untouched; this changes only what a *new* import mints. Two consequences worth stating plainly:

- **Re-importing a source produces different ids than it did before.** Anything that recorded a pre-4.1.5 `_:fdb-…` id externally and expects a rebuild to reproduce it will not get it back.
- **ndjson blank-node scope changes.** Labels that used to merge within a chunk and split across chunks now merge across a whole context segment and split at `@context` switches.

`ns_encoding::canonical_split` keeps its `_:` special case: pre-4.1.5 ledgers hold ids with colons in them, and a user-authored label can carry one on any surface that admits it. The comment now says that is what it is for.

Two serialization paths are pinned down rather than changed. `validate`'s Turtle renderer keeps its lossy sanitizer and now says why that is right for a human-facing report and wrong on the export path. `export` says explicitly that it writes labels verbatim to preserve identity, and that a pre-4.1.5 ledger is the one case where that emits Turtle a strict parser rejects — sanitizing there would merge two distinct nodes onto one id, which is worse than invalid syntax.

## Cost

No cross-worker coordination and no throughput cost. `blank_node_sid` is a pure function of the key, so two threads parsing chunk 1 and chunk 7 independently derive the same Sid for the same label — no shared map, no lock, no ordering dependency. The chunk channel stays allocation-free: `DocChunk` is a `Copy` 16-byte struct, and the skolem base is rendered once per chunk in the worker (the same one `format!` per chunk the old code paid). Hashing happens once per *document*, at chunk-source construction.

## Tests

Failing before, passing after:

| test | before |
|---|---|
| `imported_blank_node_id_is_writable_in_sparql` | the `DELETE` template does not parse: `_:fdb-test/skolem-sparql:main-d0-shared` |
| `minted_ids_do_not_depend_on_the_rest_of_the_directory` | one extra file ahead of the document changes both its labeled and its anonymous ids |
| `ndjson_blank_label_is_scoped_to_its_source_not_its_chunk` | the two occurrences land in different chunks and become two subjects |
| `import_ttl_blank_label_scoped_across_chunks` | `_:shared` in chunk 0 and chunk 1 of one file are two subjects |
| `import_ttl_anonymous_nodes_distinct_across_chunks` | both anonymous nodes resolve to one id |
| `ndjson_context_switch_starts_a_new_blank_node_scope` | both `_:shared` occurrences resolve to `_:fdb-d2dleqty4209so-shared`, one node |
| `import_manifest_covers_ndjson_context_segments` | one manifest row for a file that minted two scopes |
| `trig_fast_path_delegation_keeps_the_document_key` | (mutation-verified) rebuilding the key inside `import_commit` splits the delegating and direct TriG paths |

Invariant pins that hold on both sides, kept because the new code re-derives what they assert: `ledger_id_spelling_does_not_change_minted_ids`, `different_ledgers_mint_different_ids`, `labels_stay_distinct_between_documents`.

Plus: `explicit_skolem_namespace_shares_ids_across_ledgers`, `import_manifest_maps_blank_node_scopes_back_to_documents` (the full id → scope → document round trip), `duplicate_remote_addresses_abort_the_import`, `rechunk_scopes_survive_split_and_coalesced_files_interleaved` (serial vs. 4-worker parity plus a no-reused-`(doc, sub-chunk)`-pair check), the `fluree_db_core::skolem` unit tests, and a CLI integration test that drives the real binary — the only thing that catches a flag being defined but not plumbed.

## Named residuals

- **Federated same-name servers still unify.** The salt is a ledger id, not a server identity, so two Fluree servers hosting `my/ledger:main` and importing the same tree mint the same blank-node ids. Under federation those look like one node. `--skolem-namespace` is the lever if that matters.
- **ndjson written as one independent document per line still unifies.** An inline `@context` on *every* line makes those lines ordinary nodes in one `@graph` — one document — so a `_:x` reused across them resolves to one node. Correct JSON-LD, but not what the NDJSON-of-independent-documents convention suggests. Making each inline-context line its own segment would vary the document key *within* a chunk, and the pipeline is one sink and one skolem base per chunk. Documented in `docs/cli/create.md`; exposure needs explicit `_:` labels reused across lines of a per-line-context file.
- **Anonymous ids remain chunk-config dependent.** They key on the sub-chunk index, so re-importing the same tree at a different `chunk_size_mb` renumbers them (labeled ids are unaffected). They also move if coalescing pulls a file into a neighbour's payload — `coalesce_unsafe` refuses files with `_:` labels, which protects labeled nodes but not anonymous ones. Nothing can *reference* an anonymous node, so this is an identity-stability limit, not a correctness one.
- **`OrderedObjects` keys are backend-flavored.** No listing prefix to strip, and `RemoteObject::address` is opaque by contract, so re-importing the same objects through a different backend mints different ids.
- **The server's `POST /import` route has no `skolem_namespace`.** It exposes no import tuning knobs at all today (no memory budget, no parallelism), so adding one there is its own change.
- **`StreamingTurtleReader` does not terminate on a sub-KB chunk size.** Found while sizing the rechunk fixture. Unreachable from the import config, which sizes chunks in megabytes; noted at the fixture and not fixed here.
