### PR TITLE
fix: stop mapping one VMA per dictionary pack (ENOMEM with memory free)

### DIFF
--- a/fluree-db-binary-index/src/dict/pack_reader.rs
+++ b/fluree-db-binary-index/src/dict/pack_reader.rs
@@ -1,4 +1,4 @@
-//! Multi-pack reader with mmap support for forward dictionary packs.
+//! Multi-pack reader for forward dictionary packs.
 //!
 //! `ForwardPackReader` manages one or more `FPK1` packs and routes lookups
 //! to the correct pack via binary search on ID ranges.
@@ -56,7 +56,7 @@ enum LoadedBacking {
 
 struct LazyLoaded {
     meta: ParsedPackMeta,
-    mmap: memmap2::Mmap,
+    backing: LoadedBacking,
 }
 
 impl LoadedBacking {
@@ -70,7 +70,7 @@ impl LoadedBacking {
 
 impl PackHandle {
     /// Get pre-parsed metadata and raw bytes. For lazy packs, triggers
-    /// fetch + cache + mmap + parse on first call (subsequent calls return cached).
+    /// fetch + cache + load + parse on first call (subsequent calls return cached).
     fn ensure_loaded(&self, ctx: Option<&LoadContext>) -> io::Result<(&ParsedPackMeta, &[u8])> {
         match &self.inner {
             PackInner::Loaded { meta, backing } => Ok((meta, backing.bytes())),
@@ -83,7 +83,7 @@ impl PackHandle {
                 let lazy = loaded.get_or_try_init(|| {
                     fetch_and_load(self.first_id, self.last_id, pack_cid, cache_path, ctx)
                 })?;
-                Ok((&lazy.meta, lazy.mmap.as_ref()))
+                Ok((&lazy.meta, lazy.backing.bytes()))
             }
         }
     }
@@ -117,9 +117,14 @@ impl ForwardPackReader {
     /// Load packs from CAS. Does not perform remote fetches.
     ///
     /// For each `PackBranchEntry`:
-    /// 1. If `cs.resolve_local_path(&cid)` returns a path → mmap + validate → `Loaded`.
-    /// 2. Else if cache file exists → mmap + validate → `Loaded`.
-    /// 3. Else → `Lazy` handle (fetched + cached + mmapped on first lookup).
+    /// 1. If `cs.resolve_local_path(&cid)` returns a path → load + validate → `Loaded`.
+    /// 2. Else if cache file exists → load + validate → `Loaded`.
+    /// 3. Else → `Lazy` handle (fetched + cached + loaded on first lookup).
+    ///
+    /// "Load" is `read()` for small packs and `mmap` for large ones — see
+    /// [`DEFAULT_MMAP_MIN_BYTES`]. This path is eager over EVERY pack in the
+    /// routing table, so it is where a mapping-per-pack becomes a hard cap on
+    /// how many ledgers a process can hold open at once.
     ///
     /// Loaded packs are validated: ID range must match the routing entry, and
     /// `kind`/`ns_code` must match `expected_kind`/`expected_ns_code`. Lazy packs
@@ -147,30 +152,24 @@ impl ForwardPackReader {
             let local_path = cs.resolve_local_path(&entry.pack_cid);
 
             if let Some(path) = local_path {
-                // Local CAS path — mmap directly.
-                let mmap = mmap_file(&path)?;
-                let meta = parse_pack_meta(mmap.as_ref())?;
+                // Local CAS path.
+                let backing = load_pack_backing(&path)?;
+                let meta = parse_pack_meta(backing.bytes())?;
                 validate_meta(&meta, entry, expected_kind, expected_ns_code)?;
                 packs.push(PackHandle {
                     first_id: entry.first_id,
                     last_id: entry.last_id,
-                    inner: PackInner::Loaded {
-                        meta,
-                        backing: LoadedBacking::Mmap(mmap),
-                    },
+                    inner: PackInner::Loaded { meta, backing },
                 });
             } else if cache_path.exists() {
-                // Cached on disk — mmap.
-                let mmap = mmap_file(&cache_path)?;
-                let meta = parse_pack_meta(mmap.as_ref())?;
+                // Cached on disk.
+                let backing = load_pack_backing(&cache_path)?;
+                let meta = parse_pack_meta(backing.bytes())?;
                 validate_meta(&meta, entry, expected_kind, expected_ns_code)?;
                 packs.push(PackHandle {
                     first_id: entry.first_id,
                     last_id: entry.last_id,
-                    inner: PackInner::Loaded {
-                        meta,
-                        backing: LoadedBacking::Mmap(mmap),
-                    },
+                    inner: PackInner::Loaded { meta, backing },
                 });
             } else {
                 // Remote — defer to lazy fetch on first lookup.
@@ -403,16 +402,16 @@ fn fetch_and_load(
 ) -> io::Result<LazyLoaded> {
     // Fast paths: check if something appeared since construction.
     if let Some(path) = ctx.cs.resolve_local_path(pack_cid) {
-        let mmap = mmap_file(&path)?;
-        let meta = parse_pack_meta(mmap.as_ref())?;
+        let backing = load_pack_backing(&path)?;
+        let meta = parse_pack_meta(backing.bytes())?;
         validate_lazy_meta(&meta, expected_first_id, expected_last_id, ctx)?;
-        return Ok(LazyLoaded { meta, mmap });
+        return Ok(LazyLoaded { meta, backing });
     }
     if cache_path.exists() {
-        let mmap = mmap_file(cache_path)?;
-        let meta = parse_pack_meta(mmap.as_ref())?;
+        let backing = load_pack_backing(cache_path)?;
+        let meta = parse_pack_meta(backing.bytes())?;
         validate_lazy_meta(&meta, expected_first_id, expected_last_id, ctx)?;
-        return Ok(LazyLoaded { meta, mmap });
+        return Ok(LazyLoaded { meta, backing });
     }
 
     // Remote fetch: bridge the sync lookup to the async CAS get via the shared
@@ -456,14 +455,18 @@ fn fetch_and_load(
         io::Error::other(format!("lazy pack fetch: {e}"))
     })?;
 
-    // Write to cache, then mmap the cache file (no heap duplication).
+    // Write to cache, then re-open it. Re-opening rather than keeping `bytes`
+    // is deliberate: `load_pack_backing` is the single place that decides
+    // read-vs-mmap, so a large pack still ends up mapped (no heap duplication)
+    // and a small one still ends up on the heap, without duplicating the
+    // threshold logic here.
     atomic_write_to_cache(cache_path, &bytes)?;
     drop(bytes);
 
-    let mmap = mmap_file(cache_path)?;
-    let meta = parse_pack_meta(mmap.as_ref())?;
+    let backing = load_pack_backing(cache_path)?;
+    let meta = parse_pack_meta(backing.bytes())?;
     validate_lazy_meta(&meta, expected_first_id, expected_last_id, ctx)?;
-    Ok(LazyLoaded { meta, mmap })
+    Ok(LazyLoaded { meta, backing })
 }
 
 /// Validate metadata for a lazily loaded pack (same checks as eager, but using
@@ -508,15 +511,73 @@ fn validate_lazy_meta(
 // Helpers
 // ============================================================================
 
-fn mmap_file(path: &Path) -> io::Result<memmap2::Mmap> {
+/// Packs at or below this many bytes are `read()` into the heap instead of
+/// being mapped. Override with `FLUREE_DICT_PACK_MMAP_MIN_BYTES`; 0 restores
+/// the old always-mmap behaviour.
+///
+/// **A mapping is a scarcer resource than the bytes it exposes.** Every mmap
+/// costs a VMA, and a process is hard-capped at `vm.max_map_count` (65,530 by
+/// default) *regardless of how much memory is free* — past it `mmap` returns
+/// ENOMEM, which surfaces here as "failed to load binary index: Cannot allocate
+/// memory (os error 12)" on a host with gigabytes idle. That is not a
+/// theoretical limit: dict packs are per-ID-range and never compacted, so a
+/// ledger's routing table grows without bound. Measured on one deployment,
+/// 23 ledgers held **103,426 packs** and the process carried **47,336
+/// mappings** against the 65,530 cap — every ledger load pushing it closer, and
+/// raising the container's memory limit doing nothing at all because bytes were
+/// never the constraint.
+///
+/// The size split works because pack sizes are extremely skewed: on that same
+/// deployment **91% of packs were under 4 KiB and 99.8% of the mapped ones were
+/// under 64 KiB, holding 30 MB between them.** Mapping a 113-byte file (the
+/// median!) spends a VMA and a whole page of address space to expose less than
+/// a cache line's worth of useful data. So this trades ~30 MB of heap for
+/// ~47,000 mappings, and the large packs that actually justify demand paging —
+/// 5,728 files holding 12.1 of the 12.5 GiB — still get mapped.
+const DEFAULT_MMAP_MIN_BYTES: u64 = 64 * 1024;
+
+fn mmap_min_bytes() -> u64 {
+    static CACHED: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var("FLUREE_DICT_PACK_MMAP_MIN_BYTES")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(DEFAULT_MMAP_MIN_BYTES)
+    })
+}
+
+/// Open a pack: heap-read when small, mmap when large. See
+/// [`DEFAULT_MMAP_MIN_BYTES`] for why the small case is the important one.
+fn load_pack_backing(path: &Path) -> io::Result<LoadedBacking> {
     let file = std::fs::File::open(path).map_err(|e| {
         io::Error::new(
             io::ErrorKind::NotFound,
             format!("open pack file {}: {}", path.display(), e),
         )
     })?;
+
+    // A failed `metadata()` falls through to mmap rather than erroring: the
+    // threshold is an optimisation, so losing the size must not lose the read.
+    let small = match file.metadata() {
+        Ok(meta) => meta.len() <= mmap_min_bytes(),
+        Err(_) => false,
+    };
+
+    if small {
+        // `read_to_end` on a fresh Vec, not `fs::read`, so the already-open
+        // handle is reused and the path is not resolved twice (a GC/promotion
+        // unlink between the two would turn a live pack into NotFound).
+        let mut bytes = Vec::new();
+        {
+            use std::io::Read;
+            let mut file = file;
+            file.read_to_end(&mut bytes)?;
+        }
+        return Ok(LoadedBacking::InMemory(Arc::from(bytes)));
+    }
+
     // SAFETY: The file is an immutable CAS artifact, not concurrently modified.
-    unsafe { memmap2::Mmap::map(&file) }
+    Ok(LoadedBacking::Mmap(unsafe { memmap2::Mmap::map(&file)? }))
 }
 
 /// Page size used to stride `touch_pages`. 4 KiB is the smallest common page
@@ -804,5 +865,78 @@ mod tests {
 
         // Cleanup.
         let _ = std::fs::remove_dir_all(&cache_dir);
+    }
+
+    /// A small pack must be read onto the heap, not mapped — the whole point of
+    /// [`DEFAULT_MMAP_MIN_BYTES`]. Asserting on the backing VARIANT rather than
+    /// on lookups is deliberate: lookups pass either way, which is exactly why
+    /// the mapping leak went unnoticed for months. This is the only assertion
+    /// that can fail if someone reverts to always-mmap.
+    #[test]
+    fn small_packs_are_read_not_mapped() {
+        let bytes = make_pack_bytes(0, 10);
+        assert!(
+            (bytes.len() as u64) <= DEFAULT_MMAP_MIN_BYTES,
+            "fixture must be under the threshold to exercise the read path, got {} bytes",
+            bytes.len()
+        );
+
+        let dir =
+            std::env::temp_dir().join(format!("fluree_test_small_pack_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("small.fpk");
+        std::fs::write(&path, &bytes).unwrap();
+
+        let backing = load_pack_backing(&path).unwrap();
+        assert!(
+            matches!(backing, LoadedBacking::InMemory(_)),
+            "a {}-byte pack must not consume a VMA",
+            bytes.len()
+        );
+        // The bytes must survive the trip, or we have traded a mapping for a bug.
+        assert_eq!(backing.bytes(), bytes.as_slice());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Above the threshold we still map: large packs are where demand paging
+    /// actually pays, and this pins that the split is a split and not a
+    /// wholesale move to heap reads (which would pull GiB-sized packs into RAM).
+    #[test]
+    fn large_packs_are_still_mapped() {
+        let dir =
+            std::env::temp_dir().join(format!("fluree_test_large_pack_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("large.fpk");
+        // Content is irrelevant here — load_pack_backing does not parse.
+        std::fs::write(&path, vec![0u8; (DEFAULT_MMAP_MIN_BYTES + 1) as usize]).unwrap();
+
+        let backing = load_pack_backing(&path).unwrap();
+        assert!(
+            matches!(backing, LoadedBacking::Mmap(_)),
+            "packs over the threshold should still be mapped"
+        );
+        assert_eq!(backing.bytes().len(), (DEFAULT_MMAP_MIN_BYTES + 1) as usize);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The boundary is inclusive (`<=`), so a pack exactly at the threshold is
+    /// read. Pinned because an off-by-one here silently changes which side of
+    /// the split the most common pack size lands on.
+    #[test]
+    fn threshold_boundary_is_inclusive() {
+        let dir =
+            std::env::temp_dir().join(format!("fluree_test_edge_pack_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("edge.fpk");
+        std::fs::write(&path, vec![0u8; DEFAULT_MMAP_MIN_BYTES as usize]).unwrap();
+
+        assert!(matches!(
+            load_pack_backing(&path).unwrap(),
+            LoadedBacking::InMemory(_)
+        ));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## Summary

A process is capped at `vm.max_map_count` memory mappings — **65,530** by default on Linux. Past that `mmap` returns `ENOMEM` **regardless of how much memory is free**, which surfaces as:

```
failed to load binary index: Cannot allocate memory (os error 12)
```

`ForwardPackReader::from_pack_refs` maps **every pack in a dictionary's routing table**, eagerly, one mapping each, held for the reader's lifetime, with no bound and no eviction. Dict packs are per-ID-range and never compacted, so the routing table grows without limit; loading many ledgers in one process multiplies it.

The fix is a size split: `read()` packs at or below 64 KiB onto the heap, keep mapping the larger ones. Behaviour is otherwise unchanged.

## Why this is worth your time

Measured on a deployment running 23 ledgers under continuous ingest:

```
dict packs on disk                       103,441
live mappings held by the server          47,336   (72% of the 65,530 cap, climbing)
  of which @shared/dicts/*.dict           47,336   (99.8% of all mappings)
largest single ledger                     19,629   packs in one routing table
process memory at the time of ENOMEM     1.6 GiB of a 24 GiB limit, memory.events:oom_kill = 0
```

**Failing to allocate at 6% of the memory limit is the part that makes this expensive to diagnose.** Every instinct says "memory pressure", and every memory metric says you have plenty. We raised the container limit from 16 to 24 GiB, which of course changed nothing, and spent a day on the wrong resource. The error string contains the word "memory" and the cause has nothing to do with memory.

## Why a size split is the right shape

Pack sizes are extremely skewed. Across those 103,441 packs:

| bucket | packs | share |
|---|---|---|
| < 4 KiB | 94,415 | **91.3%** |
| < 64 KiB | 96,637 | 93.4% |
| ≥ 1 MiB | 5,728 | 5.5% (holding 12.1 of the 12.5 GiB) |

The median pack is **113 bytes**. Of the packs actually mapped at the time of measurement, **99.8% were under 64 KiB and held 30 MB between them**.

Mapping a 113-byte file spends a VMA and a page of address space to expose less than a cache line of useful data, and buys nothing a `read()` does not: demand paging cannot help a file smaller than one page, and the kernel-side cost of the mapping exceeds the data. So the trade is heavily one-sided.

On that deployment's data, the worst case — every pack on disk loaded at once — becomes:

```
before   103,441 mappings
after      6,793 mappings  +  47 MiB of heap
```

15x headroom against the cap, for 47 MiB out of gigabytes. The large packs that genuinely justify demand paging are still mapped.

## What changed

- **`load_pack_backing`** replaces `mmap_file` as the single place that opens a pack, and decides read-vs-mmap by size. `LoadedBacking::InMemory` already existed for the in-memory constructor, so there is no new representation.
- **`LazyLoaded` now holds a `LoadedBacking`** rather than a bare `Mmap`, so the lazy path gets the same treatment as the eager one. Previously only the eager path could have been fixed in isolation.
- **The remote-fetch path still writes to cache and re-opens** rather than keeping the `Vec` it already has. That looks like a wasted read, and it is deliberate: it keeps `load_pack_backing` the only place the threshold is applied, so a large pack still avoids heap duplication and a small one still lands on the heap, without a second copy of the policy that can drift.
- **A failed `metadata()` falls through to mmap.** The threshold is an optimisation; losing the size must not lose the read.
- **`FLUREE_DICT_PACK_MMAP_MIN_BYTES`** overrides the threshold. `0` restores the previous always-mmap behaviour exactly, which makes this trivially revertible in a deployment without a rollback.

## Tests

Three tests, and they assert on the **backing variant**, not on lookups:

| test | pins |
|---|---|
| `small_packs_are_read_not_mapped` | a pack under the threshold yields `InMemory`, and the bytes survive |
| `large_packs_are_still_mapped` | over the threshold still yields `Mmap` — this is a split, not a move to heap reads |
| `threshold_boundary_is_inclusive` | exactly-at-threshold is read, so an off-by-one cannot silently move the most common pack size across the boundary |

Asserting on the variant rather than on lookup results is the whole point. **Lookups pass either way** — which is precisely why a mapping-per-pack survived from the v4 baseline without anyone noticing. The variant is the only assertion that fails if someone reverts to always-mmap.

`fluree-db-binary-index`: **345 passed**. `fmt` clean; `clippy --all-features --all-targets` clean.

**Heads-up on an unrelated failure that is already on `main`:** `read::binary_index_store::tests::open_leaf_handle_caches_remote_metadata` fails on **pristine `upstream/main`** with no changes from this PR present — verified by reverting `pack_reader.rs` to the `upstream/main` version on this very branch and re-running (342 tests filtered, so none of the three tests above were even compiled in). It is in a file this PR does not touch. Flagging it rather than letting it look like fallout from this change; happy to open a separate issue if useful.

## Notes for review

- **64 KiB is a judgement call from one deployment's distribution.** We have no attachment to it. The argument for "at least a few pages" is that below one page a mapping cannot pay for itself; the argument against a much larger value is heap growth. If you prefer a different default, or prefer the threshold opt-in rather than on by default, both are one-line changes.
- **This bounds mappings, not the pack count.** The underlying growth — dict packs are per-ID-range and never compacted — is untouched, and a deployment large enough will eventually reach 65,530 packs of ≥64 KiB. Compaction of dictionary packs would be the real fix for that and is out of scope here.
- **A bounded mmap cache with eviction would be the more general answer** (the leaflet cache already does exactly this via `try_get_or_load_leaf_mmap`). We went with the size split because it is smaller, has no eviction policy to tune, and removes 99.8% of the mappings on real data. If you would rather see the packs go through a bounded cache instead, say so and we will do that version.
