### PR TITLE
fix(api): repair the #1529 x #1552 merge seam — main is red

### DIFF
--- a/fluree-db-api/src/materialize.rs
+++ b/fluree-db-api/src/materialize.rs
@@ -246,7 +246,11 @@ impl TripleObserver for InterningObserver<'_, '_> {
         let s = intern_term(self.sink, subject);
         let p = self.sink.term_iri(predicate);
         let o = intern_term(self.sink, object);
-        self.sink.emit_triple(s, p, o);
+        // ImportSink uses deferred-error semantics: emit_* stashes the first
+        // encode failure and `into_parts()` surfaces it as a hard error, so
+        // discarding this Result is deliberate, not lossy. Propagating here
+        // instead would also be sound if a per-triple failure site is wanted.
+        let _ = self.sink.emit_triple(s, p, o);
         *self.bytes += triple_weight(subject, predicate, object);
         Ok(())
     }
@@ -325,7 +329,7 @@ pub fn build_stamp_chunk(
     let txn_meta = encode_stamp(&mut sink, stamp)?;
 
     let (writer, prefix_map, spool_ctx) = sink
-        .finish()
+        .into_parts()
         .map_err(|e| R2rmlError::Materialization(format!("flake encode: {e}")))?;
     let op_count = writer.op_count();
     let new_codes = worker_cache.into_new_codes();
@@ -866,8 +870,9 @@ fn spawn_produce_workers(
 
                         // Finish + ship this chunk (always non-empty: it holds
                         // `first`). Mirror build_stamp_chunk's finalize.
-                        let (writer, prefix_map, spool_ctx) =
-                            sink.finish().map_err(|e| format!("flake encode: {e}"))?;
+                        let (writer, prefix_map, spool_ctx) = sink
+                            .into_parts()
+                            .map_err(|e| format!("flake encode: {e}"))?;
                         let op_count = writer.op_count();
                         let new_codes = worker_cache.into_new_codes();
                         let spool_result = spool_ctx.map(SpoolContext::finish_buffered);


### PR DESCRIPTION
main is red at eadc31e11 (the #1552 merge): two E0308s in `fluree-db-api/src/materialize.rs`, plus an `unused_must_use` behind CI's `-D warnings`. This is a three-line repair.

## Why neither PR's CI could see it

This is a semantic seam between two PRs that were each green on their own base:

- #1552 renamed the inherent `ImportSink::finish()` → `into_parts()` — deliberately, to free the `finish` name for the new `GraphSink::finish()` trait method, which returns `()`. Its doc comment says so.
- #1529 (materialize-builder) landed on main while #1552 was in review, adding `materialize.rs` with two `sink.finish()` calls that destructure the 3-tuple.

Merged together, `sink.finish()` resolves to the trait method returning `()`, and both destructurings fail to typecheck. Each PR's CI ran against its own pre-merge base; the merge commit is the first place the two changes coexist, and main's CI went red exactly there (parent `dcfd7838c` = success, `eadc31e11` = failure).

## The fix

- Both `sink.finish()` call sites → `sink.into_parts()` (the renamed inherent method; same 3-tuple, same error).
- `self.sink.emit_triple(s, p, o)` → `let _ = self.sink.emit_triple(s, p, o)` with a comment stating the contract: `ImportSink` uses deferred-error semantics — `emit_*` stashes the first encode failure and `into_parts()` surfaces it as a hard error — so the discard is deliberate, not lossy. If the materialize owner prefers a per-triple failure site, propagating instead is also sound; happy to follow up.

Verified: `cargo check --workspace --all-targets` clean at this branch, `cargo clippy -p fluree-db-api --all-features --all-targets -- -D warnings` clean, `fluree-db-api` test suite green (counts in the checks below).

Every open PR is currently inheriting this red; nothing else in the repo touches these lines, so this should be safe to land quickly.
