### PR TITLE
chore: Release v4.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,11 +2422,11 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-bench-alloc"
-version = "4.1.4"
+version = "4.1.5"
 
 [[package]]
 name = "fluree-bench-support"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "chrono",
  "rand 0.8.5",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-bench-virtual"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-api"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2573,14 +2573,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-bolt"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-db-cli"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-consensus"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cypher"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-docs"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "pulldown-cmark",
  "rust-embed",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-iceberg"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-mcp"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-db-docs",
  "fluree-db-memory",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-memory"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "chrono",
  "fluree-db-api",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice-sync"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-peer"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-server"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-aws"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-ipfs"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "cid",
@@ -3271,14 +3271,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-vocab",
  "pretty_assertions",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-httpd"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-service"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3422,14 +3422,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-sse"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-vocab"
-version = "4.1.4"
+version = "4.1.5"
 
 [[package]]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ members = [
 exclude = ["testsuite-sparql", "testsuite-shacl", "scripts/local/load"]
 
 [workspace.package]
-version = "4.1.4"
+version = "4.1.5"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/fluree/db"

--- a/testsuite-shacl/Cargo.lock
+++ b/testsuite-shacl/Cargo.lock
@@ -668,7 +668,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-db-api"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -692,6 +692,7 @@ dependencies = [
  "fluree-db-shacl",
  "fluree-db-sparql",
  "fluree-db-spatial",
+ "fluree-db-tabular",
  "fluree-db-transact",
  "fluree-graph-format",
  "fluree-graph-ir",
@@ -710,6 +711,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "thiserror 1.0.69",
  "tokio",
@@ -720,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "bigdecimal 0.4.10",
  "chrono",
@@ -752,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -766,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -780,6 +782,7 @@ dependencies = [
  "futures",
  "hashbrown 0.16.1",
  "hex",
+ "libc",
  "moka",
  "multihash",
  "num-bigint",
@@ -800,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "base64",
  "bs58",
@@ -813,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -829,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cypher"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -844,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -879,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -895,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -911,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -929,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -941,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -990,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -1006,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1022,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -1035,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -1052,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -1080,14 +1083,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1127,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-graph-ir",
  "serde",
@@ -1137,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-vocab",
  "serde",
@@ -1147,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1159,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1172,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1181,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-vocab"
-version = "4.1.4"
+version = "4.1.5"
 
 [[package]]
 name = "foldhash"
@@ -2396,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "testsuite-shacl"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "anyhow",
  "fluree-db-api",

--- a/testsuite-shacl/Cargo.toml
+++ b/testsuite-shacl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testsuite-shacl"
-version = "4.1.4"
+version = "4.1.5"
 edition = "2021"
 publish = false
 

--- a/testsuite-sparql/Cargo.lock
+++ b/testsuite-sparql/Cargo.lock
@@ -662,7 +662,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-db-api"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "bigdecimal 0.4.10",
  "chrono",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -775,6 +775,7 @@ dependencies = [
  "futures",
  "hashbrown 0.16.1",
  "hex",
+ "libc",
  "moka",
  "multihash",
  "num-bigint",
@@ -795,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "base64",
  "bs58",
@@ -808,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -824,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cypher"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -839,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -874,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -890,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -906,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -924,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -936,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -985,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -1001,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1017,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -1034,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -1062,14 +1063,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1108,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-graph-ir",
  "serde",
@@ -1118,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-vocab",
  "serde",
@@ -1128,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1140,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1153,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1162,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-vocab"
-version = "4.1.4"
+version = "4.1.5"
 
 [[package]]
 name = "foldhash"
@@ -2403,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "testsuite-sparql"
-version = "4.1.4"
+version = "4.1.5"
 dependencies = [
  "anyhow",
  "fluree-db-api",

--- a/testsuite-sparql/Cargo.toml
+++ b/testsuite-sparql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testsuite-sparql"
-version = "4.1.4"
+version = "4.1.5"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Bump workspace version from 4.1.4 to 4.1.5.

Updates the version in the root workspace package plus the excluded `testsuite-sparql` and `testsuite-shacl` crates, along with their respective `Cargo.lock` files.