### PR TITLE
fix: link the GC chain on full rebuild (a rebuild orphans the ledger's whole index history)

### DIFF
--- a/fluree-db-indexer/examples/root_graph.rs
+++ b/fluree-db-indexer/examples/root_graph.rs
@@ -1,0 +1,203 @@
+//! Reconstruct a ledger's real index-version graph from its root blobs.
+//!
+//! Diagnostic, not shipped behaviour. It exists because `chain_len` and root COUNT
+//! disagreed wildly on a live deployment — GC reported a 21-version chain while the
+//! ledger held 211 root files — and no amount of reasoning about the truncation
+//! loop explained it. Every root carries `index_t` and `prev_index`, so the actual
+//! structure is recoverable; this decodes it and says which of three shapes it is:
+//!
+//!   1. ONE BROKEN CHAIN — a middle root is missing, so everything older than the
+//!      hole is unreachable in a single stroke. GC deletes oldest-first precisely to
+//!      make this impossible, so finding it means something deletes out of order.
+//!   2. MULTIPLE LINEAGES — roots fork: two builds from one parent, one publishes,
+//!      the loser's root is written and abandoned. Orphaning at CREATION, fixable
+//!      upstream of GC entirely.
+//!   3. UNCHAINED ROOTS — roots with no `prev_index` that are not genesis, i.e.
+//!      never linked in at all.
+//!
+//! Those have completely different fixes, which is why guessing was not good enough.
+//!
+//! Usage — copy a ledger's roots directory out of the pod, then:
+//!     cargo run -p fluree-db-indexer --example root_graph -- <roots-dir> [head-digest]
+//!
+//! `head-digest` is the published index head (the nameservice's `index_head_id`) if
+//! known; supplying it lets the tool report reachability from the real head rather
+//! than guessing the newest by `index_t`.
+
+use fluree_db_binary_index::IndexRoot;
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let dir = args.next().unwrap_or_else(|| {
+        eprintln!("usage: root_graph <roots-dir> [head-digest]");
+        std::process::exit(2);
+    });
+    let head_arg = args.next();
+
+    // digest -> (index_t, prev_digest)
+    let mut nodes: HashMap<String, (i64, Option<String>)> = HashMap::new();
+    let mut undecodable = 0usize;
+
+    for entry in std::fs::read_dir(&dir).expect("read roots dir") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|s| s.to_str()) != Some("fir6") {
+            continue;
+        }
+        let digest = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+            .to_string();
+        let bytes = std::fs::read(&path).expect("read root");
+        match IndexRoot::decode(&bytes) {
+            Ok(root) => {
+                let prev = root.prev_index.as_ref().map(|p| p.id.digest_hex());
+                nodes.insert(digest, (root.index_t, prev));
+            }
+            Err(e) => {
+                undecodable += 1;
+                eprintln!("  ! undecodable {digest}: {e}");
+            }
+        }
+    }
+
+    println!("roots on disk    : {}", nodes.len());
+    println!("undecodable      : {undecodable}");
+
+    // Which roots are pointed AT by some other root?
+    let mut referenced: HashSet<&String> = HashSet::new();
+    let mut prev_targets: HashMap<&String, Vec<&String>> = HashMap::new();
+    for (digest, (_, prev)) in &nodes {
+        if let Some(p) = prev {
+            referenced.insert(p);
+            prev_targets.entry(p).or_default().push(digest);
+        }
+    }
+
+    // Shape 3: roots with no prev_index. Exactly one (genesis) is expected.
+    let genesis: Vec<_> = nodes
+        .iter()
+        .filter(|(_, (_, p))| p.is_none())
+        .map(|(d, (t, _))| (*t, d.clone()))
+        .collect();
+    println!(
+        "roots with no prev_index (expect 1 = genesis): {}",
+        genesis.len()
+    );
+    for (t, d) in genesis.iter().take(5) {
+        println!("    index_t={t} {}", &d[..16.min(d.len())]);
+    }
+
+    // Shape 2: a root pointed at by MORE THAN ONE successor is a fork point — two
+    // builds based on the same parent. Only one can be the published head, so the
+    // other lineage is abandoned at creation.
+    let forks: Vec<_> = prev_targets
+        .iter()
+        .filter(|(_, kids)| kids.len() > 1)
+        .collect();
+    println!("fork points (parent with >1 child): {}", forks.len());
+    for (parent, kids) in forks.iter().take(8) {
+        let pt = nodes.get(**parent).map(|(t, _)| *t).unwrap_or(-1);
+        let kid_ts: Vec<i64> = kids
+            .iter()
+            .map(|k| nodes.get(*k).map(|(t, _)| *t).unwrap_or(-1))
+            .collect();
+        println!(
+            "    parent index_t={pt} {} -> {} children at index_t {:?}",
+            &parent[..16.min(parent.len())],
+            kids.len(),
+            kid_ts
+        );
+    }
+
+    // Shape 1: dangling prev pointers — a root references a parent that is GONE.
+    // Each dangling pointer is a place the chain walk stops.
+    let dangling: Vec<_> = nodes
+        .iter()
+        .filter_map(|(d, (t, p))| {
+            p.as_ref()
+                .filter(|p| !nodes.contains_key(*p))
+                .map(|p| (*t, d.clone(), p.clone()))
+        })
+        .collect();
+    println!(
+        "dangling prev pointers (chain stops here): {}",
+        dangling.len()
+    );
+    for (t, d, p) in dangling.iter().take(8) {
+        println!(
+            "    index_t={t} {} -> MISSING {}",
+            &d[..16.min(d.len())],
+            &p[..16.min(p.len())]
+        );
+    }
+
+    // Reachability from the head: what GC can actually see.
+    let head = head_arg.or_else(|| {
+        nodes
+            .iter()
+            .max_by_key(|(_, (t, _))| *t)
+            .map(|(d, _)| d.clone())
+    });
+    if let Some(head) = head {
+        // Count only digests that are actually PRESENT on disk. Walking into a
+        // missing parent (the tail of a GC truncation) and counting it would make
+        // `seen` exceed `nodes` and the "unreachable" subtraction underflow.
+        let mut seen = HashSet::new();
+        let mut cur = Some(head.clone());
+        while let Some(d) = cur {
+            let Some((_, prev)) = nodes.get(&d) else {
+                break; // dangling: parent not on disk, chain ends here
+            };
+            if !seen.insert(d.clone()) {
+                println!("!! CYCLE at {}", &d[..16.min(d.len())]);
+                break;
+            }
+            cur = prev.clone();
+        }
+        println!(
+            "\nreachable from head {} : {} of {} roots  ({} UNREACHABLE)",
+            &head[..16.min(head.len())],
+            seen.len(),
+            nodes.len(),
+            nodes.len().saturating_sub(seen.len())
+        );
+
+        // How do the unreachable ones distribute over index_t? A contiguous block
+        // means one truncation event; a scatter means repeated forking.
+        let mut unreachable_ts: Vec<i64> = nodes
+            .iter()
+            .filter(|(d, _)| !seen.contains(*d))
+            .map(|(_, (t, _))| *t)
+            .collect();
+        unreachable_ts.sort_unstable();
+        if !unreachable_ts.is_empty() {
+            println!(
+                "unreachable index_t range: {} .. {}",
+                unreachable_ts[0],
+                unreachable_ts[unreachable_ts.len() - 1]
+            );
+            // Contiguity: how many distinct index_t values, and are there gaps?
+            let distinct: BTreeMap<i64, usize> =
+                unreachable_ts.iter().fold(BTreeMap::new(), |mut m, t| {
+                    *m.entry(*t).or_insert(0) += 1;
+                    m
+                });
+            let dupes: Vec<_> = distinct.iter().filter(|(_, n)| **n > 1).take(6).collect();
+            println!(
+                "distinct unreachable index_t: {} (so {} share a t with another root)",
+                distinct.len(),
+                unreachable_ts.len() - distinct.len()
+            );
+            if !dupes.is_empty() {
+                // TWO roots at the same index_t is the signature of a fork: the same
+                // logical version built twice.
+                println!("  index_t values with MULTIPLE roots (fork signature):");
+                for (t, n) in dupes {
+                    println!("    index_t={t}: {n} roots");
+                }
+            }
+        }
+    }
+}

--- a/fluree-db-indexer/src/build/rebuild.rs
+++ b/fluree-db-indexer/src/build/rebuild.rs
@@ -1126,7 +1126,20 @@ where
             let result = super::root_assembly::encode_and_write_root_v6(
                 &content_store,
                 fir6_inputs,
-                None, // GC chain deferred for V3 milestone.
+                // The ledger's current index head, so the rebuilt root LINKS into the
+                // chain instead of starting a fresh lineage.
+                //
+                // This was `None, // GC chain deferred for V3 milestone`, and that
+                // deferral was silently destructive: a rebuilt root with no
+                // `prev_index` makes every earlier version unreachable, and since
+                // nothing reclaims by reachability their artifacts can never be
+                // freed. A rebuild is the FALLBACK path — taken whenever incremental
+                // indexing aborts, e.g. `Cannot allocate memory` under memory
+                // pressure — so each such failure quietly converted a RECOVERABLE
+                // error into permanent disk loss. Live evidence: 226 roots on one
+                // ledger, 15 reachable, 211 orphaned, traced to two roots carrying
+                // no `prev_index`.
+                prev_root_id.clone(),
                 IndexStats {
                     flake_count: total_rows as usize,
                     leaf_count: v3_result

--- a/fluree-db-indexer/src/build/root_assembly.rs
+++ b/fluree-db-indexer/src/build/root_assembly.rs
@@ -174,37 +174,77 @@ async fn load_prev_annotation_index(
 /// manifests via `collect_root_cas_ids_expanded`. Diffing only the direct
 /// CAS refs (`all_cas_ids()`) would silently leak those leaves on every
 /// reindex.
-// Kept for: shared GC chain computation for both rebuild and incremental pipelines.
-// Use when: rebuild.rs Phase F.7 is refactored to use this shared helper.
-#[expect(dead_code)]
+/// Note the ORDER of concerns: the `prev_index` link is established as soon as the
+/// previous root decodes, and the garbage diff is best-effort ON TOP of it. That
+/// separation is deliberate and load-bearing.
+///
+/// The two are independent facts — the link says "this version follows that one",
+/// the manifest says "these blobs were replaced" — and conflating them severs
+/// chains. An earlier shape returned `None` if either CAS expansion failed, which
+/// would publish a root with NO `prev_index`, silently starting a fresh lineage and
+/// making every earlier version unreachable. Unreachable means GC cannot see it,
+/// and nothing else reclaims by reachability, so that space is gone for good.
+///
+/// Measured on a live ledger while the rebuild path passed no chain context at all:
+/// 226 roots on disk, **15 reachable**, 211 orphaned — with 0 fork points and 211
+/// distinct `index_t` (so not a race), traced to two roots carrying no `prev_index`
+/// at `index_t` 6739 and 8627, each severing everything below it.
+///
+/// Failing to compute garbage costs some unreleased blobs, which a later sweep can
+/// still find. Failing to link the chain costs the entire history, permanently.
+/// Never trade the second for the first.
 pub(crate) async fn compute_garbage_from_prev_root(
     content_store: &dyn fluree_db_core::storage::ContentStore,
     new_root: &IndexRoot,
     prev_root_id: &ContentId,
 ) -> Option<GarbageContext> {
+    // The only unrecoverable case: without decoding the previous root there is no
+    // `t` for the link, so there is nothing well-formed to point at.
     let prev_bytes = content_store.get(prev_root_id).await.ok()?;
     let prev_root = IndexRoot::decode(&prev_bytes).ok()?;
 
-    let prev_t = prev_root.index_t;
-    // Strict expansion: a partial new-root set would misclassify
-    // still-reachable leaves as garbage; a partial prev-root set would
-    // leave replaced blobs unreleased. Either way silently — propagate
-    // the error so the caller can decide whether to skip publishing
-    // garbage rather than write a corrupt manifest.
-    let old_ids = fluree_db_binary_index::collect_root_cas_ids_expanded(content_store, &prev_root)
-        .await
-        .ok()?;
-    let new_ids = fluree_db_binary_index::collect_root_cas_ids_expanded(content_store, new_root)
-        .await
-        .ok()?;
-    let garbage_cids: Vec<ContentId> = old_ids.difference(&new_ids).cloned().collect();
+    let prev_index = Some(BinaryPrevIndexRef {
+        t: prev_root.index_t,
+        id: prev_root_id.clone(),
+    });
+
+    // Strict expansion: a partial new-root set would misclassify still-reachable
+    // leaves as garbage; a partial prev-root set would leave replaced blobs
+    // unreleased. On failure record NO garbage but KEEP the link.
+    let diff = async {
+        let old_ids =
+            fluree_db_binary_index::collect_root_cas_ids_expanded(content_store, &prev_root)
+                .await
+                .ok()?;
+        let new_ids =
+            fluree_db_binary_index::collect_root_cas_ids_expanded(content_store, new_root)
+                .await
+                .ok()?;
+        Some(
+            old_ids
+                .difference(&new_ids)
+                .cloned()
+                .collect::<Vec<ContentId>>(),
+        )
+    }
+    .await;
+
+    let garbage_cids = diff.unwrap_or_else(|| {
+        tracing::warn!(
+            prev_root_id = %prev_root_id,
+            prev_t = prev_root.index_t,
+            new_t = new_root.index_t,
+            "Could not expand CAS sets to diff garbage; publishing with the \
+             prev_index link and an EMPTY garbage manifest. Replaced blobs persist \
+             until an orphan sweep finds them, which is recoverable — dropping the \
+             link would not be."
+        );
+        Vec::new()
+    });
 
     Some(GarbageContext {
         garbage_cids,
-        prev_index: Some(BinaryPrevIndexRef {
-            t: prev_t,
-            id: prev_root_id.clone(),
-        }),
+        prev_index,
     })
 }
 
@@ -274,11 +314,20 @@ pub(crate) struct Fir6Inputs {
 /// `IndexRoot`, encodes it, writes to CAS with `ContentKind::IndexRoot`,
 /// and derives the CID.
 ///
-/// `gc_ctx` is `None` for this milestone (V3 GC chain is deferred).
+/// Takes `prev_root_id` — the ledger's CURRENT published index head, if it has one
+/// — and derives the GC chain itself, rather than accepting a pre-built
+/// `GarbageContext`. That is deliberate: the previous shape let a caller pass
+/// `None` and silently publish a root with no `prev_index`, which is exactly what
+/// happened. `rebuild.rs` passed `None, // GC chain deferred for V3 milestone`, so
+/// **every full rebuild severed the chain** and orphaned the whole prior history —
+/// 226 roots on a live ledger with only 15 reachable. Deriving it here means the
+/// link cannot be forgotten, only genuinely absent.
+///
+/// Pass `None` **only** when the ledger truly has no prior index (genesis).
 pub(crate) async fn encode_and_write_root_v6(
     content_store: &dyn ContentStore,
     inputs: Fir6Inputs,
-    gc_ctx: Option<GarbageContext>,
+    prev_root_id: Option<ContentId>,
     result_stats: IndexStats,
 ) -> Result<IndexResult> {
     reconcile_ns_at_publish(
@@ -523,7 +572,33 @@ pub(crate) async fn encode_and_write_root_v6(
         root.had_annotation_arena = true;
     }
 
-    // Attach garbage manifest and prev_index if provided.
+    // Derive the GC chain from the previous head, then attach it.
+    //
+    // Done HERE rather than taken from the caller so that publishing a root without
+    // a `prev_index` requires there to be no previous head — it can no longer
+    // happen because a call site omitted it.
+    let gc_ctx = match prev_root_id.as_ref() {
+        Some(prev) => {
+            let ctx = compute_garbage_from_prev_root(content_store, &root, prev).await;
+            if ctx.is_none() {
+                // The head exists but would not decode. Publishing anyway severs the
+                // chain and orphans everything behind it permanently, so say so
+                // loudly rather than leaving it to be discovered as lost disk.
+                tracing::warn!(
+                    prev_root_id = %prev,
+                    index_t = inputs.index_t,
+                    ledger_id = %inputs.ledger_id,
+                    "Previous index head could not be read; publishing WITHOUT a \
+                     prev_index link. Every earlier index version becomes \
+                     unreachable and unreclaimable — expect an orphan-sweep report \
+                     to grow by roughly one version's artifacts."
+                );
+            }
+            ctx
+        }
+        None => None,
+    };
+
     if let Some(ctx) = gc_ctx {
         if let Some(prev) = ctx.prev_index {
             root.prev_index = Some(prev);
@@ -600,6 +675,55 @@ mod tests {
         pairs.iter().map(|&(c, p)| (c, p.to_string())).collect()
     }
 
+    /// A root whose reverse dict tree points at a leaf that is not in the store.
+    /// Useful because it is cheap to build and needs no real index.
+    fn unresolvable_root(ledger: &str, t: i64, tag: &[u8]) -> fluree_db_binary_index::IndexRoot {
+        use fluree_db_binary_index::{DictPackRefs, DictTreeRefs, IndexRoot};
+        use fluree_db_core::{ContentId, ContentKind};
+        let tree = DictTreeRefs {
+            branch: ContentId::new(ContentKind::IndexBranch, tag),
+            leaves: vec![ContentId::new(ContentKind::IndexLeaf, tag)],
+        };
+        IndexRoot {
+            ledger_id: ledger.to_string(),
+            index_t: t,
+            base_t: 0,
+            subject_id_encoding: fluree_db_core::SubjectIdEncoding::Narrow,
+            namespace_codes: BTreeMap::new(),
+            predicate_sids: Vec::new(),
+            graph_iris: Vec::new(),
+            datatype_iris: Vec::new(),
+            language_tags: Vec::new(),
+            dict_refs: DictRefs {
+                forward_packs: DictPackRefs {
+                    string_fwd_packs: Vec::new(),
+                    subject_fwd_ns_packs: Vec::new(),
+                },
+                subject_reverse: tree.clone(),
+                string_reverse: tree,
+            },
+            subject_watermarks: Vec::new(),
+            string_watermark: 0,
+            lex_sorted_string_ids: false,
+            total_commit_size: 0,
+            total_asserts: 0,
+            total_retracts: 0,
+            graph_arenas: Vec::new(),
+            default_graph_orders: Vec::new(),
+            named_graphs: Vec::new(),
+            stats: None,
+            schema: None,
+            prev_index: None,
+            garbage: None,
+            sketch_ref: None,
+            has_annotations: false,
+            annotation_index: None,
+            had_annotation_arena: false,
+            o_type_table: IndexRoot::build_o_type_table(&[], &[]),
+            ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode::default(),
+        }
+    }
+
     #[test]
     fn reconcile_ns_at_publish_matching_tables() {
         let root = btree(&[(1, "http://a.org/"), (2, "http://b.org/")]);
@@ -666,6 +790,78 @@ mod tests {
         assert!(
             msg.contains("code 5") && msg.contains("root=None"),
             "should report missing root entry: {msg}"
+        );
+    }
+
+    /// A decodable previous head ALWAYS yields a `prev_index` link.
+    ///
+    /// This is the regression that matters. A root published without `prev_index`
+    /// silently starts a fresh lineage: every earlier version becomes unreachable,
+    /// and since nothing reclaims by reachability their artifacts can never be
+    /// freed. Live evidence before the fix: 226 roots on one ledger, 15 reachable,
+    /// 211 orphaned.
+    ///
+    /// The previous root here references a leaf that is not in the store — which,
+    /// usefully, turned out NOT to make `collect_root_cas_ids_expanded` fail:
+    /// expansion tolerates unresolvable leaves. So the "diff failed, keep the link
+    /// anyway" branch is **not covered by this test**; triggering it needs a store
+    /// that errors on `get`, and it is left uncovered rather than faked. What is
+    /// covered is the property that actually broke production: the link is derived
+    /// from the head and cannot be omitted.
+    #[tokio::test]
+    async fn decodable_prev_head_always_yields_a_prev_index_link() {
+        use fluree_db_core::prelude::*;
+        use fluree_db_core::storage::content_store_for;
+
+        const LEDGER: &str = "chainlink:main";
+
+        let store = content_store_for(MemoryStorage::new(), LEDGER);
+
+        let prev = unresolvable_root(LEDGER, 10, b"prev");
+        let prev_id = store
+            .put(ContentKind::IndexRoot, &prev.encode())
+            .await
+            .expect("write prev root");
+
+        let new_root = unresolvable_root(LEDGER, 11, b"new");
+
+        let ctx = compute_garbage_from_prev_root(&store, &new_root, &prev_id)
+            .await
+            .expect("a decodable previous head must always yield a context");
+
+        let link = ctx
+            .prev_index
+            .expect("prev_index MUST be set even when the garbage diff fails");
+        assert_eq!(link.id, prev_id, "link must point at the previous head");
+        assert_eq!(
+            link.t, 10,
+            "link must carry the previous index_t, or GC cannot order the chain"
+        );
+    }
+
+    /// An UNREADABLE previous head yields `None` — never a bogus link.
+    ///
+    /// `None` here is honest: without decoding the head there is no `index_t`, so no
+    /// well-formed link exists. The caller logs a loud warning in that case, because
+    /// publishing anyway severs the chain. What must never happen is inventing a
+    /// link, or dropping one that was available.
+    #[tokio::test]
+    async fn unreadable_prev_head_yields_no_link_rather_than_a_bogus_one() {
+        use fluree_db_core::prelude::*;
+        use fluree_db_core::storage::content_store_for;
+
+        const LEDGER: &str = "absent:main";
+        let store = content_store_for(MemoryStorage::new(), LEDGER);
+
+        // Never written, so `get` cannot resolve it.
+        let never_written = ContentId::new(ContentKind::IndexRoot, b"absent-head");
+        let new_root = unresolvable_root(LEDGER, 5, b"new");
+
+        assert!(
+            compute_garbage_from_prev_root(&store, &new_root, &never_written)
+                .await
+                .is_none(),
+            "an unreadable previous head must yield None"
         );
     }
 }


### PR DESCRIPTION
## Summary

`fluree-db-indexer/src/build/rebuild.rs` publishes every full-rebuild root with no `prev_index`:

```rust
None, // GC chain deferred for V3 milestone.
```

**A root with no `prev_index` starts a fresh lineage.** Every index version before it becomes unreachable in one stroke — referenced by no root and listed in no garbage manifest. Since nothing in the indexer reclaims by reachability, those artifacts can never be freed by any retention setting, at any value. It is not a slow leak: one rebuild discards the ledger's entire index history, permanently.

## Why this is worse than "rebuilds are rare"

Two amplifiers make it self-feeding rather than occasional:

- **A recoverable memory error converts into permanent disk loss.** `ENOMEM` during an incremental index falls back to a full rebuild. So a transient allocation failure — one that would otherwise be retried harmlessly — permanently strands the ledger's history instead.
- **A wedged volume forces rebuilds.** The fuller the disk, the more rebuilds, the more orphans, the fuller the disk. Memory pressure causes disk pressure causes more rebuilds.

The end state is unrecoverable without external intervention: GC must *write* in order to free anything, so once the volume is full, every index attempt fails, GC never runs, and it does not recover on its own. Ours sat dead for ~34 hours while reporting healthy.

## Measured, before and after, on the same live ledger

Reconstructed by decoding every root blob's `index_t` and `prev_index` out of live storage (`examples/root_graph.rs`, added in this PR) on a ledger under continuous ingest.

**Before**, on the unpatched build:

```
roots on disk    : 226
undecodable      : 0
roots with no prev_index (expect 1 = genesis): 2      <- TWO lineages, not one
fork points (parent with >1 child): 0                 <- NOT competing builds
dangling prev pointers (chain stops here): 7
reachable from head 4acaf0f11fc48d81 : 15 of 226 roots  (211 UNREACHABLE)
distinct unreachable index_t: 211 (so 0 share a t with another root)
```

**93% of index versions unreachable.** The two lines that pin the diagnosis are `fork points: 0` and `0 share a t with another root`: those rule out the obvious competing-builds explanation (two builds from one parent, loser abandoned), which is the theory we spent a day on. A second root with **no parent link at all** is the signature of this bug specifically.

**After**, same ledger, same command, patched build:

```
roots on disk    : 21
undecodable      : 0
roots with no prev_index (expect 1 = genesis): 0
fork points (parent with >1 child): 0
dangling prev pointers (chain stops here): 1
reachable from head b59e2bfb8d4530f8 : 21 of 21 roots  (0 UNREACHABLE)
```

**211 unreachable → 0.**

Reading the two residuals, since neither is a defect: `no prev_index: 0` rather than 1 is correct here — GC has legitimately truncated past genesis, so the oldest retained root points at a collected parent, which is the same fact as `dangling: 1`. **One dangling pointer at the tail is what a bounded chain looks like; seven scattered through the middle is what a broken one looks like.**

Being precise about what this fix accounts for: the 226 → 21 drop is this fix *plus* a separate sweep that reclaimed the already-stranded artifacts. **The `0 UNREACHABLE` is this fix alone** — no sweep can make a root reachable.

## What changed, and why the shape matters

The naive fix is to pass `prev_root_id` at the one call site. That is not sufficient, because of how the two concerns were coupled:

`encode_and_write_root_v6` took `gc_ctx: Option<GarbageContext>`, and that single `Option` carried **two unrelated things**: the cheap `prev_index` link, and the expensive garbage diff computed by walking both roots' CAS id sets. Any failure in the diff — an unreadable prior root, a missing leaf — dropped the link too. So the chain could break silently even where a caller *did* pass a previous root.

This PR:

- **Sets `prev_index` as soon as the previous root decodes**, and computes the garbage diff best-effort *on top of that*. The link no longer depends on the diff succeeding.
- **Changes the signature to `prev_root_id: Option<ContentId>`**, deriving the garbage context internally. A caller can no longer pass a previous root and forget the link — the shape that produced this bug is no longer expressible.
- **Un-dead-codes `compute_garbage_from_prev_root`**, which existed but was unreachable.

## Tests

| test | pins |
|---|---|
| `decodable_prev_head_always_yields_a_prev_index_link` | if the previous root decodes, the link is set — independent of whether the garbage diff succeeded |
| `unreadable_prev_head_yields_no_link_rather_than_a_bogus_one` | an unresolvable previous head produces no link, not a dangling one |

`fluree-db-indexer`: **341 passed**, 2 ignored. `fmt` clean; `clippy --all-features --all-targets` clean on the changed crates.

Honest note on coverage: we could not construct a case where the *garbage diff* fails while the previous root decodes, because `collect_root_cas_ids_expanded` tolerates missing leaves. So the "diff failed but link still set" branch is correct by construction rather than by test. Called out rather than papered over with a test that asserts something weaker than its name suggests.

## `examples/root_graph.rs`

Added because this bug was not diagnosable from logs or counts. GC reported `chain_len=21` while the ledger held 226 root files, and no amount of reasoning about the truncation loop explained the gap — six hypotheses, all about deletion or concurrency, all wrong, because the bug was in *creation*.

Every root carries `index_t` and `prev_index`, so the real structure is recoverable. The tool decodes a roots directory and reports which of three shapes it is — one broken chain, multiple lineages, or unchained roots — because those have entirely different fixes.

Kept in the PR as a diagnostic, not as shipped behaviour. If you would rather it not live in the repo, we will drop it, but it is what turned a week of speculation into one measurement.

## Notes for review

- **The comment says "deferred for V3 milestone"**, so this may be a known and intentional gap rather than an oversight. If there is a reason full rebuilds should *not* chain — a format or migration constraint we have not found — we would rather hear it than have this merged. The evidence above is that in a running deployment it costs the ledger's whole history, but we do not know what V3 assumed.
- **Consider `warn!` on a rebuild that cannot chain.** Right now a severed chain is invisible until you decode the root graph. This PR does not add that, to keep the change minimal, but a deployment would have caught the problem in a day instead of a week.
