### PR TITLE
feat(graph-ir): fallible GraphSink protocol, quad capability, statement lifecycle + Turtle ParserOptions conformance

### DIFF
--- a/fluree-db-api/src/inline_ontology.rs
+++ b/fluree-db-api/src/inline_ontology.rs
@@ -55,7 +55,7 @@ pub(crate) fn parse_inline_ontology_to_bundle(
     })?;
 
     let flakes: Vec<Flake> = sink
-        .finish()
+        .into_flakes()
         .map_err(|e| crate::ApiError::config(format!("inline ontology flake build failed: {e}")))?;
     if flakes.is_empty() {
         return Ok(None);

--- a/fluree-db-api/src/inline_shapes.rs
+++ b/fluree-db-api/src/inline_shapes.rs
@@ -79,7 +79,7 @@ pub(crate) fn parse_inline_shapes_turtle_to_bundle(
 }
 
 fn bundle_from_sink(sink: FlakeSink<'_>) -> Result<Option<Arc<SchemaBundleFlakes>>, TransactError> {
-    let flakes: Vec<Flake> = sink.finish()?;
+    let flakes: Vec<Flake> = sink.into_flakes()?;
     if flakes.is_empty() {
         return Ok(None);
     }

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -3021,7 +3021,7 @@ impl crate::Fluree {
             let _g = parse_span.enter();
             let mut sink = FlakeSink::new(&mut ns_registry, new_t, txn_id);
             fluree_graph_turtle::parse(turtle, &mut sink)?;
-            sink.finish().map_err(ApiError::from)?
+            sink.into_flakes().map_err(ApiError::from)?
         };
         tracing::info!(flake_count = flakes.len(), "turtle parsed to flakes");
 

--- a/fluree-db-api/src/validate.rs
+++ b/fluree-db-api/src/validate.rs
@@ -703,7 +703,7 @@ mod tests {
         let turtle = sample_report().to_turtle();
         let mut sink = fluree_graph_ir::GraphCollectorSink::new();
         fluree_graph_turtle::parse(&turtle, &mut sink).expect("report Turtle must parse");
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         // report node (type + conforms + result) and the result node's fields
         assert!(graph.len() >= 8, "expected full report triples: {turtle}");
         assert!(turtle.contains("sh:MinCountConstraintComponent"));

--- a/fluree-db-r2rml/src/loader/extractor.rs
+++ b/fluree-db-r2rml/src/loader/extractor.rs
@@ -500,7 +500,7 @@ mod tests {
     fn parse_r2rml(turtle: &str) -> Graph {
         let mut sink = GraphCollectorSink::new();
         parse_turtle(turtle, &mut sink).unwrap();
-        sink.finish()
+        sink.into_graph()
     }
 
     #[test]

--- a/fluree-db-r2rml/src/loader/mod.rs
+++ b/fluree-db-r2rml/src/loader/mod.rs
@@ -52,7 +52,7 @@ impl R2rmlLoader {
     pub fn from_turtle(content: &str) -> R2rmlResult<Self> {
         let mut sink = GraphCollectorSink::new();
         parse_turtle(content, &mut sink).map_err(|e| R2rmlError::Parse(e.to_string()))?;
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         Ok(Self { graph })
     }
 

--- a/fluree-db-transact/src/flake_sink.rs
+++ b/fluree-db-transact/src/flake_sink.rs
@@ -11,7 +11,7 @@ use crate::value_convert::{convert_native_literal, convert_string_literal};
 use fluree_db_core::edge::EdgeKey;
 use fluree_db_core::DatatypeConstraint;
 use fluree_db_core::{Flake, FlakeMeta, FlakeValue, Sid};
-use fluree_graph_ir::{Datatype, GraphSink, LiteralValue, TermId};
+use fluree_graph_ir::{Datatype, GraphSink, LiteralValue, SinkResult, TermId};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -48,7 +48,7 @@ enum ResolvedTerm {
 /// let mut ns = NamespaceRegistry::from_db(&db);
 /// let mut sink = FlakeSink::new(&mut ns, new_t, txn_id);
 /// fluree_graph_turtle::parse(ttl, &mut sink)?;
-/// let flakes = sink.finish().expect("no invariant violation");
+/// let flakes = sink.into_flakes().expect("no invariant violation");
 /// ```
 pub struct FlakeSink<'a> {
     /// Resolved terms indexed by TermId
@@ -93,9 +93,15 @@ impl<'a> FlakeSink<'a> {
 
     /// Consume the sink and return the accumulated flakes, or surface the
     /// first storage-invariant violation observed during parsing as a hard
-    /// error. Mirrors [`ImportSink::finish`](crate::import_sink::ImportSink)
+    /// error. Mirrors
+    /// [`ImportSink::into_parts`](crate::import_sink::ImportSink::into_parts)
     /// — bad input must fail the transaction, not silently omit a triple.
-    pub fn finish(self) -> Result<Vec<Flake>, TransactError> {
+    ///
+    /// Distinct from the protocol's [`GraphSink::finish`] (flush/finalize):
+    /// this is the sink's *product*. Deferred-error semantics are unchanged
+    /// by the fallible protocol — `emit_*` still records the first violation
+    /// and keeps going, and this method is where it becomes a hard error.
+    pub fn into_flakes(self) -> Result<Vec<Flake>, TransactError> {
         if let Some(err) = self.invariant_error {
             return Err(err);
         }
@@ -260,16 +266,24 @@ impl GraphSink for FlakeSink<'_> {
         })
     }
 
-    fn emit_triple(&mut self, subject: TermId, predicate: TermId, object: TermId) {
+    fn emit_triple(&mut self, subject: TermId, predicate: TermId, object: TermId) -> SinkResult {
         if let Some(flake) = self.build_flake(subject, predicate, object, None) {
             self.flakes.push(flake);
         }
+        Ok(())
     }
 
-    fn emit_list_item(&mut self, subject: TermId, predicate: TermId, object: TermId, index: i32) {
+    fn emit_list_item(
+        &mut self,
+        subject: TermId,
+        predicate: TermId,
+        object: TermId,
+        index: i32,
+    ) -> SinkResult {
         if let Some(flake) = self.build_flake(subject, predicate, object, Some(index)) {
             self.flakes.push(flake);
         }
+        Ok(())
     }
 
     fn supports_reified_triples(&self) -> bool {
@@ -287,18 +301,18 @@ impl GraphSink for FlakeSink<'_> {
         predicate: TermId,
         object: TermId,
         reifier: TermId,
-    ) {
+    ) -> SinkResult {
         let Some(s) = self.resolve_sid(subject) else {
-            return;
+            return Ok(());
         };
         let Some(p) = self.resolve_sid(predicate) else {
-            return;
+            return Ok(());
         };
         let Some((o, dtc)) = self.resolve_object(object) else {
-            return;
+            return Ok(());
         };
         let Some(ann) = self.resolve_sid(reifier) else {
-            return;
+            return Ok(());
         };
 
         match crate::generate::flakes::reified_triple_bundle(s, p, o, &dtc, &ann, self.t) {
@@ -310,6 +324,7 @@ impl GraphSink for FlakeSink<'_> {
                 }
             }
         }
+        Ok(())
     }
 }
 
@@ -337,9 +352,9 @@ mod tests {
         let s = sink.term_iri("http://example.org/alice");
         let p = sink.term_iri("http://example.org/name");
         let o = sink.term_literal("Alice", Datatype::xsd_string(), None);
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         let f = &flakes[0];
         assert!(f.op); // assertion
@@ -356,9 +371,9 @@ mod tests {
         let s = sink.term_iri("http://example.org/alice");
         let p = sink.term_iri("http://example.org/age");
         let o = sink.term_literal_value(LiteralValue::Integer(30), Datatype::xsd_integer());
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::Long(30)));
     }
@@ -371,9 +386,9 @@ mod tests {
         let s = sink.term_iri("http://example.org/x");
         let p = sink.term_iri("http://example.org/val");
         let o = sink.term_literal_value(LiteralValue::Double(3.13), Datatype::xsd_double());
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::Double(d) if (*d - 3.13).abs() < f64::EPSILON));
     }
@@ -386,9 +401,9 @@ mod tests {
         let s = sink.term_iri("http://example.org/x");
         let p = sink.term_iri("http://example.org/active");
         let o = sink.term_literal_value(LiteralValue::Boolean(true), Datatype::xsd_boolean());
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::Boolean(true)));
     }
@@ -401,9 +416,9 @@ mod tests {
         let s = sink.term_iri("http://example.org/alice");
         let p = sink.term_iri("http://example.org/name");
         let o = sink.term_literal("Alice", Datatype::rdf_lang_string(), Some("en"));
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         let f = &flakes[0];
         assert!(matches!(&f.o, FlakeValue::String(s) if s == "Alice"));
@@ -458,9 +473,9 @@ mod tests {
         let s = sink.term_iri("http://example.org/alice");
         let p = sink.term_iri("http://example.org/knows");
         let o = sink.term_iri("http://example.org/bob");
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         let f = &flakes[0];
         assert!(matches!(&f.o, FlakeValue::Ref(_)));
@@ -478,11 +493,11 @@ mod tests {
         let o0 = sink.term_literal_value(LiteralValue::Integer(10), Datatype::xsd_integer());
         let o1 = sink.term_literal_value(LiteralValue::Integer(20), Datatype::xsd_integer());
         let o2 = sink.term_literal_value(LiteralValue::Integer(30), Datatype::xsd_integer());
-        sink.emit_list_item(s, p, o0, 0);
-        sink.emit_list_item(s, p, o1, 1);
-        sink.emit_list_item(s, p, o2, 2);
+        sink.emit_list_item(s, p, o0, 0).unwrap();
+        sink.emit_list_item(s, p, o1, 1).unwrap();
+        sink.emit_list_item(s, p, o2, 2).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         assert_eq!(flakes.len(), 3);
         for (i, f) in flakes.iter().enumerate() {
             let meta = f.m.as_ref().expect("list items should have meta");
@@ -499,9 +514,9 @@ mod tests {
         let s = sink.term_iri("http://example.org/event");
         let p = sink.term_iri("http://example.org/date");
         let o = sink.term_literal("2024-01-15T10:30:00Z", Datatype::xsd_date_time(), None);
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::DateTime(_)));
     }
@@ -514,9 +529,9 @@ mod tests {
         let s = sink.term_iri("http://example.org/x");
         let p = sink.term_iri("http://example.org/count");
         let o = sink.term_literal("42", Datatype::xsd_integer(), None);
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::Long(42)));
     }
@@ -530,9 +545,9 @@ mod tests {
         let s = sink.term_iri("http://example.org/x");
         let p = sink.term_iri("http://example.org/count");
         let o = sink.term_literal("42", Datatype::xsd_long(), None);
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         assert_eq!(flakes.len(), 1);
         assert!(matches!(&flakes[0].o, FlakeValue::Long(42)));
         // dt must be xsd:long (declared), not xsd:integer (inferred)
@@ -556,10 +571,10 @@ mod tests {
         let p = sink.term_iri("http://example.org/worksFor");
         let o = sink.term_iri("http://example.org/acme");
         let r = sink.term_iri("http://example.org/reifier");
-        sink.emit_triple(s, p, o);
-        sink.emit_reified_triple(s, p, o, r);
+        sink.emit_triple(s, p, o).unwrap();
+        sink.emit_reified_triple(s, p, o, r).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         // 1 base + 3 bundle flakes.
         assert_eq!(flakes.len(), 4);
         let base = &flakes[0];
@@ -598,10 +613,10 @@ mod tests {
         let p = sink.term_iri("http://example.org/label");
         let o = sink.term_literal("chat", Datatype::rdf_lang_string(), Some("fr"));
         let r = sink.term_iri("http://example.org/reifier");
-        sink.emit_triple(s, p, o);
-        sink.emit_reified_triple(s, p, o, r);
+        sink.emit_triple(s, p, o).unwrap();
+        sink.emit_reified_triple(s, p, o, r).unwrap();
 
-        let flakes = sink.finish().expect("no invariant violation");
+        let flakes = sink.into_flakes().expect("no invariant violation");
         // 1 base + 4 bundle flakes (S, P, O, Lang).
         assert_eq!(flakes.len(), 5);
         let base = &flakes[0];
@@ -642,9 +657,11 @@ mod tests {
             Datatype::from_iri(fluree_vocab::fluree::EMBEDDING_VECTOR),
             None,
         );
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let err = sink.finish().expect_err("invariant violation must abort");
+        let err = sink
+            .into_flakes()
+            .expect_err("invariant violation must abort");
         let msg = err.to_string();
         assert!(
             msg.contains("embeddingVector"),

--- a/fluree-db-transact/src/import.rs
+++ b/fluree-db-transact/src/import.rs
@@ -179,7 +179,7 @@ mod inner {
         let (writer, op_count, spool_result, envelope) = {
             let _span = tracing::debug_span!("import_build_envelope", t = new_t).entered();
             let (writer, chunk_prefix_map, spool_ctx) = sink
-                .finish()
+                .into_parts()
                 .map_err(|e| TransactError::Parse(format!("flake encode error: {e}")))?;
             state.prefix_map.extend(chunk_prefix_map);
 
@@ -338,7 +338,7 @@ mod inner {
         let (writer, op_count, spool_result, envelope) = {
             let _span = tracing::debug_span!("import_build_envelope", t = new_t).entered();
             let (writer, _chunk_prefix_map, spool_ctx) = sink
-                .finish()
+                .into_parts()
                 .map_err(|e| TransactError::Parse(format!("flake encode error: {e}")))?;
 
             let spool_result = spool_ctx.map(crate::import_sink::SpoolContext::finish_buffered);
@@ -520,7 +520,7 @@ mod inner {
         // root's `named_graphs` routing exactly like default-graph triples.
         // The spool is finished only after the named-graph loop completes.
         let (mut writer, chunk_prefix_map, mut spool_ctx) = sink
-            .finish()
+            .into_parts()
             .map_err(|e| TransactError::Parse(format!("flake encode error: {e}")))?;
         state.prefix_map.extend(chunk_prefix_map);
         let mut op_count = writer.op_count();
@@ -875,7 +875,7 @@ mod inner {
         drop(_parse_span);
 
         let (writer, prefix_map, spool_ctx) = sink
-            .finish()
+            .into_parts()
             .map_err(|e| TransactError::Parse(format!("flake encode error: {e}")))?;
         let op_count = writer.op_count();
         let new_codes = worker_cache.into_new_codes();
@@ -940,7 +940,7 @@ mod inner {
         drop(_parse_span);
 
         let (writer, _prefix_map, spool_ctx) = sink
-            .finish()
+            .into_parts()
             .map_err(|e| TransactError::Parse(format!("flake encode error: {e}")))?;
         let op_count = writer.op_count();
         let new_codes = worker_cache.into_new_codes();
@@ -1086,7 +1086,7 @@ mod inner {
         drop(_parse_span);
 
         let (writer, prefix_map, spool_ctx) = sink
-            .finish()
+            .into_parts()
             .map_err(|e| TransactError::Parse(format!("flake encode error: {e}")))?;
         let op_count = writer.op_count();
         let new_codes = worker_cache.into_new_codes();

--- a/fluree-db-transact/src/import_sink.rs
+++ b/fluree-db-transact/src/import_sink.rs
@@ -38,7 +38,7 @@ mod inner {
     use fluree_db_indexer::run_index::global_dict::{DictWorkerCache, SharedDictAllocator};
     use fluree_db_indexer::run_index::shared_pool::{SharedNumBigPool, SharedVectorArenaPool};
     use fluree_db_indexer::run_index::spool::{SpoolFileInfo, SpoolWriter};
-    use fluree_graph_ir::{Datatype, GraphSink, LiteralValue, TermId};
+    use fluree_graph_ir::{Datatype, GraphSink, LiteralValue, SinkResult, TermId};
     use rustc_hash::FxHashMap;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -522,7 +522,7 @@ mod inner {
     /// ```ignore
     /// let mut sink = ImportSink::new(&mut ns, t, txn_id, true)?;
     /// fluree_graph_turtle::parse(ttl, &mut sink)?;
-    /// let writer = sink.finish();
+    /// let writer = sink.into_parts();
     /// let result = writer.finish(&envelope)?;
     /// ```
     pub struct ImportSink<'a> {
@@ -599,8 +599,14 @@ mod inner {
         /// Consume the sink and return the writer for finalization.
         ///
         /// Returns an error if any flake failed to encode during parsing.
+        ///
+        /// Distinct from the protocol's [`GraphSink::finish`] (flush /
+        /// finalize): this is the sink's *product*. Deferred-error semantics
+        /// are unchanged by the fallible protocol — `emit_*` still records the
+        /// first encode failure and keeps going, and this method is where it
+        /// becomes a hard error.
         #[allow(clippy::type_complexity)]
-        pub fn finish(
+        pub fn into_parts(
             self,
         ) -> Result<
             (
@@ -798,8 +804,14 @@ mod inner {
             })
         }
 
-        fn emit_triple(&mut self, subject: TermId, predicate: TermId, object: TermId) {
+        fn emit_triple(
+            &mut self,
+            subject: TermId,
+            predicate: TermId,
+            object: TermId,
+        ) -> SinkResult {
             self.push_triple(subject, predicate, object, None);
+            Ok(())
         }
 
         fn emit_list_item(
@@ -808,8 +820,9 @@ mod inner {
             predicate: TermId,
             object: TermId,
             index: i32,
-        ) {
+        ) -> SinkResult {
             self.push_triple(subject, predicate, object, Some(index));
+            Ok(())
         }
 
         fn supports_reified_triples(&self) -> bool {
@@ -829,18 +842,18 @@ mod inner {
             predicate: TermId,
             object: TermId,
             reifier: TermId,
-        ) {
+        ) -> SinkResult {
             let Some(s) = self.resolve_sid(subject) else {
-                return;
+                return Ok(());
             };
             let Some(p) = self.resolve_sid(predicate) else {
-                return;
+                return Ok(());
             };
             let Some((o, dtc)) = self.resolve_object(object) else {
-                return;
+                return Ok(());
             };
             let Some(ann) = self.resolve_sid(reifier) else {
-                return;
+                return Ok(());
             };
 
             let bundle =
@@ -852,7 +865,7 @@ mod inner {
                             tracing::error!("ImportSink: {msg}");
                             self.encode_error = Some(CommitCodecError::InvalidOp(msg));
                         }
-                        return;
+                        return Ok(());
                     }
                 };
             for flake in bundle {
@@ -861,7 +874,7 @@ mod inner {
                         tracing::error!("ImportSink: reifier bundle flake encode failed: {}", e);
                         self.encode_error = Some(e);
                     }
-                    return; // Don't spool a flake that failed to encode
+                    return Ok(()); // Don't spool a flake that failed to encode
                 }
                 if let Some(ctx) = &mut self.spool_ctx {
                     ctx.write_record(FlakeRecord {
@@ -875,6 +888,7 @@ mod inner {
                     });
                 }
             }
+            Ok(())
         }
     }
 
@@ -956,9 +970,9 @@ mod inner {
             let s = sink.term_iri("http://example.org/alice");
             let p = sink.term_iri("http://example.org/name");
             let o = sink.term_literal("Alice", Datatype::xsd_string(), None);
-            sink.emit_triple(s, p, o);
+            sink.emit_triple(s, p, o).unwrap();
 
-            let (writer, _prefix_map, _spool) = sink.finish().unwrap();
+            let (writer, _prefix_map, _spool) = sink.into_parts().unwrap();
             assert_eq!(writer.op_count(), 1);
 
             let result = writer.finish(&make_envelope(1)).unwrap();
@@ -978,29 +992,29 @@ mod inner {
             // String
             let p = sink.term_iri("http://example.org/str");
             let o = sink.term_literal("hello", Datatype::xsd_string(), None);
-            sink.emit_triple(s, p, o);
+            sink.emit_triple(s, p, o).unwrap();
 
             // Integer
             let p = sink.term_iri("http://example.org/num");
             let o = sink.term_literal_value(LiteralValue::Integer(42), Datatype::xsd_integer());
-            sink.emit_triple(s, p, o);
+            sink.emit_triple(s, p, o).unwrap();
 
             // Double
             let p = sink.term_iri("http://example.org/dbl");
             let o = sink.term_literal_value(LiteralValue::Double(3.13), Datatype::xsd_double());
-            sink.emit_triple(s, p, o);
+            sink.emit_triple(s, p, o).unwrap();
 
             // Boolean
             let p = sink.term_iri("http://example.org/flag");
             let o = sink.term_literal_value(LiteralValue::Boolean(true), Datatype::xsd_boolean());
-            sink.emit_triple(s, p, o);
+            sink.emit_triple(s, p, o).unwrap();
 
             // Ref (IRI in object position)
             let p = sink.term_iri("http://example.org/knows");
             let o = sink.term_iri("http://example.org/bob");
-            sink.emit_triple(s, p, o);
+            sink.emit_triple(s, p, o).unwrap();
 
-            let (writer, _prefix_map, _spool) = sink.finish().unwrap();
+            let (writer, _prefix_map, _spool) = sink.into_parts().unwrap();
             assert_eq!(writer.op_count(), 5);
 
             let result = writer.finish(&make_envelope(1)).unwrap();
@@ -1021,9 +1035,9 @@ mod inner {
             let s = sink.term_iri("http://example.org/alice");
             let p = sink.term_iri("http://example.org/name");
             let o = sink.term_literal("Alice", Datatype::rdf_lang_string(), Some("en"));
-            sink.emit_triple(s, p, o);
+            sink.emit_triple(s, p, o).unwrap();
 
-            let (writer, _prefix_map, _spool) = sink.finish().unwrap();
+            let (writer, _prefix_map, _spool) = sink.into_parts().unwrap();
             let result = writer.finish(&make_envelope(1)).unwrap();
             let decoded = read_commit(&result.bytes).unwrap();
 
@@ -1050,10 +1064,10 @@ mod inner {
             let p = sink.term_iri("http://example.org/worksFor");
             let o = sink.term_iri("http://example.org/acme");
             let r = sink.term_iri("http://example.org/reifier");
-            sink.emit_triple(s, p, o);
-            sink.emit_reified_triple(s, p, o, r);
+            sink.emit_triple(s, p, o).unwrap();
+            sink.emit_reified_triple(s, p, o, r).unwrap();
 
-            let (writer, _prefix_map, _spool) = sink.finish().unwrap();
+            let (writer, _prefix_map, _spool) = sink.into_parts().unwrap();
             assert_eq!(writer.op_count(), 4, "base + 3 bundle flakes");
 
             let result = writer.finish(&make_envelope(1)).unwrap();
@@ -1094,11 +1108,11 @@ mod inner {
             let o0 = sink.term_literal_value(LiteralValue::Integer(10), Datatype::xsd_integer());
             let o1 = sink.term_literal_value(LiteralValue::Integer(20), Datatype::xsd_integer());
             let o2 = sink.term_literal_value(LiteralValue::Integer(30), Datatype::xsd_integer());
-            sink.emit_list_item(s, p, o0, 0);
-            sink.emit_list_item(s, p, o1, 1);
-            sink.emit_list_item(s, p, o2, 2);
+            sink.emit_list_item(s, p, o0, 0).unwrap();
+            sink.emit_list_item(s, p, o1, 1).unwrap();
+            sink.emit_list_item(s, p, o2, 2).unwrap();
 
-            let (writer, _prefix_map, _spool) = sink.finish().unwrap();
+            let (writer, _prefix_map, _spool) = sink.into_parts().unwrap();
             assert_eq!(writer.op_count(), 3);
 
             let result = writer.finish(&make_envelope(1)).unwrap();
@@ -1137,11 +1151,11 @@ mod inner {
             let o_name = sink.term_literal("Alice", Datatype::xsd_string(), None);
             let o_age = sink.term_literal_value(LiteralValue::Integer(30), Datatype::xsd_integer());
             let bob = sink.term_iri("http://example.org/bob");
-            sink.emit_triple(s, p_name, o_name);
-            sink.emit_triple(s, p_age, o_age);
-            sink.emit_triple(s, p_knows, bob);
+            sink.emit_triple(s, p_name, o_name).unwrap();
+            sink.emit_triple(s, p_age, o_age).unwrap();
+            sink.emit_triple(s, p_knows, bob).unwrap();
 
-            let (writer, _prefix_map, spool_ctx) = sink.finish().unwrap();
+            let (writer, _prefix_map, spool_ctx) = sink.into_parts().unwrap();
             assert_eq!(writer.op_count(), 3);
 
             // Verify spool recorded the same number of records
@@ -1205,16 +1219,16 @@ mod inner {
             // Language-tagged string
             let p = sink.term_iri("http://example.org/name");
             let o = sink.term_literal("Alice", Datatype::rdf_lang_string(), Some("en"));
-            sink.emit_triple(s, p, o);
+            sink.emit_triple(s, p, o).unwrap();
 
             // List items
             let p = sink.term_iri("http://example.org/scores");
             let o0 = sink.term_literal_value(LiteralValue::Integer(10), Datatype::xsd_integer());
             let o1 = sink.term_literal_value(LiteralValue::Integer(20), Datatype::xsd_integer());
-            sink.emit_list_item(s, p, o0, 0);
-            sink.emit_list_item(s, p, o1, 1);
+            sink.emit_list_item(s, p, o0, 0).unwrap();
+            sink.emit_list_item(s, p, o1, 1).unwrap();
 
-            let (_writer, _prefix_map, spool_ctx) = sink.finish().unwrap();
+            let (_writer, _prefix_map, spool_ctx) = sink.into_parts().unwrap();
             let spool_ctx = spool_ctx.unwrap();
             assert_eq!(spool_ctx.record_count(), 3);
             let result = spool_ctx.finish().unwrap();
@@ -1257,10 +1271,10 @@ mod inner {
             let bob = sink.term_iri("http://example.org/bob");
             let p1 = sink.term_iri("http://example.org/knows");
             let p2 = sink.term_iri("http://example.org/likes");
-            sink.emit_triple(alice, p1, bob);
-            sink.emit_triple(alice, p2, bob);
+            sink.emit_triple(alice, p1, bob).unwrap();
+            sink.emit_triple(alice, p2, bob).unwrap();
 
-            let (_writer, _prefix_map, spool_ctx) = sink.finish().unwrap();
+            let (_writer, _prefix_map, spool_ctx) = sink.into_parts().unwrap();
             let spool_ctx = spool_ctx.unwrap();
             let result = spool_ctx.finish().unwrap();
 

--- a/fluree-graph-ir/src/graph.rs
+++ b/fluree-graph-ir/src/graph.rs
@@ -90,6 +90,17 @@ impl Graph {
         self.triples.len()
     }
 
+    /// Drop every triple past `len`, keeping the first `len` in insertion
+    /// order. No-op if the graph is already that short.
+    ///
+    /// Exists for statement-scoped rollback: a sink that has emitted part of
+    /// a statement before it turned out to be invalid rewinds to the mark it
+    /// took at the statement boundary (see
+    /// [`GraphSink::abort_statement`](crate::GraphSink::abort_statement)).
+    pub fn truncate(&mut self, len: usize) {
+        self.triples.truncate(len);
+    }
+
     /// Check if the graph is empty
     pub fn is_empty(&self) -> bool {
         self.triples.is_empty()

--- a/fluree-graph-ir/src/lib.rs
+++ b/fluree-graph-ir/src/lib.rs
@@ -46,7 +46,7 @@ pub mod xsd_double;
 
 pub use datatype::Datatype;
 pub use graph::Graph;
-pub use sink::{GraphCollectorSink, GraphSink, TermId};
+pub use sink::{GraphCollectorSink, GraphSink, SinkError, SinkResult, TermId};
 pub use term::{BlankId, LiteralValue, Term};
 pub use triple::Triple;
 pub use xsd_double::{canonical_xsd_double, push_canonical_xsd_double, write_canonical_xsd_double};

--- a/fluree-graph-ir/src/sink.rs
+++ b/fluree-graph-ir/src/sink.rs
@@ -424,6 +424,29 @@ impl GraphCollectorSink {
         id
     }
 
+    /// Debug-only invariant: every slot the current statement is about to
+    /// retire still holds a literal.
+    ///
+    /// `literal_slots` may only ever contain slots minted by
+    /// [`Self::add_literal_term`]. If an IRI or blank term is found in one,
+    /// something has routed a session-scoped term through the literal lane,
+    /// and retiring the slot would hand a producer-cached id to the next
+    /// literal — corrupting the graph silently and in a way that still looks
+    /// well-formed. Fail loudly in debug builds instead; compiled out of
+    /// release.
+    fn debug_assert_retiring_slots_are_literals(&self) {
+        if cfg!(debug_assertions) {
+            for &slot in &self.literal_slots[..self.literal_cursor] {
+                debug_assert!(
+                    matches!(self.terms[slot as usize], Term::Literal { .. }),
+                    "retiring non-literal slot {slot}: {:?} — literal_slots is polluted, \
+                     recycling it would clobber a producer-cached term id",
+                    self.terms[slot as usize]
+                );
+            }
+        }
+    }
+
     /// Add a literal term, reusing a slot retired by [`GraphSink::end_statement`]
     /// when one is available.
     ///
@@ -519,6 +542,7 @@ impl GraphSink for GraphCollectorSink {
     /// `emit_*` has already cloned every term it needed into the graph, and
     /// because producers only cache IRI and blank ids across statements.
     fn end_statement(&mut self) {
+        self.debug_assert_retiring_slots_are_literals();
         self.literal_cursor = 0;
         self.statement_mark = self.graph.len();
     }
@@ -527,6 +551,8 @@ impl GraphSink for GraphCollectorSink {
     /// failed mid-emit contributes nothing. Its literal slots are retired
     /// exactly as a successful statement's are.
     fn abort_statement(&mut self) {
+        // Same retirement, same invariant.
+        self.debug_assert_retiring_slots_are_literals();
         self.graph.truncate(self.statement_mark);
         self.literal_cursor = 0;
     }

--- a/fluree-graph-ir/src/sink.rs
+++ b/fluree-graph-ir/src/sink.rs
@@ -311,11 +311,13 @@ pub trait GraphSink {
     /// - Annotation-body properties (`{| p o |}`) arrive as ordinary
     ///   [`Self::emit_triple`] events with `reifier` as the subject.
     ///
-    /// Only called when [`Self::supports_reified_triples`] returns `true`;
-    /// the default implementation is a no-op guarded by a debug assert
-    /// (every producer of these events already refuses the input up-front
-    /// when the capability probe is `false`, so the default body is
-    /// unreachable rather than a silent fallback).
+    /// Only called when [`Self::supports_reified_triples`] returns `true`.
+    /// The default body refuses — `debug_assert` in development, an error in
+    /// release — for the same reason [`Self::emit_quad`] does: a dropped
+    /// reification is data loss, not a fallback. Every producer already
+    /// checks the probe and rejects the input up-front, so the refusal costs
+    /// nothing on any path that exists today; it is the backstop for the
+    /// producer that forgets.
     fn emit_reified_triple(
         &mut self,
         subject: TermId,
@@ -328,7 +330,9 @@ pub trait GraphSink {
             self.supports_reified_triples(),
             "emit_reified_triple called on a sink that does not support reified triples"
         );
-        Ok(())
+        Err(SinkError::rejected(
+            "this sink cannot represent reified triples",
+        ))
     }
 }
 
@@ -731,6 +735,43 @@ mod tests {
         }
     }
 
+    /// Claims reified-triple support but never overrides
+    /// `emit_reified_triple` — reaches the trait default past its
+    /// `debug_assert`, which is the release-build backstop under test.
+    #[derive(Default)]
+    struct ReifyClaimingSink {
+        terms: u32,
+    }
+
+    impl GraphSink for ReifyClaimingSink {
+        fn on_base(&mut self, _base_iri: &str) {}
+        fn on_prefix(&mut self, _prefix: &str, _namespace_iri: &str) {}
+        fn term_iri(&mut self, _iri: &str) -> TermId {
+            self.terms += 1;
+            TermId::new(self.terms)
+        }
+        fn term_blank(&mut self, _label: Option<&str>) -> TermId {
+            TermId::new(0)
+        }
+        fn term_literal(
+            &mut self,
+            _value: &str,
+            _datatype: Datatype,
+            _language: Option<&str>,
+        ) -> TermId {
+            TermId::new(0)
+        }
+        fn term_literal_value(&mut self, _value: LiteralValue, _datatype: Datatype) -> TermId {
+            TermId::new(0)
+        }
+        fn emit_triple(&mut self, _s: TermId, _p: TermId, _o: TermId) -> SinkResult {
+            Ok(())
+        }
+        fn supports_reified_triples(&self) -> bool {
+            true
+        }
+    }
+
     #[test]
     fn triple_only_sinks_do_not_claim_quad_support() {
         // The capability probe producers of N-Quads/TriG/`@graph` must
@@ -738,6 +779,24 @@ mod tests {
         let sink = GraphCollectorSink::new();
         assert!(!sink.supports_quads());
         assert!(!sink.supports_reified_triples());
+    }
+
+    /// Symmetric with quads: a sink that claims the capability but never
+    /// overrides the method must be refused, not silently ignored. A dropped
+    /// reification is data loss.
+    #[test]
+    fn default_emit_reified_triple_refuses_instead_of_dropping_the_reifier() {
+        let mut sink = ReifyClaimingSink::default();
+        let s = sink.term_iri("http://example.org/s");
+        let p = sink.term_iri("http://example.org/p");
+        let o = sink.term_iri("http://example.org/o");
+        let r = sink.term_iri("http://example.org/r");
+
+        let err = sink
+            .emit_reified_triple(s, p, o, r)
+            .expect_err("the default reified body must refuse");
+        assert!(matches!(err, SinkError::Rejected(_)), "{err:?}");
+        assert!(err.to_string().contains("reified triples"), "{err}");
     }
 
     #[test]

--- a/fluree-graph-ir/src/sink.rs
+++ b/fluree-graph-ir/src/sink.rs
@@ -243,10 +243,34 @@ pub trait GraphSink {
     ///   statement (needed for `--continue-on-error`, because triples are
     ///   emitted during descent, before the terminating `.` proves the
     ///   statement valid) commits its buffer here. A statement that fails to
-    ///   parse never reaches this call, so it contributes nothing.
+    ///   parse reaches [`Self::abort_statement`] instead, and so contributes
+    ///   nothing.
     ///
     /// Default: no-op.
     fn end_statement(&mut self) {}
+
+    /// Called by the producer when a statement FAILS after it had already
+    /// emitted — the counterpart to [`Self::end_statement`].
+    ///
+    /// The parser emits during descent: property lists and collections push
+    /// triples before the terminating `.` proves the statement well-formed.
+    /// Without this hook a rejected statement still leaves its partial
+    /// triples in the sink, so "a rejected statement contributes nothing"
+    /// (riot's semantics, and what `--continue-on-error` has to guarantee)
+    /// would be false at the sink level.
+    ///
+    /// Contract:
+    /// - Called at most once per statement, and only when at least one
+    ///   `emit_*` succeeded for it — a statement that fails before emitting
+    ///   has nothing to roll back.
+    /// - Never paired with [`Self::end_statement`] for the same statement:
+    ///   exactly one of the two ends a statement.
+    /// - Implementations discard everything emitted since the last statement
+    ///   boundary and may reclaim the same storage `end_statement` reclaims.
+    ///
+    /// Default: no-op, preserving the pre-rollback behavior for sinks that
+    /// have no notion of a statement.
+    fn abort_statement(&mut self) {}
 
     /// Flush and finalize. Called once by whoever owns the sink, after the
     /// last producer has finished emitting.
@@ -333,6 +357,10 @@ pub struct GraphCollectorSink {
     /// Reset to 0 by `end_statement`, which is what turns the list into a
     /// per-statement ring instead of a per-document one.
     literal_cursor: usize,
+    /// Graph length at the current statement's start — the rewind point for
+    /// [`GraphSink::abort_statement`]. Advanced at every statement boundary,
+    /// so it is always "everything before the statement in flight".
+    statement_mark: usize,
 }
 
 impl GraphCollectorSink {
@@ -345,6 +373,7 @@ impl GraphCollectorSink {
             blank_labels: HashMap::new(),
             literal_slots: Vec::new(),
             literal_cursor: 0,
+            statement_mark: 0,
         }
     }
 
@@ -357,6 +386,7 @@ impl GraphCollectorSink {
             blank_labels: HashMap::new(),
             literal_slots: Vec::new(),
             literal_cursor: 0,
+            statement_mark: 0,
         }
     }
 
@@ -480,10 +510,20 @@ impl GraphSink for GraphCollectorSink {
         self.add_literal_term(term)
     }
 
-    /// Retire this statement's literal slots for reuse. Sound because
+    /// Retire this statement's literal slots for reuse, and move the rewind
+    /// point past the statement just committed. Recycling is sound because
     /// `emit_*` has already cloned every term it needed into the graph, and
     /// because producers only cache IRI and blank ids across statements.
     fn end_statement(&mut self) {
+        self.literal_cursor = 0;
+        self.statement_mark = self.graph.len();
+    }
+
+    /// Roll the graph back to the statement's start, so a statement that
+    /// failed mid-emit contributes nothing. Its literal slots are retired
+    /// exactly as a successful statement's are.
+    fn abort_statement(&mut self) {
+        self.graph.truncate(self.statement_mark);
         self.literal_cursor = 0;
     }
 

--- a/fluree-graph-ir/src/sink.rs
+++ b/fluree-graph-ir/src/sink.rs
@@ -321,6 +321,18 @@ pub struct GraphCollectorSink {
     blank_counter: u32,
     /// Cache for blank node labels to TermId mapping
     blank_labels: HashMap<String, TermId>,
+    /// Slots in `terms` that hold literals, in mint order.
+    ///
+    /// Literals are the only statement-scoped terms (see [`TermId`]): they
+    /// are minted per occurrence and never deduplicated, while IRI and blank
+    /// ids are cached by producers for the whole parse. `emit_*` clones a
+    /// term into the graph, so once the statement ends its literal slots hold
+    /// nothing anyone can still reference and may be overwritten.
+    literal_slots: Vec<u32>,
+    /// How far into `literal_slots` the current statement has consumed.
+    /// Reset to 0 by `end_statement`, which is what turns the list into a
+    /// per-statement ring instead of a per-document one.
+    literal_cursor: usize,
 }
 
 impl GraphCollectorSink {
@@ -331,6 +343,8 @@ impl GraphCollectorSink {
             terms: Vec::new(),
             blank_counter: 0,
             blank_labels: HashMap::new(),
+            literal_slots: Vec::new(),
+            literal_cursor: 0,
         }
     }
 
@@ -341,6 +355,8 @@ impl GraphCollectorSink {
             terms: Vec::new(),
             blank_counter: 0,
             blank_labels: HashMap::new(),
+            literal_slots: Vec::new(),
+            literal_cursor: 0,
         }
     }
 
@@ -371,6 +387,26 @@ impl GraphCollectorSink {
     fn add_term(&mut self, term: Term) -> TermId {
         let id = TermId(self.terms.len() as u32);
         self.terms.push(term);
+        id
+    }
+
+    /// Add a literal term, reusing a slot retired by [`GraphSink::end_statement`]
+    /// when one is available.
+    ///
+    /// Without this, the term table grows by one entry per literal
+    /// *occurrence* for the length of the document; with it, the high-water
+    /// mark is the widest single statement. Producers that never delimit
+    /// statements (the JSON-LD adapter) simply never recycle and keep
+    /// today's behavior.
+    fn add_literal_term(&mut self, term: Term) -> TermId {
+        if let Some(&slot) = self.literal_slots.get(self.literal_cursor) {
+            self.literal_cursor += 1;
+            self.terms[slot as usize] = term;
+            return TermId(slot);
+        }
+        let id = self.add_term(term);
+        self.literal_slots.push(id.0);
+        self.literal_cursor = self.literal_slots.len();
         id
     }
 }
@@ -422,7 +458,7 @@ impl GraphSink for GraphCollectorSink {
             None if datatype.is_xsd_string() => Term::string(value),
             None => Term::typed(value, datatype),
         };
-        self.add_term(term)
+        self.add_literal_term(term)
     }
 
     fn term_literal_value(&mut self, value: LiteralValue, datatype: Datatype) -> TermId {
@@ -431,7 +467,14 @@ impl GraphSink for GraphCollectorSink {
             datatype,
             language: None,
         };
-        self.add_term(term)
+        self.add_literal_term(term)
+    }
+
+    /// Retire this statement's literal slots for reuse. Sound because
+    /// `emit_*` has already cloned every term it needed into the graph, and
+    /// because producers only cache IRI and blank ids across statements.
+    fn end_statement(&mut self) {
+        self.literal_cursor = 0;
     }
 
     fn emit_triple(&mut self, subject: TermId, predicate: TermId, object: TermId) -> SinkResult {
@@ -694,5 +737,93 @@ mod tests {
 
         let rejected = SinkError::rejected("nope");
         assert!(!rejected.is_broken_pipe());
+    }
+
+    // =====================================================================
+    // Statement-scoped literal term recycling
+    // =====================================================================
+
+    #[test]
+    fn literal_slots_are_reused_after_a_statement_ends() {
+        let mut sink = GraphCollectorSink::new();
+        let a = sink.term_literal("a", Datatype::xsd_string(), None);
+        let b = sink.term_literal("b", Datatype::xsd_string(), None);
+        assert_ne!(a, b, "literals within one statement must stay distinct");
+
+        sink.end_statement();
+
+        let c = sink.term_literal("c", Datatype::xsd_string(), None);
+        let d = sink.term_literal("d", Datatype::xsd_string(), None);
+        assert_eq!((a, b), (c, d), "the next statement reuses the same slots");
+    }
+
+    #[test]
+    fn recycling_does_not_disturb_already_emitted_triples() {
+        // The soundness argument: `emit_*` clones into the graph, so
+        // overwriting the slot afterwards cannot reach back into a triple
+        // that was already collected.
+        let mut sink = GraphCollectorSink::new();
+        let s = sink.term_iri("http://example.org/s");
+        let p = sink.term_iri("http://example.org/p");
+
+        let first = sink.term_literal("first", Datatype::xsd_string(), None);
+        sink.emit_triple(s, p, first).unwrap();
+        sink.end_statement();
+
+        let second = sink.term_literal("second", Datatype::xsd_string(), None);
+        assert_eq!(first, second, "slot reused — the aliasing case under test");
+        sink.emit_triple(s, p, second).unwrap();
+        sink.end_statement();
+
+        let graph = sink.into_graph();
+        let objects: Vec<String> = graph
+            .iter()
+            .map(|t| match &t.o {
+                Term::Literal { value, .. } => value.lexical(),
+                other => panic!("expected literal, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(objects, vec!["first".to_string(), "second".to_string()]);
+    }
+
+    #[test]
+    fn iri_and_blank_ids_survive_statement_boundaries() {
+        // Producers cache these for the whole parse, so recycling them would
+        // dangle. Only literals are statement-scoped.
+        let mut sink = GraphCollectorSink::new();
+        let iri = sink.term_iri("http://example.org/s");
+        let labeled = sink.term_blank(Some("b0"));
+        let anon = sink.term_blank(None);
+        sink.end_statement();
+
+        let literal = sink.term_literal("v", Datatype::xsd_string(), None);
+        assert_ne!(literal, iri);
+        assert_ne!(literal, labeled);
+        assert_ne!(literal, anon);
+
+        // And the originals still resolve to what they were.
+        sink.emit_triple(iri, iri, literal).unwrap();
+        let graph = sink.into_graph();
+        let t = graph.iter().next().unwrap();
+        assert_eq!(t.s.as_iri(), Some("http://example.org/s"));
+    }
+
+    #[test]
+    fn the_term_table_tracks_the_widest_statement_not_the_document() {
+        // The O(document) growth this exists to remove: 1000 statements of
+        // two literals each must not leave 2000 live term slots behind.
+        let mut sink = GraphCollectorSink::new();
+        let s = sink.term_iri("http://example.org/s");
+        let p = sink.term_iri("http://example.org/p");
+        for i in 0..1000 {
+            let a = sink.term_literal(&format!("a{i}"), Datatype::xsd_string(), None);
+            let b = sink.term_literal(&format!("b{i}"), Datatype::xsd_string(), None);
+            sink.emit_triple(s, p, a).unwrap();
+            sink.emit_triple(s, p, b).unwrap();
+            sink.end_statement();
+        }
+        // 2 IRIs + 2 recycled literal slots.
+        assert_eq!(sink.terms.len(), 4);
+        assert_eq!(sink.into_graph().len(), 2000);
     }
 }

--- a/fluree-graph-ir/src/sink.rs
+++ b/fluree-graph-ir/src/sink.rs
@@ -444,9 +444,19 @@ impl GraphSink for GraphCollectorSink {
                 id
             }
             None => {
-                // Generate a fresh blank node ID
+                // Anonymous blank node (`[ … ]`, collection spine nodes,
+                // reifiers) — unique counter-based label. The leading '-'
+                // keeps the minted namespace disjoint from every
+                // user-written label: Turtle's BLANK_NODE_LABEL must start
+                // with PN_CHARS_U | [0-9], so `_:-b1` can never lex, while
+                // '-' stays legal medially so the label still serializes.
+                //
+                // Without it a document's own `_:b1` and the first mint are
+                // the same `BlankId` and their nodes silently MERGE. Matches
+                // `FlakeSink`/`ImportSink`, which carry the same fix for the
+                // same reason.
                 self.blank_counter += 1;
-                let label = format!("b{}", self.blank_counter);
+                let label = format!("-b{}", self.blank_counter);
                 self.add_term(Term::blank(label))
             }
         }
@@ -737,6 +747,31 @@ mod tests {
 
         let rejected = SinkError::rejected("nope");
         assert!(!rejected.is_broken_pipe());
+    }
+
+    /// Minted anonymous labels must live in a namespace no user-written
+    /// label can occupy. Turtle's BLANK_NODE_LABEL starts with
+    /// PN_CHARS_U | [0-9], so a leading '-' is unlexable and therefore safe;
+    /// a bare `b{N}` mint collides with a document's own `_:b1` and the two
+    /// nodes MERGE.
+    #[test]
+    fn anonymous_mints_are_disjoint_from_user_written_labels() {
+        let mut sink = GraphCollectorSink::new();
+        let user = sink.term_blank(Some("b1"));
+        let minted = sink.term_blank(None);
+        assert_ne!(user, minted);
+
+        let label_of = |sink: &GraphCollectorSink, id: TermId| match sink.get_term(id) {
+            Term::BlankNode(b) => b.as_str().to_string(),
+            other => panic!("expected blank, got {other:?}"),
+        };
+        assert_eq!(label_of(&sink, user), "b1");
+        let minted_label = label_of(&sink, minted);
+        assert_eq!(minted_label, "-b1");
+        assert!(
+            !minted_label.starts_with(|c: char| c.is_alphanumeric() || c == '_'),
+            "a mint that can lex as BLANK_NODE_LABEL can collide: {minted_label}"
+        );
     }
 
     // =====================================================================

--- a/fluree-graph-ir/src/sink.rs
+++ b/fluree-graph-ir/src/sink.rs
@@ -14,10 +14,65 @@
 use crate::{Datatype, Graph, LiteralValue, Term, Triple};
 use std::collections::HashMap;
 
+/// Error returned by a [`GraphSink`] when it cannot accept an event.
+///
+/// Emission is fallible so a sink that writes somewhere (a file, a socket,
+/// a pipe) can report failure at the point it happens and have the producer
+/// stop immediately. That is what makes `convert big.ttl | head -5` cost five
+/// statements instead of a full parse against a dead pipe.
+///
+/// Producers MUST propagate this error rather than continuing to emit; a sink
+/// that has failed once is not required to behave sensibly afterwards.
+#[derive(Debug, thiserror::Error)]
+pub enum SinkError {
+    /// The sink's downstream writer failed (broken pipe, disk full, …).
+    #[error("sink I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The sink refused the event: an unsupported capability, or an
+    /// invariant the event would violate.
+    #[error("sink rejected event: {0}")]
+    Rejected(String),
+}
+
+impl SinkError {
+    /// Build a [`SinkError::Rejected`] from any message.
+    pub fn rejected(message: impl Into<String>) -> Self {
+        Self::Rejected(message.into())
+    }
+
+    /// Whether this error is a broken pipe.
+    ///
+    /// CLI drivers use this to exit quietly (status 0) when a downstream
+    /// consumer such as `head` closes the pipe, rather than reporting the
+    /// normal, expected shutdown as a conversion failure.
+    pub fn is_broken_pipe(&self) -> bool {
+        matches!(self, Self::Io(e) if e.kind() == std::io::ErrorKind::BrokenPipe)
+    }
+}
+
+/// Result alias for [`GraphSink`] emission methods.
+pub type SinkResult = std::result::Result<(), SinkError>;
+
 /// Opaque term identifier for efficient triple emission
 ///
 /// `TermId` is only valid within a single sink session. It allows parsers
 /// to reference terms efficiently without repeated string allocations.
+///
+/// # Lifetime
+///
+/// Term IDs fall into two lifetime classes, and producers must respect the
+/// difference so that sinks are free to reclaim storage (see
+/// [`GraphSink::end_statement`]):
+///
+/// - IDs from [`GraphSink::term_iri`] and [`GraphSink::term_blank`] are valid
+///   for the whole sink session. Parsers cache and reuse them across
+///   statements.
+/// - IDs from [`GraphSink::term_literal`] and
+///   [`GraphSink::term_literal_value`] are **statement-scoped**: valid only
+///   until the next [`GraphSink::end_statement`] call. Literals are minted per
+///   occurrence and never deduplicated, so retaining them across statements is
+///   what makes a long document's term table grow without bound.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct TermId(pub(crate) u32);
 
@@ -41,6 +96,24 @@ impl TermId {
 /// Inspired by the Raphael library's generator pattern, this trait allows
 /// parsers to emit graph events without knowing the concrete sink type.
 ///
+/// # Fallibility
+///
+/// `term_*` methods are infallible: they only intern a term and hand back an
+/// id. `emit_*` methods return [`SinkResult`] because that is where a writing
+/// sink actually touches its output. Producers must propagate emission errors
+/// immediately (riot-style early termination) instead of parsing on against a
+/// sink that has already failed.
+///
+/// # Finishing
+///
+/// [`GraphSink::finish`] is the *protocol* finish: flush and finalize, called
+/// by whoever owns the sink once no more events are coming. It takes
+/// `&mut self` and returns no value, because a sink may be fed by several
+/// producer calls (bulk import parses one sink's worth of events per chunk).
+/// Sinks that also *produce* something — a `Graph`, a `Vec<Flake>`, a commit
+/// writer — expose that separately as a consuming `into_*` method, so that
+/// `finish()` always means "flush", never "give me your contents".
+///
 /// # Example
 ///
 /// ```
@@ -57,10 +130,11 @@ impl TermId {
 /// let alice_name = sink.term_literal("Alice", Datatype::xsd_string(), None);
 ///
 /// // Emit triple
-/// sink.emit_triple(alice, name, alice_name);
+/// sink.emit_triple(alice, name, alice_name).unwrap();
+/// sink.finish().unwrap();
 ///
 /// // Get the resulting graph
-/// let graph = sink.finish();
+/// let graph = sink.into_graph();
 /// assert_eq!(graph.len(), 1);
 /// ```
 pub trait GraphSink {
@@ -98,7 +172,7 @@ pub trait GraphSink {
     fn term_literal_value(&mut self, value: LiteralValue, datatype: Datatype) -> TermId;
 
     /// Emit a triple using previously created term IDs
-    fn emit_triple(&mut self, subject: TermId, predicate: TermId, object: TermId);
+    fn emit_triple(&mut self, subject: TermId, predicate: TermId, object: TermId) -> SinkResult;
 
     /// Emit a list item (triple with list index)
     ///
@@ -106,11 +180,84 @@ pub trait GraphSink {
     /// List items will be formatted as `{"@list": [...]}` in JSON-LD output.
     ///
     /// Default implementation falls back to `emit_triple` (ignoring index).
-    fn emit_list_item(&mut self, subject: TermId, predicate: TermId, object: TermId, index: i32) {
+    fn emit_list_item(
+        &mut self,
+        subject: TermId,
+        predicate: TermId,
+        object: TermId,
+        index: i32,
+    ) -> SinkResult {
         // Default: fall back to regular triple (losing index info)
         // Implementations that support lists should override this
         let _ = index;
-        self.emit_triple(subject, predicate, object);
+        self.emit_triple(subject, predicate, object)
+    }
+
+    /// Whether this sink can consume quad events ([`Self::emit_quad`]).
+    ///
+    /// Producers of named-graph syntaxes (N-Quads, TriG, JSON-LD `@graph`)
+    /// MUST check this before emitting any quad and reject the input with a
+    /// clear error when it returns `false`. Defaults to `false`: the IR is
+    /// triple-only today, and *silently* folding named graphs into the
+    /// default graph is a data-loss bug, not a fallback.
+    fn supports_quads(&self) -> bool {
+        false
+    }
+
+    /// Emit a quad: the triple `(subject, predicate, object)` in the named
+    /// graph `graph`.
+    ///
+    /// Only called when [`Self::supports_quads`] returns `true`. Unlike
+    /// [`Self::emit_reified_triple`] — whose producers are all guarded by an
+    /// explicit parser-side capability check — the default body **errors**
+    /// rather than no-ops, because no producer emits quads yet and this
+    /// backstop is what keeps a future quad producer from silently dropping
+    /// graph names against a triple-only sink.
+    fn emit_quad(
+        &mut self,
+        subject: TermId,
+        predicate: TermId,
+        object: TermId,
+        graph: TermId,
+    ) -> SinkResult {
+        let _ = (subject, predicate, object, graph);
+        debug_assert!(
+            self.supports_quads(),
+            "emit_quad called on a sink that does not support quads"
+        );
+        Err(SinkError::rejected(
+            "this sink is triple-only and cannot represent named graphs",
+        ))
+    }
+
+    /// Called by the producer at each statement terminator, after the
+    /// statement has parsed and emitted successfully.
+    ///
+    /// Two uses, both of which need the same boundary:
+    ///
+    /// - **Term lifetime.** Statement-scoped literal ids (see [`TermId`]) are
+    ///   dead after this call, so a sink may reclaim their storage. Without
+    ///   it, one live term-table entry accumulates per literal *occurrence*
+    ///   for the length of the document.
+    /// - **Statement-scoped buffering.** A sink that buffers output per
+    ///   statement (needed for `--continue-on-error`, because triples are
+    ///   emitted during descent, before the terminating `.` proves the
+    ///   statement valid) commits its buffer here. A statement that fails to
+    ///   parse never reaches this call, so it contributes nothing.
+    ///
+    /// Default: no-op.
+    fn end_statement(&mut self) {}
+
+    /// Flush and finalize. Called once by whoever owns the sink, after the
+    /// last producer has finished emitting.
+    ///
+    /// Producers do NOT call this — a single sink may be fed by many producer
+    /// calls (one per chunk on the bulk-import path), and flushing per chunk
+    /// would be wrong for a streaming writer.
+    ///
+    /// Default: no-op, for sinks that hold no external resource.
+    fn finish(&mut self) -> SinkResult {
+        Ok(())
     }
 
     /// Whether this sink can consume RDF 1.2 reified-triple events
@@ -141,19 +288,23 @@ pub trait GraphSink {
     ///   [`Self::emit_triple`] events with `reifier` as the subject.
     ///
     /// Only called when [`Self::supports_reified_triples`] returns `true`;
-    /// the default implementation is a no-op guarded by a debug assert.
+    /// the default implementation is a no-op guarded by a debug assert
+    /// (every producer of these events already refuses the input up-front
+    /// when the capability probe is `false`, so the default body is
+    /// unreachable rather than a silent fallback).
     fn emit_reified_triple(
         &mut self,
         subject: TermId,
         predicate: TermId,
         object: TermId,
         reifier: TermId,
-    ) {
+    ) -> SinkResult {
         let _ = (subject, predicate, object, reifier);
         debug_assert!(
             self.supports_reified_triples(),
             "emit_reified_triple called on a sink that does not support reified triples"
         );
+        Ok(())
     }
 }
 
@@ -193,10 +344,11 @@ impl GraphCollectorSink {
         }
     }
 
-    /// Finish building and return the graph
+    /// Consume the sink and return the collected graph.
     ///
-    /// Consumes the sink.
-    pub fn finish(self) -> Graph {
+    /// This is the sink's *product*, distinct from the protocol's
+    /// [`GraphSink::finish`] (flush/finalize) — see the trait docs.
+    pub fn into_graph(self) -> Graph {
         self.graph
     }
 
@@ -282,18 +434,26 @@ impl GraphSink for GraphCollectorSink {
         self.add_term(term)
     }
 
-    fn emit_triple(&mut self, subject: TermId, predicate: TermId, object: TermId) {
+    fn emit_triple(&mut self, subject: TermId, predicate: TermId, object: TermId) -> SinkResult {
         let s = self.get_term(subject).clone();
         let p = self.get_term(predicate).clone();
         let o = self.get_term(object).clone();
         self.graph.add(Triple::new(s, p, o));
+        Ok(())
     }
 
-    fn emit_list_item(&mut self, subject: TermId, predicate: TermId, object: TermId, index: i32) {
+    fn emit_list_item(
+        &mut self,
+        subject: TermId,
+        predicate: TermId,
+        object: TermId,
+        index: i32,
+    ) -> SinkResult {
         let s = self.get_term(subject).clone();
         let p = self.get_term(predicate).clone();
         let o = self.get_term(object).clone();
         self.graph.add_list_item(s, p, o, index);
+        Ok(())
     }
 }
 
@@ -309,9 +469,9 @@ mod tests {
         let p = sink.term_iri("http://xmlns.com/foaf/0.1/name");
         let o = sink.term_literal("Alice", Datatype::xsd_string(), None);
 
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         assert_eq!(graph.len(), 1);
 
         let triple = graph.iter().next().unwrap();
@@ -345,7 +505,7 @@ mod tests {
         sink.on_base("http://example.org/");
         sink.on_prefix("foaf", "http://xmlns.com/foaf/0.1/");
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
 
         assert_eq!(graph.base, Some("http://example.org/".to_string()));
         assert_eq!(
@@ -362,9 +522,9 @@ mod tests {
         let p = sink.term_iri("http://xmlns.com/foaf/0.1/name");
         let o = sink.term_literal("Alicia", Datatype::rdf_lang_string(), Some("es"));
 
-        sink.emit_triple(s, p, o);
+        sink.emit_triple(s, p, o).unwrap();
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         let triple = graph.iter().next().unwrap();
 
         if let Term::Literal {
@@ -388,18 +548,18 @@ mod tests {
         // Boolean
         let bool_val =
             sink.term_literal_value(LiteralValue::Boolean(true), Datatype::xsd_boolean());
-        sink.emit_triple(s, p, bool_val);
+        sink.emit_triple(s, p, bool_val).unwrap();
 
         // Integer
         let int_val = sink.term_literal_value(LiteralValue::Integer(42), Datatype::xsd_integer());
-        sink.emit_triple(s, p, int_val);
+        sink.emit_triple(s, p, int_val).unwrap();
 
         // Double
         let double_val =
             sink.term_literal_value(LiteralValue::Double(3.13), Datatype::xsd_double());
-        sink.emit_triple(s, p, double_val);
+        sink.emit_triple(s, p, double_val).unwrap();
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         assert_eq!(graph.len(), 3);
     }
 
@@ -412,15 +572,15 @@ mod tests {
 
         // Emit list items out of order
         let o2 = sink.term_literal("Charlie", Datatype::xsd_string(), None);
-        sink.emit_list_item(s, p, o2, 2);
+        sink.emit_list_item(s, p, o2, 2).unwrap();
 
         let o0 = sink.term_literal("Alice", Datatype::xsd_string(), None);
-        sink.emit_list_item(s, p, o0, 0);
+        sink.emit_list_item(s, p, o0, 0).unwrap();
 
         let o1 = sink.term_literal("Bob", Datatype::xsd_string(), None);
-        sink.emit_list_item(s, p, o1, 1);
+        sink.emit_list_item(s, p, o1, 1).unwrap();
 
-        let mut graph = sink.finish();
+        let mut graph = sink.into_graph();
         assert_eq!(graph.len(), 3);
 
         // All triples should have list_index
@@ -432,5 +592,107 @@ mod tests {
         graph.sort();
         let indices: Vec<_> = graph.iter().map(|t| t.list_index().unwrap()).collect();
         assert_eq!(indices, vec![0, 1, 2]);
+    }
+
+    // =====================================================================
+    // Protocol: capability probes, fallible emission, lifecycle
+    // =====================================================================
+
+    /// A sink that claims quad support but never overrides `emit_quad`.
+    ///
+    /// Exists to reach the trait's default `emit_quad` body past its
+    /// `debug_assert` — that body is the release-build backstop against a
+    /// future quad producer silently folding graph names into the default
+    /// graph, so it must be an error, not a no-op.
+    #[derive(Default)]
+    struct QuadClaimingSink {
+        terms: u32,
+    }
+
+    impl GraphSink for QuadClaimingSink {
+        fn on_base(&mut self, _base_iri: &str) {}
+        fn on_prefix(&mut self, _prefix: &str, _namespace_iri: &str) {}
+        fn term_iri(&mut self, _iri: &str) -> TermId {
+            self.terms += 1;
+            TermId::new(self.terms)
+        }
+        fn term_blank(&mut self, _label: Option<&str>) -> TermId {
+            TermId::new(0)
+        }
+        fn term_literal(
+            &mut self,
+            _value: &str,
+            _datatype: Datatype,
+            _language: Option<&str>,
+        ) -> TermId {
+            TermId::new(0)
+        }
+        fn term_literal_value(&mut self, _value: LiteralValue, _datatype: Datatype) -> TermId {
+            TermId::new(0)
+        }
+        fn emit_triple(&mut self, _s: TermId, _p: TermId, _o: TermId) -> SinkResult {
+            Ok(())
+        }
+        fn supports_quads(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn triple_only_sinks_do_not_claim_quad_support() {
+        // The capability probe producers of N-Quads/TriG/`@graph` must
+        // consult before emitting.
+        let sink = GraphCollectorSink::new();
+        assert!(!sink.supports_quads());
+        assert!(!sink.supports_reified_triples());
+    }
+
+    #[test]
+    fn default_emit_quad_refuses_instead_of_dropping_the_graph_name() {
+        let mut sink = QuadClaimingSink::default();
+        let g = sink.term_iri("http://example.org/g");
+        let s = sink.term_iri("http://example.org/s");
+        let p = sink.term_iri("http://example.org/p");
+        let o = sink.term_iri("http://example.org/o");
+
+        let err = sink
+            .emit_quad(s, p, o, g)
+            .expect_err("the default quad body must refuse, never silently fall back");
+        assert!(matches!(err, SinkError::Rejected(_)), "{err:?}");
+        assert!(err.to_string().contains("named graphs"), "{err}");
+    }
+
+    #[test]
+    fn protocol_finish_defaults_to_a_no_op_and_leaves_the_product_alone() {
+        // `finish()` flushes; `into_graph()` produces. Calling the former
+        // must not disturb the latter — the two are deliberately separate
+        // methods so `finish()` can never mean "give me your contents".
+        let mut sink = GraphCollectorSink::new();
+        let s = sink.term_iri("http://example.org/s");
+        let p = sink.term_iri("http://example.org/p");
+        let o = sink.term_literal("v", Datatype::xsd_string(), None);
+        sink.emit_triple(s, p, o).unwrap();
+
+        sink.finish().expect("default finish is infallible");
+        sink.finish().expect("and idempotent");
+
+        assert_eq!(sink.into_graph().len(), 1);
+    }
+
+    #[test]
+    fn broken_pipe_is_distinguishable_from_other_sink_failures() {
+        // CLI drivers exit quietly on a closed downstream (`… | head -5`)
+        // but must still report real failures.
+        let pipe = SinkError::Io(std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "closed",
+        ));
+        assert!(pipe.is_broken_pipe());
+
+        let full = SinkError::Io(std::io::Error::other("no space left on device"));
+        assert!(!full.is_broken_pipe());
+
+        let rejected = SinkError::rejected("nope");
+        assert!(!rejected.is_broken_pipe());
     }
 }

--- a/fluree-graph-json-ld/src/adapter.rs
+++ b/fluree-graph-json-ld/src/adapter.rs
@@ -13,7 +13,13 @@
 //!
 //! # Limitations
 //!
-//! - **`@graph`**: Named graphs are flattened into the default graph (no quad support)
+//! - **`@graph`**: dropped, not flattened. Every `@`-prefixed key except
+//!   `@type` is skipped, so the contents of a `@graph` entry never reach the
+//!   sink at all. Emitting them correctly needs the quad protocol
+//!   ([`fluree_graph_ir::GraphSink::supports_quads`] /
+//!   [`fluree_graph_ir::GraphSink::emit_quad`]); until this adapter uses it,
+//!   the behavior stays as-is rather than being silently folded into the
+//!   default graph.
 //! - **`@reverse`**: Reverse properties are not yet supported
 //!
 //! # Example
@@ -55,6 +61,11 @@ pub enum AdapterError {
     /// Invalid expanded JSON-LD structure
     #[error("Invalid expanded JSON-LD: {0}")]
     InvalidStructure(String),
+
+    /// The sink refused an emitted event, or its downstream writer failed.
+    /// Conversion stops at the first such error.
+    #[error("Sink error: {0}")]
+    Sink(#[from] fluree_graph_ir::SinkError),
 }
 
 /// Result type for adapter operations
@@ -170,7 +181,7 @@ fn process_node<S: GraphSink>(
             for type_val in types {
                 if let Some(type_iri) = type_val.as_str() {
                     let object_id = sink.term_iri(type_iri);
-                    sink.emit_triple(subject_id, rdf_type_id, object_id);
+                    sink.emit_triple(subject_id, rdf_type_id, object_id)?;
                 }
             }
             continue;
@@ -188,11 +199,11 @@ fn process_node<S: GraphSink>(
         for val in values {
             match process_value(val, sink)? {
                 ProcessedValue::Single(object_id) => {
-                    sink.emit_triple(subject_id, predicate_id, object_id);
+                    sink.emit_triple(subject_id, predicate_id, object_id)?;
                 }
                 ProcessedValue::List(items) => {
                     for (index, object_id) in items {
-                        sink.emit_list_item(subject_id, predicate_id, object_id, index);
+                        sink.emit_list_item(subject_id, predicate_id, object_id, index)?;
                     }
                 }
                 ProcessedValue::None => {}
@@ -812,7 +823,7 @@ mod tests {
         let mut sink = GraphCollectorSink::new();
         to_graph_events(&expanded, &mut sink).unwrap();
 
-        let mut graph = sink.finish();
+        let mut graph = sink.into_graph();
         assert_eq!(graph.len(), 3, "Should have 3 list item triples");
 
         // All triples should be list elements
@@ -858,7 +869,7 @@ mod tests {
         let mut sink = GraphCollectorSink::new();
         to_graph_events(&expanded, &mut sink).unwrap();
 
-        let mut graph = sink.finish();
+        let mut graph = sink.into_graph();
         assert_eq!(graph.len(), 2);
 
         graph.sort();
@@ -893,7 +904,7 @@ mod tests {
         let mut sink = GraphCollectorSink::new();
         to_graph_events(&expanded, &mut sink).unwrap();
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         // 2 list item triples + 2 name triples for embedded nodes = 4
         assert_eq!(
             graph.len(),
@@ -931,7 +942,7 @@ mod tests {
         let mut sink = GraphCollectorSink::new();
         to_graph_events(&expanded, &mut sink).unwrap();
 
-        let mut graph = sink.finish();
+        let mut graph = sink.into_graph();
         assert_eq!(graph.len(), 4);
 
         graph.sort();
@@ -977,7 +988,7 @@ mod tests {
         let mut sink = GraphCollectorSink::new();
         to_graph_events(&expanded, &mut sink).unwrap();
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         // Empty list produces no triples
         assert_eq!(graph.len(), 0, "Empty list should produce no triples");
     }
@@ -998,7 +1009,7 @@ mod tests {
         let mut sink = GraphCollectorSink::new();
         to_graph_events(&expanded, &mut sink).unwrap();
 
-        let mut graph = sink.finish();
+        let mut graph = sink.into_graph();
         assert_eq!(
             graph.len(),
             3,
@@ -1042,7 +1053,7 @@ mod tests {
         let mut sink = GraphCollectorSink::new();
         to_graph_events(&expanded, &mut sink).unwrap();
 
-        let mut graph = sink.finish();
+        let mut graph = sink.into_graph();
         assert_eq!(graph.len(), 3, "Should have 3 list items");
 
         graph.sort();

--- a/fluree-graph-turtle/src/adapter.rs
+++ b/fluree-graph-turtle/src/adapter.rs
@@ -174,9 +174,9 @@ mod tests {
         let name = sink.term_iri("http://xmlns.com/foaf/0.1/name");
         let alice_name = sink.term_literal("Alice", Datatype::xsd_string(), None);
 
-        sink.emit_triple(alice, name, alice_name);
+        sink.emit_triple(alice, name, alice_name).unwrap();
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         let json = graph_to_transaction_json(&graph);
 
         assert!(json.is_array());
@@ -196,9 +196,9 @@ mod tests {
         let name = sink.term_iri("http://xmlns.com/foaf/0.1/name");
         let value = sink.term_literal("Bob", Datatype::xsd_string(), None);
 
-        sink.emit_triple(bnode, name, value);
+        sink.emit_triple(bnode, name, value).unwrap();
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         let json = graph_to_transaction_json(&graph);
 
         let arr = json.as_array().unwrap();
@@ -216,9 +216,9 @@ mod tests {
         let knows = sink.term_iri("http://xmlns.com/foaf/0.1/knows");
         let bob = sink.term_iri("http://example.org/bob");
 
-        sink.emit_triple(alice, knows, bob);
+        sink.emit_triple(alice, knows, bob).unwrap();
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         let json = graph_to_transaction_json(&graph);
 
         let arr = json.as_array().unwrap();
@@ -235,9 +235,9 @@ mod tests {
         let birthdate = sink.term_iri("http://example.org/birthdate");
         let date = sink.term_literal("2000-01-01", Datatype::xsd_date(), None);
 
-        sink.emit_triple(alice, birthdate, date);
+        sink.emit_triple(alice, birthdate, date).unwrap();
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         let json = graph_to_transaction_json(&graph);
 
         let arr = json.as_array().unwrap();
@@ -258,9 +258,9 @@ mod tests {
         let name = sink.term_iri("http://xmlns.com/foaf/0.1/name");
         let alice_name = sink.term_literal("Alice", Datatype::rdf_lang_string(), Some("en"));
 
-        sink.emit_triple(alice, name, alice_name);
+        sink.emit_triple(alice, name, alice_name).unwrap();
 
-        let graph = sink.finish();
+        let graph = sink.into_graph();
         let json = graph_to_transaction_json(&graph);
 
         let arr = json.as_array().unwrap();

--- a/fluree-graph-turtle/src/error.rs
+++ b/fluree-graph-turtle/src/error.rs
@@ -22,6 +22,13 @@ pub enum TurtleError {
     /// Invalid escape sequence
     #[error("Invalid escape sequence: {0}")]
     InvalidEscape(String),
+
+    /// The sink refused an emitted event, or its downstream writer failed.
+    ///
+    /// Parsing stops at the first such error — a writer sink whose pipe has
+    /// closed must not be handed the rest of the document.
+    #[error("Sink error: {0}")]
+    Sink(#[from] fluree_graph_ir::SinkError),
 }
 
 /// Result type for Turtle operations

--- a/fluree-graph-turtle/src/lib.rs
+++ b/fluree-graph-turtle/src/lib.rs
@@ -18,7 +18,7 @@
 //! // Option 1: Parse to GraphSink
 //! let mut sink = GraphCollectorSink::new();
 //! parse(turtle, &mut sink).unwrap();
-//! let graph = sink.finish();
+//! let graph = sink.into_graph();
 //!
 //! // Option 2: Parse directly to transaction JSON
 //! let json = parse_to_json(turtle).unwrap();
@@ -56,7 +56,7 @@ use serde_json::Value as JsonValue;
 pub fn parse_to_json(input: &str) -> Result<JsonValue> {
     let mut sink = GraphCollectorSink::new();
     parse(input, &mut sink)?;
-    let graph = sink.finish();
+    let graph = sink.into_graph();
     Ok(graph_to_transaction_json(&graph))
 }
 

--- a/fluree-graph-turtle/src/lib.rs
+++ b/fluree-graph-turtle/src/lib.rs
@@ -34,13 +34,17 @@
 pub mod adapter;
 pub mod error;
 pub mod lex;
+pub mod options;
 pub mod parser;
 pub mod splitter;
 
 pub use adapter::graph_to_transaction_json;
 pub use error::{Result, TurtleError};
 pub use lex::{tokenize, Lexer, StreamingLexer, Token, TokenKind};
-pub use parser::{parse, parse_with_prefixes_base};
+pub use options::{CollectionStyle, NumericStyle, ParserOptions};
+pub use parser::{
+    parse, parse_with_options, parse_with_prefixes_base, parse_with_prefixes_base_options,
+};
 
 use fluree_graph_ir::GraphCollectorSink;
 use serde_json::Value as JsonValue;

--- a/fluree-graph-turtle/src/options.rs
+++ b/fluree-graph-turtle/src/options.rs
@@ -1,0 +1,127 @@
+//! Parser conformance options.
+//!
+//! The Turtle grammar is one thing; what a *consumer* wants out of it is not.
+//! Fluree's ingest paths want collections flattened into indexed list items
+//! and numeric literals canonicalized into native values, because that is
+//! what a flake stores. A conversion tool wants neither: it has to reproduce
+//! the RDF the document actually denotes, `rdf:first`/`rdf:rest` spine and
+//! source lexical forms included.
+//!
+//! Rather than fork the grammar, both shapes come out of the same parser
+//! under [`ParserOptions`]. [`ParserOptions::default`] is exactly today's
+//! ingest behavior, so every existing caller is unchanged.
+
+/// How RDF collections (`( a b c )`) reach the sink.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum CollectionStyle {
+    /// Object-position collections become indexed
+    /// [`emit_list_item`](fluree_graph_ir::GraphSink::emit_list_item) events
+    /// on the enclosing subject/predicate, and an object-position `()` emits
+    /// nothing.
+    ///
+    /// This is Fluree's storage shape — a list is metadata on the edge, not a
+    /// chain of blank nodes — and it is lossy as RDF: the W3C-defined three
+    /// triples of a one-item collection arrive as one event, and the empty
+    /// collection's `rdf:nil` triple is dropped entirely. Subject-position
+    /// collections are unaffected; they have always emitted a spine.
+    #[default]
+    IndexedItems,
+
+    /// Collections become an `rdf:first`/`rdf:rest` blank-node spine
+    /// terminated by `rdf:nil`, in every position, and `()` denotes
+    /// `rdf:nil`. This is what RDF says a collection *is*, and what the W3C
+    /// Turtle suite tests.
+    ///
+    /// In this mode a collection has a single object term (the spine head),
+    /// so an RDF 1.2 annotation may follow one — the deferral that applies in
+    /// [`CollectionStyle::IndexedItems`] exists only because indexed items
+    /// leave nothing to reify.
+    Spine,
+}
+
+/// How numeric literal tokens reach the sink.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum NumericStyle {
+    /// `Integer` and `Double` tokens are parsed into native
+    /// [`LiteralValue`](fluree_graph_ir::LiteralValue) values, discarding the
+    /// source spelling. `+1`, `01`, and `1` all become `Integer(1)`; `1e0`
+    /// and `1.0E0` both become `Double(1.0)`.
+    ///
+    /// Correct for ingest, where the value is what gets stored, and lossy for
+    /// conversion, where the lexical form is part of the term's identity.
+    #[default]
+    Canonicalize,
+
+    /// Numeric literals keep their source lexical form, typed as
+    /// `xsd:integer` / `xsd:double`, exactly as `Decimal` and
+    /// i64-overflowing integer tokens already do.
+    PreserveLexical,
+}
+
+/// Conformance knobs for the Turtle parser.
+///
+/// The default is today's ingest behavior in every field; opting in is
+/// per-parse and affects nothing else.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub struct ParserOptions {
+    /// How collections reach the sink.
+    pub collections: CollectionStyle,
+    /// How numeric literals reach the sink.
+    pub numerics: NumericStyle,
+}
+
+impl ParserOptions {
+    /// Ingest defaults: [`CollectionStyle::IndexedItems`] +
+    /// [`NumericStyle::Canonicalize`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Faithful-RDF preset: spine collections and preserved numeric
+    /// lexical forms — what a syntax-conformant reader/converter wants.
+    pub fn conformant() -> Self {
+        Self {
+            collections: CollectionStyle::Spine,
+            numerics: NumericStyle::PreserveLexical,
+        }
+    }
+
+    /// Set the collection style.
+    pub fn with_collections(mut self, collections: CollectionStyle) -> Self {
+        self.collections = collections;
+        self
+    }
+
+    /// Set the numeric style.
+    pub fn with_numerics(mut self, numerics: NumericStyle) -> Self {
+        self.numerics = numerics;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_the_ingest_shape() {
+        let o = ParserOptions::default();
+        assert_eq!(o.collections, CollectionStyle::IndexedItems);
+        assert_eq!(o.numerics, NumericStyle::Canonicalize);
+        assert_eq!(o, ParserOptions::new());
+    }
+
+    #[test]
+    fn conformant_preset_opts_into_both() {
+        let o = ParserOptions::conformant();
+        assert_eq!(o.collections, CollectionStyle::Spine);
+        assert_eq!(o.numerics, NumericStyle::PreserveLexical);
+        assert_eq!(
+            o,
+            ParserOptions::new()
+                .with_collections(CollectionStyle::Spine)
+                .with_numerics(NumericStyle::PreserveLexical)
+        );
+    }
+}

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -2314,16 +2314,73 @@ mod tests {
     // Blank-node namespace disjointness
     // =========================================================================
 
+    /// Count the DISTINCT blank-node identities in a graph.
+    fn distinct_blanks(graph: &Graph) -> Vec<String> {
+        let mut labels: Vec<String> = graph
+            .iter()
+            .flat_map(|t| [&t.s, &t.o])
+            .filter_map(|t| match t {
+                Term::BlankNode(b) => Some(b.as_str().to_string()),
+                _ => None,
+            })
+            .collect();
+        labels.sort();
+        labels.dedup();
+        labels
+    }
+
     /// User-written labels and parser-minted anonymous nodes must never
     /// collide. An isomorphism check structurally CANNOT catch this: merged
     /// nodes are isomorphic to themselves, so the merged graph looks
     /// well-formed. Only counting distinct identities finds it.
     ///
-    /// Spine mode makes it systematic — every collection mints spine nodes —
-    /// but `[ … ]` and reifiers hit the same mint, so this guards all of them.
+    /// Both mint sites are covered, because they fail independently:
+    /// Spine-mode collections (systematic — every collection mints spine
+    /// nodes) and `[ … ]` property lists (which mint in EVERY mode, so a
+    /// spine-only test would pass while the bracket path stayed broken).
     #[test]
     fn minted_blanks_never_collide_with_user_written_labels() {
-        // `_:b1`/`_:b2` are exactly what a naive `b{N}` counter mints.
+        // Site 1: Spine collection. `( ex:a ex:b )` mints two spine nodes,
+        // which a `b{N}` counter would name `b1`/`b2` — exactly the labels
+        // this document already uses. Four distinct RDF nodes must stay four.
+        let spine_doc = r#"
+            @prefix ex: <http://example.org/> .
+            _:b1 ex:p "user-one" .
+            _:b2 ex:p "user-two" .
+            ex:s ex:list ( ex:a ex:b ) .
+        "#;
+        let mut sink = GraphCollectorSink::new();
+        parse_with_options(spine_doc, &mut sink, ParserOptions::conformant()).expect("spine parse");
+        let graph = sink.into_graph();
+        let blanks = distinct_blanks(&graph);
+        assert_eq!(
+            blanks.len(),
+            4,
+            "2 user labels + 2 spine nodes = 4 distinct nodes, got {blanks:?}"
+        );
+
+        // Site 2: blank-node property list, in the DEFAULT mode — `[ … ]`
+        // mints regardless of collection style, so this path is not covered
+        // by the spine case above. Two distinct nodes must stay two.
+        let bracket_doc = r#"
+            @prefix ex: <http://example.org/> .
+            _:b1 ex:p "user-one" .
+            ex:t ex:has [ ex:q "anon" ] .
+        "#;
+        let mut sink = GraphCollectorSink::new();
+        parse_with_options(bracket_doc, &mut sink, ParserOptions::default())
+            .expect("default parse");
+        let graph = sink.into_graph();
+        let blanks = distinct_blanks(&graph);
+        assert_eq!(
+            blanks.len(),
+            2,
+            "1 user label + 1 bracket node = 2 distinct nodes, got {blanks:?}"
+        );
+
+        // And in both modes: each user label owns exactly its own triple, and
+        // no minted label can lex as a user label — which is what makes the
+        // disjointness structural rather than lucky.
         let doc = r#"
             @prefix ex: <http://example.org/> .
             _:b1 ex:p "user-one" .
@@ -2331,7 +2388,6 @@ mod tests {
             ex:s ex:list ( ex:a ex:b ) .
             ex:t ex:has [ ex:q "anon" ] .
         "#;
-
         for (mode, options) in [
             ("spine", ParserOptions::conformant()),
             ("default", ParserOptions::default()),
@@ -2340,7 +2396,6 @@ mod tests {
             parse_with_options(doc, &mut sink, options).expect("parses");
             let graph = sink.into_graph();
 
-            // Each user label must own exactly the one triple written for it.
             for (label, object) in [("b1", "user-one"), ("b2", "user-two")] {
                 let owned: Vec<String> = graph
                     .iter()
@@ -2356,18 +2411,10 @@ mod tests {
                 assert!(owned[0].contains(object), "[{mode}] {owned:?}");
             }
 
-            // And no minted label may be lexable as a user label, which is
-            // what makes the disjointness structural rather than lucky.
-            let minted: Vec<String> = graph
-                .iter()
-                .flat_map(|t| [&t.s, &t.o])
-                .filter_map(|t| match t {
-                    Term::BlankNode(b) => Some(b.as_str().to_string()),
-                    _ => None,
-                })
-                .filter(|l| l != "b1" && l != "b2")
-                .collect();
-            for label in &minted {
+            for label in distinct_blanks(&graph) {
+                if label == "b1" || label == "b2" {
+                    continue;
+                }
                 assert!(
                     label.starts_with('-'),
                     "[{mode}] minted label {label} can lex as BLANK_NODE_LABEL and so can collide"

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -73,6 +73,16 @@ pub struct Parser<'a, 'input, S> {
     /// [`GraphSink::abort_statement`] — a statement that failed before
     /// emitting has nothing to roll back.
     emit_count: u64,
+    /// Whether the statement currently being parsed already committed itself
+    /// via [`Self::end_statement_at_dot`].
+    ///
+    /// Lives on `self` rather than riding a return value because the case it
+    /// exists for is the ERROR path: a statement commits at its `.`, then the
+    /// one-token lookahead hits a lexical error in the next statement, so the
+    /// commit has happened but `parse_statement` still returns `Err`. Without
+    /// this the error arm would also fire `abort_statement`, breaking the
+    /// published "exactly one of end/abort per statement" contract.
+    committed_current: bool,
 }
 
 impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
@@ -122,6 +132,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             nesting_depth: 0,
             options,
             emit_count: 0,
+            committed_current: false,
         })
     }
 
@@ -163,11 +174,13 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         let mut statement_count: u64 = 0;
         while !self.is_at_end() {
             let emitted_before = self.emit_count;
+            self.committed_current = false;
             match self.parse_statement() {
-                // Committed at its own terminator; anything else (the
-                // SPARQL-style directives) commits here.
-                Ok(committed) => {
-                    if !committed {
+                Ok(()) => {
+                    // Statements ending in `.` commit at the terminator; the
+                    // SPARQL-style `PREFIX`/`BASE` forms have none, so they
+                    // commit here.
+                    if !self.committed_current {
                         self.sink.end_statement();
                     }
                     statement_count += 1;
@@ -177,12 +190,17 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
                     // fail having already pushed triples. Tell the sink to
                     // drop them, so "a rejected statement contributes
                     // nothing" holds at the sink and not just in the error
-                    // return. Nothing emitted means nothing to roll back.
+                    // return.
                     //
-                    // A statement that already committed and then failed on
-                    // the lookahead advance lands here too; its rollback is a
-                    // no-op because the commit moved the sink's mark past it.
-                    if self.emit_count > emitted_before {
+                    // Two guards, and both are load-bearing. Nothing emitted
+                    // means nothing to roll back. And a statement that
+                    // already committed is NOT rolled back at all: it reaches
+                    // here only because the one-token lookahead failed while
+                    // reading the NEXT statement, and it is complete and
+                    // valid. Firing abort there would also break the "exactly
+                    // one of end/abort per statement" contract this trait
+                    // publishes.
+                    if !self.committed_current && self.emit_count > emitted_before {
                         self.sink.abort_statement();
                     }
                     return Err(e);
@@ -480,25 +498,26 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             ));
         }
         self.sink.end_statement();
+        self.committed_current = true;
         self.advance()
     }
 
     /// Parse a single statement (directive or triples).
     ///
-    /// Returns whether the statement already committed itself to the sink via
-    /// [`Self::end_statement_at_dot`]; the SPARQL-style `PREFIX`/`BASE` forms
-    /// have no terminator, so the caller commits those.
-    fn parse_statement(&mut self) -> Result<bool> {
+    /// Whether the statement committed itself is reported through
+    /// [`Self::committed_current`], not the return value, because the caller
+    /// needs that answer on the error path too.
+    fn parse_statement(&mut self) -> Result<()> {
         match self.current().kind {
             TokenKind::KwPrefix | TokenKind::KwSparqlPrefix => self.parse_prefix_directive(),
             TokenKind::KwBase | TokenKind::KwSparqlBase => self.parse_base_directive(),
-            TokenKind::Eof => Ok(false),
-            _ => self.parse_triples().map(|()| true),
+            TokenKind::Eof => Ok(()),
+            _ => self.parse_triples(),
         }
     }
 
     /// Parse @prefix or PREFIX directive.
-    fn parse_prefix_directive(&mut self) -> Result<bool> {
+    fn parse_prefix_directive(&mut self) -> Result<()> {
         let is_sparql_style = matches!(self.current().kind, TokenKind::KwSparqlPrefix);
         self.advance()?; // consume @prefix or PREFIX
 
@@ -542,15 +561,14 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
         // Consume trailing dot (required for @prefix, not for PREFIX)
         if !is_sparql_style {
-            self.end_statement_at_dot()?;
-            return Ok(true);
+            return self.end_statement_at_dot();
         }
 
-        Ok(false)
+        Ok(())
     }
 
     /// Parse @base or BASE directive.
-    fn parse_base_directive(&mut self) -> Result<bool> {
+    fn parse_base_directive(&mut self) -> Result<()> {
         let is_sparql_style = matches!(self.current().kind, TokenKind::KwSparqlBase);
         self.advance()?; // consume @base or BASE
 
@@ -577,11 +595,10 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
         // Consume trailing dot (required for @base, not for BASE)
         if !is_sparql_style {
-            self.end_statement_at_dot()?;
-            return Ok(true);
+            return self.end_statement_at_dot();
         }
 
-        Ok(false)
+        Ok(())
     }
 
     /// Parse a triple statement.

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -68,6 +68,11 @@ pub struct Parser<'a, 'input, S> {
     nesting_depth: u32,
     /// Conformance knobs; [`ParserOptions::default`] is the ingest shape.
     options: ParserOptions,
+    /// Emissions so far. Compared against its value at the statement's start
+    /// to decide whether a failed statement needs
+    /// [`GraphSink::abort_statement`] — a statement that failed before
+    /// emitting has nothing to roll back.
+    emit_count: u64,
 }
 
 impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
@@ -116,6 +121,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             annotation_depth: 0,
             nesting_depth: 0,
             options,
+            emit_count: 0,
         })
     }
 
@@ -156,12 +162,32 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
         let mut statement_count: u64 = 0;
         while !self.is_at_end() {
-            self.parse_statement()?;
-            // Statement terminator: only reached once the statement parsed
-            // and emitted cleanly, so a sink may reclaim statement-scoped
-            // literal term ids / commit statement-scoped buffers here.
-            self.sink.end_statement();
-            statement_count += 1;
+            let emitted_before = self.emit_count;
+            match self.parse_statement() {
+                // Committed at its own terminator; anything else (the
+                // SPARQL-style directives) commits here.
+                Ok(committed) => {
+                    if !committed {
+                        self.sink.end_statement();
+                    }
+                    statement_count += 1;
+                }
+                Err(e) => {
+                    // The parser emits during descent, so a statement can
+                    // fail having already pushed triples. Tell the sink to
+                    // drop them, so "a rejected statement contributes
+                    // nothing" holds at the sink and not just in the error
+                    // return. Nothing emitted means nothing to roll back.
+                    //
+                    // A statement that already committed and then failed on
+                    // the lookahead advance lands here too; its rollback is a
+                    // no-op because the commit moved the sink's mark past it.
+                    if self.emit_count > emitted_before {
+                        self.sink.abort_statement();
+                    }
+                    return Err(e);
+                }
+            }
         }
         span.record("statement_count", statement_count);
         span.record("iri_cache_hits", self.iri_cache_hits);
@@ -274,6 +300,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         object: TermId,
     ) -> Result<()> {
         self.sink.emit_triple(subject, predicate, object)?;
+        self.emit_count += 1;
         Ok(())
     }
 
@@ -287,6 +314,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
     ) -> Result<()> {
         self.sink
             .emit_list_item(subject, predicate, object, index)?;
+        self.emit_count += 1;
         Ok(())
     }
 
@@ -300,6 +328,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
     ) -> Result<()> {
         self.sink
             .emit_reified_triple(subject, predicate, object, reifier)?;
+        self.emit_count += 1;
         Ok(())
     }
 
@@ -435,18 +464,41 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
     // Parsing
     // =========================================================================
 
+    /// Consume the `.` terminating a statement, committing the statement to
+    /// the sink BEFORE advancing.
+    ///
+    /// The commit has to happen before the advance because the parser keeps
+    /// one token of lookahead: advancing past the `.` lexes the first token
+    /// of the NEXT statement, and a lexical error there would otherwise be
+    /// reported while this statement is still in flight — rolling back a
+    /// statement that was in fact complete and valid.
+    fn end_statement_at_dot(&mut self) -> Result<()> {
+        if !self.check(&TokenKind::Dot) {
+            return Err(TurtleError::parse(
+                self.current().start as usize,
+                format!("expected Dot, found {:?}", self.current().kind),
+            ));
+        }
+        self.sink.end_statement();
+        self.advance()
+    }
+
     /// Parse a single statement (directive or triples).
-    fn parse_statement(&mut self) -> Result<()> {
+    ///
+    /// Returns whether the statement already committed itself to the sink via
+    /// [`Self::end_statement_at_dot`]; the SPARQL-style `PREFIX`/`BASE` forms
+    /// have no terminator, so the caller commits those.
+    fn parse_statement(&mut self) -> Result<bool> {
         match self.current().kind {
             TokenKind::KwPrefix | TokenKind::KwSparqlPrefix => self.parse_prefix_directive(),
             TokenKind::KwBase | TokenKind::KwSparqlBase => self.parse_base_directive(),
-            TokenKind::Eof => Ok(()),
-            _ => self.parse_triples(),
+            TokenKind::Eof => Ok(false),
+            _ => self.parse_triples().map(|()| true),
         }
     }
 
     /// Parse @prefix or PREFIX directive.
-    fn parse_prefix_directive(&mut self) -> Result<()> {
+    fn parse_prefix_directive(&mut self) -> Result<bool> {
         let is_sparql_style = matches!(self.current().kind, TokenKind::KwSparqlPrefix);
         self.advance()?; // consume @prefix or PREFIX
 
@@ -490,14 +542,15 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
         // Consume trailing dot (required for @prefix, not for PREFIX)
         if !is_sparql_style {
-            self.expect(&TokenKind::Dot)?;
+            self.end_statement_at_dot()?;
+            return Ok(true);
         }
 
-        Ok(())
+        Ok(false)
     }
 
     /// Parse @base or BASE directive.
-    fn parse_base_directive(&mut self) -> Result<()> {
+    fn parse_base_directive(&mut self) -> Result<bool> {
         let is_sparql_style = matches!(self.current().kind, TokenKind::KwSparqlBase);
         self.advance()?; // consume @base or BASE
 
@@ -524,10 +577,11 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
         // Consume trailing dot (required for @base, not for BASE)
         if !is_sparql_style {
-            self.expect(&TokenKind::Dot)?;
+            self.end_statement_at_dot()?;
+            return Ok(true);
         }
 
-        Ok(())
+        Ok(false)
     }
 
     /// Parse a triple statement.
@@ -540,8 +594,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         if !(bnode_list_subject && matches!(self.current().kind, TokenKind::Dot)) {
             self.parse_predicate_object_list(subject)?;
         }
-        self.expect(&TokenKind::Dot)?;
-        Ok(())
+        self.end_statement_at_dot()
     }
 
     /// Parse a subject term.

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -13,6 +13,7 @@ use rustc_hash::FxHashMap;
 
 use crate::error::{Result, TurtleError};
 use crate::lex::{StreamingLexer, Token, TokenKind};
+use crate::options::{CollectionStyle, NumericStyle, ParserOptions};
 
 /// RDF well-known IRIs (imported from vocab crate)
 const RDF_TYPE: &str = rdf::TYPE;
@@ -65,11 +66,22 @@ pub struct Parser<'a, 'input, S> {
     /// [`crate::error::MAX_NESTING_DEPTH`] so adversarial nesting errors
     /// instead of overflowing the stack.
     nesting_depth: u32,
+    /// Conformance knobs; [`ParserOptions::default`] is the ingest shape.
+    options: ParserOptions,
 }
 
 impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
-    /// Create a new parser.
+    /// Create a new parser with the default (ingest) options.
     pub fn new(input: &'input str, sink: &'a mut S) -> Result<Self> {
+        Self::with_options(input, sink, ParserOptions::default())
+    }
+
+    /// Create a new parser with explicit conformance options.
+    pub fn with_options(
+        input: &'input str,
+        sink: &'a mut S,
+        options: ParserOptions,
+    ) -> Result<Self> {
         crate::error::check_input_len(input.len())?;
         let mut lexer = StreamingLexer::new(input);
         let current_token = lexer.next_token()?;
@@ -103,6 +115,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             base: None,
             annotation_depth: 0,
             nesting_depth: 0,
+            options,
         })
     }
 
@@ -632,19 +645,25 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
     /// Parse an object list (comma-separated objects).
     ///
-    /// Collections in object position are emitted as indexed list items via
-    /// `emit_list_item()` instead of rdf:first/rdf:rest linked lists.
+    /// Under [`CollectionStyle::IndexedItems`] (the default), collections in
+    /// object position are emitted as indexed list items via
+    /// `emit_list_item()` instead of rdf:first/rdf:rest linked lists, and an
+    /// object-position `()` emits nothing. Under [`CollectionStyle::Spine`]
+    /// both fall through to the ordinary object path, which already builds a
+    /// spine for `( … )` and resolves `()` to `rdf:nil` — so the two
+    /// positions share one code path and one grammar.
     ///
     /// Each object may carry an RDF 1.2 annotation tail (`~ reifier` and/or
     /// `{| … |}` blocks) — see [`Self::parse_annotation_tail`].
     fn parse_object_list(&mut self, subject: TermId, predicate: TermId) -> Result<()> {
+        let indexed_lists = self.options.collections == CollectionStyle::IndexedItems;
         loop {
             match self.current().kind {
-                TokenKind::LParen => {
+                TokenKind::LParen if indexed_lists => {
                     self.parse_collection_as_list(subject, predicate)?;
                     self.reject_annotation_on_collection()?;
                 }
-                TokenKind::Nil => {
+                TokenKind::Nil if indexed_lists => {
                     self.advance()?;
                     self.reject_annotation_on_collection()?;
                 }
@@ -755,10 +774,27 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
                 self.advance()?;
                 self.parse_string_suffix_escaped(&value)
             }
-            TokenKind::Integer(n) => {
-                self.advance()?;
-                Ok(self.sink_term_literal_value(LiteralValue::Integer(n), Datatype::xsd_integer()))
-            }
+            // Branch on the option BEFORE touching the span: the default arm
+            // must stay exactly the work it did before options existed, since
+            // this is the ingest hot path.
+            TokenKind::Integer(n) => match self.options.numerics {
+                NumericStyle::Canonicalize => {
+                    self.advance()?;
+                    Ok(self
+                        .sink_term_literal_value(LiteralValue::Integer(n), Datatype::xsd_integer()))
+                }
+                // PreserveLexical routes through the typed-string lane, the
+                // same one `IntegerOverflow` and `Decimal` already use, so
+                // `+1` / `01` / `1` stay distinguishable instead of all
+                // collapsing to `Integer(1)`.
+                NumericStyle::PreserveLexical => {
+                    let s = self.current().start;
+                    let e = self.current().end;
+                    let text = self.decimal_content(s, e);
+                    self.advance()?;
+                    Ok(self.sink_term_literal(text, Datatype::xsd_integer(), None))
+                }
+            },
             TokenKind::IntegerOverflow => {
                 // Beyond i64: keep the lexical so downstream promotes to BigInt.
                 let s = self.current().start;
@@ -774,10 +810,22 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
                 self.advance()?;
                 Ok(self.sink_term_literal(text, Datatype::xsd_decimal(), None))
             }
-            TokenKind::Double(n) => {
-                self.advance()?;
-                Ok(self.sink_term_literal_value(LiteralValue::Double(n), Datatype::xsd_double()))
-            }
+            TokenKind::Double(n) => match self.options.numerics {
+                NumericStyle::Canonicalize => {
+                    self.advance()?;
+                    Ok(self
+                        .sink_term_literal_value(LiteralValue::Double(n), Datatype::xsd_double()))
+                }
+                // `1e0`, `1.0e0`, and `1.0E0` are three spellings of one
+                // value; canonicalizing keeps only the value.
+                NumericStyle::PreserveLexical => {
+                    let s = self.current().start;
+                    let e = self.current().end;
+                    let text = self.decimal_content(s, e);
+                    self.advance()?;
+                    Ok(self.sink_term_literal(text, Datatype::xsd_double(), None))
+                }
+            },
             TokenKind::KwTrue => {
                 self.advance()?;
                 Ok(self
@@ -1259,9 +1307,24 @@ fn unescape_pn_local(local: &str) -> String {
     result
 }
 
-/// Parse a Turtle document into GraphSink events.
+/// Parse a Turtle document into GraphSink events, with the ingest-shaped
+/// [`ParserOptions::default`].
 pub fn parse<S: GraphSink>(input: &str, sink: &mut S) -> Result<()> {
     Parser::new(input, sink)?.parse()
+}
+
+/// Parse a Turtle document into GraphSink events under explicit
+/// [`ParserOptions`].
+///
+/// [`parse`] is this with [`ParserOptions::default`]; use
+/// [`ParserOptions::conformant`] for the faithful-RDF shape (spine
+/// collections, preserved numeric lexical forms).
+pub fn parse_with_options<S: GraphSink>(
+    input: &str,
+    sink: &mut S,
+    options: ParserOptions,
+) -> Result<()> {
+    Parser::with_options(input, sink, options)?.parse()
 }
 
 /// Parse Turtle input with a pre-seeded prefix map and optional base IRI.
@@ -1282,7 +1345,22 @@ pub fn parse_with_prefixes_base<S: GraphSink>(
     prefixes: &[(String, String)],
     base: Option<&str>,
 ) -> Result<()> {
-    let mut parser = Parser::new(input, sink)?;
+    parse_with_prefixes_base_options(input, sink, prefixes, base, ParserOptions::default())
+}
+
+/// [`parse_with_prefixes_base`] under explicit [`ParserOptions`].
+///
+/// This is the full entry point — every other `parse*` function is this one
+/// with something defaulted — so the chunked reader paths, which need the
+/// pre-seeded prelude, can opt into conformance options too.
+pub fn parse_with_prefixes_base_options<S: GraphSink>(
+    input: &str,
+    sink: &mut S,
+    prefixes: &[(String, String)],
+    base: Option<&str>,
+    options: ParserOptions,
+) -> Result<()> {
+    let mut parser = Parser::with_options(input, sink, options)?;
     if let Some(base) = base {
         parser.base = Some(base.to_string());
     }
@@ -2157,6 +2235,469 @@ mod tests {
                 ("http://example.org/c".to_string(), "three".to_string()),
             ]
         );
+    }
+
+    // =========================================================================
+    // ParserOptions — collection + numeric conformance
+    // =========================================================================
+    //
+    // Two shapes out of one grammar: the DEFAULT is Fluree's ingest shape and
+    // is pinned bit-for-bit by the pre-existing tests above (`test_collection`,
+    // `test_empty_collection`, `test_integer_literal`) plus the explicit
+    // default-mode tests here; `ParserOptions::conformant()` is the RDF the
+    // document actually denotes, which is what the W3C Turtle suite tests.
+
+    const EX: &str = "http://example.org/";
+
+    fn parse_conformant(input: &str) -> Graph {
+        let mut sink = GraphCollectorSink::new();
+        parse_with_options(input, &mut sink, ParserOptions::conformant())
+            .expect("conformant parse");
+        sink.into_graph()
+    }
+
+    fn parse_spine(input: &str) -> Graph {
+        let mut sink = GraphCollectorSink::new();
+        parse_with_options(
+            input,
+            &mut sink,
+            ParserOptions::new().with_collections(CollectionStyle::Spine),
+        )
+        .expect("spine parse");
+        sink.into_graph()
+    }
+
+    /// Every triple as `(subject, predicate, object)` in `Term`'s N-Triples-ish
+    /// display form.
+    fn rendered(graph: &Graph) -> Vec<(String, String, String)> {
+        graph
+            .iter()
+            .map(|t| (t.s.to_string(), t.p.to_string(), t.o.to_string()))
+            .collect()
+    }
+
+    /// Follow an `rdf:first`/`rdf:rest` spine from `head`, returning each
+    /// item's rendered form. Panics if the chain is not well-formed, which is
+    /// the point: a partial spine must not read as a short list.
+    fn walk_spine(graph: &Graph, head: &Term) -> Vec<String> {
+        let mut items = Vec::new();
+        let mut node = head.clone();
+        loop {
+            if matches!(&node, Term::Iri(iri) if iri.as_ref() == RDF_NIL) {
+                return items;
+            }
+            let first = graph
+                .iter()
+                .find(|t| t.s == node && matches!(&t.p, Term::Iri(p) if p.as_ref() == RDF_FIRST))
+                .unwrap_or_else(|| panic!("no rdf:first for {node}"));
+            items.push(first.o.to_string());
+            let rest = graph
+                .iter()
+                .find(|t| t.s == node && matches!(&t.p, Term::Iri(p) if p.as_ref() == RDF_REST))
+                .unwrap_or_else(|| panic!("no rdf:rest for {node}"));
+            node = rest.o.clone();
+        }
+    }
+
+    /// The object of the single `ex:s ex:p ?o` triple.
+    fn object_of_p(graph: &Graph) -> Term {
+        let matches: Vec<_> = graph
+            .iter()
+            .filter(|t| matches!(&t.p, Term::Iri(p) if p.as_ref() == format!("{EX}p")))
+            .collect();
+        assert_eq!(matches.len(), 1, "expected exactly one ex:p triple");
+        matches[0].o.clone()
+    }
+
+    // -- Spine mode ---------------------------------------------------------
+
+    /// W3C `turtle-syntax-*` shape: a one-item object collection denotes
+    /// three triples. The default mode emits one `emit_list_item` event for
+    /// the same input.
+    #[test]
+    fn spine_object_collection_of_one_emits_three_triples() {
+        let graph = parse_spine(&format!("@prefix ex: <{EX}> .\nex:s ex:p ( ex:o ) ."));
+        assert_eq!(graph.len(), 3, "{:#?}", rendered(&graph));
+
+        let head = object_of_p(&graph);
+        assert!(head.is_blank(), "collection head must be a blank node");
+        assert_eq!(walk_spine(&graph, &head), vec![format!("<{EX}o>")]);
+        assert!(
+            graph.iter().all(|t| !t.is_list_element()),
+            "spine mode must not emit indexed list items"
+        );
+    }
+
+    #[test]
+    fn spine_object_collection_of_two_chains_through_a_second_node() {
+        let graph = parse_spine(&format!("@prefix ex: <{EX}> .\nex:s ex:p ( ex:a ex:b ) ."));
+        // 2 items x (first + rest) + the ex:p edge.
+        assert_eq!(graph.len(), 5, "{:#?}", rendered(&graph));
+
+        let head = object_of_p(&graph);
+        assert_eq!(
+            walk_spine(&graph, &head),
+            vec![format!("<{EX}a>"), format!("<{EX}b>")]
+        );
+    }
+
+    /// The silent-triple-loss bug: `()` in object position emitted NOTHING.
+    /// In spine mode it denotes `rdf:nil`, as RDF says.
+    #[test]
+    fn spine_empty_object_collection_is_rdf_nil() {
+        let graph = parse_spine(&format!("@prefix ex: <{EX}> .\nex:s ex:p () ."));
+        assert_eq!(
+            rendered(&graph),
+            vec![(
+                format!("<{EX}s>"),
+                format!("<{EX}p>"),
+                format!("<{RDF_NIL}>")
+            )]
+        );
+    }
+
+    /// Subject position already emitted a spine before this change; the point
+    /// of `Spine` is that both positions now share the one code path.
+    #[test]
+    fn spine_subject_and_object_collections_agree() {
+        let subject_side = parse_spine(&format!("@prefix ex: <{EX}> .\n( ex:a ) ex:p ex:o ."));
+        let object_side = parse_spine(&format!("@prefix ex: <{EX}> .\nex:s ex:p ( ex:a ) ."));
+        // Same shape either way: 1 first + 1 rest + 1 edge.
+        assert_eq!(subject_side.len(), 3);
+        assert_eq!(object_side.len(), 3);
+
+        let spine_of = |g: &Graph| {
+            let head = g
+                .iter()
+                .find(|t| matches!(&t.p, Term::Iri(p) if p.as_ref() == RDF_FIRST))
+                .map(|t| t.s.clone())
+                .expect("a spine node");
+            walk_spine(g, &head)
+        };
+        assert_eq!(spine_of(&subject_side), vec![format!("<{EX}a>")]);
+        assert_eq!(spine_of(&object_side), vec![format!("<{EX}a>")]);
+    }
+
+    #[test]
+    fn spine_nested_collections_nest_their_spines() {
+        let graph = parse_spine(&format!(
+            "@prefix ex: <{EX}> .\nex:s ex:p ( ( ex:a ) ex:b ) ."
+        ));
+        // outer: 2 nodes x 2 + inner: 1 node x 2 + the ex:p edge.
+        assert_eq!(graph.len(), 7, "{:#?}", rendered(&graph));
+
+        let outer = object_of_p(&graph);
+        let outer_items = walk_spine(&graph, &outer);
+        assert_eq!(outer_items.len(), 2);
+        assert_eq!(outer_items[1], format!("<{EX}b>"));
+
+        let inner_head = graph
+            .iter()
+            .find(|t| {
+                matches!(&t.p, Term::Iri(p) if p.as_ref() == RDF_FIRST)
+                    && t.s == outer
+                    && t.o.is_blank()
+            })
+            .map(|t| t.o.clone())
+            .expect("inner collection head");
+        assert_eq!(walk_spine(&graph, &inner_head), vec![format!("<{EX}a>")]);
+    }
+
+    /// An empty collection nested inside a collection is `rdf:nil` as an item.
+    #[test]
+    fn spine_nested_empty_collection_is_a_nil_item() {
+        let graph = parse_spine(&format!("@prefix ex: <{EX}> .\nex:s ex:p ( () ) ."));
+        assert_eq!(graph.len(), 3, "{:#?}", rendered(&graph));
+        let head = object_of_p(&graph);
+        assert_eq!(walk_spine(&graph, &head), vec![format!("<{RDF_NIL}>")]);
+    }
+
+    /// In `IndexedItems` a collection object has no single term to reify, so
+    /// annotations on it are refused. In `Spine` it has one — the head — so
+    /// the refusal does not apply.
+    #[test]
+    fn spine_mode_admits_annotations_on_collections() {
+        let mut sink = StarSink::default();
+        parse_with_options(
+            &format!("{P}:s :p ( :a ) {{| :q :z |}} ."),
+            &mut sink,
+            ParserOptions::new().with_collections(CollectionStyle::Spine),
+        )
+        .expect("a spine collection has a head term to reify");
+        assert_eq!(sink.reified.len(), 1);
+
+        // Same input, default mode: still refused.
+        let mut sink = StarSink::default();
+        let err = parse(&format!("{P}:s :p ( :a ) {{| :q :z |}} ."), &mut sink)
+            .expect_err("indexed items leave nothing to reify");
+        assert!(err.to_string().contains("collection objects"), "{err}");
+    }
+
+    // -- Default (IndexedItems) mode ----------------------------------------
+
+    /// The default shape, pinned explicitly: one indexed event per item, no
+    /// spine triples at all.
+    #[test]
+    fn default_object_collection_stays_indexed_with_no_spine() {
+        let graph =
+            parse_to_graph(&format!("@prefix ex: <{EX}> .\nex:s ex:p ( ex:a ex:b ) .")).unwrap();
+        assert_eq!(graph.len(), 2);
+        assert!(graph.iter().all(fluree_graph_ir::Triple::is_list_element));
+        assert!(
+            !graph
+                .iter()
+                .any(|t| matches!(&t.p, Term::Iri(p) if p.as_ref() == RDF_FIRST
+                    || p.as_ref() == RDF_REST)),
+            "default mode must not emit a spine"
+        );
+    }
+
+    /// Documented (lossy) default: an object-position `()` emits nothing.
+    /// Changing this is exactly what `Spine` is for.
+    #[test]
+    fn default_empty_object_collection_still_emits_nothing() {
+        let graph = parse_to_graph(&format!("@prefix ex: <{EX}> .\nex:s ex:p () .")).unwrap();
+        assert_eq!(graph.len(), 0);
+    }
+
+    /// Subject-position collections emitted a spine before this change and
+    /// still do in the default mode — the change is scoped to object position.
+    #[test]
+    fn default_subject_collection_still_emits_a_spine() {
+        let graph = parse_to_graph(&format!("@prefix ex: <{EX}> .\n( ex:a ) ex:p ex:o .")).unwrap();
+        assert_eq!(graph.len(), 3);
+        assert!(graph
+            .iter()
+            .any(|t| matches!(&t.p, Term::Iri(p) if p.as_ref() == RDF_FIRST)));
+    }
+
+    // -- Numerics -----------------------------------------------------------
+
+    /// `+1`, `01`, `1e0`, `1.0e0` are distinct lexical forms of two values.
+    /// Canonicalizing makes them unrepresentable; several W3C files depend on
+    /// them surviving.
+    #[test]
+    fn preserve_lexical_keeps_the_source_spelling_of_numerics() {
+        let cases = [
+            ("+1", "http://www.w3.org/2001/XMLSchema#integer"),
+            ("01", "http://www.w3.org/2001/XMLSchema#integer"),
+            ("-0", "http://www.w3.org/2001/XMLSchema#integer"),
+            ("1e0", "http://www.w3.org/2001/XMLSchema#double"),
+            ("1.0e0", "http://www.w3.org/2001/XMLSchema#double"),
+            ("1.0E0", "http://www.w3.org/2001/XMLSchema#double"),
+            ("+1.0e-1", "http://www.w3.org/2001/XMLSchema#double"),
+        ];
+        for (lexical, datatype) in cases {
+            let graph = parse_conformant(&format!("@prefix ex: <{EX}> .\nex:s ex:p {lexical} ."));
+            assert_eq!(graph.len(), 1, "{lexical}");
+            let triple = graph.iter().next().unwrap();
+            match &triple.o {
+                Term::Literal {
+                    value, datatype: d, ..
+                } => {
+                    assert_eq!(value.lexical(), lexical, "lexical form of {lexical}");
+                    assert_eq!(d.as_iri(), datatype, "datatype of {lexical}");
+                }
+                other => panic!("expected literal for {lexical}, got {other:?}"),
+            }
+        }
+    }
+
+    /// The default: the value survives, the spelling does not.
+    #[test]
+    fn canonicalize_is_the_default_and_discards_the_spelling() {
+        let graph =
+            parse_to_graph(&format!("@prefix ex: <{EX}> .\nex:s ex:p +1 ; ex:q 1e0 .")).unwrap();
+        let mut objects: Vec<_> = graph.iter().map(|t| t.o.clone()).collect();
+        objects.sort();
+        assert!(
+            objects.iter().any(|o| matches!(
+                o,
+                Term::Literal {
+                    value: LiteralValue::Integer(1),
+                    ..
+                }
+            )),
+            "+1 must canonicalize to Integer(1): {objects:?}"
+        );
+        assert!(
+            objects.iter().any(|o| matches!(
+                o,
+                Term::Literal { value: LiteralValue::Double(d), .. } if *d == 1.0
+            )),
+            "1e0 must canonicalize to Double(1.0): {objects:?}"
+        );
+    }
+
+    /// Decimals and i64-overflowing integers already preserved their lexical
+    /// form; `PreserveLexical` extends that lane rather than adding a second
+    /// one, so these must be identical under both modes.
+    #[test]
+    fn decimal_and_bigint_lexicals_are_mode_independent() {
+        let doc =
+            format!("@prefix ex: <{EX}> .\nex:s ex:p 1.50 ; ex:q 123456789012345678901234567890 .");
+        let render = |g: &Graph| {
+            let mut r = rendered(g);
+            r.sort();
+            r
+        };
+        assert_eq!(
+            render(&parse_to_graph(&doc).unwrap()),
+            render(&parse_conformant(&doc))
+        );
+        let graph = parse_conformant(&doc);
+        let lexicals: Vec<String> = graph
+            .iter()
+            .map(|t| match &t.o {
+                Term::Literal { value, .. } => value.lexical(),
+                other => panic!("expected literal, got {other:?}"),
+            })
+            .collect();
+        assert!(lexicals.contains(&"1.50".to_string()), "{lexicals:?}");
+        assert!(
+            lexicals.contains(&"123456789012345678901234567890".to_string()),
+            "{lexicals:?}"
+        );
+    }
+
+    /// Booleans, strings, typed and language-tagged literals are untouched by
+    /// `NumericStyle` — the knob is numerics only.
+    #[test]
+    fn non_numeric_literals_are_identical_under_both_modes() {
+        let doc = format!(
+            r#"@prefix ex: <{EX}> .
+               @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+               ex:s ex:a true ; ex:b "plain" ; ex:c "tagged"@en ;
+                    ex:d "2000-01-01"^^xsd:date ."#
+        );
+        let render = |g: &Graph| {
+            let mut r = rendered(g);
+            r.sort();
+            r
+        };
+        assert_eq!(
+            render(&parse_to_graph(&doc).unwrap()),
+            render(&parse_conformant(&doc))
+        );
+    }
+
+    // -- Default-mode pinning across the whole surface ----------------------
+
+    /// One document exercising every construct the options touch, asserted
+    /// triple-for-triple in the DEFAULT mode. This is the regression guard
+    /// for "existing callers are unchanged": if adding options moved anything
+    /// on the ingest path, it moves here.
+    #[test]
+    fn default_mode_output_is_pinned_triple_for_triple() {
+        let doc = format!(
+            r#"@prefix ex: <{EX}> .
+               ex:s ex:int 30 ; ex:dbl 1.5e3 ; ex:dec 2.25 ; ex:list ( ex:a ex:b ) ;
+                    ex:empty () ; ex:str "v" ."#
+        );
+        let mut got = rendered(&parse_to_graph(&doc).unwrap());
+        got.sort();
+
+        let xsd = "http://www.w3.org/2001/XMLSchema#";
+        let mut want = vec![
+            (
+                format!("<{EX}s>"),
+                format!("<{EX}int>"),
+                format!("\"30\"^^<{xsd}integer>"),
+            ),
+            (
+                format!("<{EX}s>"),
+                format!("<{EX}dbl>"),
+                format!("\"1.5E3\"^^<{xsd}double>"),
+            ),
+            (
+                format!("<{EX}s>"),
+                format!("<{EX}dec>"),
+                format!("\"2.25\"^^<{xsd}decimal>"),
+            ),
+            (
+                format!("<{EX}s>"),
+                format!("<{EX}list>"),
+                format!("<{EX}a>"),
+            ),
+            (
+                format!("<{EX}s>"),
+                format!("<{EX}list>"),
+                format!("<{EX}b>"),
+            ),
+            (
+                format!("<{EX}s>"),
+                format!("<{EX}str>"),
+                "\"v\"".to_string(),
+            ),
+        ];
+        want.sort();
+        assert_eq!(got, want);
+    }
+
+    /// And the same document under `conformant()`, so the two shapes are
+    /// visibly different in exactly the intended places.
+    #[test]
+    fn conformant_mode_differs_only_in_collections_and_numerics() {
+        let doc = format!(
+            r#"@prefix ex: <{EX}> .
+               ex:s ex:int 30 ; ex:dbl 1.5e3 ; ex:list ( ex:a ) ; ex:empty () ;
+                    ex:str "v" ."#
+        );
+        let graph = parse_conformant(&doc);
+        let xsd = "http://www.w3.org/2001/XMLSchema#";
+        let rows = rendered(&graph);
+
+        // Numerics keep their spelling.
+        assert!(rows.contains(&(
+            format!("<{EX}s>"),
+            format!("<{EX}int>"),
+            format!("\"30\"^^<{xsd}integer>")
+        )));
+        assert!(rows.contains(&(
+            format!("<{EX}s>"),
+            format!("<{EX}dbl>"),
+            format!("\"1.5e3\"^^<{xsd}double>")
+        )));
+        // `()` is rdf:nil rather than nothing.
+        assert!(rows.contains(&(
+            format!("<{EX}s>"),
+            format!("<{EX}empty>"),
+            format!("<{RDF_NIL}>")
+        )));
+        // Non-numeric, non-collection terms are untouched.
+        assert!(rows.contains(&(
+            format!("<{EX}s>"),
+            format!("<{EX}str>"),
+            "\"v\"".to_string()
+        )));
+        // 4 scalar edges + 1 collection edge + 2 spine triples.
+        assert_eq!(graph.len(), 7, "{rows:#?}");
+    }
+
+    /// Options ride through the pre-seeded-prelude entry point too — that is
+    /// the one the chunked/parallel readers use.
+    #[test]
+    fn options_apply_on_the_prefixes_base_entry_point() {
+        let mut sink = GraphCollectorSink::new();
+        parse_with_prefixes_base_options(
+            "ex:s ex:p ( ex:a ) .",
+            &mut sink,
+            &[("ex".to_string(), EX.to_string())],
+            None,
+            ParserOptions::conformant(),
+        )
+        .expect("prelude-seeded conformant parse");
+        assert_eq!(sink.into_graph().len(), 3);
+
+        let mut sink = GraphCollectorSink::new();
+        parse_with_prefixes_base(
+            "ex:s ex:p ( ex:a ) .",
+            &mut sink,
+            &[("ex".to_string(), EX.to_string())],
+            None,
+        )
+        .expect("prelude-seeded default parse");
+        assert_eq!(sink.into_graph().len(), 1, "default entry point unchanged");
     }
 
     // =========================================================================

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -144,6 +144,10 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         let mut statement_count: u64 = 0;
         while !self.is_at_end() {
             self.parse_statement()?;
+            // Statement terminator: only reached once the statement parsed
+            // and emitted cleanly, so a sink may reclaim statement-scoped
+            // literal term ids / commit statement-scoped buffers here.
+            self.sink.end_statement();
             statement_count += 1;
         }
         span.record("statement_count", statement_count);
@@ -247,9 +251,17 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         self.sink.term_literal_value(value, datatype)
     }
 
+    /// Emit a triple, mapping a sink refusal into a parse-level error so the
+    /// caller stops immediately (broken-pipe / early-termination semantics).
     #[inline]
-    fn sink_emit_triple(&mut self, subject: TermId, predicate: TermId, object: TermId) {
-        self.sink.emit_triple(subject, predicate, object);
+    fn sink_emit_triple(
+        &mut self,
+        subject: TermId,
+        predicate: TermId,
+        object: TermId,
+    ) -> Result<()> {
+        self.sink.emit_triple(subject, predicate, object)?;
+        Ok(())
     }
 
     #[inline]
@@ -259,8 +271,23 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         predicate: TermId,
         object: TermId,
         index: i32,
-    ) {
-        self.sink.emit_list_item(subject, predicate, object, index);
+    ) -> Result<()> {
+        self.sink
+            .emit_list_item(subject, predicate, object, index)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn sink_emit_reified_triple(
+        &mut self,
+        subject: TermId,
+        predicate: TermId,
+        object: TermId,
+        reifier: TermId,
+    ) -> Result<()> {
+        self.sink
+            .emit_reified_triple(subject, predicate, object, reifier)?;
+        Ok(())
     }
 
     // =========================================================================
@@ -623,7 +650,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
                 }
                 _ => {
                     let object = self.parse_object()?;
-                    self.sink_emit_triple(subject, predicate, object);
+                    self.sink_emit_triple(subject, predicate, object)?;
                     if matches!(
                         self.current().kind,
                         TokenKind::Tilde | TokenKind::AnnotationOpen
@@ -649,7 +676,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             let mut index: i32 = 0;
             while !matches!(p.current().kind, TokenKind::RParen) {
                 let item = p.parse_object()?;
-                p.sink_emit_list_item(subject, predicate, item, index);
+                p.sink_emit_list_item(subject, predicate, item, index)?;
                 index += 1;
             }
             p.expect(&TokenKind::RParen)?;
@@ -903,14 +930,14 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
             loop {
                 let item = p.parse_object()?;
-                p.sink_emit_triple(current_node, rdf_first, item);
+                p.sink_emit_triple(current_node, rdf_first, item)?;
 
                 if matches!(p.current().kind, TokenKind::RParen) {
-                    p.sink_emit_triple(current_node, rdf_rest, rdf_nil);
+                    p.sink_emit_triple(current_node, rdf_rest, rdf_nil)?;
                     break;
                 }
                 let next_node = p.sink_term_blank(None);
-                p.sink_emit_triple(current_node, rdf_rest, next_node);
+                p.sink_emit_triple(current_node, rdf_rest, next_node)?;
                 current_node = next_node;
             }
 
@@ -1025,9 +1052,8 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             // base triple, then the reifier attachment (documented divergence
             // from RDF 1.2's non-asserting `<< >>`; see the roadmap's construct
             // inventory).
-            p.sink_emit_triple(subject, predicate, object);
-            p.sink
-                .emit_reified_triple(subject, predicate, object, reifier);
+            p.sink_emit_triple(subject, predicate, object)?;
+            p.sink_emit_reified_triple(subject, predicate, object, reifier)?;
 
             Ok(reifier)
         })
@@ -1156,8 +1182,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
                     self.check_star_allowed("reifier ('~')")?;
                     self.advance()?;
                     let reifier = self.parse_reifier_term()?;
-                    self.sink
-                        .emit_reified_triple(subject, predicate, object, reifier);
+                    self.sink_emit_reified_triple(subject, predicate, object, reifier)?;
                     pending = Some(reifier);
                 }
                 TokenKind::AnnotationOpen => {
@@ -1167,7 +1192,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
                         Some(r) => r,
                         None => {
                             let r = self.sink_term_blank(None);
-                            self.sink.emit_reified_triple(subject, predicate, object, r);
+                            self.sink_emit_reified_triple(subject, predicate, object, r)?;
                             r
                         }
                     };
@@ -1278,7 +1303,7 @@ mod tests {
     fn parse_to_graph(input: &str) -> Result<Graph> {
         let mut sink = GraphCollectorSink::new();
         parse(input, &mut sink)?;
-        Ok(sink.finish())
+        Ok(sink.into_graph())
     }
 
     #[test]
@@ -1693,7 +1718,7 @@ mod tests {
         ";
         let mut sink = GraphCollectorSink::new();
         parse(turtle, &mut sink).expect("bare [ ... ] . statement must parse");
-        assert_eq!(sink.finish().len(), 2);
+        assert_eq!(sink.into_graph().len(), 2);
     }
 
     // =========================================================================
@@ -1765,9 +1790,15 @@ mod tests {
         fn term_literal_value(&mut self, value: LiteralValue, _datatype: Datatype) -> TermId {
             self.add(RecTerm::Literal(value.lexical()))
         }
-        fn emit_triple(&mut self, subject: TermId, predicate: TermId, object: TermId) {
+        fn emit_triple(
+            &mut self,
+            subject: TermId,
+            predicate: TermId,
+            object: TermId,
+        ) -> fluree_graph_ir::SinkResult {
             let t = (self.t(subject), self.t(predicate), self.t(object));
             self.triples.push(t);
+            Ok(())
         }
         fn supports_reified_triples(&self) -> bool {
             true
@@ -1778,7 +1809,7 @@ mod tests {
             predicate: TermId,
             object: TermId,
             reifier: TermId,
-        ) {
+        ) -> fluree_graph_ir::SinkResult {
             let r = (
                 self.t(subject),
                 self.t(predicate),
@@ -1786,6 +1817,7 @@ mod tests {
                 self.t(reifier),
             );
             self.reified.push(r);
+            Ok(())
         }
     }
 
@@ -2086,6 +2118,142 @@ mod tests {
     #[test]
     fn deeply_nested_property_lists_do_not_overflow_the_stack() {
         assert_depth_err(parse_to_graph(&nested_property_lists(100_000)).expect_err("deep"));
+    }
+
+    // =========================================================================
+    // Sink protocol: early termination + statement lifecycle
+    // =========================================================================
+
+    /// A sink that accepts `budget` triples and then fails, standing in for a
+    /// writer whose downstream pipe closed (`fluree rdf convert f.ttl | head`).
+    struct FailingSink {
+        budget: usize,
+        emitted: usize,
+        statements: usize,
+        finished: usize,
+    }
+
+    impl FailingSink {
+        fn new(budget: usize) -> Self {
+            Self {
+                budget,
+                emitted: 0,
+                statements: 0,
+                finished: 0,
+            }
+        }
+    }
+
+    impl GraphSink for FailingSink {
+        fn on_base(&mut self, _base_iri: &str) {}
+        fn on_prefix(&mut self, _prefix: &str, _namespace_iri: &str) {}
+        fn term_iri(&mut self, _iri: &str) -> TermId {
+            TermId::new(0)
+        }
+        fn term_blank(&mut self, _label: Option<&str>) -> TermId {
+            TermId::new(0)
+        }
+        fn term_literal(
+            &mut self,
+            _value: &str,
+            _datatype: Datatype,
+            _language: Option<&str>,
+        ) -> TermId {
+            TermId::new(0)
+        }
+        fn term_literal_value(&mut self, _value: LiteralValue, _datatype: Datatype) -> TermId {
+            TermId::new(0)
+        }
+        fn emit_triple(
+            &mut self,
+            _subject: TermId,
+            _predicate: TermId,
+            _object: TermId,
+        ) -> fluree_graph_ir::SinkResult {
+            if self.emitted >= self.budget {
+                return Err(fluree_graph_ir::SinkError::Io(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "downstream closed",
+                )));
+            }
+            self.emitted += 1;
+            Ok(())
+        }
+        fn end_statement(&mut self) {
+            self.statements += 1;
+        }
+        fn finish(&mut self) -> fluree_graph_ir::SinkResult {
+            self.finished += 1;
+            Ok(())
+        }
+    }
+
+    fn many_statements(n: usize) -> String {
+        let mut doc = String::from("@prefix ex: <http://example.org/> .\n");
+        for i in 0..n {
+            doc.push_str(&format!("ex:s{i} ex:p ex:o{i} .\n"));
+        }
+        doc
+    }
+
+    /// The `| head -5` case: once the sink refuses, parsing stops at that
+    /// statement instead of running to EOF against a dead pipe.
+    #[test]
+    fn sink_failure_terminates_the_parse_immediately() {
+        let mut sink = FailingSink::new(5);
+        let err = parse(&many_statements(10_000), &mut sink)
+            .expect_err("a refusing sink must fail the parse");
+
+        assert!(
+            matches!(&err, TurtleError::Sink(e) if e.is_broken_pipe()),
+            "the sink's error must survive, not be flattened into a generic parse error: {err}"
+        );
+        assert_eq!(sink.emitted, 5, "no emission past the budget");
+        // The `@prefix` directive plus five completed triple statements. The
+        // sixth failed mid-flight and so was never terminated — exactly what
+        // statement-scoped buffering needs.
+        assert_eq!(sink.statements, 6);
+    }
+
+    /// `end_statement` fires once per completed statement, and directives
+    /// count as statements (Turtle grammar: `statement ::= directive |
+    /// triples '.'`).
+    #[test]
+    fn end_statement_fires_once_per_completed_statement() {
+        let mut sink = FailingSink::new(usize::MAX);
+        parse(&many_statements(3), &mut sink).unwrap();
+        // 1 `@prefix` directive + 3 triple statements.
+        assert_eq!(sink.statements, 4);
+        assert_eq!(sink.emitted, 3);
+    }
+
+    /// A multi-triple statement is ONE statement: the boundary is the `.`,
+    /// not the triple, so statement-scoped literal ids stay live across the
+    /// whole predicate-object list.
+    #[test]
+    fn predicate_object_list_is_a_single_statement() {
+        let mut sink = FailingSink::new(usize::MAX);
+        parse(
+            r#"@prefix ex: <http://example.org/> .
+               ex:s ex:p "a", "b" ; ex:q "c" .
+            "#,
+            &mut sink,
+        )
+        .unwrap();
+        assert_eq!(sink.emitted, 3);
+        assert_eq!(sink.statements, 2, "one directive + one triple statement");
+    }
+
+    /// The parser never calls the protocol `finish()`: a sink can be fed by
+    /// many `parse()` calls (one per chunk on the bulk-import path), so
+    /// flushing is the owner's call, not the producer's.
+    #[test]
+    fn the_parser_does_not_call_protocol_finish() {
+        let mut sink = FailingSink::new(usize::MAX);
+        parse(&many_statements(3), &mut sink).unwrap();
+        parse(&many_statements(3), &mut sink).unwrap();
+        assert_eq!(sink.finished, 0);
+        assert_eq!(sink.emitted, 6, "both parses fed the same sink");
     }
 
     /// Siblings at the same level do not accumulate depth: only the nesting

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -2238,6 +2238,72 @@ mod tests {
     }
 
     // =========================================================================
+    // Blank-node namespace disjointness
+    // =========================================================================
+
+    /// User-written labels and parser-minted anonymous nodes must never
+    /// collide. An isomorphism check structurally CANNOT catch this: merged
+    /// nodes are isomorphic to themselves, so the merged graph looks
+    /// well-formed. Only counting distinct identities finds it.
+    ///
+    /// Spine mode makes it systematic — every collection mints spine nodes —
+    /// but `[ … ]` and reifiers hit the same mint, so this guards all of them.
+    #[test]
+    fn minted_blanks_never_collide_with_user_written_labels() {
+        // `_:b1`/`_:b2` are exactly what a naive `b{N}` counter mints.
+        let doc = r#"
+            @prefix ex: <http://example.org/> .
+            _:b1 ex:p "user-one" .
+            _:b2 ex:p "user-two" .
+            ex:s ex:list ( ex:a ex:b ) .
+            ex:t ex:has [ ex:q "anon" ] .
+        "#;
+
+        for (mode, options) in [
+            ("spine", ParserOptions::conformant()),
+            ("default", ParserOptions::default()),
+        ] {
+            let mut sink = GraphCollectorSink::new();
+            parse_with_options(doc, &mut sink, options).expect("parses");
+            let graph = sink.into_graph();
+
+            // Each user label must own exactly the one triple written for it.
+            for (label, object) in [("b1", "user-one"), ("b2", "user-two")] {
+                let owned: Vec<String> = graph
+                    .iter()
+                    .filter(|t| matches!(&t.s, Term::BlankNode(b) if b.as_str() == label))
+                    .map(|t| format!("{} {} {}", t.s, t.p, t.o))
+                    .collect();
+                assert_eq!(
+                    owned.len(),
+                    1,
+                    "[{mode}] _:{label} must own only its own triple; extra triples mean a \
+                     minted node merged into it: {owned:#?}"
+                );
+                assert!(owned[0].contains(object), "[{mode}] {owned:?}");
+            }
+
+            // And no minted label may be lexable as a user label, which is
+            // what makes the disjointness structural rather than lucky.
+            let minted: Vec<String> = graph
+                .iter()
+                .flat_map(|t| [&t.s, &t.o])
+                .filter_map(|t| match t {
+                    Term::BlankNode(b) => Some(b.as_str().to_string()),
+                    _ => None,
+                })
+                .filter(|l| l != "b1" && l != "b2")
+                .collect();
+            for label in &minted {
+                assert!(
+                    label.starts_with('-'),
+                    "[{mode}] minted label {label} can lex as BLANK_NODE_LABEL and so can collide"
+                );
+            }
+        }
+    }
+
+    // =========================================================================
     // ParserOptions — collection + numeric conformance
     // =========================================================================
     //

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -2120,6 +2120,45 @@ mod tests {
         assert_depth_err(parse_to_graph(&nested_property_lists(100_000)).expect_err("deep"));
     }
 
+    /// End-to-end guard for the statement-scoped literal recycling that
+    /// `end_statement` enables in `GraphCollectorSink`: a later statement
+    /// reuses an earlier statement's literal slot, so if any triple held a
+    /// slot reference instead of a clone, the earlier values would be
+    /// overwritten here.
+    #[test]
+    fn recycled_literal_slots_do_not_corrupt_earlier_statements() {
+        let input = r#"
+            @prefix ex: <http://example.org/> .
+            ex:a ex:p "one" .
+            ex:b ex:p "two" .
+            ex:c ex:p "three", "four" .
+        "#;
+        let graph = parse_to_graph(input).unwrap();
+        assert_eq!(graph.len(), 4);
+
+        let mut pairs: Vec<(String, String)> = graph
+            .iter()
+            .map(|t| {
+                let subject = t.s.as_iri().expect("IRI subject").to_string();
+                let object = match &t.o {
+                    Term::Literal { value, .. } => value.lexical(),
+                    other => panic!("expected literal, got {other:?}"),
+                };
+                (subject, object)
+            })
+            .collect();
+        pairs.sort();
+        assert_eq!(
+            pairs,
+            vec![
+                ("http://example.org/a".to_string(), "one".to_string()),
+                ("http://example.org/b".to_string(), "two".to_string()),
+                ("http://example.org/c".to_string(), "four".to_string()),
+                ("http://example.org/c".to_string(), "three".to_string()),
+            ]
+        );
+    }
+
     // =========================================================================
     // Sink protocol: early termination + statement lifecycle
     // =========================================================================

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -1276,6 +1276,26 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         predicate: TermId,
         object: TermId,
     ) -> Result<()> {
+        // TERM-LIFETIME HAZARD, named here because this is the one place it
+        // can bite. `object` may be a LITERAL id, and it stays live across the
+        // annotation body — which mints further terms, including literals of
+        // its own — before being handed to `emit_reified_triple` below.
+        //
+        // Everywhere else the parser emits a literal immediately after minting
+        // it, so at most one literal id is live at a time and a sink may
+        // recycle literal slots per statement (see `GraphSink::end_statement`)
+        // without any live id being clobbered. Here that is not true: the
+        // invariant this code relies on is that a sink does NOT reuse a
+        // literal slot until `end_statement`, and the whole annotation tail is
+        // inside one statement.
+        //
+        // Unreachable today — star constructs require
+        // `supports_reified_triples()`, and the only recycling sink
+        // (`GraphCollectorSink`) returns false, so no sink both recycles and
+        // accepts these events. It becomes live the moment a writer sink
+        // supports both. A sink that does must either keep literal ids valid
+        // for the whole statement (what `end_statement` already promises) or
+        // this function must materialize `object` before parsing the body.
         let mut pending: Option<TermId> = None;
         loop {
             match self.current().kind {

--- a/fluree-graph-turtle/src/splitter.rs
+++ b/fluree-graph-turtle/src/splitter.rs
@@ -25,7 +25,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::{parse, tokenize, TokenKind};
-use fluree_graph_ir::{Datatype, GraphSink, LiteralValue, TermId};
+use fluree_graph_ir::{Datatype, GraphSink, LiteralValue, SinkResult, TermId};
 
 // ============================================================================
 // Configuration
@@ -890,7 +890,9 @@ impl GraphSink for PreludeSink {
         TermId::new(0)
     }
 
-    fn emit_triple(&mut self, _subject: TermId, _predicate: TermId, _object: TermId) {}
+    fn emit_triple(&mut self, _subject: TermId, _predicate: TermId, _object: TermId) -> SinkResult {
+        Ok(())
+    }
 
     fn emit_list_item(
         &mut self,
@@ -898,7 +900,8 @@ impl GraphSink for PreludeSink {
         _predicate: TermId,
         _object: TermId,
         _index: i32,
-    ) {
+    ) -> SinkResult {
+        Ok(())
     }
 }
 

--- a/fluree-graph-turtle/tests/adversarial_recycling.rs
+++ b/fluree-graph-turtle/tests/adversarial_recycling.rs
@@ -12,13 +12,23 @@
 //! another, which per-triple assertions written by the same author who wrote
 //! the recycling are unlikely to anticipate.
 //!
-//! Mutation-checked: making the recycling unsound (recycling IRI slots, which
-//! the parser caches across statements) fails
-//! `hostile_document_default_mode_matches_the_no_recycle_oracle` and
-//! `hostile_document_spine_mode_matches_the_no_recycle_oracle`. Keep it that
-//! way — a differential that cannot fail is worse than no test, and the
-//! single-sink and failed-statement cases below do NOT catch that mutation on
-//! their own.
+//! Mutation-checked, and the limits are part of the record:
+//!
+//! - Recycling IRI slots — which the parser caches across statements — fails
+//!   `hostile_document_default_mode_matches_the_no_recycle_oracle` and
+//!   `hostile_document_spine_mode_matches_the_no_recycle_oracle`. The
+//!   single-sink and failed-statement cases do NOT catch it, so those two are
+//!   load-bearing; don't trim the corpus believing they are redundant.
+//! - Always reusing literal slot 0 escapes this differential entirely. It is
+//!   caught by the `fluree-graph-ir` unit tests instead
+//!   (`literal_slots_are_reused_after_a_statement_ends`,
+//!   `the_term_table_tracks_the_widest_statement_not_the_document`). The
+//!   reason: outside the annotation path the parser emits each literal
+//!   immediately after minting it, so at most one literal id is live at a
+//!   time and slot-0-collapse is observationally equivalent here. This
+//!   differential's power is the aliasing dimension, not statement width — if
+//!   a future producer holds several literal ids at once, that changes and
+//!   this file should grow a case for it.
 
 use fluree_graph_ir::{
     Datatype, Graph, GraphCollectorSink, GraphSink, LiteralValue, SinkResult, TermId,

--- a/fluree-graph-turtle/tests/adversarial_recycling.rs
+++ b/fluree-graph-turtle/tests/adversarial_recycling.rs
@@ -22,13 +22,22 @@
 //! - Always reusing literal slot 0 escapes this differential entirely. It is
 //!   caught by the `fluree-graph-ir` unit tests instead
 //!   (`literal_slots_are_reused_after_a_statement_ends`,
-//!   `the_term_table_tracks_the_widest_statement_not_the_document`). The
-//!   reason: outside the annotation path the parser emits each literal
-//!   immediately after minting it, so at most one literal id is live at a
-//!   time and slot-0-collapse is observationally equivalent here. This
-//!   differential's power is the aliasing dimension, not statement width — if
-//!   a future producer holds several literal ids at once, that changes and
-//!   this file should grow a case for it.
+//!   `the_term_table_tracks_the_widest_statement_not_the_document`).
+//!
+//!   The reason, stated precisely: **no literal is minted while another
+//!   literal id is live.** Not "one term id at a time" — the parser routinely
+//!   holds several. `parse_reified_triple` holds a possibly-literal `object`
+//!   while it mints the reifier, but the reifier grammar is `iri | BlankNode`,
+//!   so the term minted there is never a literal. Only
+//!   `parse_annotation_tail` breaks the rule, by holding `object` across an
+//!   annotation body that can mint literals of its own — and it is
+//!   unreachable from a recycling sink today (see the comment at that
+//!   function).
+//!
+//!   So slot-0-collapse is observationally equivalent here, and this
+//!   differential's power is the aliasing dimension rather than statement
+//!   width. If a producer ever mints a literal while another literal id is
+//!   live, that stops being true and this file needs a case for it.
 
 use fluree_graph_ir::{
     Datatype, Graph, GraphCollectorSink, GraphSink, LiteralValue, SinkResult, TermId,
@@ -67,6 +76,61 @@ impl GraphSink for NoRecycle {
     }
     // end_statement deliberately NOT forwarded — this is the control arm.
 }
+
+/// Records the statement-lifecycle events in order, forwarding everything to
+/// a real collector. The protocol publishes "exactly one of
+/// `end_statement`/`abort_statement` per statement", and that is a claim about
+/// the SEQUENCE, not about the resulting graph — a wrong sequence can still
+/// produce a correct graph today and corrupt a buffering sink tomorrow. So
+/// assert the sequence.
+#[derive(Default)]
+struct LoggingSink {
+    inner: GraphCollectorSink,
+    log: Vec<&'static str>,
+}
+
+impl GraphSink for LoggingSink {
+    fn on_base(&mut self, b: &str) {
+        self.inner.on_base(b);
+    }
+    fn on_prefix(&mut self, p: &str, n: &str) {
+        self.inner.on_prefix(p, n);
+    }
+    fn term_iri(&mut self, i: &str) -> TermId {
+        self.inner.term_iri(i)
+    }
+    fn term_blank(&mut self, l: Option<&str>) -> TermId {
+        self.inner.term_blank(l)
+    }
+    fn term_literal(&mut self, v: &str, d: Datatype, l: Option<&str>) -> TermId {
+        self.inner.term_literal(v, d, l)
+    }
+    fn term_literal_value(&mut self, v: LiteralValue, d: Datatype) -> TermId {
+        self.inner.term_literal_value(v, d)
+    }
+    fn emit_triple(&mut self, s: TermId, p: TermId, o: TermId) -> SinkResult {
+        self.log.push("Emit");
+        self.inner.emit_triple(s, p, o)
+    }
+    fn emit_list_item(&mut self, s: TermId, p: TermId, o: TermId, i: i32) -> SinkResult {
+        self.log.push("Emit");
+        self.inner.emit_list_item(s, p, o, i)
+    }
+    fn end_statement(&mut self) {
+        self.log.push("End");
+        self.inner.end_statement();
+    }
+    fn abort_statement(&mut self) {
+        self.log.push("Abort");
+        self.inner.abort_statement();
+    }
+}
+
+/// Two committed statements — the `@prefix` directive and one triple
+/// statement — followed by a third that fails somehow.
+const TWO_GOOD_THEN: &str = r#"@prefix ex: <http://example.org/> .
+                 ex:a ex:p "1" ; ex:q "2" .
+"#;
 
 fn rows(g: &Graph) -> Vec<String> {
     let mut v: Vec<String> = g
@@ -171,15 +235,20 @@ fn one_sink_many_parses_survives_recycling() {
 /// rejected statement would leave partial triples behind.
 #[test]
 fn failed_statement_contributes_nothing() {
-    let mut sink = GraphCollectorSink::new();
-    // Statement 1 completes (2 literals). Statement 2 emits one triple then
-    // hits a syntax error before its terminator.
-    let doc = r#"@prefix ex: <http://example.org/> .
-                 ex:a ex:p "1" ; ex:q "2" .
-                 ex:b ex:p "3" ; ex:q @@@ ."#;
-    parse(doc, &mut sink).expect_err("statement 2 must fail");
+    // Statement 3 emits one triple, then hits a lexical error at its second
+    // object — inside the statement, before its terminator.
+    let doc = format!("{TWO_GOOD_THEN}                 ex:b ex:p \"3\" ; ex:q @@@ .");
+    let mut sink = LoggingSink::default();
+    parse(&doc, &mut sink).expect_err("statement 3 must fail");
 
-    let g = sink.into_graph();
+    assert_eq!(
+        sink.log,
+        vec!["End", "Emit", "Emit", "End", "Emit", "Abort"],
+        "the failing statement emitted once and was then aborted, and neither \
+         committed statement was disturbed"
+    );
+
+    let g = sink.inner.into_graph();
     let objects: Vec<String> = g
         .iter()
         .map(|t| t.o.to_string())
@@ -189,29 +258,63 @@ fn failed_statement_contributes_nothing() {
         !objects.iter().any(|o| o.contains("\"3\"")),
         "the failed statement's triples must be rolled back, got {objects:?}"
     );
-    // …and only the failed statement is rolled back; the committed one stays.
     assert_eq!(
         objects.len(),
         2,
-        "statement 1 must survive intact: {objects:?}"
+        "statement 2 must survive intact: {objects:?}"
     );
-    assert!(objects.iter().any(|o| o.contains("\"1\"")), "{objects:?}");
-    assert!(objects.iter().any(|o| o.contains("\"2\"")), "{objects:?}");
 }
 
-/// The rollback must not fire when the statement failed before emitting —
-/// there is nothing to roll back, and a spurious `abort_statement` would
-/// discard the PREVIOUS statement (whose triples sit past the mark only
-/// until `end_statement` advances it).
+/// A statement that fails BEFORE emitting must not abort: there is nothing to
+/// roll back, and a spurious `abort_statement` would discard the previous
+/// statement, whose triples sit past the mark until `end_statement` advances
+/// it. This is the true branch of the `emit_count` guard.
+///
+/// `"strsubject"` is chosen deliberately: it LEXES fine (it is a valid string
+/// token) and is rejected by `parse_subject`, so the failure lands inside
+/// statement 3 with zero emissions — which a lexical error could not do.
 #[test]
-fn failure_before_any_emit_leaves_earlier_statements_intact() {
-    let mut sink = GraphCollectorSink::new();
-    // Statement 2 fails at its subject, before a single triple is emitted.
-    let doc = r#"@prefix ex: <http://example.org/> .
-                 ex:a ex:p "1" ; ex:q "2" .
-                 @@@ ex:p "3" ."#;
-    parse(doc, &mut sink).expect_err("statement 2 must fail");
+fn failure_before_any_emit_does_not_abort() {
+    let doc = format!("{TWO_GOOD_THEN}                 \"strsubject\" ex:p \"3\" .");
+    let mut sink = LoggingSink::default();
+    parse(&doc, &mut sink).expect_err("a literal subject must be rejected");
 
-    let g = sink.into_graph();
-    assert_eq!(g.len(), 2, "the committed statement must survive");
+    assert_eq!(
+        sink.log,
+        vec!["End", "Emit", "Emit", "End"],
+        "no Abort: the failing statement never emitted"
+    );
+    assert_eq!(
+        sink.inner.into_graph().len(),
+        2,
+        "the committed statements must survive"
+    );
+}
+
+/// The other guard: a statement that already COMMITTED at its `.` must not be
+/// aborted either. It reaches the error arm only because the one-token
+/// lookahead failed while reading the NEXT statement — the committed
+/// statement is complete and valid.
+///
+/// `@@@` is a LEXICAL error, raised while advancing past statement 2's
+/// terminator, so it surfaces from statement 2's own parse call. Before the
+/// `committed_current` guard this logged a trailing `Abort`, breaking the
+/// published "exactly one of end/abort per statement" contract (the graph
+/// survived only because the commit had already moved the sink's mark).
+#[test]
+fn lexical_error_in_lookahead_does_not_abort_the_committed_statement() {
+    let doc = format!("{TWO_GOOD_THEN}                 @@@ ex:p \"3\" .");
+    let mut sink = LoggingSink::default();
+    parse(&doc, &mut sink).expect_err("@@@ must fail to lex");
+
+    assert_eq!(
+        sink.log,
+        vec!["End", "Emit", "Emit", "End"],
+        "no Abort: statement 2 had already committed at its terminator"
+    );
+    assert_eq!(
+        sink.inner.into_graph().len(),
+        2,
+        "the committed statements must survive"
+    );
 }

--- a/fluree-graph-turtle/tests/adversarial_recycling.rs
+++ b/fluree-graph-turtle/tests/adversarial_recycling.rs
@@ -154,21 +154,21 @@ fn one_sink_many_parses_survives_recycling() {
     assert_eq!(rows(&recycling.into_graph()), rows(&control.0.into_graph()));
 }
 
-/// A statement that FAILS after emitting: the parser returns Err without
-/// calling `end_statement`, so the failed statement's literal slots stay
-/// consumed. Documents the observable consequence for a resuming producer.
+/// A statement that FAILS after emitting contributes NOTHING: the parser
+/// calls `abort_statement` and the sink rolls back to the statement
+/// boundary. This is riot's semantics, and what `--continue-on-error` has to
+/// guarantee — the parser emits during descent, so without the rollback a
+/// rejected statement would leave partial triples behind.
 #[test]
-fn failed_statement_leaves_its_slots_consumed() {
+fn failed_statement_contributes_nothing() {
     let mut sink = GraphCollectorSink::new();
-    // Statement 1 completes (2 literals). Statement 2 emits one literal then
+    // Statement 1 completes (2 literals). Statement 2 emits one triple then
     // hits a syntax error before its terminator.
     let doc = r#"@prefix ex: <http://example.org/> .
                  ex:a ex:p "1" ; ex:q "2" .
                  ex:b ex:p "3" ; ex:q @@@ ."#;
     parse(doc, &mut sink).expect_err("statement 2 must fail");
 
-    // The graph already holds the half-statement's triple — there is no
-    // rollback hook in the protocol.
     let g = sink.into_graph();
     let objects: Vec<String> = g
         .iter()
@@ -176,7 +176,32 @@ fn failed_statement_leaves_its_slots_consumed() {
         .filter(|s| s.starts_with('"'))
         .collect();
     assert!(
-        objects.iter().any(|o| o.contains("\"3\"")),
-        "half-emitted statement is retained by the sink: {objects:?}"
+        !objects.iter().any(|o| o.contains("\"3\"")),
+        "the failed statement's triples must be rolled back, got {objects:?}"
     );
+    // …and only the failed statement is rolled back; the committed one stays.
+    assert_eq!(
+        objects.len(),
+        2,
+        "statement 1 must survive intact: {objects:?}"
+    );
+    assert!(objects.iter().any(|o| o.contains("\"1\"")), "{objects:?}");
+    assert!(objects.iter().any(|o| o.contains("\"2\"")), "{objects:?}");
+}
+
+/// The rollback must not fire when the statement failed before emitting —
+/// there is nothing to roll back, and a spurious `abort_statement` would
+/// discard the PREVIOUS statement (whose triples sit past the mark only
+/// until `end_statement` advances it).
+#[test]
+fn failure_before_any_emit_leaves_earlier_statements_intact() {
+    let mut sink = GraphCollectorSink::new();
+    // Statement 2 fails at its subject, before a single triple is emitted.
+    let doc = r#"@prefix ex: <http://example.org/> .
+                 ex:a ex:p "1" ; ex:q "2" .
+                 @@@ ex:p "3" ."#;
+    parse(doc, &mut sink).expect_err("statement 2 must fail");
+
+    let g = sink.into_graph();
+    assert_eq!(g.len(), 2, "the committed statement must survive");
 }

--- a/fluree-graph-turtle/tests/adversarial_recycling.rs
+++ b/fluree-graph-turtle/tests/adversarial_recycling.rs
@@ -1,0 +1,182 @@
+//! Differential guard for statement-scoped literal-slot recycling.
+//!
+//! The same document is parsed into a `GraphCollectorSink` that recycles
+//! (`end_statement` reaches it) and into one that never recycles
+//! (`end_statement` swallowed by a forwarding wrapper — "today's behavior" as
+//! the oracle). Any `TermId` that outlives its statement while still
+//! referenced shows up as a divergence between the two graphs.
+//!
+//! This is a differential rather than a set of hand-written expectations
+//! because the failure mode is aliasing, not arithmetic: a wrong answer here
+//! looks like a perfectly well-formed graph with one term substituted for
+//! another, which per-triple assertions written by the same author who wrote
+//! the recycling are unlikely to anticipate.
+//!
+//! Mutation-checked: making the recycling unsound (recycling IRI slots, which
+//! the parser caches across statements) fails
+//! `hostile_document_default_mode_matches_the_no_recycle_oracle` and
+//! `hostile_document_spine_mode_matches_the_no_recycle_oracle`. Keep it that
+//! way — a differential that cannot fail is worse than no test, and the
+//! single-sink and failed-statement cases below do NOT catch that mutation on
+//! their own.
+
+use fluree_graph_ir::{
+    Datatype, Graph, GraphCollectorSink, GraphSink, LiteralValue, SinkResult, TermId,
+};
+use fluree_graph_turtle::{parse, parse_with_options, CollectionStyle, ParserOptions};
+
+/// Forwards every protocol method to an inner `GraphCollectorSink` EXCEPT
+/// `end_statement`, which it swallows — so the inner sink never recycles a
+/// literal slot. This is "today's behavior" as the oracle.
+struct NoRecycle(GraphCollectorSink);
+
+impl GraphSink for NoRecycle {
+    fn on_base(&mut self, base_iri: &str) {
+        self.0.on_base(base_iri);
+    }
+    fn on_prefix(&mut self, prefix: &str, ns: &str) {
+        self.0.on_prefix(prefix, ns);
+    }
+    fn term_iri(&mut self, iri: &str) -> TermId {
+        self.0.term_iri(iri)
+    }
+    fn term_blank(&mut self, label: Option<&str>) -> TermId {
+        self.0.term_blank(label)
+    }
+    fn term_literal(&mut self, v: &str, dt: Datatype, lang: Option<&str>) -> TermId {
+        self.0.term_literal(v, dt, lang)
+    }
+    fn term_literal_value(&mut self, v: LiteralValue, dt: Datatype) -> TermId {
+        self.0.term_literal_value(v, dt)
+    }
+    fn emit_triple(&mut self, s: TermId, p: TermId, o: TermId) -> SinkResult {
+        self.0.emit_triple(s, p, o)
+    }
+    fn emit_list_item(&mut self, s: TermId, p: TermId, o: TermId, i: i32) -> SinkResult {
+        self.0.emit_list_item(s, p, o, i)
+    }
+    // end_statement deliberately NOT forwarded — this is the control arm.
+}
+
+fn rows(g: &Graph) -> Vec<String> {
+    let mut v: Vec<String> = g
+        .iter()
+        .map(|t| format!("{} {} {} [{:?}]", t.s, t.p, t.o, t.list_index()))
+        .collect();
+    v.sort();
+    v
+}
+
+fn differential(doc: &str, options: ParserOptions) {
+    let mut recycling = GraphCollectorSink::new();
+    parse_with_options(doc, &mut recycling, options).expect("recycling parse");
+
+    let mut control = NoRecycle(GraphCollectorSink::new());
+    parse_with_options(doc, &mut control, options).expect("control parse");
+
+    assert_eq!(
+        rows(&recycling.into_graph()),
+        rows(&control.0.into_graph()),
+        "recycling diverged from the never-recycle oracle for:\n{doc}"
+    );
+}
+
+/// Every construct that emits during descent, with literal counts that shrink
+/// and grow across statement boundaries so slots get reused at every width.
+const HOSTILE: &str = r#"
+@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# wide statement: many literals, mixed kinds, one statement
+ex:wide ex:a "l1" ; ex:b "l2"@en ; ex:c "l3"^^xsd:token ; ex:d 1 ; ex:e 2.5 ;
+        ex:f 3.0e0 ; ex:g true ; ex:h "l1" , "l1" , "l2" .
+
+# narrow statement immediately after: reuses slot 0 only
+ex:narrow ex:a "only" .
+
+# blank-node property list: emits during descent, literals at two depths
+ex:outer ex:has [ ex:x "inner1" ; ex:y [ ex:z "inner2" ; ex:w "inner3" ] ] ;
+         ex:tail "outer-tail" .
+
+# collection of literals in object position
+ex:coll ex:items ( "c1" "c2" "c3" ) .
+
+# nested collection with literals at both levels
+ex:nest ex:items ( "n1" ( "n2" "n3" ) "n4" ) .
+
+# subject-position collection (always a spine) whose items are literals
+( "s1" "s2" ) ex:p "s-obj" .
+
+# empty collection then a wide statement again
+ex:empty ex:e () .
+ex:wide2 ex:a "z1" ; ex:b "z2" ; ex:c "z3" ; ex:d "z4" ; ex:e "z5" ; ex:f "z6" .
+
+# repeated identical literals across statements (slot aliasing bait)
+ex:r1 ex:p "same" .
+ex:r2 ex:p "same" .
+ex:r3 ex:p "same" , "same" , "same" .
+
+# blank node labels that look like the anonymous mint
+_:b0 ex:p "labeled0" .
+_:b1 ex:p "labeled1" ; ex:q [ ex:r "anon-in-labeled" ] .
+"#;
+
+#[test]
+fn hostile_document_default_mode_matches_the_no_recycle_oracle() {
+    differential(HOSTILE, ParserOptions::default());
+}
+
+#[test]
+fn hostile_document_spine_mode_matches_the_no_recycle_oracle() {
+    differential(HOSTILE, ParserOptions::conformant());
+    differential(
+        HOSTILE,
+        ParserOptions::new().with_collections(CollectionStyle::Spine),
+    );
+}
+
+/// The bulk-import shape: one sink, many `parse()` calls. Slots retired by the
+/// last statement of chunk N are handed out again in chunk N+1.
+#[test]
+fn one_sink_many_parses_survives_recycling() {
+    let chunks = [
+        r#"@prefix ex: <http://example.org/> . ex:a ex:p "1" ; ex:q "2" ; ex:r "3" ."#,
+        r#"@prefix ex: <http://example.org/> . ex:b ex:p "4" ."#,
+        r#"@prefix ex: <http://example.org/> . ex:c ex:p "5" ; ex:q "6" ; ex:r "7" ; ex:s "8" ."#,
+    ];
+
+    let mut recycling = GraphCollectorSink::new();
+    let mut control = NoRecycle(GraphCollectorSink::new());
+    for c in chunks {
+        parse(c, &mut recycling).unwrap();
+        parse(c, &mut control).unwrap();
+    }
+    assert_eq!(rows(&recycling.into_graph()), rows(&control.0.into_graph()));
+}
+
+/// A statement that FAILS after emitting: the parser returns Err without
+/// calling `end_statement`, so the failed statement's literal slots stay
+/// consumed. Documents the observable consequence for a resuming producer.
+#[test]
+fn failed_statement_leaves_its_slots_consumed() {
+    let mut sink = GraphCollectorSink::new();
+    // Statement 1 completes (2 literals). Statement 2 emits one literal then
+    // hits a syntax error before its terminator.
+    let doc = r#"@prefix ex: <http://example.org/> .
+                 ex:a ex:p "1" ; ex:q "2" .
+                 ex:b ex:p "3" ; ex:q @@@ ."#;
+    parse(doc, &mut sink).expect_err("statement 2 must fail");
+
+    // The graph already holds the half-statement's triple — there is no
+    // rollback hook in the protocol.
+    let g = sink.into_graph();
+    let objects: Vec<String> = g
+        .iter()
+        .map(|t| t.o.to_string())
+        .filter(|s| s.starts_with('"'))
+        .collect();
+    assert!(
+        objects.iter().any(|o| o.contains("\"3\"")),
+        "half-emitted statement is retained by the sink: {objects:?}"
+    );
+}

--- a/fluree-graph-turtle/tests/adversarial_recycling.rs
+++ b/fluree-graph-turtle/tests/adversarial_recycling.rs
@@ -291,6 +291,73 @@ fn failure_before_any_emit_does_not_abort() {
     );
 }
 
+/// LATCH GUARDS. `committed_current` is reset at the start of every statement;
+/// if it ever stopped being reset, it would latch true after the first
+/// committed statement and `abort_statement` would never fire again —
+/// rollback dying silently, which is worse than the contract bug the flag
+/// fixes. A latched flag turns both cases below into no-Abort / 2 triples.
+///
+/// Both use a COMMITTED statement followed by one that emits and then fails,
+/// so the trailing Abort is mandatory.
+#[test]
+fn abort_still_fires_after_a_committed_statement_wrong_terminator() {
+    // `ex:q` sits where the `.` belongs: it lexes fine, the triple is emitted,
+    // and the statement then fails at its terminator.
+    let doc = "@prefix ex: <http://example.org/> .\nex:a ex:p \"1\" .\nex:b ex:p \"2\" ex:q .\n";
+    let mut sink = LoggingSink::default();
+    parse(doc, &mut sink).expect_err("a non-dot terminator must fail");
+
+    assert_eq!(
+        sink.log,
+        vec!["End", "Emit", "End", "Emit", "Abort"],
+        "the flag must have reset: statement 3 emitted and must still abort"
+    );
+    assert_eq!(
+        sink.inner.into_graph().len(),
+        1,
+        "only the committed statement's triple survives"
+    );
+}
+
+#[test]
+fn abort_still_fires_after_a_committed_statement_missing_final_dot() {
+    // Runs out of input before the terminator — the same shape a truncated
+    // file produces.
+    let doc = "@prefix ex: <http://example.org/> .\nex:a ex:p \"1\" .\nex:b ex:p \"2\"\n";
+    let mut sink = LoggingSink::default();
+    parse(doc, &mut sink).expect_err("a missing final dot must fail");
+
+    assert_eq!(
+        sink.log,
+        vec!["End", "Emit", "End", "Emit", "Abort"],
+        "the flag must have reset: statement 3 emitted and must still abort"
+    );
+    assert_eq!(
+        sink.inner.into_graph().len(),
+        1,
+        "only the committed statement's triple survives"
+    );
+}
+
+/// A lexical error can also strike BEFORE the emit, even mid-statement: a
+/// literal's `@lang`/`^^type` suffix is checked by lexing the next token, so
+/// `"2" @@@` fails before the triple is emitted. Recorded because it looks
+/// like the wrong-terminator case above and behaves differently — no Abort,
+/// because nothing was emitted.
+#[test]
+fn lexical_error_in_a_literal_suffix_aborts_nothing() {
+    let doc = "@prefix ex: <http://example.org/> .\nex:a ex:p \"1\" .\nex:b ex:p \"2\" @@@\n";
+    let mut sink = LoggingSink::default();
+    parse(doc, &mut sink).expect_err("@@@ must fail to lex");
+
+    assert_eq!(
+        sink.log,
+        vec!["End", "Emit", "End"],
+        "no Emit and so no Abort: the lexer failed inside the literal's suffix lookahead"
+    );
+    assert_eq!(sink.inner.into_graph().len(), 1);
+}
+
 /// The other guard: a statement that already COMMITTED at its `.` must not be
 /// aborted either. It reaches the error arm only because the one-token
 /// lookahead failed while reading the NEXT statement — the committed

--- a/testsuite-shacl/src/manifest.rs
+++ b/testsuite-shacl/src/manifest.rs
@@ -79,7 +79,7 @@ fn walk(manifest_path: &Path, out: &mut Vec<TestCase>) -> Result<()> {
     let mut sink = GraphCollectorSink::new();
     parse(&content, &mut sink)
         .with_context(|| format!("parsing manifest {}", manifest_path.display()))?;
-    let graph = sink.finish();
+    let graph = sink.into_graph();
 
     let manifest_subject = find_manifest_subject(&graph, &base)
         .ok_or_else(|| anyhow!("no mf:Manifest subject in {}", manifest_path.display()))?;

--- a/testsuite-sparql/src/manifest.rs
+++ b/testsuite-sparql/src/manifest.rs
@@ -109,7 +109,7 @@ impl TestManifest {
         // each test ID *before* the next `load_manifest()` call (enforced by the
         // `loop` in `Iterator::next`). Cross-manifest test references are not
         // supported by the W3C test suite structure.
-        self.graph = sink.finish();
+        self.graph = sink.into_graph();
 
         // Find the manifest subject (type mf:Manifest or has mf:entries/mf:include)
         let manifest_subject = self.find_manifest_subject(url);

--- a/testsuite-sparql/src/result_format.rs
+++ b/testsuite-sparql/src/result_format.rs
@@ -695,7 +695,7 @@ pub fn parse_expected_graph(url: &str) -> Result<Vec<Triple>> {
     let mut sink = GraphCollectorSink::new();
     parse_turtle(&with_base, &mut sink)
         .with_context(|| format!("Parsing expected graph: {url}"))?;
-    let graph = sink.finish();
+    let graph = sink.into_graph();
     Ok(graph
         .iter()
         .map(|t| Triple {
@@ -723,7 +723,7 @@ fn parse_ttl_result(content: &str, url: &str) -> Result<SparqlResults> {
     let with_base = format!("@base <{url}> .\n{content}");
     let mut sink = GraphCollectorSink::new();
     parse_turtle(&with_base, &mut sink).context("Turtle parse error")?;
-    let graph = sink.finish();
+    let graph = sink.into_graph();
 
     // Check for DAWG Result Set vocabulary
     let is_result_set = graph


### PR DESCRIPTION
# PR-0: GraphSink protocol + Turtle ParserOptions

Foundation PR for the `fluree rdf` (riot-analog) effort. It lands nothing
user-visible: it changes the shared parser→sink abstraction so the writers,
converters and diagnostics of the later PRs are expressible at all, and it
makes the Turtle parser able to produce conformant RDF as well as the ingest
shape. Blast radius is every ingest path, so the gate is the full transact +
`fluree-db-api` suites, not the light crates alone.

Implements the locked decisions H-1 (PR-0 split), H-2 (ParserOptions on the
shared parser, ingest pinned to current behavior), and §1.2 of
`riot-analog-pr-plan.md` (fallible emission, `finish()`, quad capability
probe, term lifetime).

## A. GraphSink protocol

**Fallible emission.** `emit_triple` / `emit_list_item` / `emit_reified_triple`
now return `Result<(), SinkError>`, and the new `emit_quad` does too. `term_*`
stay infallible — they intern a term and hand back an id; a writer only
touches its output on emit.

The point is early termination. Today a sink cannot report that its downstream
died, so `convert big.ttl | head -5` would parse to EOF against a closed pipe.
`SinkError` carries an `io::Error` or a rejection message and answers
`is_broken_pipe()`, so a CLI can exit quietly on the expected shutdown and
loudly on a real failure. The Turtle parser stops at the first refusal and
preserves the sink's error as `TurtleError::Sink` rather than flattening it
into a generic parse error; the JSON-LD adapter does the same via
`AdapterError::Sink`.

**Quad capability.** `supports_quads()` + `emit_quad()`, mirroring the existing
`supports_reified_triples` probe. No producer emits quads in this PR — this is
the protocol landing, so M2's TriG/N-Quads readers have something to refuse
against.

The default `emit_quad` body **errors** rather than no-ops. The asymmetry with
`emit_reified_triple` (whose default stays a no-op) is deliberate: every
producer of reified-triple events already refuses the input up-front on the
capability probe, so that default body is unreachable, not a fallback. Nothing
guards quads yet, so the default has to be the guard. Silently folding named
graphs into the default graph is the exact defect the JSON-LD adapter has
today; this is what stops it being repeated.

**Statement lifecycle.** `end_statement()`, called by the Turtle parser at each
statement terminator and only for statements that parsed and emitted cleanly.
It serves two later features that need the same boundary: term lifetime (below)
and the statement-scoped output buffering `--continue-on-error` requires, since
triples are emitted during descent, before the terminating `.` proves the
statement valid. A failed statement never reaches the call, so it contributes
nothing.

**`finish()` and the naming split.** The trait gains
`finish(&mut self) -> Result<(), SinkError>` — flush and finalize, called by
whoever owns the sink, never by a producer (one sink can be fed by many
producer calls, a chunk each on the bulk-import path).

Three sinks already had an inherent `finish()` that *consumed* the sink and
returned its product. Leaving those named `finish()` would have type-checked
while letting a concrete-typed caller silently skip the protocol finish —
survivable for a graph collector, not for a writer. They are renamed to
consuming `into_*` methods, so `finish()` always means "flush" and never "give
me your contents":

| sink | was | now |
| --- | --- | --- |
| `GraphCollectorSink` | `finish() -> Graph` | `into_graph()` |
| `FlakeSink` | `finish() -> Result<Vec<Flake>, _>` | `into_flakes()` |
| `ImportSink` | `finish() -> Result<(writer, prefixes, spool), _>` | `into_parts()` |

Deferred-error semantics are unchanged: `FlakeSink`/`ImportSink` `emit_*` still
record the first invariant violation and keep going, and the consuming method
is still where it becomes a hard error.

**Term lifetime.** `TermId`s now have a documented split. IRI and blank ids are
session-scoped (producers cache them across statements); literal ids are
statement-scoped, because literals are minted per occurrence and never
deduplicated — which is why the term table grew by one live entry per literal
*occurrence* for the length of the document.

`GraphCollectorSink` acts on it: `end_statement` retires the statement's
literal slots for reuse, so the high-water mark is the widest single statement
rather than the whole document (1000 statements × 2 literals leaves 4 slots,
not 2002). Soundness rests on two facts, both pinned by tests: `emit_*` clones
into the graph before returning, so overwriting a slot cannot reach an
already-collected triple; and the parser caches only IRI and prefixed-name ids
across statements.

**This is groundwork, not a shipped win — no production path benefits today.**
`FlakeSink` and `ImportSink`, the sinks on the ingest hot path, ignore
`end_statement` entirely and are deliberately untouched. `GraphCollectorSink`'s
users are the W3C/SHACL testsuite harnesses, the R2RML loader, and
`parse_to_json` — none of them memory-bound. Producers that never delimit
statements, such as the JSON-LD adapter, never recycle at all and keep today's
allocation behavior exactly. The reason to land it here is that the memory
profile of a *writer* sink is the differentiator the effort is being built on,
and the protocol hook plus a proven-sound reference implementation is what a
writer needs to exist. Applying it to the ingest sinks is a separate,
separately-benchmarked change.

**Statement rollback.** `abort_statement()` is the counterpart to
`end_statement()`, and lands now so `--continue-on-error` does not force a
second breaking trait change later. The parser emits during descent — property
lists and collections push triples before the terminating `.` proves the
statement well-formed — so a rejected statement used to leave partial triples
in the sink; riot's "a rejected statement contributes nothing" held only in the
error return, not in the data. The parser calls it only when a statement fails
having already emitted, and exactly one of `end_statement`/`abort_statement`
ends any statement. `GraphCollectorSink` rewinds the graph to a mark taken at
the statement boundary.

Writing that test found a real bug in the first cut: the parser keeps one token
of lookahead, so consuming a statement's `.` lexes the first token of the
*next* statement, and a lexical error there was reported while the finished
statement was still in flight — the rollback then discarded a statement that
was complete and valid. Committing at the terminator, before the lookahead
advance, fixes it; the regression is pinned and mutation-verified.

**Blank-node namespace.** `GraphCollectorSink` minted anonymous blanks as
`b{N}`, the exact shape a document writes by hand, so a file containing `_:b1`
plus any anonymous node produced one node where RDF says two — silently merging
user data into a parser-minted node. Pre-existing via `[ … ]` and reifiers, but
`CollectionStyle::Spine` makes it systematic, since every collection mints
spine nodes. Fixed the way `FlakeSink`/`ImportSink` already do it: mint `-b{N}`,
which cannot lex as a `BLANK_NODE_LABEL` and so is unreachable from any input.
The tests count distinct identities rather than checking isomorphism, because
merged nodes are isomorphic to themselves and an isomorphism check
structurally cannot see this class of bug.

## B. Turtle ParserOptions

The parser canonicalizes in three places that are right for ingest and wrong
for conversion:

- an object-position collection emits flat indexed list items, so the three
  triples W3C defines for `( ex:o )` arrive as one event;
- an object-position `()` emits **nothing** — a silently lost triple, since
  `()` denotes `rdf:nil`;
- `Integer`/`Double` tokens are parsed to native values, so `+1`, `01`, `1e0`,
  `1.0E0` are unrepresentable (`Decimal` and i64-overflowing integers already
  keep their lexical form).

Meanwhile subject-position collections have always emitted a proper spine, so
the two positions disagreed with each other.

`ParserOptions { collections, numerics }` gets both shapes out of one grammar —
one conformance surface, no fork. `ParserOptions::default()` is today's
behavior in every field, so every existing caller is unchanged;
`ParserOptions::conformant()` is the faithful-RDF preset. New entry points
`parse_with_options` and `parse_with_prefixes_base_options` (the latter is the
full one — every other `parse*` delegates to it with something defaulted, so
the chunked reader paths can opt in too).

`CollectionStyle::Spine` needed no new collection code: it drops the
object-list special cases, so `( … )` and `()` fall through to the ordinary
object path, which already builds a spine and already resolves `()` to
`rdf:nil`. Both positions now share one code path.

One consequence worth naming for review: a spine collection has a single object
term (the head), so the RDF 1.2 annotation-on-collection deferral — which
exists *only* because indexed items leave nothing to reify — does not apply in
this mode. The deferral is unchanged in the default mode, and both halves are
pinned by a test.

`NumericStyle::PreserveLexical` routes numeric tokens through the typed-string
lane `Decimal` and `IntegerOverflow` already use. **Deviation from the brief,
flagged for review:** the brief anticipated a new `LiteralValue`/`Datatype`
variant carrying the lexical string. That turned out to be unnecessary — the
existing typed-string lane already represents "this datatype, this exact
lexical", and is the pattern the brief also said to extend. So
`fluree-graph-ir` gains nothing for this feature, the ingest path hits the
identical branch it hits today, and there is no second numeric representation
to keep consistent. Downstream conversion is unaffected:
`convert_string_literal` already parses `"42"^^xsd:integer` back to a native
value (pinned by the pre-existing `test_typed_string_integer`).

## Testing

New tests, beyond the existing suites staying green:

- **Early termination** — a sink that refuses after N triples: the parse stops
  there (emits exactly N), the sink's error survives as `TurtleError::Sink`
  with `is_broken_pipe()` intact, and the failed statement is never terminated.
- **Lifecycle** — `end_statement` fires once per completed statement,
  directives included; a multi-triple predicate-object list is one statement;
  the parser never calls the protocol `finish()`, and two parses can feed one
  sink.
- **Quad refusal** — triple-only sinks report `supports_quads() == false`, and
  the default `emit_quad` body returns an error instead of dropping the graph
  name.
- **Recycling** — literal slots are reused after a statement ends, IRI and
  blank ids are not, an already-emitted triple is unaffected by the reuse, and
  the term table tracks the widest statement rather than the document; plus an
  end-to-end Turtle guard that a later statement reusing an earlier slot cannot
  corrupt the earlier values.
- **Collections** — W3C-shaped spine assertions that *walk* the
  `rdf:first`/`rdf:rest` chain rather than counting triples; one-item,
  two-item, nested and nested-empty collections; `()` in both positions;
  subject and object positions agreeing; annotations admitted in spine mode and
  still refused in the default.
- **Numerics** — seven lexical forms preserved with correct datatypes;
  canonicalization still the default; decimals and big integers identical under
  both modes; non-numeric literals untouched by the knob.
- **Default-mode pinning** — one document covering every construct the options
  touch, asserted triple-for-triple in the default mode. This is the regression
  guard for "existing callers are unchanged". The pre-existing
  `test_collection`, `test_empty_collection` and `test_integer_literal`
  assertions are unmodified and still pass.

### The recycling differential

Slot recycling is the one change here whose failure mode is *aliasing*: a wrong
answer is a perfectly well-formed graph with one term silently substituted for
another. Per-triple expectations written by the author of the recycling are
unlikely to anticipate that, so `fluree-graph-turtle/tests/adversarial_recycling.rs`
asserts against an oracle instead — the same document parsed into a recycling
sink and into one whose `end_statement` is swallowed by a forwarding wrapper,
i.e. today's behavior. Any `TermId` outliving its statement while still
referenced shows up as a divergence.

Two things make that evidence rather than ceremony:

- **Mutation-checked, with the limits stated.** Recycling IRI slots — which the
  parser caches across statements — is detected by **2 of the 9 tests in the
  file through output comparison alone, and by 9 of 9 once the retirement
  assert is present**; the 7 additional detections come from the assert
  tripping on the polluted slot list, not from any graph diverging. Both
  figures were measured by applying the mutation with the assert enabled and
  disabled.
- A *second* mutation, always reusing literal slot 0, escapes this file
  entirely and is caught only by the `fluree-graph-ir` unit tests. The reason
  is worth knowing: no literal is ever minted while another literal id is live
  (the parser emits each literal immediately after minting it), so
  slot-0-collapse is observationally equivalent here. The differential's power
  comes from the aliasing dimension, not from statement width. Both facts are
  recorded in the module docs so nobody trims the corpus believing the cases
  are redundant.
- **Corpus-scale.** Run against the real W3C `rdf-tests` Turtle corpus —
  **1148 files, 718 parsed, 430 rejected, across all three option modes
  (default, conformant, spine-only) — zero output divergence from the
  no-recycle oracle and zero acceptance divergence**, with two temporary
  probes live in `end_statement`: a poison canary overwriting every retired
  slot with a sentinel, and an assertion that every retiring slot still holds a
  `Literal`. Neither probe ships; both are review instrumentation.

The corpus harness itself is **not** in this PR: it hardcodes an absolute path
into the `rdf-tests` submodule. Its home is the `testsuite-rdf` harness of the
plan's §2, which is where this differential should be re-landed so the result
keeps being enforced rather than being a one-off measurement.

## Gates

- `cargo nextest run -p fluree-graph-ir -p fluree-graph-turtle -p fluree-graph-json-ld -p fluree-graph-format -p fluree-db-transact` — 730 passed, 0 failed.
- `cargo nextest run -p fluree-db-api` (full, grouped `grp_*` bins, no per-file
  filters) — 2919 passed, 0 failed, 11 skipped.
- `cargo clippy --all-targets --no-deps` on every touched crate — clean
  (workspace deny-lints, incl. `uninlined_format_args`).
- `cargo fmt --all --check` — clean.
- `cargo check --all-targets` on the excluded `testsuite-sparql` and
  `testsuite-shacl` workspaces — clean. They call the renamed
  `GraphCollectorSink::finish` and would otherwise break in their own CI job,
  which the workspace gates do not cover.

## Review follow-ups deferred to M1

Raised in review, agreed as non-blocking, recorded here so they are not lost:

- **Record that the two lifecycle guards do not overlap.** The two mutations
  on `committed_current` are caught by disjoint sets of tests: dropping the
  *guard* (aborting a statement that already committed) is caught only by
  `lexical_error_in_lookahead_does_not_abort_the_committed_statement`, while
  dropping the *per-statement reset* is caught only by
  `failed_statement_contributes_nothing` and the two
  `abort_still_fires_after_a_committed_statement_*` cases. Neither side
  subsumes the other, and every one of them looks redundant beside its
  neighbours until you actually run the mutations. The test file currently
  explains the latch hazard but not this mapping; it wants one comment naming
  which test covers which mutation, so nobody trims either side.
- **Upstream the rest of the reviewer's probe.** The two
  after-a-committed-statement rollback cases are already shipped, with
  different fixtures — the reviewer reaches the error-at-dot path with a
  trailing `,` where this PR uses a wrong token in the terminator position.
  What is *not* covered here is their
  `exactly_one_terminator_per_statement_everywhere` sweep, which asserts the
  invariant across bracket, collection, bare-bnode, subject-collection,
  SPARQL-prefix and nested-list shapes in a single pass. That sweep is the
  valuable remainder.
- **Promote the sharp invariant phrasing into the parser.** The precise form
  is "no literal is minted while another literal id is live"; the comment at
  `parse_annotation_tail` still leads with the looser "at most one literal id
  is live at a time", which is not literally true (`parse_reified_triple`
  holds a literal object while minting a reifier — the reifier grammar just
  guarantees that term is never a literal). The sharp form is already in the
  test module docs; the parser comment should lead with it too.

## Not in this PR

No quad producer, no writer sink, no CLI surface, no `--continue-on-error` —
those are the protocol's first consumers, in M1/M2. `FlakeSink`/`ImportSink` do
not recycle literal slots and do not implement `abort_statement`; both are
hot-path changes that want their own benchmarking. The JSON-LD adapter has no
statement boundaries, so it neither recycles nor rolls back, and it still drops
`@graph` contents — its module docs now say so accurately (they previously
claimed "flattened into the default graph", which is not what the code does),
and fixing it needs the quad protocol this PR lands.
