### PR TITLE
fix: un-orphan build()'s #[cfg(native)] from with_secret_resolver

### DIFF
--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -1156,8 +1156,7 @@ fn build_local_storage_from_config(
             "S3 storage in addressIdentifiers requires 'aws' feature",
         )),
         StorageType::Unsupported { type_iri, .. } => Err(ApiError::config(format!(
-            "Unsupported storage type in addressIdentifiers: {}",
-            type_iri
+            "Unsupported storage type in addressIdentifiers: {type_iri}"
         ))),
     }
 }
@@ -1963,6 +1962,22 @@ impl FlureeBuilder {
         self
     }
 
+    /// Inject a secret resolver used to hydrate `ConfigValue::SecretRef` auth
+    /// references in Iceberg graph sources built by this builder. It is forwarded
+    /// to the finalized `Fluree`. Most hosts inject per-request via
+    /// [`Fluree::with_secret_resolver`] instead; use this for a build-time default.
+    ///
+    /// Gated on `iceberg` ONLY (not `native`): the no-native BYO-IAM `SecretRef`
+    /// surface this exists for must be available on a per-lambda fast path.
+    #[cfg(feature = "iceberg")]
+    pub fn with_secret_resolver(
+        mut self,
+        resolver: Arc<dyn fluree_db_iceberg::SecretResolver>,
+    ) -> Self {
+        self.secret_resolver = Some(resolver);
+        self
+    }
+
     /// Build a file-backed Fluree instance
     ///
     /// Returns an error if storage_path is not set.
@@ -1973,19 +1988,6 @@ impl FlureeBuilder {
     /// spawned on the tokio runtime, so `build()` must be called within a
     /// tokio context.
     #[cfg(feature = "native")]
-    /// Inject a secret resolver used to hydrate `ConfigValue::SecretRef` auth
-    /// references in Iceberg graph sources built by this builder. It is forwarded
-    /// to the finalized `Fluree`. Most hosts inject per-request via
-    /// [`Fluree::with_secret_resolver`] instead; use this for a build-time default.
-    #[cfg(feature = "iceberg")]
-    pub fn with_secret_resolver(
-        mut self,
-        resolver: Arc<dyn fluree_db_iceberg::SecretResolver>,
-    ) -> Self {
-        self.secret_resolver = Some(resolver);
-        self
-    }
-
     pub fn build(mut self) -> Result<Fluree> {
         let path = self
             .storage_path

--- a/fluree-db-api/src/server_defaults.rs
+++ b/fluree-db-api/src/server_defaults.rs
@@ -75,7 +75,11 @@ pub fn default_reindex_max_bytes() -> usize {
 /// reach this budget. Page-cache pages are clean and reclaimable, so two-thirds
 /// is a soft target that still leaves the OS room to back the heap, the leaflet
 /// cache, and in-flight requests.
+///
+/// Only consumed by the `native` warming path.
+#[cfg(feature = "native")]
 const WARM_BUDGET_NUMERATOR: u64 = 2;
+#[cfg(feature = "native")]
 const WARM_BUDGET_DENOMINATOR: u64 = 3;
 
 /// Fallback warming budget when RAM detection is unavailable (WASM, sandbox).


### PR DESCRIPTION
## Problem

`fluree-db-api` does not compile for any consumer using `default-features = false`. On current `main`:

```
$ cargo check -p fluree-db-api --no-default-features --features aws,iceberg,shacl
error[E0609]: no field `storage_path` on type `FlureeBuilder`   lib.rs:1991
error[E0433]: cannot find type `FileStorage`                    lib.rs:1995
error[E0433]: cannot find type `FileNameService`                lib.rs:1996
```

`f305df480` (#1500 §3, `ConfigValue::SecretRef`) inserted `FlureeBuilder::with_secret_resolver` *between* `build()`'s doc comment and its `#[cfg(feature = "native")]` attribute, so the gate attached to the wrong function:

```rust
    /// Build a file-backed Fluree instance
    /// ...
    #[cfg(feature = "native")]        // <-- was build()'s gate
    /// Inject a secret resolver ...
    #[cfg(feature = "iceberg")]
    pub fn with_secret_resolver(...) -> Self { ... }

    pub fn build(mut self) -> Result<Fluree> {   // <-- ungated, native-only body
```

Two consequences:

- **`build()` was left cfg-less**, so a no-native compile pulls in its native-only body (`storage_path` / `FileStorage` / `FileNameService`) and fails.
- **`with_secret_resolver` became `native` + `iceberg`**, over-gating the no-native BYO-IAM `SecretRef` surface it was added for behind `native`.

## Fix

Move `with_secret_resolver` (with its own doc comment and `#[cfg(iceberg)]`) after `build()`, rejoining `build()`'s doc comment with its `#[cfg(native)]`. `with_secret_resolver` is now gated on `iceberg` only.

Two follow-ons so the no-native featureset is genuinely clean rather than merely compiling — both pre-existing, both invisible until the crate could compile at all on this featureset:

- `WARM_BUDGET_{NUMERATOR,DENOMINATOR}` gated on `native` (their only consumer, `warm_budget_bytes()`, already is) — otherwise two `dead_code` warnings.
- One inlined format arg in the `#[cfg(not(feature = "native"))] build_local_storage_from_config` — otherwise a `clippy::uninlined_format_args` denial.

## Why CI never caught this

`--all-features` and workspace builds structurally mask this class of bug through feature unification: `native` is always on, so no existing job ever compiles the no-native combination downstream lambda consumers actually use. Worth adding that exact featureset as a CI job; not done here to keep this reviewable.

## Verification

| Gate | Before | After |
|---|---|---|
| `check -p fluree-db-api --no-default-features --features aws,iceberg,shacl` | FAIL (3 errors) | pass |
| `clippy` same featureset, `-D warnings` | FAIL | pass |
| `check -p fluree-db-api --features iceberg` (native default) | pass | pass |
| `clippy -p fluree-db-api --all-features --all-targets -D warnings` | pass | pass |
| `cargo fmt --all -- --check` | clean | clean |

Behavior under `--all-features` is unchanged — the cfg expansion is identical to before, so the workspace test suite is unaffected by construction.

## Note on history

`988b1affb` (Andrew Johnson, Jul 20) fixed this same gate and is on `audit-program/land-on-main`, `feat/materialize-builder`, `perf/browse-parity`, `perf/family-c-filter-join` and `perf/audit-mainmerge-base` — but it never reached `main`. This commit supersedes it; those branches will resolve on their next merge from main.

The bug was reported against `3a87233d` on `fix/upsert-staging-new-subject-scan`, with a request to cherry-pick there. That branch is already merged into main, so fixing it on main instead covers it and the 15 other live refs descending from `f305df480` that still carry the orphaned gate.