### PR TITLE
[Fixes Main] Follow the fallible GraphSink protocol

### DIFF
--- a/fluree-db-api/src/materialize.rs
+++ b/fluree-db-api/src/materialize.rs
@@ -246,7 +246,9 @@ impl TripleObserver for InterningObserver<'_, '_> {
         let s = intern_term(self.sink, subject);
         let p = self.sink.term_iri(predicate);
         let o = intern_term(self.sink, object);
-        self.sink.emit_triple(s, p, o);
+        self.sink
+            .emit_triple(s, p, o)
+            .map_err(|e| R2rmlError::Materialization(format!("flake encode: {e}")))?;
         *self.bytes += triple_weight(subject, predicate, object);
         Ok(())
     }
@@ -325,7 +327,7 @@ pub fn build_stamp_chunk(
     let txn_meta = encode_stamp(&mut sink, stamp)?;
 
     let (writer, prefix_map, spool_ctx) = sink
-        .finish()
+        .into_parts()
         .map_err(|e| R2rmlError::Materialization(format!("flake encode: {e}")))?;
     let op_count = writer.op_count();
     let new_codes = worker_cache.into_new_codes();
@@ -866,8 +868,9 @@ fn spawn_produce_workers(
 
                         // Finish + ship this chunk (always non-empty: it holds
                         // `first`). Mirror build_stamp_chunk's finalize.
-                        let (writer, prefix_map, spool_ctx) =
-                            sink.finish().map_err(|e| format!("flake encode: {e}"))?;
+                        let (writer, prefix_map, spool_ctx) = sink
+                            .into_parts()
+                            .map_err(|e| format!("flake encode: {e}"))?;
                         let op_count = writer.op_count();
                         let new_codes = worker_cache.into_new_codes();
                         let spool_result = spool_ctx.map(SpoolContext::finish_buffered);


### PR DESCRIPTION
bf7c0a6f7 made `GraphSink` fallible and renamed `ImportSink::finish` to `into_parts`, updating every caller inside import_sink.rs. materialize.rs landed on a parallel branch and kept the old calls, so main has not compiled since the two merged. This patch updates materialize.rs to follow he new fallible `GraphSinc` protocol.