### PR TITLE
fix(turtle): a redeclared prefix must change what later names mean

### DIFF
--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -596,6 +596,25 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
     /// The cost on the path that matters is nil: one extra hash lookup per
     /// prefix *directive*, of which a document has a handful, against a cache
     /// consulted once per prefixed *name*, of which it has millions.
+    ///
+    /// # The comparison is on meaning, not spelling
+    ///
+    /// `namespace` arrives already resolved — `parse_prefix_directive` runs
+    /// `resolve_iri` before calling this — so `prefixes` holds resolved IRIs
+    /// and this compares what the two declarations MEAN. Both directions of
+    /// that are load-bearing, and neither is obvious:
+    ///
+    /// - Same spelling, different meaning. `@prefix e: <a/>` under
+    ///   `@base <http://x/>` and again under `@base <http://y/>` is the same
+    ///   text naming two different namespaces. Comparing raw text would find
+    ///   them equal and skip a clear that is required.
+    /// - Different spelling, same meaning. `<http://x/a/>` and `<a/>` under
+    ///   `@base <http://x/>` name one namespace. Comparing raw text would
+    ///   clear a cache that was entirely correct.
+    ///
+    /// So storing the resolved form is not an incidental convenience of the
+    /// directive parser; it is what makes this comparison the right one. Both
+    /// cases are pinned in `tests/prefix_redefinition.rs`.
     fn bind_prefix(&mut self, prefix: String, namespace: String) {
         let rebinds = self
             .prefixes
@@ -603,12 +622,28 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             .is_some_and(|current| *current != namespace);
         self.prefixes.insert(prefix, namespace);
         if rebinds {
-            // Coarse on purpose. A rebind could strand only the entries for
-            // that one prefix, but finding them means scanning every key, and
-            // a rebind is rare enough that paying O(cache) once beats making
-            // the common path cleverer.
+            // Coarse on purpose: a rebind invalidates only that prefix's
+            // entries, but finding them means scanning every key, so we drop
+            // them all. A rebind is rare enough that paying O(cache) once
+            // beats making the common path cleverer.
             self.prefixed_term_cache.clear();
         }
+    }
+
+    /// Test-only: parse, then report `(prefixed_cache_hits, prefixed_cache_misses)`.
+    ///
+    /// The "only if it rebinds" in [`Self::bind_prefix`] is invisible in parser
+    /// output — clearing on a same-binding redeclaration yields identical
+    /// triples, just colder, because `iri_term_cache` absorbs the repeated
+    /// work before it can reach the sink. Without a view of the counters,
+    /// nothing stops a later simplification from clearing unconditionally and
+    /// quietly costing hit rate on every chunk of every import.
+    #[cfg(test)]
+    fn parse_reporting_cache(mut self) -> Result<(u64, u64)> {
+        while !self.is_at_end() {
+            self.parse_statement()?;
+        }
+        Ok((self.prefixed_cache_hits, self.prefixed_cache_misses))
     }
 
     /// Parse @base or BASE directive.
@@ -1511,6 +1546,48 @@ pub fn parse_with_prefixes_base_options<S: GraphSink>(
 mod tests {
     use super::*;
     use fluree_graph_ir::{Graph, GraphCollectorSink, Term};
+
+    /// Counts for a document whose only prefixed names are two `e:x`.
+    fn prefixed_cache_counts(doc: &str) -> (u64, u64) {
+        let mut sink = GraphCollectorSink::new();
+        Parser::new(doc, &mut sink)
+            .unwrap()
+            .parse_reporting_cache()
+            .unwrap()
+    }
+
+    /// Redeclaring the SAME binding must leave the expansion cache warm.
+    ///
+    /// This is the shape chunked import produces on every chunk, and it is the
+    /// reason `bind_prefix` clears only on a real rebinding. No output pins it:
+    /// the triples are identical either way.
+    #[test]
+    fn a_same_binding_redeclaration_keeps_the_cache_warm() {
+        let doc = "@prefix e: <http://a/> .\n\
+                   e:x <http://p/> \"1\" .\n\
+                   @prefix e: <http://a/> .\n\
+                   e:x <http://p/> \"2\" .\n";
+        assert_eq!(
+            prefixed_cache_counts(doc),
+            (1, 1),
+            "same-binding redeclaration must NOT clear the expansion cache"
+        );
+    }
+
+    /// A real rebinding must drop the cached expansion — the correctness half,
+    /// pinned at the cache rather than only through the emitted triples.
+    #[test]
+    fn a_rebinding_drops_the_cached_expansion() {
+        let doc = "@prefix e: <http://a/> .\n\
+                   e:x <http://p/> \"1\" .\n\
+                   @prefix e: <http://b/> .\n\
+                   e:x <http://p/> \"2\" .\n";
+        assert_eq!(
+            prefixed_cache_counts(doc),
+            (0, 2),
+            "a rebinding MUST clear the expansion cache"
+        );
+    }
 
     fn parse_to_graph(input: &str) -> Result<Graph> {
         let mut sink = GraphCollectorSink::new();

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -614,7 +614,8 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
     ///
     /// So storing the resolved form is not an incidental convenience of the
     /// directive parser; it is what makes this comparison the right one. Both
-    /// cases are pinned in `tests/prefix_redefinition.rs`.
+    /// cases are pinned in `tests/prefix_redefinition_adversarial.rs` (A1 and
+    /// A2) — they need a moving `@base`, which the other file never varies.
     fn bind_prefix(&mut self, prefix: String, namespace: String) {
         let rebinds = self
             .prefixes
@@ -626,6 +627,15 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             // entries, but finding them means scanning every key, so we drop
             // them all. A rebind is rare enough that paying O(cache) once
             // beats making the common path cleverer.
+            //
+            // To be exact about the trade, since "scanning every key" could be
+            // read as the reason: `retain` scans every key too, so the cost is
+            // the same order either way. What a `retain` would buy is keeping
+            // OTHER prefixes warm after a rebind; what it costs is a predicate
+            // that has to be right — the keys are span texts like `ex:name`,
+            // so the obvious `k.starts_with(prefix)` evicts `ex:name` when `e`
+            // rebinds, and the correct form has to compare up to the colon.
+            // Simplicity over post-rebind hit rate, not cost over cost.
             self.prefixed_term_cache.clear();
         }
     }

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -37,9 +37,12 @@ pub struct Parser<'a, 'input, S> {
     iri_term_cache: FxHashMap<Arc<str>, TermId>,
     /// Cache of prefixed name span text -> TermId.
     ///
-    /// Keyed by the raw span text (e.g., `"ex:name"` or `"ex:"`), which uniquely
-    /// identifies the expanded IRI for a given prefix mapping. Handles both
-    /// PrefixedName and PrefixedNameNs tokens in one cache.
+    /// Keyed by the raw span text (e.g., `"ex:name"` or `"ex:"`) — which
+    /// identifies the expanded IRI only WHILE the prefix mapping is stable.
+    /// A `@prefix` redefinition changes what a cached span means, so
+    /// [`Parser::bind_prefix`] clears this cache on any rebinding; every
+    /// prefix write must go through it. Handles both PrefixedName and
+    /// PrefixedNameNs tokens in one cache.
     prefixed_term_cache: FxHashMap<Arc<str>, TermId>,
     /// Cache hit/miss counters (recorded on `turtle_parse_events` span).
     iri_cache_hits: u64,
@@ -1546,7 +1549,15 @@ pub fn parse_with_prefixes_base_options<S: GraphSink>(
     if !prefixes.is_empty() {
         parser.prefixes.reserve(prefixes.len());
         for (prefix, namespace) in prefixes {
-            parser.prefixes.insert(prefix.clone(), namespace.clone());
+            // Through bind_prefix, not a raw insert: on an empty cache the
+            // invalidation is a no-op, but this is the entry point chunked
+            // import uses, and any future change that seeds AFTER names have
+            // been cached ("re-seed after the prelude", "top up between
+            // chunks") would reintroduce the stale-cache bug this parser
+            // guards against — with no test able to see it, because seeding
+            // normally happens before anything is cached. Routing it here
+            // makes the invariant structural instead of conventional.
+            parser.bind_prefix(prefix.clone(), namespace.clone());
         }
     }
     parser.parse()

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -367,8 +367,10 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
     /// Look up a prefixed name (PrefixedName or PrefixedNameNs) by span text.
     ///
-    /// The span text (e.g., `"ex:name"` or `"ex:"`) uniquely identifies the
-    /// expanded IRI for the current prefix mappings, so it serves as the cache key.
+    /// The span text (e.g., `"ex:name"` or `"ex:"`) identifies the expanded
+    /// IRI **for the prefix bindings in force**, so it serves as the cache key
+    /// only as long as those bindings hold. [`Self::bind_prefix`] is what
+    /// keeps that true.
     fn resolve_prefixed_term(&mut self, start: u32, end: u32) -> Result<TermId> {
         let span = self.span_text(start, end);
         if let Some(&id) = self.prefixed_term_cache.get(span) {
@@ -557,7 +559,7 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
         // Register prefix
         self.sink_on_prefix(&prefix, &namespace);
-        self.prefixes.insert(prefix, namespace);
+        self.bind_prefix(prefix, namespace);
 
         // Consume trailing dot (required for @prefix, not for PREFIX)
         if !is_sparql_style {
@@ -565,6 +567,48 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         }
 
         Ok(())
+    }
+
+    /// Bind a prefix, discarding cached expansions if this REBINDS it.
+    ///
+    /// Turtle lets a prefix be redeclared part-way through a document, and
+    /// every prefixed name after the redeclaration means something new.
+    /// `prefixed_term_cache` is keyed by span text (`ex:name`), which
+    /// identifies an IRI only relative to the binding that was in force when
+    /// the entry was made — so without this, the second `ex:name` in
+    ///
+    /// ```turtle
+    /// @prefix e: <http://a/> .   e:x <http://p/> "1" .
+    /// @prefix e: <http://b/> .   e:x <http://p/> "2" .
+    /// ```
+    ///
+    /// resolves from the cache to `<http://a/x>`. Both statements land on one
+    /// subject, the redeclaration does nothing, and no error is raised
+    /// anywhere: the document says one thing and the graph holds another.
+    ///
+    /// Only a rebind to a *different* namespace clears. Redeclaring the same
+    /// binding leaves every cached expansion correct, and it is the common
+    /// case rather than a curiosity — chunked import prepends the file's
+    /// prefix block to every chunk over a pre-seeded map, so the parser sees
+    /// each prefix declared twice by construction. Clearing there would cost
+    /// hit rate on the hot path for nothing.
+    ///
+    /// The cost on the path that matters is nil: one extra hash lookup per
+    /// prefix *directive*, of which a document has a handful, against a cache
+    /// consulted once per prefixed *name*, of which it has millions.
+    fn bind_prefix(&mut self, prefix: String, namespace: String) {
+        let rebinds = self
+            .prefixes
+            .get(&prefix)
+            .is_some_and(|current| *current != namespace);
+        self.prefixes.insert(prefix, namespace);
+        if rebinds {
+            // Coarse on purpose. A rebind could strand only the entries for
+            // that one prefix, but finding them means scanning every key, and
+            // a rebind is rare enough that paying O(cache) once beats making
+            // the common path cleverer.
+            self.prefixed_term_cache.clear();
+        }
     }
 
     /// Parse @base or BASE directive.

--- a/fluree-graph-turtle/tests/prefix_redefinition.rs
+++ b/fluree-graph-turtle/tests/prefix_redefinition.rs
@@ -1,0 +1,182 @@
+//! Mid-document prefix redeclaration.
+//!
+//! Turtle allows a prefix to be rebound part-way through a document, and every
+//! prefixed name after the rebinding denotes something new. The parser caches
+//! expanded prefixed names by their span text (`ex:name`), which identifies an
+//! IRI only relative to the bindings in force — so a stale cache turns a
+//! rebinding into a silent no-op.
+//!
+//! Discovered while wiring term validation for H-8 (the burn-down's cause C),
+//! when a probe of the prefix path produced two statements on one subject.
+//! Nothing about it is specific to validation; it reproduces on plain `parse`.
+
+use fluree_graph_ir::GraphCollectorSink;
+use fluree_graph_turtle::{parse, parse_with_prefixes_base};
+
+/// Subjects in document order.
+fn subjects(doc: &str) -> Vec<String> {
+    let mut sink = GraphCollectorSink::new();
+    parse(doc, &mut sink).expect("parses");
+    sink.finish()
+        .iter()
+        .filter_map(|t| t.s.as_iri().map(str::to_string))
+        .collect()
+}
+
+/// The reproduction, verbatim. Before the fix both subjects came back as
+/// `http://a/x`: the second statement was attributed to the first namespace,
+/// with no error anywhere.
+#[test]
+fn a_rebound_prefix_changes_what_later_names_mean() {
+    let doc = "@prefix e: <http://a/> .\n\
+               e:x <http://p/> \"1\" .\n\
+               @prefix e: <http://b/> .\n\
+               e:x <http://p/> \"2\" .\n";
+    assert_eq!(subjects(doc), vec!["http://a/x", "http://b/x"]);
+}
+
+/// The same thing in SPARQL spelling, which takes the same code path and would
+/// have been just as broken.
+#[test]
+fn the_sparql_style_directive_rebinds_too() {
+    let doc = "PREFIX e: <http://a/>\n\
+               e:x <http://p/> \"1\" .\n\
+               PREFIX e: <http://b/>\n\
+               e:x <http://p/> \"2\" .\n";
+    assert_eq!(subjects(doc), vec!["http://a/x", "http://b/x"]);
+}
+
+/// Rebinding must not disturb prefixes it did not name.
+#[test]
+fn a_rebinding_leaves_other_prefixes_alone() {
+    let doc = "@prefix e: <http://a/> .\n\
+               @prefix f: <http://f/> .\n\
+               e:x f:p \"1\" .\n\
+               @prefix e: <http://b/> .\n\
+               e:x f:p \"2\" .\n";
+    let mut sink = GraphCollectorSink::new();
+    parse(doc, &mut sink).expect("parses");
+    let graph = sink.finish();
+
+    let subjects: Vec<&str> = graph.iter().filter_map(|t| t.s.as_iri()).collect();
+    assert_eq!(subjects, vec!["http://a/x", "http://b/x"]);
+    let predicates: Vec<&str> = graph.iter().filter_map(|t| t.p.as_iri()).collect();
+    assert_eq!(
+        predicates,
+        vec!["http://f/p", "http://f/p"],
+        "f: was never rebound"
+    );
+}
+
+/// Rebinding back to a namespace already used has to work too — the cache must
+/// be rebuilt, not merely invalidated once.
+#[test]
+fn rebinding_back_and_forth_keeps_working() {
+    let doc = "@prefix e: <http://a/> .\n\
+               e:x <http://p/> \"1\" .\n\
+               @prefix e: <http://b/> .\n\
+               e:x <http://p/> \"2\" .\n\
+               @prefix e: <http://a/> .\n\
+               e:x <http://p/> \"3\" .\n";
+    assert_eq!(
+        subjects(doc),
+        vec!["http://a/x", "http://b/x", "http://a/x"]
+    );
+}
+
+/// The empty prefix is a prefix.
+#[test]
+fn the_default_prefix_rebinds() {
+    let doc = "@prefix : <http://a/> .\n\
+               :x <http://p/> \"1\" .\n\
+               @prefix : <http://b/> .\n\
+               :x <http://p/> \"2\" .\n";
+    assert_eq!(subjects(doc), vec!["http://a/x", "http://b/x"]);
+}
+
+/// A namespace-only prefixed name (`e:`) is cached under the same key space
+/// and must be invalidated with the rest.
+#[test]
+fn a_namespace_only_name_is_invalidated_too() {
+    let doc = "@prefix e: <http://a/> .\n\
+               e: <http://p/> \"1\" .\n\
+               @prefix e: <http://b/> .\n\
+               e: <http://p/> \"2\" .\n";
+    assert_eq!(subjects(doc), vec!["http://a/", "http://b/"]);
+}
+
+/// Redeclaring a prefix to the SAME namespace changes nothing, and must not.
+///
+/// This is the case that decides the invalidation strategy: it is what chunked
+/// import does on every chunk — the file's prefix block is prepended to a
+/// parser already seeded with those same bindings — so clearing on every
+/// declaration rather than on every *rebinding* would throw away cache hits
+/// across the whole import path for no correctness gain.
+#[test]
+fn redeclaring_the_same_binding_is_not_a_rebinding() {
+    let doc = "@prefix e: <http://a/> .\n\
+               e:x <http://p/> \"1\" .\n\
+               @prefix e: <http://a/> .\n\
+               e:x <http://p/> \"2\" .\n";
+    assert_eq!(subjects(doc), vec!["http://a/x", "http://a/x"]);
+}
+
+/// The chunked-import shape: a pre-seeded prefix map plus a prelude that
+/// declares the same bindings, then a genuine rebinding inside the chunk.
+#[test]
+fn a_pre_seeded_map_rebinds_the_same_way() {
+    let seeded = [("e".to_string(), "http://a/".to_string())];
+    let doc = "@prefix e: <http://a/> .\n\
+               e:x <http://p/> \"1\" .\n\
+               @prefix e: <http://b/> .\n\
+               e:x <http://p/> \"2\" .\n";
+
+    let mut sink = GraphCollectorSink::new();
+    parse_with_prefixes_base(doc, &mut sink, &seeded, None).expect("parses");
+    let subjects: Vec<String> = sink
+        .finish()
+        .iter()
+        .filter_map(|t| t.s.as_iri().map(str::to_string))
+        .collect();
+    assert_eq!(subjects, vec!["http://a/x", "http://b/x"]);
+}
+
+/// `@base` was never affected, and this pins that the scope of the fix is
+/// right rather than merely asserted.
+///
+/// Resolved IRIs are cached under the *resolved* string, so changing the base
+/// produces a different key and never collided. Prefixed names do not consult
+/// the base at lookup time either — a namespace is resolved once, when its
+/// directive is read.
+#[test]
+fn rebasing_was_never_broken_and_still_is_not() {
+    let doc = "@base <http://a/> .\n\
+               <x> <http://p/> \"1\" .\n\
+               @base <http://b/> .\n\
+               <x> <http://p/> \"2\" .\n";
+    assert_eq!(subjects(doc), vec!["http://a/x", "http://b/x"]);
+}
+
+/// A rebinding deep in a document must not lose the entries cached before it,
+/// nor keep them. Exercises the cache at a size where a bug would show as a
+/// partial rather than total failure.
+#[test]
+fn a_rebinding_after_many_names_invalidates_all_of_them() {
+    let mut doc = String::from("@prefix e: <http://a/> .\n");
+    for i in 0..500 {
+        doc.push_str(&format!("e:s{i} <http://p/> \"v\" .\n"));
+    }
+    doc.push_str("@prefix e: <http://b/> .\n");
+    for i in 0..500 {
+        doc.push_str(&format!("e:s{i} <http://p/> \"w\" .\n"));
+    }
+
+    let got = subjects(&doc);
+    assert_eq!(got.len(), 1000);
+    for (i, subject) in got.iter().enumerate().take(500) {
+        assert_eq!(subject, &format!("http://a/s{i}"));
+    }
+    for (i, subject) in got.iter().skip(500).enumerate() {
+        assert_eq!(subject, &format!("http://b/s{i}"));
+    }
+}

--- a/fluree-graph-turtle/tests/prefix_redefinition.rs
+++ b/fluree-graph-turtle/tests/prefix_redefinition.rs
@@ -17,7 +17,7 @@ use fluree_graph_turtle::{parse, parse_with_prefixes_base};
 fn subjects(doc: &str) -> Vec<String> {
     let mut sink = GraphCollectorSink::new();
     parse(doc, &mut sink).expect("parses");
-    sink.finish()
+    sink.into_graph()
         .iter()
         .filter_map(|t| t.s.as_iri().map(str::to_string))
         .collect()
@@ -56,7 +56,7 @@ fn a_rebinding_leaves_other_prefixes_alone() {
                e:x f:p \"2\" .\n";
     let mut sink = GraphCollectorSink::new();
     parse(doc, &mut sink).expect("parses");
-    let graph = sink.finish();
+    let graph = sink.into_graph();
 
     let subjects: Vec<&str> = graph.iter().filter_map(|t| t.s.as_iri()).collect();
     assert_eq!(subjects, vec!["http://a/x", "http://b/x"]);
@@ -134,7 +134,7 @@ fn a_pre_seeded_map_rebinds_the_same_way() {
     let mut sink = GraphCollectorSink::new();
     parse_with_prefixes_base(doc, &mut sink, &seeded, None).expect("parses");
     let subjects: Vec<String> = sink
-        .finish()
+        .into_graph()
         .iter()
         .filter_map(|t| t.s.as_iri().map(str::to_string))
         .collect();

--- a/fluree-graph-turtle/tests/prefix_redefinition_adversarial.rs
+++ b/fluree-graph-turtle/tests/prefix_redefinition_adversarial.rs
@@ -21,7 +21,7 @@ use fluree_graph_turtle::{parse, parse_with_prefixes_base};
 fn subjects(doc: &str) -> Vec<String> {
     let mut sink = GraphCollectorSink::new();
     parse(doc, &mut sink).expect("parses");
-    sink.finish()
+    sink.into_graph()
         .iter()
         .filter_map(|t| t.s.as_iri().map(str::to_string))
         .collect()
@@ -30,7 +30,7 @@ fn subjects(doc: &str) -> Vec<String> {
 fn objects(doc: &str) -> Vec<String> {
     let mut sink = GraphCollectorSink::new();
     parse(doc, &mut sink).expect("parses");
-    sink.finish()
+    sink.into_graph()
         .iter()
         .filter_map(|t| t.o.as_iri().map(str::to_string))
         .collect()
@@ -180,7 +180,7 @@ fn f_preseeded_relative_vs_resolved() {
     let mut sink = GraphCollectorSink::new();
     parse_with_prefixes_base(doc, &mut sink, &seeded, None).expect("parses");
     let subs: Vec<String> = sink
-        .finish()
+        .into_graph()
         .iter()
         .filter_map(|t| t.s.as_iri().map(str::to_string))
         .collect();

--- a/fluree-graph-turtle/tests/prefix_redefinition_adversarial.rs
+++ b/fluree-graph-turtle/tests/prefix_redefinition_adversarial.rs
@@ -1,0 +1,214 @@
+//! Adversarial probes for prefix-rebind cache invalidation, authored by the
+//! review of this fix and adopted as permanent regression tests.
+//!
+//! `prefix_redefinition.rs` covers the shapes the fix was written against.
+//! These attack the two directions the *comparison* can be wrong in, which the
+//! first file cannot reach because it never varies the base:
+//!
+//! - A1, a MISSED clear: one spelling, two meanings.
+//! - A2, a SPURIOUS clear: two spellings, one meaning.
+//!
+//! Both work only because `prefixes` stores the RESOLVED namespace, so the
+//! comparison is on meaning rather than text — see `bind_prefix`. Then B..H
+//! walk the epochs (A→B→A with overlapping and disjoint names), the coarse
+//! whole-cache clear with twenty live prefixes, terms nested inside `[ ]` and
+//! `( )`, escaped local names, a pre-seeded relative binding, and the two
+//! directive spellings mixed.
+
+use fluree_graph_ir::GraphCollectorSink;
+use fluree_graph_turtle::{parse, parse_with_prefixes_base};
+
+fn subjects(doc: &str) -> Vec<String> {
+    let mut sink = GraphCollectorSink::new();
+    parse(doc, &mut sink).expect("parses");
+    sink.finish()
+        .iter()
+        .filter_map(|t| t.s.as_iri().map(str::to_string))
+        .collect()
+}
+
+fn objects(doc: &str) -> Vec<String> {
+    let mut sink = GraphCollectorSink::new();
+    parse(doc, &mut sink).expect("parses");
+    sink.finish()
+        .iter()
+        .filter_map(|t| t.o.as_iri().map(str::to_string))
+        .collect()
+}
+
+/// A1 — MISSED CLEAR probe. Same lexical namespace text, different in-scope
+/// base, so the two declarations mean different IRIs. If `prefixes` stored the
+/// raw text the comparison would find them equal and skip the clear.
+#[test]
+fn a1_same_spelling_different_base_must_clear() {
+    let doc = "@base <http://x/> .\n\
+               @prefix e: <a/> .\n\
+               e:q <http://p/> \"1\" .\n\
+               @base <http://y/> .\n\
+               @prefix e: <a/> .\n\
+               e:q <http://p/> \"2\" .\n";
+    assert_eq!(subjects(doc), vec!["http://x/a/q", "http://y/a/q"]);
+}
+
+/// A2 — SPURIOUS CLEAR probe (correctness half). Two different spellings that
+/// resolve to the SAME namespace must keep resolving names identically.
+#[test]
+fn a2_different_spelling_same_namespace_stays_correct() {
+    let doc = "@prefix e: <http://x/a/> .\n\
+               e:q <http://p/> \"1\" .\n\
+               @base <http://x/> .\n\
+               @prefix e: <a/> .\n\
+               e:q <http://p/> \"2\" .\n";
+    assert_eq!(subjects(doc), vec!["http://x/a/q", "http://x/a/q"]);
+}
+
+/// B — A→B→A with names cached in every epoch, overlapping and disjoint, so a
+/// stale entry surviving from the first A epoch into the second would show.
+#[test]
+fn b_abba_with_overlapping_and_disjoint_names() {
+    let doc = "@prefix e: <http://a/> .\n\
+               e:shared <http://p/> \"1\" .\n\
+               e:onlyA <http://p/> \"1\" .\n\
+               @prefix e: <http://b/> .\n\
+               e:shared <http://p/> \"2\" .\n\
+               e:onlyB <http://p/> \"2\" .\n\
+               @prefix e: <http://a/> .\n\
+               e:shared <http://p/> \"3\" .\n\
+               e:onlyB <http://p/> \"3\" .\n\
+               e:onlyA <http://p/> \"3\" .\n";
+    assert_eq!(
+        subjects(doc),
+        vec![
+            "http://a/shared",
+            "http://a/onlyA",
+            "http://b/shared",
+            "http://b/onlyB",
+            "http://a/shared",
+            "http://a/onlyB",
+            "http://a/onlyA",
+        ]
+    );
+}
+
+/// C — many prefixes, one rebinds: the survivors must still resolve, and the
+/// rebound one must move. Exercises the coarse (whole-cache) clear.
+#[test]
+fn c_many_prefixes_one_rebinds() {
+    let mut doc = String::new();
+    for i in 0..20 {
+        doc.push_str(&format!("@prefix p{i}: <http://n{i}/> .\n"));
+    }
+    for i in 0..20 {
+        doc.push_str(&format!("p{i}:s <http://p/> p{i}:o .\n"));
+    }
+    doc.push_str("@prefix p7: <http://REBOUND/> .\n");
+    for i in 0..20 {
+        doc.push_str(&format!("p{i}:s <http://p/> p{i}:o .\n"));
+    }
+
+    let subs = subjects(&doc);
+    let objs = objects(&doc);
+    assert_eq!(subs.len(), 40);
+    for i in 0..20 {
+        assert_eq!(subs[i], format!("http://n{i}/s"));
+        assert_eq!(objs[i], format!("http://n{i}/o"));
+    }
+    for i in 0..20 {
+        let want_ns = if i == 7 {
+            "http://REBOUND/".to_string()
+        } else {
+            format!("http://n{i}/")
+        };
+        assert_eq!(subs[20 + i], format!("{want_ns}s"), "subject prefix p{i}");
+        assert_eq!(objs[20 + i], format!("{want_ns}o"), "object prefix p{i}");
+    }
+}
+
+/// D — a rebind between the two halves of a predicate-object list is not
+/// reachable (a directive cannot appear mid-triple), but a rebind straddling
+/// blank-node and collection syntax is. Terms inside `[ ]` and `( )` come from
+/// the same cache.
+#[test]
+fn d_rebind_around_blank_nodes_and_collections() {
+    let doc = "@prefix e: <http://a/> .\n\
+               e:s <http://p/> [ <http://q/> e:inner ] .\n\
+               e:s2 <http://p/> ( e:i1 e:i2 ) .\n\
+               @prefix e: <http://b/> .\n\
+               e:s <http://p/> [ <http://q/> e:inner ] .\n\
+               e:s2 <http://p/> ( e:i1 e:i2 ) .\n";
+    let objs = objects(doc);
+    let inner: Vec<&String> = objs
+        .iter()
+        .filter(|o| o.contains("inner") || o.contains("/i1") || o.contains("/i2"))
+        .collect();
+    assert_eq!(
+        inner,
+        vec![
+            "http://a/inner",
+            "http://a/i1",
+            "http://a/i2",
+            "http://b/inner",
+            "http://b/i1",
+            "http://b/i2",
+        ]
+    );
+}
+
+/// E — an undefined prefix errors before anything is cached, and defining it
+/// afterwards must work.
+#[test]
+fn e_undefined_then_defined() {
+    let mut sink = GraphCollectorSink::new();
+    let err = parse("e:x <http://p/> \"1\" .\n", &mut sink);
+    assert!(err.is_err(), "undefined prefix must error");
+
+    let doc = "@prefix e: <http://a/> .\n\
+               e:x <http://p/> \"1\" .\n";
+    assert_eq!(subjects(doc), vec!["http://a/x"]);
+}
+
+/// F — pre-seeded map whose namespace is a RELATIVE reference while the
+/// in-document declaration resolves against a base. The stored binding really
+/// does change, so clearing is correct, not spurious.
+#[test]
+fn f_preseeded_relative_vs_resolved() {
+    let seeded = [("e".to_string(), "a/".to_string())];
+    let doc = "e:before <http://p/> \"0\" .\n\
+               @base <http://x/> .\n\
+               @prefix e: <a/> .\n\
+               e:after <http://p/> \"1\" .\n";
+    let mut sink = GraphCollectorSink::new();
+    parse_with_prefixes_base(doc, &mut sink, &seeded, None).expect("parses");
+    let subs: Vec<String> = sink
+        .finish()
+        .iter()
+        .filter_map(|t| t.s.as_iri().map(str::to_string))
+        .collect();
+    assert_eq!(subs, vec!["a/before", "http://x/a/after"]);
+}
+
+/// G — local-name escapes take the non-cached branch on a miss but are cached
+/// by span like everything else, so they must follow a rebind too.
+#[test]
+fn g_escaped_local_names_follow_the_rebind() {
+    let doc = "@prefix e: <http://a/> .\n\
+               e:a\\-b <http://p/> \"1\" .\n\
+               @prefix e: <http://b/> .\n\
+               e:a\\-b <http://p/> \"2\" .\n";
+    assert_eq!(subjects(doc), vec!["http://a/a-b", "http://b/a-b"]);
+}
+
+/// H — mixing SPARQL-style and @-style declarations of the same prefix.
+#[test]
+fn h_mixed_directive_styles_rebind() {
+    let doc = "@prefix e: <http://a/> .\n\
+               e:x <http://p/> \"1\" .\n\
+               PREFIX e: <http://b/>\n\
+               e:x <http://p/> \"2\" .\n\
+               @prefix e: <http://c/> .\n\
+               e:x <http://p/> \"3\" .\n";
+    assert_eq!(
+        subjects(doc),
+        vec!["http://a/x", "http://b/x", "http://c/x"]
+    );
+}

--- a/fluree-graph-turtle/tests/prefix_redefinition_blast_radius.rs
+++ b/fluree-graph-turtle/tests/prefix_redefinition_blast_radius.rs
@@ -1,0 +1,191 @@
+//! The blast radius of this fix, reproduced rather than asserted — authored by
+//! the review of this fix and adopted as a permanent test.
+//!
+//! The PR claims that a mid-document prefix redefinition reaching bulk import
+//! meets TWO independent defects, and that this fix closes only one of them.
+//! Every step of that claim is executed here: the streaming reader accepts such
+//! a file (no `PrefixAfterData` guard on the import path), the extracted
+//! prelude holds only the head binding, the redefinition arrives as ordinary
+//! chunk data with chunks after it, and the guarded pre-scan path would have
+//! rejected the same file.
+//!
+//! # One assertion here describes a LIVE DEFECT on purpose
+//!
+//! `wrong_after_carrier > 0` asserts that chunks *after* the redefinition are
+//! still mis-resolved. That is not a property worth having — it is the §1.4
+//! chunker gap (mid-file directive detection → serial fallback), which belongs
+//! to the parallel-convert workstream and is not touched here.
+//!
+//! It is asserted rather than `#[ignore]`d deliberately. An ignored test runs
+//! nowhere and rots; this one runs every time and will FAIL the moment §1.4
+//! lands — which is the signal wanted, because whoever closes that gap should
+//! be told to come here and flip this to `== 0`. Same for
+//! `the_guard_misses_a_mid_line_directive`, which pins that `PrefixCheck` only
+//! matches a directive keyword at line start.
+//!
+//! Adapted from the review probe in one respect: temporary files go through
+//! `tempfile` rather than a fixed path under the system temp dir, so
+//! concurrent runs of this binary cannot interfere with each other.
+
+use fluree_graph_ir::GraphCollectorSink;
+use fluree_graph_turtle::parse_with_prefixes_base;
+use fluree_graph_turtle::splitter::{
+    compute_chunk_boundaries, extract_prefix_block, StreamingTurtleReader,
+};
+use std::io::Write;
+
+/// 4000 statements with a redefinition of `e:` exactly half way through.
+fn write_corpus(path: &std::path::Path, n: usize) {
+    let mut f = std::fs::File::create(path).unwrap();
+    writeln!(f, "@prefix e: <http://a/> .").unwrap();
+    for i in 0..n / 2 {
+        writeln!(f, "e:s{i} <http://p/> \"v\" .").unwrap();
+    }
+    writeln!(f, "@prefix e: <http://b/> .").unwrap();
+    for i in n / 2..n {
+        writeln!(f, "e:s{i} <http://p/> \"v\" .").unwrap();
+    }
+}
+
+#[test]
+fn streaming_reader_accepts_a_mid_file_redefinition() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let path = dir.join("corpus.ttl");
+    write_corpus(&path, 4000);
+
+    // Claim 1: StreamingTurtleReader ACCEPTS the file (no PrefixAfterData).
+    let reader = StreamingTurtleReader::new(&path, 16 * 1024, 4, None)
+        .expect("StreamingTurtleReader accepts a mid-file redefinition");
+
+    // Claim 2: the extracted prefix block is only the HEAD binding.
+    let block = reader.prefix_block().to_string();
+    println!("prefix_block = {block:?}");
+    assert!(block.contains("http://a/"), "head binding present");
+    assert!(
+        !block.contains("http://b/"),
+        "redefinition is NOT in the extracted prelude"
+    );
+
+    let prelude = reader.prelude().clone();
+    println!("prelude prefixes = {:?}", prelude.prefixes);
+
+    // Claim 3: the redefinition is delivered as ordinary chunk data.
+    let mut chunks: Vec<(usize, String)> = Vec::new();
+    while let Some((idx, raw)) = reader.recv_chunk().unwrap() {
+        chunks.push((idx, String::from_utf8(raw).unwrap()));
+    }
+    chunks.sort_by_key(|(i, _)| *i);
+    println!("chunk count = {}", chunks.len());
+    let carrier: Vec<usize> = chunks
+        .iter()
+        .filter(|(_, t)| t.contains("@prefix e: <http://b/>"))
+        .map(|(i, _)| *i)
+        .collect();
+    assert_eq!(
+        carrier.len(),
+        1,
+        "redefinition delivered inside exactly one chunk"
+    );
+    println!("redefinition carried in chunk index {}", carrier[0]);
+    assert!(
+        chunks.len() > carrier[0] + 1,
+        "there ARE chunks after the carrier — cross-chunk exposure is real"
+    );
+
+    // Claim 4: parse each chunk the way import does — prelude prefixes seeded,
+    // prefix block prepended — and count how many subjects are wrong.
+    let seeded: Vec<(String, String)> = prelude.prefixes.to_vec();
+    let mut wrong_in_carrier = 0usize;
+    let mut wrong_after_carrier = 0usize;
+    for (idx, text) in &chunks {
+        let doc = format!("{block}{text}");
+        let mut sink = GraphCollectorSink::new();
+        parse_with_prefixes_base(&doc, &mut sink, &seeded, None).expect("chunk parses");
+        for t in sink.finish().iter() {
+            let s = t.s.as_iri().unwrap_or("");
+            let n: usize = s
+                .rsplit("/s")
+                .next()
+                .and_then(|d| d.parse().ok())
+                .unwrap_or(usize::MAX);
+            if n >= 2000 && n != usize::MAX && !s.starts_with("http://b/") {
+                if *idx == carrier[0] {
+                    wrong_in_carrier += 1;
+                } else {
+                    wrong_after_carrier += 1;
+                }
+            }
+        }
+    }
+    println!(
+        "post-redefinition subjects still on the OLD namespace: \
+         in carrier chunk = {wrong_in_carrier}, in later chunks = {wrong_after_carrier}"
+    );
+
+    // The fix repairs the carrier chunk. Later chunks remain broken — the PR
+    // says so explicitly and does not claim otherwise.
+    assert_eq!(
+        wrong_in_carrier, 0,
+        "within the carrier chunk the fix must hold"
+    );
+    assert!(
+        wrong_after_carrier > 0,
+        "later chunks are still mis-resolved — the separate chunker defect"
+    );
+
+    // Claim 5: the guarded pre-scan path WOULD have rejected this file.
+    let (_, guard_ds) = extract_prefix_block(&path).unwrap();
+    let guarded = compute_chunk_boundaries(&path, guard_ds, 16 * 1024);
+    println!("compute_chunk_boundaries => {guarded:?}");
+    assert!(
+        guarded.is_err(),
+        "the guarded path rejects what the streaming path accepts"
+    );
+}
+
+/// The PR also notes, without fixing: `PrefixCheck` only matches a directive
+/// keyword at line start, so a mid-line redefinition slips even the guard.
+#[test]
+fn the_guard_misses_a_mid_line_directive() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    let at_line_start = dir.join("line_start.ttl");
+    {
+        let mut f = std::fs::File::create(&at_line_start).unwrap();
+        writeln!(f, "@prefix e: <http://a/> .").unwrap();
+        writeln!(f, "e:s <http://p/> \"v\" .").unwrap();
+        writeln!(f, "@prefix e: <http://b/> .").unwrap();
+        writeln!(f, "e:t <http://p/> \"v\" .").unwrap();
+    }
+    // Feed the guard the way its real caller does: scanning starts AFTER the
+    // extracted header block. (Passing 0 makes the header's own directive look
+    // like a post-data one, because PrefixCheck marks data_started on the
+    // keyword's first byte.)
+    let (_, ds) = extract_prefix_block(&at_line_start).unwrap();
+    let res_line_start = compute_chunk_boundaries(&at_line_start, ds, 1024);
+    println!("line-start directive (data_start={ds}) => {res_line_start:?}");
+    assert!(
+        res_line_start.is_err(),
+        "line-start directive after data IS caught"
+    );
+
+    let mid_line = dir.join("mid_line.ttl");
+    {
+        let mut f = std::fs::File::create(&mid_line).unwrap();
+        writeln!(f, "@prefix e: <http://a/> .").unwrap();
+        writeln!(
+            f,
+            "e:s <http://p/> \"v\" . @prefix e: <http://b/> . e:t <http://p/> \"v\" ."
+        )
+        .unwrap();
+    }
+    let (_, ds2) = extract_prefix_block(&mid_line).unwrap();
+    let res = compute_chunk_boundaries(&mid_line, ds2, 1024);
+    println!("mid-line directive (data_start={ds2}) => {res:?}");
+    assert!(
+        res.is_ok(),
+        "mid-line directive after data is MISSED by the guard (noted, not fixed)"
+    );
+}

--- a/fluree-graph-turtle/tests/prefix_redefinition_blast_radius.rs
+++ b/fluree-graph-turtle/tests/prefix_redefinition_blast_radius.rs
@@ -126,7 +126,7 @@ fn streaming_reader_accepts_a_mid_file_redefinition() {
         let doc = format!("{block}{text}");
         let mut sink = GraphCollectorSink::new();
         parse_with_prefixes_base(&doc, &mut sink, &seeded, None).expect("chunk parses");
-        for t in sink.finish().iter() {
+        for t in sink.into_graph().iter() {
             let s = t.s.as_iri().unwrap_or("");
             let n: usize = s
                 .rsplit("/s")

--- a/fluree-graph-turtle/tests/prefix_redefinition_blast_radius.rs
+++ b/fluree-graph-turtle/tests/prefix_redefinition_blast_radius.rs
@@ -35,15 +35,26 @@ use fluree_graph_turtle::splitter::{
 use std::io::Write;
 
 /// 4000 statements with a redefinition of `e:` exactly half way through.
+///
+/// The OBJECT is the load-bearing part, and an earlier version of this corpus
+/// did not have it. Subjects are `e:s{i}`, a distinct span every time, so no
+/// prefixed name is ever looked up twice and the expansion cache is never
+/// consulted for a span it already holds — which is the only way the bug can
+/// show. With a literal object, the carrier-chunk assertion below passed
+/// against a parser with the fix entirely removed: it proved nothing.
+///
+/// `e:tag` repeats on every line, so it is cached under the FIRST binding and
+/// then requested again after the rebinding. That is the whole defect in one
+/// term.
 fn write_corpus(path: &std::path::Path, n: usize) {
     let mut f = std::fs::File::create(path).unwrap();
     writeln!(f, "@prefix e: <http://a/> .").unwrap();
     for i in 0..n / 2 {
-        writeln!(f, "e:s{i} <http://p/> \"v\" .").unwrap();
+        writeln!(f, "e:s{i} <http://p/> e:tag .").unwrap();
     }
     writeln!(f, "@prefix e: <http://b/> .").unwrap();
     for i in n / 2..n {
-        writeln!(f, "e:s{i} <http://p/> \"v\" .").unwrap();
+        writeln!(f, "e:s{i} <http://p/> e:tag .").unwrap();
     }
 }
 
@@ -98,6 +109,11 @@ fn streaming_reader_accepts_a_mid_file_redefinition() {
     let seeded: Vec<(String, String)> = prelude.prefixes.to_vec();
     let mut wrong_in_carrier = 0usize;
     let mut wrong_after_carrier = 0usize;
+    // The object side is what distinguishes the fix. `e:tag` is cached under
+    // the first binding; after the rebinding, a stale cache serves the old
+    // expansion for the same span. Counted only inside the carrier chunk,
+    // because only there has the parser actually SEEN the redefinition.
+    let mut stale_objects_in_carrier = 0usize;
     for (idx, text) in &chunks {
         let doc = format!("{block}{text}");
         let mut sink = GraphCollectorSink::new();
@@ -109,18 +125,32 @@ fn streaming_reader_accepts_a_mid_file_redefinition() {
                 .next()
                 .and_then(|d| d.parse().ok())
                 .unwrap_or(usize::MAX);
-            if n >= 2000 && n != usize::MAX && !s.starts_with("http://b/") {
+            let post_redefinition = n >= 2000 && n != usize::MAX;
+            if post_redefinition && !s.starts_with("http://b/") {
                 if *idx == carrier[0] {
                     wrong_in_carrier += 1;
                 } else {
                     wrong_after_carrier += 1;
                 }
             }
+            if post_redefinition && *idx == carrier[0] && t.o.as_iri() == Some("http://a/tag") {
+                stale_objects_in_carrier += 1;
+            }
         }
     }
     println!(
         "post-redefinition subjects still on the OLD namespace: \
          in carrier chunk = {wrong_in_carrier}, in later chunks = {wrong_after_carrier}"
+    );
+    println!("post-redefinition objects still resolving to http://a/tag inside the carrier chunk = {stale_objects_in_carrier}");
+
+    // THE assertion that distinguishes the fix. Without it, `e:tag` after the
+    // rebinding is served from the cache under the OLD namespace: this count
+    // is greater than zero (verified by reverting the parser to merge-base).
+    // With it, every one of them resolves to the new namespace.
+    assert_eq!(
+        stale_objects_in_carrier, 0,
+        "a prefixed name reused across the rebinding must follow it, not the cache"
     );
 
     // The fix repairs the carrier chunk. Later chunks remain broken — the PR

--- a/fluree-graph-turtle/tests/prefix_redefinition_blast_radius.rs
+++ b/fluree-graph-turtle/tests/prefix_redefinition_blast_radius.rs
@@ -114,6 +114,14 @@ fn streaming_reader_accepts_a_mid_file_redefinition() {
     // expansion for the same span. Counted only inside the carrier chunk,
     // because only there has the parser actually SEEN the redefinition.
     let mut stale_objects_in_carrier = 0usize;
+    // Non-vacuity witness: post-redefinition triples in the carrier chunk
+    // REGARDLESS of how they resolved. The two `== 0` assertions below are
+    // only meaningful if the carrier actually contains such triples — at
+    // chunk sizes below 16 KB it contains none, and both assertions pass
+    // against a parser with the fix entirely removed. Counting structurally
+    // makes non-vacuity a property of the test, not of the `16 * 1024`
+    // constant above.
+    let mut post_redef_in_carrier = 0usize;
     for (idx, text) in &chunks {
         let doc = format!("{block}{text}");
         let mut sink = GraphCollectorSink::new();
@@ -126,6 +134,9 @@ fn streaming_reader_accepts_a_mid_file_redefinition() {
                 .and_then(|d| d.parse().ok())
                 .unwrap_or(usize::MAX);
             let post_redefinition = n >= 2000 && n != usize::MAX;
+            if post_redefinition && *idx == carrier[0] {
+                post_redef_in_carrier += 1;
+            }
             if post_redefinition && !s.starts_with("http://b/") {
                 if *idx == carrier[0] {
                     wrong_in_carrier += 1;
@@ -138,6 +149,12 @@ fn streaming_reader_accepts_a_mid_file_redefinition() {
             }
         }
     }
+    assert!(
+        post_redef_in_carrier > 0,
+        "VACUOUS: the carrier chunk holds no post-redefinition triples, so the \
+         assertions below cannot distinguish the fix — the chunk size no longer \
+         places statements after the redefinition inside its chunk"
+    );
     println!(
         "post-redefinition subjects still on the OLD namespace: \
          in carrier chunk = {wrong_in_carrier}, in later chunks = {wrong_after_carrier}"
@@ -161,7 +178,8 @@ fn streaming_reader_accepts_a_mid_file_redefinition() {
     );
     assert!(
         wrong_after_carrier > 0,
-        "later chunks are still mis-resolved — the separate chunker defect"
+        "if this fails, the §1.4 chunker fix has landed: later chunks now see \
+         the redefinition — flip this to `== 0` and delete the tripwire note"
     );
 
     // Claim 5: the guarded pre-scan path WOULD have rejected this file.
@@ -216,6 +234,8 @@ fn the_guard_misses_a_mid_line_directive() {
     println!("mid-line directive (data_start={ds2}) => {res:?}");
     assert!(
         res.is_ok(),
-        "mid-line directive after data is MISSED by the guard (noted, not fixed)"
+        "if this fails, PrefixCheck has learned to match mid-line directives: \
+         the guard now catches what this test documents as missed — flip to \
+         `is_err()` and retire this note"
     );
 }


### PR DESCRIPTION
# Two correctness fixes against main

Both found while building the RDF toolkit, both independent of it, both small enough that one review slot beats two.

1. **`fix(turtle)`** — a redeclared prefix silently didn't change what later prefixed names meant. Data corruption, no error.
2. **`fix(api)`** — a literal NUL byte in an `admin.rs` comment made the whole file binary to every text tool, so plain `grep` reported "no match" for patterns that occur 23 times in it.

---

## 1. A redeclared prefix must change what later names mean

Silent data corruption in the Turtle parser. Turtle allows a prefix to be rebound part-way through a document; the parser ignored the rebinding for any prefixed name it had already seen.

```turtle
@prefix e: <http://a/> .   e:x <http://p/> "1" .
@prefix e: <http://b/> .   e:x <http://p/> "2" .
```

Both statements land on `<http://a/x>`. The second should be `<http://b/x>`. No error, no warning — the document says one thing and the graph holds another.

## Cause

`prefixed_term_cache` is keyed by span text (`e:x`). That text identifies an IRI only *relative to the bindings in force* when the entry was made, and nothing invalidated it when a binding changed.

Two neighbours were **not** affected, and the PR pins both so the scope is demonstrated rather than asserted:

- `iri_term_cache` keys on the **resolved** IRI, so a different base produces a different key and never collided.
- `@base` redeclaration was always correct — a prefix namespace is resolved once, when its directive is read, and prefixed names never consult the base at lookup time.

## Fix

On a prefix directive, clear the expansion cache **if the prefix rebinds to a different namespace**. Only if.

Redeclaring the *same* binding is the common case rather than a curiosity: chunked import prepends the file's prefix block to every chunk over a pre-seeded prefix map, so the parser sees each prefix declared twice by construction. Every cached expansion stays correct through that, and clearing there would cost hit rate across the entire import path for no correctness gain.

**The per-term path is untouched.** The diff adds no instruction to `resolve_prefixed_term` or `sink_term_iri` — the only executable change is inside the prefix-directive handler. Added work is one hash lookup per prefix *directive*, of which a document has a handful, against a cache consulted once per prefixed *name*, of which it has millions. That is a structural property of the diff, not a benchmark result; a wall-clock A/B on this host was noise-dominated (a 4× swing between runs of identical code under concurrent load) and is not offered as evidence.

Clearing is coarse on purpose: a rebind invalidates only that prefix's entries, but finding them means scanning every key, so we drop them all. A per-lookup epoch check would make rebinding O(1) at the cost of a comparison on every cache hit — the wrong trade when the overwhelming majority of documents rebind nothing.

**The comparison is on meaning, not spelling**, and both directions matter. `parse_prefix_directive` resolves the namespace before storing it, so `prefixes` holds resolved IRIs. The same spelling under two different bases (`@prefix e: <a/>` under `<http://x/>` then under `<http://y/>`) names two namespaces and *must* clear; two spellings that resolve alike (`<http://x/a/>` and `<a/>` under `<http://x/>`) name one and must *not*. Comparing raw text would get each backwards.

### The "only when" needs its own guard

Clearing on a same-binding redeclaration produces *identical triples* — just colder — because `iri_term_cache` absorbs the repeated work before it reaches the sink. So a mutation deleting the condition passed every gate in the first version of this PR; confirmed by running it, with all eleven triple-level tests still green.

The cache hit/miss counters are the only place the behaviour is observable, so a test-only `parse_reporting_cache` exposes them and two tests read them: same-binding redeclaration must leave the cache warm (1 hit, 1 miss), a real rebinding must drop it (0 hits, 2 misses). The same mutation now fails the first.

## Blast radius — honest version

**This is not serial-only.** Bulk import is affected, and this fix is necessary but *not sufficient* there.

The `PrefixAfterData` guard lives in `compute_chunk_boundaries` (the whole-file pre-scan behind `TurtleChunkReader`). Import does not use that reader. `fluree-db-api/src/import.rs` uses `StreamingTurtleReader` exclusively, which has no such guard — verified empirically: a 4000-statement file with a mid-file redefinition is **accepted**, its extracted prefix block is only the head binding `@prefix e: <http://a/> .`, and the redefinition is delivered in a chunk like any other data.

So a mid-document redefinition reaching import hits two independent defects, and `prefix_redefinition_blast_radius.rs` *executes* the split rather than asserting it. The corpus is 4000 statements of `e:s{i} <http://p/> e:tag .` with a redefinition half way through, parsed the way import parses it (prelude seeded, prefix block prepended).

The `e:tag` object is the load-bearing part. It repeats on every line, so it is cached under the first binding and requested again after the rebinding — which is the only shape in which this bug can appear at all. Counting inside the **carrier chunk** (the one that actually contains the redefinition), post-redefinition triples whose object still resolves to `http://a/tag`:

1. **Carrier chunk — 379 stale without the fix, 0 with it.** This is the cache bug, and this assertion is what distinguishes the fix; verified by reverting the parser to the merge base. **Fixed here.**
2. **Later chunks — 1621 subjects mis-resolved.** The head-extracted prefix block is prepended to each chunk, so they parse with the *original* binding and never see the redefinition. **Not fixed here**; that is the §1.4 chunker work (mid-file directive detection → serial fallback), and it needs the splitter, not the parser.

An earlier version of this test used a literal object and asserted only that no *subject* was mis-resolved in the carrier chunk. That was vacuous — every subject is a distinct span, so no prefixed name was ever looked up twice and the cache was never consulted for a span it held. It passed against a parser with the fix entirely removed. Caught in review; the corpus and the assertion above are the remediation.

The later-chunk defect is asserted live (`> 0`) rather than `#[ignore]`d: an ignored test runs nowhere and rots, while this one fails the moment §1.4 lands and tells whoever closed it to come here. The 1621 is a printed diagnostic, not part of the assertion, so ordinary chunking changes cannot make it flap.

Also noted, not addressed: `PrefixCheck` only matches a directive keyword at line start, so even the guarded pre-scan path would miss `… . @prefix e: <…> .` written mid-line. Same §1.4 bucket.

## Discovery

Found while wiring term validation for H-8 (burn-down cause C), when a probe of the prefix path returned two statements on one subject. Nothing about it is specific to validation — it reproduces on plain `parse`, on `main` at `5598ffd6a`, with no feature flags.

## Tests

Ten, in `fluree-graph-turtle/tests/prefix_redefinition.rs`. **Eight fail without the fix** (verified by stashing the parser change and re-running). The two that pass either way are `@base` and same-binding redeclaration — the pair that shows the fix is scoped correctly rather than accidentally.

Covered: the verbatim repro; SPARQL-style `PREFIX`; other prefixes left alone; rebinding back and forth; the default (empty) prefix; namespace-only names (`e:`); same-binding redeclaration as a no-op; the pre-seeded-map shape chunked import uses; `@base` unaffected; and a 1000-statement case where a partial invalidation would show as a partial failure.

---

## 2. Name U+0000 in a comment instead of embedding one

`fluree-db-api/src/admin.rs` line 283 carried a literal NUL byte inside a comment that meant to *name* the character — "callers can otherwise sneak a `<NUL>` past". The lines immediately above spell the same class correctly (`U+0000..=U+001F`, `U+007F`); this is the one that got away.

**The cost is not cosmetic.** A single NUL makes the whole file binary to every text tool:

- `file(1)` reported it as `data`, not source.
- Search behaviour then **splits by grep implementation**, and naming which one matters:
  - **ugrep 7.5.0** — what `grep` resolves to in the dev environment this was found in — exits 1 and prints nothing for a pattern occurring 23 times in the file. Not "binary file matches", not a warning: a clean, confident "not found".
  - **BSD grep 2.6.0-FreeBSD** (`/usr/bin/grep`, GNU-compatible; what CI and most contributors get) prints `Binary file … matches` and exits 0. It withholds the matching lines but does not lie about the match.

So the severe reading holds for anyone on ugrep and the milder one for everyone else — both worse than a file that simply works. After: `file` reports UTF-8 text and both greps find all 23. (An earlier draft of this claim asserted the silent-exit-1 behaviour universally; it was measured in one shell. Corrected on review.)

Comment-only and byte-precise — one line, the NUL replaced by the text `U+0000`. 670 `fluree-db-api` lib tests unchanged, full suite re-run at the tip.

Found by the control-byte guard built for the RDF-toolkit work, which flagged this as its second literal NUL; the first was in a Turtle test fixture and is fixed on that branch. Riding here rather than standing alone because a one-byte PR against main is not worth its own review slot.

---

## Gates

| Gate | Result |
| --- | --- |
| `nextest` turtle + graph-ir + json-ld + format + transact + vocab | 720 passed, 0 failed |
| `nextest -p fluree-db-api` (full) | 2929 passed, 11 skipped |
| `clippy --all-targets --no-deps` | 0 warnings |
| `cargo fmt --all --check` | clean |
| `cargo check --all-targets` on excluded `testsuite-sparql` / `testsuite-shacl` | clean |
