### PR TITLE
fix(ci): exclude internal bench crates from the release plan

### DIFF
--- a/fluree-bench-support/Cargo.toml
+++ b/fluree-bench-support/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+# Internal benchmark tooling — never a release artifact.
+[package.metadata.dist]
+dist = false
+
 # Library + one small CLI (`bench-baseline`, capture/compare). No benches in
 # this crate — see <workspace>/BENCHMARKING.md and per-crate `benches/`.
 

--- a/fluree-bench-virtual/Cargo.toml
+++ b/fluree-bench-virtual/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+# Internal benchmark tooling — never a release artifact.
+[package.metadata.dist]
+dist = false
+
 # A single binary. The crate is a runner, not a library — its schema types live
 # in `src/schema.rs` and are exercised by the in-crate unit tests.
 [[bin]]


### PR DESCRIPTION
`fluree-bench-virtual` (`vbench`) and `fluree-bench-support` (`bench-baseline`) are internal tooling, but neither carried `[package.metadata.dist] dist = false`. cargo-dist auto-discovers any workspace package with a binary, so the v4.1.5 plan contained three releases instead of one.

That broke the v4.1.5 release two ways:

**`publish-homebrew-formula` failed.** All three releases declare the same `fluree.rb` artifact, and the job loops over every `.rb`-bearing release committing that one file. Iteration 1 committed it; iteration 2 had nothing staged and `git commit` exited 1 under `bash -e`, so `git push` never ran. The tap is still on 4.1.4.

**The release shipped internal tooling.** 24 of the 36 v4.1.5 assets are bench harness tarballs, zips, and installer scripts, and the generated notes headline `fluree-bench-virtual` ahead of the CLI.

`fluree-db-server` and `fluree-search-httpd` already use this exact exclusion; this applies it to the two bench crates.

Verified with `dist plan`: one release (`fluree-db-cli`), one `.rb`-bearing release — the v4.1.4 shape. `dist generate --check` passes, so `release.yml` needs no regeneration and the hand-added AUR job is untouched.