### PR TITLE
preserve fully-retracted history through full index rebuilds

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -224,6 +224,7 @@
 
 - [Troubleshooting](troubleshooting/README.md)
   - [Common errors](troubleshooting/common-errors.md)
+  - [Missing results at a historical `t`](troubleshooting/historical-results-missing.md)
   - [Debugging queries](troubleshooting/debugging-queries.md)
   - [Performance investigation with distributed tracing](troubleshooting/performance-tracing.md)
 

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -15,6 +15,11 @@ Reference for frequently encountered errors:
 - Storage issues
 - Indexing problems
 
+### [Missing results at a historical `t`](historical-results-missing.md)
+
+Historical reads that return empty for retracted properties or deleted
+entities, and the reindex that repairs them.
+
 ### [Debugging Queries](debugging-queries.md)
 
 Tools and techniques for query debugging:
@@ -307,6 +312,7 @@ Retain logs for historical analysis:
 ## Related Documentation
 
 - [Common Errors](common-errors.md) - Error reference
+- [Missing results at a historical `t`](historical-results-missing.md) - Historical reads after an old index build
 - [Debugging Queries](debugging-queries.md) - Query debugging
 - [API Errors](../api/errors.md) - HTTP error codes
 - [Operations](../operations/README.md) - Operational guides

--- a/docs/troubleshooting/historical-results-missing.md
+++ b/docs/troubleshooting/historical-results-missing.md
@@ -1,0 +1,88 @@
+# Missing results at a historical `t`
+
+A query against a past `t` returns nothing (or returns rows with unbound
+values) for data that demonstrably existed at that `t`, while the same query
+against current state is correct.
+
+This happens when the ledger's published index was built by a version
+predating [fluree/db#1624](https://github.com/fluree/db/pull/1624). The commit
+history is complete and undamaged; only the index artifact is missing the
+entries needed to reconstruct those facts. Reindexing rebuilds it.
+
+## Affected data
+
+Two shapes, both of which leave nothing live to anchor the index entry:
+
+- A **property whose every value was retracted**. Nothing currently uses the
+  property anywhere in the ledger.
+- An **entity that was deleted outright**, i.e. every triple about that
+  subject was retracted.
+
+Data that was only partially retracted is not affected — surviving values keep
+the index entry alive, so history reads through it correctly.
+
+## Symptoms
+
+```sparql
+# Returns 0 rows, though every invoice carried the flag at t=1
+SELECT ?inv FROM <mydb:main@t:1> WHERE { ?inv ex:legacyFlag "true" }
+```
+
+`OPTIONAL` is the easiest form to miss, because it returns a full result set
+rather than an empty one:
+
+```sparql
+# Returns every invoice with ?flag unbound, which reads as
+# "the property did not exist at t=1"
+SELECT ?inv ?flag FROM <mydb:main@t:1>
+WHERE { ?inv a ex:Invoice . OPTIONAL { ?inv ex:legacyFlag ?flag } }
+```
+
+`COUNT`, `FILTER EXISTS`, and history-range queries over the same property
+report the same absence.
+
+## Confirming the cause
+
+Compare a historical read against the same read on an unindexed view of the
+data. A ledger serving from novelty (not yet indexed) reconstructs these facts
+correctly, so a disagreement between the two points at the index.
+
+The cheapest confirmation is to run the remediation below on a copy and see
+whether the historical result changes.
+
+## Remediation
+
+Reindex the ledger. Nothing triggers this automatically — neither ordinary
+writes nor incremental index builds repair an index that is already missing
+the entries.
+
+```bash
+# CLI
+fluree reindex mydb:main
+
+# Or via the admin API
+curl -X POST https://<fluree-server>/v1/fluree/reindex \
+  -H 'Content-Type: application/json' \
+  -d '{"ledger": "mydb:main"}'
+```
+
+A reindex rebuilds from the commit chain starting at genesis and does not
+carry anything forward from the previous index, so it restores the missing
+entries regardless of which version wrote the index being replaced. Reindexing
+is safe to repeat.
+
+Plan for it as a full index build: cost scales with total history, not with
+the amount of affected data.
+
+## After reindexing
+
+Indexes built by a version that includes the fix are not affected, and stay
+correct across subsequent incremental index builds. No further action is
+needed once a ledger has been reindexed once.
+
+## Related documentation
+
+- [Background indexing](../indexing-and-search/background-indexing.md) —
+  novelty and reindex thresholds
+- [Debugging queries](debugging-queries.md) — EXPLAIN plans and query tracing
+- [Time travel](../concepts/time-travel.md) — querying at a past `t`

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -1182,3 +1182,41 @@ async fn time_travel_after_everything_is_retracted() {
         "nothing left at t=2"
     );
 }
+
+/// The history surface (`from`/`to` with `@t`/`@op` bindings) over the same
+/// fully-retracted predicate. It reads through `BinaryHistoryScanOperator`
+/// rather than a time-travel replay, but it enters through the same
+/// predicate-keyed order, so a dropped partition hides every event.
+#[tokio::test]
+async fn history_range_over_fully_retracted_predicate() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-history-surface:main";
+    let _ledger = seed_fully_retracted_ledger(&fluree, ledger_id).await;
+
+    let q = json!({
+        "@context": ctx(),
+        "from": format!("{ledger_id}@t:1"),
+        "to": format!("{ledger_id}@t:latest"),
+        "select": ["?inv", "?t", "?op"],
+        "where": [{
+            "@id": "?inv",
+            "ns:legacyFlag": {"@value": "?v", "@t": "?t", "@op": "?op"}
+        }],
+    });
+    let result = fluree
+        .query_from()
+        .jsonld(&q)
+        .format(fluree_db_api::FormatterConfig::typed_json().with_normalize_arrays())
+        .execute_tracked()
+        .await
+        .expect("history range query");
+    let value = serde_json::to_value(&result.result).expect("serialize");
+    let rows = value.as_array().expect("rows array");
+
+    assert_eq!(
+        rows.len(),
+        10,
+        "5 asserts at t=1 and 5 retracts at t=2; got {rows:#?}"
+    );
+}

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -82,25 +82,59 @@ async fn seed_invoice_ledger(fluree: &fluree_db_api::Fluree) -> fluree_db_api::L
     ledger2
 }
 
+/// Which index the fully-retracted fixture should be served from.
+///
+/// The three strategies are separately reachable in production and were
+/// separately wrong/right before the full-rebuild fix, so every shape below
+/// is measured against all three rather than against whichever one the
+/// helper happened to pick.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IndexStrategy {
+    /// `rebuild_index_from_commits` — the path `Fluree::reindex()` takes.
+    FullRebuild,
+    /// `build_index_for_record` — incremental once a base index exists.
+    Incremental,
+    /// Never indexed; everything served from novelty.
+    NoveltyOnly,
+}
+
+impl IndexStrategy {
+    async fn publish(self, fluree: &fluree_db_api::Fluree, ledger_id: &str) {
+        match self {
+            Self::FullRebuild => support::rebuild_and_publish_index(fluree, ledger_id).await,
+            Self::Incremental => support::build_and_publish_index(fluree, ledger_id).await,
+            Self::NoveltyOnly => {}
+        }
+    }
+}
+
 /// Seed a ledger that exercises the empty-after-retract leaflet case.
 ///
 /// At t=1 every invoice has a `ns:legacyFlag "true"` triple. At t=2 the
 /// legacy flag is fully retracted from every invoice (no replacement). The
-/// indexer preserves the now-empty leaflet's metadata (`row_count == 0`
-/// but `history_*` populated) so time-travel can still recover the
-/// retracted state. Historical queries at t=1 must see the legacy flag;
-/// queries at t=2 must not.
-async fn seed_fully_retracted_ledger(
+/// predicate then has zero live rows, so nothing but its history sidecar
+/// can answer a query at t=1 — the builder must still emit its (zero-row)
+/// partition, or every predicate-keyed lane silently reports "no rows".
+/// Historical queries at t=1 must see the legacy flag; queries at t=2 must
+/// not.
+///
+/// `ns:status` is a deliberate live-predicate control: it shares the
+/// subjects and survives t=2, so a shape that returns nothing for
+/// `ns:legacyFlag` but 5 for `ns:status` isolates the defect to the
+/// fully-retracted predicate rather than to time travel in general.
+async fn seed_fully_retracted_ledger_with(
     fluree: &fluree_db_api::Fluree,
     ledger_id: &str,
+    strategy: IndexStrategy,
+    invoice_count: usize,
 ) -> fluree_db_api::LedgerState {
     let ledger0 = genesis_ledger(fluree, ledger_id);
 
-    // t=1: 5 invoices, all carrying ns:legacyFlag "true" and a status.
-    let mut invoices = Vec::with_capacity(5);
-    for i in 0..5 {
+    // t=1: N invoices, all carrying ns:legacyFlag "true" and a status.
+    let mut invoices = Vec::with_capacity(invoice_count);
+    for i in 0..invoice_count {
         invoices.push(json!({
-            "@id": format!("ns:Invoice/inv-{:02}", i),
+            "@id": format!("ns:Invoice/inv-{:04}", i),
             "@type": "ns:Invoice",
             "ns:status": "paid",
             "ns:legacyFlag": "true",
@@ -108,7 +142,7 @@ async fn seed_fully_retracted_ledger(
     }
     let tx1 = json!({"@context": ctx(), "@graph": invoices});
     let _ = fluree.insert(ledger0, &tx1).await.expect("tx1");
-    support::rebuild_and_publish_index(fluree, ledger_id).await;
+    strategy.publish(fluree, ledger_id).await;
     let l1 = fluree.ledger(ledger_id).await.expect("reload after t=1");
 
     // t=2: retract every ns:legacyFlag triple — no replacement value.
@@ -118,9 +152,34 @@ async fn seed_fully_retracted_ledger(
         "delete": {"@id": "?inv", "ns:legacyFlag": "?flag"}
     });
     let l2 = fluree.update(l1, &tx2).await.expect("tx2").ledger;
-    support::rebuild_and_publish_index(fluree, ledger_id).await;
+    strategy.publish(fluree, ledger_id).await;
     fluree.ledger(ledger_id).await.expect("reload after t=2");
     l2
+}
+
+async fn seed_fully_retracted_ledger(
+    fluree: &fluree_db_api::Fluree,
+    ledger_id: &str,
+) -> fluree_db_api::LedgerState {
+    seed_fully_retracted_ledger_with(fluree, ledger_id, IndexStrategy::FullRebuild, 5).await
+}
+
+/// Run a SPARQL SELECT and return the raw JSON-LD row array.
+async fn run_rows(fluree: &fluree_db_api::Fluree, sparql: &str) -> Vec<JsonValue> {
+    fluree
+        .query_from()
+        .sparql(sparql)
+        .format(fluree_db_api::FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .unwrap_or_else(|e| panic!("sparql should succeed: {e}\n{sparql}"))
+        .as_array()
+        .expect("array result")
+        .clone()
+}
+
+async fn run_row_count(fluree: &fluree_db_api::Fluree, sparql: &str) -> usize {
+    run_rows(fluree, sparql).await.len()
 }
 
 async fn run_count_sparql(fluree: &fluree_db_api::Fluree, sparql: &str) -> i64 {
@@ -263,15 +322,13 @@ async fn time_travel_type_plus_group_by_property_respects_t() {
 /// is fully retracted with no replacement. Historical queries at t=1
 /// must still see the flag, queries at t=2 must not.
 ///
-/// Note: a *full* `rebuild_index_from_commits` of this small ledger does
-/// not actually produce a `row_count == 0` (empty-after-retract) leaflet
-/// — the rebuild path just omits the predicate from the t=2 index. The
-/// specific empty-leaflet+sidecar shape is covered by
-/// `replay_at_t_reconstructs_empty_after_retract_leaflet` in
-/// `fluree-db-binary-index/src/read/replay.rs`, and the four batched
-/// probe sites + the cursor were updated to not pre-skip those leaflets.
-/// Even so, this end-to-end test locks in the post-retract time-travel
-/// behavior at the SPARQL surface.
+/// The three variants after the original two-triple star are the meaning-
+/// preserving edits that used to flip this test from 5 to 0: a null
+/// `FILTER`, putting the retracted predicate first, and dropping the
+/// `rdf:type` anchor. Each one moves the query off `PropertyJoinOperator`,
+/// which is the only lane that reached the retracted rows while the
+/// full-rebuild builder was dropping their partition. They are pinned here
+/// so this test gates the storage invariant rather than one plan shape.
 #[tokio::test]
 async fn time_travel_fully_retracted_leaflet_respects_t() {
     assert_index_defaults();
@@ -337,6 +394,287 @@ async fn time_travel_fully_retracted_leaflet_respects_t() {
         Some(5),
         "at t=1 group-by must see all 5 retracted-since flags; got {jsonld}"
     );
+
+    // Edit 1: add a semantically-null FILTER. `isIRI(?inv)` cannot change the
+    // answer — but it stops the block being triples-only, so the star no
+    // longer fuses into PropertyJoinOperator.
+    let q_filter = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT (COUNT(?inv) AS ?n)
+          FROM <{ledger_id}@t:1>
+          WHERE {{ ?inv a ns:Invoice ; ns:legacyFlag "true" . FILTER(isIRI(?inv)) }}"#
+    );
+    assert_eq!(
+        run_count_sparql(&fluree, &q_filter).await,
+        5,
+        "a null FILTER must not change the answer"
+    );
+
+    // Edit 2: put the retracted predicate first, so it becomes the driver.
+    let q_flag_first = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT (COUNT(?inv) AS ?n)
+          FROM <{ledger_id}@t:1>
+          WHERE {{ ?inv ns:legacyFlag "true" ; ns:status "paid" }}"#
+    );
+    assert_eq!(
+        run_count_sparql(&fluree, &q_flag_first).await,
+        5,
+        "triple order must not change the answer"
+    );
+
+    // Edit 3: drop the rdf:type anchor entirely — a plain single-triple scan.
+    let q_plain = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT (COUNT(?inv) AS ?n)
+          FROM <{ledger_id}@t:1>
+          WHERE {{ ?inv ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(
+        run_count_sparql(&fluree, &q_plain).await,
+        5,
+        "a plain scan of a fully-retracted predicate must replay its history"
+    );
+}
+
+/// Every query shape the fully-retracted fixture can be read through, under
+/// every index strategy.
+///
+/// Before the full-rebuild fix, eight of these ten cells were wrong under
+/// `FullRebuild` and every cell was correct under `Incremental` and
+/// `NoveltyOnly` — the builder dropped the predicate's partition because it
+/// had no live rows, and only `PropertyJoinOperator`'s batched subject probe
+/// reached the surviving SPOT sidecars. Running the whole grid keeps the
+/// two correct writers pinned as controls while the third is changed.
+async fn assert_fully_retracted_shapes(strategy: IndexStrategy, ledger_id: &str) {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let _ledger = seed_fully_retracted_ledger_with(&fluree, ledger_id, strategy, 5).await;
+    let ctx = format!("strategy {strategy:?}");
+
+    let prefix = "PREFIX ns: <http://example.org/ns#>";
+
+    // 1. Single triple, bound object.
+    let q = format!(
+        r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
+           WHERE {{ ?inv ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: single triple, bound object");
+
+    // 2. Single triple, var object — and the value must be the real one.
+    let q = format!(
+        r"{prefix} SELECT ?inv ?f FROM <{ledger_id}@t:1>
+           WHERE {{ ?inv ns:legacyFlag ?f }}"
+    );
+    let rows = run_rows(&fluree, &q).await;
+    assert_eq!(rows.len(), 5, "{ctx}: single triple, var object");
+    assert!(
+        rows.iter()
+            .all(|r| r.as_array().and_then(|a| a[1].as_str()) == Some("true")),
+        "{ctx}: var object must bind the historical value; got {rows:?}"
+    );
+
+    // 3. COUNT over the single triple.
+    let q = format!(
+        r#"{prefix} SELECT (COUNT(?inv) AS ?n) FROM <{ledger_id}@t:1>
+           WHERE {{ ?inv ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_count_sparql(&fluree, &q).await, 5, "{ctx}: COUNT over single triple");
+
+    // 4. Type-anchored 2-star (the property-join lane).
+    let q = format!(
+        r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
+           WHERE {{ ?inv a ns:Invoice ; ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: type-anchored 2-star");
+
+    // 5. Same 2-star plus a null FILTER.
+    let q = format!(
+        r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
+           WHERE {{ ?inv a ns:Invoice ; ns:legacyFlag "true" . FILTER(isIRI(?inv)) }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: 2-star + null FILTER");
+
+    // 6. Flag-first 2-star.
+    let q = format!(
+        r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
+           WHERE {{ ?inv ns:legacyFlag "true" ; ns:status "paid" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: flag-first 2-star");
+
+    // 7. OPTIONAL — the worst presentation: pre-fix this returned 5 rows with
+    //    ?f unbound, which reads as a truthful "the flag did not exist at t=1".
+    let q = format!(
+        r"{prefix} SELECT ?inv ?f FROM <{ledger_id}@t:1>
+           WHERE {{ ?inv a ns:Invoice . OPTIONAL {{ ?inv ns:legacyFlag ?f }} }}"
+    );
+    let rows = run_rows(&fluree, &q).await;
+    assert_eq!(rows.len(), 5, "{ctx}: OPTIONAL row count");
+    let bound = rows
+        .iter()
+        .filter(|r| r.as_array().and_then(|a| a[1].as_str()) == Some("true"))
+        .count();
+    assert_eq!(
+        bound, 5,
+        "{ctx}: OPTIONAL must bind ?f for all 5 invoices at t=1, not report null; got {rows:?}"
+    );
+
+    // 8. FILTER EXISTS.
+    let q = format!(
+        r"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
+           WHERE {{ ?inv a ns:Invoice . FILTER EXISTS {{ ?inv ns:legacyFlag ?f }} }}"
+    );
+    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: FILTER EXISTS");
+
+    // 9. Live-predicate control — must be unaffected in every cell.
+    let q = format!(
+        r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
+           WHERE {{ ?inv ns:status "paid" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: live-predicate control");
+
+    // 10. Current state: the predicate really is gone at t=2.
+    let q = format!(
+        r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:2>
+           WHERE {{ ?inv ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q).await, 0, "{ctx}: current state must be empty");
+
+    // 11. Latest (no @t) must also stay empty — the preserved zero-row
+    //     partition must never resurrect rows outside a replay.
+    let q = format!(
+        r#"{prefix} SELECT ?inv FROM <{ledger_id}>
+           WHERE {{ ?inv ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q).await, 0, "{ctx}: latest must be empty");
+}
+
+#[tokio::test]
+async fn fully_retracted_shapes_full_rebuild() {
+    assert_fully_retracted_shapes(IndexStrategy::FullRebuild, "tt-matrix-full:main").await;
+}
+
+#[tokio::test]
+async fn fully_retracted_shapes_incremental() {
+    assert_fully_retracted_shapes(IndexStrategy::Incremental, "tt-matrix-incr:main").await;
+}
+
+#[tokio::test]
+async fn fully_retracted_shapes_novelty_only() {
+    assert_fully_retracted_shapes(IndexStrategy::NoveltyOnly, "tt-matrix-novelty:main").await;
+}
+
+/// Membership-join sized fixture: 300 subjects clears
+/// `MEMBERSHIP_JOIN_MIN_DRIVING` (256), so the driving side takes the
+/// membership-join lane rather than the nested-loop one. The defect is a
+/// build-side absence, so the mechanism predicts this lane fails too — pin
+/// that it does not.
+#[tokio::test]
+async fn time_travel_fully_retracted_membership_join_sized() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-membership:main";
+    let _ledger =
+        seed_fully_retracted_ledger_with(&fluree, ledger_id, IndexStrategy::FullRebuild, 300).await;
+
+    let q = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT ?inv FROM <{ledger_id}@t:1>
+          WHERE {{ ?inv a ns:Invoice ; ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q).await, 300, "membership-join lane at t=1");
+
+    let q_plain = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT ?inv FROM <{ledger_id}@t:1>
+          WHERE {{ ?inv ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q_plain).await, 300, "plain scan at t=1");
+}
+
+/// Partial retraction bounds the blast radius: when only some of a
+/// predicate's rows are retracted the partition survives on its remaining
+/// live rows, so this shape was already correct. Pinned as a control so a
+/// future change to the emission rule cannot quietly break it.
+#[tokio::test]
+async fn time_travel_partially_retracted_predicate_respects_t() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-partial:main";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    let mut invoices = Vec::with_capacity(5);
+    for i in 0..5 {
+        invoices.push(json!({
+            "@id": format!("ns:Invoice/inv-{i:02}"),
+            "@type": "ns:Invoice",
+            "ns:status": "paid",
+            "ns:legacyFlag": "true",
+        }));
+    }
+    let tx1 = json!({"@context": ctx(), "@graph": invoices});
+    let _ = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let l1 = fluree.ledger(ledger_id).await.expect("reload after t=1");
+
+    // Retract the flag from two of the five.
+    let tx2 = json!({
+        "@context": ctx(),
+        "where": {"@id": "?inv", "ns:legacyFlag": "?flag"},
+        "values": ["?inv", [{"@value": "ns:Invoice/inv-00", "@type": "@id"},
+                            {"@value": "ns:Invoice/inv-01", "@type": "@id"}]],
+        "delete": {"@id": "?inv", "ns:legacyFlag": "?flag"}
+    });
+    let _ = fluree.update(l1, &tx2).await.expect("tx2");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    fluree.ledger(ledger_id).await.expect("reload after t=2");
+
+    let q_t1 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT ?inv FROM <{ledger_id}@t:1>
+          WHERE {{ ?inv ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q_t1).await, 5, "all 5 carried the flag at t=1");
+
+    let q_t2 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT ?inv FROM <{ledger_id}@t:2>
+          WHERE {{ ?inv ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q_t2).await, 3, "3 still carry the flag at t=2");
+}
+
+/// Remediation story for indexes already damaged by an older binary: a
+/// rebuild reads the commit chain from genesis and never the previous
+/// index's leaves, so re-running `reindex` with a fixed binary reconstructs
+/// the missing partitions. Pinned by rebuilding a second time over an
+/// already-published index and re-asserting the historical read.
+#[tokio::test]
+async fn repeat_full_rebuild_restores_retracted_history() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-reindex-again:main";
+    let _ledger = seed_fully_retracted_ledger(&fluree, ledger_id).await;
+
+    let q = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT ?inv FROM <{ledger_id}@t:1>
+          WHERE {{ ?inv ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q).await, 5, "first rebuild");
+
+    // A second reindex over the already-published index — the user-facing
+    // remediation for a ledger indexed by an older binary.
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    fluree.ledger(ledger_id).await.expect("reload after reindex");
+    assert_eq!(run_row_count(&fluree, &q).await, 5, "reindex again");
+
+    let q_t2 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT ?inv FROM <{ledger_id}@t:2>
+          WHERE {{ ?inv ns:legacyFlag "true" }}"#
+    );
+    assert_eq!(run_row_count(&fluree, &q_t2).await, 0, "t=2 stays empty after reindex");
 }
 
 /// Microbench: compare latest vs historical batched-probe timing.
@@ -608,4 +946,60 @@ async fn time_travel_property_join_spot_walk_respects_t() {
         approved_at_t2, 0,
         "at t=2 no invoice is 'approved' anymore; got {jsonld_t2}"
     );
+}
+
+/// A fully-retracted *subject* is the SPOT-order analogue of the
+/// fully-retracted predicate: at t=2 the entity is gone entirely, so no
+/// leaflet in the primary order materializes a row for it. Its transitions
+/// still ride along in a neighbouring leaflet's sidecar, but the leaf's
+/// routing keys stop at the last live record — so branch-level leaf
+/// selection can miss it.
+#[tokio::test]
+async fn time_travel_fully_retracted_subject_respects_t() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-dead-subject:main";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    let mut invoices = Vec::with_capacity(5);
+    for i in 0..5 {
+        invoices.push(json!({
+            "@id": format!("ns:Invoice/inv-{i:02}"),
+            "@type": "ns:Invoice",
+            "ns:status": "paid",
+            "ns:legacyFlag": "true",
+        }));
+    }
+    let tx1 = json!({"@context": ctx(), "@graph": invoices});
+    let _ = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let l1 = fluree.ledger(ledger_id).await.expect("reload after t=1");
+
+    // Delete every triple of the highest-sorting invoice.
+    let tx2 = json!({
+        "@context": ctx(),
+        "where": {"@id": "ns:Invoice/inv-04", "?p": "?o"},
+        "delete": {"@id": "ns:Invoice/inv-04", "?p": "?o"}
+    });
+    let _ = fluree.update(l1, &tx2).await.expect("tx2");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    fluree.ledger(ledger_id).await.expect("reload after t=2");
+
+    let q_t1 = format!(
+        r"PREFIX ns: <http://example.org/ns#>
+          SELECT ?p ?o FROM <{ledger_id}@t:1>
+          WHERE {{ <http://example.org/ns#Invoice/inv-04> ?p ?o }}"
+    );
+    assert_eq!(
+        run_row_count(&fluree, &q_t1).await,
+        3,
+        "at t=1 the deleted invoice still had @type, status and legacyFlag"
+    );
+
+    let q_t2 = format!(
+        r"PREFIX ns: <http://example.org/ns#>
+          SELECT ?p ?o FROM <{ledger_id}@t:2>
+          WHERE {{ <http://example.org/ns#Invoice/inv-04> ?p ?o }}"
+    );
+    assert_eq!(run_row_count(&fluree, &q_t2).await, 0, "gone at t=2");
 }

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -1131,3 +1131,54 @@ async fn rebuild_cost_of_retracted_partitions() {
     println!("leaves:      {}", result.stats.leaf_count);
     println!("total_bytes: {}", result.stats.total_bytes);
 }
+
+/// Degenerate edge: every fact in the ledger is retracted, so no order has a
+/// single live row and every leaflet the rebuild emits is a zero-row one.
+/// The leaf and branch assembly must still produce a routable index, and the
+/// whole t=1 state must remain readable.
+#[tokio::test]
+async fn time_travel_after_everything_is_retracted() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-all-gone:main";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    let tx1 = json!({"@context": ctx(), "@graph": [
+        {"@id": "ns:Invoice/inv-00", "@type": "ns:Invoice", "ns:status": "paid"},
+        {"@id": "ns:Invoice/inv-01", "@type": "ns:Invoice", "ns:status": "paid"},
+    ]});
+    let _ = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let l1 = fluree.ledger(ledger_id).await.expect("reload after t=1");
+
+    let tx2 = json!({
+        "@context": ctx(),
+        "where": {"@id": "?s", "?p": "?o"},
+        "delete": {"@id": "?s", "?p": "?o"}
+    });
+    let _ = fluree.update(l1, &tx2).await.expect("tx2");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    fluree.ledger(ledger_id).await.expect("reload after t=2");
+
+    let q_t1 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT ?inv FROM <{ledger_id}@t:1>
+          WHERE {{ ?inv ns:status "paid" }}"#
+    );
+    assert_eq!(
+        run_row_count(&fluree, &q_t1).await,
+        2,
+        "t=1 state survives an empty index"
+    );
+
+    let q_t2 = format!(
+        r#"PREFIX ns: <http://example.org/ns#>
+          SELECT ?inv FROM <{ledger_id}@t:2>
+          WHERE {{ ?inv ns:status "paid" }}"#
+    );
+    assert_eq!(
+        run_row_count(&fluree, &q_t2).await,
+        0,
+        "nothing left at t=2"
+    );
+}

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -459,7 +459,11 @@ async fn assert_fully_retracted_shapes(strategy: IndexStrategy, ledger_id: &str)
         r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
            WHERE {{ ?inv ns:legacyFlag "true" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: single triple, bound object");
+    assert_eq!(
+        run_row_count(&fluree, &q).await,
+        5,
+        "{ctx}: single triple, bound object"
+    );
 
     // 2. Single triple, var object — and the value must be the real one.
     let q = format!(
@@ -479,28 +483,44 @@ async fn assert_fully_retracted_shapes(strategy: IndexStrategy, ledger_id: &str)
         r#"{prefix} SELECT (COUNT(?inv) AS ?n) FROM <{ledger_id}@t:1>
            WHERE {{ ?inv ns:legacyFlag "true" }}"#
     );
-    assert_eq!(run_count_sparql(&fluree, &q).await, 5, "{ctx}: COUNT over single triple");
+    assert_eq!(
+        run_count_sparql(&fluree, &q).await,
+        5,
+        "{ctx}: COUNT over single triple"
+    );
 
     // 4. Type-anchored 2-star (the property-join lane).
     let q = format!(
         r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
            WHERE {{ ?inv a ns:Invoice ; ns:legacyFlag "true" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: type-anchored 2-star");
+    assert_eq!(
+        run_row_count(&fluree, &q).await,
+        5,
+        "{ctx}: type-anchored 2-star"
+    );
 
     // 5. Same 2-star plus a null FILTER.
     let q = format!(
         r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
            WHERE {{ ?inv a ns:Invoice ; ns:legacyFlag "true" . FILTER(isIRI(?inv)) }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: 2-star + null FILTER");
+    assert_eq!(
+        run_row_count(&fluree, &q).await,
+        5,
+        "{ctx}: 2-star + null FILTER"
+    );
 
     // 6. Flag-first 2-star.
     let q = format!(
         r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
            WHERE {{ ?inv ns:legacyFlag "true" ; ns:status "paid" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: flag-first 2-star");
+    assert_eq!(
+        run_row_count(&fluree, &q).await,
+        5,
+        "{ctx}: flag-first 2-star"
+    );
 
     // 7. OPTIONAL — the worst presentation: pre-fix this returned 5 rows with
     //    ?f unbound, which reads as a truthful "the flag did not exist at t=1".
@@ -531,14 +551,22 @@ async fn assert_fully_retracted_shapes(strategy: IndexStrategy, ledger_id: &str)
         r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:1>
            WHERE {{ ?inv ns:status "paid" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q).await, 5, "{ctx}: live-predicate control");
+    assert_eq!(
+        run_row_count(&fluree, &q).await,
+        5,
+        "{ctx}: live-predicate control"
+    );
 
     // 10. Current state: the predicate really is gone at t=2.
     let q = format!(
         r#"{prefix} SELECT ?inv FROM <{ledger_id}@t:2>
            WHERE {{ ?inv ns:legacyFlag "true" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q).await, 0, "{ctx}: current state must be empty");
+    assert_eq!(
+        run_row_count(&fluree, &q).await,
+        0,
+        "{ctx}: current state must be empty"
+    );
 
     // 11. Latest (no @t) must also stay empty — the preserved zero-row
     //     partition must never resurrect rows outside a replay.
@@ -546,7 +574,11 @@ async fn assert_fully_retracted_shapes(strategy: IndexStrategy, ledger_id: &str)
         r#"{prefix} SELECT ?inv FROM <{ledger_id}>
            WHERE {{ ?inv ns:legacyFlag "true" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q).await, 0, "{ctx}: latest must be empty");
+    assert_eq!(
+        run_row_count(&fluree, &q).await,
+        0,
+        "{ctx}: latest must be empty"
+    );
 }
 
 #[tokio::test]
@@ -582,14 +614,22 @@ async fn time_travel_fully_retracted_membership_join_sized() {
           SELECT ?inv FROM <{ledger_id}@t:1>
           WHERE {{ ?inv a ns:Invoice ; ns:legacyFlag "true" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q).await, 300, "membership-join lane at t=1");
+    assert_eq!(
+        run_row_count(&fluree, &q).await,
+        300,
+        "membership-join lane at t=1"
+    );
 
     let q_plain = format!(
         r#"PREFIX ns: <http://example.org/ns#>
           SELECT ?inv FROM <{ledger_id}@t:1>
           WHERE {{ ?inv ns:legacyFlag "true" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q_plain).await, 300, "plain scan at t=1");
+    assert_eq!(
+        run_row_count(&fluree, &q_plain).await,
+        300,
+        "plain scan at t=1"
+    );
 }
 
 /// Partial retraction bounds the blast radius: when only some of a
@@ -634,14 +674,22 @@ async fn time_travel_partially_retracted_predicate_respects_t() {
           SELECT ?inv FROM <{ledger_id}@t:1>
           WHERE {{ ?inv ns:legacyFlag "true" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q_t1).await, 5, "all 5 carried the flag at t=1");
+    assert_eq!(
+        run_row_count(&fluree, &q_t1).await,
+        5,
+        "all 5 carried the flag at t=1"
+    );
 
     let q_t2 = format!(
         r#"PREFIX ns: <http://example.org/ns#>
           SELECT ?inv FROM <{ledger_id}@t:2>
           WHERE {{ ?inv ns:legacyFlag "true" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q_t2).await, 3, "3 still carry the flag at t=2");
+    assert_eq!(
+        run_row_count(&fluree, &q_t2).await,
+        3,
+        "3 still carry the flag at t=2"
+    );
 }
 
 /// Remediation story for indexes already damaged by an older binary: a
@@ -666,7 +714,10 @@ async fn repeat_full_rebuild_restores_retracted_history() {
     // A second reindex over the already-published index — the user-facing
     // remediation for a ledger indexed by an older binary.
     support::rebuild_and_publish_index(&fluree, ledger_id).await;
-    fluree.ledger(ledger_id).await.expect("reload after reindex");
+    fluree
+        .ledger(ledger_id)
+        .await
+        .expect("reload after reindex");
     assert_eq!(run_row_count(&fluree, &q).await, 5, "reindex again");
 
     let q_t2 = format!(
@@ -674,7 +725,11 @@ async fn repeat_full_rebuild_restores_retracted_history() {
           SELECT ?inv FROM <{ledger_id}@t:2>
           WHERE {{ ?inv ns:legacyFlag "true" }}"#
     );
-    assert_eq!(run_row_count(&fluree, &q_t2).await, 0, "t=2 stays empty after reindex");
+    assert_eq!(
+        run_row_count(&fluree, &q_t2).await,
+        0,
+        "t=2 stays empty after reindex"
+    );
 }
 
 /// Microbench: compare latest vs historical batched-probe timing.
@@ -1002,4 +1057,77 @@ async fn time_travel_fully_retracted_subject_respects_t() {
           WHERE {{ <http://example.org/ns#Invoice/inv-04> ?p ?o }}"
     );
     assert_eq!(run_row_count(&fluree, &q_t2).await, 0, "gone at t=2");
+}
+
+/// Measurement: what preserving the zero-row partitions costs a rebuild.
+///
+/// Run with: `cargo test -p fluree-db-api --features native --test
+/// grp_query_history -- --ignored --nocapture rebuild_cost_of_retracted`.
+///
+/// 200 subjects carry 60 predicates each; 50 of the 60 are then retracted
+/// outright, so the rebuild must emit 50 zero-row partitions per
+/// predicate-keyed order. Reports the same numbers on either side of the
+/// fix so the delta is the emission's cost and nothing else.
+#[tokio::test]
+#[ignore]
+async fn rebuild_cost_of_retracted_partitions() {
+    use std::time::Instant;
+
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-rebuild-cost:main";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    const SUBJECTS: usize = 200;
+    const PREDICATES: usize = 60;
+    const RETRACTED: usize = 50;
+
+    let mut subjects = Vec::with_capacity(SUBJECTS);
+    for s in 0..SUBJECTS {
+        let mut node = serde_json::Map::new();
+        node.insert("@id".into(), json!(format!("ns:Thing/s-{s:04}")));
+        node.insert("@type".into(), json!("ns:Thing"));
+        for p in 0..PREDICATES {
+            node.insert(format!("ns:p{p:03}"), json!(format!("v-{s}-{p}")));
+        }
+        subjects.push(JsonValue::Object(node));
+    }
+    let tx1 = json!({"@context": ctx(), "@graph": subjects});
+    let _ = fluree.insert(ledger0, &tx1).await.expect("tx1");
+
+    let mut ledger = fluree.ledger(ledger_id).await.expect("reload");
+    for p in 0..RETRACTED {
+        let tx = json!({
+            "@context": ctx(),
+            "where": {"@id": "?s", format!("ns:p{p:03}"): "?o"},
+            "delete": {"@id": "?s", format!("ns:p{p:03}"): "?o"}
+        });
+        ledger = fluree.update(ledger, &tx).await.expect("retract").ledger;
+    }
+
+    let record = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .expect("lookup")
+        .expect("record");
+    let start = Instant::now();
+    let result = fluree_db_indexer::rebuild_index_from_commits(
+        fluree.content_store(ledger_id),
+        ledger_id,
+        &record,
+        fluree_db_indexer::IndexerConfig::default(),
+    )
+    .await
+    .expect("rebuild");
+    let elapsed = start.elapsed();
+
+    println!(
+        "\n--- rebuild cost ({SUBJECTS} subjects x {PREDICATES} predicates, \
+         {RETRACTED} fully retracted) ---"
+    );
+    println!("elapsed:     {:.3} s", elapsed.as_secs_f64());
+    println!("flakes:      {}", result.stats.flake_count);
+    println!("leaves:      {}", result.stats.leaf_count);
+    println!("total_bytes: {}", result.stats.total_bytes);
 }

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -1275,3 +1275,59 @@ async fn history_range_over_fully_retracted_predicate() {
         "5 asserts at t=1 and 5 retracts at t=2; got {rows:#?}"
     );
 }
+
+/// End-to-end flow across all three generations: rebuild, retract-all
+/// rebuild, then an incremental index on top of the preserved zero-row
+/// partition. Historical reads at each `t` must stay correct throughout.
+///
+/// The storage-level version of this seam — where a rebuild-emitted
+/// zero-row partition is merged into directly — is pinned deterministically
+/// by `test_update_into_rebuild_emitted_empty_partition` in the indexer.
+/// This test does not by itself reach `merge_and_encode_leaflet`: it passes
+/// with or without that function's `row_count == 0` guard, so treat it as
+/// flow coverage rather than as the guard's regression test.
+#[tokio::test]
+async fn incremental_merges_into_a_rebuilt_zero_row_partition() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-rebuild-then-incremental:main";
+
+    // t=1 and t=2: the full-rebuild fixture, leaving ns:legacyFlag with a
+    // preserved but zero-row partition in the published index.
+    let _ledger = seed_fully_retracted_ledger(&fluree, ledger_id).await;
+    let l2 = fluree.ledger(ledger_id).await.expect("reload after t=2");
+
+    // t=3: re-assert the predicate on two invoices, then index INCREMENTALLY
+    // so novelty routes back into the rebuild's zero-row partition.
+    let tx3 = json!({"@context": ctx(), "@graph": [
+        {"@id": "ns:Invoice/inv-0000", "ns:legacyFlag": "true"},
+        {"@id": "ns:Invoice/inv-0001", "ns:legacyFlag": "true"},
+    ]});
+    let _ = fluree.insert(l2, &tx3).await.expect("tx3");
+    support::build_and_publish_index(&fluree, ledger_id).await;
+    fluree.ledger(ledger_id).await.expect("reload after t=3");
+
+    let flags_at = |t: u32| {
+        format!(
+            r#"PREFIX ns: <http://example.org/ns#>
+              SELECT ?inv FROM <{ledger_id}@t:{t}>
+              WHERE {{ ?inv ns:legacyFlag "true" }}"#
+        )
+    };
+
+    assert_eq!(
+        run_row_count(&fluree, &flags_at(1)).await,
+        5,
+        "t=1 still replays from the preserved partition"
+    );
+    assert_eq!(
+        run_row_count(&fluree, &flags_at(2)).await,
+        0,
+        "t=2 is still the fully-retracted state"
+    );
+    assert_eq!(
+        run_row_count(&fluree, &flags_at(3)).await,
+        2,
+        "t=3 sees the two re-asserted flags"
+    );
+}

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -1331,3 +1331,70 @@ async fn incremental_merges_into_a_rebuilt_zero_row_partition() {
         "t=3 sees the two re-asserted flags"
     );
 }
+
+/// The deleted-entity case carried through a later incremental update.
+///
+/// A rebuild widens the routing keys so the deleted subject stays reachable,
+/// but the leaf header is re-derived from leaflet keys on the next
+/// incremental (`build_leaf_from_group` → `update_branch` → the branch
+/// entry). If only the header carried the bound, the first incremental after
+/// the rebuild would silently narrow it and the entity would vanish from
+/// `@t:1` again.
+#[tokio::test]
+async fn time_travel_fully_retracted_subject_survives_later_incremental() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "tt-dead-subject-incr:main";
+    let ledger0 = genesis_ledger(&fluree, ledger_id);
+
+    let mut invoices = Vec::with_capacity(5);
+    for i in 0..5 {
+        invoices.push(json!({
+            "@id": format!("ns:Invoice/inv-{i:02}"),
+            "@type": "ns:Invoice",
+            "ns:status": "paid",
+        }));
+    }
+    let tx1 = json!({"@context": ctx(), "@graph": invoices});
+    let _ = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let l1 = fluree.ledger(ledger_id).await.expect("reload after t=1");
+
+    // t=2: delete the highest-sorting invoice outright, then rebuild.
+    let tx2 = json!({
+        "@context": ctx(),
+        "where": {"@id": "ns:Invoice/inv-04", "?p": "?o"},
+        "delete": {"@id": "ns:Invoice/inv-04", "?p": "?o"}
+    });
+    let l2 = fluree.update(l1, &tx2).await.expect("tx2").ledger;
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    fluree.ledger(ledger_id).await.expect("reload after t=2");
+
+    let q_t1 = format!(
+        r"PREFIX ns: <http://example.org/ns#>
+          SELECT ?p ?o FROM <{ledger_id}@t:1>
+          WHERE {{ <http://example.org/ns#Invoice/inv-04> ?p ?o }}"
+    );
+    assert_eq!(
+        run_row_count(&fluree, &q_t1).await,
+        2,
+        "reachable after the rebuild"
+    );
+
+    // t=3: any unrelated write, indexed INCREMENTALLY.
+    let tx3 = json!({
+        "@context": ctx(),
+        "where": {"@id": "ns:Invoice/inv-00", "ns:status": "?s"},
+        "delete": {"@id": "ns:Invoice/inv-00", "ns:status": "?s"},
+        "insert": {"@id": "ns:Invoice/inv-00", "ns:status": "void"}
+    });
+    let _ = fluree.update(l2, &tx3).await.expect("tx3");
+    support::build_and_publish_index(&fluree, ledger_id).await;
+    fluree.ledger(ledger_id).await.expect("reload after t=3");
+
+    assert_eq!(
+        run_row_count(&fluree, &q_t1).await,
+        2,
+        "the deleted entity must still be reachable at t=1 after an incremental"
+    );
+}

--- a/fluree-db-api/tests/it_query_time_travel_bgp.rs
+++ b/fluree-db-api/tests/it_query_time_travel_bgp.rs
@@ -1074,13 +1074,36 @@ async fn rebuild_cost_of_retracted_partitions() {
     use std::time::Instant;
 
     assert_index_defaults();
-    let fluree = FlureeBuilder::memory().build_memory();
-    let ledger_id = "tt-rebuild-cost:main";
-    let ledger0 = genesis_ledger(&fluree, ledger_id);
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let store_path = tmp.path().to_str().unwrap();
+    let fluree = FlureeBuilder::file(store_path).build().expect("build");
+    let ledger_id = "cost/rebuild:main";
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("create");
 
     const SUBJECTS: usize = 200;
     const PREDICATES: usize = 60;
     const RETRACTED: usize = 50;
+    const REPS: u32 = 5;
+
+    /// Total bytes of every file under `dir`, recursively.
+    fn dir_bytes(dir: &std::path::Path) -> u64 {
+        let mut total = 0;
+        let mut stack = vec![dir.to_path_buf()];
+        while let Some(d) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&d) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let Ok(meta) = entry.metadata() else { continue };
+                if meta.is_dir() {
+                    stack.push(entry.path());
+                } else {
+                    total += meta.len();
+                }
+            }
+        }
+        total
+    }
 
     let mut subjects = Vec::with_capacity(SUBJECTS);
     for s in 0..SUBJECTS {
@@ -1093,9 +1116,9 @@ async fn rebuild_cost_of_retracted_partitions() {
         subjects.push(JsonValue::Object(node));
     }
     let tx1 = json!({"@context": ctx(), "@graph": subjects});
-    let _ = fluree.insert(ledger0, &tx1).await.expect("tx1");
+    let r1 = fluree.insert(ledger0, &tx1).await.expect("tx1");
 
-    let mut ledger = fluree.ledger(ledger_id).await.expect("reload");
+    let mut ledger = r1.ledger;
     for p in 0..RETRACTED {
         let tx = json!({
             "@context": ctx(),
@@ -1105,31 +1128,63 @@ async fn rebuild_cost_of_retracted_partitions() {
         ledger = fluree.update(ledger, &tx).await.expect("retract").ledger;
     }
 
+    // Commits only from here on: the delta across a rebuild is exactly the
+    // index artifacts it writes (leaves, sidecars, branches, root).
+    let before = dir_bytes(tmp.path());
     let record = fluree
         .nameservice()
         .lookup(ledger_id)
         .await
         .expect("lookup")
         .expect("record");
-    let start = Instant::now();
-    let result = fluree_db_indexer::rebuild_index_from_commits(
-        fluree.content_store(ledger_id),
-        ledger_id,
-        &record,
-        fluree_db_indexer::IndexerConfig::default(),
-    )
-    .await
-    .expect("rebuild");
-    let elapsed = start.elapsed();
+
+    let mut times = Vec::with_capacity(REPS as usize);
+    let mut result = None;
+    let mut after_first = 0u64;
+    let mut roots = Vec::with_capacity(REPS as usize);
+    for rep in 0..REPS {
+        let start = Instant::now();
+        let r = fluree_db_indexer::rebuild_index_from_commits(
+            fluree.content_store(ledger_id),
+            ledger_id,
+            &record,
+            fluree_db_indexer::IndexerConfig::default(),
+        )
+        .await
+        .expect("rebuild");
+        times.push(start.elapsed());
+        roots.push(r.root_id.to_string());
+        result = Some(r);
+        if rep == 0 {
+            after_first = dir_bytes(tmp.path());
+        }
+    }
+    // A reproducible rebuild is content-addressed to the same bytes, so
+    // repeating it must not grow the store. Report both so a divergence
+    // between the two numbers shows up as nondeterminism rather than size.
+    let one_index_bytes = after_first - before;
+    let all_reps_bytes = dir_bytes(tmp.path()) - before;
+    times.sort_unstable();
+    let result = result.expect("at least one rebuild");
+    let distinct_roots = roots
+        .iter()
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
 
     println!(
         "\n--- rebuild cost ({SUBJECTS} subjects x {PREDICATES} predicates, \
-         {RETRACTED} fully retracted) ---"
+         {RETRACTED} fully retracted, {REPS} reps) ---"
     );
-    println!("elapsed:     {:.3} s", elapsed.as_secs_f64());
-    println!("flakes:      {}", result.stats.flake_count);
-    println!("leaves:      {}", result.stats.leaf_count);
-    println!("total_bytes: {}", result.stats.total_bytes);
+    println!(
+        "median:         {:.3} s",
+        times[times.len() / 2].as_secs_f64()
+    );
+    println!("min:            {:.3} s", times[0].as_secs_f64());
+    println!("flakes:         {}", result.stats.flake_count);
+    println!("leaves:         {}", result.stats.leaf_count);
+    println!("one_index_bytes: {one_index_bytes}");
+    println!("all_reps_bytes:  {all_reps_bytes}");
+    println!("distinct_roots:  {distinct_roots} of {REPS}");
 }
 
 /// Degenerate edge: every fact in the ledger is retracted, so no order has a

--- a/fluree-db-binary-index/src/format/leaf.rs
+++ b/fluree-db-binary-index/src/format/leaf.rs
@@ -82,6 +82,40 @@ pub struct LeafInfo {
 
 // ── Writer ─────────────────────────────────────────────────────────────
 
+/// The value a leaflet holds constant for a given sort order. POST/PSOT
+/// leaflets are predicate-homogeneous and OPST leaflets are type-homogeneous;
+/// SPOT leaflets are unsegmented, so every row shares the one key.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SegmentKey {
+    Predicate(u32),
+    OType(u16),
+    Unsegmented,
+}
+
+impl SegmentKey {
+    fn of(order: RunSortOrder, p_id: u32, o_type: u16) -> Self {
+        match order {
+            RunSortOrder::Post | RunSortOrder::Psot => Self::Predicate(p_id),
+            RunSortOrder::Opst => Self::OType(o_type),
+            RunSortOrder::Spot => Self::Unsegmented,
+        }
+    }
+}
+
+/// The routing identity of a history entry, as a record. `t` and `g_id` are
+/// carried for completeness; neither appears in an ordered routing key.
+fn record_from_history(entry: &HistEntryV2) -> RunRecordV2 {
+    RunRecordV2 {
+        s_id: entry.s_id,
+        o_key: entry.o_key,
+        p_id: entry.p_id,
+        t: entry.t,
+        o_i: entry.o_i,
+        o_type: entry.o_type,
+        g_id: 0,
+    }
+}
+
 /// V3 leaf writer — segmentation-aware, columnar, sidecar-producing.
 pub struct LeafWriter {
     order: RunSortOrder,
@@ -179,6 +213,22 @@ impl LeafWriter {
             self.flush_leaf_if_target_reached()?;
         }
 
+        // Anything still pending belongs to a segment that ended without ever
+        // materializing a row — every one of its facts was retracted. Give each
+        // such segment its own zero-row leaflet before this record's leaflet
+        // claims the entries. Must precede the `leaf_first_record` assignment:
+        // those segments sort below this record, so they set the leaf's low
+        // routing bound when they open the leaf.
+        self.flush_history_only_segments(Some(&record))?;
+
+        // This record's transition entries (and those of any preceding
+        // non-materialized facts in the same gap) belong to the leaflet that
+        // holds this record — the current one, post any segment-boundary flush.
+        // Committed before the leaf's routing keys are taken from `record`,
+        // since those entries sort at or below it and so set the leaf's low
+        // bound when they open it.
+        self.commit_all_pending();
+
         // Track first record of the leaf.
         if self.leaf_first_record.is_none() {
             self.leaf_first_record = Some(record);
@@ -194,11 +244,6 @@ impl LeafWriter {
             }
             RunSortOrder::Spot => {}
         }
-
-        // This record's transition entries (and those of any preceding
-        // non-materialized facts in the same gap) belong to the leaflet that
-        // holds this record — the current one, post any segment-boundary flush.
-        self.commit_all_pending();
 
         self.record_buf.push(record);
         self.last_record = Some(record);
@@ -237,6 +282,27 @@ impl LeafWriter {
             self.sidecar_builder.start_leaflet();
             self.current_segment_started = true;
         }
+        // A fact whose final state is absent materializes no row, so nothing
+        // else widens the leaf's routing keys to cover it — and branch-level
+        // leaf selection drops a leaf whose range stops short of the key being
+        // probed, which is how a fully-retracted subject becomes unreadable at
+        // a historical `t`. Entries are committed in build order, so taking the
+        // latest unconditionally keeps the leaf's bounds monotonic.
+        let rec = record_from_history(&entry);
+        debug_assert!(
+            self.last_record.is_none_or(|last| {
+                let (mut prev, mut next) = ([0u8; ORDERED_KEY_V2_SIZE], [0u8; ORDERED_KEY_V2_SIZE]);
+                write_ordered_key_v2(self.order, &last, &mut prev);
+                write_ordered_key_v2(self.order, &rec, &mut next);
+                prev <= next
+            }),
+            "history entries must be committed in build order — an out-of-order \
+             entry would push the leaf's last routing key backwards"
+        );
+        if self.leaf_first_record.is_none() {
+            self.leaf_first_record = Some(rec);
+        }
+        self.last_record = Some(rec);
         self.sidecar_builder.push_entry(entry);
     }
 
@@ -296,16 +362,127 @@ impl LeafWriter {
     /// Consume the writer, flushing any remaining data, and return all
     /// produced leaves.
     pub fn finish(mut self) -> io::Result<Vec<LeafInfo>> {
-        // Trailing history (a non-materialized fact at the tail of the order)
-        // belongs to the final leaflet — commit it before the closing flush.
-        self.commit_all_pending();
         if !self.record_buf.is_empty() {
+            // Trailing history matching the buffered segment (a non-materialized
+            // fact at the tail of the order) belongs to the final leaflet —
+            // commit it before the closing flush.
+            self.commit_pending_for_current_segment();
             self.flush_leaflet()?;
         }
+        // Whatever is still pending has no leaflet left to live in: the tail of
+        // the order is made up of segments every one of whose facts was
+        // retracted. Each gets its own zero-row leaflet.
+        self.flush_history_only_segments(None)?;
         if !self.encoded_leaflets.is_empty() {
             self.flush_leaf()?;
         }
         Ok(self.completed_leaves)
+    }
+
+    /// Emit a zero-row leaflet, plus its sidecar segment, for every pending
+    /// segment that no record will ever open a leaflet for.
+    ///
+    /// A predicate whose rows have all been retracted contributes no winning
+    /// row to a rebuild, so segmentation never opens a leaflet for it and its
+    /// transitions would otherwise be filed under a neighbouring predicate's
+    /// leaflet — where a predicate-keyed reader skips them by `p_const` and
+    /// reports a silent zero at every historical `t`. Emitting the empty
+    /// leaflet restores the same shape the incremental writer preserves when a
+    /// merge empties an existing leaflet (`row_count == 0` with `history_*`
+    /// intact), which the reader already knows how to replay.
+    ///
+    /// `next` is the record about to be buffered, or `None` at `finish`.
+    /// Entries in its segment stay pending so they land in its leaflet.
+    ///
+    /// Callers must have no buffered records and no open sidecar segment, so
+    /// the emitted leaflet and its segment stay index-aligned.
+    fn flush_history_only_segments(&mut self, next: Option<&RunRecordV2>) -> io::Result<()> {
+        if self.pending_history.is_empty() {
+            return Ok(());
+        }
+        let order = self.order;
+        let next_seg = next.map(|r| SegmentKey::of(order, r.p_id, r.o_type));
+
+        let pending = std::mem::take(&mut self.pending_history);
+        let mut retained = Vec::new();
+        let mut group: Vec<HistEntryV2> = Vec::new();
+        let mut group_seg: Option<SegmentKey> = None;
+
+        // Entries arrive in the build's sort order, so a segment's entries are
+        // contiguous and the segment matching `next` (if any) comes last.
+        for entry in pending {
+            let seg = SegmentKey::of(order, entry.p_id, entry.o_type);
+            if next_seg == Some(seg) {
+                retained.push(entry);
+                continue;
+            }
+            if group_seg != Some(seg) && !group.is_empty() {
+                self.emit_history_only_leaflet(&group)?;
+                group.clear();
+            }
+            group_seg = Some(seg);
+            group.push(entry);
+        }
+        if !group.is_empty() {
+            self.emit_history_only_leaflet(&group)?;
+        }
+
+        self.pending_history = retained;
+        Ok(())
+    }
+
+    /// Append one zero-row leaflet holding `entries` as its history segment.
+    fn emit_history_only_leaflet(&mut self, entries: &[HistEntryV2]) -> io::Result<()> {
+        debug_assert!(
+            self.record_buf.is_empty() && !self.current_segment_started,
+            "history-only leaflet must not interleave with a leaflet still being \
+             accumulated — its sidecar segment would take that leaflet's index"
+        );
+        let Some(first) = entries.first().map(record_from_history) else {
+            return Ok(());
+        };
+        let last = record_from_history(entries.last().expect("non-empty"));
+
+        let mut first_key = [0u8; ORDERED_KEY_V2_SIZE];
+        let mut last_key = [0u8; ORDERED_KEY_V2_SIZE];
+        write_ordered_key_v2(self.order, &first, &mut first_key);
+        write_ordered_key_v2(self.order, &last, &mut last_key);
+
+        // Segment first, so its index matches the leaflet pushed just below.
+        self.sidecar_builder.start_leaflet();
+        for entry in entries {
+            self.sidecar_builder.push_entry(*entry);
+        }
+
+        let homogeneous_o_type = entries
+            .iter()
+            .all(|e| e.o_type == first.o_type)
+            .then_some(first.o_type);
+        self.encoded_leaflets.push(EncodedLeaflet {
+            row_count: 0,
+            lead_group_count: 0,
+            first_key,
+            last_key,
+            p_const: match self.order {
+                RunSortOrder::Post | RunSortOrder::Psot => Some(first.p_id),
+                RunSortOrder::Opst | RunSortOrder::Spot => None,
+            },
+            o_type_const: match self.order {
+                RunSortOrder::Opst => Some(first.o_type),
+                _ => homogeneous_o_type,
+            },
+            flags: 0,
+            column_refs: Vec::new(),
+            payload: Vec::new(),
+        });
+
+        // The leaf's routing keys must span this segment or branch-level leaf
+        // selection never opens the leaf that holds it.
+        if self.leaf_first_record.is_none() {
+            self.leaf_first_record = Some(first);
+        }
+        self.last_record = Some(last);
+        Ok(())
     }
 
     // ── Segmentation ───────────────────────────────────────────────────
@@ -955,5 +1132,176 @@ mod tests {
         dir.iter()
             .map(|e| 80 + e.column_refs.len() * COLUMN_BLOCK_REF_SIZE + 20)
             .sum()
+    }
+
+    fn hist(s_id: u64, p_id: u32, o_key: u64, t: u32, op: u8) -> HistEntryV2 {
+        HistEntryV2 {
+            s_id: SubjectId(s_id),
+            p_id,
+            o_type: OType::XSD_STRING.as_u16(),
+            o_key,
+            o_i: LIST_INDEX_NONE,
+            t,
+            op,
+        }
+    }
+
+    /// Read back each leaflet's sidecar entries, by directory index.
+    fn segments_of(leaf: &LeafInfo) -> Vec<Vec<HistEntryV2>> {
+        let header = decode_leaf_header_v3(&leaf.leaf_bytes).unwrap();
+        let dir = decode_leaf_dir_v3(&leaf.leaf_bytes, &header).unwrap();
+        let bytes = leaf.sidecar_bytes.as_ref().expect("sidecar");
+        dir.iter()
+            .map(|e| {
+                if e.history_len == 0 {
+                    return Vec::new();
+                }
+                let seg = HistorySegmentRef {
+                    offset: e.history_offset,
+                    len: e.history_len,
+                    min_t: e.history_min_t,
+                    max_t: e.history_max_t,
+                };
+                super::super::history_sidecar::decode_history_segment(bytes, &seg).unwrap()
+            })
+            .collect()
+    }
+
+    /// A predicate whose facts were all retracted materializes no row, so
+    /// segmentation never opens a leaflet for it. Without one, its history is
+    /// filed under the next predicate's leaflet and a predicate-keyed reader
+    /// skips it by `p_const` — the full-rebuild time-travel hole. The writer
+    /// must emit a zero-row leaflet carrying that predicate's `p_const` and
+    /// its own sidecar segment.
+    #[test]
+    fn fully_retracted_predicate_gets_its_own_zero_row_leaflet() {
+        let mut writer = LeafWriter::new(RunSortOrder::Psot, 100, 1000, 1);
+
+        // p_id=1: one live row (its assert transition is history too).
+        writer.push_history_entry(hist(1, 1, 10, 1, 1));
+        writer
+            .push_record(make_rec(1, 1, OType::XSD_STRING.as_u16(), 10, 1))
+            .unwrap();
+
+        // p_id=2: asserted at t=1, retracted at t=2 — nothing survives.
+        writer.push_history_entry(hist(1, 2, 20, 1, 1));
+        writer.push_history_entry(hist(1, 2, 20, 2, 0));
+        writer.push_history_entry(hist(2, 2, 21, 1, 1));
+        writer.push_history_entry(hist(2, 2, 21, 2, 0));
+
+        // p_id=3: one live row.
+        writer.push_history_entry(hist(1, 3, 30, 1, 1));
+        writer
+            .push_record(make_rec(1, 3, OType::XSD_STRING.as_u16(), 30, 1))
+            .unwrap();
+
+        let leaves = writer.finish().unwrap();
+        assert_eq!(leaves.len(), 1);
+        let leaf = &leaves[0];
+        assert_eq!(leaf.total_rows, 2, "only p_id 1 and 3 have live rows");
+
+        let header = decode_leaf_header_v3(&leaf.leaf_bytes).unwrap();
+        let dir = decode_leaf_dir_v3(&leaf.leaf_bytes, &header).unwrap();
+        assert_eq!(
+            dir.iter().map(|e| e.p_const).collect::<Vec<_>>(),
+            vec![Some(1), Some(2), Some(3)],
+            "the fully-retracted predicate must still have a partition"
+        );
+        assert_eq!(dir[1].row_count, 0, "and it must carry no live rows");
+        assert!(
+            dir[1].history_len > 0 && dir[1].history_max_t == 2,
+            "the zero-row leaflet must carry its own history segment"
+        );
+
+        // The segment holds exactly p_id=2's four transitions, and only those.
+        let segs = segments_of(leaf);
+        assert_eq!(segs.len(), 3);
+        assert!(
+            segs[1].iter().all(|e| e.p_id == 2) && segs[1].len() == 4,
+            "got {:?}",
+            segs[1]
+        );
+        assert!(
+            segs[0].iter().all(|e| e.p_id == 1) && segs[2].iter().all(|e| e.p_id == 3),
+            "no retracted predicate's history may leak into a neighbour"
+        );
+    }
+
+    /// Same shape at the tail of the order, where no following record exists
+    /// to trigger the emission. Previously `finish` committed these entries to
+    /// a sidecar segment past the last leaflet, where nothing referenced them.
+    #[test]
+    fn trailing_fully_retracted_predicate_is_not_dropped() {
+        let mut writer = LeafWriter::new(RunSortOrder::Psot, 100, 1000, 1);
+
+        writer.push_history_entry(hist(1, 1, 10, 1, 1));
+        writer
+            .push_record(make_rec(1, 1, OType::XSD_STRING.as_u16(), 10, 1))
+            .unwrap();
+
+        writer.push_history_entry(hist(1, 9, 90, 1, 1));
+        writer.push_history_entry(hist(1, 9, 90, 2, 0));
+
+        let leaves = writer.finish().unwrap();
+        let leaf = &leaves[0];
+        let header = decode_leaf_header_v3(&leaf.leaf_bytes).unwrap();
+        let dir = decode_leaf_dir_v3(&leaf.leaf_bytes, &header).unwrap();
+        assert_eq!(
+            dir.iter().map(|e| e.p_const).collect::<Vec<_>>(),
+            vec![Some(1), Some(9)]
+        );
+        assert_eq!(dir[1].row_count, 0);
+        let segs = segments_of(leaf);
+        assert_eq!(segs[1].len(), 2, "trailing history must stay reachable");
+
+        // The leaf's routing range must cover the trailing partition, or
+        // branch-level leaf selection never opens this leaf for p_id=9.
+        assert_eq!(leaf.last_key.p_id, 9);
+    }
+
+    /// Bounded emission: a predicate that only ever had retracts of facts it
+    /// never asserted nets to nothing and produces no history, so it must not
+    /// leave a partition behind.
+    #[test]
+    fn predicates_without_history_get_no_partition() {
+        let mut writer = LeafWriter::new(RunSortOrder::Psot, 100, 1000, 1);
+        for p in [1u32, 2] {
+            writer.push_history_entry(hist(1, p, 10, 1, 1));
+            writer
+                .push_record(make_rec(1, p, OType::XSD_STRING.as_u16(), 10, 1))
+                .unwrap();
+        }
+        let leaves = writer.finish().unwrap();
+        let header = decode_leaf_header_v3(&leaves[0].leaf_bytes).unwrap();
+        let dir = decode_leaf_dir_v3(&leaves[0].leaf_bytes, &header).unwrap();
+        assert_eq!(dir.len(), 2, "no empty partitions for predicates with no history");
+    }
+
+    /// SPOT is unsegmented, so a fully-retracted subject rides along in the
+    /// leaflet holding the next subject's rows — except at the tail, where
+    /// there is no next subject. Pin that the tail case keeps its history.
+    #[test]
+    fn trailing_fully_retracted_subject_is_not_dropped_in_spot() {
+        let mut writer = LeafWriter::new(RunSortOrder::Spot, 100, 1000, 1);
+
+        writer.push_history_entry(hist(1, 1, 10, 1, 1));
+        writer
+            .push_record(make_rec(1, 1, OType::XSD_STRING.as_u16(), 10, 1))
+            .unwrap();
+
+        writer.push_history_entry(hist(2, 1, 20, 1, 1));
+        writer.push_history_entry(hist(2, 1, 20, 2, 0));
+
+        let leaves = writer.finish().unwrap();
+        let leaf = &leaves[0];
+        let segs = segments_of(leaf);
+        let all: Vec<_> = segs.iter().flatten().collect();
+        assert_eq!(all.len(), 3, "every transition must be reachable from a leaflet");
+        assert_eq!(
+            leaf.last_key.s_id,
+            SubjectId(2),
+            "the leaf's routing range must span the retracted subject, or \
+             branch-level leaf selection never opens the leaf that holds it"
+        );
     }
 }

--- a/fluree-db-binary-index/src/format/leaf.rs
+++ b/fluree-db-binary-index/src/format/leaf.rs
@@ -40,7 +40,9 @@ use super::column_block::{ColumnBlockRef, COLUMN_BLOCK_REF_SIZE};
 use super::history_sidecar::{HistEntryV2, HistSidecarBuilder, HistorySegmentRef};
 use super::leaflet::{encode_leaflet, EncodedLeaflet};
 use super::run_record::RunSortOrder;
-use super::run_record_v2::{write_ordered_key_v2, RunRecordV2, ORDERED_KEY_V2_SIZE};
+use super::run_record_v2::{
+    cmp_v2_for_order, write_ordered_key_v2, RunRecordV2, ORDERED_KEY_V2_SIZE,
+};
 
 // ── Constants ──────────────────────────────────────────────────────────
 
@@ -221,14 +223,6 @@ impl LeafWriter {
         // routing bound when they open the leaf.
         self.flush_history_only_segments(Some(&record))?;
 
-        // This record's transition entries (and those of any preceding
-        // non-materialized facts in the same gap) belong to the leaflet that
-        // holds this record — the current one, post any segment-boundary flush.
-        // Committed before the leaf's routing keys are taken from `record`,
-        // since those entries sort at or below it and so set the leaf's low
-        // bound when they open it.
-        self.commit_all_pending();
-
         // Track first record of the leaf.
         if self.leaf_first_record.is_none() {
             self.leaf_first_record = Some(record);
@@ -244,6 +238,11 @@ impl LeafWriter {
             }
             RunSortOrder::Spot => {}
         }
+
+        // This record's transition entries (and those of any preceding
+        // non-materialized facts in the same gap) belong to the leaflet that
+        // holds this record — the current one, post any segment-boundary flush.
+        self.commit_all_pending();
 
         self.record_buf.push(record);
         self.last_record = Some(record);
@@ -282,28 +281,32 @@ impl LeafWriter {
             self.sidecar_builder.start_leaflet();
             self.current_segment_started = true;
         }
-        // A fact whose final state is absent materializes no row, so nothing
-        // else widens the leaf's routing keys to cover it — and branch-level
-        // leaf selection drops a leaf whose range stops short of the key being
-        // probed, which is how a fully-retracted subject becomes unreadable at
-        // a historical `t`. Entries are committed in build order, so taking the
-        // latest unconditionally keeps the leaf's bounds monotonic.
-        let rec = record_from_history(&entry);
-        debug_assert!(
-            self.last_record.is_none_or(|last| {
-                let (mut prev, mut next) = ([0u8; ORDERED_KEY_V2_SIZE], [0u8; ORDERED_KEY_V2_SIZE]);
-                write_ordered_key_v2(self.order, &last, &mut prev);
-                write_ordered_key_v2(self.order, &rec, &mut next);
-                prev <= next
-            }),
-            "history entries must be committed in build order — an out-of-order \
-             entry would push the leaf's last routing key backwards"
-        );
-        if self.leaf_first_record.is_none() {
+        self.widen_leaf_bounds(record_from_history(&entry));
+        self.sidecar_builder.push_entry(entry);
+    }
+
+    /// Grow the leaf's routing key range to cover `rec`.
+    ///
+    /// A fact whose final state is absent materializes no row, so nothing else
+    /// widens the leaf's keys to cover it — and branch-level leaf selection
+    /// drops a leaf whose range stops short of the key being probed, which is
+    /// how a fully-retracted subject becomes unreadable at a historical `t`.
+    /// Widening is strict, so an entry sharing its own row's identity (the
+    /// common case) leaves that row as the routing key.
+    fn widen_leaf_bounds(&mut self, rec: RunRecordV2) {
+        let cmp = cmp_v2_for_order(self.order);
+        if self
+            .leaf_first_record
+            .is_none_or(|first| cmp(&rec, &first) == std::cmp::Ordering::Less)
+        {
             self.leaf_first_record = Some(rec);
         }
-        self.last_record = Some(rec);
-        self.sidecar_builder.push_entry(entry);
+        if self
+            .last_record
+            .is_none_or(|last| cmp(&rec, &last) == std::cmp::Ordering::Greater)
+        {
+            self.last_record = Some(rec);
+        }
     }
 
     /// Commit every buffered history entry to the current leaflet's segment.
@@ -478,10 +481,8 @@ impl LeafWriter {
 
         // The leaf's routing keys must span this segment or branch-level leaf
         // selection never opens the leaf that holds it.
-        if self.leaf_first_record.is_none() {
-            self.leaf_first_record = Some(first);
-        }
-        self.last_record = Some(last);
+        self.widen_leaf_bounds(first);
+        self.widen_leaf_bounds(last);
         Ok(())
     }
 
@@ -1274,7 +1275,11 @@ mod tests {
         let leaves = writer.finish().unwrap();
         let header = decode_leaf_header_v3(&leaves[0].leaf_bytes).unwrap();
         let dir = decode_leaf_dir_v3(&leaves[0].leaf_bytes, &header).unwrap();
-        assert_eq!(dir.len(), 2, "no empty partitions for predicates with no history");
+        assert_eq!(
+            dir.len(),
+            2,
+            "no empty partitions for predicates with no history"
+        );
     }
 
     /// SPOT is unsegmented, so a fully-retracted subject rides along in the
@@ -1296,7 +1301,11 @@ mod tests {
         let leaf = &leaves[0];
         let segs = segments_of(leaf);
         let all: Vec<_> = segs.iter().flatten().collect();
-        assert_eq!(all.len(), 3, "every transition must be reachable from a leaflet");
+        assert_eq!(
+            all.len(),
+            3,
+            "every transition must be reachable from a leaflet"
+        );
         assert_eq!(
             leaf.last_key.s_id,
             SubjectId(2),

--- a/fluree-db-binary-index/src/format/leaf.rs
+++ b/fluree-db-binary-index/src/format/leaf.rs
@@ -145,6 +145,18 @@ pub struct LeafWriter {
     /// a new predicate/o_type segment (and thus a new leaflet). See
     /// `commit_pending_for_current_segment` / `commit_all_pending`.
     pending_history: Vec<HistEntryV2>,
+    /// Ordered-key span of the history committed into the leaflet currently
+    /// buffered, when it reaches outside that leaflet's rows. Applied to the
+    /// encoded leaflet's own routing keys at `flush_leaflet`, and reset with
+    /// it.
+    ///
+    /// Widening only the leaf header is not durable: an incremental update
+    /// re-derives the header from the leaflet directory
+    /// (`build_leaf_from_group`) and republishes the branch entry from it, so
+    /// a bound that lives only in the header is narrowed away by the first
+    /// update that touches the leaf.
+    leaflet_hist_min: Option<[u8; ORDERED_KEY_V2_SIZE]>,
+    leaflet_hist_max: Option<[u8; ORDERED_KEY_V2_SIZE]>,
 
     // Segmentation tracking.
     current_seg_p_id: Option<u32>,
@@ -182,6 +194,8 @@ impl LeafWriter {
             sidecar_builder: HistSidecarBuilder::new(),
             current_segment_started: false,
             pending_history: Vec::new(),
+            leaflet_hist_min: None,
+            leaflet_hist_max: None,
             current_seg_p_id: None,
             current_seg_o_type: None,
             encoded_leaflets: Vec::new(),
@@ -281,7 +295,20 @@ impl LeafWriter {
             self.sidecar_builder.start_leaflet();
             self.current_segment_started = true;
         }
-        self.widen_leaf_bounds(record_from_history(&entry));
+        let rec = record_from_history(&entry);
+        self.widen_leaf_bounds(rec);
+
+        // Record the span for the leaflet itself as well. Ordered keys are
+        // big-endian in sort-field order, so `memcmp` is the order's compare.
+        let mut key = [0u8; ORDERED_KEY_V2_SIZE];
+        write_ordered_key_v2(self.order, &rec, &mut key);
+        if self.leaflet_hist_min.is_none_or(|min| key < min) {
+            self.leaflet_hist_min = Some(key);
+        }
+        if self.leaflet_hist_max.is_none_or(|max| key > max) {
+            self.leaflet_hist_max = Some(key);
+        }
+
         self.sidecar_builder.push_entry(entry);
     }
 
@@ -400,11 +427,19 @@ impl LeafWriter {
     /// Callers must have no buffered records and no open sidecar segment, so
     /// the emitted leaflet and its segment stay index-aligned.
     fn flush_history_only_segments(&mut self, next: Option<&RunRecordV2>) -> io::Result<()> {
-        if self.pending_history.is_empty() {
+        let Some(first) = self.pending_history.first() else {
             return Ok(());
-        }
+        };
         let order = self.order;
         let next_seg = next.map(|r| SegmentKey::of(order, r.p_id, r.o_type));
+
+        // Entries are sorted and `next`'s segment sorts last, so if even the
+        // first entry belongs to it then all of them do and there is nothing
+        // to emit. This runs on every `push_record`, so take the O(1) exit
+        // before the take/copy/assign churn below.
+        if next_seg == Some(SegmentKey::of(order, first.p_id, first.o_type)) {
+            return Ok(());
+        }
 
         let pending = std::mem::take(&mut self.pending_history);
         let mut retained = Vec::new();
@@ -436,8 +471,17 @@ impl LeafWriter {
 
     /// Append one zero-row leaflet holding `entries` as its history segment.
     fn emit_history_only_leaflet(&mut self, entries: &[HistEntryV2]) -> io::Result<()> {
-        debug_assert!(
-            self.record_buf.is_empty() && !self.current_segment_started,
+        // Hard assert, not `debug_assert!`: a violation puts every subsequent
+        // leaf's history segments off by one against its leaflet directory,
+        // silently, and index artifacts are written by release builds where a
+        // debug assertion compiles to nothing. The damage reads as wrong
+        // history replay — the bug class this code exists to prevent — and is
+        // unrepairable short of another full rebuild. The check is two boolean
+        // loads, once per retracted segment.
+        assert!(
+            self.record_buf.is_empty()
+                && !self.current_segment_started
+                && self.leaflet_hist_min.is_none(),
             "history-only leaflet must not interleave with a leaflet still being \
              accumulated — its sidecar segment would take that leaflet's index"
         );
@@ -457,10 +501,6 @@ impl LeafWriter {
             self.sidecar_builder.push_entry(*entry);
         }
 
-        let homogeneous_o_type = entries
-            .iter()
-            .all(|e| e.o_type == first.o_type)
-            .then_some(first.o_type);
         self.encoded_leaflets.push(EncodedLeaflet {
             row_count: 0,
             lead_group_count: 0,
@@ -470,9 +510,13 @@ impl LeafWriter {
                 RunSortOrder::Post | RunSortOrder::Psot => Some(first.p_id),
                 RunSortOrder::Opst | RunSortOrder::Spot => None,
             },
+            // OPST segments by type, so the constant is known without a scan.
             o_type_const: match self.order {
                 RunSortOrder::Opst => Some(first.o_type),
-                _ => homogeneous_o_type,
+                _ => entries
+                    .iter()
+                    .all(|e| e.o_type == first.o_type)
+                    .then_some(first.o_type),
             },
             flags: 0,
             column_refs: Vec::new(),
@@ -513,8 +557,26 @@ impl LeafWriter {
         }
 
         let records = std::mem::take(&mut self.record_buf);
-        let encoded = encode_leaflet(&records, self.order, self.zstd_level)?;
+        let mut encoded = encode_leaflet(&records, self.order, self.zstd_level)?;
         let row_count = encoded.row_count as u64;
+
+        // Grow the leaflet's own routing keys over any history that reaches
+        // outside its rows — a fully-retracted subject in SPOT, or one sorting
+        // above the last live row in PSOT/POST. The leaf header is re-derived
+        // from these keys by the next incremental update, so a bound recorded
+        // only on the header does not survive. It also makes the
+        // `leaflet_out_of_range` prune sound on the leaflet's own terms rather
+        // than by way of the replay guard.
+        if let Some(min) = self.leaflet_hist_min.take() {
+            if min < encoded.first_key {
+                encoded.first_key = min;
+            }
+        }
+        if let Some(max) = self.leaflet_hist_max.take() {
+            if max > encoded.last_key {
+                encoded.last_key = max;
+            }
+        }
 
         // Ensure a history segment exists for this leaflet.
         // If committed history already started one, skip. Otherwise start an empty one.
@@ -593,9 +655,15 @@ impl LeafWriter {
             re_encoded_leaflet_count,
         });
 
-        // Reset for next leaf.
+        // Reset for next leaf. `last_record` is cleared alongside
+        // `leaf_first_record` so the next leaf's bounds are derived only from
+        // its own contents: a leaf can now consist solely of history-only
+        // leaflets, and leaving a value behind would make its `last_key`
+        // depend on the previous leaf's — sound only because build order is
+        // ascending, which is not an invariant worth carrying across leaves.
         self.leaf_accumulated_rows = 0;
         self.leaf_first_record = None;
+        self.last_record = None;
         self.history_seg_refs.clear();
 
         Ok(())

--- a/fluree-db-indexer/src/run_index/build/incremental_leaf.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_leaf.rs
@@ -1280,6 +1280,69 @@ mod tests {
         assert_eq!(s_ids, vec![10, 20, 35, 50, 60]);
     }
 
+    /// Companion to `test_update_after_retract_all_reinserts_into_empty_leaflet`
+    /// with generation one produced by the REBUILD writer rather than an
+    /// incremental merge.
+    ///
+    /// A full rebuild preserves a fully-retracted predicate's partition as a
+    /// zero-row leaflet so time travel can still reach its history. That
+    /// leaflet carries no column blocks, exactly like
+    /// `empty_encoded_leaflet_with_keys`, so the next incremental routing
+    /// novelty back into it depends on the same `row_count == 0` guard.
+    #[test]
+    fn test_update_into_rebuild_emitted_empty_partition() {
+        // Generation 1, rebuild-side: p_id=1 keeps a live row, p_id=2 is
+        // fully retracted and survives only as a zero-row partition.
+        let mut writer = LeafWriter::new(RunSortOrder::Psot, 100, 10000, 1);
+        writer.push_record(rec2(100, 1, 10, 1)).unwrap();
+        for (t, op) in [(1u32, 1u8), (5, 0)] {
+            writer.push_history_entry(HistEntryV2 {
+                s_id: SubjectId(100),
+                p_id: 2,
+                o_type: OType::XSD_INTEGER.as_u16(),
+                o_key: ObjKey::encode_i64(20).as_u64(),
+                o_i: OI_NONE,
+                t,
+                op,
+            });
+        }
+        let leaves = writer.finish().unwrap();
+        assert_eq!(leaves.len(), 1);
+        let leaf = &leaves[0];
+        assert_eq!(leaf.total_rows, 1, "only p_id=1 has a live row");
+
+        let header = decode_leaf_header_v3(&leaf.leaf_bytes).unwrap();
+        let dir = decode_leaf_dir_v3_with_base(&leaf.leaf_bytes, &header).unwrap();
+        assert_eq!(
+            dir.entries.iter().map(|e| e.p_const).collect::<Vec<_>>(),
+            vec![Some(1), Some(2)],
+            "the rebuild must preserve the fully-retracted predicate's partition"
+        );
+        assert_eq!(dir.entries[1].row_count, 0);
+        assert!(dir.entries[1].column_refs.is_empty(), "no column blocks");
+
+        // Generation 2: re-assert p_id=2, routing novelty into that partition.
+        let novelty = vec![rec2(100, 2, 20, 9)];
+        let ops = vec![1u8];
+        let input = LeafUpdateInput {
+            leaf_bytes: &leaf.leaf_bytes,
+            novelty: &novelty,
+            novelty_ops: &ops,
+            superseded: &[],
+            superseded_ops: &[],
+            order: RunSortOrder::Psot,
+            g_id: 0,
+            zstd_level: 1,
+            leaflet_target_rows: 100,
+            leaf_target_rows: 10000,
+            sidecar_bytes: leaf.sidecar_bytes.as_deref(),
+        };
+        let gen2 = update_leaf(&input)
+            .expect("merging novelty into a rebuild-emitted empty partition must not fail");
+        assert_eq!(gen2.leaves.len(), 1);
+        assert_eq!(gen2.leaves[0].info.total_rows, 2);
+    }
+
     /// Regression: when a leaflet splits into multiple chunks, history entries
     /// must be partitioned to the correct chunk (not all in chunk 0).
     /// Retracting the lowest and highest existing facts produces entries

--- a/fluree-db-indexer/src/run_index/build/incremental_leaf.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_leaf.rs
@@ -422,7 +422,8 @@ fn merge_and_encode_leaflet(
 
     if chunks.len() == 1 {
         // Common case: no split, all history stays with the single chunk.
-        let encoded = encode_leaflet(chunks[0], order, zstd_level)?;
+        let mut encoded = encode_leaflet(chunks[0], order, zstd_level)?;
+        widen_leaflet_keys_over_history(&mut encoded, &history, order);
         result.push(ProcessedLeafletV3 {
             encoded: EncodedLeafletInfo::Encoded(encoded),
             history,
@@ -431,7 +432,8 @@ fn merge_and_encode_leaflet(
         // Multiple chunks: partition history entries by chunk key boundaries.
         let partitioned = partition_history_to_chunks(&chunks, &history, order);
         for (chunk, chunk_history) in chunks.iter().zip(partitioned) {
-            let encoded = encode_leaflet(chunk, order, zstd_level)?;
+            let mut encoded = encode_leaflet(chunk, order, zstd_level)?;
+            widen_leaflet_keys_over_history(&mut encoded, &chunk_history, order);
             result.push(ProcessedLeafletV3 {
                 encoded: EncodedLeafletInfo::Encoded(encoded),
                 history: chunk_history,
@@ -440,6 +442,46 @@ fn merge_and_encode_leaflet(
     }
 
     Ok(result)
+}
+
+/// Grow a re-encoded leaflet's routing keys to span the history kept with it.
+///
+/// `encode_leaflet` derives keys from live rows alone, but a leaflet's sidecar
+/// can hold facts sorting outside them — a fully-retracted subject in SPOT, or
+/// one above the last live row in PSOT/POST. Routing, the
+/// `leaflet_out_of_range` prune, and the leaf header (hence the branch entry,
+/// via `build_leaf_from_group`) all read these keys, so a leaflet that stops
+/// at its rows makes that history unreachable at a historical `t`. The
+/// empty-after-retract branch above already preserves the range for the
+/// zero-row case; this is the same contract for a leaflet that still has rows.
+///
+/// The union stays inside the leaflet's routing interval — carried-forward
+/// history was already in it and novelty is sliced to it — so widening cannot
+/// make sibling leaflets overlap.
+fn widen_leaflet_keys_over_history(
+    encoded: &mut fluree_db_binary_index::format::leaflet::EncodedLeaflet,
+    history: &[HistEntryV2],
+    order: RunSortOrder,
+) {
+    let mut key = [0u8; ORDERED_KEY_V2_SIZE];
+    for entry in history {
+        let rec = RunRecordV2 {
+            s_id: entry.s_id,
+            o_key: entry.o_key,
+            p_id: entry.p_id,
+            t: entry.t,
+            o_i: entry.o_i,
+            o_type: entry.o_type,
+            g_id: 0,
+        };
+        write_ordered_key_v2(order, &rec, &mut key);
+        if key < encoded.first_key {
+            encoded.first_key = key;
+        }
+        if key > encoded.last_key {
+            encoded.last_key = key;
+        }
+    }
 }
 
 /// Split merged records by segmentation constraints and row-count limits.
@@ -1341,6 +1383,76 @@ mod tests {
             .expect("merging novelty into a rebuild-emitted empty partition must not fail");
         assert_eq!(gen2.leaves.len(), 1);
         assert_eq!(gen2.leaves[0].info.total_rows, 2);
+    }
+
+    /// Regression: a leaf bound widened to cover retracted-only history must
+    /// survive an incremental update.
+    ///
+    /// `build_leaf_from_group` re-derives the leaf header's keys from the
+    /// leaflet directory entries, and `update_branch` reads the branch entry
+    /// back out of that header. So widening only the leaf header is not
+    /// durable: the first `update_leaf` narrows it to the leaflets' own keys
+    /// and `find_leaves_in_range` starts skipping the leaf again. The
+    /// leaflet holding the history must span it too.
+    ///
+    /// SPOT is the case that bites, because its history commits into the
+    /// leaflet holding the neighbouring subject's rows rather than into a
+    /// history-only leaflet of its own.
+    #[test]
+    fn test_update_preserves_widened_bound_for_retracted_subject() {
+        // Generation 1, rebuild-side: subject 100 lives, subject 200 is fully
+        // retracted and survives only in the sidecar.
+        let mut writer = LeafWriter::new(RunSortOrder::Spot, 100, 10000, 1);
+        writer.push_record(rec2(100, 1, 10, 1)).unwrap();
+        for (t, op) in [(1u32, 1u8), (5, 0)] {
+            writer.push_history_entry(HistEntryV2 {
+                s_id: SubjectId(200),
+                p_id: 1,
+                o_type: OType::XSD_INTEGER.as_u16(),
+                o_key: ObjKey::encode_i64(20).as_u64(),
+                o_i: OI_NONE,
+                t,
+                op,
+            });
+        }
+        let leaves = writer.finish().unwrap();
+        let leaf = &leaves[0];
+        assert_eq!(
+            leaf.last_key.s_id,
+            SubjectId(200),
+            "the rebuild's own bound must span the retracted subject"
+        );
+
+        // Generation 2: any later incremental touching this leaf.
+        let novelty = vec![rec2(100, 2, 11, 9)];
+        let ops = vec![1u8];
+        let input = LeafUpdateInput {
+            leaf_bytes: &leaf.leaf_bytes,
+            novelty: &novelty,
+            novelty_ops: &ops,
+            superseded: &[],
+            superseded_ops: &[],
+            order: RunSortOrder::Spot,
+            g_id: 0,
+            zstd_level: 1,
+            leaflet_target_rows: 100,
+            leaf_target_rows: 10000,
+            sidecar_bytes: leaf.sidecar_bytes.as_deref(),
+        };
+        let gen2 = update_leaf(&input).unwrap();
+        assert_eq!(gen2.leaves.len(), 1);
+
+        let header = decode_leaf_header_v3(&gen2.leaves[0].info.leaf_bytes).unwrap();
+        let last = fluree_db_binary_index::format::run_record_v2::read_ordered_key_v2(
+            RunSortOrder::Spot,
+            &header.last_key,
+        );
+        assert_eq!(
+            last.s_id,
+            SubjectId(200),
+            "the incremental re-derives the header from leaflet keys, so the \
+             leaflet must span the history or the bound is lost"
+        );
     }
 
     /// Regression: when a leaflet splits into multiple chunks, history entries


### PR DESCRIPTION
A full rebuild materializes no row for a predicate whose facts have all been retracted, so leaflet segmentation never opened a partition for it — its transitions got filed under the next predicate's leaflet, where a predicate-keyed reader skips them by `p_const`. The same absence hit fully-retracted subjects in SPOT: their transitions fell outside the leaf's routing keys, so no read ever routed to them. The visible effect was that after a full reindex, time-travel queries over a fully-retracted predicate or subject returned no rows at a historical `t` (or, with `OPTIONAL`, rows with nulls where values existed), while incremental and novelty-only indexes answered the same queries correctly.

The fix emits a zero-row leaflet plus its own history sidecar for each segment that ends without a live row, and grows routing keys to span history that sorts outside a leaflet's live rows. That's the same shape the incremental writer already preserves when a merge empties a leaflet, and the reader already replays it — this just makes the rebuild produce it too.

Those keys are widened on the **leaflet**, not only on the leaf header. `build_leaf_from_group` re-derives the header from the leaflet directory and `update_branch` republishes the branch entry from it, so a bound recorded only on the header is narrowed away by the first incremental that touches the leaf — reintroducing the original symptom for that subject. `merge_and_encode_leaflet` needed the same treatment, since it re-encodes from live rows while carrying history that sorts outside them. Both halves are pinned by round-trip tests through `update_leaf`, and end-to-end by a deleted entity that stays readable at `@t:1` across a later incremental.

On #1603: its `row_count == 0` guard is what lets a later incremental merge into these zero-column-block partitions. It merged to `main` on 2026-08-10, so the dependency is already satisfied here — it binds only for backports into any release line that lacks it. A test pins the seam (reverting the guard turns it red with the exact failure #1603 fixed).

Verification: an 11-shape × 3-index-strategy matrix (the full-rebuild column was wrong in 8 of 11 cells before, all correct after; incremental and novelty pinned as controls), the existing pinned test extended with the plain single-triple variants, history-surface coverage, and a repeat-rebuild test showing an index built by a pre-fix binary is fully repaired by rebuilding again with this fix — the rebuild walks commits from genesis and reuses no leaves, so reindexing is the complete remediation for any already-affected index. Artifact cost measured at +0.69% bytes on a retraction-heavy fixture; rebuild time within noise.

Because nothing repairs an already-published index automatically, the symptom and the reindex remediation are documented for operators at `docs/troubleshooting/historical-results-missing.md`.
