### PR TITLE
seed connected values through type-anchored stars

### DIFF
--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -9501,3 +9501,227 @@ async fn indexed_values_bound_subject_through_type_anchor() {
         })
         .await;
 }
+
+/// Assert `sparql` plans as a *seeded* VALUES star, so the result assertions
+/// around it are actually exercising the batched-subject-probe lanes rather
+/// than the deferred property-join plan they replaced.
+async fn assert_values_seeded(
+    fluree: &fluree_db_api::Fluree,
+    view: &fluree_db_api::GraphDb,
+    sparql: &str,
+) {
+    let plan = fluree
+        .explain_sparql(view, sparql)
+        .await
+        .expect("explain should succeed");
+    let physical = plan["plan"]["physical"].to_string();
+    assert!(
+        physical.contains("ValuesOperator"),
+        "expected the VALUES to be planned, got {physical}"
+    );
+    assert!(
+        !physical.contains("PropertyJoinOperator"),
+        "expected the seeded lane, not the deferred property join: {physical}"
+    );
+}
+
+const NOVELTY_SUBJECT_QUERY: &str = r"
+    PREFIX ex: <http://example.org/ns/>
+    SELECT ?n
+    WHERE { VALUES ?s { ex:thing2 } ?s a ex:Thing ; ex:name ?n }
+";
+
+/// The seeded `VALUES` plan reads through the batched-subject-probe lanes, which
+/// read base leaflets directly and are latest-`t` only. Replay must still win.
+///
+/// `ex:thing1 ex:name` changes value between t=1 and t=2, so the predicate keeps
+/// live rows throughout and the query is a pure replay question. Asserts values,
+/// not plan shape — a lane that bails to a slower fallback is fine, one that
+/// serves the latest-`t` value for a historical read is not.
+#[tokio::test]
+async fn indexed_values_seeded_star_replays_at_historical_t() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/values-seed-historical:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 50_000_000,
+            };
+            let seed = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "@graph": [
+                    {"@id": "ex:thing1", "@type": "ex:Thing", "ex:name": "old"},
+                    {"@id": "ex:thing2", "@type": "ex:Thing", "ex:name": "keep"}
+                ]
+            });
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &seed,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let t1 = ledger1.t();
+
+            // t=2: change ex:thing1's name. ex:name keeps live rows either side.
+            let update = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "where": {"@id": "ex:thing1", "ex:name": "?n"},
+                "delete": {"@id": "ex:thing1", "ex:name": "?n"},
+                "insert": {"@id": "ex:thing1", "ex:name": "new"}
+            });
+            let ledger2 = fluree
+                .update(ledger1, &update)
+                .await
+                .expect("update")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger2.t()).await;
+
+            let q = r"
+                PREFIX ex: <http://example.org/ns/>
+                SELECT ?n
+                WHERE { VALUES ?s { ex:thing1 } ?s a ex:Thing ; ex:name ?n }
+            ";
+
+            let view_t1 = fluree.db_at_t(ledger_id, t1).await.expect("view at t=1");
+            assert_values_seeded(&fluree, &view_t1, q).await;
+            let at_t1 = fluree
+                .query(&view_t1, QueryInput::Sparql(q))
+                .await
+                .expect("historical query");
+            assert_eq!(
+                normalize_rows(&at_t1.to_jsonld(&view_t1.snapshot).expect("to_jsonld")),
+                normalize_rows(&json!([["old"]])),
+                "the seeded plan must replay to t=1, not serve the latest value"
+            );
+
+            let view_now = fluree.db(ledger_id).await.expect("current view");
+            let now = fluree
+                .query(&view_now, QueryInput::Sparql(q))
+                .await
+                .expect("current query");
+            assert_eq!(
+                normalize_rows(&now.to_jsonld(&view_now.snapshot).expect("to_jsonld")),
+                normalize_rows(&json!([["new"]])),
+                "the same plan at head must see the updated value"
+            );
+        })
+        .await;
+}
+
+/// Same lanes, novelty-overlay side: rows committed after the last index build
+/// live only in novelty, and the batched probes bail rather than read them.
+/// Whichever path the bail lands on must still return every matching row.
+#[tokio::test]
+async fn indexed_values_seeded_star_sees_novelty_overlay() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/values-seed-novelty:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 50_000_000,
+            };
+            let indexed = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "@graph": [{"@id": "ex:thing1", "@type": "ex:Thing", "ex:name": "indexed"}]
+            });
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &indexed,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("indexed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+
+            // Committed but never indexed: ex:thing2 exists only in novelty, and
+            // ex:thing1 gains a second name there.
+            let overlay = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "@graph": [
+                    {"@id": "ex:thing2", "@type": "ex:Thing", "ex:name": "novel"},
+                    {"@id": "ex:thing1", "ex:name": "also"}
+                ]
+            });
+            let _ = fluree
+                .insert(ledger1, &overlay)
+                .await
+                .expect("novelty insert");
+
+            let view = fluree.db(ledger_id).await.expect("view with novelty");
+
+            assert_values_seeded(&fluree, &view, NOVELTY_SUBJECT_QUERY).await;
+            // Novelty-only subject, reached through the seeded lane.
+            let novel = fluree
+                .query(&view, QueryInput::Sparql(NOVELTY_SUBJECT_QUERY))
+                .await
+                .expect("novelty-subject query");
+            assert_eq!(
+                normalize_rows(&novel.to_jsonld(&view.snapshot).expect("to_jsonld")),
+                normalize_rows(&json!([["novel"]])),
+                "a subject that exists only in novelty must survive the seeded plan"
+            );
+
+            // Indexed subject whose values straddle the index/novelty boundary.
+            let straddle = fluree
+                .query(
+                    &view,
+                    QueryInput::Sparql(
+                        r"
+                        PREFIX ex: <http://example.org/ns/>
+                        SELECT ?n
+                        WHERE { VALUES ?s { ex:thing1 } ?s a ex:Thing ; ex:name ?n }
+                    ",
+                    ),
+                )
+                .await
+                .expect("straddling query");
+            let mut rows = normalize_rows(&straddle.to_jsonld(&view.snapshot).expect("to_jsonld"));
+            rows.sort_by_key(std::string::ToString::to_string);
+            assert_eq!(
+                rows,
+                normalize_rows(&json!([["also"], ["indexed"]])),
+                "the probe must merge the novelty value with the indexed one"
+            );
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -9322,3 +9322,182 @@ async fn indexed_exists_graph_var_decodes_encoded_bindings() {
         })
         .await;
 }
+
+// =============================================================================
+// VALUES-bound subject through an rdf:type anchor (issue #51)
+// =============================================================================
+
+/// `VALUES ?s { <iri> } . ?s a ex:Thing ; ex:name ?n` on an indexed ledger.
+///
+/// The planner used to defer a VALUES that preceded a star block, which left
+/// `?s` unbound when the star was planned: the bound-object `rdf:type` triple
+/// won the driver race, the whole `ex:Thing` extent was drained, and the VALUES
+/// discarded all but the matching subject. Seeding the VALUES instead makes the
+/// cost a function of the VALUES arity rather than the class size.
+///
+/// These assertions are on *results*, not latency — the plan-shape assertions
+/// live in `fluree-db-query`'s `test_connected_values_seeds_type_anchored_star`.
+/// The corpus gives `ex:name` a second class (`ex:Other`) so the anchor is not
+/// redundant and cannot be elided; `ex:Other` subjects in the VALUES set must
+/// still be excluded by it.
+#[tokio::test]
+async fn indexed_values_bound_subject_through_type_anchor() {
+    /// `ex:Thing` count. Large enough that a class-extent scan is visible in the
+    /// latency print, small enough to stay cheap in CI.
+    const THINGS: usize = 5_000;
+    /// `ex:Other` subjects, which carry `ex:name` but not `@type ex:Thing`.
+    const OTHERS: usize = 500;
+
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "it/indexed-values-type-anchor:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 50_000_000,
+            };
+            let mut graph: Vec<serde_json::Value> = (0..THINGS)
+                .map(|i| {
+                    json!({
+                        "@id": format!("ex:thing{i}"),
+                        "@type": "ex:Thing",
+                        "ex:name": format!("name{i}")
+                    })
+                })
+                .collect();
+            graph.extend((0..OTHERS).map(|i| {
+                json!({
+                    "@id": format!("ex:other{i}"),
+                    "@type": "ex:Other",
+                    "ex:name": format!("othername{i}")
+                })
+            }));
+            let insert = json!({
+                "@context": { "ex": "http://example.org/ns/" },
+                "@graph": graph
+            });
+
+            let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let ledger1 = fluree
+                .insert_with_opts(
+                    ledger0,
+                    &insert,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+            let _ = trigger_index_and_wait_outcome(&handle, ledger_id, ledger1.t()).await;
+            let view = fluree
+                .db_at_t(ledger_id, ledger1.t())
+                .await
+                .expect("load indexed view");
+
+            /// Sorted `?n` bindings, with the elapsed wall time for human eyes.
+            async fn names(
+                fluree: &fluree_db_api::Fluree,
+                view: &fluree_db_api::GraphDb,
+                label: &str,
+                sparql: &str,
+            ) -> Vec<String> {
+                let t0 = std::time::Instant::now();
+                let result = fluree
+                    .query(view, QueryInput::Sparql(sparql))
+                    .await
+                    .unwrap_or_else(|e| panic!("{label} query: {e}"));
+                let elapsed = t0.elapsed();
+                let json = result
+                    .to_sparql_json(&view.snapshot)
+                    .expect("sparql results json");
+                let mut names: Vec<String> = json["results"]["bindings"]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("{label}: bindings array in {json}"))
+                    .iter()
+                    .map(|b| b["n"]["value"].as_str().expect("?n binding").to_string())
+                    .collect();
+                names.sort();
+                println!("  [{label}] {elapsed:?}  rows={}", names.len());
+                names
+            }
+
+            let target = THINGS / 2;
+
+            // The shape under test: VALUES feeds the star's subject.
+            let seeded = names(
+                &fluree,
+                &view,
+                "values + type anchor",
+                &format!(
+                    "PREFIX ex: <http://example.org/ns/>
+                     SELECT ?s ?n
+                     WHERE {{ VALUES ?s {{ ex:thing{target} }} ?s a ex:Thing ; ex:name ?n }}"
+                ),
+            )
+            .await;
+
+            // Control: the same query with the IRI written inline.
+            let inlined = names(
+                &fluree,
+                &view,
+                "iri inlined         ",
+                &format!(
+                    "PREFIX ex: <http://example.org/ns/>
+                     SELECT ?n WHERE {{ ex:thing{target} a ex:Thing ; ex:name ?n }}"
+                ),
+            )
+            .await;
+
+            // Control: the same VALUES with the type anchor dropped.
+            let unanchored = names(
+                &fluree,
+                &view,
+                "values, no anchor   ",
+                &format!(
+                    "PREFIX ex: <http://example.org/ns/>
+                     SELECT ?s ?n WHERE {{ VALUES ?s {{ ex:thing{target} }} ?s ex:name ?n }}"
+                ),
+            )
+            .await;
+
+            let expected = vec![format!("name{target}")];
+            assert_eq!(seeded, expected, "VALUES + type anchor");
+            assert_eq!(inlined, expected, "IRI inlined control");
+            assert_eq!(unanchored, expected, "no-anchor control");
+
+            // Multi-row VALUES: the seeded plan must still apply the anchor, so
+            // the two ex:Other rows drop out even though they carry ex:name.
+            let mixed = names(
+                &fluree,
+                &view,
+                "values arity 5      ",
+                "PREFIX ex: <http://example.org/ns/>
+                 SELECT ?s ?n
+                 WHERE {
+                   VALUES ?s { ex:thing1 ex:other1 ex:thing2 ex:other2 ex:missing }
+                   ?s a ex:Thing ; ex:name ?n
+                 }",
+            )
+            .await;
+            assert_eq!(
+                mixed,
+                vec!["name1".to_string(), "name2".to_string()],
+                "the anchor must exclude ex:Other subjects and the absent IRI"
+            );
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -9725,3 +9725,73 @@ async fn indexed_values_seeded_star_sees_novelty_overlay() {
         })
         .await;
 }
+
+/// The seeded plan over a predicate that a later full rebuild left with no live
+/// rows at all — the shape the batched-subject probes cannot reach through
+/// PSOT/POST, only through the SPOT history sidecars that #1624 now preserves.
+///
+/// This is the case the seeded plan changed the answer to: deferring routed it
+/// through `PropertyJoinOperator`, whose replay-aware driver selection happened
+/// to keep it correct, and seeding takes it off that lane. Full rebuild (not
+/// incremental) is the point — it is the path that used to drop the partition.
+#[tokio::test]
+async fn indexed_values_seeded_star_replays_fully_retracted_predicate() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "it/values-seed-retracted:main";
+
+    let seed = json!({
+        "@context": { "ex": "http://example.org/ns/" },
+        "@graph": [
+            {"@id": "ex:thing1", "@type": "ex:Thing", "ex:name": "n1", "ex:legacy": "yes"},
+            {"@id": "ex:thing2", "@type": "ex:Thing", "ex:name": "n2", "ex:legacy": "yes"}
+        ]
+    });
+    let ledger0 = genesis_ledger_for_fluree(&fluree, ledger_id);
+    let ledger1 = fluree
+        .insert(ledger0, &seed)
+        .await
+        .expect("seed insert")
+        .ledger;
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let t1 = ledger1.t();
+    let ledger1 = fluree.ledger(ledger_id).await.expect("reload at t=1");
+
+    // Retract every ex:legacy triple: the predicate is left with zero live rows.
+    let retract = json!({
+        "@context": { "ex": "http://example.org/ns/" },
+        "where": {"@id": "?s", "ex:legacy": "?v"},
+        "delete": {"@id": "?s", "ex:legacy": "?v"}
+    });
+    let _ = fluree.update(ledger1, &retract).await.expect("retract");
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let _ = fluree.ledger(ledger_id).await.expect("reload at t=2");
+
+    let q = r"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT ?v
+        WHERE { VALUES ?s { ex:thing1 } ?s a ex:Thing ; ex:legacy ?v }
+    ";
+
+    let view_t1 = fluree.db_at_t(ledger_id, t1).await.expect("view at t=1");
+    assert_values_seeded(&fluree, &view_t1, q).await;
+    let at_t1 = fluree
+        .query(&view_t1, QueryInput::Sparql(q))
+        .await
+        .expect("historical query");
+    assert_eq!(
+        normalize_rows(&at_t1.to_jsonld(&view_t1.snapshot).expect("to_jsonld")),
+        normalize_rows(&json!([["yes"]])),
+        "a fully-retracted predicate must still replay at t=1 through the seeded plan"
+    );
+
+    let view_now = fluree.db(ledger_id).await.expect("current view");
+    let now = fluree
+        .query(&view_now, QueryInput::Sparql(q))
+        .await
+        .expect("current query");
+    assert!(
+        normalize_rows(&now.to_jsonld(&view_now.snapshot).expect("to_jsonld")).is_empty(),
+        "the predicate is gone at head, so the same plan must return nothing"
+    );
+}

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1044,18 +1044,26 @@ fn apply_values(
     operator
 }
 
-/// Does any VALUES pattern bind a variable that the triples also mention?
+/// Split a block's VALUES into those that can seed a same-subject star and the
+/// rest, which must stay behind the triples.
 ///
-/// Answers whether the VALUES can seed the triples. A connected VALUES constrains
-/// them; a disconnected one only multiplies rows.
-fn values_feed_triples(values: &[ValuesPattern], triples: &[TriplePattern]) -> bool {
-    let triple_vars: HashSet<VarId> = triples
-        .iter()
-        .flat_map(TriplePattern::referenced_vars)
-        .collect();
+/// A VALUES binding the star's subject constrains every triple in it at once, so
+/// seeding hands the star a bound driving set. Anything else — a VALUES binding
+/// only a leaf object var, or sharing no variable with the star at all — would
+/// seed a cartesian product instead, so it defers.
+///
+/// The caller only reaches this for a star (`is_property_join`), which guarantees
+/// every triple shares the first triple's subject var.
+fn split_values_seeding_star(
+    values: Vec<ValuesPattern>,
+    triples: &[TriplePattern],
+) -> (Vec<ValuesPattern>, Vec<ValuesPattern>) {
+    let Some(subject) = triples.first().and_then(|tp| tp.s.as_var()) else {
+        return (Vec::new(), values);
+    };
     values
-        .iter()
-        .any(|vp| vp.vars.iter().any(|v| triple_vars.contains(v)))
+        .into_iter()
+        .partition(|vp| vp.vars.contains(&subject))
 }
 
 /// Partition filters into those eligible for inline evaluation and those still waiting.
@@ -1946,30 +1954,34 @@ pub fn build_where_operators_seeded_with_needed(
                     // a pure star block. Wrapping VALUES first seeds the schema/operator and
                     // prevents `build_triple_operators()` from taking the property-join path.
                     //
-                    // Only defer a VALUES that is *disconnected* from the star (e.g. a pinned
-                    // vector-search query vector): seeding it would build a cartesian product
-                    // and cost a profitable fusion. A VALUES that shares a variable with the
-                    // star is a guaranteed producer with exact cardinality, and seeding it
-                    // lets `build_scan_or_join()` pick a bound-driven lane — batched-subject
-                    // -exists, MembershipJoin, or HashJoin — instead of draining the whole
-                    // class or predicate extent and filtering afterwards.
-                    let values_after_triples = operator.is_none()
+                    // A VALUES binding the star's SUBJECT is the exception: it constrains
+                    // every triple at once, so seeding it lets `build_scan_or_join()` pick a
+                    // bound-driven lane — batched-subject-exists, MembershipJoin, or HashJoin
+                    // — instead of draining the whole class or predicate extent and filtering
+                    // afterwards. Every other VALUES still defers, including one binding only
+                    // a leaf object var: seeding that costs the fusion for the whole star
+                    // without constraining the driving scan.
+                    //
+                    // The split is per-VALUES because the hazard is. A block may legally hold
+                    // both kinds, and seeding a disconnected VALUES alongside a subject-bound
+                    // one would reintroduce the cartesian seed the deferral exists to prevent.
+                    let (seed_values, deferred_values) = if operator.is_none()
                         && !block.values.is_empty()
                         && block.triples.len() >= 2
                         && is_property_join(&block.triples)
-                        && !values_feed_triples(&block.values, &block.triples);
+                    {
+                        split_values_seeding_star(block.values, &block.triples)
+                    } else {
+                        (block.values, Vec::new())
+                    };
 
                     // The deferred VALUES wrapper joins on its vars AFTER the triple
                     // operators run, so those vars must survive schema pruning even
                     // when the SELECT list doesn't mention them.
-                    if values_after_triples {
-                        if let Some(rwv) = augmented_rwv.as_mut() {
-                            for vp in &block.values {
-                                for v in &vp.vars {
-                                    if !rwv.contains(v) {
-                                        rwv.push(*v);
-                                    }
-                                }
+                    if let Some(rwv) = augmented_rwv.as_mut() {
+                        for v in deferred_values.iter().flat_map(|vp| &vp.vars) {
+                            if !rwv.contains(v) {
+                                rwv.push(*v);
                             }
                         }
                     }
@@ -1985,17 +1997,13 @@ pub fn build_where_operators_seeded_with_needed(
                         stats: stats.as_deref(),
                     };
                     let mut built = build_triple_operators(
-                        if values_after_triples {
-                            operator.take()
-                        } else {
-                            apply_values(operator.take(), block.values.clone())
-                        },
+                        apply_values(operator.take(), seed_values),
                         &block.triples,
                         &HashMap::new(),
                         &ctx,
                     )?;
-                    if values_after_triples {
-                        built = apply_values(Some(built), block.values)
+                    if !deferred_values.is_empty() {
+                        built = apply_values(Some(built), deferred_values)
                             .expect("apply_values should preserve operator");
                     }
                     operator = Some(built);
@@ -3324,15 +3332,147 @@ mod tests {
         let plan = op.describe();
         let ops = plan_ops(&plan);
 
+        assert_ne!(
+            ops.first(),
+            Some(&"ValuesOperator"),
+            "a subject-bound VALUES must seed the star, not filter it afterwards: {ops:?}"
+        );
+        assert!(
+            !ops.contains(&"PropertyJoinOperator"),
+            "the star must not fuse into a driver scan of the class extent: {ops:?}"
+        );
+        assert!(
+            ops.contains(&"ValuesOperator"),
+            "the VALUES must still be applied somewhere in the plan: {ops:?}"
+        );
+    }
+
+    /// A VALUES binding only a leaf OBJECT var must not seed.
+    ///
+    /// It constrains one predicate of the star, not the driving scan, so seeding
+    /// it buys nothing and costs the fusion — a wide star becomes one join per
+    /// predicate. The #51 evidence (the arity sweep) only covers the
+    /// subject-connected shape, so this shape keeps the pre-#51 plan.
+    #[test]
+    fn test_object_var_values_keeps_property_join() {
+        use crate::binding::Binding;
+
+        // VALUES ?n { "x" } . ?s a <ex:Thing> ; <ex:name> ?n
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(1)],
+                rows: vec![vec![Binding::lit(
+                    FlakeValue::String("x".into()),
+                    Sid::new(1, "string"),
+                )]],
+            },
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Iri(Arc::from(fluree_vocab::rdf::TYPE)),
+                Term::Iri(Arc::from("ex:Thing")),
+            )),
+            Pattern::Triple(make_pattern(VarId(0), "name", VarId(1))),
+        ];
+
+        let op = build_where_operators(&patterns, None).unwrap();
+        let plan = op.describe();
+        let ops = plan_ops(&plan);
+
         assert_eq!(
-            ops,
-            vec![
-                "NestedLoopJoinOperator",
-                "NestedLoopJoinOperator",
-                "ValuesOperator",
-                "EmptyOperator",
-            ],
-            "expected the VALUES to seed the star from the base of the plan"
+            ops.first(),
+            Some(&"ValuesOperator"),
+            "an object-var VALUES must stay above the star: {ops:?}"
+        );
+        assert!(
+            ops.contains(&"PropertyJoinOperator"),
+            "the star must keep its fusion when nothing binds its subject: {ops:?}"
+        );
+    }
+
+    /// A block may hold both kinds of VALUES; only the subject-binding one seeds.
+    ///
+    /// The gate is per-VALUES because the hazard is. Seeding the whole slice
+    /// because one member happens to be connected would put the disconnected
+    /// VALUES at the base of the plan — the cartesian seed the deferral exists
+    /// to prevent.
+    #[test]
+    fn test_mixed_values_seeds_only_the_subject_binding_one() {
+        use crate::binding::Binding;
+
+        // VALUES ?s { <ex:thing1> } VALUES ?q { 0 } . ?s a <ex:Thing> ; <ex:name> ?n
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(0)],
+                rows: vec![vec![Binding::iri("ex:thing1")]],
+            },
+            Pattern::Values {
+                vars: vec![VarId(9)],
+                rows: vec![vec![Binding::lit(FlakeValue::Long(0), Sid::new(2, "long"))]],
+            },
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Iri(Arc::from(fluree_vocab::rdf::TYPE)),
+                Term::Iri(Arc::from("ex:Thing")),
+            )),
+            Pattern::Triple(make_pattern(VarId(0), "name", VarId(1))),
+        ];
+
+        let op = build_where_operators(&patterns, None).unwrap();
+        let plan = op.describe();
+        let ops = plan_ops(&plan);
+
+        assert_eq!(
+            ops.first(),
+            Some(&"ValuesOperator"),
+            "the disconnected VALUES must stay above the star: {ops:?}"
+        );
+        assert_eq!(
+            ops.iter().rev().nth(1),
+            Some(&"ValuesOperator"),
+            "the subject-bound VALUES must seed from the base of the plan: {ops:?}"
+        );
+        assert!(
+            !ops.contains(&"PropertyJoinOperator"),
+            "the seeded star must not drain the class extent: {ops:?}"
+        );
+    }
+
+    /// Neither VALUES binds the star's subject, so both defer.
+    ///
+    /// `{ VALUES ?a {..} VALUES ?b {..} ?s :p ?a . ?s :q ?r }` — legal SPARQL
+    /// where `?a` is a leaf object var and `?b` shares nothing. Keying the gate
+    /// on "any shared var" seeded both, putting the disconnected `?b` at the
+    /// base of the plan.
+    #[test]
+    fn test_values_sharing_only_object_vars_all_defer() {
+        use crate::binding::Binding;
+
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(1)],
+                rows: vec![vec![Binding::iri("ex:a1")]],
+            },
+            Pattern::Values {
+                vars: vec![VarId(9)],
+                rows: vec![vec![Binding::iri("ex:b1")]],
+            },
+            Pattern::Triple(make_pattern(VarId(0), "p", VarId(1))),
+            Pattern::Triple(make_pattern(VarId(0), "q", VarId(2))),
+        ];
+
+        let op = build_where_operators(&patterns, None).unwrap();
+        let plan = op.describe();
+        let ops = plan_ops(&plan);
+
+        assert_ne!(
+            ops.iter().rev().nth(1),
+            Some(&"ValuesOperator"),
+            "no VALUES binds the subject, so none may seed the plan's base: {ops:?}"
+        );
+        assert_eq!(
+            ops.last(),
+            Some(&"DatasetOperator"),
+            "the star should still drive its own scan: {ops:?}"
         );
     }
 

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1044,6 +1044,20 @@ fn apply_values(
     operator
 }
 
+/// Does any VALUES pattern bind a variable that the triples also mention?
+///
+/// Answers whether the VALUES can seed the triples. A connected VALUES constrains
+/// them; a disconnected one only multiplies rows.
+fn values_feed_triples(values: &[ValuesPattern], triples: &[TriplePattern]) -> bool {
+    let triple_vars: HashSet<VarId> = triples
+        .iter()
+        .flat_map(TriplePattern::referenced_vars)
+        .collect();
+    values
+        .iter()
+        .any(|vp| vp.vars.iter().any(|v| triple_vars.contains(v)))
+}
+
 /// Partition filters into those eligible for inline evaluation and those still waiting.
 ///
 /// Filters consumed by pushdown are silently dropped. Filters whose required
@@ -1931,10 +1945,19 @@ pub fn build_where_operators_seeded_with_needed(
                     // Preserve property-join eligibility when a top-level VALUES precedes
                     // a pure star block. Wrapping VALUES first seeds the schema/operator and
                     // prevents `build_triple_operators()` from taking the property-join path.
+                    //
+                    // Only defer a VALUES that is *disconnected* from the star (e.g. a pinned
+                    // vector-search query vector): seeding it would build a cartesian product
+                    // and cost a profitable fusion. A VALUES that shares a variable with the
+                    // star is a guaranteed producer with exact cardinality, and seeding it
+                    // lets `build_scan_or_join()` pick a bound-driven lane — batched-subject
+                    // -exists, MembershipJoin, or HashJoin — instead of draining the whole
+                    // class or predicate extent and filtering afterwards.
                     let values_after_triples = operator.is_none()
                         && !block.values.is_empty()
                         && block.triples.len() >= 2
-                        && is_property_join(&block.triples);
+                        && is_property_join(&block.triples)
+                        && !values_feed_triples(&block.values, &block.triples);
 
                     // The deferred VALUES wrapper joins on its vars AFTER the triple
                     // operators run, so those vars must survive schema pruning even
@@ -3260,6 +3283,94 @@ mod tests {
         assert!(
             schema.contains(&VarId(9)),
             "expected VALUES var (?queryVec) to appear in schema"
+        );
+    }
+
+    /// Operator names of a linear plan, root first.
+    fn plan_ops(node: &crate::plan_node::PlanNode) -> Vec<&str> {
+        let mut ops = vec![node.op.as_str()];
+        for edge in &node.children {
+            ops.extend(plan_ops(&edge.node));
+        }
+        ops
+    }
+
+    /// Regression (#51): a VALUES sharing a variable with the star must seed it.
+    ///
+    /// Deferring it left `?s` unbound when the star was planned, so the driver
+    /// race picked the bound-object `rdf:type` triple and drained the entire
+    /// class extent, only for the deferred VALUES to discard all but one row —
+    /// O(|:Thing|) work for an O(1) lookup. Seeding puts the bound subject at
+    /// the base of the plan, where the join lanes can probe for it directly.
+    #[test]
+    fn test_connected_values_seeds_type_anchored_star() {
+        use crate::binding::Binding;
+
+        // VALUES ?s { <ex:thing1> } . ?s a <ex:Thing> ; <ex:name> ?n
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(0)],
+                rows: vec![vec![Binding::iri("ex:thing1")]],
+            },
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Iri(Arc::from(fluree_vocab::rdf::TYPE)),
+                Term::Iri(Arc::from("ex:Thing")),
+            )),
+            Pattern::Triple(make_pattern(VarId(0), "name", VarId(1))),
+        ];
+
+        let op = build_where_operators(&patterns, None).unwrap();
+        let plan = op.describe();
+        let ops = plan_ops(&plan);
+
+        assert_eq!(
+            ops,
+            vec![
+                "NestedLoopJoinOperator",
+                "NestedLoopJoinOperator",
+                "ValuesOperator",
+                "EmptyOperator",
+            ],
+            "expected the VALUES to seed the star from the base of the plan"
+        );
+    }
+
+    /// Companion to `test_connected_values_seeds_type_anchored_star`: the
+    /// disjointness gate must not disturb a VALUES the star cannot consume.
+    ///
+    /// Same vector-search shape as
+    /// `test_values_does_not_block_property_join_schema_order`, asserted on the
+    /// operator tree rather than on schema order: seeding `?queryVec` here would
+    /// only cross-product the star, so the VALUES stays at the root.
+    #[test]
+    fn test_disconnected_values_stays_deferred_above_star() {
+        use crate::binding::Binding;
+
+        // VALUES ?queryVec { 0 } . ?article :date ?date ; :vec ?vec ; :title ?title
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(9)],
+                rows: vec![vec![Binding::lit(FlakeValue::Long(0), Sid::new(2, "long"))]],
+            },
+            Pattern::Triple(make_pattern(VarId(0), "date", VarId(1))),
+            Pattern::Triple(make_pattern(VarId(0), "vec", VarId(2))),
+            Pattern::Triple(make_pattern(VarId(0), "title", VarId(3))),
+        ];
+
+        let op = build_where_operators(&patterns, None).unwrap();
+        let plan = op.describe();
+        let ops = plan_ops(&plan);
+
+        assert_eq!(
+            ops.first(),
+            Some(&"ValuesOperator"),
+            "disconnected VALUES must stay above the star, not seed it: {ops:?}"
+        );
+        assert_eq!(
+            ops.last(),
+            Some(&"DatasetOperator"),
+            "the star should still drive its own scan: {ops:?}"
         );
     }
 


### PR DESCRIPTION
`SELECT ?s ?n WHERE { VALUES ?s { <iri> } ?s a :Thing ; :name ?n }` was O(class size) rather than O(VALUES rows): the values-after-triples deferral fired on any VALUES preceding a 2+-triple star, including one whose variable *is* the star's subject. That left `?s` unbound at planning time, the bound-object `rdf:type` triple won the driver race, and the whole class extent was drained before the deferred VALUES discarded all but the matching rows. Measured in-process at 1.5ms/17ms/47ms for N=2K/20K/50K against a flat ~0.02ms for the equivalent inlined-IRI query.

The gate now checks whether the VALUES shares a variable with the star. Disconnected VALUES (the case the deferral was written for — a pinned vector-search query vector, where seeding would produce a cartesian seed) keep the deferred plan unchanged; connected VALUES seed first, and `build_scan_or_join` picks a bound-driven lane from real cardinality estimates. No cardinality threshold was added: an arity sweep to k=32,768 against a 50,000-member class found no crossover where the extent scan wins — the old plan pays the full scan *and* the post-filter, so it never comes out ahead.

Plan-shape regression tests pin both directions (the existing disconnected-VALUES vector test passes unchanged), plus result-correctness tests on indexed ledgers. Sequencing note: this should land after #1624 — the seeded plan routes some historical-`t` reads through lanes that #1624 makes correct on rebuilt indexes.
