### PR TITLE
fix(api): materialize sink call sites — finish() → into_parts() (#1529 × #1552 merge skew)

### DIFF
--- a/fluree-db-api/src/materialize.rs
+++ b/fluree-db-api/src/materialize.rs
@@ -866,8 +866,9 @@ fn spawn_produce_workers(
 
                         // Finish + ship this chunk (always non-empty: it holds
                         // `first`). Mirror build_stamp_chunk's finalize.
-                        let (writer, prefix_map, spool_ctx) =
-                            sink.into_parts().map_err(|e| format!("flake encode: {e}"))?;
+                        let (writer, prefix_map, spool_ctx) = sink
+                            .into_parts()
+                            .map_err(|e| format!("flake encode: {e}"))?;
                         let op_count = writer.op_count();
                         let new_codes = worker_cache.into_new_codes();
                         let spool_result = spool_ctx.map(SpoolContext::finish_buffered);

--- a/fluree-db-api/src/materialize.rs
+++ b/fluree-db-api/src/materialize.rs
@@ -246,7 +246,9 @@ impl TripleObserver for InterningObserver<'_, '_> {
         let s = intern_term(self.sink, subject);
         let p = self.sink.term_iri(predicate);
         let o = intern_term(self.sink, object);
-        self.sink.emit_triple(s, p, o);
+        self.sink
+            .emit_triple(s, p, o)
+            .map_err(|e| R2rmlError::Materialization(format!("flake encode: {e}")))?;
         *self.bytes += triple_weight(subject, predicate, object);
         Ok(())
     }

--- a/fluree-db-api/src/materialize.rs
+++ b/fluree-db-api/src/materialize.rs
@@ -325,7 +325,7 @@ pub fn build_stamp_chunk(
     let txn_meta = encode_stamp(&mut sink, stamp)?;
 
     let (writer, prefix_map, spool_ctx) = sink
-        .finish()
+        .into_parts()
         .map_err(|e| R2rmlError::Materialization(format!("flake encode: {e}")))?;
     let op_count = writer.op_count();
     let new_codes = worker_cache.into_new_codes();
@@ -867,7 +867,7 @@ fn spawn_produce_workers(
                         // Finish + ship this chunk (always non-empty: it holds
                         // `first`). Mirror build_stamp_chunk's finalize.
                         let (writer, prefix_map, spool_ctx) =
-                            sink.finish().map_err(|e| format!("flake encode: {e}"))?;
+                            sink.into_parts().map_err(|e| format!("flake encode: {e}"))?;
                         let op_count = writer.op_count();
                         let new_codes = worker_cache.into_new_codes();
                         let spool_result = spool_ctx.map(SpoolContext::finish_buffered);


### PR DESCRIPTION
Main currently fails `cargo check -p fluree-db-api --all-features --all-targets` with two E0308s in `fluree-db-api/src/materialize.rs` (:327, :869). Cause: cross-PR semantic skew — #1529 (merged 18:12) added two `sink.finish()` call sites destructuring the spool tuple; #1552 (merged 19:40) renamed that tuple-returning method to `into_parts()` and adapted every caller visible on its branch, which predated #1529's merge. Each PR was CI-green against pre-other main; no textual conflict existed to flag it.

This is the same two-line mechanical rename #1552 applied to its own callers, nothing more. The two similarly-named `writer.finish()` calls at :1442/:1757 are a different type (the verify spool writer) and are deliberately untouched.

Verified at head: `cargo check -p fluree-db-api --all-features --all-targets` clean (the reproducing command), materialize lib tests 20/20.



**Update (third skew site):** `#1552` also made `emit_triple` fallible; #1529's `InterningObserver` discarded the new `Result` (an encode error would have vanished silently — and it fails main's `-D warnings` clippy). `2910309a7` propagates it as an `R2rmlError` through the observer's existing `Result` return, matching the file's error-wrap idiom. Note main's own push CI at the #1552 merge is red across `test`/`clippy`/`testsuite-sparql` from these same skew sites — this PR should restore it.