### PR TITLE
fix(policy): key the class cache on the graph, not just the subject

### DIFF
--- a/fluree-db-api/src/block_fetch.rs
+++ b/fluree-db-api/src/block_fetch.rs
@@ -422,7 +422,7 @@ pub async fn apply_policy_filter(
         .map_err(|e| BlockFetchError::PolicyFilter(e.to_string()))?;
 
     let filtered = enforcer
-        .filter_flakes_for_graph(snapshot, overlay, to_t, &tracker, flakes)
+        .filter_flakes_for_graph(snapshot, db.g_id, overlay, to_t, &tracker, flakes)
         .await
         .map_err(|e| BlockFetchError::PolicyFilter(e.to_string()))?;
 

--- a/fluree-db-api/src/format/cypher_typed.rs
+++ b/fluree-db-api/src/format/cypher_typed.rs
@@ -523,7 +523,7 @@ impl<'a> NodeHydrator<'a> {
             .map_err(|e| FormatError::InvalidBinding(format!("policy class lookup failed: {e}")))?;
         let tracker = fluree_db_core::Tracker::disabled();
         enforcer
-            .filter_flakes_for_graph(db.snapshot, db.overlay, db.t, &tracker, flakes)
+            .filter_flakes_for_graph(db.snapshot, db.g_id, db.overlay, db.t, &tracker, flakes)
             .await
             .map_err(|e| FormatError::InvalidBinding(format!("policy filtering failed: {e}")))
     }

--- a/fluree-db-api/src/format/hydration.rs
+++ b/fluree-db-api/src/format/hydration.rs
@@ -2503,6 +2503,7 @@ impl<'a> HydrationFormatter<'a> {
         enforcer
             .filter_flakes_for_graph(
                 self.db.snapshot,
+                self.db.g_id,
                 self.db.overlay,
                 self.db.t,
                 tracker,

--- a/fluree-db-api/src/graph_commit_builder.rs
+++ b/fluree-db-api/src/graph_commit_builder.rs
@@ -317,6 +317,7 @@ impl<'a, 'g> CommitBuilder<'a, 'g> {
                 commit.flakes = enforcer
                     .filter_flakes_for_graph(
                         &snapshot.snapshot,
+                        db.g_id,
                         overlay,
                         commit.t,
                         &tracker,

--- a/fluree-db-policy/src/class_lookup.rs
+++ b/fluree-db-policy/src/class_lookup.rs
@@ -108,10 +108,13 @@ pub async fn populate_class_cache(
         return Ok(());
     }
 
+    // Key on the graph this ref reads, so classes resolved in one graph are never
+    // consulted for a decision about another.
+    let g_id = db.g_id;
     let class_map = lookup_subject_classes(subjects, db).await?;
 
     for (subject, classes) in class_map {
-        policy_ctx.cache_subject_classes(subject, classes);
+        policy_ctx.cache_subject_classes(g_id, subject, classes);
     }
 
     Ok(())

--- a/fluree-db-policy/src/evaluate.rs
+++ b/fluree-db-policy/src/evaluate.rs
@@ -14,7 +14,7 @@ use crate::types::{
     TargetMode, WriteFlakeInfo,
 };
 use crate::Result;
-use fluree_db_core::{FlakeValue, Sid, Tracker};
+use fluree_db_core::{FlakeValue, GraphId, Sid, Tracker};
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
@@ -66,8 +66,13 @@ pub struct PolicyContext {
     pub wrapper: PolicyWrapper,
     /// The grounded identity (always has a value, even if random)
     pub identity: Sid,
-    /// Cache of subject -> classes for runtime class membership checks
-    class_cache: Arc<RwLock<std::collections::HashMap<Sid, Vec<Sid>>>>,
+    /// Cache of (graph, subject) -> classes for runtime class membership checks.
+    ///
+    /// Keyed on the graph as well as the subject: the same subject IRI can carry
+    /// different `rdf:type` values in different named graphs, and an `f:onClass`
+    /// decision made against another graph's classes is simply wrong. Keying on
+    /// `Sid` alone made the result depend on which graph populated the entry first.
+    class_cache: Arc<RwLock<std::collections::HashMap<(GraphId, Sid), Vec<Sid>>>>,
 }
 
 impl PolicyContext {
@@ -908,19 +913,19 @@ impl PolicyContext {
         Ok((false, evaluated))
     }
 
-    /// Cache subject classes for repeated lookups
-    pub fn cache_subject_classes(&self, subject: Sid, classes: Vec<Sid>) {
+    /// Cache subject classes for repeated lookups, within one graph.
+    pub fn cache_subject_classes(&self, g_id: GraphId, subject: Sid, classes: Vec<Sid>) {
         if let Ok(mut cache) = self.class_cache.write() {
-            cache.insert(subject, classes);
+            cache.insert((g_id, subject), classes);
         }
     }
 
-    /// Get cached subject classes
-    pub fn get_cached_subject_classes(&self, subject: &Sid) -> Option<Vec<Sid>> {
+    /// Get cached subject classes for a subject in a specific graph.
+    pub fn get_cached_subject_classes(&self, g_id: GraphId, subject: &Sid) -> Option<Vec<Sid>> {
         self.class_cache
             .read()
             .ok()
-            .and_then(|cache| cache.get(subject).cloned())
+            .and_then(|cache| cache.get(&(g_id, subject.clone())).cloned())
     }
 }
 
@@ -1188,6 +1193,46 @@ mod tests {
             values.get("?$identity"),
             Some(&FlakeValue::Ref(identity.clone()))
         );
+    }
+
+    #[test]
+    fn class_cache_keeps_graphs_apart() {
+        // The same subject IRI can be typed differently in two named graphs —
+        // exactly what `rr:graphMap` routing produces. Before the cache was keyed
+        // on the graph, the second population overwrote the first and every
+        // subsequent `f:onClass` decision for that subject used whichever graph
+        // happened to be cached last.
+        let ctx = PolicyContext::new(PolicyWrapper::root(), None);
+        let subject = make_sid(100, "alice");
+        let employee = make_sid(100, "Employee");
+        let patient = make_sid(100, "Patient");
+
+        ctx.cache_subject_classes(3, subject.clone(), vec![employee.clone()]);
+        ctx.cache_subject_classes(4, subject.clone(), vec![patient.clone()]);
+
+        assert_eq!(
+            ctx.get_cached_subject_classes(3, &subject),
+            Some(vec![employee]),
+            "graph 3's classes were clobbered by the graph 4 population"
+        );
+        assert_eq!(
+            ctx.get_cached_subject_classes(4, &subject),
+            Some(vec![patient]),
+            "graph 4 did not get its own entry"
+        );
+    }
+
+    #[test]
+    fn class_cache_miss_does_not_borrow_another_graphs_classes() {
+        // A graph with no cached entry must miss, not silently inherit another
+        // graph's classes. A miss degrades to "no classes", which is the
+        // conservative direction; borrowing is what produces a wrong decision.
+        let ctx = PolicyContext::new(PolicyWrapper::root(), None);
+        let subject = make_sid(100, "alice");
+
+        ctx.cache_subject_classes(3, subject.clone(), vec![make_sid(100, "Employee")]);
+
+        assert_eq!(ctx.get_cached_subject_classes(7, &subject), None);
     }
 
     #[test]

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1024,7 +1024,7 @@ impl BinaryScanOperator {
             .map_err(|e| QueryError::Policy(e.to_string()))?;
 
         enforcer
-            .filter_flakes_for_graph(snapshot, overlay, to_t, &ctx.tracker, flakes)
+            .filter_flakes_for_graph(snapshot, db.g_id, overlay, to_t, &ctx.tracker, flakes)
             .await
             .map_err(|e| QueryError::Policy(e.to_string()))
     }

--- a/fluree-db-query/src/policy/enforcer.rs
+++ b/fluree-db-query/src/policy/enforcer.rs
@@ -4,7 +4,7 @@
 
 use super::QueryPolicyExecutor;
 use crate::error::Result;
-use fluree_db_core::{Flake, LedgerSnapshot, OverlayProvider, Sid, Tracker};
+use fluree_db_core::{Flake, GraphId, LedgerSnapshot, OverlayProvider, Sid, Tracker};
 use fluree_db_policy::{is_schema_flake, PolicyContext};
 use std::sync::Arc;
 
@@ -91,6 +91,8 @@ impl QueryPolicyEnforcer {
     /// # Arguments
     ///
     /// * `snapshot` - The database for this graph
+    /// * `g_id` - The graph these flakes belong to, used to look up class
+    ///   membership in the graph that actually asserted it
     /// * `overlay` - The overlay provider for this graph
     /// * `to_t` - Target transaction time for this graph
     /// * `tracker` - Fuel tracker for limits
@@ -102,6 +104,7 @@ impl QueryPolicyEnforcer {
     pub async fn filter_flakes_for_graph(
         &self,
         snapshot: &LedgerSnapshot,
+        g_id: GraphId,
         overlay: &dyn OverlayProvider,
         to_t: i64,
         tracker: &Tracker,
@@ -127,7 +130,7 @@ impl QueryPolicyEnforcer {
             // Get subject classes from cache
             let subject_classes = self
                 .policy
-                .get_cached_subject_classes(&flake.s)
+                .get_cached_subject_classes(g_id, &flake.s)
                 .unwrap_or_default();
 
             // Async policy check with f:query support
@@ -163,6 +166,7 @@ impl QueryPolicyEnforcer {
     pub async fn allow_flake_for_graph(
         &self,
         snapshot: &LedgerSnapshot,
+        g_id: GraphId,
         overlay: &dyn OverlayProvider,
         to_t: i64,
         tracker: &Tracker,
@@ -184,7 +188,7 @@ impl QueryPolicyEnforcer {
         // Get subject classes from cache
         let subject_classes = self
             .policy
-            .get_cached_subject_classes(&flake.s)
+            .get_cached_subject_classes(g_id, &flake.s)
             .unwrap_or_default();
 
         // Async policy check


### PR DESCRIPTION
`PolicyContext::class_cache` is a `HashMap<Sid, Vec<Sid>>`. The same subject IRI can carry different `rdf:type` values in different named graphs, so two graphs sharing a subject collapse into one cache entry and whichever populated it first decides the classes for both.

Every `f:onClass` restriction evaluated for that subject afterwards uses the wrong class set — allowing or denying based on population order rather than on the data. That is order-dependent behaviour in an authorization path, not a stale-cache annoyance.

This is not a hypothetical shape. Named graphs are a general feature — any `from-named` query spans them — and `docs/security/policy-in-queries.md:203-205` explicitly recommends `f:onClass` as the tool to reach for when "different graphs need different policy regimes". That is precisely the restriction this bug corrupts, so the documented workaround for graph-differentiated policy is the one that misbehaves on multi-graph data.

It has gone unnoticed because it needs the *same subject IRI* present in two graphs with different types, which is rarer than multi-graph data generally. I came across it while auditing how far the graph identifier travels through the read path; R2RML `rr:graphMap` routing is the workload that produces the shape per row #1581, which is why I went looking. Nothing about the bug or the fix is specific to R2RML.

**What changes**

The graph was already available at both ends and simply wasn't carried across:

- `populate_class_cache` (`fluree-db-policy/src/class_lookup.rs`) receives a `GraphDbRef`, whose `g_id` is a public field, so the insert side now keys on the graph it actually read.
- The two lookups live in `filter_flakes_for_graph` / `allow_flake_for_graph` (`fluree-db-query/src/policy/enforcer.rs`) — the one boundary where the graph was being dropped. Both now take a `g_id: GraphId`.
- `class_cache` becomes `HashMap<(GraphId, Sid), Vec<Sid>>`; `cache_subject_classes` and `get_cached_subject_classes` take the graph.

**One design note worth a reviewer's eye.** Callers pass the graph of the `GraphDbRef` they populated the cache from, rather than a literal. Populate and lookup therefore agree by construction rather than by convention. Two callers — `block_fetch.rs` and `graph_commit_builder.rs` — build that ref with a hardcoded graph `0`, so their behaviour is byte-identical after this change. That hardcoding is a separate defect and is deliberately left alone here, but because the lookup now follows the ref, fixing it later corrects both halves in one edit instead of two.

**Tests** — two units in `evaluate.rs`: the same subject cached with different classes in graphs 3 and 4 keeps both entries; a graph with no entry misses rather than borrowing another graph's classes (a miss degrades to "no classes", which is the conservative direction).

**Be aware of what those tests do not do.** They cannot be run against the unfixed code, because the accessors did not take a graph at all — so they pin the new keying without demonstrating the old wrong decision. Showing the authorization outcome end to end needs an enforcer-level integration test over a real two-graph ledger. That belongs with the `rr:graphMap` work, where the data shape arises naturally, and I would rather say so than let the test count imply more coverage than it has.

**Why it is worth having on its own:** it is a correctness bug in an authorization path, the fix is contained, and it stands independent of anything else I have open — it needs no other change to be worth landing, and nothing else needs to land first.