### PR TITLE
fix: stop hiding user f:-namespace data from variable-predicate scans

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -2360,6 +2360,21 @@ mem:constraint-01kyke812e1np5c9ag45ac7580 a mem:Constraint ;
     mem:createdAt "2026-07-28T04:03:09.006298+00:00"^^xsd:dateTime ;
     mem:rationale "Using required_aggregate_vars (rather than checking the projection directly) folds in projection, HAVING, post-binds and ORDER BY in one check — a post-bind whose EXPRESSION reads a non-key var still reads a grouped list, which a bind-output whitelist would miss. Regression tests need a fan-in fixture; the pinned grouped-list test has none and cannot catch dedup." .
 
+mem:fact-01kz9zn33sjc3rh7r9s2zr825w a mem:Fact ;
+    mem:content "Wildcard (?p) scan visibility narrowed to f:reifies* only (branch fix/wildcard-fluree-ns-visibility): removed the legacy default-graph hide of the whole FLUREE_DB namespace in binary_scan::is_internal_predicate and its two fast_whole_graph_agg mirrors (overlay flake walk + graph_has_scan_hidden_predicates). That hide was a fossil from before named graphs, when commit metadata lived in the main graph; today all commit meta routes to txn-meta g_id=1 (stamp_graph_on_commit_flakes on novelty side, emit_txn_meta g_id=1 in indexer), db:flakes has no writers, so the only thing it hid was user-authored f: data (policies) — and only post-index, since the novelty path never applied it. opts.includeSystemFacts still reveals f:reifies*." ;
+    mem:tag "binary-scan" ;
+    mem:tag "fluree-namespace" ;
+    mem:tag "system-facts" ;
+    mem:tag "visibility" ;
+    mem:tag "wildcard" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/tests/it_query_wildcard_system_facts.rs" ;
+    mem:artifactRef "fluree-db-novelty/src/commit_flakes.rs" ;
+    mem:artifactRef "fluree-db-query/src/binary_scan.rs" ;
+    mem:artifactRef "fluree-db-query/src/fast_whole_graph_agg.rs" ;
+    mem:branch "fix/wildcard-fluree-ns-visibility" ;
+    mem:createdAt "2026-08-05T22:10:40.377307+00:00"^^xsd:dateTime .
+
 mem:constraint-01kjte29y3cp8mae56xy6yfv2n a mem:Constraint ;
     mem:content "SPARQL↔JSON-LD Parity: both compile to the same IR (fluree-db-query/src/ir.rs) and share the entire execution engine. When adding SPARQL features: (1) shared IR changes already affect JSON-LD — verify JSON-LD tests pass, (2) if expressible in JSON-LD, add parallel tests, (3) execution path missing in JSON-LD lower → track follow-up.\n\nSPARQL tests: it_query_sparql.rs | JSON-LD tests: it_query.rs, it_query_analytical.rs, it_query_grouping.rs\nValidate: `cd testsuite-sparql && make test-eval-cat CAT=<cat>` then `cargo test -p fluree-db-api --test it_query`" ;
     mem:tag "compliance" ;

--- a/docs/query/jsonld-query.md
+++ b/docs/query/jsonld-query.md
@@ -268,6 +268,27 @@ Use variables (starting with `?`) to match unknown values:
 }
 ```
 
+A variable can also stand in predicate position to enumerate all properties of
+a subject:
+
+```json
+{
+  "@id": "?person",
+  "?p": "?o"
+}
+```
+
+Variable-predicate scans return every stored triple, including data written
+with the Fluree vocabulary (`https://ns.flur.ee/db#`, e.g. stored
+`f:AccessPolicy` definitions). The one exception is the seven `f:reifies*`
+predicates — the internal storage encoding of edge annotations. They are
+system-written (user transactions cannot assert them), redundant with the
+edge and annotation content already in the results, and therefore hidden from
+variable-predicate scans. Pass `"opts": {"includeSystemFacts": true}` to
+surface them for debugging or inspection. Commit metadata (`f:t`, `f:address`,
+…) lives in the ledger's txn-meta graph, not the default graph, so it never
+appears in default-graph scans either way.
+
 ### Type Patterns
 
 Match entities by type:

--- a/fluree-db-api/tests/grp_query.rs
+++ b/fluree-db-api/tests/grp_query.rs
@@ -53,3 +53,5 @@ mod it_query_reverse;
 mod it_query_typed_json;
 #[path = "it_query_vocab_id_compaction.rs"]
 mod it_query_vocab_id_compaction;
+#[path = "it_query_wildcard_system_facts.rs"]
+mod it_query_wildcard_system_facts;

--- a/fluree-db-api/tests/it_query_wildcard_system_facts.rs
+++ b/fluree-db-api/tests/it_query_wildcard_system_facts.rs
@@ -1,0 +1,148 @@
+//! Wildcard (variable-predicate) visibility of `f:`-namespace data.
+//!
+//! User-authored data in the Fluree namespace (e.g. stored `f:AccessPolicy`
+//! definitions) must be visible to `?s ?p ?o` scans like any other triple —
+//! before and after indexing. Historically the default graph hid the whole
+//! `f:` namespace from variable-predicate scans (a fossil from the era when
+//! commit metadata was stored in the main graph), which made policy nodes
+//! look truncated to a wildcard dump and made results flip when the
+//! background indexer caught up. Only the `f:reifies*` annotation-encoding
+//! predicates remain hidden (covered by `it_edge_annotations.rs`).
+
+use crate::support;
+use crate::support::{genesis_ledger, MemoryFluree, MemoryLedger};
+use fluree_db_api::FlureeBuilder;
+use serde_json::{json, Value as JsonValue};
+
+fn policy_tx() -> JsonValue {
+    json!({
+        "@context": {"f": "https://ns.flur.ee/db#", "ex": "http://example.org/ns/"},
+        "@graph": [{
+            "@id": "ex:p1",
+            "@type": ["f:AccessPolicy"],
+            "f:action": [{"@id": "f:view"}],
+            "f:allow": true,
+            "f:exMessage": "visible to wildcards"
+        }]
+    })
+}
+
+async fn wildcard_predicates(fluree: &MemoryFluree, ledger: &MemoryLedger) -> Vec<String> {
+    let q = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "select": ["?p", "?o"],
+        "where": [{"@id": "ex:p1", "?p": "?o"}]
+    });
+    let rows = support::query_jsonld_formatted(fluree, ledger, &q)
+        .await
+        .expect("wildcard query");
+    let mut preds: Vec<String> = rows
+        .as_array()
+        .expect("array")
+        .iter()
+        .filter_map(|row| row.as_array())
+        .filter_map(|cols| cols.first())
+        .filter_map(|v| {
+            v.as_str()
+                .map(String::from)
+                .or_else(|| v.get("@id").and_then(|i| i.as_str()).map(String::from))
+        })
+        .collect();
+    preds.sort();
+    preds
+}
+
+fn expected_policy_predicates() -> Vec<String> {
+    let mut v = vec![
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".to_string(),
+        "https://ns.flur.ee/db#action".to_string(),
+        "https://ns.flur.ee/db#allow".to_string(),
+        "https://ns.flur.ee/db#exMessage".to_string(),
+    ];
+    v.sort();
+    v
+}
+
+/// Pre-index (novelty-only): user `f:` data is visible to wildcard scans.
+#[tokio::test]
+async fn wildcard_returns_user_fluree_ns_data_novelty() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "wildcard-sysfacts/novelty");
+    let ledger = fluree
+        .insert(ledger0, &policy_tx())
+        .await
+        .expect("insert")
+        .ledger;
+    assert_eq!(
+        wildcard_predicates(&fluree, &ledger).await,
+        expected_policy_predicates()
+    );
+}
+
+/// Post-index: identical result — visibility must not flip when the
+/// background indexer catches up (the historical hide only applied on the
+/// indexed scan path, so the same query changed answers after indexing).
+#[tokio::test]
+async fn wildcard_returns_user_fluree_ns_data_indexed() {
+    use fluree_db_api::ReindexOptions;
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "wildcard-sysfacts/indexed";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    fluree.insert(ledger0, &policy_tx()).await.expect("insert");
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let ledger = fluree.ledger(ledger_id).await.expect("load indexed");
+    assert!(
+        ledger.snapshot.range_provider.is_some(),
+        "expected binary range provider after reindex"
+    );
+    assert_eq!(
+        wildcard_predicates(&fluree, &ledger).await,
+        expected_policy_predicates()
+    );
+}
+
+/// Commit metadata lives in the txn-meta graph, not the default graph, so a
+/// full default-graph wildcard dump stays free of system bookkeeping even
+/// with the namespace hide removed.
+#[tokio::test]
+async fn wildcard_dump_carries_no_commit_metadata() {
+    use fluree_db_api::ReindexOptions;
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "wildcard-sysfacts/no-commit-meta";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    fluree.insert(ledger0, &policy_tx()).await.expect("insert");
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let ledger = fluree.ledger(ledger_id).await.expect("load indexed");
+
+    let q = json!({
+        "select": ["?s", "?p", "?o"],
+        "where": [{"@id": "?s", "?p": "?o"}]
+    });
+    let rows = support::query_jsonld_formatted(&fluree, &ledger, &q)
+        .await
+        .expect("dump query");
+    let commit_meta = [
+        "address", "alias", "time", "t", "asserts", "retracts", "size",
+    ];
+    for row in rows.as_array().expect("array") {
+        let p = row.as_array().and_then(|c| c.get(1)).and_then(|v| {
+            v.as_str()
+                .map(String::from)
+                .or_else(|| v.get("@id").and_then(|i| i.as_str()).map(String::from))
+        });
+        if let Some(p) = p {
+            if let Some(local) = p.strip_prefix("https://ns.flur.ee/db#") {
+                assert!(
+                    !commit_meta.contains(&local),
+                    "commit metadata predicate {p} leaked into default-graph wildcard dump"
+                );
+            }
+        }
+    }
+}

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1151,23 +1151,23 @@ impl BinaryScanOperator {
             .unwrap_or_else(|| Sid::new(0, ""))
     }
 
-    /// Filter: skip Fluree-system predicates when predicate is a
+    /// Filter: skip `f:reifies*` system predicates when predicate is a
     /// variable.
     ///
-    /// Two predicate sets are filtered:
+    /// The seven edge-annotation bundle predicates are hidden in
+    /// **every** graph context: the annotation bundle is emitted in the
+    /// reified edge's graph, so a per-graph `?p` scan would otherwise
+    /// leak the bundle into the user's results. They are the internal
+    /// encoding of `@annotation` — user transactions cannot write them,
+    /// so surfacing them would break export/re-import round-trips.
     ///
-    /// 1. **`f:reifies*`** (the seven edge-annotation bundle
-    ///    predicates) are hidden in **every** graph context. The
-    ///    annotation bundle is emitted in the reified edge's
-    ///    graph, so a per-graph `?p` scan would otherwise leak the
-    ///    bundle into the user's results.
-    /// 2. Other Fluree-namespace predicates (commit metadata,
-    ///    nameservice, etc.) are hidden only in the **default
-    ///    graph**, matching the prior behavior of this filter.
-    ///    Those predicates live in their own system graphs (e.g.
-    ///    txn-meta at `g_id == 1`) and the legacy default-graph
-    ///    filter is preserved to avoid behavior drift for queries
-    ///    that have grown to depend on it.
+    /// Other Fluree-namespace predicates are NOT filtered: system
+    /// metadata lives in its own graphs (txn-meta at `g_id == 1`,
+    /// config at `g_id == 2`), and `f:`-vocabulary data users author in
+    /// the default graph (e.g. `f:AccessPolicy` definitions) must stay
+    /// visible to wildcard scans. A default-graph namespace-wide hide
+    /// existed historically, from the era when commit metadata was
+    /// stored in the main graph.
     #[inline]
     fn is_internal_predicate(&self, p_id: u32) -> bool {
         if !self.p_is_var {
@@ -1184,12 +1184,7 @@ impl BinaryScanOperator {
                 None => return false,
             },
         };
-        // Always hide `f:reifies*` regardless of graph.
-        if fluree_db_core::is_reserved_reifies_predicate(sid) {
-            return true;
-        }
-        // Default-graph: also hide the broader Fluree-namespace set.
-        self.g_id == 0 && sid.namespace_code == fluree_vocab::namespaces::FLUREE_DB
+        fluree_db_core::is_reserved_reifies_predicate(sid)
     }
 
     /// Enforce within-pattern repeated-variable constraints.

--- a/fluree-db-query/src/fast_whole_graph_agg.rs
+++ b/fluree-db-query/src/fast_whole_graph_agg.rs
@@ -628,12 +628,10 @@ fn overlay_all_subjects_count(
             if declined {
                 return;
             }
-            // Mirror the pipeline's `?n ?p ?o` visibility: `f:reifies*` anywhere
-            // and the `f:` namespace in the default graph are invisible to the
-            // scan but present in SPOT — their subjects must not be counted.
-            if fluree_db_core::is_reserved_reifies_predicate(&flake.p)
-                || (g_id == 0 && flake.p.namespace_code == fluree_vocab::namespaces::FLUREE_DB)
-            {
+            // Mirror the pipeline's `?n ?p ?o` visibility: `f:reifies*` is
+            // invisible to the scan but present in SPOT — its subjects must
+            // not be counted.
+            if fluree_db_core::is_reserved_reifies_predicate(&flake.p) {
                 declined = true;
                 return;
             }
@@ -1063,8 +1061,7 @@ fn compute_task(
 }
 
 /// Whether the queried graph carries rows under any predicate the
-/// variable-predicate scan hides — `f:reifies*` in every graph, the broader
-/// `f:` namespace in the default graph (mirrors
+/// variable-predicate scan hides — `f:reifies*`, in every graph (mirrors
 /// `BinaryScanOperator::is_internal_predicate`). Such facts are invisible to
 /// the `?n ?p ?o` pipeline but present in the SPOT directories this fold
 /// reads, so their presence makes the fold inexact.
@@ -1076,9 +1073,9 @@ fn compute_task(
 ///   can silently pass on a graph that does carry hidden facts.
 /// - Each hidden candidate is confirmed by its **row count in the queried
 ///   graph** (`count_rows_for_predicate_psot`, directory-only): the
-///   dictionary is global across graphs, so commit-metadata `f:` predicates
-///   from the txn-meta graph are always present in it — bare membership
-///   would permanently decline every ledger.
+///   dictionary is global across graphs, so a `f:reifies*` predicate minted
+///   by annotations in another graph is always present in it — bare
+///   membership would permanently decline every annotated ledger.
 pub(crate) fn graph_has_scan_hidden_predicates(
     ctx: &crate::context::ExecutionContext<'_>,
     store: &BinaryIndexStore,
@@ -1088,9 +1085,9 @@ pub(crate) fn graph_has_scan_hidden_predicates(
             // Unresolvable dictionary entry — err toward declining.
             return Ok(true);
         };
-        let hidden = fluree_db_core::is_reserved_reifies_predicate(&sid)
-            || (ctx.binary_g_id == 0 && sid.namespace_code == fluree_vocab::namespaces::FLUREE_DB);
-        if hidden && count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)? > 0 {
+        if fluree_db_core::is_reserved_reifies_predicate(&sid)
+            && count_rows_for_predicate_psot(store, ctx.binary_g_id, p_id)? > 0
+        {
             return Ok(true);
         }
     }


### PR DESCRIPTION
> Stacked on #1593 — contains that branch's commit; diff shown here is just this change.

## Problem

A `?s ?p ?o` scan of a stored `f:AccessPolicy` node returned only its `rdf:type` triple — `f:action`, `f:allow`, `f:exMessage` were invisible, while explicit-predicate lookups of the same triples returned them. Variable-predicate scans hid the **entire** `https://ns.flur.ee/db#` namespace in the default graph.

That hide is a fossil from before named graphs existed, when commit metadata was stored in the main graph. Today commit metadata routes to the txn-meta graph (`g_id=1`) on every path — novelty-side stamping (`stamp_graph_on_commit_flakes`, all three call sites) and both indexer emitters hard-code `g_id=1` — and an empirical dump of a current ledger's default graph with `includeSystemFacts: true` contains zero system-written `f:` triples. The only data the hide still caught was user-authored `f:` vocabulary, policies being the prime case: a wildcard inspection of a policy write looks like the write silently dropped everything but `@type`, and an export-by-crawl silently loses policy definitions.

Worse, the hide only ran on the indexed scan path — the novelty path never applied it — so the same query returned all triples right after the write and dropped them once the background indexer caught up.

## Fix

Narrow the filter to the seven `f:reifies*` predicates, hidden in **every** graph as before. Those stay hidden deliberately: they are the system-written storage encoding of edge annotations (user transactions cannot assert them, so surfacing them would break export/re-import round-trips), they are redundant with the edge and annotation content already visible in results, and they live in the same graph as the edge they reify so there is no system graph to banish them to. `opts.includeSystemFacts: true` still reveals them for inspection.

Applied at all three mirrors so scan and fast-path semantics agree:
- `BinaryScanOperator::is_internal_predicate` (`binary_scan.rs`)
- the whole-graph fold's overlay-flake walk (`fast_whole_graph_agg.rs`)
- the fold's exactness preflight `graph_has_scan_hidden_predicates` (`fast_whole_graph_agg.rs`)

Other `FLUREE_DB` checks in the query crate (planner selectivity, annotation probes, wildcard hydration, fulltext datatype) were audited and are reifies-specific or unrelated — untouched.

## Compatibility note

A ledger whose index predates txn-meta routing and has never been rebuilt could re-expose old commit metadata in default-graph wildcard dumps; reindexing re-emits commit metadata into the txn-meta graph.

## Testing

- New `it_query_wildcard_system_facts.rs`: user `f:` data visible to wildcards **pre-index and post-index** (pinning the novelty/indexed flip), and a full default-graph dump stays free of commit-metadata predicates.
- Existing `it_edge_annotations.rs` reifies-hide and `includeSystemFacts` tests pass unchanged.
- Full `fluree-db-api` suite green (30 targets, 3,041 tests); `fluree-db-query` full tests green; clippy `--all-features` clean on both crates.
- Docs: variable-predicate visibility rule, the `f:reifies*` exception, and `includeSystemFacts` documented in `docs/query/jsonld-query.md` (the flag was previously undocumented).