### PR TITLE
Import: survive low open-file limits — best-effort raise + FD-budgeted index build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "futures",
  "hashbrown 0.16.1",
  "hex",
+ "libc",
  "moka",
  "multihash",
  "num-bigint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,6 +2513,7 @@ dependencies = [
  "hex",
  "indexmap 2.13.0",
  "itoa",
+ "libc",
  "lru 0.12.5",
  "mimalloc",
  "moka",

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -120,6 +120,8 @@ sysinfo = { workspace = true, optional = true }
 [dev-dependencies]
 tracing-subscriber.workspace = true
 tempfile = "3.19"
+# it_import_low_fd: the re-exec'd child lowers RLIMIT_NOFILE on itself.
+libc = "0.2"
 mimalloc.workspace = true
 fs2 = "0.4"
 # Used by import tests to produce .gz / .zst fixtures inline.
@@ -146,6 +148,12 @@ path = "tests/grp_graphsource.rs"
 [[test]]
 name = "grp_import"
 path = "tests/grp_import.rs"
+
+# Standalone (NOT in grp_import): re-execs itself and lowers RLIMIT_NOFILE
+# hard+soft in the child, which must not share a process with other tests.
+[[test]]
+name = "it_import_low_fd"
+path = "tests/it_import_low_fd.rs"
 
 [[test]]
 name = "grp_index"

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -325,6 +325,14 @@ impl ImportConfig {
         }
     }
 
+    /// Effective file-descriptor budget for this import: the live soft
+    /// `RLIMIT_NOFILE` (read fresh, so it reflects the pipeline's best-effort
+    /// raise) minus a reserve, overridable via `FLUREE_FD_BUDGET`. The index
+    /// build plans every fan-in/fan-out stage within it.
+    pub fn effective_fd_budget(&self) -> fluree_db_core::fd_limit::FdBudget {
+        fluree_db_core::fd_limit::FdBudget::detect()
+    }
+
     /// Effective coalesce threshold (number of small files above which the local
     /// directory rechunk producer merges sub-`chunk_size` files into larger work
     /// items). Overridable via `FLUREE_IMPORT_COALESCE_THRESHOLD`; `0` disables.
@@ -612,6 +620,26 @@ pub enum ImportError {
     /// tokio runtime. Its producer drives an async scan via `Handle::block_on`
     /// off a dedicated thread, which deadlocks on a current-thread runtime.
     UnsupportedRuntime(String),
+    /// The process open-file limit is too low for a bulk import even with
+    /// descriptor-conserving strategies. Raised by preflight so the import
+    /// fails in milliseconds instead of mid-build.
+    FdLimit(String),
+}
+
+/// Wrap an index-build I/O failure, upgrading descriptor exhaustion
+/// (`EMFILE`/`ENFILE`) into an actionable message carrying the observed limit.
+fn index_build_error(e: &std::io::Error) -> ImportError {
+    if fluree_db_core::fd_limit::is_fd_exhaustion(e) {
+        let soft = fluree_db_core::fd_limit::nofile_limits()
+            .map_or_else(|| "unknown".to_string(), |l| l.soft.to_string());
+        ImportError::IndexBuild(format!(
+            "{e}. The process open-file limit (currently {soft}) was exhausted \
+             despite descriptor budgeting; raise it (`ulimit -n <n>`, or \
+             launchd/systemd LimitNOFILE) or lower import parallelism"
+        ))
+    } else {
+        ImportError::IndexBuild(e.to_string())
+    }
 }
 
 impl std::fmt::Display for ImportError {
@@ -634,6 +662,7 @@ impl std::fmt::Display for ImportError {
                 e.limit_fuel()
             ),
             Self::UnsupportedRuntime(msg) => write!(f, "unsupported runtime: {msg}"),
+            Self::FdLimit(msg) => write!(f, "open-file limit: {msg}"),
         }
     }
 }
@@ -2926,6 +2955,30 @@ where
     let span = tracing::debug_span!("bulk_import", alias = %alias);
 
     async {
+        // ---- FD preflight ----
+        // Best-effort raise (idempotent — covers library embedders that never
+        // ran a CLI/server entry point), then fail fast on limits so low that
+        // even the descriptor-conserving build strategies cannot run, instead
+        // of dying twenty minutes into the index build.
+        let fd_raise = fluree_db_core::fd_limit::raise_nofile_soft_to_hard();
+        fluree_db_core::fd_limit::log_raise_outcome(&fd_raise);
+        let fd_budget = config.effective_fd_budget();
+        if fd_budget.soft < 64 {
+            return Err(ImportError::FdLimit(format!(
+                "process open-file limit is {}; bulk import needs at least 64 \
+                 (raise it with `ulimit -n <n>` or launchd/systemd LimitNOFILE)",
+                fd_budget.soft
+            )));
+        }
+        if fd_budget.soft < 256 {
+            tracing::warn!(
+                soft = fd_budget.soft,
+                reserve = fd_budget.reserve,
+                "open-file limit is low; import will conserve descriptors \
+                 (bounded scatter pool, cascaded merges)"
+            );
+        }
+
         // ---- Log effective settings and resolve chunk source ----
         config.log_effective_settings();
         let chunk_source = match &import_source {
@@ -5520,7 +5573,7 @@ where
                     stage_marker: Some(v3_stage_marker),
                 };
                 std::fs::create_dir_all(&cfg_g0.run_dir)
-                    .map_err(|e| ImportError::IndexBuild(e.to_string()))?;
+                    .map_err(|e| index_build_error(&e))?;
 
                 let (g0_result, mut spot_class_stats) =
                     fluree_db_indexer::build_indexes_from_commits(
@@ -5528,7 +5581,7 @@ where
                         &cfg_g0,
                         stats_hook.as_mut(),
                     )
-                    .map_err(|e| ImportError::IndexBuild(e.to_string()))?;
+                    .map_err(|e| index_build_error(&e))?;
 
                 // Meta chunk is always the last chunk when present. We build
                 // it BEFORE stats finalize and share the IdStatsHook so the
@@ -5550,7 +5603,7 @@ where
                         stage_marker: None,
                     };
                     std::fs::create_dir_all(&cfg_g1.run_dir)
-                        .map_err(|e| ImportError::IndexBuild(e.to_string()))?;
+                        .map_err(|e| index_build_error(&e))?;
 
                     Some(
                         fluree_db_indexer::build_indexes_from_commits(
@@ -5558,7 +5611,7 @@ where
                             &cfg_g1,
                             stats_hook.as_mut(),
                         )
-                        .map_err(|e| ImportError::IndexBuild(e.to_string()))?,
+                        .map_err(|e| index_build_error(&e))?,
                     )
                 } else {
                     None
@@ -5588,7 +5641,7 @@ where
                         stage_marker: None,
                     };
                     std::fs::create_dir_all(&cfg_ng.run_dir)
-                        .map_err(|e| ImportError::IndexBuild(e.to_string()))?;
+                        .map_err(|e| index_build_error(&e))?;
 
                     // Fold this named graph's per-class SPOT stats into the
                     // default-graph accumulator. All `SpotClassStats` maps are
@@ -5603,7 +5656,7 @@ where
                         &cfg_ng,
                         stats_hook.as_mut(),
                     )
-                    .map_err(|e| ImportError::IndexBuild(e.to_string()))?;
+                    .map_err(|e| index_build_error(&e))?;
                     if let Some(ng) = ng_spot {
                         match &mut spot_class_stats {
                             Some(acc) => acc.merge(ng),
@@ -5744,8 +5797,7 @@ where
                     let stage = stage_marker.load(std::sync::atomic::Ordering::Relaxed);
                     emit_index_progress(stage, &mut current_stage, &mut stage_start);
                     break result
-                        .map_err(|e| ImportError::IndexBuild(format!("build task panicked: {e}")))?
-                        .map_err(|e| ImportError::IndexBuild(e.to_string()))?;
+                        .map_err(|e| ImportError::IndexBuild(format!("build task panicked: {e}")))??;
                 }
                 () = tokio::time::sleep(std::time::Duration::from_millis(250)) => {
                     let stage = stage_marker.load(std::sync::atomic::Ordering::Relaxed);

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -5137,10 +5137,16 @@ where
             vocab_concurrent_peak,
             "serializing dictionary merges to fit fd budget"
         );
-        if fd_available < vocab_serial_peak {
+        // Warn against the KERNEL limit, not the plan: a deliberately
+        // shrunken FLUREE_FD_BUDGET plan can serialize the merges while the
+        // real limit still fits them comfortably.
+        let kernel_headroom = fluree_db_core::fd_limit::nofile_limits().map_or(fd_available, |l| {
+            fluree_db_core::fd_limit::FdBudget::from_soft(l.soft).available()
+        });
+        if kernel_headroom < vocab_serial_peak {
             tracing::warn!(
                 chunks = vocab_chunks,
-                fd_available,
+                kernel_headroom,
                 vocab_serial_peak,
                 "dictionary merge may exceed the open-file limit even serialized; \
                  raise the limit or import fewer/larger chunks"

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -620,9 +620,9 @@ pub enum ImportError {
     /// tokio runtime. Its producer drives an async scan via `Handle::block_on`
     /// off a dedicated thread, which deadlocks on a current-thread runtime.
     UnsupportedRuntime(String),
-    /// The process open-file limit is too low for a bulk import even with
-    /// descriptor-conserving strategies. Raised by preflight so the import
-    /// fails in milliseconds instead of mid-build.
+    /// The process open-file limit was exhausted (or is demonstrably too low)
+    /// during an import phase with a per-chunk descriptor cost, such as the
+    /// dictionary merge. Carries the observed limit and the remedy.
     FdLimit(String),
 }
 
@@ -2957,26 +2957,26 @@ where
     async {
         // ---- FD preflight ----
         // Best-effort raise (idempotent — covers library embedders that never
-        // ran a CLI/server entry point), then fail fast on limits so low that
-        // even the descriptor-conserving build strategies cannot run, instead
-        // of dying twenty minutes into the index build. The gate reads the
-        // OBSERVED kernel limit, deliberately not `effective_fd_budget()`:
-        // the FLUREE_FD_BUDGET override shapes how the build *plans*, but
-        // only the real limit decides whether an import can run at all. The
-        // floor of 96 covers the budgeted build's worst phase plus the
-        // ~20–25 descriptors the rest of the process holds concurrently
-        // (stdio, tokio, the dictionary upload).
+        // ran a CLI/server entry point), then warn early on low limits. The
+        // warnings read the OBSERVED kernel limit, deliberately not
+        // `effective_fd_budget()`: the FLUREE_FD_BUDGET override shapes how
+        // the build *plans*, but only the real limit describes the
+        // environment. No hard refusal here — a small single-chunk import
+        // can succeed at limits the worst multi-chunk phase could not, so
+        // refusing on a fixed floor would regress imports that used to work;
+        // if exhaustion does happen, the EMFILE errors now carry the
+        // observed limit and the remedy.
         let fd_raise = fluree_db_core::fd_limit::raise_nofile_soft_to_hard();
         fluree_db_core::fd_limit::log_raise_outcome(&fd_raise);
         if let Some(limits) = fluree_db_core::fd_limit::nofile_limits() {
             if limits.soft < 96 {
-                return Err(ImportError::FdLimit(format!(
-                    "process open-file limit is {}; bulk import needs at least 96 \
-                     (raise it with `ulimit -n <n>` or launchd/systemd LimitNOFILE)",
-                    limits.soft
-                )));
-            }
-            if limits.soft < 256 {
+                tracing::warn!(
+                    soft = limits.soft,
+                    "open-file limit is very low; small imports may succeed but \
+                     multi-chunk imports are likely to exhaust it — raise it with \
+                     `ulimit -n <n>` or launchd/systemd LimitNOFILE"
+                );
+            } else if limits.soft < 256 {
                 tracing::warn!(
                     soft = limits.soft,
                     "open-file limit is low; import will conserve descriptors \

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -5572,8 +5572,7 @@ where
                     build_progress: Some(v3_build_counter),
                     stage_marker: Some(v3_stage_marker),
                 };
-                std::fs::create_dir_all(&cfg_g0.run_dir)
-                    .map_err(|e| index_build_error(&e))?;
+                std::fs::create_dir_all(&cfg_g0.run_dir).map_err(|e| index_build_error(&e))?;
 
                 let (g0_result, mut spot_class_stats) =
                     fluree_db_indexer::build_indexes_from_commits(
@@ -5602,8 +5601,7 @@ where
                         build_progress: None,
                         stage_marker: None,
                     };
-                    std::fs::create_dir_all(&cfg_g1.run_dir)
-                        .map_err(|e| index_build_error(&e))?;
+                    std::fs::create_dir_all(&cfg_g1.run_dir).map_err(|e| index_build_error(&e))?;
 
                     Some(
                         fluree_db_indexer::build_indexes_from_commits(
@@ -5640,8 +5638,7 @@ where
                         build_progress: None,
                         stage_marker: None,
                     };
-                    std::fs::create_dir_all(&cfg_ng.run_dir)
-                        .map_err(|e| index_build_error(&e))?;
+                    std::fs::create_dir_all(&cfg_ng.run_dir).map_err(|e| index_build_error(&e))?;
 
                     // Fold this named graph's per-class SPOT stats into the
                     // default-graph accumulator. All `SpotClassStats` maps are

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -2959,24 +2959,30 @@ where
         // Best-effort raise (idempotent — covers library embedders that never
         // ran a CLI/server entry point), then fail fast on limits so low that
         // even the descriptor-conserving build strategies cannot run, instead
-        // of dying twenty minutes into the index build.
+        // of dying twenty minutes into the index build. The gate reads the
+        // OBSERVED kernel limit, deliberately not `effective_fd_budget()`:
+        // the FLUREE_FD_BUDGET override shapes how the build *plans*, but
+        // only the real limit decides whether an import can run at all. The
+        // floor of 96 covers the budgeted build's worst phase plus the
+        // ~20–25 descriptors the rest of the process holds concurrently
+        // (stdio, tokio, the dictionary upload).
         let fd_raise = fluree_db_core::fd_limit::raise_nofile_soft_to_hard();
         fluree_db_core::fd_limit::log_raise_outcome(&fd_raise);
-        let fd_budget = config.effective_fd_budget();
-        if fd_budget.soft < 64 {
-            return Err(ImportError::FdLimit(format!(
-                "process open-file limit is {}; bulk import needs at least 64 \
-                 (raise it with `ulimit -n <n>` or launchd/systemd LimitNOFILE)",
-                fd_budget.soft
-            )));
-        }
-        if fd_budget.soft < 256 {
-            tracing::warn!(
-                soft = fd_budget.soft,
-                reserve = fd_budget.reserve,
-                "open-file limit is low; import will conserve descriptors \
-                 (bounded scatter pool, cascaded merges)"
-            );
+        if let Some(limits) = fluree_db_core::fd_limit::nofile_limits() {
+            if limits.soft < 96 {
+                return Err(ImportError::FdLimit(format!(
+                    "process open-file limit is {}; bulk import needs at least 96 \
+                     (raise it with `ulimit -n <n>` or launchd/systemd LimitNOFILE)",
+                    limits.soft
+                )));
+            }
+            if limits.soft < 256 {
+                tracing::warn!(
+                    soft = limits.soft,
+                    "open-file limit is low; import will conserve descriptors \
+                     (bounded scatter pool, cascaded merges)"
+                );
+            }
         }
 
         // ---- Log effective settings and resolve chunk source ----
@@ -5109,9 +5115,54 @@ where
     use fluree_db_indexer::run_index::vocab_merge;
 
     // Phase B can use more CPU: subject, string, and language merges are independent.
-    // Run them concurrently to better utilize cores while this phase is otherwise I/O-bound.
+    // Run them concurrently to better utilize cores while this phase is otherwise I/O-bound —
+    // unless the FD budget can't cover the concurrent peak. Each merge holds
+    // one reader per chunk, the subject/string merges additionally hold one
+    // remap writer per chunk, plus a handful of output streams: ~5 descriptors
+    // per chunk when all three run at once, ~2 per chunk serialized. This was
+    // the import's first unbudgeted EMFILE site on multi-chunk imports at low
+    // limits — before the index build even starts.
     let run_dir_path = run_dir.to_path_buf();
     let remap_dir_path = remap_dir.to_path_buf();
+
+    let vocab_chunks = sorted_commit_infos.len();
+    let vocab_concurrent_peak = 5 * vocab_chunks + 16;
+    let vocab_serial_peak = 2 * vocab_chunks + 8;
+    let fd_available = config.effective_fd_budget().available();
+    let vocab_merge_serial = fd_available < vocab_concurrent_peak;
+    if vocab_merge_serial {
+        tracing::info!(
+            chunks = vocab_chunks,
+            fd_available,
+            vocab_concurrent_peak,
+            "serializing dictionary merges to fit fd budget"
+        );
+        if fd_available < vocab_serial_peak {
+            tracing::warn!(
+                chunks = vocab_chunks,
+                fd_available,
+                vocab_serial_peak,
+                "dictionary merge may exceed the open-file limit even serialized; \
+                 raise the limit or import fewer/larger chunks"
+            );
+        }
+    }
+
+    /// Map a vocab-merge failure, upgrading descriptor exhaustion into the
+    /// actionable open-file-limit error.
+    fn vocab_merge_error(e: std::io::Error) -> ImportError {
+        if fluree_db_core::fd_limit::is_fd_exhaustion(&e) {
+            let soft = fluree_db_core::fd_limit::nofile_limits()
+                .map_or_else(|| "unknown".to_string(), |l| l.soft.to_string());
+            ImportError::FdLimit(format!(
+                "{e} during dictionary merge; the process open-file limit (currently \
+                 {soft}) is too low for this many import chunks — raise it \
+                 (`ulimit -n <n>`, LimitNOFILE) or use fewer/larger chunks"
+            ))
+        } else {
+            ImportError::Io(e)
+        }
+    }
 
     let subj_vocab_paths_for_task = subject_vocab_paths.clone();
     let chunk_ids_for_subj = chunk_ids.clone();
@@ -5130,6 +5181,17 @@ where
             namespace_codes_for_subj.as_ref(),
         )
     });
+    // Serial mode: drain each merge before spawning the next, so only one
+    // merge's per-chunk descriptors are live at a time.
+    let (subj_stats_serial, subj_handle) = if vocab_merge_serial {
+        let stats = subj_handle
+            .await
+            .map_err(|e| ImportError::RunGeneration(format!("subject vocab merge panicked: {e}")))?
+            .map_err(vocab_merge_error)?;
+        (Some(stats), None)
+    } else {
+        (None, Some(subj_handle))
+    };
 
     let str_vocab_paths_for_task = string_vocab_paths.clone();
     let chunk_ids_for_str = chunk_ids.clone();
@@ -5145,6 +5207,15 @@ where
             &run_dir_for_str,
         )
     });
+    let (str_stats_serial, str_handle) = if vocab_merge_serial {
+        let stats = str_handle
+            .await
+            .map_err(|e| ImportError::RunGeneration(format!("string vocab merge panicked: {e}")))?
+            .map_err(vocab_merge_error)?;
+        (Some(stats), None)
+    } else {
+        (None, Some(str_handle))
+    };
 
     let lang_vocab_paths_for_task = lang_vocab_paths.clone();
     let lang_span = merge_parent_span;
@@ -5153,14 +5224,22 @@ where
         fluree_db_indexer::run_index::build_lang_remap_from_vocabs(&lang_vocab_paths_for_task)
     });
 
-    let subj_stats = subj_handle
-        .await
-        .map_err(|e| ImportError::RunGeneration(format!("subject vocab merge panicked: {e}")))?
-        .map_err(ImportError::Io)?;
-    let str_stats = str_handle
-        .await
-        .map_err(|e| ImportError::RunGeneration(format!("string vocab merge panicked: {e}")))?
-        .map_err(ImportError::Io)?;
+    let subj_stats = match (subj_stats_serial, subj_handle) {
+        (Some(stats), _) => stats,
+        (None, Some(handle)) => handle
+            .await
+            .map_err(|e| ImportError::RunGeneration(format!("subject vocab merge panicked: {e}")))?
+            .map_err(vocab_merge_error)?,
+        (None, None) => unreachable!("serial mode stores stats, concurrent mode stores handle"),
+    };
+    let str_stats = match (str_stats_serial, str_handle) {
+        (Some(stats), _) => stats,
+        (None, Some(handle)) => handle
+            .await
+            .map_err(|e| ImportError::RunGeneration(format!("string vocab merge panicked: {e}")))?
+            .map_err(vocab_merge_error)?,
+        (None, None) => unreachable!("serial mode stores stats, concurrent mode stores handle"),
+    };
     let (unified_lang_dict, lang_remaps) = lang_handle
         .await
         .map_err(|e| ImportError::RunGeneration(format!("language vocab merge panicked: {e}")))?

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -5500,6 +5500,11 @@ where
                 let v3_runs_g0 = v3_run_dir.join("v3_runs_g0");
                 let v3_runs_g1 = v3_run_dir.join("v3_runs_g1");
 
+                // One FD budget for every graph's build in this import: the
+                // builds are sequential and plan against the same process
+                // limit (post best-effort raise at startup/preflight).
+                let fd_budget = fluree_db_core::fd_limit::FdBudget::detect();
+
                 let cfg_g0 = fluree_db_indexer::BuildConfig {
                     run_dir: v3_runs_g0,
                     index_dir: v3_index_dir.clone(),
@@ -5509,6 +5514,7 @@ where
                     zstd_level: 1,
                     run_budget_bytes: v3_run_budget,
                     worker_count: v3_worker_count,
+                    fd_budget,
                     remap_progress: Some(v3_remap_counter),
                     build_progress: Some(v3_build_counter),
                     stage_marker: Some(v3_stage_marker),
@@ -5538,6 +5544,7 @@ where
                         zstd_level: 1,
                         run_budget_bytes: v3_run_budget,
                         worker_count: 1,
+                        fd_budget,
                         remap_progress: None,
                         build_progress: None,
                         stage_marker: None,
@@ -5575,6 +5582,7 @@ where
                         zstd_level: 1,
                         run_budget_bytes: v3_run_budget,
                         worker_count: 1,
+                        fd_budget,
                         remap_progress: None,
                         build_progress: None,
                         stage_marker: None,

--- a/fluree-db-api/tests/it_import_low_fd.rs
+++ b/fluree-db-api/tests/it_import_low_fd.rs
@@ -202,10 +202,9 @@ async fn import_under_low_fd_limit() {
     );
 
     // Ran-marker + flake-count equality.
-    let child_result: serde_json::Value = serde_json::from_slice(
-        &std::fs::read(&result_path).expect("child result file must exist"),
-    )
-    .expect("child result json");
+    let child_result: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&result_path).expect("child result file must exist"))
+            .expect("child result json");
     assert_eq!(
         child_result["flake_count"].as_u64(),
         Some(baseline_flakes),

--- a/fluree-db-api/tests/it_import_low_fd.rs
+++ b/fluree-db-api/tests/it_import_low_fd.rs
@@ -1,0 +1,219 @@
+//! End-to-end regression: bulk import must succeed — and produce the same
+//! ledger — under a low `RLIMIT_NOFILE`.
+//!
+//! Before FD budgeting, the index build opened 256 class-membership partition
+//! writers up front (plus one descriptor per chunk for the SPOT merge and
+//! every run file of an order at once for the secondary merges), so any
+//! import of typed data died with `EMFILE` at soft limits ≤ 256 — macOS's
+//! stock default. This test proves the budgeted build completes under a
+//! 96-descriptor limit and matches an unconstrained import bit-for-bit at
+//! the query level.
+//!
+//! Process shape: the test re-executes itself (`current_exe`) in "child"
+//! mode, and the child lowers `RLIMIT_NOFILE` — **hard and soft** — to 96
+//! before importing. The hard limit must drop too, otherwise the pipeline's
+//! own best-effort raise would undo the constraint and the test would prove
+//! nothing. A separate process is mandatory: rlimits are process-global and
+//! irreversible (hard can only go down), so doing this in the main test
+//! process would poison every other test in the target.
+//!
+//! This is a standalone `[[test]]` target (not bundled into `grp_import`)
+//! for exactly that isolation reason.
+
+#![cfg(all(unix, feature = "native"))]
+
+#[path = "support/mod.rs"]
+mod support;
+
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+use std::io::Write;
+
+const CHILD_ENV: &str = "FLUREE_LOW_FD_CHILD";
+const DB_DIR_ENV: &str = "FLUREE_LOW_FD_DB_DIR";
+const TTL_ENV: &str = "FLUREE_LOW_FD_TTL";
+const RESULT_ENV: &str = "FLUREE_LOW_FD_RESULT";
+
+/// Below the 256 partition writers the unbudgeted scatter opened up front
+/// (the test must fail on a build without FD budgeting), with headroom above
+/// what the harness + tokio + storage backend themselves need.
+const LOW_FD_LIMIT: u64 = 96;
+
+const LEDGER: &str = "test/import-low-fd:main";
+const USERS: u64 = 30_000;
+
+/// Typed subjects are required: `rdf:type` + id-stats is what unconditionally
+/// triggered the 256-file scatter. Mixed literal/ref properties give the
+/// secondary orders non-trivial shape.
+fn generate_ttl(path: &std::path::Path) {
+    let mut f = std::io::BufWriter::new(std::fs::File::create(path).expect("create ttl"));
+    writeln!(
+        f,
+        "@prefix ex: <http://example.org/ns/> .\n@prefix schema: <http://schema.org/> ."
+    )
+    .expect("write prefix");
+    for i in 0..USERS {
+        writeln!(
+            f,
+            "ex:user{i} a ex:User ;\n    schema:name \"User {i}\" ;\n    schema:age {} ;\n    ex:score {} ;\n    ex:friend ex:user{} .",
+            i % 90 + 10,
+            i * 7 % 1000,
+            (i + 1) % USERS,
+        )
+        .expect("write subject");
+    }
+    f.flush().expect("flush ttl");
+}
+
+fn lower_nofile_limit_hard(limit: u64) {
+    let rl = libc::rlimit {
+        rlim_cur: limit as libc::rlim_t,
+        rlim_max: limit as libc::rlim_t,
+    };
+    // SAFETY: setrlimit reads the struct we pass; lowering is always allowed.
+    let rc = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &rl) };
+    assert_eq!(
+        rc,
+        0,
+        "setrlimit(NOFILE, {limit}) failed: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+async fn run_import(db_dir: &std::path::Path, ttl: &std::path::Path) -> (u64, i64) {
+    let fluree = FlureeBuilder::file(db_dir.to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    let result = fluree
+        .create(LEDGER)
+        .import(ttl)
+        .threads(2)
+        .memory_budget_mb(256)
+        .execute()
+        .await
+        .expect("import should succeed");
+    assert!(result.root_id.is_some(), "index should have been built");
+    (result.flake_count, result.t)
+}
+
+/// Deterministic fingerprint of ledger contents: row count plus the sorted
+/// first/last names and the sum of all ages, via a fresh builder on the dir.
+async fn fingerprint(db_dir: &std::path::Path) -> (usize, String, String, i64) {
+    let fluree = FlureeBuilder::file(db_dir.to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    let ledger = fluree.ledger(LEDGER).await.expect("load ledger");
+    let query = json!({
+        "@context": { "ex": "http://example.org/ns/", "schema": "http://schema.org/" },
+        "select": ["?name", "?age"],
+        "where": { "schema:name": "?name", "schema:age": "?age" }
+    });
+    let qr = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let rows = qr.to_jsonld(&ledger.snapshot).expect("format jsonld");
+    let rows = rows.as_array().expect("array result");
+    let mut names: Vec<String> = Vec::with_capacity(rows.len());
+    let mut age_sum: i64 = 0;
+    for row in rows {
+        let cols = row.as_array().expect("row array");
+        names.push(cols[0].as_str().expect("name string").to_string());
+        age_sum += cols[1].as_i64().expect("age i64");
+    }
+    names.sort();
+    (
+        names.len(),
+        names.first().cloned().unwrap_or_default(),
+        names.last().cloned().unwrap_or_default(),
+        age_sum,
+    )
+}
+
+fn child_main() {
+    // Constrain BEFORE anything import-related opens files. The tokio::test
+    // runtime already holds its descriptors; lowering the limit below the
+    // open count only gates *new* opens, which is exactly the contract the
+    // import must survive.
+    lower_nofile_limit_hard(LOW_FD_LIMIT);
+
+    let db_dir = std::env::var(DB_DIR_ENV).expect("child db dir env");
+    let ttl = std::env::var(TTL_ENV).expect("child ttl env");
+    let result_path = std::env::var(RESULT_ENV).expect("child result env");
+
+    // Fresh multi-thread runtime built AFTER the constraint, so every
+    // descriptor the import path opens is subject to the low limit.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("child runtime");
+    let (flake_count, t) = runtime.block_on(run_import(
+        std::path::Path::new(&db_dir),
+        std::path::Path::new(&ttl),
+    ));
+
+    // Positive ran-marker: the parent treats a missing/invalid result file
+    // as failure, so a child that silently did nothing cannot pass.
+    std::fs::write(
+        &result_path,
+        serde_json::to_vec(&json!({ "flake_count": flake_count, "t": t })).expect("encode"),
+    )
+    .expect("write result file");
+}
+
+#[tokio::test]
+async fn import_under_low_fd_limit() {
+    if std::env::var(CHILD_ENV).is_ok() {
+        // Already inside the constrained re-exec; tokio::test's runtime is
+        // irrelevant here — the child builds its own after the setrlimit.
+        tokio::task::spawn_blocking(child_main)
+            .await
+            .expect("child mode");
+        return;
+    }
+
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+    let baseline_db = tempfile::tempdir().expect("baseline db tmpdir");
+    let child_db = tempfile::tempdir().expect("child db tmpdir");
+
+    let ttl_path = data_dir.path().join("users.ttl");
+    generate_ttl(&ttl_path);
+
+    // Unconstrained baseline in this process.
+    let (baseline_flakes, _t) = run_import(baseline_db.path(), &ttl_path).await;
+    let baseline_print = fingerprint(baseline_db.path()).await;
+
+    // Constrained import in a re-exec'd child.
+    let result_path = data_dir.path().join("child_result.json");
+    let exe = std::env::current_exe().expect("current exe");
+    let output = std::process::Command::new(&exe)
+        .args(["import_under_low_fd_limit", "--exact", "--nocapture"])
+        .env(CHILD_ENV, "1")
+        .env(DB_DIR_ENV, child_db.path())
+        .env(TTL_ENV, &ttl_path)
+        .env(RESULT_ENV, &result_path)
+        .output()
+        .expect("spawn child");
+    assert!(
+        output.status.success(),
+        "constrained child import failed (limit {LOW_FD_LIMIT}).\n--- child stdout ---\n{}\n--- child stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // Ran-marker + flake-count equality.
+    let child_result: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(&result_path).expect("child result file must exist"),
+    )
+    .expect("child result json");
+    assert_eq!(
+        child_result["flake_count"].as_u64(),
+        Some(baseline_flakes),
+        "constrained import wrote a different flake count"
+    );
+
+    // Content equality, queried through a fresh handle on each dir.
+    let child_print = fingerprint(child_db.path()).await;
+    assert_eq!(baseline_print, child_print);
+    assert_eq!(baseline_print.0 as u64, USERS);
+}

--- a/fluree-db-api/tests/it_import_low_fd.rs
+++ b/fluree-db-api/tests/it_import_low_fd.rs
@@ -40,7 +40,12 @@ const RESULT_ENV: &str = "FLUREE_LOW_FD_RESULT";
 const LOW_FD_LIMIT: u64 = 96;
 
 const LEDGER: &str = "test/import-low-fd:main";
-const USERS: u64 = 30_000;
+/// Sized so the whole test (two baselines + two constrained children, four
+/// imports total) stays well inside nextest's slow-test kill window on a
+/// 2-vCPU CI runner. The FD mechanics under test depend on chunk counts and
+/// typed-subject presence, not data volume, so shrinking users loses no
+/// coverage. Must divide evenly by the 30 files of scenario B.
+const USERS: u64 = 12_000;
 
 /// Typed subjects are required: `rdf:type` + id-stats is what unconditionally
 /// triggered the 256-file scatter. Mixed literal/ref properties give the
@@ -239,8 +244,8 @@ fn run_child(
 ///    scatter pool (56 open writers instead of 256) and overall descriptor
 ///    discipline survive the stock-macOS-sized limit.
 /// B. 30-file directory import with `FLUREE_FD_BUDGET=40` shrinking the
-///    *plan* (spot_fan_in 24, merge fan-in 12) while the kernel still
-///    enforces 96. 30 chunks > 24 forces the hierarchical SPOT merge, and
+///    *plan* (spot_fan_in 16, merge fan-in 12) while the kernel still
+///    enforces 96. 30 chunks > 16 forces the hierarchical SPOT merge, and
 ///    ≥30 run files per order > 12 forces cascaded secondary merges — both
 ///    fallbacks run against a real limit, not a synthetic plan.
 ///

--- a/fluree-db-api/tests/it_import_low_fd.rs
+++ b/fluree-db-api/tests/it_import_low_fd.rs
@@ -161,6 +161,94 @@ fn child_main() {
     .expect("write result file");
 }
 
+/// Same triples as [`generate_ttl`], split across `files` self-contained
+/// Turtle files so the directory import produces one chunk per file — enough
+/// chunks to push the SPOT merge past a shrunken fan-in cap.
+fn generate_ttl_directory(dir: &std::path::Path, files: u64) {
+    let per_file = USERS / files;
+    for f in 0..files {
+        let mut w = std::io::BufWriter::new(
+            std::fs::File::create(dir.join(format!("users_{f:03}.ttl"))).expect("create ttl"),
+        );
+        writeln!(
+            w,
+            "@prefix ex: <http://example.org/ns/> .\n@prefix schema: <http://schema.org/> ."
+        )
+        .expect("write prefix");
+        for i in (f * per_file)..((f + 1) * per_file) {
+            writeln!(
+                w,
+                "ex:user{i} a ex:User ;\n    schema:name \"User {i}\" ;\n    schema:age {} ;\n    ex:score {} ;\n    ex:friend ex:user{} .",
+                i % 90 + 10,
+                i * 7 % 1000,
+                (i + 1) % USERS,
+            )
+            .expect("write subject");
+        }
+        w.flush().expect("flush ttl");
+    }
+}
+
+/// Spawn this test binary in child mode against `source`, under the real
+/// 96-descriptor kernel limit, with scenario-specific extra env. Returns the
+/// child's reported flake count (the positive ran-marker: a missing/invalid
+/// result file fails the test, so a child that silently did nothing cannot
+/// pass).
+fn run_child(
+    exe: &std::path::Path,
+    db_dir: &std::path::Path,
+    source: &std::path::Path,
+    result_path: &std::path::Path,
+    extra_env: &[(&str, &str)],
+    scenario: &str,
+) -> u64 {
+    let mut cmd = std::process::Command::new(exe);
+    cmd.args(["import_under_low_fd_limit", "--exact", "--nocapture"])
+        .env(CHILD_ENV, "1")
+        .env(DB_DIR_ENV, db_dir)
+        .env(TTL_ENV, source)
+        .env(RESULT_ENV, result_path)
+        // Determinism: never inherit budget/compression overrides from the
+        // invoking environment; scenarios set what they need explicitly.
+        .env_remove("FLUREE_FD_BUDGET")
+        .env_remove("FLUREE_RUN_ZSTD")
+        .env_remove("FLUREE_RUN_ZSTD_LEVEL")
+        .env_remove("FLUREE_IMPORT_COALESCE_THRESHOLD");
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("spawn child");
+    assert!(
+        output.status.success(),
+        "constrained child import failed (scenario {scenario}, limit {LOW_FD_LIMIT}).\n\
+         --- child stdout ---\n{}\n--- child stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let child_result: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(result_path).expect("child result file must exist"))
+            .expect("child result json");
+    child_result["flake_count"]
+        .as_u64()
+        .expect("flake_count in child result")
+}
+
+/// Two constrained scenarios, both under a REAL kernel limit of 96:
+///
+/// A. Single-file import (one chunk). End-to-end proof that the bounded
+///    scatter pool (56 open writers instead of 256) and overall descriptor
+///    discipline survive the stock-macOS-sized limit.
+/// B. 30-file directory import with `FLUREE_FD_BUDGET=40` shrinking the
+///    *plan* (spot_fan_in 24, merge fan-in 12) while the kernel still
+///    enforces 96. 30 chunks > 24 forces the hierarchical SPOT merge, and
+///    ≥30 run files per order > 12 forces cascaded secondary merges — both
+///    fallbacks run against a real limit, not a synthetic plan.
+///
+/// Equality is asserted via flake counts and a content fingerprint (row
+/// count, sorted first/last names, age sum) — not `root_id`, which embeds
+/// commit CIDs with timestamps and is not stable across separate imports.
+/// Byte-level identity of the cascade/hierarchical outputs is pinned by the
+/// leaf-CID-equality unit tests in fluree-db-indexer.
 #[tokio::test]
 async fn import_under_low_fd_limit() {
     if std::env::var(CHILD_ENV).is_ok() {
@@ -173,46 +261,55 @@ async fn import_under_low_fd_limit() {
     }
 
     let data_dir = tempfile::tempdir().expect("data tmpdir");
-    let baseline_db = tempfile::tempdir().expect("baseline db tmpdir");
-    let child_db = tempfile::tempdir().expect("child db tmpdir");
+    let exe = std::env::current_exe().expect("current exe");
 
+    // --- Scenario A: single file ---
     let ttl_path = data_dir.path().join("users.ttl");
     generate_ttl(&ttl_path);
 
-    // Unconstrained baseline in this process.
+    let baseline_db = tempfile::tempdir().expect("baseline db tmpdir");
     let (baseline_flakes, _t) = run_import(baseline_db.path(), &ttl_path).await;
     let baseline_print = fingerprint(baseline_db.path()).await;
-
-    // Constrained import in a re-exec'd child.
-    let result_path = data_dir.path().join("child_result.json");
-    let exe = std::env::current_exe().expect("current exe");
-    let output = std::process::Command::new(&exe)
-        .args(["import_under_low_fd_limit", "--exact", "--nocapture"])
-        .env(CHILD_ENV, "1")
-        .env(DB_DIR_ENV, child_db.path())
-        .env(TTL_ENV, &ttl_path)
-        .env(RESULT_ENV, &result_path)
-        .output()
-        .expect("spawn child");
-    assert!(
-        output.status.success(),
-        "constrained child import failed (limit {LOW_FD_LIMIT}).\n--- child stdout ---\n{}\n--- child stderr ---\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
-
-    // Ran-marker + flake-count equality.
-    let child_result: serde_json::Value =
-        serde_json::from_slice(&std::fs::read(&result_path).expect("child result file must exist"))
-            .expect("child result json");
-    assert_eq!(
-        child_result["flake_count"].as_u64(),
-        Some(baseline_flakes),
-        "constrained import wrote a different flake count"
-    );
-
-    // Content equality, queried through a fresh handle on each dir.
-    let child_print = fingerprint(child_db.path()).await;
-    assert_eq!(baseline_print, child_print);
     assert_eq!(baseline_print.0 as u64, USERS);
+
+    let child_db = tempfile::tempdir().expect("child db tmpdir");
+    let child_flakes = run_child(
+        &exe,
+        child_db.path(),
+        &ttl_path,
+        &data_dir.path().join("child_a.json"),
+        &[],
+        "A/single-file",
+    );
+    assert_eq!(child_flakes, baseline_flakes);
+    assert_eq!(fingerprint(child_db.path()).await, baseline_print);
+
+    // --- Scenario B: 30-chunk directory, shrunken plan ---
+    let ttl_dir = data_dir.path().join("chunks");
+    std::fs::create_dir_all(&ttl_dir).expect("chunks dir");
+    generate_ttl_directory(&ttl_dir, 30);
+
+    let dir_baseline_db = tempfile::tempdir().expect("dir baseline tmpdir");
+    let (dir_baseline_flakes, _t) = run_import(dir_baseline_db.path(), &ttl_dir).await;
+    let dir_baseline_print = fingerprint(dir_baseline_db.path()).await;
+    assert_eq!(dir_baseline_print.0 as u64, USERS);
+
+    let dir_child_db = tempfile::tempdir().expect("dir child tmpdir");
+    let dir_child_flakes = run_child(
+        &exe,
+        dir_child_db.path(),
+        &ttl_dir,
+        &data_dir.path().join("child_b.json"),
+        &[
+            // Shrink the PLAN below the chunk/run counts so the hierarchical
+            // SPOT merge and the cascade both fire; the kernel limit stays 96.
+            ("FLUREE_FD_BUDGET", "40"),
+            // One chunk per file: don't let the producer coalesce the small
+            // files back into few chunks.
+            ("FLUREE_IMPORT_COALESCE_THRESHOLD", "0"),
+        ],
+        "B/directory-cascades",
+    );
+    assert_eq!(dir_child_flakes, dir_baseline_flakes);
+    assert_eq!(fingerprint(dir_child_db.path()).await, dir_baseline_print);
 }

--- a/fluree-db-cli/src/main.rs
+++ b/fluree-db-cli/src/main.rs
@@ -213,6 +213,10 @@ fn main() {
 }
 
 async fn async_main() {
+    // Best-effort raise of the open-file soft limit (macOS defaults to 256,
+    // which large imports exceed). Done before tracing init; logged after.
+    let fd_raise = fluree_db_core::fd_limit::raise_nofile_soft_to_hard();
+
     let cli = Cli::parse();
 
     // Disable color when --no-color flag or NO_COLOR env var is set.
@@ -242,6 +246,7 @@ async fn async_main() {
     if !skip_tracing {
         init_tracing(&cli);
     }
+    fluree_db_core::fd_limit::log_raise_outcome(&fd_raise);
 
     let result = fluree_db_cli::run(cli).await;
     shutdown_tracer().await;

--- a/fluree-db-core/Cargo.toml
+++ b/fluree-db-core/Cargo.toml
@@ -53,6 +53,10 @@ tracing = { workspace = true }
 # Optional: commit signing (used by commit_v2 writer)
 fluree-db-credential = { path = "../fluree-db-credential", optional = true }
 
+# RLIMIT_NOFILE introspection/raise (fd_limit module)
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tokio = { workspace = true }
 postcard = { workspace = true }

--- a/fluree-db-core/src/fd_limit.rs
+++ b/fluree-db-core/src/fd_limit.rs
@@ -92,9 +92,25 @@ fn macos_max_files_per_proc() -> u64 {
     }
 }
 
+/// Linux rejects `setrlimit(RLIMIT_NOFILE)` soft values above
+/// `/proc/sys/fs/nr_open` — notably `RLIM_INFINITY` when the hard limit is
+/// unlimited — so the raise target must be clamped to it, symmetrically with
+/// macOS's `kern.maxfilesperproc`. Falls back to the kernel default
+/// (1 048 576) if the file is unreadable.
+#[cfg(target_os = "linux")]
+fn linux_nr_open() -> u64 {
+    const NR_OPEN_DEFAULT: u64 = 1_048_576;
+    std::fs::read_to_string("/proc/sys/fs/nr_open")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(NR_OPEN_DEFAULT)
+}
+
 /// Best-effort raise of the `RLIMIT_NOFILE` soft limit to the hard limit
-/// (clamped to `kern.maxfilesperproc` on macOS). Never errors — callers log
-/// the outcome via [`log_raise_outcome`] once tracing is initialized.
+/// (clamped to `kern.maxfilesperproc` on macOS and `/proc/sys/fs/nr_open`
+/// on Linux — both kernels refuse soft values above those ceilings even
+/// when the hard limit is `RLIM_INFINITY`). Never errors — callers log the
+/// outcome via [`log_raise_outcome`] once tracing is initialized.
 #[cfg(unix)]
 pub fn raise_nofile_soft_to_hard() -> RaiseOutcome {
     let Some(NofileLimits { soft, hard }) = nofile_limits() else {
@@ -106,7 +122,9 @@ pub fn raise_nofile_soft_to_hard() -> RaiseOutcome {
 
     #[cfg(target_os = "macos")]
     let target = hard.min(macos_max_files_per_proc());
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    let target = hard.min(linux_nr_open());
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     let target = hard;
 
     if soft >= target {
@@ -234,14 +252,19 @@ impl FdBudget {
         }
     }
 
-    /// Descriptors available for planning: `max(soft - reserve, 32)`, so even
-    /// absurdly low limits yield a plan that can make progress (the kernel
-    /// will still enforce the real limit; 32 merely keeps the plan sane).
+    /// Descriptors available for planning: `soft - reserve`, floored at
+    /// `min(32, soft)` so a reserve-dominated budget still yields a plan
+    /// that can make progress — but never a number larger than the stated
+    /// limit itself, which would mislead an operator debugging an EMFILE
+    /// with a deliberately tiny `FLUREE_FD_BUDGET`. (The per-phase plan
+    /// floors in `fd_plan` may still exceed a degenerate budget by design;
+    /// the kernel, not the plan, enforces reality.)
     pub fn available(&self) -> usize {
         if self.soft == u64::MAX {
             return usize::MAX;
         }
-        usize::try_from(self.soft.saturating_sub(self.reserve).max(32)).unwrap_or(usize::MAX)
+        let floor = self.soft.min(32);
+        usize::try_from(self.soft.saturating_sub(self.reserve).max(floor)).unwrap_or(usize::MAX)
     }
 }
 
@@ -264,8 +287,10 @@ mod tests {
         assert_eq!(FdBudget::from_soft(96).available(), 64);
         assert_eq!(FdBudget::from_soft(256).available(), 192);
         assert_eq!(FdBudget::from_soft(1024).available(), 960);
-        // Degenerate limits floor at 32 rather than planning zero fan-in.
-        assert_eq!(FdBudget::from_soft(8).available(), 32);
+        // Reserve-dominated budgets floor at 32 rather than planning zero
+        // fan-in — but never above the stated limit itself.
+        assert_eq!(FdBudget::from_soft(40).available(), 32);
+        assert_eq!(FdBudget::from_soft(8).available(), 8);
         assert_eq!(FdBudget::unlimited().available(), usize::MAX);
     }
 

--- a/fluree-db-core/src/fd_limit.rs
+++ b/fluree-db-core/src/fd_limit.rs
@@ -1,0 +1,291 @@
+//! Process open-file-limit (`RLIMIT_NOFILE`) helpers.
+//!
+//! Large bulk imports fan out over many temporary files (spool chunks, sorted
+//! run files, class-membership partitions). On platforms with a low default
+//! soft limit — macOS ships 256 — an unbounded fan-out dies with
+//! `EMFILE`/"Too many open files". Two complementary mechanisms live here:
+//!
+//! 1. [`raise_nofile_soft_to_hard`] — a best-effort, unprivileged raise of the
+//!    soft limit to the hard limit, called once at process startup (CLI,
+//!    server) and again defensively at the start of an import.
+//! 2. [`FdBudget`] — the observed post-raise limit minus a reserve, handed to
+//!    the index build so every fan-in/fan-out stage plans within it (mirroring
+//!    how `run_budget_bytes` plans memory). This is what keeps imports correct
+//!    in environments where the hard limit itself is low and fixed (containers,
+//!    AWS Lambda's 1024).
+//!
+//! Memory-mapped regions do not count against `RLIMIT_NOFILE` once their
+//! `File` is dropped; only real open handles need budgeting.
+
+/// Soft and hard `RLIMIT_NOFILE` values as reported by `getrlimit`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NofileLimits {
+    /// Current (soft) limit — the enforced ceiling on open descriptors.
+    pub soft: u64,
+    /// Maximum (hard) limit the soft limit can be raised to without privileges.
+    pub hard: u64,
+}
+
+/// Result of a [`raise_nofile_soft_to_hard`] attempt.
+#[derive(Clone, Copy, Debug)]
+pub enum RaiseOutcome {
+    /// Soft limit was raised.
+    Raised { from: u64, to: u64 },
+    /// Soft limit already at the effective maximum; nothing to do.
+    AlreadyAtMax { soft: u64 },
+    /// `setrlimit` (or `getrlimit`) failed; `soft` is the still-current limit.
+    Failed { errno: i32, soft: u64 },
+    /// Not a unix platform; limits are not observable here.
+    Unsupported,
+}
+
+/// Read the current `RLIMIT_NOFILE`. `None` on non-unix platforms or if
+/// `getrlimit` fails.
+#[cfg(unix)]
+pub fn nofile_limits() -> Option<NofileLimits> {
+    let mut rl = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: getrlimit only writes into the rlimit struct we pass.
+    let rc = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rl) };
+    if rc != 0 {
+        return None;
+    }
+    Some(NofileLimits {
+        soft: rl.rlim_cur as u64,
+        hard: rl.rlim_max as u64,
+    })
+}
+
+/// Read the current `RLIMIT_NOFILE`. `None` on non-unix platforms.
+#[cfg(not(unix))]
+pub fn nofile_limits() -> Option<NofileLimits> {
+    None
+}
+
+/// macOS refuses `setrlimit` soft values above `kern.maxfilesperproc` even
+/// when the hard limit reports `RLIM_INFINITY`, so the raise target must be
+/// clamped to it. Falls back to `OPEN_MAX` (10240) if the sysctl fails.
+#[cfg(target_os = "macos")]
+fn macos_max_files_per_proc() -> u64 {
+    const OPEN_MAX: u64 = 10_240;
+    let mut val: libc::c_int = 0;
+    let mut len = std::mem::size_of::<libc::c_int>();
+    // SAFETY: sysctlbyname writes at most `len` bytes into `val`.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            c"kern.maxfilesperproc".as_ptr(),
+            std::ptr::from_mut(&mut val).cast::<libc::c_void>(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc == 0 && val > 0 {
+        val as u64
+    } else {
+        OPEN_MAX
+    }
+}
+
+/// Best-effort raise of the `RLIMIT_NOFILE` soft limit to the hard limit
+/// (clamped to `kern.maxfilesperproc` on macOS). Never errors — callers log
+/// the outcome via [`log_raise_outcome`] once tracing is initialized.
+#[cfg(unix)]
+pub fn raise_nofile_soft_to_hard() -> RaiseOutcome {
+    let Some(NofileLimits { soft, hard }) = nofile_limits() else {
+        return RaiseOutcome::Failed {
+            errno: std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+            soft: 0,
+        };
+    };
+
+    #[cfg(target_os = "macos")]
+    let target = hard.min(macos_max_files_per_proc());
+    #[cfg(not(target_os = "macos"))]
+    let target = hard;
+
+    if soft >= target {
+        return RaiseOutcome::AlreadyAtMax { soft };
+    }
+
+    let rl = libc::rlimit {
+        rlim_cur: target as libc::rlim_t,
+        rlim_max: hard as libc::rlim_t,
+    };
+    // SAFETY: setrlimit reads the rlimit struct we pass; raising the soft
+    // limit up to the hard limit needs no privileges.
+    let rc = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &rl) };
+    if rc == 0 {
+        RaiseOutcome::Raised {
+            from: soft,
+            to: target,
+        }
+    } else {
+        RaiseOutcome::Failed {
+            errno: std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+            soft,
+        }
+    }
+}
+
+/// Best-effort raise; no-op on non-unix platforms.
+#[cfg(not(unix))]
+pub fn raise_nofile_soft_to_hard() -> RaiseOutcome {
+    RaiseOutcome::Unsupported
+}
+
+/// Emit the outcome of a raise attempt on the `tracing` subscriber. Split
+/// from [`raise_nofile_soft_to_hard`] because entry points raise *before*
+/// initializing tracing and log after.
+pub fn log_raise_outcome(outcome: &RaiseOutcome) {
+    match *outcome {
+        RaiseOutcome::Raised { from, to } => {
+            tracing::debug!(from, to, "raised open-file (RLIMIT_NOFILE) soft limit");
+        }
+        RaiseOutcome::AlreadyAtMax { soft } => {
+            tracing::debug!(soft, "open-file soft limit already at effective maximum");
+        }
+        RaiseOutcome::Failed { errno, soft } => {
+            tracing::warn!(
+                errno,
+                soft,
+                "failed to raise open-file (RLIMIT_NOFILE) soft limit; \
+                 large imports fall back to file-descriptor-conserving strategies"
+            );
+        }
+        RaiseOutcome::Unsupported => {}
+    }
+}
+
+/// True when an I/O error is file-descriptor exhaustion: `EMFILE` (per-process
+/// limit) or `ENFILE` (system-wide table full).
+#[cfg(unix)]
+pub fn is_fd_exhaustion(e: &std::io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(code) if code == libc::EMFILE || code == libc::ENFILE)
+}
+
+/// True when an I/O error is file-descriptor exhaustion. Always false on
+/// non-unix platforms (no stable errno mapping).
+#[cfg(not(unix))]
+pub fn is_fd_exhaustion(_e: &std::io::Error) -> bool {
+    false
+}
+
+/// The file-descriptor budget an FD-heavy operation may plan against: the
+/// observed soft limit minus a reserve for descriptors owned by everything
+/// else in the process (stdio, tokio's poller/wakeup pipes, tracing/OTEL
+/// sockets, storage-backend I/O, the concurrent dictionary upload).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FdBudget {
+    /// Observed (or overridden) soft limit.
+    pub soft: u64,
+    /// Descriptors held back from planning.
+    pub reserve: u64,
+}
+
+impl FdBudget {
+    /// Budget from the live `getrlimit` soft limit, overridable with the
+    /// `FLUREE_FD_BUDGET` environment variable (ops/test escape hatch: the
+    /// override replaces the *soft* value the reserve is derived from).
+    pub fn detect() -> Self {
+        if let Some(soft) = std::env::var("FLUREE_FD_BUDGET")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .filter(|&n| n > 0)
+        {
+            return Self::from_soft(soft);
+        }
+        match nofile_limits() {
+            Some(limits) => Self::from_soft(limits.soft),
+            None => Self::unlimited(),
+        }
+    }
+
+    /// Budget for a given soft limit; reserve is `min(soft/4, 64)`.
+    pub fn from_soft(soft: u64) -> Self {
+        Self {
+            soft,
+            reserve: (soft / 4).min(64),
+        }
+    }
+
+    /// No budgeting: every stage plans as if descriptors were free. This is
+    /// the pre-budget legacy behavior, used by tests and callers that manage
+    /// limits themselves.
+    pub fn unlimited() -> Self {
+        Self {
+            soft: u64::MAX,
+            reserve: 0,
+        }
+    }
+
+    /// Descriptors available for planning: `max(soft - reserve, 32)`, so even
+    /// absurdly low limits yield a plan that can make progress (the kernel
+    /// will still enforce the real limit; 32 merely keeps the plan sane).
+    pub fn available(&self) -> usize {
+        if self.soft == u64::MAX {
+            return usize::MAX;
+        }
+        usize::try_from(self.soft.saturating_sub(self.reserve).max(32)).unwrap_or(usize::MAX)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_reserve_formula() {
+        // Low limits reserve a quarter; high limits cap the reserve at 64.
+        assert_eq!(FdBudget::from_soft(96).reserve, 24);
+        assert_eq!(FdBudget::from_soft(256).reserve, 64);
+        assert_eq!(FdBudget::from_soft(1024).reserve, 64);
+        assert_eq!(FdBudget::from_soft(10_240).reserve, 64);
+    }
+
+    #[test]
+    fn budget_available_floors_and_saturates() {
+        assert_eq!(FdBudget::from_soft(96).available(), 72);
+        assert_eq!(FdBudget::from_soft(256).available(), 192);
+        assert_eq!(FdBudget::from_soft(1024).available(), 960);
+        // Degenerate limits floor at 32 rather than planning zero fan-in.
+        assert_eq!(FdBudget::from_soft(8).available(), 32);
+        assert_eq!(FdBudget::unlimited().available(), usize::MAX);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn limits_observable_and_raise_is_safe() {
+        let before = nofile_limits().expect("getrlimit should succeed on unix");
+        assert!(before.soft > 0);
+        // Raising is monotonic and never errors out of the process.
+        let outcome = raise_nofile_soft_to_hard();
+        match outcome {
+            RaiseOutcome::Raised { from, to } => assert!(to > from),
+            RaiseOutcome::AlreadyAtMax { .. } | RaiseOutcome::Failed { .. } => {}
+            RaiseOutcome::Unsupported => panic!("unix build must not report Unsupported"),
+        }
+        let after = nofile_limits().expect("getrlimit should succeed on unix");
+        assert!(after.soft >= before.soft);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fd_exhaustion_detection() {
+        assert!(is_fd_exhaustion(&std::io::Error::from_raw_os_error(
+            libc::EMFILE
+        )));
+        assert!(is_fd_exhaustion(&std::io::Error::from_raw_os_error(
+            libc::ENFILE
+        )));
+        assert!(!is_fd_exhaustion(&std::io::Error::from_raw_os_error(
+            libc::ENOENT
+        )));
+        assert!(!is_fd_exhaustion(&std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "no raw os error"
+        )));
+    }
+}

--- a/fluree-db-core/src/fd_limit.rs
+++ b/fluree-db-core/src/fd_limit.rs
@@ -178,8 +178,13 @@ pub fn is_fd_exhaustion(_e: &std::io::Error) -> bool {
 
 /// The file-descriptor budget an FD-heavy operation may plan against: the
 /// observed soft limit minus a reserve for descriptors owned by everything
-/// else in the process (stdio, tokio's poller/wakeup pipes, tracing/OTEL
-/// sockets, storage-backend I/O, the concurrent dictionary upload).
+/// else in the process. The reserve's largest audited consumer is the
+/// dictionary upload that runs concurrently with the index build (~15–19
+/// simultaneous handles across its four `try_join` arms), plus stdio, the
+/// tokio poller/wakeup pipes, and tracing/OTEL sockets — hence the floor of
+/// 32. The reserve is storage-backend-blind: an object-store backend's
+/// connection pool also draws from it, so callers on such backends at very
+/// low limits should prefer `FLUREE_FD_BUDGET` to shrink the plan further.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FdBudget {
     /// Observed (or overridden) soft limit.
@@ -191,7 +196,9 @@ pub struct FdBudget {
 impl FdBudget {
     /// Budget from the live `getrlimit` soft limit, overridable with the
     /// `FLUREE_FD_BUDGET` environment variable (ops/test escape hatch: the
-    /// override replaces the *soft* value the reserve is derived from).
+    /// override replaces the *soft* value the reserve is derived from — it
+    /// changes how the build *plans*, never what the kernel enforces, and
+    /// preflight limit checks deliberately read the real limit instead).
     pub fn detect() -> Self {
         if let Some(soft) = std::env::var("FLUREE_FD_BUDGET")
             .ok()
@@ -206,17 +213,20 @@ impl FdBudget {
         }
     }
 
-    /// Budget for a given soft limit; reserve is `min(soft/4, 64)`.
+    /// Budget for a given soft limit; reserve is `min(max(soft/4, 32), 64)`
+    /// (see the struct docs for what the 32-descriptor floor covers).
     pub fn from_soft(soft: u64) -> Self {
         Self {
             soft,
-            reserve: (soft / 4).min(64),
+            reserve: (soft / 4).clamp(32, 64),
         }
     }
 
     /// No budgeting: every stage plans as if descriptors were free. This is
     /// the pre-budget legacy behavior, used by tests and callers that manage
-    /// limits themselves.
+    /// limits themselves. (The `u64::MAX` sentinel coincides with Linux's
+    /// `RLIM_INFINITY`; that collision is benign — a genuinely uncapped
+    /// process and "no budgeting" want identical plans.)
     pub fn unlimited() -> Self {
         Self {
             soft: u64::MAX,
@@ -241,8 +251,9 @@ mod tests {
 
     #[test]
     fn budget_reserve_formula() {
-        // Low limits reserve a quarter; high limits cap the reserve at 64.
-        assert_eq!(FdBudget::from_soft(96).reserve, 24);
+        // A quarter of the limit, floored at 32 (stdio + tokio + the
+        // concurrent dict upload), capped at 64.
+        assert_eq!(FdBudget::from_soft(96).reserve, 32);
         assert_eq!(FdBudget::from_soft(256).reserve, 64);
         assert_eq!(FdBudget::from_soft(1024).reserve, 64);
         assert_eq!(FdBudget::from_soft(10_240).reserve, 64);
@@ -250,7 +261,7 @@ mod tests {
 
     #[test]
     fn budget_available_floors_and_saturates() {
-        assert_eq!(FdBudget::from_soft(96).available(), 72);
+        assert_eq!(FdBudget::from_soft(96).available(), 64);
         assert_eq!(FdBudget::from_soft(256).available(), 192);
         assert_eq!(FdBudget::from_soft(1024).available(), 960);
         // Degenerate limits floor at 32 rather than planning zero fan-in.

--- a/fluree-db-core/src/fd_limit.rs
+++ b/fluree-db-core/src/fd_limit.rs
@@ -286,8 +286,6 @@ mod tests {
         assert!(!is_fd_exhaustion(&std::io::Error::from_raw_os_error(
             libc::ENOENT
         )));
-        assert!(!is_fd_exhaustion(&std::io::Error::other(
-            "no raw os error"
-        )));
+        assert!(!is_fd_exhaustion(&std::io::Error::other("no raw os error")));
     }
 }

--- a/fluree-db-core/src/fd_limit.rs
+++ b/fluree-db-core/src/fd_limit.rs
@@ -42,6 +42,9 @@ pub enum RaiseOutcome {
 /// Read the current `RLIMIT_NOFILE`. `None` on non-unix platforms or if
 /// `getrlimit` fails.
 #[cfg(unix)]
+// rlim_t is platform-dependent (u64 on 64-bit macOS/glibc, narrower
+// elsewhere), so the widening casts are not universally redundant.
+#[allow(clippy::unnecessary_cast)]
 pub fn nofile_limits() -> Option<NofileLimits> {
     let mut rl = libc::rlimit {
         rlim_cur: 0,
@@ -283,8 +286,7 @@ mod tests {
         assert!(!is_fd_exhaustion(&std::io::Error::from_raw_os_error(
             libc::ENOENT
         )));
-        assert!(!is_fd_exhaustion(&std::io::Error::new(
-            std::io::ErrorKind::Other,
+        assert!(!is_fd_exhaustion(&std::io::Error::other(
             "no raw os error"
         )));
     }

--- a/fluree-db-core/src/lib.rs
+++ b/fluree-db-core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod dict_novelty;
 pub mod disk_cache;
 pub mod edge;
 pub mod error;
+pub mod fd_limit;
 pub mod flake;
 pub mod geo;
 pub mod graph_db_ref;

--- a/fluree-db-indexer/src/build/rebuild.rs
+++ b/fluree-db-indexer/src/build/rebuild.rs
@@ -739,6 +739,7 @@ where
                     zstd_level: 1,
                     run_budget_bytes: config.run_budget_bytes,
                     worker_count: 1,
+                    fd_budget: fluree_db_core::fd_limit::FdBudget::detect(),
                     remap_progress: None,
                     build_progress: None,
                     stage_marker: None,

--- a/fluree-db-indexer/src/build/rebuild.rs
+++ b/fluree-db-indexer/src/build/rebuild.rs
@@ -739,7 +739,14 @@ where
                     zstd_level: 1,
                     run_budget_bytes: config.run_budget_bytes,
                     worker_count: 1,
-                    fd_budget: fluree_db_core::fd_limit::FdBudget::detect(),
+                    // The rebuild path has no CLI/server-style entry point,
+                    // so raise the soft limit here before detecting the
+                    // budget (library embedders reach this cold).
+                    fd_budget: {
+                        let raise = fluree_db_core::fd_limit::raise_nofile_soft_to_hard();
+                        fluree_db_core::fd_limit::log_raise_outcome(&raise);
+                        fluree_db_core::fd_limit::FdBudget::detect()
+                    },
                     remap_progress: None,
                     build_progress: None,
                     stage_marker: None,

--- a/fluree-db-indexer/src/run_index/build/build_from_commits.rs
+++ b/fluree-db-indexer/src/run_index/build/build_from_commits.rs
@@ -17,11 +17,11 @@ use crate::run_index::runs::run_file::StreamingRunFileWriter;
 use crate::run_index::runs::run_writer::{
     MultiOrderConfig, MultiOrderRunWriter, MultiOrderRunWriterWithOp,
 };
-use crate::run_index::runs::streaming_reader::{MergeSource, StreamingRunReader};
 use crate::run_index::runs::spool::{
     link_chunk_run_files_to_flat, remap_commit_to_runs_with_op, remap_sorted_commit_v2_to_runs,
     MmapStringRemap, MmapSubjectRemap, SortedCommitMergeReaderV2, SubjectRemap,
 };
+use crate::run_index::runs::streaming_reader::{MergeSource, StreamingRunReader};
 use crate::stats::{stats_record_from_v2, SpotClassStats, DT_REF_ID};
 use fluree_db_binary_index::format::run_record::RunSortOrder;
 use fluree_db_binary_index::format::run_record_v2::{cmp_v2_spot, RunRecordV2};
@@ -372,7 +372,9 @@ impl BucketWriterPool {
             self.slots[bucket] = Some(std::io::BufWriter::new(file));
             self.open_count += 1;
         }
-        Ok(self.slots[bucket].as_mut().expect("slot ensured open above"))
+        Ok(self.slots[bucket]
+            .as_mut()
+            .expect("slot ensured open above"))
     }
 
     /// Flush and close every open writer. Errors instead of silently dropping
@@ -1944,10 +1946,13 @@ mod tests {
             },
         ];
 
-        let membership =
-            ClassMembership::build_from_commits(&commits, &dir.path().join("membership"), usize::MAX)
-                .unwrap()
-                .expect("membership");
+        let membership = ClassMembership::build_from_commits(
+            &commits,
+            &dir.path().join("membership"),
+            usize::MAX,
+        )
+        .unwrap()
+        .expect("membership");
         assert!(matches!(membership, ClassMembership::Disk(_)));
         assert_eq!(membership.summary().1, 4);
         assert_eq!(membership.summary().2, 3);

--- a/fluree-db-indexer/src/run_index/build/build_from_commits.rs
+++ b/fluree-db-indexer/src/run_index/build/build_from_commits.rs
@@ -7,6 +7,7 @@
 //! Bulk import now writes V2-native sorted-commit artifacts directly, so this
 //! module consumes those artifacts without a bulk-import-only V1 → V2 pass.
 
+use crate::run_index::build::fd_plan::{plan_fd_usage, FdPlan};
 use crate::run_index::build::index_build::{
     build_all_indexes, BuildAllConfig, IndexBuildResult, PersistingLeafWriter,
 };
@@ -21,6 +22,7 @@ use crate::run_index::runs::spool::{
 use crate::stats::{stats_record_from_v2, SpotClassStats, DT_REF_ID};
 use fluree_db_binary_index::format::run_record::RunSortOrder;
 use fluree_db_binary_index::format::run_record_v2::cmp_v2_spot;
+use fluree_db_core::fd_limit::FdBudget;
 use fluree_db_core::o_type::OType;
 use fluree_db_core::o_type_registry::OTypeRegistry;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -119,6 +121,11 @@ pub struct BuildConfig {
     pub run_budget_bytes: usize,
     /// Worker count for chunk-parallel secondary-order generation.
     pub worker_count: usize,
+    /// File-descriptor budget the build plans its fan-in/fan-out within
+    /// (see [`crate::run_index::build::fd_plan`]). Use
+    /// [`FdBudget::detect`] for real builds; [`FdBudget::unlimited`]
+    /// preserves the legacy unbudgeted behavior.
+    pub fd_budget: FdBudget,
     /// Remap progress counter (optional).
     pub remap_progress: Option<Arc<AtomicU64>>,
     /// Merge/build progress counter (optional).
@@ -292,6 +299,94 @@ fn mmap_readonly(path: &Path) -> io::Result<memmap2::Mmap> {
     unsafe { memmap2::Mmap::map(&file) }
 }
 
+/// Bounded pool of append-mode class-membership bucket writers.
+///
+/// The scatter pass sprays `TypeEntry` records across
+/// [`CLASS_MEMBERSHIP_BUCKETS`] logical bucket files. Opening all of them up
+/// front held 256 descriptors for the whole pass — the entire soft limit on a
+/// stock macOS shell — so at most `max_open` writers are open at once; the
+/// least-recently-used writer is flushed and closed on eviction and its
+/// bucket transparently reopened in append mode on the next write.
+///
+/// Correctness: bucket files are created lazily, so a bucket that never
+/// receives an entry has no file (the materialization pass treats missing as
+/// empty). Records are fixed-width and every eviction flushes the `BufWriter`
+/// before closing, so no partial record can straddle a close/reopen boundary.
+/// Within-bucket record order is irrelevant — the materialization pass sorts —
+/// which is what makes append-reopen lossless.
+struct BucketWriterPool {
+    dir: PathBuf,
+    max_open: usize,
+    slots: Vec<Option<std::io::BufWriter<std::fs::File>>>,
+    /// Monotonic use stamps per bucket; eviction takes the open slot with the
+    /// lowest stamp (linear scan over 256 slots — evictions are rare relative
+    /// to entry volume and the scan is cache-resident).
+    last_used: Vec<u64>,
+    clock: u64,
+    open_count: usize,
+}
+
+impl BucketWriterPool {
+    fn new(dir: PathBuf, max_open: usize) -> Self {
+        Self {
+            dir,
+            max_open: max_open.max(1),
+            slots: (0..CLASS_MEMBERSHIP_BUCKETS).map(|_| None).collect(),
+            last_used: vec![0; CLASS_MEMBERSHIP_BUCKETS],
+            clock: 0,
+            open_count: 0,
+        }
+    }
+
+    fn bucket_path(dir: &Path, bucket: usize) -> PathBuf {
+        dir.join(format!("bucket_{bucket:03}.typ"))
+    }
+
+    fn writer(&mut self, bucket: usize) -> io::Result<&mut std::io::BufWriter<std::fs::File>> {
+        use std::io::Write;
+
+        self.clock += 1;
+        self.last_used[bucket] = self.clock;
+        if self.slots[bucket].is_none() {
+            if self.open_count >= self.max_open {
+                let victim = self
+                    .slots
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, slot)| slot.as_ref().map(|_| i))
+                    .min_by_key(|&i| self.last_used[i])
+                    .expect("open_count >= max_open >= 1 implies an open slot");
+                let mut evicted = self.slots[victim].take().expect("victim slot is open");
+                evicted.flush()?;
+                self.open_count -= 1;
+            }
+            // `append` covers both first open and reopen-after-eviction;
+            // `File::create` would truncate previously scattered entries.
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(Self::bucket_path(&self.dir, bucket))?;
+            self.slots[bucket] = Some(std::io::BufWriter::new(file));
+            self.open_count += 1;
+        }
+        Ok(self.slots[bucket].as_mut().expect("slot ensured open above"))
+    }
+
+    /// Flush and close every open writer. Errors instead of silently dropping
+    /// buffered entries (a plain `drop` would swallow flush failures).
+    fn finish(mut self) -> io::Result<()> {
+        use std::io::Write;
+
+        for slot in &mut self.slots {
+            if let Some(writer) = slot.as_mut() {
+                writer.flush()?;
+            }
+            *slot = None;
+        }
+        Ok(())
+    }
+}
+
 impl DiskClassMembership {
     fn classes_of(&self, g_id: u16, sid: u64, out: &mut Vec<u64>) {
         out.clear();
@@ -396,7 +491,15 @@ impl ClassMembership {
 
     /// Build from per-chunk `.types` sidecars whose IDs are chunk-local and are
     /// remapped to global via each commit's `MmapSubjectRemap`. Import path.
-    fn build_from_commits(commits: &[CommitInput], scratch_dir: &Path) -> io::Result<Option<Self>> {
+    ///
+    /// `max_open_writers` bounds how many partition files the scatter pass
+    /// holds open simultaneously (see [`BucketWriterPool`]); size it from
+    /// [`FdPlan::scatter_pool`].
+    fn build_from_commits(
+        commits: &[CommitInput],
+        scratch_dir: &Path,
+        max_open_writers: usize,
+    ) -> io::Result<Option<Self>> {
         use std::io::{BufReader, BufWriter, Read, Write};
 
         let build_start = Instant::now();
@@ -420,11 +523,7 @@ impl ClassMembership {
         std::fs::create_dir_all(&index_dir)?;
         std::fs::create_dir_all(&data_dir)?;
 
-        let mut partition_writers = Vec::with_capacity(CLASS_MEMBERSHIP_BUCKETS);
-        for bucket in 0..CLASS_MEMBERSHIP_BUCKETS {
-            let path = partition_dir.join(format!("bucket_{bucket:03}.typ"));
-            partition_writers.push(BufWriter::new(std::fs::File::create(path)?));
-        }
+        let mut partition_writers = BucketWriterPool::new(partition_dir.clone(), max_open_writers);
 
         for commit in commits {
             let Some(types_map_path) = &commit.types_map_path else {
@@ -450,7 +549,7 @@ impl ClassMembership {
                 distinct_classes.insert(c_global);
                 let bucket = class_membership_bucket(g_id, s_global);
                 write_type_entry(
-                    &mut partition_writers[bucket],
+                    partition_writers.writer(bucket)?,
                     TypeEntry {
                         g_id,
                         subject: s_global,
@@ -463,10 +562,7 @@ impl ClassMembership {
         if !saw_sidecar {
             return Ok(None);
         }
-        for writer in &mut partition_writers {
-            writer.flush()?;
-        }
-        drop(partition_writers);
+        partition_writers.finish()?;
 
         let mut buckets = Vec::with_capacity(CLASS_MEMBERSHIP_BUCKETS);
         let mut subject_entries = 0usize;
@@ -474,7 +570,13 @@ impl ClassMembership {
         let bucket_build_start = Instant::now();
         for bucket in 0..CLASS_MEMBERSHIP_BUCKETS {
             let partition_path = partition_dir.join(format!("bucket_{bucket:03}.typ"));
-            let partition_bytes = std::fs::metadata(&partition_path)?.len();
+            // Bucket files are created lazily by the writer pool: a bucket
+            // that never received an entry has no file at all.
+            let partition_bytes = match std::fs::metadata(&partition_path) {
+                Ok(meta) => meta.len(),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => 0,
+                Err(e) => return Err(e),
+            };
             if partition_bytes == 0 {
                 buckets.push(None);
                 continue;
@@ -948,11 +1050,18 @@ pub fn build_indexes_from_commits(
     mut stats_hook: Option<&mut crate::stats::IdStatsHook>,
 ) -> io::Result<(BuildResult, Option<SpotClassStats>)> {
     let overall_start = Instant::now();
+    let fd_plan = plan_fd_usage(config.fd_budget, config.worker_count);
     tracing::info!(
         chunks = commits.len(),
         worker_count = config.worker_count,
         run_budget_bytes = config.run_budget_bytes,
         g_id = config.g_id,
+        fd_soft_limit = config.fd_budget.soft,
+        fd_reserve = config.fd_budget.reserve,
+        scatter_pool = fd_plan.scatter_pool,
+        spot_fan_in = fd_plan.spot_fan_in,
+        worker_cap = fd_plan.worker_cap,
+        merge_fan_in_per_order = fd_plan.merge_fan_in_per_order,
         "starting build_indexes_from_commits"
     );
     log_index_memory("build_indexes_from_commits:start");
@@ -969,7 +1078,11 @@ pub fn build_indexes_from_commits(
     // while letting that membership heap drop before the secondary phases begin.
     let spot_rdf_type_p_id = stats_hook.as_ref().and_then(|hook| hook.rdf_type_p_id());
     let spot_class_membership = if spot_rdf_type_p_id.is_some() {
-        ClassMembership::build_from_commits(commits, &config.run_dir.join("class_membership"))?
+        ClassMembership::build_from_commits(
+            commits,
+            &config.run_dir.join("class_membership"),
+            fd_plan.scatter_pool,
+        )?
     } else {
         None
     };
@@ -982,8 +1095,13 @@ pub fn build_indexes_from_commits(
             "class membership built for ref-target stats"
         );
     }
-    let (spot_result, spot_class_stats) =
-        build_spot_index_from_commits(commits, config, spot_rdf_type_p_id, spot_class_membership)?;
+    let (spot_result, spot_class_stats) = build_spot_index_from_commits(
+        commits,
+        config,
+        spot_rdf_type_p_id,
+        spot_class_membership,
+        &fd_plan,
+    )?;
     log_index_memory("spot_build:joined_before_secondary_phases");
 
     // Phase 1: Generate secondary-order runs in parallel.
@@ -991,7 +1109,11 @@ pub fn build_indexes_from_commits(
         stage.store(BUILD_STAGE_REMAP, Ordering::Relaxed);
     }
     let remap_start = Instant::now();
-    let worker_count = config.worker_count.max(1).min(commits.len().max(1));
+    let worker_count = config
+        .worker_count
+        .max(1)
+        .min(commits.len().max(1))
+        .min(fd_plan.worker_cap);
     let per_thread_budget_bytes = (config.run_budget_bytes / worker_count).max(64 * 1024 * 1024);
     log_index_memory("secondary_run_generation:start");
     tracing::info!(
@@ -1141,6 +1263,7 @@ pub fn build_indexes_from_commits(
         // concurrency no longer overlaps with the class-membership heap.
         // build_all_indexes clamps this to the number of buildable orders.
         max_concurrency: config.worker_count,
+        fan_in_cap: fd_plan.merge_fan_in_per_order,
     };
 
     let mut order_results = build_all_indexes(&build_config).map_err(io::Error::other)?;
@@ -1186,6 +1309,7 @@ fn build_spot_index_from_commits(
     config: &BuildConfig,
     rdf_type_p_id: Option<u32>,
     class_membership: Option<ClassMembership>,
+    fd_plan: &FdPlan,
 ) -> io::Result<(IndexBuildResult, Option<SpotClassStats>)> {
     let g_id = config.g_id;
     let index_dir = &config.index_dir;
@@ -1372,6 +1496,7 @@ pub fn build_indexes_from_remapped_commits(
         // Rebuild path builds all 4 orders here (no separate SPOT thread), so
         // concurrency can cover all of them, bounded by the core budget.
         max_concurrency: config.worker_count,
+        fan_in_cap: plan_fd_usage(config.fd_budget, config.worker_count).merge_fan_in_per_order,
     };
 
     let order_results = build_all_indexes(&build_config).map_err(io::Error::other)?;
@@ -1501,6 +1626,7 @@ mod tests {
             zstd_level: 1,
             run_budget_bytes: 256 * 1024,
             worker_count: 1,
+            fd_budget: FdBudget::unlimited(),
             remap_progress: None,
             build_progress: None,
             stage_marker: None,
@@ -1598,7 +1724,7 @@ mod tests {
         ];
 
         let membership =
-            ClassMembership::build_from_commits(&commits, &dir.path().join("membership"))
+            ClassMembership::build_from_commits(&commits, &dir.path().join("membership"), usize::MAX)
                 .unwrap()
                 .expect("membership");
         assert!(matches!(membership, ClassMembership::Disk(_)));
@@ -1614,6 +1740,77 @@ mod tests {
         assert_eq!(buf, vec![4000]);
         membership.collect_classes(0, 999, &mut buf);
         assert!(buf.is_empty());
+    }
+
+    /// A tiny writer pool (forcing heavy LRU eviction and append-reopen)
+    /// must produce byte-for-byte the same membership as the unbounded
+    /// scatter, including buckets that never receive an entry (lazily
+    /// uncreated files read as empty).
+    #[test]
+    fn scatter_pool_matches_unbounded() {
+        let build = |max_open: usize| {
+            let dir = tempfile::tempdir().unwrap();
+            let types0 = dir.path().join("chunk_00000.types");
+            let types1 = dir.path().join("chunk_00001.types");
+            let subj0 = dir.path().join("subjects_00000.rmp");
+            let subj1 = dir.path().join("subjects_00001.rmp");
+            let str0 = dir.path().join("strings_00000.rmp");
+            let str1 = dir.path().join("strings_00001.rmp");
+            write_identity_subject_remap(&subj0, 6000);
+            write_identity_subject_remap(&subj1, 6000);
+            write_identity_string_remap(&str0, 1);
+            write_identity_string_remap(&str1, 1);
+
+            // ~500 subjects spraying across many (but not all) buckets, with
+            // interleaved revisits so evicted buckets are reopened mid-pass.
+            let entries0: Vec<(u16, u64, u64)> = (0..500u64)
+                .map(|s| (0u16, s * 7 % 1500, 1000 + s % 70))
+                .collect();
+            let entries1: Vec<(u16, u64, u64)> = (0..500u64)
+                .map(|s| (0u16, s * 13 % 1500, 1000 + s % 90))
+                .collect();
+            write_types_sidecar(&types0, &entries0);
+            write_types_sidecar(&types1, &entries1);
+
+            let commits = vec![
+                CommitInput {
+                    commit_path: dir.path().join("unused0.fsv2"),
+                    record_count: 0,
+                    subject_remap_path: subj0,
+                    string_remap_path: str0,
+                    lang_remap: vec![],
+                    types_map_path: Some(types0),
+                },
+                CommitInput {
+                    commit_path: dir.path().join("unused1.fsv2"),
+                    record_count: 0,
+                    subject_remap_path: subj1,
+                    string_remap_path: str1,
+                    lang_remap: vec![],
+                    types_map_path: Some(types1),
+                },
+            ];
+
+            let membership =
+                ClassMembership::build_from_commits(&commits, &dir.path().join("m"), max_open)
+                    .unwrap()
+                    .expect("membership");
+            let mut buf = Vec::new();
+            let per_subject: Vec<(u64, Vec<u64>)> = (0..1500u64)
+                .map(|s| {
+                    membership.collect_classes(0, s, &mut buf);
+                    (s, buf.clone())
+                })
+                .collect();
+            // Keep the tempdir alive until reads are done (mmaps hold pages,
+            // not paths, but the reads above already completed regardless).
+            drop(dir);
+            (membership.summary().1, membership.summary().2, per_subject)
+        };
+
+        let unbounded = build(usize::MAX);
+        let pooled = build(4);
+        assert_eq!(unbounded, pooled);
     }
 
     #[test]

--- a/fluree-db-indexer/src/run_index/build/build_from_commits.rs
+++ b/fluree-db-indexer/src/run_index/build/build_from_commits.rs
@@ -7,9 +7,11 @@
 //! Bulk import now writes V2-native sorted-commit artifacts directly, so this
 //! module consumes those artifacts without a bulk-import-only V1 → V2 pass.
 
-use crate::run_index::build::fd_plan::{plan_fd_usage, FdPlan};
+use crate::run_index::build::fd_plan::{
+    plan_fd_usage, FdPlan, IMPORT_CONCURRENT_ORDERS, REBUILD_CONCURRENT_ORDERS,
+};
 use crate::run_index::build::index_build::{
-    build_all_indexes, cascade_runs_to_fan_in, BuildAllConfig, IndexBuildResult,
+    build_all_indexes, cascade_runs_to_fan_in, BuildAllConfig, IndexBuildError, IndexBuildResult,
     PersistingLeafWriter,
 };
 use crate::run_index::build::merge::KWayMerge;
@@ -1055,7 +1057,11 @@ pub fn build_indexes_from_commits(
     mut stats_hook: Option<&mut crate::stats::IdStatsHook>,
 ) -> io::Result<(BuildResult, Option<SpotClassStats>)> {
     let overall_start = Instant::now();
-    let fd_plan = plan_fd_usage(config.fd_budget, config.worker_count);
+    let fd_plan = plan_fd_usage(
+        config.fd_budget,
+        config.worker_count,
+        IMPORT_CONCURRENT_ORDERS,
+    );
     tracing::info!(
         chunks = commits.len(),
         worker_count = config.worker_count,
@@ -1114,6 +1120,13 @@ pub fn build_indexes_from_commits(
         stage.store(BUILD_STAGE_REMAP, Ordering::Relaxed);
     }
     let remap_start = Instant::now();
+    // The fd cap changes worker_count → per_thread_budget_bytes → run-file
+    // boundaries, which permutes equal-comparing records across a chunk's
+    // run files (RunWriter sorts unstably per flush). That is unobservable
+    // because bulk import assigns one t per chunk, so records comparing
+    // Equal under a secondary-order comparator within a chunk are equal in
+    // every serialized field. (Pre-existing worker_count variation by CPU
+    // count already leaned on the same invariant.)
     let worker_count = config
         .worker_count
         .max(1)
@@ -1271,7 +1284,7 @@ pub fn build_indexes_from_commits(
         fan_in_cap: fd_plan.merge_fan_in_per_order,
     };
 
-    let mut order_results = build_all_indexes(&build_config).map_err(io::Error::other)?;
+    let mut order_results = build_all_indexes(&build_config).map_err(index_build_err_to_io)?;
     log_index_memory("secondary_index_merge:complete");
     order_results.push((RunSortOrder::Spot, spot_result));
 
@@ -1369,6 +1382,7 @@ fn build_spot_index_from_commits(
         pump_spot_merge(
             &mut merge,
             &mut writer,
+            g_id,
             class_stats_collector.as_mut(),
             progress.as_deref(),
         )?
@@ -1423,6 +1437,7 @@ fn build_spot_index_from_commits(
         let rows = pump_spot_merge(
             &mut merge,
             &mut writer,
+            g_id,
             class_stats_collector.as_mut(),
             progress.as_deref(),
         )?;
@@ -1452,6 +1467,17 @@ fn build_spot_index_from_commits(
     ))
 }
 
+/// Unwrap an [`IndexBuildError`] into an `io::Error` **preserving the
+/// original OS error** — a plain `io::Error::other` wrapper erases
+/// `raw_os_error`, which would make descriptor exhaustion (`EMFILE`) inside
+/// the secondary-order merges invisible to the import layer's diagnostics.
+fn index_build_err_to_io(e: IndexBuildError) -> io::Error {
+    match e {
+        IndexBuildError::Io(io_err) => io_err,
+        other => io::Error::other(other),
+    }
+}
+
 /// Open one remapping SPOT reader per commit chunk. Each holds one real file
 /// descriptor (the sorted-commit `BufReader`) for its lifetime; the two remap
 /// mmaps drop their `File` on open and cost address space only.
@@ -1479,9 +1505,18 @@ fn open_spot_commit_readers(
 /// Drain a SPOT merge into the leaf writer (and class-stats collector),
 /// batching progress updates. Shared by the flat and hierarchical SPOT
 /// arms so both consume the merged sequence identically.
+///
+/// `g_id` is restamped onto every record before consumption: the FRN2 run
+/// wire format carries no g_id (readers decode it as 0), so records arriving
+/// through the hierarchical arm's intermediate run files would otherwise
+/// reach the class-stats collector as g_id 0 — silently folding a named
+/// graph's class stats into the default graph's. The flat arm's records
+/// already carry `g_id` (its readers filter on it), so the stamp is a no-op
+/// there; the pipeline is graph-scoped by construction either way.
 fn pump_spot_merge<T, F>(
     merge: &mut KWayMerge<T, F>,
     writer: &mut PersistingLeafWriter,
+    g_id: u16,
     mut class_stats_collector: Option<&mut SpotClassStatsCollector>,
     progress: Option<&AtomicU64>,
 ) -> io::Result<u64>
@@ -1491,10 +1526,11 @@ where
 {
     let mut total_rows = 0u64;
     let mut progress_batch = 0u64;
-    while let Some((record, op)) = merge.next_record()? {
+    while let Some((mut record, op)) = merge.next_record()? {
         if op == 0 {
             continue;
         }
+        record.g_id = g_id;
         if let Some(collector) = class_stats_collector.as_deref_mut() {
             collector.on_record(&record);
         }
@@ -1596,12 +1632,18 @@ pub fn build_indexes_from_remapped_commits(
         g_id: config.g_id,
         progress: config.build_progress.clone(),
         // Rebuild path builds all 4 orders here (no separate SPOT thread), so
-        // concurrency can cover all of them, bounded by the core budget.
+        // concurrency can cover all of them, bounded by the core budget —
+        // which is why the fan-in share divides by 4, not the import path's 3.
         max_concurrency: config.worker_count,
-        fan_in_cap: plan_fd_usage(config.fd_budget, config.worker_count).merge_fan_in_per_order,
+        fan_in_cap: plan_fd_usage(
+            config.fd_budget,
+            config.worker_count,
+            REBUILD_CONCURRENT_ORDERS,
+        )
+        .merge_fan_in_per_order,
     };
 
-    let order_results = build_all_indexes(&build_config).map_err(io::Error::other)?;
+    let order_results = build_all_indexes(&build_config).map_err(index_build_err_to_io)?;
 
     let build_elapsed = build_start.elapsed();
 
@@ -1860,7 +1902,7 @@ mod tests {
                 .0
         };
 
-        let unlimited = plan_fd_usage(FdBudget::unlimited(), 1);
+        let unlimited = plan_fd_usage(FdBudget::unlimited(), 1, IMPORT_CONCURRENT_ORDERS);
         let constrained = FdPlan {
             spot_fan_in: 2,
             ..unlimited
@@ -1884,6 +1926,136 @@ mod tests {
 
         // The hierarchical arm must clean up its intermediate copy.
         assert!(!dir.path().join("runs_hier/spot_cascade").exists());
+    }
+
+    /// Regression for the FRN2 g_id round-trip bug: run wire records carry no
+    /// g_id (readers decode 0), so the hierarchical arm's intermediates used
+    /// to hand the class-stats collector g_id-0 records — silently folding a
+    /// named graph's class stats into the default graph and resolving ref
+    /// targets against the wrong graph. The pump now restamps g_id; this test
+    /// runs both arms at g_id 5 with a live collector + membership and
+    /// requires identical, correctly-keyed stats.
+    #[test]
+    fn spot_hierarchical_matches_flat_stats_nonzero_graph() {
+        const G: u16 = 5;
+        const TYPE_P: u32 = 7;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        // 5 chunks × 40 subjects (disjoint, interleaved). Each subject: one
+        // rdf:type assertion, one literal, one ref into a typed neighbor.
+        let mut commits = Vec::new();
+        for j in 0..5u64 {
+            let commit_path = dir.path().join(format!("commit_{j:05}.fsv2"));
+            let mut recs: Vec<RunRecordV2> = Vec::new();
+            for i in 0..40u64 {
+                let s = i * 5 + j;
+                recs.push(RunRecordV2 {
+                    s_id: SubjectId(s),
+                    o_key: 1000 + s % 3,
+                    p_id: TYPE_P,
+                    t: j as u32 + 1,
+                    o_i: fluree_db_binary_index::format::run_record::LIST_INDEX_NONE,
+                    o_type: OType::IRI_REF.as_u16(),
+                    g_id: G,
+                });
+                recs.push(RunRecordV2 {
+                    s_id: SubjectId(s),
+                    o_key: ObjKey::encode_i64(s as i64).as_u64(),
+                    p_id: 1,
+                    t: j as u32 + 1,
+                    o_i: fluree_db_binary_index::format::run_record::LIST_INDEX_NONE,
+                    o_type: OType::XSD_INTEGER.as_u16(),
+                    g_id: G,
+                });
+                recs.push(RunRecordV2 {
+                    s_id: SubjectId(s),
+                    o_key: (s + 1) % 200,
+                    p_id: 2,
+                    t: j as u32 + 1,
+                    o_i: fluree_db_binary_index::format::run_record::LIST_INDEX_NONE,
+                    o_type: OType::IRI_REF.as_u16(),
+                    g_id: G,
+                });
+            }
+            recs.sort_by(cmp_v2_spot);
+
+            let mut spool = SortedCommitWriterV2::new(&commit_path, 0).unwrap();
+            for rec in &recs {
+                spool.push(rec).unwrap();
+            }
+            let info = spool.finish().unwrap();
+
+            let subj_path = dir.path().join(format!("subjects_{j:05}.rmp"));
+            let subj_data: Vec<u8> = (0u64..1024).flat_map(u64::to_le_bytes).collect();
+            std::fs::write(&subj_path, &subj_data).unwrap();
+            let str_path = dir.path().join(format!("strings_{j:05}.rmp"));
+            let str_data: Vec<u8> = (0u32..10).flat_map(u32::to_le_bytes).collect();
+            std::fs::write(&str_path, &str_data).unwrap();
+
+            commits.push(CommitInput {
+                commit_path,
+                record_count: info.record_count,
+                subject_remap_path: subj_path,
+                string_remap_path: str_path,
+                lang_remap: vec![],
+                types_map_path: None,
+            });
+        }
+
+        // Membership keyed under g_id 5 so ref-target class resolution only
+        // succeeds when the collector sees correctly-stamped records.
+        let types_path = dir.path().join("global.types");
+        let entries: Vec<(u16, u64, u64)> = (0..200u64).map(|s| (G, s, 1000 + s % 3)).collect();
+        write_types_sidecar(&types_path, &entries);
+
+        let build = |tag: &str, plan: &FdPlan| {
+            let membership =
+                ClassMembership::build_from_global_types(std::slice::from_ref(&types_path))
+                    .unwrap()
+                    .expect("membership");
+            let config = BuildConfig {
+                run_dir: dir.path().join(format!("runs_{tag}")),
+                index_dir: dir.path().join(format!("index_{tag}")),
+                g_id: G,
+                leaflet_target_rows: 16,
+                leaf_target_rows: 64,
+                zstd_level: 1,
+                run_budget_bytes: 256 * 1024,
+                worker_count: 1,
+                fd_budget: FdBudget::unlimited(),
+                remap_progress: None,
+                build_progress: None,
+                stage_marker: None,
+            };
+            std::fs::create_dir_all(&config.run_dir).unwrap();
+            build_spot_index_from_commits(&commits, &config, Some(TYPE_P), Some(membership), plan)
+                .unwrap()
+        };
+
+        let unlimited = plan_fd_usage(FdBudget::unlimited(), 1, IMPORT_CONCURRENT_ORDERS);
+        let constrained = FdPlan {
+            spot_fan_in: 2,
+            ..unlimited
+        };
+
+        let (flat_result, flat_stats) = build("statflat", &unlimited);
+        let (hier_result, hier_stats) = build("stathier", &constrained);
+        let flat_stats = flat_stats.expect("flat stats");
+        let hier_stats = hier_stats.expect("hier stats");
+
+        assert_eq!(flat_result.total_rows, hier_result.total_rows);
+
+        // Non-vacuous: counts exist, keyed under the named graph, and ref
+        // targets resolved through the membership.
+        assert!(!flat_stats.class_counts.is_empty());
+        assert!(flat_stats.class_counts.keys().all(|&(g, _)| g == G));
+        assert!(!flat_stats.class_prop_refs.is_empty());
+
+        assert_eq!(flat_stats.class_counts, hier_stats.class_counts);
+        assert_eq!(flat_stats.class_prop_dts, hier_stats.class_prop_dts);
+        assert_eq!(flat_stats.class_prop_langs, hier_stats.class_prop_langs);
+        assert_eq!(flat_stats.class_prop_refs, hier_stats.class_prop_refs);
     }
 
     /// Helper: write `.types` sidecar entries (g_id: u16, s_id: u64, class_sid64: u64).

--- a/fluree-db-indexer/src/run_index/build/build_from_commits.rs
+++ b/fluree-db-indexer/src/run_index/build/build_from_commits.rs
@@ -9,19 +9,22 @@
 
 use crate::run_index::build::fd_plan::{plan_fd_usage, FdPlan};
 use crate::run_index::build::index_build::{
-    build_all_indexes, BuildAllConfig, IndexBuildResult, PersistingLeafWriter,
+    build_all_indexes, cascade_runs_to_fan_in, BuildAllConfig, IndexBuildResult,
+    PersistingLeafWriter,
 };
 use crate::run_index::build::merge::KWayMerge;
+use crate::run_index::runs::run_file::StreamingRunFileWriter;
 use crate::run_index::runs::run_writer::{
     MultiOrderConfig, MultiOrderRunWriter, MultiOrderRunWriterWithOp,
 };
+use crate::run_index::runs::streaming_reader::{MergeSource, StreamingRunReader};
 use crate::run_index::runs::spool::{
     link_chunk_run_files_to_flat, remap_commit_to_runs_with_op, remap_sorted_commit_v2_to_runs,
     MmapStringRemap, MmapSubjectRemap, SortedCommitMergeReaderV2, SubjectRemap,
 };
 use crate::stats::{stats_record_from_v2, SpotClassStats, DT_REF_ID};
 use fluree_db_binary_index::format::run_record::RunSortOrder;
-use fluree_db_binary_index::format::run_record_v2::cmp_v2_spot;
+use fluree_db_binary_index::format::run_record_v2::{cmp_v2_spot, RunRecordV2};
 use fluree_db_core::fd_limit::FdBudget;
 use fluree_db_core::o_type::OType;
 use fluree_db_core::o_type_registry::OTypeRegistry;
@@ -1321,26 +1324,12 @@ fn build_spot_index_from_commits(
     tracing::info!(
         chunks = commits.len(),
         g_id,
+        spot_fan_in = fd_plan.spot_fan_in,
         "starting direct SPOT build from sorted commits"
     );
     log_index_memory("spot_build:start");
-    let streams: Vec<SortedCommitMergeReaderV2<MmapSubjectRemap, MmapStringRemap>> = commits
-        .iter()
-        .map(|commit| {
-            let s_remap = MmapSubjectRemap::open(&commit.subject_remap_path)?;
-            let str_remap = MmapStringRemap::open(&commit.string_remap_path)?;
-            SortedCommitMergeReaderV2::open(
-                &commit.commit_path,
-                commit.record_count,
-                s_remap,
-                str_remap,
-                commit.lang_remap.clone(),
-                g_id,
-            )
-        })
-        .collect::<io::Result<Vec<_>>>()?;
 
-    if streams.is_empty() {
+    if commits.is_empty() {
         return Ok((
             IndexBuildResult {
                 graphs: Vec::new(),
@@ -1352,7 +1341,6 @@ fn build_spot_index_from_commits(
         ));
     }
 
-    let mut merge = KWayMerge::new(streams, cmp_v2_spot)?;
     let order = RunSortOrder::Spot;
 
     // Streams each completed leaf to disk as produced (see PersistingLeafWriter)
@@ -1368,32 +1356,80 @@ fn build_spot_index_from_commits(
     )?;
     writer.set_skip_history(true);
 
-    let mut total_rows = 0u64;
-    let mut progress_batch = 0u64;
     let mut class_stats_collector =
         rdf_type_p_id.map(|p_id| SpotClassStatsCollector::new(p_id, class_membership));
-    while let Some((record, op)) = merge.next_record()? {
-        if op == 0 {
-            continue;
+
+    let total_rows = if commits.len() <= fd_plan.spot_fan_in {
+        // Flat merge: one long-lived reader per chunk, all open at once.
+        // The common case, and byte-for-byte the pre-budget behavior.
+        let streams = open_spot_commit_readers(commits, g_id)?;
+        let mut merge = KWayMerge::new(streams, cmp_v2_spot)?;
+        pump_spot_merge(
+            &mut merge,
+            &mut writer,
+            class_stats_collector.as_mut(),
+            progress.as_deref(),
+        )?
+    } else {
+        // More chunks than the FD budget allows open at once: merge
+        // consecutive chunk groups into globally-remapped intermediate run
+        // files first (each group holds ≤ spot_fan_in readers), then feed
+        // the final merge from those. Grouping is consecutive and the group
+        // outputs are consumed in group order, so the emitted record
+        // sequence — and therefore every leaf byte — is identical to the
+        // flat merge (see `cascade_runs_to_fan_in` for the full argument).
+        tracing::info!(
+            chunks = commits.len(),
+            spot_fan_in = fd_plan.spot_fan_in,
+            "chunk count exceeds fd budget; hierarchical SPOT merge"
+        );
+        let scratch = config.run_dir.join("spot_cascade");
+        if scratch.exists() {
+            std::fs::remove_dir_all(&scratch)?;
         }
-        if let Some(ref mut collector) = class_stats_collector {
-            collector.on_record(&record);
-        }
-        writer.push_record(record)?;
-        total_rows += 1;
-        progress_batch += 1;
-        if progress_batch >= PROGRESS_BATCH_SIZE {
-            if let Some(ref ctr) = progress {
-                ctr.fetch_add(progress_batch, Ordering::Relaxed);
+        let pass_dir = scratch.join("pass_1");
+        std::fs::create_dir_all(&pass_dir)?;
+
+        let mut intermediates = Vec::with_capacity(commits.len().div_ceil(fd_plan.spot_fan_in));
+        for (i, group) in commits.chunks(fd_plan.spot_fan_in).enumerate() {
+            let streams = open_spot_commit_readers(group, g_id)?;
+            let mut merge = KWayMerge::new(streams, cmp_v2_spot)?;
+            let out_path = pass_dir.join(format!("merged_{i:06}.frn"));
+            // Spool sources carry no op sideband (`peek_op` is uniformly 1
+            // on the import path), so version-1 intermediates lose nothing.
+            let mut inter = StreamingRunFileWriter::create(&out_path, order, false)?;
+            while let Some((record, _op)) = merge.next_record()? {
+                inter.push(record, 1)?;
             }
-            progress_batch = 0;
+            inter.finish()?;
+            intermediates.push(out_path);
         }
-    }
-    if progress_batch > 0 {
-        if let Some(ref ctr) = progress {
-            ctr.fetch_add(progress_batch, Ordering::Relaxed);
-        }
-    }
+        // chunks > spot_fan_in² leaves the first pass still over the cap;
+        // reduce the intermediates themselves (rare, tiny-budget case).
+        let intermediates = cascade_runs_to_fan_in(
+            intermediates,
+            order,
+            fd_plan.spot_fan_in,
+            &scratch.join("cascade"),
+        )?;
+
+        let streams: Vec<StreamingRunReader> = intermediates
+            .iter()
+            .map(|p| StreamingRunReader::open(p))
+            .collect::<io::Result<Vec<_>>>()?;
+        let mut merge = KWayMerge::new(streams, cmp_v2_spot)?;
+        let rows = pump_spot_merge(
+            &mut merge,
+            &mut writer,
+            class_stats_collector.as_mut(),
+            progress.as_deref(),
+        )?;
+        drop(merge);
+        // Reclaim the intermediate copy of the dataset before the
+        // secondary-order phases start writing their own run files.
+        std::fs::remove_dir_all(&scratch)?;
+        rows
+    };
 
     let result = writer.finish()?;
     tracing::info!(
@@ -1412,6 +1448,70 @@ fn build_spot_index_from_commits(
         },
         class_stats_collector.map(SpotClassStatsCollector::finish),
     ))
+}
+
+/// Open one remapping SPOT reader per commit chunk. Each holds one real file
+/// descriptor (the sorted-commit `BufReader`) for its lifetime; the two remap
+/// mmaps drop their `File` on open and cost address space only.
+fn open_spot_commit_readers(
+    commits: &[CommitInput],
+    g_id: u16,
+) -> io::Result<Vec<SortedCommitMergeReaderV2<MmapSubjectRemap, MmapStringRemap>>> {
+    commits
+        .iter()
+        .map(|commit| {
+            let s_remap = MmapSubjectRemap::open(&commit.subject_remap_path)?;
+            let str_remap = MmapStringRemap::open(&commit.string_remap_path)?;
+            SortedCommitMergeReaderV2::open(
+                &commit.commit_path,
+                commit.record_count,
+                s_remap,
+                str_remap,
+                commit.lang_remap.clone(),
+                g_id,
+            )
+        })
+        .collect()
+}
+
+/// Drain a SPOT merge into the leaf writer (and class-stats collector),
+/// batching progress updates. Shared by the flat and hierarchical SPOT
+/// arms so both consume the merged sequence identically.
+fn pump_spot_merge<T, F>(
+    merge: &mut KWayMerge<T, F>,
+    writer: &mut PersistingLeafWriter,
+    mut class_stats_collector: Option<&mut SpotClassStatsCollector>,
+    progress: Option<&AtomicU64>,
+) -> io::Result<u64>
+where
+    T: MergeSource,
+    F: Fn(&RunRecordV2, &RunRecordV2) -> std::cmp::Ordering,
+{
+    let mut total_rows = 0u64;
+    let mut progress_batch = 0u64;
+    while let Some((record, op)) = merge.next_record()? {
+        if op == 0 {
+            continue;
+        }
+        if let Some(collector) = class_stats_collector.as_deref_mut() {
+            collector.on_record(&record);
+        }
+        writer.push_record(record)?;
+        total_rows += 1;
+        progress_batch += 1;
+        if progress_batch >= PROGRESS_BATCH_SIZE {
+            if let Some(ctr) = progress {
+                ctr.fetch_add(progress_batch, Ordering::Relaxed);
+            }
+            progress_batch = 0;
+        }
+    }
+    if progress_batch > 0 {
+        if let Some(ctr) = progress {
+            ctr.fetch_add(progress_batch, Ordering::Relaxed);
+        }
+    }
+    Ok(total_rows)
 }
 
 /// Build V3 indexes from globally-remapped sorted commit files (rebuild path).
@@ -1661,6 +1761,127 @@ mod tests {
         assert_eq!(leaf_dir[1].p_const, Some(2));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The hierarchical SPOT merge (chunk count above the fan-in cap) must
+    /// produce byte-identical leaves to the flat merge — leaf and branch
+    /// CIDs are content-addressed, so CID equality is byte equality.
+    #[test]
+    fn spot_hierarchical_matches_flat() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = OTypeRegistry::builtin_only();
+
+        // 5 chunks × 41 records: interleaved disjoint subjects plus one
+        // shared identical-comparing record per chunk (comparators exclude
+        // t), so the cross-group tie-break seam is exercised.
+        let mut commits = Vec::new();
+        for j in 0..5u64 {
+            let commit_path = dir.path().join(format!("commit_{j:05}.fsv2"));
+            let mut recs: Vec<RunRecordV2> = (0..40u64)
+                .map(|i| {
+                    let s = i * 5 + j;
+                    RunRecordV2::from_v1(
+                        &RunRecord::new(
+                            0,
+                            SubjectId(s),
+                            1,
+                            ObjKind::NUM_INT,
+                            ObjKey::encode_i64(s as i64),
+                            j as u32 + 1,
+                            true,
+                            3,
+                            0,
+                            None,
+                        ),
+                        &registry,
+                    )
+                })
+                .collect();
+            recs.push(RunRecordV2::from_v1(
+                &RunRecord::new(
+                    0,
+                    SubjectId(1000),
+                    1,
+                    ObjKind::NUM_INT,
+                    ObjKey::encode_i64(7),
+                    j as u32 + 1,
+                    true,
+                    3,
+                    0,
+                    None,
+                ),
+                &registry,
+            ));
+            recs.sort_by(cmp_v2_spot);
+
+            let mut spool = SortedCommitWriterV2::new(&commit_path, 0).unwrap();
+            for rec in &recs {
+                spool.push(rec).unwrap();
+            }
+            let info = spool.finish().unwrap();
+
+            let subj_path = dir.path().join(format!("subjects_{j:05}.rmp"));
+            let subj_data: Vec<u8> = (0u64..1024).flat_map(u64::to_le_bytes).collect();
+            std::fs::write(&subj_path, &subj_data).unwrap();
+            let str_path = dir.path().join(format!("strings_{j:05}.rmp"));
+            let str_data: Vec<u8> = (0u32..10).flat_map(u32::to_le_bytes).collect();
+            std::fs::write(&str_path, &str_data).unwrap();
+
+            commits.push(CommitInput {
+                commit_path,
+                record_count: info.record_count,
+                subject_remap_path: subj_path,
+                string_remap_path: str_path,
+                lang_remap: vec![],
+                types_map_path: None,
+            });
+        }
+
+        let build = |tag: &str, plan: &FdPlan| {
+            let config = BuildConfig {
+                run_dir: dir.path().join(format!("runs_{tag}")),
+                index_dir: dir.path().join(format!("index_{tag}")),
+                g_id: 0,
+                leaflet_target_rows: 16,
+                leaf_target_rows: 64,
+                zstd_level: 1,
+                run_budget_bytes: 256 * 1024,
+                worker_count: 1,
+                fd_budget: FdBudget::unlimited(),
+                remap_progress: None,
+                build_progress: None,
+                stage_marker: None,
+            };
+            std::fs::create_dir_all(&config.run_dir).unwrap();
+            build_spot_index_from_commits(&commits, &config, None, None, plan)
+                .unwrap()
+                .0
+        };
+
+        let unlimited = plan_fd_usage(FdBudget::unlimited(), 1);
+        let constrained = FdPlan {
+            spot_fan_in: 2,
+            ..unlimited
+        };
+
+        let flat = build("flat", &unlimited);
+        let hier = build("hier", &constrained);
+
+        assert_eq!(flat.total_rows, 5 * 41);
+        assert_eq!(flat.total_rows, hier.total_rows);
+        let cids = |r: &IndexBuildResult| {
+            r.graphs
+                .iter()
+                .flat_map(|g| {
+                    std::iter::once(g.branch_cid.clone())
+                        .chain(g.leaf_infos.iter().map(|l| l.leaf_cid.clone()))
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(cids(&flat), cids(&hier));
+
+        // The hierarchical arm must clean up its intermediate copy.
+        assert!(!dir.path().join("runs_hier/spot_cascade").exists());
     }
 
     /// Helper: write `.types` sidecar entries (g_id: u16, s_id: u64, class_sid64: u64).

--- a/fluree-db-indexer/src/run_index/build/build_from_commits.rs
+++ b/fluree-db-indexer/src/run_index/build/build_from_commits.rs
@@ -319,6 +319,13 @@ fn mmap_readonly(path: &Path) -> io::Result<memmap2::Mmap> {
 /// before closing, so no partial record can straddle a close/reopen boundary.
 /// Within-bucket record order is irrelevant — the materialization pass sorts —
 /// which is what makes append-reopen lossless.
+///
+/// Performance: bucket choice is a hash, so under a pool smaller than 256 the
+/// access pattern is LRU's worst case and evictions are proportional to the
+/// shortfall. That tax is intended to be RARE — the startup/preflight
+/// `RLIMIT_NOFILE` raise normally lifts macOS's 256 default well above the
+/// point where the pool binds — so don't "optimize" the pool away; it exists
+/// for the environments where the raise cannot succeed.
 struct BucketWriterPool {
     dir: PathBuf,
     max_open: usize,
@@ -576,7 +583,7 @@ impl ClassMembership {
         let mut non_empty_buckets = 0usize;
         let bucket_build_start = Instant::now();
         for bucket in 0..CLASS_MEMBERSHIP_BUCKETS {
-            let partition_path = partition_dir.join(format!("bucket_{bucket:03}.typ"));
+            let partition_path = BucketWriterPool::bucket_path(&partition_dir, bucket);
             // Bucket files are created lazily by the writer pool: a bucket
             // that never received an entry has no file at all.
             let partition_bytes = match std::fs::metadata(&partition_path) {

--- a/fluree-db-indexer/src/run_index/build/build_from_commits.rs
+++ b/fluree-db-indexer/src/run_index/build/build_from_commits.rs
@@ -1283,11 +1283,13 @@ pub fn build_indexes_from_commits(
         skip_history: true, // Append-only: no time-travel data.
         g_id: config.g_id,
         progress: config.build_progress.clone(),
-        // Build the secondary orders (PSOT/POST/OPST) concurrently, bounded by
-        // the import core budget. SPOT has already completed, so this
-        // concurrency no longer overlaps with the class-membership heap.
-        // build_all_indexes clamps this to the number of buildable orders.
-        max_concurrency: config.worker_count,
+        // Build the secondary orders (PSOT/POST/OPST) concurrently. SPOT has
+        // already completed, so this concurrency no longer overlaps with the
+        // class-membership heap. Taken from the SAME plan field the fan-in
+        // share was divided by — never independently from worker_count — so
+        // the merge budget cannot drift from the actual concurrency.
+        // build_all_indexes still clamps to the number of buildable orders.
+        max_concurrency: fd_plan.order_concurrency,
         fan_in_cap: fd_plan.merge_fan_in_per_order,
     };
 
@@ -1418,11 +1420,16 @@ fn build_spot_index_from_commits(
             let streams = open_spot_commit_readers(group, g_id)?;
             let mut merge = KWayMerge::new(streams, cmp_v2_spot)?;
             let out_path = pass_dir.join(format!("merged_{i:06}.frn"));
-            // Spool sources carry no op sideband (`peek_op` is uniformly 1
-            // on the import path), so version-1 intermediates lose nothing.
-            let mut inter = StreamingRunFileWriter::create(&out_path, order, false)?;
-            while let Some((record, _op)) = merge.next_record()? {
-                inter.push(record, 1)?;
+            // Carry op bytes through verbatim (with-op intermediates), so
+            // this arm agrees with the flat arm by construction: the shared
+            // pump's `op == 0` skip sees the same ops either way. Today the
+            // V2 spool reader reports a uniform op = 1 (no `peek_op`
+            // override), but the spool wire format round-trips retractions
+            // and the pump guards for them — preserve, don't assume, exactly
+            // as `cascade_runs_to_fan_in` does.
+            let mut inter = StreamingRunFileWriter::create(&out_path, order, true)?;
+            while let Some((record, op)) = merge.next_record()? {
+                inter.push(record, op)?;
             }
             inter.finish()?;
             intermediates.push(out_path);
@@ -1628,6 +1635,11 @@ pub fn build_indexes_from_remapped_commits(
     }
     let build_start = Instant::now();
 
+    let rebuild_fd_plan = plan_fd_usage(
+        config.fd_budget,
+        config.worker_count,
+        REBUILD_CONCURRENT_ORDERS,
+    );
     let build_config = BuildAllConfig {
         base_run_dir: config.run_dir.clone(),
         index_dir: config.index_dir.clone(),
@@ -1639,15 +1651,11 @@ pub fn build_indexes_from_remapped_commits(
         g_id: config.g_id,
         progress: config.build_progress.clone(),
         // Rebuild path builds all 4 orders here (no separate SPOT thread), so
-        // concurrency can cover all of them, bounded by the core budget —
-        // which is why the fan-in share divides by 4, not the import path's 3.
-        max_concurrency: config.worker_count,
-        fan_in_cap: plan_fd_usage(
-            config.fd_budget,
-            config.worker_count,
-            REBUILD_CONCURRENT_ORDERS,
-        )
-        .merge_fan_in_per_order,
+        // concurrency can cover all of them — which is why the fan-in share
+        // divides by 4, not the import path's 3. Concurrency and share both
+        // come from the same plan so they cannot drift apart.
+        max_concurrency: rebuild_fd_plan.order_concurrency,
+        fan_in_cap: rebuild_fd_plan.merge_fan_in_per_order,
     };
 
     let order_results = build_all_indexes(&build_config).map_err(index_build_err_to_io)?;

--- a/fluree-db-indexer/src/run_index/build/fd_plan.rs
+++ b/fluree-db-indexer/src/run_index/build/fd_plan.rs
@@ -1,0 +1,111 @@
+//! Static per-phase file-descriptor apportionment for the V3 build pipeline.
+//!
+//! `build_indexes_from_commits` runs its FD-heavy phases strictly
+//! sequentially — class-membership scatter → SPOT merge → secondary run
+//! generation → secondary order merges — so each phase may plan against
+//! (nearly) the whole [`FdBudget`] and no runtime permit tracking is needed.
+//! The only concurrent consumers are the dictionary upload running on the
+//! tokio side (a handful of transient handles, covered by the budget's
+//! reserve) and the up-to-three parallel order merges (handled by dividing
+//! the merge share by that concurrency).
+//!
+//! Degradation reference (reserve = `min(soft/4, 64)`, `A = soft - reserve`):
+//!
+//! | soft limit          | A      | scatter | SPOT fan-in | workers | merge fan-in (3 orders) |
+//! |---------------------|--------|---------|-------------|---------|-------------------------|
+//! | 256 (raise failed)  | 192    | 184     | 184         | 24      | 60                      |
+//! | 1024 (AWS Lambda)   | 960    | 256     | 952         | 120     | 316                     |
+//! | 10240 (raised macOS)| 10 176 | 256     | 10 168      | 1272    | 3388                    |
+//!
+//! Every value floors well above zero (see [`FdBudget::available`]'s floor of
+//! 32), so even a degenerate limit produces a plan that makes progress and
+//! lets the kernel — not an overflow — report genuinely impossible limits.
+
+use fluree_db_core::fd_limit::FdBudget;
+
+/// Per-phase file-descriptor allowances for one `build_indexes_from_commits`
+/// invocation. All values are counts of *simultaneously open* descriptors the
+/// phase may plan for; transient open-read-close handles ride on the reserve.
+#[derive(Clone, Copy, Debug)]
+pub struct FdPlan {
+    /// Max simultaneously open class-membership bucket writers (≤ 256; the
+    /// scatter multiplexes its 256 logical buckets through a pool this size).
+    pub scatter_pool: usize,
+    /// Max sorted-commit readers the SPOT merge may hold open at once; chunk
+    /// counts beyond this trigger the hierarchical (group-merge) fallback.
+    pub spot_fan_in: usize,
+    /// Cap on secondary-run-generation workers (each holds ~6-8 descriptors:
+    /// commit reader + three order run writers + background-flush transients).
+    pub worker_cap: usize,
+    /// Max run files one order's k-way merge may hold open at once; run
+    /// counts beyond this trigger the cascaded multi-pass merge. Sized for
+    /// up to three order merges running concurrently.
+    pub merge_fan_in_per_order: usize,
+}
+
+/// Compute the per-phase FD plan for a build with `worker_count` workers.
+pub fn plan_fd_usage(budget: FdBudget, worker_count: usize) -> FdPlan {
+    let a = budget.available();
+    // Secondary-order merges run up to min(worker_count, 3) at a time
+    // (three buildable secondary orders; see build_all_indexes).
+    let order_concurrency = worker_count.clamp(1, 3);
+    FdPlan {
+        scatter_pool: a.saturating_sub(8).clamp(16, 256),
+        spot_fan_in: a.saturating_sub(8).max(16),
+        worker_cap: (a / 8).max(1),
+        merge_fan_in_per_order: (a / order_concurrency).saturating_sub(4).max(8),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_matches_degradation_table() {
+        // S=256 with a failed raise: the historical worst case must still plan.
+        let p = plan_fd_usage(FdBudget::from_soft(256), 8);
+        assert_eq!(p.scatter_pool, 184);
+        assert_eq!(p.spot_fan_in, 184);
+        assert_eq!(p.worker_cap, 24);
+        assert_eq!(p.merge_fan_in_per_order, 60);
+
+        // S=1024 (AWS Lambda's fixed hard limit).
+        let p = plan_fd_usage(FdBudget::from_soft(1024), 8);
+        assert_eq!(p.scatter_pool, 256);
+        assert_eq!(p.spot_fan_in, 952);
+        assert_eq!(p.worker_cap, 120);
+        assert_eq!(p.merge_fan_in_per_order, 316);
+
+        // S=10240 (macOS after a successful raise).
+        let p = plan_fd_usage(FdBudget::from_soft(10_240), 16);
+        assert_eq!(p.scatter_pool, 256);
+        assert_eq!(p.spot_fan_in, 10_168);
+        assert_eq!(p.worker_cap, 1272);
+        assert_eq!(p.merge_fan_in_per_order, 3388);
+    }
+
+    #[test]
+    fn plan_survives_degenerate_budgets() {
+        let p = plan_fd_usage(FdBudget::from_soft(8), 1);
+        assert!(p.scatter_pool >= 16);
+        assert!(p.spot_fan_in >= 16);
+        assert!(p.worker_cap >= 1);
+        assert!(p.merge_fan_in_per_order >= 8);
+    }
+
+    #[test]
+    fn unlimited_budget_never_constrains() {
+        let p = plan_fd_usage(FdBudget::unlimited(), 32);
+        assert_eq!(p.scatter_pool, 256);
+        assert!(p.spot_fan_in > 1 << 40);
+        assert!(p.merge_fan_in_per_order > 1 << 40);
+    }
+
+    #[test]
+    fn single_worker_gets_full_merge_share() {
+        let one = plan_fd_usage(FdBudget::from_soft(256), 1);
+        let three = plan_fd_usage(FdBudget::from_soft(256), 3);
+        assert!(one.merge_fan_in_per_order > three.merge_fan_in_per_order);
+    }
+}

--- a/fluree-db-indexer/src/run_index/build/fd_plan.rs
+++ b/fluree-db-indexer/src/run_index/build/fd_plan.rs
@@ -14,10 +14,10 @@
 //!
 //! | soft limit          | A      | scatter | SPOT fan-in | workers | merge fan-in/order |
 //! |---------------------|--------|---------|-------------|---------|--------------------|
-//! | 96 (regression test)| 64     | 56      | 56          | 8       | 17                 |
-//! | 256 (raise failed)  | 192    | 184     | 184         | 24      | 60                 |
-//! | 1024 (AWS Lambda)   | 960    | 256     | 952         | 120     | 316                |
-//! | 10240 (raised macOS)| 10 176 | 256     | 10 168      | 1272    | 3388               |
+//! | 96 (regression test)| 64     | 56      | 32          | 8       | 17                 |
+//! | 256 (raise failed)  | 192    | 184     | 96          | 24      | 60                 |
+//! | 1024 (AWS Lambda)   | 960    | 256     | 480         | 120     | 316                |
+//! | 10240 (raised macOS)| 10 176 | 256     | 5088        | 1272    | 3388               |
 //!
 //! Every value floors well above zero (see [`FdBudget::available`]'s floor of
 //! 32), so even a degenerate limit produces a plan that makes progress and
@@ -60,7 +60,13 @@ pub fn plan_fd_usage(budget: FdBudget, worker_count: usize, concurrent_orders: u
     let order_concurrency = worker_count.clamp(1, concurrent_orders.max(1));
     FdPlan {
         scatter_pool: a.saturating_sub(8).clamp(16, 256),
-        spot_fan_in: a.saturating_sub(8).max(16),
+        // Half of A, not A-minus-slack: the SPOT phase could safely claim
+        // nearly everything (phases are sequential), but the reserve is an
+        // estimate — object-store connection pools and OTEL sockets draw
+        // from it invisibly — and a 50% share keeps real margin at the cost
+        // of at most one extra grouping pass when chunk counts land between
+        // A/2 and A.
+        spot_fan_in: (a / 2).max(16),
         worker_cap: (a / 8).max(1),
         merge_fan_in_per_order: (a / order_concurrency).saturating_sub(4).max(8),
     }
@@ -83,28 +89,28 @@ mod tests {
         // S=96: the shipped end-to-end regression limit.
         let p = plan_fd_usage(FdBudget::from_soft(96), 8, IMPORT_CONCURRENT_ORDERS);
         assert_eq!(p.scatter_pool, 56);
-        assert_eq!(p.spot_fan_in, 56);
+        assert_eq!(p.spot_fan_in, 32);
         assert_eq!(p.worker_cap, 8);
         assert_eq!(p.merge_fan_in_per_order, 17);
 
         // S=256 with a failed raise: the historical worst case must still plan.
         let p = plan_fd_usage(FdBudget::from_soft(256), 8, IMPORT_CONCURRENT_ORDERS);
         assert_eq!(p.scatter_pool, 184);
-        assert_eq!(p.spot_fan_in, 184);
+        assert_eq!(p.spot_fan_in, 96);
         assert_eq!(p.worker_cap, 24);
         assert_eq!(p.merge_fan_in_per_order, 60);
 
         // S=1024 (AWS Lambda's fixed hard limit).
         let p = plan_fd_usage(FdBudget::from_soft(1024), 8, IMPORT_CONCURRENT_ORDERS);
         assert_eq!(p.scatter_pool, 256);
-        assert_eq!(p.spot_fan_in, 952);
+        assert_eq!(p.spot_fan_in, 480);
         assert_eq!(p.worker_cap, 120);
         assert_eq!(p.merge_fan_in_per_order, 316);
 
         // S=10240 (macOS after a successful raise).
         let p = plan_fd_usage(FdBudget::from_soft(10_240), 16, IMPORT_CONCURRENT_ORDERS);
         assert_eq!(p.scatter_pool, 256);
-        assert_eq!(p.spot_fan_in, 10_168);
+        assert_eq!(p.spot_fan_in, 5088);
         assert_eq!(p.worker_cap, 1272);
         assert_eq!(p.merge_fan_in_per_order, 3388);
     }

--- a/fluree-db-indexer/src/run_index/build/fd_plan.rs
+++ b/fluree-db-indexer/src/run_index/build/fd_plan.rs
@@ -5,17 +5,19 @@
 //! generation → secondary order merges — so each phase may plan against
 //! (nearly) the whole [`FdBudget`] and no runtime permit tracking is needed.
 //! The only concurrent consumers are the dictionary upload running on the
-//! tokio side (a handful of transient handles, covered by the budget's
-//! reserve) and the up-to-three parallel order merges (handled by dividing
-//! the merge share by that concurrency).
+//! tokio side (covered by the budget's reserve — see [`FdBudget`]) and the
+//! parallel order merges (handled by dividing the merge share by that
+//! concurrency).
 //!
-//! Degradation reference (reserve = `min(soft/4, 64)`, `A = soft - reserve`):
+//! Degradation reference (reserve = `min(max(soft/4, 32), 64)`,
+//! `A = soft − reserve`, three concurrent orders):
 //!
-//! | soft limit          | A      | scatter | SPOT fan-in | workers | merge fan-in (3 orders) |
-//! |---------------------|--------|---------|-------------|---------|-------------------------|
-//! | 256 (raise failed)  | 192    | 184     | 184         | 24      | 60                      |
-//! | 1024 (AWS Lambda)   | 960    | 256     | 952         | 120     | 316                     |
-//! | 10240 (raised macOS)| 10 176 | 256     | 10 168      | 1272    | 3388                    |
+//! | soft limit          | A      | scatter | SPOT fan-in | workers | merge fan-in/order |
+//! |---------------------|--------|---------|-------------|---------|--------------------|
+//! | 96 (regression test)| 64     | 56      | 56          | 8       | 17                 |
+//! | 256 (raise failed)  | 192    | 184     | 184         | 24      | 60                 |
+//! | 1024 (AWS Lambda)   | 960    | 256     | 952         | 120     | 316                |
+//! | 10240 (raised macOS)| 10 176 | 256     | 10 168      | 1272    | 3388               |
 //!
 //! Every value floors well above zero (see [`FdBudget::available`]'s floor of
 //! 32), so even a degenerate limit produces a plan that makes progress and
@@ -23,9 +25,9 @@
 
 use fluree_db_core::fd_limit::FdBudget;
 
-/// Per-phase file-descriptor allowances for one `build_indexes_from_commits`
-/// invocation. All values are counts of *simultaneously open* descriptors the
-/// phase may plan for; transient open-read-close handles ride on the reserve.
+/// Per-phase file-descriptor allowances for one index build. All values are
+/// counts of *simultaneously open* descriptors the phase may plan for;
+/// transient open-read-close handles ride on the reserve.
 #[derive(Clone, Copy, Debug)]
 pub struct FdPlan {
     /// Max simultaneously open class-membership bucket writers (≤ 256; the
@@ -34,21 +36,28 @@ pub struct FdPlan {
     /// Max sorted-commit readers the SPOT merge may hold open at once; chunk
     /// counts beyond this trigger the hierarchical (group-merge) fallback.
     pub spot_fan_in: usize,
-    /// Cap on secondary-run-generation workers (each holds ~6-8 descriptors:
-    /// commit reader + three order run writers + background-flush transients).
+    /// Cap on secondary-run-generation workers. Each worker's true peak is 4
+    /// descriptors (1 sorted-commit reader + up to 3 concurrent run-flush
+    /// files — `RunWriter` joins the previous flush thread before spawning
+    /// the next, so flushes cannot pile up); the `/8` divisor in the formula
+    /// deliberately budgets 2× that for headroom.
     pub worker_cap: usize,
     /// Max run files one order's k-way merge may hold open at once; run
-    /// counts beyond this trigger the cascaded multi-pass merge. Sized for
-    /// up to three order merges running concurrently.
+    /// counts beyond this trigger the cascaded multi-pass merge. Sized as
+    /// `A / concurrent_orders − 4`, where the −4 covers each in-flight
+    /// cascade pass's single output writer (plus slack).
     pub merge_fan_in_per_order: usize,
 }
 
 /// Compute the per-phase FD plan for a build with `worker_count` workers.
-pub fn plan_fd_usage(budget: FdBudget, worker_count: usize) -> FdPlan {
+///
+/// `concurrent_orders` is the number of order merges `build_all_indexes` may
+/// run at once for this pipeline: 3 on the import path (SPOT is built
+/// separately, before the secondary orders), 4 on the remapped-rebuild path
+/// (all four orders build together).
+pub fn plan_fd_usage(budget: FdBudget, worker_count: usize, concurrent_orders: usize) -> FdPlan {
     let a = budget.available();
-    // Secondary-order merges run up to min(worker_count, 3) at a time
-    // (three buildable secondary orders; see build_all_indexes).
-    let order_concurrency = worker_count.clamp(1, 3);
+    let order_concurrency = worker_count.clamp(1, concurrent_orders.max(1));
     FdPlan {
         scatter_pool: a.saturating_sub(8).clamp(16, 256),
         spot_fan_in: a.saturating_sub(8).max(16),
@@ -57,28 +66,43 @@ pub fn plan_fd_usage(budget: FdBudget, worker_count: usize) -> FdPlan {
     }
 }
 
+/// Order-merge concurrency on the import path: PSOT/POST/OPST build in
+/// parallel after SPOT has already completed on its own.
+pub const IMPORT_CONCURRENT_ORDERS: usize = 3;
+
+/// Order-merge concurrency on the remapped-rebuild path: all four orders
+/// (including SPOT) build through `build_all_indexes` together.
+pub const REBUILD_CONCURRENT_ORDERS: usize = 4;
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn plan_matches_degradation_table() {
+        // S=96: the shipped end-to-end regression limit.
+        let p = plan_fd_usage(FdBudget::from_soft(96), 8, IMPORT_CONCURRENT_ORDERS);
+        assert_eq!(p.scatter_pool, 56);
+        assert_eq!(p.spot_fan_in, 56);
+        assert_eq!(p.worker_cap, 8);
+        assert_eq!(p.merge_fan_in_per_order, 17);
+
         // S=256 with a failed raise: the historical worst case must still plan.
-        let p = plan_fd_usage(FdBudget::from_soft(256), 8);
+        let p = plan_fd_usage(FdBudget::from_soft(256), 8, IMPORT_CONCURRENT_ORDERS);
         assert_eq!(p.scatter_pool, 184);
         assert_eq!(p.spot_fan_in, 184);
         assert_eq!(p.worker_cap, 24);
         assert_eq!(p.merge_fan_in_per_order, 60);
 
         // S=1024 (AWS Lambda's fixed hard limit).
-        let p = plan_fd_usage(FdBudget::from_soft(1024), 8);
+        let p = plan_fd_usage(FdBudget::from_soft(1024), 8, IMPORT_CONCURRENT_ORDERS);
         assert_eq!(p.scatter_pool, 256);
         assert_eq!(p.spot_fan_in, 952);
         assert_eq!(p.worker_cap, 120);
         assert_eq!(p.merge_fan_in_per_order, 316);
 
         // S=10240 (macOS after a successful raise).
-        let p = plan_fd_usage(FdBudget::from_soft(10_240), 16);
+        let p = plan_fd_usage(FdBudget::from_soft(10_240), 16, IMPORT_CONCURRENT_ORDERS);
         assert_eq!(p.scatter_pool, 256);
         assert_eq!(p.spot_fan_in, 10_168);
         assert_eq!(p.worker_cap, 1272);
@@ -86,8 +110,21 @@ mod tests {
     }
 
     #[test]
+    fn rebuild_divides_by_four_concurrent_orders() {
+        // The remapped-rebuild path runs all four orders concurrently, so its
+        // per-order share must be smaller than the import path's at the same
+        // budget and worker count.
+        let import = plan_fd_usage(FdBudget::from_soft(256), 8, IMPORT_CONCURRENT_ORDERS);
+        let rebuild = plan_fd_usage(FdBudget::from_soft(256), 8, REBUILD_CONCURRENT_ORDERS);
+        assert_eq!(rebuild.merge_fan_in_per_order, 192 / 4 - 4);
+        assert!(rebuild.merge_fan_in_per_order < import.merge_fan_in_per_order);
+        // 4 × (fan_in + 1 cascade writer) must fit in A.
+        assert!(4 * (rebuild.merge_fan_in_per_order + 1) <= 192);
+    }
+
+    #[test]
     fn plan_survives_degenerate_budgets() {
-        let p = plan_fd_usage(FdBudget::from_soft(8), 1);
+        let p = plan_fd_usage(FdBudget::from_soft(8), 1, IMPORT_CONCURRENT_ORDERS);
         assert!(p.scatter_pool >= 16);
         assert!(p.spot_fan_in >= 16);
         assert!(p.worker_cap >= 1);
@@ -96,7 +133,7 @@ mod tests {
 
     #[test]
     fn unlimited_budget_never_constrains() {
-        let p = plan_fd_usage(FdBudget::unlimited(), 32);
+        let p = plan_fd_usage(FdBudget::unlimited(), 32, IMPORT_CONCURRENT_ORDERS);
         assert_eq!(p.scatter_pool, 256);
         assert!(p.spot_fan_in > 1 << 40);
         assert!(p.merge_fan_in_per_order > 1 << 40);
@@ -104,8 +141,8 @@ mod tests {
 
     #[test]
     fn single_worker_gets_full_merge_share() {
-        let one = plan_fd_usage(FdBudget::from_soft(256), 1);
-        let three = plan_fd_usage(FdBudget::from_soft(256), 3);
+        let one = plan_fd_usage(FdBudget::from_soft(256), 1, IMPORT_CONCURRENT_ORDERS);
+        let three = plan_fd_usage(FdBudget::from_soft(256), 3, IMPORT_CONCURRENT_ORDERS);
         assert!(one.merge_fan_in_per_order > three.merge_fan_in_per_order);
     }
 }

--- a/fluree-db-indexer/src/run_index/build/fd_plan.rs
+++ b/fluree-db-indexer/src/run_index/build/fd_plan.rs
@@ -44,9 +44,15 @@ pub struct FdPlan {
     pub worker_cap: usize,
     /// Max run files one order's k-way merge may hold open at once; run
     /// counts beyond this trigger the cascaded multi-pass merge. Sized as
-    /// `A / concurrent_orders − 4`, where the −4 covers each in-flight
+    /// `A / order_concurrency − 4`, where the −4 covers each in-flight
     /// cascade pass's single output writer (plus slack).
     pub merge_fan_in_per_order: usize,
+    /// The order-merge concurrency `merge_fan_in_per_order` was divided by.
+    /// Callers MUST size `BuildAllConfig::max_concurrency` from this field —
+    /// never independently from `worker_count` — so the share arithmetic and
+    /// the actual concurrency cannot drift apart (running more simultaneous
+    /// order merges than this would overrun the budget by the excess ratio).
+    pub order_concurrency: usize,
 }
 
 /// Compute the per-phase FD plan for a build with `worker_count` workers.
@@ -69,6 +75,7 @@ pub fn plan_fd_usage(budget: FdBudget, worker_count: usize, concurrent_orders: u
         spot_fan_in: (a / 2).max(16),
         worker_cap: (a / 8).max(1),
         merge_fan_in_per_order: (a / order_concurrency).saturating_sub(4).max(8),
+        order_concurrency,
     }
 }
 
@@ -113,6 +120,18 @@ mod tests {
         assert_eq!(p.spot_fan_in, 5088);
         assert_eq!(p.worker_cap, 1272);
         assert_eq!(p.merge_fan_in_per_order, 3388);
+    }
+
+    #[test]
+    fn order_concurrency_field_matches_divisor() {
+        // The plan must expose the exact divisor it used, so callers can set
+        // BuildAllConfig::max_concurrency from it and stay structurally in
+        // sync with the share arithmetic.
+        for (workers, orders, expect) in [(1, 3, 1), (2, 3, 2), (8, 3, 3), (8, 4, 4), (2, 4, 2)] {
+            let p = plan_fd_usage(FdBudget::from_soft(256), workers, orders);
+            assert_eq!(p.order_concurrency, expect);
+            assert_eq!(p.merge_fan_in_per_order, (192 / expect - 4).max(8));
+        }
     }
 
     #[test]

--- a/fluree-db-indexer/src/run_index/build/index_build.rs
+++ b/fluree-db-indexer/src/run_index/build/index_build.rs
@@ -521,7 +521,7 @@ pub fn discover_run_files_v2(dir: &Path) -> io::Result<Vec<PathBuf>> {
 /// run files, typically symlinks into per-chunk dirs — are never touched).
 /// Passes needed: `ceil(log_fan_in(runs)) - 1`; disk overhead: one extra
 /// zstd-compressed copy of the order per live pass.
-fn cascade_runs_to_fan_in(
+pub(crate) fn cascade_runs_to_fan_in(
     mut run_paths: Vec<PathBuf>,
     order: RunSortOrder,
     fan_in: usize,

--- a/fluree-db-indexer/src/run_index/build/index_build.rs
+++ b/fluree-db-indexer/src/run_index/build/index_build.rs
@@ -290,6 +290,23 @@ pub fn build_index(config: &IndexBuildConfig) -> Result<IndexBuildResult, IndexB
     let result = writer.finish()?;
     let graph_results = vec![result];
 
+    // Reclaim the cascade's final-pass intermediates (a full zstd copy of
+    // this order) now that the merge has consumed them, instead of carrying
+    // them until the whole run dir is torn down. Best-effort: the build
+    // result is already complete, and on an error path above the import-level
+    // teardown removes the run dir wholesale anyway.
+    drop(merge);
+    let cascade_dir = config.run_dir.join("cascade");
+    if cascade_dir.exists() {
+        if let Err(e) = std::fs::remove_dir_all(&cascade_dir) {
+            tracing::warn!(
+                order = config.sort_order.dir_name(),
+                error = %e,
+                "failed to remove cascade scratch dir"
+            );
+        }
+    }
+
     Ok(IndexBuildResult {
         graphs: graph_results,
         total_rows,

--- a/fluree-db-indexer/src/run_index/build/index_build.rs
+++ b/fluree-db-indexer/src/run_index/build/index_build.rs
@@ -10,6 +10,7 @@
 //! history sidecar production is skipped.
 
 use super::merge::KWayMerge;
+use crate::run_index::runs::run_file::StreamingRunFileWriter;
 use crate::run_index::runs::streaming_reader::StreamingRunReader;
 use fluree_db_binary_index::format::branch::{build_branch_bytes, LeafEntry};
 use fluree_db_binary_index::format::history_sidecar::HistEntryV2;
@@ -154,7 +155,24 @@ pub fn build_index(config: &IndexBuildConfig) -> Result<IndexBuildResult, IndexB
     let t0 = Instant::now();
 
     // Discover run files.
-    let run_paths = discover_run_files_v2(&config.run_dir)?;
+    let mut run_paths = discover_run_files_v2(&config.run_dir)?;
+    if run_paths.len() > config.fan_in_cap {
+        // More runs than the FD budget allows open at once: losslessly
+        // reduce the fan-in first (extra sequential merge passes trade
+        // I/O for descriptors; output is byte-identical either way).
+        tracing::info!(
+            order = config.sort_order.dir_name(),
+            runs = run_paths.len(),
+            fan_in_cap = config.fan_in_cap,
+            "run count exceeds fd budget; cascading merge passes"
+        );
+        run_paths = cascade_runs_to_fan_in(
+            run_paths,
+            config.sort_order,
+            config.fan_in_cap,
+            &config.run_dir.join("cascade"),
+        )?;
+    }
     if run_paths.is_empty() {
         // Empty graph/order: produce no artifacts.
         //
@@ -467,6 +485,97 @@ pub fn discover_run_files_v2(dir: &Path) -> io::Result<Vec<PathBuf>> {
     }
     paths.sort();
     Ok(paths)
+}
+
+/// Losslessly reduce a sorted run-file set to at most `fan_in` files via
+/// multi-pass merges of **consecutive** groups, so the final k-way merge
+/// never holds more than `fan_in` descriptors open.
+///
+/// Byte-identity argument (why a cascade is exactly a flat merge):
+///
+/// 1. The V2 comparators order on identity fields only — they exclude `t`
+///    and op (`run_record_v2.rs`, proven by `comparator_excludes_t`) — and
+///    `KWayMerge::next_record` performs no dedup, filtering, or op
+///    resolution: every input `(record, op)` pair is emitted exactly once.
+/// 2. For records comparing unequal, flat and cascaded merges trivially
+///    agree. For records comparing equal, `KWayMerge` tie-breaks by
+///    `stream_idx`. Flat merge therefore emits equal records in run-file
+///    order. In the cascade, equal records within one group keep in-group
+///    run order (in-group `stream_idx` = run order), and across groups the
+///    next pass tie-breaks by intermediate-file index — which equals group
+///    order, because groups are **consecutive** slices of the (sorted) path
+///    list and outputs are named `merged_{i:06}` and consumed in that order.
+///    Every run in group *g* precedes every run in group *g+1* in the flat
+///    order too, so the emitted sequence is identical; induction extends
+///    this to any cascade depth.
+/// 3. Downstream consumers are pure functions of the emitted sequence: the
+///    import path (`skip_dedup`) consumes `next_record` directly, and the
+///    rebuild path's `next_deduped_with_history` resolves winners from the
+///    same sequence. Intermediate passes preserve rather than resolve — op
+///    bytes are carried verbatim (version-2 output whenever any input
+///    carries ops) and nothing is dropped — so retract/assert resolution
+///    still happens exactly once, in the final consumer.
+///
+/// Intermediates live under `scratch_dir/pass_{n}/`; each pass's inputs are
+/// deleted once the pass completes (pass-0 inputs — the caller's original
+/// run files, typically symlinks into per-chunk dirs — are never touched).
+/// Passes needed: `ceil(log_fan_in(runs)) - 1`; disk overhead: one extra
+/// zstd-compressed copy of the order per live pass.
+fn cascade_runs_to_fan_in(
+    mut run_paths: Vec<PathBuf>,
+    order: RunSortOrder,
+    fan_in: usize,
+    scratch_dir: &Path,
+) -> io::Result<Vec<PathBuf>> {
+    // fan_in == 1 would make chunks(1) a no-op loop; 2 always terminates.
+    let fan_in = fan_in.max(2);
+    if scratch_dir.exists() {
+        std::fs::remove_dir_all(scratch_dir)?;
+    }
+
+    let mut pass = 0usize;
+    let mut prev_pass_dir: Option<PathBuf> = None;
+    while run_paths.len() > fan_in {
+        pass += 1;
+        let pass_dir = scratch_dir.join(format!("pass_{pass}"));
+        std::fs::create_dir_all(&pass_dir)?;
+
+        let mut outputs = Vec::with_capacity(run_paths.len().div_ceil(fan_in));
+        for (i, group) in run_paths.chunks(fan_in).enumerate() {
+            let out_path = pass_dir.join(format!("merged_{i:06}.frn"));
+            let streams: Vec<StreamingRunReader> = group
+                .iter()
+                .map(|p| StreamingRunReader::open(p))
+                .collect::<io::Result<Vec<_>>>()?;
+            // Version-2 output iff any input carries ops: op bytes must
+            // survive the cascade for the final merge's dedup/history.
+            let with_op = streams.iter().any(|s| s.header.has_op());
+            let mut merge = KWayMerge::new(streams, cmp_v2_for_order(order))?;
+            let mut writer = StreamingRunFileWriter::create(&out_path, order, with_op)?;
+            while let Some((record, op)) = merge.next_record()? {
+                writer.push(record, op)?;
+            }
+            writer.finish()?;
+            outputs.push(out_path);
+        }
+
+        tracing::info!(
+            order = order.dir_name(),
+            pass,
+            inputs = run_paths.len(),
+            outputs = outputs.len(),
+            "cascade merge pass complete"
+        );
+
+        // The just-consumed inputs of pass N were pass N-1's outputs; the
+        // originals (pass 0 inputs) stay owned by the caller's run dir.
+        if let Some(dir) = prev_pass_dir.replace(pass_dir) {
+            std::fs::remove_dir_all(&dir)?;
+        }
+        run_paths = outputs;
+    }
+
+    Ok(run_paths)
 }
 
 // ============================================================================
@@ -787,6 +896,150 @@ mod tests {
         assert_eq!(leaf_dir[1].o_type_const, Some(OType::XSD_STRING.as_u16()));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn leaf_cids(r: &IndexBuildResult) -> Vec<(ContentId, Option<ContentId>, u64)> {
+        r.graphs
+            .iter()
+            .flat_map(|g| g.leaf_infos.iter())
+            .map(|l| (l.leaf_cid.clone(), l.sidecar_cid.clone(), l.total_rows))
+            .collect()
+    }
+
+    fn branch_cids(r: &IndexBuildResult) -> Vec<ContentId> {
+        r.graphs.iter().map(|g| g.branch_cid.clone()).collect()
+    }
+
+    /// A cascaded merge (fan_in_cap 3 forces two passes over 9 runs) must be
+    /// byte-identical to the flat merge: leaf/sidecar/branch CIDs are
+    /// content-addressed, so CID equality is byte equality. Import path
+    /// (skip_dedup, no ops).
+    #[test]
+    fn cascade_matches_flat_merge_no_op() {
+        use fluree_db_binary_index::format::run_record_v2::cmp_v2_spot;
+
+        let dir = tempfile::tempdir().unwrap();
+        let build = |fan_in_cap: usize, tag: &str| {
+            let run_dir = dir.path().join(format!("runs_{tag}"));
+            let index_dir = dir.path().join(format!("index_{tag}"));
+            std::fs::create_dir_all(&run_dir).unwrap();
+            for j in 0..9u64 {
+                // Overlapping subjects across runs; identical-comparing
+                // records (comparators exclude t) land in different runs so
+                // the stream-idx tie-break is exercised across group seams.
+                let mut records: Vec<RunRecordV2> = (0..200u64)
+                    .map(|i| {
+                        make_rec(
+                            0,
+                            (i * 3 + j) % 350,
+                            1,
+                            OType::XSD_INTEGER.as_u16(),
+                            (i % 40) * 10,
+                            j as u32 + 1,
+                        )
+                    })
+                    .collect();
+                records.sort_by(cmp_v2_spot);
+                write_run_file(
+                    &run_dir.join(format!("run_{j:05}.frn")),
+                    &records,
+                    RunSortOrder::Spot,
+                    j as u32 + 1,
+                    j as u32 + 1,
+                )
+                .unwrap();
+            }
+            let config = IndexBuildConfig {
+                run_dir,
+                index_dir,
+                sort_order: RunSortOrder::Spot,
+                leaflet_target_rows: 64,
+                leaf_target_rows: 256,
+                zstd_level: 1,
+                skip_dedup: true,
+                skip_history: true,
+                g_id: 0,
+                progress: None,
+                fan_in_cap,
+            };
+            build_index(&config).unwrap()
+        };
+
+        let flat = build(usize::MAX, "flat");
+        let cascaded = build(3, "cascade");
+
+        assert_eq!(flat.total_rows, 9 * 200);
+        assert_eq!(flat.total_rows, cascaded.total_rows);
+        assert_eq!(leaf_cids(&flat), leaf_cids(&cascaded));
+        assert_eq!(branch_cids(&flat), branch_cids(&cascaded));
+    }
+
+    /// Same byte-identity through the rebuild path: op bytes must survive
+    /// cascade passes verbatim so dedup (max-t wins) and history-sidecar
+    /// resolution happen exactly once, in the final merge, with identical
+    /// results.
+    #[test]
+    fn cascade_matches_flat_merge_with_op() {
+        use crate::run_index::runs::run_file::write_run_file_with_op;
+        use fluree_db_binary_index::format::run_record_v2::cmp_v2_spot;
+
+        let dir = tempfile::tempdir().unwrap();
+        let build = |fan_in_cap: usize, tag: &str| {
+            let run_dir = dir.path().join(format!("runs_{tag}"));
+            let index_dir = dir.path().join(format!("index_{tag}"));
+            std::fs::create_dir_all(&run_dir).unwrap();
+            for j in 0..9u64 {
+                // Identities recur across runs at distinct t with alternating
+                // assert/retract, so the final merge resolves multi-event
+                // lifecycles (rows + history entries + vanished facts).
+                let mut recs: Vec<(RunRecordV2, u8)> = (0..150u64)
+                    .map(|i| {
+                        let rec = make_rec(
+                            0,
+                            (i * 5 + j * 2) % 100,
+                            1,
+                            OType::XSD_INTEGER.as_u16(),
+                            (i % 25) * 4,
+                            (j * 150 + i) as u32 + 1,
+                        );
+                        (rec, ((i + j) % 2) as u8)
+                    })
+                    .collect();
+                recs.sort_by(|a, b| cmp_v2_spot(&a.0, &b.0));
+                let records: Vec<RunRecordV2> = recs.iter().map(|(r, _)| *r).collect();
+                let ops: Vec<u8> = recs.iter().map(|&(_, op)| op).collect();
+                write_run_file_with_op(
+                    &run_dir.join(format!("run_{j:05}.frn")),
+                    &records,
+                    &ops,
+                    RunSortOrder::Spot,
+                    j as u32 * 150 + 1,
+                    j as u32 * 150 + 150,
+                )
+                .unwrap();
+            }
+            let config = IndexBuildConfig {
+                run_dir,
+                index_dir,
+                sort_order: RunSortOrder::Spot,
+                leaflet_target_rows: 64,
+                leaf_target_rows: 256,
+                zstd_level: 1,
+                skip_dedup: false,
+                skip_history: false,
+                g_id: 0,
+                progress: None,
+                fan_in_cap,
+            };
+            build_index(&config).unwrap()
+        };
+
+        let flat = build(usize::MAX, "flat");
+        let cascaded = build(3, "cascade");
+
+        assert_eq!(flat.total_rows, cascaded.total_rows);
+        assert_eq!(leaf_cids(&flat), leaf_cids(&cascaded));
+        assert_eq!(branch_cids(&flat), branch_cids(&cascaded));
     }
 
     /// Decode every history entry from a persisted leaf's sidecar.

--- a/fluree-db-indexer/src/run_index/build/index_build.rs
+++ b/fluree-db-indexer/src/run_index/build/index_build.rs
@@ -90,6 +90,11 @@ pub struct IndexBuildConfig {
     pub g_id: u16,
     /// Shared progress counter.
     pub progress: Option<Arc<AtomicU64>>,
+    /// Max run files the k-way merge may hold open simultaneously. Run counts
+    /// beyond this are first reduced by a lossless cascaded merge (see
+    /// `cascade_runs_to_fan_in`). `usize::MAX` disables cascading (legacy
+    /// unbudgeted behavior).
+    pub fan_in_cap: usize,
 }
 
 // ============================================================================
@@ -514,6 +519,10 @@ pub struct BuildAllConfig {
     /// build times from additive into `max()`. `0`/`1` preserves the legacy
     /// serial build; callers size this from the effective import core budget.
     pub max_concurrency: usize,
+    /// Per-order merge fan-in cap, forwarded to [`IndexBuildConfig`]. Callers
+    /// size this from the FD budget divided by the order concurrency (see
+    /// `fd_plan::plan_fd_usage`); `usize::MAX` disables cascading.
+    pub fan_in_cap: usize,
 }
 
 /// Build V2 indexes for all four orders from a base run directory.
@@ -579,6 +588,7 @@ pub fn build_all_indexes(
             // Import progress reflects all order builds, not just one
             // representative order, so attach the shared counter to each.
             progress: config.progress.clone(),
+            fan_in_cap: config.fan_in_cap,
         };
 
         let result = build_index(&order_config)?;
@@ -746,6 +756,7 @@ mod tests {
             skip_history: true,
             g_id: 0,
             progress: None,
+            fan_in_cap: usize::MAX,
         };
 
         let result = build_index(&config).unwrap();
@@ -838,6 +849,7 @@ mod tests {
             skip_history: false,
             g_id: 0,
             progress: None,
+            fan_in_cap: usize::MAX,
         };
 
         let result = build_index(&config).unwrap();
@@ -900,6 +912,7 @@ mod tests {
             skip_history: false,
             g_id: 0,
             progress: None,
+            fan_in_cap: usize::MAX,
         };
 
         let result = build_index(&config).unwrap();
@@ -952,6 +965,7 @@ mod tests {
             skip_history: false,
             g_id: 0,
             progress: None,
+            fan_in_cap: usize::MAX,
         };
 
         let result = build_index(&config).unwrap();
@@ -1011,6 +1025,7 @@ mod tests {
             skip_history: true,
             g_id: 0,
             progress: None,
+            fan_in_cap: usize::MAX,
         };
 
         let result = build_index(&config).unwrap();

--- a/fluree-db-indexer/src/run_index/build/index_build.rs
+++ b/fluree-db-indexer/src/run_index/build/index_build.rs
@@ -545,6 +545,9 @@ pub(crate) fn cascade_runs_to_fan_in(
     scratch_dir: &Path,
 ) -> io::Result<Vec<PathBuf>> {
     // fan_in == 1 would make chunks(1) a no-op loop; 2 always terminates.
+    // Defense-in-depth only: `plan_fd_usage` already floors
+    // `merge_fan_in_per_order` at 8, so this can bite only a caller passing
+    // a hand-built cap — the plan's floor is the authoritative one.
     let fan_in = fan_in.max(2);
     if scratch_dir.exists() {
         std::fs::remove_dir_all(scratch_dir)?;

--- a/fluree-db-indexer/src/run_index/build/mod.rs
+++ b/fluree-db-indexer/src/run_index/build/mod.rs
@@ -1,5 +1,6 @@
 pub mod build_from_commits;
 pub use build_from_commits::{ClassMembership, SpotClassStatsCollector};
+pub mod fd_plan;
 pub mod incremental_branch;
 pub mod incremental_leaf;
 pub mod incremental_resolve;

--- a/fluree-db-indexer/src/run_index/build/replay_property_tests.rs
+++ b/fluree-db-indexer/src/run_index/build/replay_property_tests.rs
@@ -248,6 +248,7 @@ fn build_leaf_via_rebuild(
         skip_history: false,
         g_id: 0,
         progress: None,
+        fan_in_cap: usize::MAX,
     };
     let result = build_index(&config).unwrap();
     let leaf = &result.graphs[0].leaf_infos[0];

--- a/fluree-db-indexer/src/run_index/runs/run_file.rs
+++ b/fluree-db-indexer/src/run_index/runs/run_file.rs
@@ -299,6 +299,208 @@ pub struct RunFileInfo {
     pub max_t: u32,
 }
 
+/// Records per streamed block (matches `write_run_file`'s block size, so
+/// streamed output is byte-compatible with the slice-based writers).
+const STREAM_BLOCK_RECORDS: usize = 8192;
+
+/// Streaming V2 run-file writer: writes a placeholder header, streams records
+/// in [`STREAM_BLOCK_RECORDS`]-sized blocks (same wire format as
+/// [`write_run_file`] / [`write_run_file_with_op`]), then seeks back and
+/// patches `record_count`/`min_t`/`max_t` on [`Self::finish`].
+///
+/// Exists for cascaded merges, whose output is produced record-at-a-time from
+/// a k-way merge and must not be buffered wholesale in memory. Version is 2
+/// (with-op, 31-byte records) when `with_op` is set, else 1 —
+/// `StreamingRunReader` auto-detects both, so cascade output is transparently
+/// readable wherever original run files are.
+pub(crate) struct StreamingRunFileWriter {
+    file: io::BufWriter<std::fs::File>,
+    sort_order: RunSortOrder,
+    with_op: bool,
+    compress: bool,
+    zstd_level: i32,
+    block_records: Vec<RunRecordV2>,
+    /// Parallel to `block_records`; only populated when `with_op`.
+    block_ops: Vec<u8>,
+    record_count: u64,
+    min_t: u32,
+    max_t: u32,
+    path: std::path::PathBuf,
+}
+
+impl StreamingRunFileWriter {
+    /// Create with compression settings from the environment — the same
+    /// `FLUREE_RUN_ZSTD` / `FLUREE_RUN_ZSTD_LEVEL` contract as
+    /// [`write_run_file`].
+    pub(crate) fn create(path: &Path, sort_order: RunSortOrder, with_op: bool) -> io::Result<Self> {
+        let compress = std::env::var("FLUREE_RUN_ZSTD")
+            .ok()
+            .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false")))
+            .unwrap_or(true);
+        let zstd_level = std::env::var("FLUREE_RUN_ZSTD_LEVEL")
+            .ok()
+            .and_then(|v| v.parse::<i32>().ok())
+            .unwrap_or(1);
+        Self::create_with_options(path, sort_order, with_op, compress, zstd_level)
+    }
+
+    /// Create with explicit compression settings (tests exercise both paths
+    /// without mutating process-global environment variables).
+    pub(crate) fn create_with_options(
+        path: &Path,
+        sort_order: RunSortOrder,
+        with_op: bool,
+        compress: bool,
+        zstd_level: i32,
+    ) -> io::Result<Self> {
+        let raw = std::fs::File::create(path)?;
+        #[cfg(target_os = "macos")]
+        {
+            use std::os::unix::io::AsRawFd;
+            unsafe {
+                let _ = libc::fcntl(raw.as_raw_fd(), libc::F_NOCACHE, 1);
+            }
+        }
+        let mut file = io::BufWriter::new(raw);
+
+        // Placeholder header; patched in `finish`.
+        let header = Self::header(with_op, sort_order, compress, 0, 0, 0);
+        let mut header_buf = [0u8; RUN_V2_HEADER_LEN];
+        header.write_to(&mut header_buf);
+        file.write_all(&header_buf)?;
+
+        Ok(Self {
+            file,
+            sort_order,
+            with_op,
+            compress,
+            zstd_level,
+            block_records: Vec::with_capacity(STREAM_BLOCK_RECORDS),
+            block_ops: if with_op {
+                Vec::with_capacity(STREAM_BLOCK_RECORDS)
+            } else {
+                Vec::new()
+            },
+            record_count: 0,
+            min_t: u32::MAX,
+            max_t: 0,
+            path: path.to_path_buf(),
+        })
+    }
+
+    fn header(
+        with_op: bool,
+        sort_order: RunSortOrder,
+        compress: bool,
+        record_count: u64,
+        min_t: u32,
+        max_t: u32,
+    ) -> RunFileHeader {
+        RunFileHeader {
+            version: if with_op {
+                RUN_V2_VERSION_WITH_OP
+            } else {
+                RUN_V2_VERSION
+            },
+            sort_order,
+            flags: if compress { RUN_FLAG_ZSTD_BLOCKS } else { 0 },
+            record_count,
+            records_offset: RUN_V2_HEADER_LEN as u64,
+            min_t,
+            max_t,
+        }
+    }
+
+    /// Append one record (with its op byte; ignored unless `with_op`).
+    pub(crate) fn push(&mut self, record: RunRecordV2, op: u8) -> io::Result<()> {
+        self.min_t = self.min_t.min(record.t);
+        self.max_t = self.max_t.max(record.t);
+        self.record_count += 1;
+        self.block_records.push(record);
+        if self.with_op {
+            self.block_ops.push(op);
+        }
+        if self.block_records.len() >= STREAM_BLOCK_RECORDS {
+            self.flush_block()?;
+        }
+        Ok(())
+    }
+
+    fn flush_block(&mut self) -> io::Result<()> {
+        if self.block_records.is_empty() {
+            return Ok(());
+        }
+        let record_size = if self.with_op {
+            RECORD_V2_WITH_OP_WIRE_SIZE
+        } else {
+            RECORD_V2_WIRE_SIZE
+        };
+        let mut raw_buf = vec![0u8; self.block_records.len() * record_size];
+        if self.with_op {
+            let mut rec_buf = [0u8; RECORD_V2_WITH_OP_WIRE_SIZE];
+            for (i, (rec, &op)) in self
+                .block_records
+                .iter()
+                .zip(self.block_ops.iter())
+                .enumerate()
+            {
+                rec.write_run_le_with_op(op, &mut rec_buf);
+                let off = i * record_size;
+                raw_buf[off..off + record_size].copy_from_slice(&rec_buf);
+            }
+        } else {
+            let mut rec_buf = [0u8; RECORD_V2_WIRE_SIZE];
+            for (i, rec) in self.block_records.iter().enumerate() {
+                rec.write_run_le(&mut rec_buf);
+                let off = i * record_size;
+                raw_buf[off..off + record_size].copy_from_slice(&rec_buf);
+            }
+        }
+        if self.compress {
+            let compressed = zstd::bulk::compress(&raw_buf, self.zstd_level)?;
+            self.file
+                .write_all(&(self.block_records.len() as u32).to_le_bytes())?;
+            self.file.write_all(&(raw_buf.len() as u32).to_le_bytes())?;
+            self.file
+                .write_all(&(compressed.len() as u32).to_le_bytes())?;
+            self.file.write_all(&compressed)?;
+        } else {
+            self.file.write_all(&raw_buf)?;
+        }
+        self.block_records.clear();
+        self.block_ops.clear();
+        Ok(())
+    }
+
+    /// Flush the trailing block, patch the header, and sync buffered bytes.
+    pub(crate) fn finish(mut self) -> io::Result<RunFileInfo> {
+        use std::io::Seek;
+
+        self.flush_block()?;
+        let min_t = if self.record_count == 0 { 0 } else { self.min_t };
+        let header = Self::header(
+            self.with_op,
+            self.sort_order,
+            self.compress,
+            self.record_count,
+            min_t,
+            self.max_t,
+        );
+        let mut header_buf = [0u8; RUN_V2_HEADER_LEN];
+        header.write_to(&mut header_buf);
+        self.file.seek(io::SeekFrom::Start(0))?;
+        self.file.write_all(&header_buf)?;
+        self.file.flush()?;
+        Ok(RunFileInfo {
+            path: self.path,
+            record_count: self.record_count,
+            sort_order: self.sort_order,
+            min_t,
+            max_t: self.max_t,
+        })
+    }
+}
+
 // ── Language dictionary serialization (format-independent) ─────────────────
 
 use crate::run_index::resolve::global_dict::LanguageTagDict;
@@ -443,6 +645,110 @@ mod tests {
         assert!(header.has_op());
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The streaming writer must be byte-identical to the slice-based
+    /// writers (same header, same 8192-record zstd blocks) — cascade
+    /// intermediates are read by the same `StreamingRunReader` as originals.
+    #[test]
+    fn streaming_writer_matches_slice_writers() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Multi-block volume (> 8192 records) with wrapping t values.
+        let records: Vec<RunRecordV2> = (0..20_000u64)
+            .map(|i| {
+                make_rec(
+                    i,
+                    1,
+                    OType::XSD_INTEGER.as_u16(),
+                    i * 3,
+                    (i % 7) as u32 + 1,
+                )
+            })
+            .collect();
+        let ops: Vec<u8> = (0..20_000u64).map(|i| (i % 2) as u8).collect();
+        let min_t = 1;
+        let max_t = 7;
+
+        // No-op variant (version 1), compressed level 1 — the slice writer's
+        // defaults with no FLUREE_RUN_ZSTD* env set.
+        let slice_path = dir.path().join("slice.frn");
+        write_run_file(&slice_path, &records, RunSortOrder::Spot, min_t, max_t).unwrap();
+        let stream_path = dir.path().join("stream.frn");
+        let mut writer =
+            StreamingRunFileWriter::create_with_options(&stream_path, RunSortOrder::Spot, false, true, 1)
+                .unwrap();
+        for rec in &records {
+            writer.push(*rec, 1).unwrap();
+        }
+        let info = writer.finish().unwrap();
+        assert_eq!(info.record_count, records.len() as u64);
+        assert_eq!(info.min_t, min_t);
+        assert_eq!(info.max_t, max_t);
+        assert_eq!(
+            std::fs::read(&slice_path).unwrap(),
+            std::fs::read(&stream_path).unwrap()
+        );
+
+        // With-op variant (version 2).
+        let slice_op_path = dir.path().join("slice_op.frn");
+        write_run_file_with_op(&slice_op_path, &records, &ops, RunSortOrder::Spot, min_t, max_t)
+            .unwrap();
+        let stream_op_path = dir.path().join("stream_op.frn");
+        let mut writer =
+            StreamingRunFileWriter::create_with_options(&stream_op_path, RunSortOrder::Spot, true, true, 1)
+                .unwrap();
+        for (rec, &op) in records.iter().zip(ops.iter()) {
+            writer.push(*rec, op).unwrap();
+        }
+        writer.finish().unwrap();
+        assert_eq!(
+            std::fs::read(&slice_op_path).unwrap(),
+            std::fs::read(&stream_op_path).unwrap()
+        );
+    }
+
+    /// Uncompressed streaming output round-trips through the auto-detecting
+    /// reader (the compressed path is covered byte-for-byte above).
+    #[test]
+    fn streaming_writer_uncompressed_roundtrip() {
+        use crate::run_index::runs::streaming_reader::{MergeSource, StreamingRunReader};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("raw.frn");
+        let records: Vec<RunRecordV2> = (0..100u64)
+            .map(|i| make_rec(i, 1, OType::XSD_INTEGER.as_u16(), i, i as u32 + 1))
+            .collect();
+
+        let mut writer =
+            StreamingRunFileWriter::create_with_options(&path, RunSortOrder::Spot, true, false, 1)
+                .unwrap();
+        for (i, rec) in records.iter().enumerate() {
+            writer.push(*rec, (i % 2) as u8).unwrap();
+        }
+        writer.finish().unwrap();
+
+        let mut reader = StreamingRunReader::open(&path).unwrap();
+        let mut n = 0usize;
+        while let Some(rec) = reader.peek() {
+            assert_eq!(rec.s_id.as_u64(), n as u64);
+            assert_eq!(reader.peek_op(), (n % 2) as u8);
+            n += 1;
+            reader.advance().unwrap();
+        }
+        assert_eq!(n, records.len());
+
+        // Empty output: header must read back with zero records.
+        let empty_path = dir.path().join("empty.frn");
+        let writer =
+            StreamingRunFileWriter::create_with_options(&empty_path, RunSortOrder::Post, false, true, 1)
+                .unwrap();
+        let info = writer.finish().unwrap();
+        assert_eq!(info.record_count, 0);
+        let mut reader = StreamingRunReader::open(&empty_path).unwrap();
+        assert!(reader.peek().is_none());
+        assert!(MergeSource::is_exhausted(&reader));
+        let _ = reader.advance();
     }
 
     #[test]

--- a/fluree-db-indexer/src/run_index/runs/run_file.rs
+++ b/fluree-db-indexer/src/run_index/runs/run_file.rs
@@ -477,7 +477,11 @@ impl StreamingRunFileWriter {
         use std::io::Seek;
 
         self.flush_block()?;
-        let min_t = if self.record_count == 0 { 0 } else { self.min_t };
+        let min_t = if self.record_count == 0 {
+            0
+        } else {
+            self.min_t
+        };
         let header = Self::header(
             self.with_op,
             self.sort_order,
@@ -656,15 +660,7 @@ mod tests {
 
         // Multi-block volume (> 8192 records) with wrapping t values.
         let records: Vec<RunRecordV2> = (0..20_000u64)
-            .map(|i| {
-                make_rec(
-                    i,
-                    1,
-                    OType::XSD_INTEGER.as_u16(),
-                    i * 3,
-                    (i % 7) as u32 + 1,
-                )
-            })
+            .map(|i| make_rec(i, 1, OType::XSD_INTEGER.as_u16(), i * 3, (i % 7) as u32 + 1))
             .collect();
         let ops: Vec<u8> = (0..20_000u64).map(|i| (i % 2) as u8).collect();
         let min_t = 1;
@@ -675,9 +671,14 @@ mod tests {
         let slice_path = dir.path().join("slice.frn");
         write_run_file(&slice_path, &records, RunSortOrder::Spot, min_t, max_t).unwrap();
         let stream_path = dir.path().join("stream.frn");
-        let mut writer =
-            StreamingRunFileWriter::create_with_options(&stream_path, RunSortOrder::Spot, false, true, 1)
-                .unwrap();
+        let mut writer = StreamingRunFileWriter::create_with_options(
+            &stream_path,
+            RunSortOrder::Spot,
+            false,
+            true,
+            1,
+        )
+        .unwrap();
         for rec in &records {
             writer.push(*rec, 1).unwrap();
         }
@@ -692,12 +693,24 @@ mod tests {
 
         // With-op variant (version 2).
         let slice_op_path = dir.path().join("slice_op.frn");
-        write_run_file_with_op(&slice_op_path, &records, &ops, RunSortOrder::Spot, min_t, max_t)
-            .unwrap();
+        write_run_file_with_op(
+            &slice_op_path,
+            &records,
+            &ops,
+            RunSortOrder::Spot,
+            min_t,
+            max_t,
+        )
+        .unwrap();
         let stream_op_path = dir.path().join("stream_op.frn");
-        let mut writer =
-            StreamingRunFileWriter::create_with_options(&stream_op_path, RunSortOrder::Spot, true, true, 1)
-                .unwrap();
+        let mut writer = StreamingRunFileWriter::create_with_options(
+            &stream_op_path,
+            RunSortOrder::Spot,
+            true,
+            true,
+            1,
+        )
+        .unwrap();
         for (rec, &op) in records.iter().zip(ops.iter()) {
             writer.push(*rec, op).unwrap();
         }
@@ -740,9 +753,14 @@ mod tests {
 
         // Empty output: header must read back with zero records.
         let empty_path = dir.path().join("empty.frn");
-        let writer =
-            StreamingRunFileWriter::create_with_options(&empty_path, RunSortOrder::Post, false, true, 1)
-                .unwrap();
+        let writer = StreamingRunFileWriter::create_with_options(
+            &empty_path,
+            RunSortOrder::Post,
+            false,
+            true,
+            1,
+        )
+        .unwrap();
         let info = writer.finish().unwrap();
         assert_eq!(info.record_count, 0);
         let mut reader = StreamingRunReader::open(&empty_path).unwrap();

--- a/fluree-db-indexer/tests/it_rebuild_history_placement.rs
+++ b/fluree-db-indexer/tests/it_rebuild_history_placement.rs
@@ -78,6 +78,7 @@ fn rebuild_psot_first_fact_of_predicate_loses_replay_history() {
         skip_history: false,
         g_id: 0,
         progress: None,
+        fan_in_cap: usize::MAX,
     };
     let result = build_index(&config).unwrap();
     let leaf = &result.graphs[0].leaf_infos[0];

--- a/fluree-db-server/src/main.rs
+++ b/fluree-db-server/src/main.rs
@@ -17,6 +17,10 @@ use fluree_db_server::{
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Best-effort raise of the open-file soft limit (macOS defaults to 256,
+    // which large imports exceed). Done before logging init; logged after.
+    let fd_raise = fluree_db_core::fd_limit::raise_nofile_soft_to_hard();
+
     // 1. Parse CLI + env via clap (get both typed config and raw matches)
     let matches = ServerConfig::command().get_matches();
     let mut config = ServerConfig::from_arg_matches(&matches)?;
@@ -37,6 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize telemetry (logging + optional tracing)
     let telemetry_config = TelemetryConfig::with_server_config(&config);
     init_logging(&telemetry_config);
+    fluree_db_core::fd_limit::log_raise_outcome(&fd_raise);
 
     // Log startup info
     tracing::info!(


### PR DESCRIPTION
## Problem

`fluree create --from <large file>` dies with `error: index build: index build: Too many open files (os error 24)` on any box with a low `RLIMIT_NOFILE` soft limit — including every stock macOS shell (soft limit 256). This is common for me, at least. The workaround is `ulimit -n 65536` before every import.

The failure is deterministic, not load-dependent: the workspace had zero rlimit/EMFILE awareness, and the import pipeline has four unbounded descriptor fan-ins that scale with input size (or are flat-out constants larger than the limit):

1. **Class-membership scatter** opened exactly 256 partition writers up front (`build_from_commits.rs`) — unconditional whenever id-stats + `rdf:type` are present, so it could not ever succeed at soft ≤ 256.
2. **Secondary-order k-way merge** opened every run file of an order simultaneously, × up to 3 orders concurrently (`index_build.rs`). Low `--memory-budget-mb` shrinks chunks and multiplies run files, so FD pressure grows exactly when memory budget shrinks.
3. **SPOT merge** held one descriptor per commit chunk for the whole merge.
4. **Dictionary merge** (found while testing this PR, pre-existing): subject/string/language vocab merges run concurrently at ~5 descriptors per chunk — the *first* wall multi-chunk imports actually hit, before the index build even starts.

## Fix: three layers, one contract

**Layer 1 — claim what the OS will give.** `fluree_db_core::fd_limit::raise_nofile_soft_to_hard()` best-effort raises soft → hard at CLI and server startup, at import preflight, and on the rebuild path (macOS clamps to `kern.maxfilesperproc`; unprivileged; never errors). On macOS this alone takes 256 → ~10k and makes the manual `ulimit` automatic.

**Layer 2 — plan the build within whatever limit remains.** Raising isn't available everywhere (AWS Lambda's hard limit is a fixed 1024; containers can be arbitrary), so the build now plans its fan-in/fan-out inside an `FdBudget` (observed soft limit minus a reserve), exactly the way `run_budget_bytes` already plans memory:

- `fd_plan::plan_fd_usage` apportions the budget per phase (phases are strictly sequential, so no runtime permit tracking is needed). Import divides the merge share by its 3 concurrent secondary orders; the remapped-rebuild path divides by its 4.
- Scatter: the 256 logical buckets now write through a bounded LRU pool of append-mode handles (`BucketWriterPool`); bucket files are created lazily and reopened with `O_APPEND` on eviction. Lossless because the materialization pass sorts.
- Secondary merges: run counts above the cap are first reduced by a **lossless cascaded merge** (`cascade_runs_to_fan_in`) — multi-pass merges of consecutive groups through a new streaming FRN2 writer. Byte-identical to the flat merge: comparators exclude `t`/op, `KWayMerge` tie-breaks by stream index, and consecutive grouping makes the cascade's tie-break order equal the flat order at any depth (full argument in the function docs). Op bytes are carried verbatim so rebuild-path dedup/history resolution still happens exactly once, in the final consumer.
- SPOT: chunk counts above the cap take a hierarchical arm — group-merge chunks into globally-remapped intermediates, then final-merge those. Same byte-identity argument; the flat arm is untouched and remains the common case. Records are re-stamped with the build's `g_id` in the shared pump because the FRN2 wire format doesn't carry it (see review notes below).
- Dictionary merges: serialized (subject → string → language) when the budget can't cover their concurrent peak, cutting per-chunk cost from ~5 descriptors to ~2.

Degradation reference (`A = soft − reserve`, reserve = `clamp(soft/4, 32, 64)`):

| soft | A | scatter pool | SPOT fan-in | run-gen workers | merge fan-in/order |
|---|---|---|---|---|---|
| 96 | 64 | 56 | 32 | 8 | 17 |
| 256 (raise failed) | 192 | 184 | 96 | 24 | 60 |
| 1024 (Lambda) | 960 | 256 | 480 | 120 | 316 |
| 10240 (raised macOS) | 10176 | 256 | 5088 | 1272 | 3388 |

**Layer 3 — fail informatively.** `EMFILE`/`ENFILE` anywhere in the build now maps to an error carrying the observed limit and remedies (the `IndexBuildError` → `io::Error` wrap preserves `raw_os_error` so exhaustion stays recognizable). Import preflight fails in milliseconds — not twenty minutes in — when the **observed** kernel limit is below 96, and warns below 256. `FLUREE_FD_BUDGET` shrinks/shapes the *plan* only; it cannot defeat the preflight.

## Verification

- **End-to-end under a real kernel limit**: `it_import_low_fd` (own `[[test]]` target — it re-execs itself and lowers `RLIMIT_NOFILE` hard+soft to 96 in the child, which must not share a process with other tests). Scenario A imports 30k typed subjects from one file (exercises the scatter pool); scenario B imports a 30-file directory with a plan shrunk via `FLUREE_FD_BUDGET=40` (30 chunks > SPOT fan-in 24, ≥30 runs/order > merge fan-in 12), so the hierarchical SPOT merge **and** the cascade both run against the real limit. Both children must produce the same flake count and content fingerprint as unconstrained baselines. Vacuity-checked: neutralizing the budget reproduces the original EMFILE, so the test provably detects the bug it guards.
- **Byte identity**: cascade-vs-flat and hierarchical-vs-flat builds assert equal content-addressed leaf/branch/sidecar CIDs (with and without op sidebands, import and rebuild consumer paths); the streaming writer is byte-compared against the slice writers; the scatter pool at size 4 is compared against the unbounded scatter.
- **Adversarial review** (three independent passes) found and this PR fixes: the FRN2 `g_id` round-trip dropping named-graph class stats into the default graph under the hierarchical SPOT arm (regression test at `g_id=5` with a live stats collector, mutation-tested); the reserve undercounting the concurrent dictionary upload (measured 15–19 descriptors, reserve floor now 32); the rebuild path lacking a raise and dividing its merge share by the wrong order-concurrency; `EMFILE` being erased by an `io::Error::other` wrap; cascade scratch dirs not being reclaimed.

## Notes for reviewers

- `FdBudget::unlimited()` (u64::MAX sentinel) preserves the exact legacy behavior everywhere a caller doesn't opt in; all existing tests construct configs with it.
- The worker-count clamp can change run-file boundaries; that is unobservable in output because bulk import assigns one `t` per chunk, so records comparing equal under a secondary-order comparator within a chunk are equal in every serialized field (same invariant pre-existing CPU-count-dependent worker counts already leaned on; now documented at the clamp).
- Gates: full `fluree-db-core`/`fluree-db-indexer` suites, `grp_import` + `grp_index` + `it_import_low_fd`, per-crate clippy (`--all-features --all-targets --no-deps -- -D warnings`) and `cargo fmt --check` all green.

