### PR TITLE
tighten indexed fast-path eligibility guards

### DIFF
--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -229,6 +229,12 @@ path = "tests/it_exists_semijoin_correlation.rs"
 name = "it_repeated_var_fast_path_guards"
 path = "tests/it_repeated_var_fast_path_guards.rs"
 
+# Own binary: toggles the process-global fast-path kill switch AND asserts
+# fast-path routing, so it must not share a process with either.
+[[test]]
+name = "it_distinct_object_numbig_gate"
+path = "tests/it_distinct_object_numbig_gate.rs"
+
 [[test]]
 name = "it_cyclic_bgp_novelty_pred"
 path = "tests/it_cyclic_bgp_novelty_pred.rs"

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -218,6 +218,11 @@ path = "tests/grp_transact.rs"
 name = "it_count_datatype_pin"
 path = "tests/it_count_datatype_pin.rs"
 
+# Own binary: asserts fast-path routing via process-scoped tracing capture.
+[[test]]
+name = "it_exists_semijoin_correlation"
+path = "tests/it_exists_semijoin_correlation.rs"
+
 [[test]]
 name = "it_cyclic_bgp_novelty_pred"
 path = "tests/it_cyclic_bgp_novelty_pred.rs"

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -223,6 +223,12 @@ path = "tests/it_count_datatype_pin.rs"
 name = "it_exists_semijoin_correlation"
 path = "tests/it_exists_semijoin_correlation.rs"
 
+# Own binary: toggles the process-global fast-path kill switch AND asserts
+# fast-path routing, so it must not share a process with either.
+[[test]]
+name = "it_repeated_var_fast_path_guards"
+path = "tests/it_repeated_var_fast_path_guards.rs"
+
 [[test]]
 name = "it_cyclic_bgp_novelty_pred"
 path = "tests/it_cyclic_bgp_novelty_pred.rs"

--- a/fluree-db-api/tests/grp_query.rs
+++ b/fluree-db-api/tests/grp_query.rs
@@ -49,6 +49,8 @@ mod it_query_property;
 mod it_query_rdf_list_parity;
 #[path = "it_query_reverse.rs"]
 mod it_query_reverse;
+#[path = "it_query_self_loop_star_join.rs"]
+mod it_query_self_loop_star_join;
 #[path = "it_query_typed_json.rs"]
 mod it_query_typed_json;
 #[path = "it_query_vocab_id_compaction.rs"]

--- a/fluree-db-api/tests/it_distinct_object_numbig_gate.rs
+++ b/fluree-db-api/tests/it_distinct_object_numbig_gate.rs
@@ -1,0 +1,530 @@
+//! Regression pin: the whole-graph `COUNT(DISTINCT ?o)` fast path must decline
+//! a graph whose objects include a NumBig arena handle.
+//!
+//! `SELECT (COUNT(DISTINCT ?o) AS ?n) WHERE { ?s ?p ?o }` is answered from OPST
+//! leaflet directory metadata by grouping on the 10-byte lead `o_type(2) +
+//! o_key(8)`, which stops immediately before `p_id` at bytes `[14..18]`. For
+//! every object kind but one that lead is a faithful graph-wide identity. The
+//! exception is `OType::NUM_BIG_OVERFLOW`, whose `o_key` is a handle into a
+//! **per-predicate** arena allocated from 0 within each `(g_id, p_id)`: the
+//! first big value under one predicate and the first under another are both
+//! handle `0` and collapse into one group.
+//!
+//! Two consequences shape this file. Every `xsd:decimal` lands in that arena
+//! unconditionally (the resolver has no inline branch), and so does any
+//! `xsd:integer` too large for `i64` — so the scope is not "decimals" but "the
+//! NumBig arena". And because handles are sequential per predicate, the result
+//! was `max` over predicates of their distinct big-value counts rather than the
+//! size of the union: a silent undercount that can never over-report, which is
+//! why nothing downstream ever tripped on it.
+//!
+//! Everything here runs on **bulk-imported, fully indexed** ledgers. A
+//! `FlureeBuilder::memory()` ledger declines every one of these fast paths and
+//! would make the whole file pass vacuously.
+//!
+//! One test function, because the kill switch is process-global and phase 1
+//! toggles it; `cargo test` runs a binary's tests on parallel threads.
+
+#![cfg(feature = "native")]
+
+#[path = "support/span_capture.rs"]
+mod span_capture;
+
+use fluree_db_api::{set_fast_paths_disabled, FlureeBuilder};
+use serde_json::Value;
+use std::io::Write;
+use tempfile::TempDir;
+
+/// Operator label the whole-graph distinct-object count stamps.
+const OBJECT_SITE: &str = "distinct object COUNT";
+/// Whole-graph distinct-**subject** count — must be untouched by the gate.
+const SUBJECT_SITE: &str = "distinct subject COUNT";
+/// Bound-predicate distinct-object count, served from POST whose 14-byte lead
+/// starts with `p_id` and therefore scopes the arena handle correctly.
+const PREDICATE_SITE: &str = "COUNT(DISTINCT)";
+
+const Q_COUNT: &str = "SELECT (COUNT(DISTINCT ?o) AS ?n) WHERE { ?s ?p ?o }";
+
+/// The reported fixture: two different decimals under two different predicates.
+const F_REPORTED: &str = r#"
+<http://valuenet/ontop/treatments/treatment_id=11> <http://valuenet/ontop/treatments#cost_of_treatment> "514.0000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://valuenet/ontop/charges/charge_id=3> <http://valuenet/ontop/charges#charge_amount> "640.0000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+"#;
+
+/// Two decimals under ONE predicate: handles 0 and 1 in a single arena, so this
+/// answered correctly even unfixed. It still declines now — the gate is on the
+/// presence of a NumBig row, not on a collision it cannot see from metadata.
+const F_ONE_PRED: &str = r#"
+<http://ex/s1> <http://ex/p1> "514.0000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/s2> <http://ex/p1> "640.0000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+"#;
+
+/// The same decimal VALUE under two predicates: two handles, one term. Correct
+/// by accident before the fix (both are handle 0).
+const F_SAME_VALUE: &str = r#"
+<http://ex/s1> <http://ex/p1> "5.5000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/s2> <http://ex/p2> "5.5000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+"#;
+
+/// 3 distinct decimals under p1, 1 disjoint under p2: union 4, `max` 3.
+const F_MAXPRED: &str = r#"
+<http://ex/a1> <http://ex/p1> "1.1000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/a2> <http://ex/p1> "2.2000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/a3> <http://ex/p1> "3.3000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/b1> <http://ex/p2> "9.9000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+"#;
+
+/// 3 and 3, all disjoint: union 6, `max` 3. Also the ledger the must-fire
+/// guards below run on.
+const F_LOSS3: &str = r#"
+<http://ex/a1> <http://ex/p1> "1.1000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/a2> <http://ex/p1> "2.2000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/a3> <http://ex/p1> "3.3000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/b1> <http://ex/p2> "4.4000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/b2> <http://ex/p2> "5.5000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/b3> <http://ex/p2> "6.6000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+"#;
+
+/// Decimals across predicates PLUS strings and small integers, so the correctly
+/// counted non-NumBig slice is exercised alongside the broken one.
+const F_MIXED: &str = r#"
+<http://ex/a1> <http://ex/p1> "1.1000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/a2> <http://ex/p1> "2.2000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/b1> <http://ex/p2> "3.3000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/b2> <http://ex/p2> "4.4000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/c1> <http://ex/p3> "alpha" .
+<http://ex/c2> <http://ex/p3> "beta" .
+<http://ex/d1> <http://ex/p4> 7 .
+<http://ex/d2> <http://ex/p4> 8 .
+"#;
+
+/// 5 decimals under p1 and 4 under p2 of which 1 is shared: union 8, `max` 5 —
+/// the reported production shape, a loss of exactly 3. Values are inserted in
+/// non-numeric order so the extrema and ORDER BY pins below are meaningful:
+/// arena handles follow insertion order, so the global min and max sit at
+/// non-extreme handle positions.
+const F_LIFECYCLE: &str = r#"
+<http://ex/a1> <http://ex/p1> "5.5000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/a2> <http://ex/p1> "6.6000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/a3> <http://ex/p1> "7.7000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/a4> <http://ex/p1> "8.8000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/a5> <http://ex/p1> "9.9000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/b1> <http://ex/p2> "9.9000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/b2> <http://ex/p2> "1.1000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/b3> <http://ex/p2> "2.2000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/b4> <http://ex/p2> "3.3000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+"#;
+
+/// `xsd:integer` beyond `i64`: the same per-predicate arena as decimals. The
+/// reported scope said integers were unaffected — true only up to `i64::MAX`.
+const F_BIGINT_CROSS: &str = r#"
+<http://ex/s1> <http://ex/p1> "170141183460469231731687303715884105727"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://ex/s2> <http://ex/p2> "170141183460469231731687303715884105999"^^<http://www.w3.org/2001/XMLSchema#integer> .
+"#;
+
+/// `xsd:integer` within `i64`: an inline, value-faithful `o_key`.
+const F_INT_CROSS: &str = r#"
+<http://ex/s1> <http://ex/p1> "514"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://ex/s2> <http://ex/p2> "640"^^<http://www.w3.org/2001/XMLSchema#integer> .
+"#;
+
+const F_DOUBLE_CROSS: &str = r#"
+<http://ex/s1> <http://ex/p1> "514.0"^^<http://www.w3.org/2001/XMLSchema#double> .
+<http://ex/s2> <http://ex/p2> "640.0"^^<http://www.w3.org/2001/XMLSchema#double> .
+"#;
+
+const F_STR_CROSS: &str = r#"
+<http://ex/s1> <http://ex/p1> "514.0000" .
+<http://ex/s2> <http://ex/p2> "640.0000" .
+"#;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Routing {
+    /// The graph holds a NumBig object: the whole-graph object count must fall
+    /// through to the general pipeline.
+    MustDecline,
+    /// No NumBig object anywhere: the fast path must still serve it, so an
+    /// over-broad gate (or a blanket disable) fails here.
+    MustProceed,
+}
+
+struct Case {
+    name: &'static str,
+    ttl: &'static str,
+    /// Hand-computed distinct object terms in the whole graph.
+    truth: usize,
+    routing: Routing,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        name: "reported: two decimals, two predicates",
+        ttl: F_REPORTED,
+        truth: 2,
+        routing: Routing::MustDecline,
+    },
+    Case {
+        name: "two decimals under one predicate",
+        ttl: F_ONE_PRED,
+        truth: 2,
+        routing: Routing::MustDecline,
+    },
+    Case {
+        name: "same decimal value under two predicates",
+        ttl: F_SAME_VALUE,
+        truth: 1,
+        routing: Routing::MustDecline,
+    },
+    Case {
+        name: "decimals 3 and 1 disjoint",
+        ttl: F_MAXPRED,
+        truth: 4,
+        routing: Routing::MustDecline,
+    },
+    Case {
+        name: "decimals 3 and 3 disjoint",
+        ttl: F_LOSS3,
+        truth: 6,
+        routing: Routing::MustDecline,
+    },
+    Case {
+        name: "decimals 5 and 4 sharing one",
+        ttl: F_LIFECYCLE,
+        truth: 8,
+        routing: Routing::MustDecline,
+    },
+    Case {
+        name: "decimals mixed with strings and small integers",
+        ttl: F_MIXED,
+        truth: 8,
+        routing: Routing::MustDecline,
+    },
+    Case {
+        name: "overflow xsd:integer across two predicates",
+        ttl: F_BIGINT_CROSS,
+        truth: 2,
+        routing: Routing::MustDecline,
+    },
+    Case {
+        name: "CTRL i64 integers across two predicates",
+        ttl: F_INT_CROSS,
+        truth: 2,
+        routing: Routing::MustProceed,
+    },
+    Case {
+        name: "CTRL doubles across two predicates",
+        ttl: F_DOUBLE_CROSS,
+        truth: 2,
+        routing: Routing::MustProceed,
+    },
+    Case {
+        name: "CTRL strings across two predicates",
+        ttl: F_STR_CROSS,
+        truth: 2,
+        routing: Routing::MustProceed,
+    },
+];
+
+/// Bulk import builds a fully persisted binary index with no trailing novelty,
+/// so `fast_path_store` holds and the detectors actually fire. The `TempDir`s
+/// are returned so the caller keeps them alive for the ledger's lifetime.
+async fn build_indexed(ttl: &str, slug: &str) -> (TempDir, TempDir, fluree_db_api::Fluree, String) {
+    let db_dir = TempDir::new().expect("db tmpdir");
+    let data_dir = TempDir::new().expect("data tmpdir");
+    let path = data_dir.path().join("00-fixture.ttl");
+    let mut f = std::fs::File::create(&path).expect("create ttl");
+    f.write_all(ttl.as_bytes()).expect("write ttl");
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    // Case names double as ledger names, so fold anything the ledger-id parser
+    // rejects (spaces, colons, parentheses) into `-`.
+    let sanitized: String = slug
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let ledger_id = format!("numbig/{sanitized}:main");
+    fluree
+        .create(&ledger_id)
+        .import(data_dir.path())
+        .threads(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import");
+    (db_dir, data_dir, fluree, ledger_id)
+}
+
+async fn run(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &fluree_db_api::LedgerState,
+    sparql: &str,
+) -> Value {
+    let db = fluree_db_api::GraphDb::from_ledger_state(ledger);
+    fluree
+        .query(&db, sparql)
+        .await
+        .unwrap_or_else(|e| panic!("query {sparql}: {e}"))
+        .to_sparql_json(&ledger.snapshot)
+        .unwrap_or_else(|e| panic!("to_sparql_json {sparql}: {e}"))
+}
+
+fn scalar(v: &Value) -> String {
+    v["results"]["bindings"][0]["n"]["value"]
+        .as_str()
+        .unwrap_or("<none>")
+        .to_string()
+}
+
+fn nrows(v: &Value) -> usize {
+    v["results"]["bindings"]
+        .as_array()
+        .map(Vec::len)
+        .unwrap_or(0)
+}
+
+/// Values of `?o`, in result order.
+fn o_values(v: &Value) -> Vec<String> {
+    v["results"]["bindings"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .map(|b| b["o"]["value"].as_str().unwrap_or("?").to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn proceeded(store: &span_capture::SpanStore, from: usize) -> Vec<String> {
+    store.find_events("fast-path outcome")[from..]
+        .iter()
+        .filter(|e| e.fields.get("outcome").map(String::as_str) == Some("proceed"))
+        .filter_map(|e| e.fields.get("site").cloned())
+        .collect()
+}
+
+/// RAII restore of the process-global kill switch, including on panic.
+struct FastPathGuard;
+impl Drop for FastPathGuard {
+    fn drop(&mut self) {
+        set_fast_paths_disabled(false);
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn distinct_object_count_declines_numbig_object_keys() {
+    // The kill switch OR's with this env var, so with it set the fast lane
+    // would run generically and every assertion below would be vacuous.
+    assert!(
+        std::env::var_os("FLUREE_DISABLE_QUERY_FAST_PATHS").is_none(),
+        "FLUREE_DISABLE_QUERY_FAST_PATHS is set — the fast lane of this test \
+         would run generically and pin nothing. Unset it."
+    );
+    let _guard = FastPathGuard;
+    let mut failures: Vec<String> = Vec::new();
+
+    // ---- Phase 1: value + routing, per fixture ---------------------------
+    for case in CASES {
+        let (_db, _data, fluree, ledger_id) = build_indexed(case.ttl, case.name).await;
+        let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
+        let truth = case.truth.to_string();
+
+        let (store, tracing_guard) = span_capture::init_test_tracing();
+        set_fast_paths_disabled(false);
+        let fast = scalar(&run(&fluree, &ledger, Q_COUNT).await);
+        let sites = proceeded(&store, 0);
+        drop(tracing_guard);
+
+        // The general pipeline is ground truth: it agrees with the
+        // hand-computed answer on every fixture, which is what makes a
+        // divergence attributable to the fast path rather than to a semantics
+        // disagreement.
+        set_fast_paths_disabled(true);
+        let generic = scalar(&run(&fluree, &ledger, Q_COUNT).await);
+        set_fast_paths_disabled(false);
+
+        if fast != truth {
+            failures.push(format!(
+                "{}: fast lane COUNT(DISTINCT ?o) = {fast}, expected {truth} \
+                 (generic {generic}) [proceeded: {sites:?}]",
+                case.name
+            ));
+        }
+        if generic != truth {
+            failures.push(format!(
+                "{}: generic pipeline = {generic}, expected {truth} — the \
+                 hand-computed answer is wrong or the general pipeline regressed",
+                case.name
+            ));
+        }
+        let did_proceed = sites.iter().any(|s| s == OBJECT_SITE);
+        match case.routing {
+            Routing::MustDecline if did_proceed => failures.push(format!(
+                "{}: `{OBJECT_SITE}` proceeded on a graph holding a NumBig \
+                 object key, whose (o_type, o_key) lead is per-predicate",
+                case.name
+            )),
+            Routing::MustProceed if !did_proceed => failures.push(format!(
+                "{}: expected `{OBJECT_SITE}` to proceed — no NumBig object \
+                 here, so the gate must narrow the fast path, not remove it \
+                 [proceeded: {sites:?}]",
+                case.name
+            )),
+            _ => {}
+        }
+    }
+
+    // ---- Phase 2: the over-broad-fix guards, on a decimal-bearing ledger --
+    // Only the whole-graph OPST object arm is unsound. Declining its siblings
+    // would be a gratuitous perf regression, so both must still fire on the
+    // very ledger that makes the object arm decline.
+    {
+        let (_db, _data, fluree, ledger_id) = build_indexed(F_LOSS3, "must-fire-guards").await;
+        let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
+        let guards: &[(&str, &str, &str, usize)] = &[
+            (
+                "COUNT(DISTINCT ?s) whole-graph",
+                "SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE { ?s ?p ?o }",
+                SUBJECT_SITE,
+                6,
+            ),
+            (
+                "COUNT(DISTINCT ?o) bound predicate",
+                "SELECT (COUNT(DISTINCT ?o) AS ?n) WHERE { ?s <http://ex/p1> ?o }",
+                PREDICATE_SITE,
+                3,
+            ),
+        ];
+        for (name, q, site, truth) in guards {
+            let (store, tracing_guard) = span_capture::init_test_tracing();
+            set_fast_paths_disabled(false);
+            let got = scalar(&run(&fluree, &ledger, q).await);
+            let sites = proceeded(&store, 0);
+            drop(tracing_guard);
+            if got != truth.to_string() {
+                failures.push(format!("{name}: got {got}, expected {truth}"));
+            }
+            if !sites.iter().any(|s| s == site) {
+                failures.push(format!(
+                    "{name}: expected `{site}` to proceed on a decimal-bearing \
+                     ledger — only the whole-graph object arm is unsound \
+                     [proceeded: {sites:?}]"
+                ));
+            }
+        }
+    }
+
+    // ---- Phase 3: the neighbourhood, which the gate must not perturb ------
+    // These decode the value through the arena instead of comparing raw keys,
+    // so they were correct before the fix and document its boundary. The
+    // same-value fixture is the mirror risk: a key that DOES carry p_id would
+    // split one decimal term into two.
+    {
+        let (_db, _data, fluree, ledger_id) = build_indexed(F_LOSS3, "neighbourhood").await;
+        let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
+        let rows: &[(&str, &str, usize)] = &[
+            (
+                "GROUP BY ?o",
+                "SELECT ?o (COUNT(*) AS ?c) WHERE { ?s ?p ?o } GROUP BY ?o",
+                6,
+            ),
+            ("DISTINCT ?o", "SELECT DISTINCT ?o WHERE { ?s ?p ?o }", 6),
+        ];
+        for (name, q, truth) in rows {
+            let got = nrows(&run(&fluree, &ledger, q).await);
+            if got != *truth {
+                failures.push(format!("{name}: {got} rows, expected {truth}"));
+            }
+        }
+
+        for (name, q, truth) in [
+            (
+                "MIN(?o) whole-graph",
+                "SELECT (MIN(?o) AS ?n) WHERE { ?s ?p ?o }",
+                "1.1",
+            ),
+            (
+                "MAX(?o) whole-graph",
+                "SELECT (MAX(?o) AS ?n) WHERE { ?s ?p ?o }",
+                "6.6",
+            ),
+        ] {
+            let got = scalar(&run(&fluree, &ledger, q).await);
+            if got != truth {
+                failures.push(format!("{name}: got {got}, expected {truth}"));
+            }
+        }
+    }
+    {
+        // Insertion order is deliberately not numeric order, so a path that
+        // read OPST/handle order as value order would fail here.
+        let (_db, _data, fluree, ledger_id) = build_indexed(F_LIFECYCLE, "ordering").await;
+        let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
+        let asc =
+            o_values(&run(&fluree, &ledger, "SELECT ?o WHERE { ?s ?p ?o } ORDER BY ?o").await);
+        let mut sorted = asc.clone();
+        sorted.sort_by(|a, b| {
+            a.parse::<f64>()
+                .unwrap_or(f64::NAN)
+                .partial_cmp(&b.parse::<f64>().unwrap_or(f64::NAN))
+                .expect("decimal fixture parses")
+        });
+        if asc != sorted {
+            failures.push(format!("ORDER BY ?o ASC is not numeric: {asc:?}"));
+        }
+        let desc = o_values(
+            &run(
+                &fluree,
+                &ledger,
+                "SELECT ?o WHERE { ?s ?p ?o } ORDER BY DESC(?o)",
+            )
+            .await,
+        );
+        let mut rev = sorted.clone();
+        rev.reverse();
+        if desc != rev {
+            failures.push(format!("ORDER BY ?o DESC is not numeric: {desc:?}"));
+        }
+    }
+    {
+        let (_db, _data, fluree, ledger_id) = build_indexed(F_SAME_VALUE, "mirror").await;
+        let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
+        let mirror: &[(&str, &str, usize)] = &[
+            (
+                "GROUP BY ?o on one value under two predicates",
+                "SELECT ?o (COUNT(*) AS ?c) WHERE { ?s ?p ?o } GROUP BY ?o",
+                1,
+            ),
+            (
+                "DISTINCT ?o on one value under two predicates",
+                "SELECT DISTINCT ?o WHERE { ?s ?p ?o }",
+                1,
+            ),
+            (
+                "cross-predicate value join",
+                "SELECT ?a ?b WHERE { ?a <http://ex/p1> ?v . ?b <http://ex/p2> ?v }",
+                1,
+            ),
+            (
+                "cross-predicate FILTER equality",
+                "SELECT ?a ?b WHERE { ?a <http://ex/p1> ?v1 . ?b <http://ex/p2> ?v2 \
+                 FILTER(?v1 = ?v2) }",
+                1,
+            ),
+        ];
+        for (name, q, truth) in mirror {
+            let got = nrows(&run(&fluree, &ledger, q).await);
+            if got != *truth {
+                failures.push(format!("{name}: {got} rows, expected {truth}"));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "distinct-object NumBig gate failures:\n  {}",
+        failures.join("\n  ")
+    );
+}

--- a/fluree-db-api/tests/it_exists_semijoin_correlation.rs
+++ b/fluree-db-api/tests/it_exists_semijoin_correlation.rs
@@ -1,0 +1,422 @@
+//! Regression pin: the EXISTS semijoin fast path must not answer a
+//! *correlated* object variable.
+//!
+//! `ExistsSemijoinKey` is `(subject_var, predicate)` — a cache entry answers
+//! "does this subject have any object for this predicate". That is the truth
+//! value of `EXISTS { ?s <p> ?o }` only when `?o` is genuinely free. The
+//! eligibility gates tested `Term::is_bound()`, which is `!is_var()` — a
+//! plan-time syntactic test that rejects a constant object but is blind to a
+//! variable the incoming row has already bound. So
+//! `NOT EXISTS { ?s2 :member ?x }` was answered as
+//! `NOT EXISTS { ?s2 :member ?anything }`, and W3C `sparql11/negation/subset-02`
+//! returned 25 solutions instead of 11.
+//!
+//! Two conditions are needed to observe it, and both are load-bearing here:
+//!
+//! * The NOT EXISTS must survive lowering as an `Expression::Exists`. A
+//!   *standalone* `FILTER (NOT EXISTS {...})` becomes a `Pattern::NotExists`
+//!   and routes to `ExistsOperator`, which seeds the subquery from the row and
+//!   is correct. Only a NOT EXISTS inside a compound expression (here, one arm
+//!   of a `||`) reaches `FilterOperator` and is offered to the semijoin cache.
+//!   The MINUS in subset-02 is incidental — `disjunctive_not_exists_*` below is
+//!   the same defect with no MINUS at all.
+//! * The read must be on an **indexed, overlay-free** view. With live novelty
+//!   `fast_path_store` declines and the generic per-row seeded path answers
+//!   correctly, which is why `testsuite-sparql` — every ledger of which is
+//!   `FlureeBuilder::memory()` — has a green negation register and could never
+//!   have caught this.
+//!
+//! The second condition is why every indexed-lane read here is preceded by a
+//! *lane probe*: an uncorrelated EXISTS of the same shape, which must stamp
+//! `exists_semijoin` → `proceed`. Without it a slow background indexer turns
+//! the whole file green while testing only the novelty lane — and the probe
+//! doubles as the must-fire assertion, so a "fix" that stops building the
+//! cache altogether fails here.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::{FlureeBuilder, IndexConfig, LedgerManagerConfig, QueryInput};
+use fluree_db_transact::{CommitOpts, TxnOpts};
+use serde_json::json;
+use support::{
+    genesis_ledger_for_fluree, span_capture, start_background_indexer_local,
+    trigger_index_and_wait_outcome, wait_for_index_application,
+};
+
+/// `fast-path outcome` site stamped by `build_exists_semijoin_cache`.
+const SEMIJOIN_SITE: &str = "exists_semijoin";
+
+/// W3C `sparql11/negation/subset-02.rq`, verbatim.
+const SUBSET_02: &str = r"PREFIX :    <http://example/>
+PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT (?s1 AS ?subset) (?s2 AS ?superset)
+WHERE
+{
+    ?s2 rdf:type :Set .
+    ?s1 rdf:type :Set .
+
+    MINUS {
+        ?s1 rdf:type :Set .
+        ?s2 rdf:type :Set .
+        ?s1 :member ?x .
+        FILTER ( ?s1 = ?s2 || NOT EXISTS { ?s2 :member ?x . } )
+    }
+    MINUS {
+        ?s1 rdf:type :Set .
+        ?s2 rdf:type :Set .
+        FILTER ( NOT EXISTS { ?s1 :member ?y . } )
+        FILTER ( NOT EXISTS { ?s2 :member ?y . } )
+    }
+}";
+
+/// `subset-02.srx`, as (subset, superset) short names: every `(empty, X)` pair
+/// except `(empty, empty)`, plus the six proper-subset pairs. Before the fix
+/// the indexed lane returned 25 — all 20 off-diagonal pairs plus the five
+/// `(empty, X)`.
+const SUBSET_02_EXPECTED: &[(&str, &str)] = &[
+    ("b", "d"),
+    ("c", "a"),
+    ("c", "e"),
+    ("d", "b"),
+    ("e", "a"),
+    ("e", "c"),
+    ("empty", "a"),
+    ("empty", "b"),
+    ("empty", "c"),
+    ("empty", "d"),
+    ("empty", "e"),
+];
+
+/// The same correlated NOT EXISTS at the TOP LEVEL — no MINUS, no disjunction.
+/// Lowering turns this into a `Pattern::NotExists`, so it never reaches the
+/// semijoin; it is the control proving the defect is the *expression* form.
+const PLAIN_NOT_EXISTS: &str = r"PREFIX :    <http://example/>
+PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?s1 ?x ?s2
+WHERE {
+    ?s1 :member ?x .
+    ?s2 rdf:type :Set .
+    FILTER ( NOT EXISTS { ?s2 :member ?x . } )
+}";
+
+/// The minimal user-facing repro: no MINUS. The only difference from
+/// `PLAIN_NOT_EXISTS` is that NOT EXISTS sits inside a `||`, so it stays an
+/// `Expression::Exists` and is offered to the semijoin. 11 solutions satisfy
+/// `?s1 = ?s2`, 27 satisfy the correlated NOT EXISTS, and the two are
+/// disjoint; the indexed lane returned 22 before the fix.
+const DISJUNCTIVE_NOT_EXISTS: &str = r"PREFIX :    <http://example/>
+PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?s1 ?x ?s2
+WHERE {
+    ?s1 :member ?x .
+    ?s2 rdf:type :Set .
+    FILTER ( ?s1 = ?s2 || NOT EXISTS { ?s2 :member ?x . } )
+}";
+
+/// Lane probe / must-fire control: `?free` occurs nowhere but inside the
+/// EXISTS, so the object position really is free and the semijoin is entitled
+/// to serve it. 6 pairs where `?s1 = ?s2`, plus the 6 where `?s2` is the
+/// memberless set, less the one they share.
+const UNCORRELATED_EXISTS: &str = r"PREFIX :    <http://example/>
+PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?s1 ?s2
+WHERE {
+    ?s1 rdf:type :Set .
+    ?s2 rdf:type :Set .
+    FILTER ( ?s1 = ?s2 || NOT EXISTS { ?s2 :member ?free . } )
+}";
+
+const UNCORRELATED_EXPECTED_ROWS: usize = 11;
+
+/// W3C `negation/set-data.ttl` as JSON-LD: five sets over `{1,2,3,9}` plus one
+/// empty set.
+fn set_data() -> serde_json::Value {
+    json!({
+        "@context": {"": "http://example/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"},
+        "@graph": [
+            {"@id": "http://example/a", "@type": "http://example/Set",
+             "http://example/member": [1, 2, 3]},
+            {"@id": "http://example/b", "@type": "http://example/Set",
+             "http://example/member": [1, 9]},
+            {"@id": "http://example/c", "@type": "http://example/Set",
+             "http://example/member": [1, 2]},
+            {"@id": "http://example/d", "@type": "http://example/Set",
+             "http://example/member": [1, 9]},
+            {"@id": "http://example/e", "@type": "http://example/Set",
+             "http://example/member": [1, 2]},
+            {"@id": "http://example/empty", "@type": "http://example/Set"}
+        ]
+    })
+}
+
+/// Reduce solutions to sorted (subset, superset) short-name pairs. Values
+/// arrive either as full IRIs or as compacted CURIEs, and rows either as
+/// positional arrays or as objects, depending on the formatter.
+fn pairs(rows: &[serde_json::Value]) -> Vec<(String, String)> {
+    let short = |v: Option<&serde_json::Value>| -> String {
+        match v {
+            None => "<unbound>".to_string(),
+            Some(serde_json::Value::String(s)) => {
+                let tail = s.rsplit('/').next().unwrap_or(s);
+                tail.trim_start_matches(':').to_string()
+            }
+            Some(other) => other.to_string(),
+        }
+    };
+    let mut out: Vec<(String, String)> = rows
+        .iter()
+        .map(|r| match r {
+            serde_json::Value::Array(a) => (short(a.first()), short(a.get(1))),
+            _ => {
+                let obj = r.as_object();
+                let get = |k: &str| obj.and_then(|o| o.get(k));
+                (short(get("subset")), short(get("superset")))
+            }
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn expected_pairs(spec: &[(&str, &str)]) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = spec
+        .iter()
+        .map(|(a, b)| ((*a).to_string(), (*b).to_string()))
+        .collect();
+    out.sort();
+    out
+}
+
+async fn run(
+    fluree: &fluree_db_api::Fluree,
+    view: &fluree_db_api::GraphDb,
+    q: &str,
+) -> Vec<serde_json::Value> {
+    let result = fluree
+        .query(view, QueryInput::Sparql(q))
+        .await
+        .expect("query");
+    let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
+    support::normalize_rows(&jsonld)
+}
+
+/// Sites that stamped `proceed` after index `from` of the capture log.
+fn proceeded_sites(store: &span_capture::SpanStore, from: usize) -> Vec<String> {
+    store.find_events("fast-path outcome")[from..]
+        .iter()
+        .filter(|e| e.fields.get("outcome").map(String::as_str) == Some("proceed"))
+        .filter_map(|e| e.fields.get("site").cloned())
+        .collect()
+}
+
+/// Assert the view is genuinely on the indexed fast-path lane by running an
+/// uncorrelated EXISTS of the same shape and requiring the semijoin to fire.
+///
+/// Without this the background indexer losing a race silently downgrades every
+/// assertion in this file to a novelty-lane assertion, which passes on the
+/// unfixed engine.
+async fn assert_semijoin_lane_live(
+    fluree: &fluree_db_api::Fluree,
+    view: &fluree_db_api::GraphDb,
+    store: &span_capture::SpanStore,
+) {
+    // The kill switch does not currently reach this fast path, but if that ever
+    // changes the must-fire assertion below would pass vacuously.
+    assert!(
+        std::env::var_os("FLUREE_DISABLE_QUERY_FAST_PATHS").is_none(),
+        "FLUREE_DISABLE_QUERY_FAST_PATHS is set — unset it; this test asserts a \
+         fast path fires."
+    );
+    let before = store.find_events("fast-path outcome").len();
+    let rows = run(fluree, view, UNCORRELATED_EXISTS).await;
+    let sites = proceeded_sites(store, before);
+    assert_eq!(
+        rows.len(),
+        UNCORRELATED_EXPECTED_ROWS,
+        "lane probe: uncorrelated NOT EXISTS = 6 self-pairs + 6 memberless-superset \
+         pairs, less the one they share"
+    );
+    assert!(
+        sites.iter().any(|s| s == SEMIJOIN_SITE),
+        "expected `{SEMIJOIN_SITE}` to proceed for a free object var on this view. \
+         Either the view is not on the indexed fast-path lane (so every assertion \
+         in this test would be vacuous), or the correlation guard is over-broad \
+         and has disabled the semijoin outright. Proceeded: {sites:?}"
+    );
+}
+
+/// Insert `set_data`, read `query` on the novelty lane, index, then read it
+/// again on the indexed lane — checking `expect` on both and requiring the
+/// semijoin to decline the (correlated) query on the indexed lane.
+async fn on_both_lanes<F>(ledger_id: &'static str, query: &'static str, expect: F)
+where
+    F: Fn(&'static str, &[serde_json::Value]) + Send + 'static,
+{
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            // `reindex_min_bytes: 0` makes the six-subject fixture index-eligible.
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let result = fluree
+                .insert_with_opts(
+                    ledger,
+                    &set_data(),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert");
+            let ledger = result.ledger;
+
+            let view = fluree.db(ledger_id).await.expect("novelty view");
+            expect("novelty", &run(&fluree, &view, query).await);
+
+            trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            wait_for_index_application(&fluree, ledger_id, ledger.t()).await;
+            let view = fluree.db(ledger_id).await.expect("indexed view");
+
+            let (store, _tracing_guard) = span_capture::init_test_tracing();
+            assert_semijoin_lane_live(&fluree, &view, &store).await;
+
+            let before = store.find_events("fast-path outcome").len();
+            let rows = run(&fluree, &view, query).await;
+            let sites = proceeded_sites(&store, before);
+            assert!(
+                !sites.iter().any(|s| s == SEMIJOIN_SITE),
+                "`{SEMIJOIN_SITE}` must decline a correlated EXISTS object var; \
+                 proceeded: {sites:?}"
+            );
+            expect("indexed", &rows);
+        })
+        .await;
+}
+
+/// W3C `sparql11/negation/subset-02`: 11 solutions, and the same 11 whether the
+/// read is served from novelty or from the merged index.
+#[tokio::test(flavor = "current_thread")]
+async fn subset_02_returns_eleven_on_both_lanes() {
+    let expected = expected_pairs(SUBSET_02_EXPECTED);
+    on_both_lanes("audit48/subset02:main", SUBSET_02, move |lane, rows| {
+        assert_eq!(
+            pairs(rows),
+            expected,
+            "{lane} lane: subset-02 must return the 11 solutions of subset-02.srx"
+        );
+    })
+    .await;
+}
+
+/// Control: a *standalone* `FILTER NOT EXISTS` lowers to `Pattern::NotExists`
+/// and never reaches the semijoin. It was correct before the fix and must stay
+/// correct — 27 solutions on both lanes.
+#[tokio::test(flavor = "current_thread")]
+async fn plain_top_level_not_exists_unchanged() {
+    on_both_lanes(
+        "audit48/plain-notexists:main",
+        PLAIN_NOT_EXISTS,
+        |lane, rows| {
+            assert_eq!(
+                rows.len(),
+                27,
+                "{lane} lane: top-level FILTER NOT EXISTS must return 27 solutions"
+            );
+        },
+    )
+    .await;
+}
+
+/// The defect with no MINUS involved: NOT EXISTS inside a `||` stays an
+/// expression, reaches the semijoin, and returned 22 instead of 38 on the
+/// indexed lane.
+#[tokio::test(flavor = "current_thread")]
+async fn disjunctive_not_exists_returns_thirty_eight_on_both_lanes() {
+    on_both_lanes(
+        "audit48/disjunctive:main",
+        DISJUNCTIVE_NOT_EXISTS,
+        |lane, rows| {
+            assert_eq!(
+                rows.len(),
+                38,
+                "{lane} lane: `?s1 = ?s2 || NOT EXISTS {{ ?s2 :member ?x }}` must \
+                 return 38 solutions"
+            );
+        },
+    )
+    .await;
+}
+
+/// The must-fire direction on its own ledger: with a free object var the
+/// semijoin still serves the query and still returns the right answer. (Every
+/// test above runs the same probe against its own view; this one names the
+/// contract.)
+#[tokio::test(flavor = "current_thread")]
+async fn uncorrelated_exists_keeps_semijoin() {
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "audit48/uncorrelated:main";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let result = fluree
+                .insert_with_opts(
+                    ledger,
+                    &set_data(),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert");
+            let ledger = result.ledger;
+
+            let view = fluree.db(ledger_id).await.expect("novelty view");
+            let novelty = run(&fluree, &view, UNCORRELATED_EXISTS).await;
+            assert_eq!(novelty.len(), UNCORRELATED_EXPECTED_ROWS, "novelty lane");
+
+            trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            wait_for_index_application(&fluree, ledger_id, ledger.t()).await;
+            let view = fluree.db(ledger_id).await.expect("indexed view");
+
+            let (store, _tracing_guard) = span_capture::init_test_tracing();
+            assert_semijoin_lane_live(&fluree, &view, &store).await;
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_query_self_loop_star_join.rs
+++ b/fluree-db-api/tests/it_query_self_loop_star_join.rs
@@ -1,0 +1,183 @@
+//! Regression pin: a self-loop triple joined to a second pattern on the same
+//! subject must execute, not fail with `Duplicate VarId`.
+//!
+//! `{ ?x <rel> ?x . ?x a ?c }` returned
+//! `Query error: Batch error: Duplicate VarId VarId(0) in schema` — a hard
+//! query failure on every lane, with or without an aggregate. The scan layer
+//! has always handled a repeated variable correctly: `schema_from_pattern_with_emit`
+//! folds both positions into one output column and `within_row_var_equality_ok`
+//! enforces the implied equality per row. `NestedLoopJoinOperator` built its
+//! right-side output vars position by position instead, so a right pattern that
+//! names one variable twice contributed two columns with the same `VarId`, and
+//! `Batch::new` rejects that schema outright.
+//!
+//! `{ ?x <rel> ?x . ?x <rel> ?y }` was unaffected, which is why the failure
+//! looked arbitrary: the same-predicate shape plans to a different operator and
+//! never asks the nested-loop join to widen a repeated variable.
+
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
+use fluree_db_api::{FlureeBuilder, IndexConfig, LedgerManagerConfig, QueryInput};
+use fluree_db_transact::{CommitOpts, TxnOpts};
+use serde_json::json;
+
+/// `rel` has 5 triples of which 2 are self-loops (n1, n2); all four nodes are
+/// typed `ex:C`; n1/n2 carry a `score`.
+fn fixture() -> serde_json::Value {
+    json!({
+        "@context": {"ex": "http://ex/"},
+        "@graph": [
+            {"@id": "ex:n1", "@type": "ex:C", "ex:score": 10,
+             "ex:rel": [{"@id": "ex:n1"}, {"@id": "ex:n2"}]},
+            {"@id": "ex:n2", "@type": "ex:C", "ex:score": 20,
+             "ex:rel": [{"@id": "ex:n2"}, {"@id": "ex:n3"}]},
+            {"@id": "ex:n3", "@type": "ex:C", "ex:rel": {"@id": "ex:n4"}},
+            {"@id": "ex:n4", "@type": "ex:C"}
+        ]
+    })
+}
+
+/// `(query, expected row count)`. Only n1 and n2 are self-related, and both are
+/// typed and scored, so every star join over the self-loop yields 2 — except
+/// the same-predicate control, where the second leg is free and n1/n2 have two
+/// `rel` objects each.
+const CASES: &[(&str, usize)] = &[
+    ("SELECT ?x ?c WHERE { ?x <http://ex/rel> ?x . ?x a ?c }", 2),
+    (
+        "SELECT (COUNT(*) AS ?n) WHERE { ?x <http://ex/rel> ?x . ?x a ?c }",
+        1,
+    ),
+    (
+        "SELECT ?x ?v WHERE { ?x <http://ex/rel> ?x . ?x <http://ex/score> ?v }",
+        2,
+    ),
+    // Reversed leg order: the self-loop is now the RIGHT side of the join with
+    // a non-empty left schema.
+    ("SELECT ?x ?c WHERE { ?x a ?c . ?x <http://ex/rel> ?x }", 2),
+    // Repeated variable across subject and PREDICATE, joined to a second leg.
+    ("SELECT ?x ?c WHERE { ?x ?x ?o . ?x a ?c }", 0),
+    // Control: same predicate on both legs — this shape always worked.
+    (
+        "SELECT ?x ?y WHERE { ?x <http://ex/rel> ?x . ?x <http://ex/rel> ?y }",
+        4,
+    ),
+];
+
+/// The aggregate case above projects one row; assert its value too, so a fix
+/// that merely stops erroring (by dropping the equality constraint) still fails.
+const SELF_LOOP_STAR_COUNT: &str =
+    "SELECT (COUNT(*) AS ?n) WHERE { ?x <http://ex/rel> ?x . ?x a ?c }";
+
+async fn seed_memory(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger = genesis_ledger(fluree, ledger_id);
+    fluree
+        .insert(ledger, &fixture())
+        .await
+        .expect("insert")
+        .ledger
+}
+
+/// Pull the count out of a one-row, one-column result. `to_jsonld` renders a
+/// projected SELECT as positional arrays; accept the object shape too so a
+/// formatter change surfaces as a failed assertion rather than a panic here.
+fn single_count(rows: &[serde_json::Value]) -> i64 {
+    assert_eq!(
+        rows.len(),
+        1,
+        "expected exactly one aggregate row: {rows:?}"
+    );
+    let cell = match &rows[0] {
+        serde_json::Value::Array(a) => a.first(),
+        other => other.get("n"),
+    };
+    cell.and_then(serde_json::Value::as_i64)
+        .unwrap_or_else(|| panic!("no integer count in {rows:?}"))
+}
+
+async fn run(
+    fluree: &fluree_db_api::Fluree,
+    view: &fluree_db_api::GraphDb,
+    q: &str,
+) -> Vec<serde_json::Value> {
+    let result = fluree
+        .query(view, QueryInput::Sparql(q))
+        .await
+        .unwrap_or_else(|e| panic!("{q}: {e}"));
+    let jsonld = result.to_jsonld(&view.snapshot).expect("to_jsonld");
+    normalize_rows(&jsonld)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn self_loop_star_join_novelty_lane() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_memory(&fluree, "selfloop/star-novelty:main").await;
+
+    for (q, expected) in CASES {
+        let view = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+        let rows = run(&fluree, &view, q).await;
+        assert_eq!(rows.len(), *expected, "novelty lane: {q}");
+    }
+
+    let view = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+    let rows = run(&fluree, &view, SELF_LOOP_STAR_COUNT).await;
+    assert_eq!(
+        single_count(&rows),
+        2,
+        "novelty lane: only n1 and n2 are self-related"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn self_loop_star_join_indexed_lane() {
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "selfloop/star-indexed:main";
+
+    let (local, handle) = support::start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .as_arc_indexing_nameservice()
+            .expect("test fluree has writable nameservice"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger = support::genesis_ledger_for_fluree(&fluree, ledger_id);
+            let result = fluree
+                .insert_with_opts(
+                    ledger,
+                    &fixture(),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert");
+            let ledger = result.ledger;
+
+            support::trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            support::wait_for_index_application(&fluree, ledger_id, ledger.t()).await;
+
+            for (q, expected) in CASES {
+                let view = fluree.db(ledger_id).await.expect("indexed view");
+                let rows = run(&fluree, &view, q).await;
+                assert_eq!(rows.len(), *expected, "indexed lane: {q}");
+            }
+
+            let view = fluree.db(ledger_id).await.expect("indexed view");
+            let rows = run(&fluree, &view, SELF_LOOP_STAR_COUNT).await;
+            assert_eq!(
+                single_count(&rows),
+                2,
+                "indexed lane: only n1 and n2 are self-related"
+            );
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_repeated_var_fast_path_guards.rs
+++ b/fluree-db-api/tests/it_repeated_var_fast_path_guards.rs
@@ -50,6 +50,13 @@ ex:n3 a ex:C ; ex:rel ex:n4 .
 ex:n4 a ex:C .
 "#;
 
+/// Two datatypes under one predicate, so a datatype constraint on the object
+/// selects a strict subset of the column: 10 of 30.
+const DTC_DATA: &str = r#"
+<http://ex/i1> <http://ex/amount> "10"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://ex/i2> <http://ex/amount> "20"^^<http://www.w3.org/2001/XMLSchema#positiveInteger> .
+"#;
+
 /// Every fast-path site that answers from per-predicate or whole-permutation
 /// metadata, and therefore may serve only a triple whose subject and object are
 /// distinct free variables. Names are the `FastPathOperator` labels the engine
@@ -309,11 +316,11 @@ impl Drop for FastPathGuard {
     }
 }
 
-async fn indexed_ledger(dir: &TempDir, name: &str) -> (fluree_db_api::Fluree, String) {
+async fn indexed_ledger(dir: &TempDir, name: &str, ttl: &str) -> (fluree_db_api::Fluree, String) {
     let data_dir = TempDir::new().expect("data tmpdir");
     let path = data_dir.path().join("00-fixture.ttl");
     let mut f = std::fs::File::create(&path).expect("create ttl");
-    f.write_all(DATA.as_bytes()).expect("write ttl");
+    f.write_all(ttl.as_bytes()).expect("write ttl");
 
     // Bulk import builds a fully persisted binary index with no trailing
     // novelty, so `fast_path_store` holds and the detectors actually fire.
@@ -345,7 +352,7 @@ async fn repeated_variable_patterns_decline_the_aggregate_fast_paths() {
     let _guard = FastPathGuard;
 
     let db_dir = TempDir::new().expect("db tmpdir");
-    let (fluree, ledger_id) = indexed_ledger(&db_dir, "repeated-var-guards").await;
+    let (fluree, ledger_id) = indexed_ledger(&db_dir, "repeated-var-guards", DATA).await;
     let ledger = fluree.ledger(&ledger_id).await.expect("load");
     let cases = cases();
 
@@ -444,6 +451,104 @@ async fn repeated_variable_patterns_decline_the_aggregate_fast_paths() {
                     ));
                 }
             }
+        }
+    }
+
+    // ---- The datatype-constrained SUM --------------------------------------
+    // Routing `detect_fused_scan_sum_i64` through `validate_simple_triple` also
+    // inherits that helper's `tp.dtc.is_some()` decline, which the SUM detector
+    // never had of its own: it read only the predicate and the object var, so a
+    // datatype-constrained SUM took the fused scan and summed the predicate's
+    // whole object column across every datatype under it.
+    //
+    // A datatype constraint alongside a *variable* object has no SPARQL
+    // surface — it is the JSON-LD `{"@value": "?v", "@type": …}` form — so this
+    // runs on its own tiny ledger with two datatypes under one predicate.
+    // `xsd:positiveInteger` is chosen because it survives numeric-datatype
+    // normalization; `xsd:long` and friends fold into `xsd:integer` and would
+    // make the constraint a no-op.
+    {
+        let db_dir = TempDir::new().expect("db tmpdir");
+        let (fluree, ledger_id) = indexed_ledger(&db_dir, "dtc-sum", DTC_DATA).await;
+        let ledger = fluree.ledger(&ledger_id).await.expect("load");
+
+        let constrained = serde_json::json!({
+            "@context": {"ex": "http://ex/", "xsd": "http://www.w3.org/2001/XMLSchema#"},
+            "select": ["(as (sum ?v) ?n)"],
+            "where": {"@id": "?s", "ex:amount": {"@value": "?v", "@type": "xsd:integer"}}
+        });
+
+        let (store, tracing_guard) = span_capture::init_test_tracing();
+        set_fast_paths_disabled(false);
+        let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+        let fast = match fluree.query(&db, &constrained).await {
+            Ok(r) => match r.to_sparql_json(&ledger.snapshot) {
+                Ok(json) => summarize(&json),
+                Err(e) => format!("ERR:{e}"),
+            },
+            Err(e) => format!("ERR:{e}"),
+        };
+        let dtc_sites: Vec<String> = store
+            .find_events("fast-path outcome")
+            .iter()
+            .filter(|e| e.fields.get("outcome").map(String::as_str) == Some("proceed"))
+            .filter_map(|e| e.fields.get("site").cloned())
+            .collect();
+
+        // Must-fire control on the same ledger: drop the constraint and the
+        // fused scan is entitled to the whole column again. Without it, a fix
+        // that disabled the detector outright would pass everything above.
+        let before = store.find_events("fast-path outcome").len();
+        let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+        let unconstrained = match fluree
+            .query(
+                &db,
+                "SELECT (SUM(?v) AS ?n) WHERE { ?s <http://ex/amount> ?v }",
+            )
+            .await
+        {
+            Ok(r) => match r.to_sparql_json(&ledger.snapshot) {
+                Ok(json) => summarize(&json),
+                Err(e) => format!("ERR:{e}"),
+            },
+            Err(e) => format!("ERR:{e}"),
+        };
+        let plain_sites: Vec<String> = store.find_events("fast-path outcome")[before..]
+            .iter()
+            .filter(|e| e.fields.get("outcome").map(String::as_str) == Some("proceed"))
+            .filter_map(|e| e.fields.get("site").cloned())
+            .collect();
+        drop(tracing_guard);
+
+        if fast != "n=10" {
+            failures.push(format!(
+                "datatype-constrained SUM: got {fast}, expected n=10 — the \
+                 constraint selects only the xsd:integer row [proceeded: \
+                 {dtc_sites:?}]"
+            ));
+        }
+        let bad: Vec<&String> = dtc_sites
+            .iter()
+            .filter(|s| GUARDED_SITES.contains(&s.as_str()))
+            .collect();
+        if !bad.is_empty() {
+            failures.push(format!(
+                "datatype-constrained SUM: metadata fast path {bad:?} proceeded \
+                 on a triple carrying a datatype constraint it cannot honour"
+            ));
+        }
+        if unconstrained != "n=30" {
+            failures.push(format!(
+                "CTRL unconstrained SUM on the same ledger: got {unconstrained}, \
+                 expected n=30"
+            ));
+        }
+        if !plain_sites.iter().any(|s| s == "SUM(?o)") {
+            failures.push(format!(
+                "CTRL unconstrained SUM: expected site `SUM(?o)` to proceed — \
+                 the dtc decline must narrow the detector, not disable it \
+                 [proceeded: {plain_sites:?}]"
+            ));
         }
     }
 

--- a/fluree-db-api/tests/it_repeated_var_fast_path_guards.rs
+++ b/fluree-db-api/tests/it_repeated_var_fast_path_guards.rs
@@ -1,0 +1,398 @@
+//! Regression pin: an aggregate fast path must decline a triple pattern whose
+//! positions repeat a variable.
+//!
+//! `{ ?x <rel> ?x }` carries an implicit equality join. The metadata-backed
+//! aggregate fast paths answer from per-predicate index metadata — a PSOT
+//! leaflet row count, a distinct-subject count, a whole-permutation triple
+//! count — and never compare the subject to the object, so every one of them
+//! returned the predicate's cardinality: `COUNT(*) WHERE { ?x <rel> ?x }` was 5
+//! where SPARQL requires 2, and `COUNT(*) WHERE { ?a a ?a }` was 4 where SPARQL
+//! requires 0. The engine's own `count_plan.rs` has rejected this shape since
+//! the v4 baseline (`test_self_loop_rejected`); the older per-shape detectors
+//! in `execute::operator_tree` never got the same guard.
+//!
+//! Two structural notes about why this survived, both of which shape this test:
+//!
+//! * It is an **indexed-lane** defect. A memory-backed ledger declines every
+//!   fast path and answers all 20+ shapes below correctly even unfixed, so a
+//!   novelty-only test is vacuous — which is exactly why `testsuite-sparql`
+//!   (`FlureeBuilder::memory()` throughout) never caught it. The ledger here is
+//!   bulk-imported so the fast paths really fire.
+//! * A value assertion alone cannot tell "the guard declined" from "the
+//!   detector silently stopped matching". Each case therefore also asserts the
+//!   engine's own `fast-path outcome` stamps: no guarded site may `proceed` for
+//!   a repeated-variable shape, and the CTRL shapes — where predicate
+//!   cardinality *is* the right answer — must still `proceed` on their named
+//!   site, so the fix cannot be a blanket disable.
+//!
+//! Own test binary: the kill switch is process-global, and this file both
+//! toggles it and asserts fast-path routing.
+
+#![cfg(feature = "native")]
+
+#[path = "support/span_capture.rs"]
+mod span_capture;
+
+use fluree_db_api::{set_fast_paths_disabled, FlureeBuilder};
+use serde_json::Value;
+use std::io::Write;
+use tempfile::TempDir;
+
+/// The reported fixture: `rel` has 5 triples of which 2 are self-loops (n1,
+/// n2); `rdf:type` has 4 triples and no self-type. `score` and `label` add
+/// literal-object predicates, where a self-loop is impossible outright.
+const DATA: &str = r#"
+@prefix ex: <http://ex/> .
+
+ex:n1 a ex:C ; ex:rel ex:n1, ex:n2 ; ex:score 10 ; ex:label "alpha" .
+ex:n2 a ex:C ; ex:rel ex:n2, ex:n3 ; ex:score 20 ; ex:label "beta" .
+ex:n3 a ex:C ; ex:rel ex:n4 .
+ex:n4 a ex:C .
+"#;
+
+/// Every fast-path site that answers from per-predicate or whole-permutation
+/// metadata, and therefore may not serve a repeated-variable pattern. Names are
+/// the `FastPathOperator` labels the engine stamps.
+const GUARDED_SITES: &[&str] = &[
+    "COUNT rows",
+    "COUNT(DISTINCT)",
+    "triples COUNT",
+    "distinct subject COUNT",
+    "AVG numeric",
+    "MIN/MAX string",
+    "SUM(?o)",
+    "SUM(ABS)",
+];
+
+/// What the engine's fast-path stamps must show for a case.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Routing {
+    /// No site in `GUARDED_SITES` may `proceed`.
+    NoGuardedSite,
+    /// This site must `proceed` — the shape is one where predicate-level
+    /// metadata is the correct answer, and it must keep its fast path.
+    MustFire(&'static str),
+}
+
+struct Case {
+    name: &'static str,
+    sparql: &'static str,
+    /// Hand-computed answer as `summarize` renders it, or `"=generic"` when the
+    /// value under test is the empty-group rendering (unbound MAX, AVG/SUM of
+    /// no rows) rather than a number worth pinning by hand — there the contract
+    /// is that the fast lane and the generic pipeline agree.
+    expected: &'static str,
+    routing: Routing,
+}
+
+fn cases() -> Vec<Case> {
+    use Routing::{MustFire, NoGuardedSite};
+    vec![
+        // ---- the reported shapes -------------------------------------------
+        Case {
+            name: "COUNT(*) {?x rel ?x}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?x <http://ex/rel> ?x }",
+            expected: "n=2",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "COUNT(?x) {?x rel ?x}",
+            sparql: "SELECT (COUNT(?x) AS ?n) WHERE { ?x <http://ex/rel> ?x }",
+            expected: "n=2",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "COUNT(*) {?a a ?a}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?a a ?a }",
+            expected: "n=0",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "COUNT(DISTINCT ?x) {?x rel ?x}",
+            sparql: "SELECT (COUNT(DISTINCT ?x) AS ?n) WHERE { ?x <http://ex/rel> ?x }",
+            expected: "n=2",
+            routing: NoGuardedSite,
+        },
+        // ---- repeated var with a VARIABLE predicate: the two detectors that
+        // destructure the triple inline instead of calling
+        // `validate_simple_triple`, so they need their own pairwise check.
+        Case {
+            name: "COUNT(*) {?x ?p ?x}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?x ?p ?x }",
+            expected: "n=2",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "COUNT(?x) {?x ?x ?o} (subject var == predicate var)",
+            sparql: "SELECT (COUNT(?x) AS ?n) WHERE { ?x ?x ?o }",
+            expected: "n=0",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "COUNT(DISTINCT ?x) {?x ?p ?x}",
+            sparql: "SELECT (COUNT(DISTINCT ?x) AS ?n) WHERE { ?x ?p ?x }",
+            expected: "n=2",
+            routing: NoGuardedSite,
+        },
+        // ---- literal-object predicate: subject is an IRI and object is a
+        // literal, so the self-loop is impossible and every answer is empty.
+        Case {
+            name: "COUNT(*) {?x score ?x} (literal obj)",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?x <http://ex/score> ?x }",
+            expected: "n=0",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "COUNT(DISTINCT ?x) {?x score ?x}",
+            sparql: "SELECT (COUNT(DISTINCT ?x) AS ?n) WHERE { ?x <http://ex/score> ?x }",
+            expected: "n=0",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "AVG(?x) {?x score ?x}",
+            sparql: "SELECT (AVG(?x) AS ?n) WHERE { ?x <http://ex/score> ?x }",
+            expected: "=generic",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "MAX(?x) {?x label ?x}",
+            sparql: "SELECT (MAX(?x) AS ?n) WHERE { ?x <http://ex/label> ?x }",
+            expected: "=generic",
+            routing: NoGuardedSite,
+        },
+        // ---- shapes that were already correct via unrelated gates and must
+        // stay correct (the fix must not perturb them).
+        Case {
+            name: "rows {?x rel ?x}",
+            sparql: "SELECT ?x WHERE { ?x <http://ex/rel> ?x }",
+            expected: "rows=2",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "rows {?a a ?a}",
+            sparql: "SELECT ?a WHERE { ?a a ?a }",
+            expected: "rows=0",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "COUNT(*) {?x rel ?x} + FILTER",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?x <http://ex/rel> ?x \
+                     FILTER(?x != <http://ex/n1>) }",
+            expected: "n=1",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "GROUP BY ?x COUNT(*) {?x rel ?x}",
+            sparql: "SELECT ?x (COUNT(*) AS ?n) WHERE { ?x <http://ex/rel> ?x } GROUP BY ?x",
+            expected: "rows=2",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "COUNT(*) {?x rel ?x . ?x rel ?y}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?x <http://ex/rel> ?x . \
+                     ?x <http://ex/rel> ?y }",
+            expected: "n=4",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "COUNT(*) {?x rel ?x} OPTIONAL {?x a ?c}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?x <http://ex/rel> ?x \
+                     OPTIONAL { ?x a ?c } }",
+            expected: "n=2",
+            routing: NoGuardedSite,
+        },
+        // ---- controls: distinct variables, where predicate-level metadata IS
+        // the right answer. These must keep their fast path.
+        Case {
+            name: "CTRL COUNT(*) {?s rel ?o}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?s <http://ex/rel> ?o }",
+            expected: "n=5",
+            routing: MustFire("COUNT rows"),
+        },
+        Case {
+            name: "CTRL COUNT(*) {?s a ?o}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?s a ?o }",
+            expected: "n=4",
+            routing: MustFire("COUNT rows"),
+        },
+        Case {
+            name: "CTRL COUNT(*) {?s ?p ?o}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }",
+            expected: "n=13",
+            routing: MustFire("triples COUNT"),
+        },
+        Case {
+            name: "CTRL COUNT(DISTINCT ?s) {?s ?p ?o}",
+            sparql: "SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE { ?s ?p ?o }",
+            expected: "n=4",
+            routing: MustFire("distinct subject COUNT"),
+        },
+    ]
+}
+
+/// Canonical one-line rendering: a single-row aggregate renders `n=<value>`,
+/// everything else renders `rows=<count>`.
+fn summarize(results: &Value) -> String {
+    let bindings = results["results"]["bindings"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no results.bindings in {results}"));
+    if bindings.len() == 1 {
+        if let Some(v) = bindings[0].get("n").and_then(|c| c["value"].as_str()) {
+            return format!("n={v}");
+        }
+    }
+    format!("rows={}", bindings.len())
+}
+
+/// RAII restore of the process-global kill switch, including on panic.
+struct FastPathGuard;
+impl Drop for FastPathGuard {
+    fn drop(&mut self) {
+        set_fast_paths_disabled(false);
+    }
+}
+
+async fn indexed_ledger(dir: &TempDir, name: &str) -> (fluree_db_api::Fluree, String) {
+    let data_dir = TempDir::new().expect("data tmpdir");
+    let path = data_dir.path().join("00-fixture.ttl");
+    let mut f = std::fs::File::create(&path).expect("create ttl");
+    f.write_all(DATA.as_bytes()).expect("write ttl");
+
+    // Bulk import builds a fully persisted binary index with no trailing
+    // novelty, so `fast_path_store` holds and the detectors actually fire.
+    let fluree = FlureeBuilder::file(dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    let ledger_id = format!("test/{name}:main");
+    fluree
+        .create(&ledger_id)
+        .import(data_dir.path())
+        .threads(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import");
+    (fluree, ledger_id)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn repeated_variable_patterns_decline_the_aggregate_fast_paths() {
+    // The kill switch OR's with this env var, so with it set the fast-path
+    // phase would run generically and every assertion below would be vacuous.
+    assert!(
+        std::env::var_os("FLUREE_DISABLE_QUERY_FAST_PATHS").is_none(),
+        "FLUREE_DISABLE_QUERY_FAST_PATHS is set — the fast-path phase of this \
+         test would run generically and pin nothing. Unset it."
+    );
+    let _guard = FastPathGuard;
+
+    let db_dir = TempDir::new().expect("db tmpdir");
+    let (fluree, ledger_id) = indexed_ledger(&db_dir, "repeated-var-guards").await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+    let cases = cases();
+
+    // Phase 1 — fast paths on, under span capture so each answer can be
+    // attributed to the site that served it.
+    let (store, tracing_guard) = span_capture::init_test_tracing();
+    set_fast_paths_disabled(false);
+    let mut fast: Vec<String> = Vec::new();
+    let mut proceeded: Vec<Vec<String>> = Vec::new();
+    for c in &cases {
+        let before = store.find_events("fast-path outcome").len();
+        let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+        let got = match fluree.query(&db, c.sparql).await {
+            Ok(r) => match r.to_sparql_json(&ledger.snapshot) {
+                Ok(json) => summarize(&json),
+                Err(e) => format!("ERR:{e}"),
+            },
+            Err(e) => format!("ERR:{e}"),
+        };
+        proceeded.push(
+            store.find_events("fast-path outcome")[before..]
+                .iter()
+                .filter(|e| e.fields.get("outcome").map(String::as_str) == Some("proceed"))
+                .filter_map(|e| e.fields.get("site").cloned())
+                .collect(),
+        );
+        fast.push(got);
+    }
+    drop(tracing_guard);
+
+    // Phase 2 — generic pipeline. It agrees with the hand-computed SPARQL
+    // answer on every shape, which is what makes any divergence attributable to
+    // a fast path rather than to a semantics disagreement.
+    set_fast_paths_disabled(true);
+    let mut generic: Vec<String> = Vec::new();
+    for c in &cases {
+        let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+        let got = match fluree.query(&db, c.sparql).await {
+            Ok(r) => match r.to_sparql_json(&ledger.snapshot) {
+                Ok(json) => summarize(&json),
+                Err(e) => format!("ERR:{e}"),
+            },
+            Err(e) => format!("ERR:{e}"),
+        };
+        generic.push(got);
+    }
+    set_fast_paths_disabled(false);
+
+    let mut failures: Vec<String> = Vec::new();
+    for (i, c) in cases.iter().enumerate() {
+        if c.expected == "=generic" {
+            if fast[i] != generic[i] {
+                failures.push(format!(
+                    "{}: fast {} != generic {} [proceeded: {:?}]",
+                    c.name, fast[i], generic[i], proceeded[i]
+                ));
+            }
+        } else {
+            if fast[i] != c.expected {
+                failures.push(format!(
+                    "{}: fast lane returned {}, expected {} [proceeded: {:?}]",
+                    c.name, fast[i], c.expected, proceeded[i]
+                ));
+            }
+            if generic[i] != c.expected {
+                failures.push(format!(
+                    "{}: generic pipeline returned {}, expected {} — the \
+                     hand-computed answer is wrong or the general pipeline \
+                     regressed",
+                    c.name, generic[i], c.expected
+                ));
+            }
+        }
+
+        match c.routing {
+            Routing::NoGuardedSite => {
+                let bad: Vec<&String> = proceeded[i]
+                    .iter()
+                    .filter(|s| GUARDED_SITES.contains(&s.as_str()))
+                    .collect();
+                if !bad.is_empty() {
+                    failures.push(format!(
+                        "{}: metadata fast path {bad:?} proceeded on a \
+                         repeated-variable pattern",
+                        c.name
+                    ));
+                }
+            }
+            Routing::MustFire(site) => {
+                if !proceeded[i].iter().any(|s| s == site) {
+                    failures.push(format!(
+                        "{}: expected site `{site}` to proceed — the guard must \
+                         narrow the gate, not disable the detector \
+                         [proceeded: {:?}]",
+                        c.name, proceeded[i]
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "repeated-variable fast-path guard failures:\n  {}",
+        failures.join("\n  ")
+    );
+}

--- a/fluree-db-api/tests/it_repeated_var_fast_path_guards.rs
+++ b/fluree-db-api/tests/it_repeated_var_fast_path_guards.rs
@@ -51,11 +51,14 @@ ex:n4 a ex:C .
 "#;
 
 /// Every fast-path site that answers from per-predicate or whole-permutation
-/// metadata, and therefore may not serve a repeated-variable pattern. Names are
-/// the `FastPathOperator` labels the engine stamps.
+/// metadata, and therefore may serve only a triple whose subject and object are
+/// distinct free variables. Names are the `FastPathOperator` labels the engine
+/// stamps.
 const GUARDED_SITES: &[&str] = &[
     "COUNT rows",
+    "COUNT rows numeric compare",
     "COUNT(DISTINCT)",
+    "COUNT blank nodes",
     "triples COUNT",
     "distinct subject COUNT",
     "AVG numeric",
@@ -160,6 +163,48 @@ fn cases() -> Vec<Case> {
             expected: "=generic",
             routing: NoGuardedSite,
         },
+        Case {
+            name: "SUM(?x) {?x score ?x}",
+            sparql: "SELECT (SUM(?x) AS ?n) WHERE { ?x <http://ex/score> ?x }",
+            expected: "=generic",
+            routing: NoGuardedSite,
+        },
+        // ---- CONSTANT SUBJECT. `detect_fused_scan_sum_i64` inspected only the
+        // predicate and object, so it also fired on a bound subject and summed
+        // the predicate across the whole ledger — "total spend for this
+        // customer" answering with everyone's. The AVG / MIN-MAX / COUNT
+        // siblings route through `validate_simple_triple` and were always
+        // correct here, which is why only the SUM rows were wrong.
+        Case {
+            name: "SUM(?v) {<n1> score ?v} (constant subject)",
+            sparql: "SELECT (SUM(?v) AS ?n) WHERE { <http://ex/n1> <http://ex/score> ?v }",
+            expected: "n=10",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "SUM(?v) {<n2> score ?v} (constant subject)",
+            sparql: "SELECT (SUM(?v) AS ?n) WHERE { <http://ex/n2> <http://ex/score> ?v }",
+            expected: "n=20",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "SUM(ABS(?v)) {<n1> score ?v} (constant subject, BIND arm)",
+            sparql: "SELECT (SUM(ABS(?v)) AS ?n) WHERE { <http://ex/n1> <http://ex/score> ?v }",
+            expected: "n=10",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "AVG(?v) {<n1> score ?v} (constant subject)",
+            sparql: "SELECT (AVG(?v) AS ?n) WHERE { <http://ex/n1> <http://ex/score> ?v }",
+            expected: "n=10",
+            routing: NoGuardedSite,
+        },
+        Case {
+            name: "COUNT(*) {<n1> score ?v} (constant subject)",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { <http://ex/n1> <http://ex/score> ?v }",
+            expected: "n=1",
+            routing: NoGuardedSite,
+        },
         // ---- shapes that were already correct via unrelated gates and must
         // stay correct (the fix must not perturb them).
         Case {
@@ -226,6 +271,18 @@ fn cases() -> Vec<Case> {
             sparql: "SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE { ?s ?p ?o }",
             expected: "n=4",
             routing: MustFire("distinct subject COUNT"),
+        },
+        Case {
+            name: "CTRL SUM(?o) {?s score ?o}",
+            sparql: "SELECT (SUM(?o) AS ?n) WHERE { ?s <http://ex/score> ?o }",
+            expected: "n=30",
+            routing: MustFire("SUM(?o)"),
+        },
+        Case {
+            name: "CTRL SUM(ABS(?o)) {?s score ?o}",
+            sparql: "SELECT (SUM(ABS(?o)) AS ?n) WHERE { ?s <http://ex/score> ?o }",
+            expected: "n=30",
+            routing: MustFire("SUM(ABS)"),
         },
     ]
 }
@@ -371,8 +428,8 @@ async fn repeated_variable_patterns_decline_the_aggregate_fast_paths() {
                     .collect();
                 if !bad.is_empty() {
                     failures.push(format!(
-                        "{}: metadata fast path {bad:?} proceeded on a \
-                         repeated-variable pattern",
+                        "{}: metadata fast path {bad:?} proceeded on a pattern it \
+                         is not entitled to answer",
                         c.name
                     ));
                 }

--- a/fluree-db-core/src/o_type.rs
+++ b/fluree-db-core/src/o_type.rs
@@ -215,7 +215,34 @@ impl OType {
     /// the `p_id` that scopes the handle.
     #[inline]
     pub const fn o_key_is_globally_identifying(self) -> bool {
-        self.0 != Self::NUM_BIG_OVERFLOW.0
+        let mut i = 0;
+        while i < Self::NOT_GLOBALLY_IDENTIFYING.len() {
+            if self.0 == Self::NOT_GLOBALLY_IDENTIFYING[i].0 {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// Every o_type whose `o_key` is scoped to something narrower than the
+    /// graph. Single source of truth for [`Self::o_key_is_globally_identifying`]
+    /// and [`Self::range_holds_non_globally_identifying`], so the point test and
+    /// the range test cannot drift apart.
+    const NOT_GLOBALLY_IDENTIFYING: [Self; 1] = [Self::NUM_BIG_OVERFLOW];
+
+    /// Whether the inclusive o_type range `[lo, hi]` can hold a row whose
+    /// `o_key` is not a graph-wide identity.
+    ///
+    /// Index keys lead with a big-endian `o_type`, so a leaflet's
+    /// `[first_key, last_key]` pair bounds every o_type it contains. This
+    /// answers the range form of [`Self::o_key_is_globally_identifying`]
+    /// without a caller having to know which o_types are the exceptions.
+    #[inline]
+    pub fn range_holds_non_globally_identifying(lo: Self, hi: Self) -> bool {
+        Self::NOT_GLOBALLY_IDENTIFYING
+            .iter()
+            .any(|t| lo.0 <= t.0 && t.0 <= hi.0)
     }
 
     // ── Constructors ───────────────────────────────────────────────────
@@ -676,6 +703,30 @@ mod tests {
             let ot = OType::from_u16(val);
             assert_eq!(ot.as_u16(), val);
         }
+    }
+
+    /// The point predicate and the range form share one exceptions list; this
+    /// pins that they agree, so a new non-identifying o_type added to the list
+    /// is answered by both.
+    #[test]
+    fn globally_identifying_point_and_range_agree() {
+        for &t in &OType::NOT_GLOBALLY_IDENTIFYING {
+            assert!(!t.o_key_is_globally_identifying(), "{t:?}");
+            assert!(OType::range_holds_non_globally_identifying(t, t));
+        }
+        // A range that straddles an exception reports it; one that stops short
+        // does not.
+        let ex = OType::NUM_BIG_OVERFLOW;
+        let below = OType::from_u16(ex.as_u16() - 1);
+        let above = OType::from_u16(ex.as_u16() + 1);
+        assert!(OType::range_holds_non_globally_identifying(below, above));
+        assert!(!OType::range_holds_non_globally_identifying(
+            OType::XSD_STRING,
+            below
+        ));
+        assert!(!OType::range_holds_non_globally_identifying(above, above));
+        assert!(below.o_key_is_globally_identifying());
+        assert!(above.o_key_is_globally_identifying());
     }
 
     #[test]

--- a/fluree-db-core/src/o_type.rs
+++ b/fluree-db-core/src/o_type.rs
@@ -90,7 +90,10 @@ impl OType {
     pub const XSD_DOUBLE: Self = Self(0x0010);
     /// `xsd:float`
     pub const XSD_FLOAT: Self = Self(0x0011);
-    /// `xsd:decimal` (inline f64 — overflow goes to NumBig arena via `NUM_BIG_OVERFLOW`).
+    /// `xsd:decimal`. Reserved: the indexer routes **every** typed
+    /// `xsd:decimal` to the NumBig arena under [`Self::NUM_BIG_OVERFLOW`]
+    /// (`resolver.rs`, `RawObject::DecimalStr` — there is no inline branch), so
+    /// no stored row carries this o_type.
     pub const XSD_DECIMAL: Self = Self(0x0012);
 
     // -- Temporal (various order-preserving encodings in o_key) --
@@ -189,6 +192,30 @@ impl OType {
     #[inline]
     pub const fn payload(self) -> u16 {
         self.0 & 0x3FFF
+    }
+
+    /// Whether `(o_type, o_key)` identifies an object term **graph-wide**.
+    ///
+    /// For almost every o_type it does: `o_key` is an inline value, a subject
+    /// dictionary id, or a handle into a graph-scoped arena, so two rows share
+    /// an `(o_type, o_key)` pair iff they carry the same object term.
+    ///
+    /// [`Self::NUM_BIG_OVERFLOW`] is the exception, and it is the whole reason
+    /// this predicate exists. Its `o_key` is a handle into a **per-predicate**
+    /// arena (`fluree-db-binary-index`, `arena::numbig` — "Per-predicate
+    /// equality-only arena") whose handles are allocated from 0 within each
+    /// `(g_id, p_id)`. The first big value under one predicate and the first
+    /// under another are both handle `0`, so the pair is an identity only once
+    /// `p_id` is fixed. Every `xsd:decimal` lands there unconditionally, as does
+    /// any `xsd:integer` too large for `i64`.
+    ///
+    /// Call this before using an `(o_type, o_key)` prefix as an object identity
+    /// in any whole-graph structure — a distinct count, a group key, a dedup
+    /// set. Per-predicate consumers are unaffected: their key already carries
+    /// the `p_id` that scopes the handle.
+    #[inline]
+    pub const fn o_key_is_globally_identifying(self) -> bool {
+        self.0 != Self::NUM_BIG_OVERFLOW.0
     }
 
     // ── Constructors ───────────────────────────────────────────────────

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -1777,20 +1777,18 @@ fn detect_fused_scan_sum_i64(query: &Query) -> Option<(Ref, SumExprI64, VarId)> 
 
     match query.patterns.as_slice() {
         [Pattern::Triple(tp)] => {
-            let pred = extract_bound_predicate(&tp.p)?;
-            let Term::Var(o_var) = &tp.o else {
-                return None;
-            };
-            if sum_input != *o_var {
+            // Via the shared helper: the scan sums the predicate's whole object
+            // column, so it is entitled to the pattern only when the subject is
+            // a free variable distinct from the object (and there is no
+            // datatype constraint to honour).
+            let (_s_var, pred, o_var) = validate_simple_triple(tp)?;
+            if sum_input != o_var {
                 return None;
             }
             Some((pred, SumExprI64::Identity, agg.output_var))
         }
         [Pattern::Triple(tp), Pattern::Bind { var, expr }] => {
-            let pred = extract_bound_predicate(&tp.p)?;
-            let Term::Var(o_var) = &tp.o else {
-                return None;
-            };
+            let (_s_var, pred, o_var) = validate_simple_triple(tp)?;
 
             // Bind must define the aggregate input var, and SUM must use it.
             if sum_input != *var {
@@ -1800,7 +1798,7 @@ fn detect_fused_scan_sum_i64(query: &Query) -> Option<(Ref, SumExprI64, VarId)> 
             let scalar = match expr {
                 crate::ir::Expression::Call { func, args }
                     if args.len() == 1
-                        && matches!(&args[0], crate::ir::Expression::Var(v) if v == o_var) =>
+                        && matches!(&args[0], crate::ir::Expression::Var(v) if *v == o_var) =>
                 {
                     match func {
                         crate::ir::Function::Year => {
@@ -1824,8 +1822,8 @@ fn detect_fused_scan_sum_i64(query: &Query) -> Option<(Ref, SumExprI64, VarId)> 
                 crate::ir::Expression::Call { func, args }
                     if *func == crate::ir::Function::Add
                         && args.len() == 2
-                        && matches!(&args[0], crate::ir::Expression::Var(v) if v == o_var)
-                        && matches!(&args[1], crate::ir::Expression::Var(v) if v == o_var) =>
+                        && matches!(&args[0], crate::ir::Expression::Var(v) if *v == o_var)
+                        && matches!(&args[1], crate::ir::Expression::Var(v) if *v == o_var) =>
                 {
                     SumExprI64::AddSelf
                 }
@@ -1864,12 +1862,12 @@ fn detect_sum_numeric_compare_as_count(
     if sum_input != *var {
         return None;
     }
-    let pred = extract_bound_predicate(&tp.p)?;
-    let Term::Var(o_var) = &tp.o else {
-        return None;
-    };
+    // Same contract as `detect_fused_scan_sum_i64`: the directory-skipping
+    // count spans the whole predicate, so a constant subject (or a repeated
+    // variable) would silently widen the question to the whole ledger.
+    let (_s_var, pred, o_var) = validate_simple_triple(tp)?;
     let (cmp_var, op, threshold) = extract_simple_numeric_compare_threshold(expr)?;
-    if cmp_var != *o_var {
+    if cmp_var != o_var {
         return None;
     }
     Some((pred, op, threshold, agg.output_var))
@@ -1919,9 +1917,15 @@ fn detect_count_blank_node_subjects(query: &Query) -> Option<VarId> {
         _ => return None,
     };
     let Ref::Var(sv) = &tp.s else { return None };
-    let Ref::Var(_pv) = &tp.p else { return None };
-    let Term::Var(_ov) = &tp.o else { return None };
+    let Ref::Var(pv) = &tp.p else { return None };
+    let Term::Var(ov) = &tp.o else { return None };
     if tp.dtc.is_some() {
+        return None;
+    }
+    // Same contract as `validate_simple_triple`, restated here because this
+    // detector admits a variable predicate: the blank-node subject count reads
+    // whole-permutation metadata and cannot honour a repeated variable.
+    if sv == pv || sv == ov || pv == ov {
         return None;
     }
 
@@ -4098,6 +4102,125 @@ mod tests {
         // A non-SUM aggregate over the same shape must be rejected.
         let q_count = make_query(AggregateFn::Count(synth));
         assert_eq!(detect_sum_numeric_compare_as_count(&q_count), None);
+    }
+
+    /// The directory-skipping count spans the whole predicate, so it may only
+    /// serve a free, distinct subject variable. A constant subject would turn
+    /// "how many of this entity's scores exceed K" into the ledger-wide answer;
+    /// a repeated variable drops the pattern's equality join. No integration
+    /// fixture discriminates these (the shapes are rare and the blank-node
+    /// sibling needs blank nodes in the data), so they are pinned here.
+    #[test]
+    fn sum_numeric_compare_declines_non_free_subject() {
+        let s = VarId(0);
+        let o = VarId(1);
+        let synth = VarId(2);
+        let out = VarId(3);
+        let pred = Ref::Sid(Sid::new(100, "score"));
+
+        let make_query = |subject: Ref, object: Term| Query {
+            context: ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::select_all(vec![out]),
+            patterns: vec![
+                Pattern::Triple(TriplePattern::new(subject, pred.clone(), object.clone())),
+                Pattern::Bind {
+                    var: synth,
+                    expr: crate::ir::Expression::gt(
+                        crate::ir::Expression::Var(match &object {
+                            Term::Var(v) => *v,
+                            _ => unreachable!("object is always a var in this test"),
+                        }),
+                        crate::ir::Expression::Const(crate::ir::FlakeValue::Long(0)),
+                    ),
+                },
+            ],
+            reasoning: ReasoningConfig::default(),
+            include_system_facts: false,
+            cypher_vocab: None,
+            grouping: Some(Grouping::Implicit {
+                aggregation: Aggregation {
+                    aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![
+                        crate::ir::AggregateSpec {
+                            function: AggregateFn::Sum(synth, InputSemantics::List),
+                            output_var: out,
+                        },
+                    ])
+                    .unwrap(),
+                    binds: Vec::new(),
+                },
+                having: None,
+            }),
+            ordering: Vec::new(),
+            order_binds: Vec::new(),
+            limit: None,
+            offset: None,
+            post_values: None,
+        };
+
+        // Baseline: a free subject var still takes the fast path.
+        let free = make_query(Ref::Var(s), Term::Var(o));
+        assert!(detect_sum_numeric_compare_as_count(&free).is_some());
+
+        let const_subject = make_query(Ref::Sid(Sid::new(100, "n1")), Term::Var(o));
+        assert_eq!(detect_sum_numeric_compare_as_count(&const_subject), None);
+
+        let self_loop = make_query(Ref::Var(o), Term::Var(o));
+        assert_eq!(detect_sum_numeric_compare_as_count(&self_loop), None);
+    }
+
+    /// `COUNT(?x) WHERE { ?x ?p ?x FILTER(isBlank(?x)) }` counts self-loops on
+    /// blank-node subjects, not every triple with a blank-node subject.
+    #[test]
+    fn count_blank_node_subjects_declines_repeated_variable() {
+        let s = VarId(0);
+        let p = VarId(1);
+        let o = VarId(2);
+        let out = VarId(3);
+
+        let make_query = |subject: VarId, object: VarId| Query {
+            context: ParsedContext::default(),
+            orig_context: None,
+            output: QueryOutput::select_all(vec![out]),
+            patterns: vec![
+                Pattern::Triple(TriplePattern::new(
+                    Ref::Var(subject),
+                    Ref::Var(p),
+                    Term::Var(object),
+                )),
+                Pattern::Filter(crate::ir::Expression::Call {
+                    func: crate::ir::Function::IsBlank,
+                    args: vec![crate::ir::Expression::Var(subject)],
+                }),
+            ],
+            reasoning: ReasoningConfig::default(),
+            include_system_facts: false,
+            cypher_vocab: None,
+            grouping: Some(Grouping::Implicit {
+                aggregation: Aggregation {
+                    aggregates: fluree_db_core::NonEmpty::try_from_vec(vec![
+                        crate::ir::AggregateSpec {
+                            function: AggregateFn::Count(subject),
+                            output_var: out,
+                        },
+                    ])
+                    .unwrap(),
+                    binds: Vec::new(),
+                },
+                having: None,
+            }),
+            ordering: Vec::new(),
+            order_binds: Vec::new(),
+            limit: None,
+            offset: None,
+            post_values: None,
+        };
+
+        assert_eq!(
+            detect_count_blank_node_subjects(&make_query(s, o)),
+            Some(out)
+        );
+        assert_eq!(detect_count_blank_node_subjects(&make_query(s, s)), None);
     }
 
     #[test]

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -79,11 +79,24 @@ pub(crate) fn extract_bound_predicate(p: &Ref) -> Option<Ref> {
 
 /// Validate a triple pattern as `?s <bound_pred> ?o` with no datatype constraint.
 /// Returns `(subject_var, bound_predicate, object_var)`.
+///
+/// **Contract: `?s` and `?o` are distinct variables.** A repeated variable
+/// (`{ ?x <p> ?x }`) carries an implicit equality join that the metadata-backed
+/// fast paths cannot express — they answer from per-predicate index metadata
+/// and never compare the subject to the object — so it is declined here and
+/// left to the general pipeline. Callers may rely on distinctness; a detector
+/// that destructures a triple itself instead of calling this helper must
+/// re-establish it (see `detect_count_distinct_position` and
+/// `detect_count_triples`, which admit a variable predicate and so check all
+/// three positions pairwise).
 pub(crate) fn validate_simple_triple(tp: &TriplePattern) -> Option<(VarId, Ref, VarId)> {
     let Ref::Var(sv) = &tp.s else { return None };
     let pred = extract_bound_predicate(&tp.p)?;
     let Term::Var(ov) = &tp.o else { return None };
     if tp.dtc.is_some() {
+        return None;
+    }
+    if sv == ov {
         return None;
     }
     Some((*sv, pred, *ov))
@@ -1973,8 +1986,11 @@ fn detect_count_literal_objects(query: &Query) -> Option<VarId> {
 /// Detect `SELECT (COUNT(DISTINCT ?v) AS ?c) WHERE { ?s ?p ?o }` and resolve
 /// which triple position `?v` binds. All three positions must be variables (the
 /// fast paths read whole-permutation metadata), matching the prior three
-/// separate detectors exactly. Priority on positional ambiguity (e.g. `?x ?p ?x`)
-/// is subjects → predicates → objects, preserving the old dispatch order.
+/// separate detectors exactly, and all three must be *distinct* — a repeated
+/// variable is an equality join over the triple that whole-permutation metadata
+/// cannot answer, so it belongs to the general pipeline
+/// (see `validate_simple_triple`, which this detector cannot use because it
+/// admits a variable predicate).
 fn detect_count_distinct_position(query: &Query) -> Option<(DistinctPosition, VarId)> {
     let (in_var, out_var) = detect_count_distinct_aggregate(query)?;
 
@@ -1991,6 +2007,9 @@ fn detect_count_distinct_position(query: &Query) -> Option<(DistinctPosition, Va
     if tp.dtc.is_some() {
         return None;
     }
+    if sv == pv || sv == ov || pv == ov {
+        return None;
+    }
 
     let position = if in_var == *sv {
         DistinctPosition::Subjects
@@ -2005,6 +2024,9 @@ fn detect_count_distinct_position(query: &Query) -> Option<(DistinctPosition, Va
     Some((position, out_var))
 }
 
+/// Detect `SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }`, answered from the
+/// whole-permutation triple count. All three positions must be distinct
+/// variables — `{ ?x ?p ?x }` counts self-loops, not triples.
 fn detect_count_triples(query: &Query) -> Option<VarId> {
     let (input_var, out_var) = detect_count_aggregate(query)?;
 
@@ -2019,6 +2041,9 @@ fn detect_count_triples(query: &Query) -> Option<VarId> {
     let Ref::Var(pv) = &tp.p else { return None };
     let Term::Var(ov) = &tp.o else { return None };
     if tp.dtc.is_some() {
+        return None;
+    }
+    if sv == pv || sv == ov || pv == ov {
         return None;
     }
 

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -1100,11 +1100,17 @@ pub fn count_distinct_position_operator(
                     "COUNT(DISTINCT) predicates",
                 ),
                 // OPST key layout: o_type(2) + o_key(8) + o_i(4) + p_id(4) + s_id(8).
-                // Distinct objects = lead bytes [0..10].
-                DistinctPosition::Objects => (
-                    count_distinct_lead_groups(store, ctx.binary_g_id, RunSortOrder::Opst, 10)?,
-                    "COUNT(DISTINCT) objects",
-                ),
+                // Distinct objects = lead bytes [0..10] — which excludes p_id,
+                // and so is not an object identity for a NumBig arena handle.
+                // Declines to the general pipeline for a graph holding any
+                // decimal or overflow integer.
+                DistinctPosition::Objects => {
+                    let Some(count) = count_distinct_object_lead_groups(store, ctx.binary_g_id)?
+                    else {
+                        return Ok(None);
+                    };
+                    (count, "COUNT(DISTINCT) objects")
+                }
             };
             let count_i64 = count_to_i64(count, overflow_label)?;
             Ok(Some(build_count_batch(out_var, count_i64)?))
@@ -1141,6 +1147,10 @@ struct LeadGroupPartial {
     count: u64,
     first_lead: Vec<u8>,
     last_lead: Vec<u8>,
+    /// Some leaflet in this chunk can hold an object key that is not a
+    /// graph-wide identity, so `count` is not a distinct-object count. Only
+    /// ever set for the OPST object walk.
+    non_identifying: bool,
 }
 
 /// Count distinct lead groups across all leaflets in a given sort order.
@@ -1160,8 +1170,48 @@ pub(crate) fn count_distinct_lead_groups(
     order: RunSortOrder,
     lead_len: usize,
 ) -> Result<u64> {
+    Ok(count_distinct_lead_groups_inner(store, g_id, order, lead_len, false)?.unwrap_or(0))
+}
+
+/// Whole-graph distinct **objects** from OPST leaflet directories, or `None`
+/// when the graph holds an object whose `(o_type, o_key)` lead is not a
+/// graph-wide identity.
+///
+/// The 10-byte OPST lead is `o_type(2) + o_key(8)` and stops immediately before
+/// `p_id` (bytes `[14..18]`). For a `NUM_BIG_OVERFLOW` row that lead is a
+/// per-predicate arena handle, so the first big value under one predicate and
+/// the first under another share a lead and collapse into one group — see
+/// [`OType::o_key_is_globally_identifying`]. Because handles are allocated from
+/// 0 within each predicate, the result would be the *max* over predicates of
+/// their distinct big-value counts rather than the size of the union: a silent
+/// undercount, never an over-report.
+///
+/// Rather than special-case the NumBig slice (which needs `p_id` payload reads
+/// and arena loads), decline the whole count to the general pipeline. Ledgers
+/// with no decimals and no overflow integers — the overwhelming majority — keep
+/// the fast path, paying one extra 2-byte comparison per directory entry.
+///
+/// The per-predicate distinct-object count is unaffected and stays on its fast
+/// path: its 14-byte POST lead starts with `p_id`, which scopes the handle
+/// correctly. So is the distinct-subject count, whose SPOT lead is `s_id`.
+pub(crate) fn count_distinct_object_lead_groups(
+    store: &BinaryIndexStore,
+    g_id: GraphId,
+) -> Result<Option<u64>> {
+    count_distinct_lead_groups_inner(store, g_id, RunSortOrder::Opst, 10, true)
+}
+
+/// Returns `None` iff `require_identifying_o_key` and some leaflet's key range
+/// covers a `NUM_BIG_OVERFLOW` row.
+fn count_distinct_lead_groups_inner(
+    store: &BinaryIndexStore,
+    g_id: GraphId,
+    order: RunSortOrder,
+    lead_len: usize,
+    require_identifying_o_key: bool,
+) -> Result<Option<u64>> {
     let Some(branch) = store.branch_for_order(g_id, order) else {
-        return Ok(0);
+        return Ok(Some(0));
     };
 
     let map = |chunk: &[LeafEntry]| -> Result<Option<LeadGroupPartial>> {
@@ -1169,6 +1219,7 @@ pub(crate) fn count_distinct_lead_groups(
             count: 0,
             first_lead: Vec::new(),
             last_lead: Vec::new(),
+            non_identifying: false,
         };
         for leaf_entry in chunk {
             let dir = store
@@ -1187,6 +1238,13 @@ pub(crate) fn count_distinct_lead_groups(
                     QueryError::execution("leaflet key shorter than expected lead_len")
                 })?;
 
+                // `o_type` is the leading big-endian u16 of an OPST key, so the
+                // entry's own `[first, last]` interval says whether the leaflet
+                // can hold a non-identifying object key — no payload read.
+                if require_identifying_o_key && leaflet_may_hold_non_identifying_o_key(entry) {
+                    partial.non_identifying = true;
+                }
+
                 partial.count += u64::from(entry.lead_group_count);
                 if !partial.last_lead.is_empty() && partial.last_lead == lead_first {
                     partial.count = partial.count.saturating_sub(1);
@@ -1202,11 +1260,20 @@ pub(crate) fn count_distinct_lead_groups(
     };
 
     let combine = |left: LeadGroupPartial, right: LeadGroupPartial| -> LeadGroupPartial {
+        // Fold the flag before the empty-side short-circuits: an all-empty
+        // chunk still carries a verdict from its (skipped) sibling.
+        let non_identifying = left.non_identifying || right.non_identifying;
         if right.first_lead.is_empty() {
-            return left;
+            return LeadGroupPartial {
+                non_identifying,
+                ..left
+            };
         }
         if left.first_lead.is_empty() {
-            return right;
+            return LeadGroupPartial {
+                non_identifying,
+                ..right
+            };
         }
         let seam_dedup = u64::from(left.last_lead == right.first_lead);
         LeadGroupPartial {
@@ -1216,12 +1283,40 @@ pub(crate) fn count_distinct_lead_groups(
                 .saturating_sub(seam_dedup),
             first_lead: left.first_lead,
             last_lead: right.last_lead,
+            non_identifying,
         }
     };
 
     let parallel = branch.leaves.len() >= crate::fast_path_common::parallel_dir_walk_min_leaves();
     let result = parallel_leaf_chunk_reduce(&branch.leaves, parallel, map, combine)?;
-    Ok(result.map_or(0, |p| p.count))
+    Ok(match result {
+        Some(p) if p.non_identifying => None,
+        Some(p) => Some(p.count),
+        None => Some(0),
+    })
+}
+
+/// Whether an OPST leaflet's key range can cover an object key that is not a
+/// graph-wide identity.
+///
+/// OPST keys lead with a big-endian `o_type`, so the directory entry's
+/// `[first_key[0..2], last_key[0..2]]` interval bounds every `o_type` in the
+/// leaflet without opening a column. Leaflets are segmented type-homogeneously
+/// today (`leaflet.rs` asserts it), which makes the interval a point — the
+/// interval form costs nothing extra and stays correct if that ever changes.
+fn leaflet_may_hold_non_identifying_o_key(
+    entry: &fluree_db_binary_index::format::leaf::LeafletDirEntryV3,
+) -> bool {
+    let o_type_at = |k: &[u8]| -> u16 {
+        u16::from_be_bytes([
+            k.first().copied().unwrap_or(0),
+            k.get(1).copied().unwrap_or(0),
+        ])
+    };
+    let lo = o_type_at(&entry.first_key);
+    let hi = o_type_at(&entry.last_key);
+    let non_identifying = fluree_db_core::OType::NUM_BIG_OVERFLOW.as_u16();
+    lo <= non_identifying && non_identifying <= hi
 }
 
 /// Per-chunk partial for the per-predicate distinct-object count: the same

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -1301,22 +1301,28 @@ fn count_distinct_lead_groups_inner(
 ///
 /// OPST keys lead with a big-endian `o_type`, so the directory entry's
 /// `[first_key[0..2], last_key[0..2]]` interval bounds every `o_type` in the
-/// leaflet without opening a column. Leaflets are segmented type-homogeneously
-/// today (`leaflet.rs` asserts it), which makes the interval a point — the
-/// interval form costs nothing extra and stays correct if that ever changes.
+/// leaflet without opening a column. Which o_types are the exceptions is the
+/// `OType` vocabulary's business, not this walk's — both branches below defer
+/// to it, so a new non-identifying o_type needs no edit here.
+///
+/// Leaflets are segmented type-homogeneously today (`leaflet.rs` asserts it),
+/// so the point branch is the live one; the range branch costs nothing extra
+/// and stays correct if that ever changes.
 fn leaflet_may_hold_non_identifying_o_key(
     entry: &fluree_db_binary_index::format::leaf::LeafletDirEntryV3,
 ) -> bool {
-    let o_type_at = |k: &[u8]| -> u16 {
-        u16::from_be_bytes([
+    let o_type_at = |k: &[u8]| -> OType {
+        OType::from_u16(u16::from_be_bytes([
             k.first().copied().unwrap_or(0),
             k.get(1).copied().unwrap_or(0),
-        ])
+        ]))
     };
     let lo = o_type_at(&entry.first_key);
     let hi = o_type_at(&entry.last_key);
-    let non_identifying = fluree_db_core::OType::NUM_BIG_OVERFLOW.as_u16();
-    lo <= non_identifying && non_identifying <= hi
+    if lo == hi {
+        return !lo.o_key_is_globally_identifying();
+    }
+    OType::range_holds_non_globally_identifying(lo, hi)
 }
 
 /// Per-chunk partial for the per-predicate distinct-object count: the same

--- a/fluree-db-query/src/filter.rs
+++ b/fluree-db-query/src/filter.rs
@@ -122,6 +122,13 @@ struct ExistsSemijoinKey {
 /// Cached subject sets for simple correlated EXISTS patterns.
 ///
 /// The cache maps (subject_var, p_id) -> set of matching subject IDs (s_id).
+///
+/// The key deliberately omits the object position: a cache entry answers
+/// "does this subject have *any* object for this predicate". That is only the
+/// truth value of the EXISTS when the inner object is a genuinely free
+/// variable, so every producer and consumer of an entry must first establish
+/// that the object variable carries no binding — see the object-position gates
+/// in [`build_exists_semijoin_cache`] and [`try_eval_simple_exists_semijoin`].
 #[derive(Default)]
 struct ExistsSemijoinCache {
     subjects_by_key: FxHashMap<ExistsSemijoinKey, FxHashSet<u64>>,
@@ -131,7 +138,19 @@ fn allow_exists_semijoin_fast_path(ctx: &ExecutionContext<'_>) -> bool {
     fast_path_store(ctx).is_some()
 }
 
-fn collect_simple_exists_keys(expr: &Expression, out: &mut Vec<(VarId, Ref)>) {
+/// `fast-path outcome` site name for the EXISTS semijoin cache. This path has
+/// no `FastPathOperator` to stamp for it, so the cache build stamps its own
+/// verdict once per FILTER `open()`.
+const EXISTS_SEMIJOIN_SITE: &str = "exists_semijoin";
+
+/// Collect `(subject_var, predicate, object_var)` for every hoistable
+/// `EXISTS { ?s <p> ?o }` in `expr`.
+///
+/// The object variable is carried out so the caller can reject the pattern
+/// when that variable is correlated; `Term::is_bound()` below is a plan-time
+/// syntactic test ("is not a variable") and says nothing about whether the
+/// variable is bound at runtime.
+fn collect_simple_exists_keys(expr: &Expression, out: &mut Vec<(VarId, Ref, VarId)>) {
     match expr {
         Expression::Exists {
             patterns,
@@ -151,13 +170,13 @@ fn collect_simple_exists_keys(expr: &Expression, out: &mut Vec<(VarId, Ref)>) {
             if !tp.p_bound() {
                 return;
             }
-            if tp.o.is_bound() {
+            let Some(ov) = tp.o.as_var() else {
                 return;
-            }
+            };
             if tp.dtc.is_some() {
                 return;
             }
-            out.push((*sv, tp.p.clone()));
+            out.push((*sv, tp.p.clone(), ov));
         }
         Expression::Call { func: _, args } => {
             for a in args {
@@ -194,7 +213,7 @@ fn build_exists_semijoin_cache(
         return Ok(None);
     };
 
-    let mut exists_nodes: Vec<(VarId, Ref)> = Vec::new();
+    let mut exists_nodes: Vec<(VarId, Ref, VarId)> = Vec::new();
     collect_simple_exists_keys(expr, &mut exists_nodes);
     if exists_nodes.is_empty() {
         return Ok(None);
@@ -204,8 +223,16 @@ fn build_exists_semijoin_cache(
     let schema_vars: HashSet<VarId> = schema.iter().copied().collect();
 
     let mut cache = ExistsSemijoinCache::default();
-    for (sv, pred_ref) in exists_nodes {
+    for (sv, pred_ref, ov) in exists_nodes {
         if !schema_vars.contains(&sv) {
+            continue;
+        }
+        // The object var is fed by an outer pattern, so this EXISTS asks about
+        // one specific object rather than "any object". The subject-set key
+        // cannot express that, and the per-row guard in
+        // `try_eval_simple_exists_semijoin` would decline every row anyway —
+        // skip the entry so the PSOT scan below is never paid for.
+        if schema_vars.contains(&ov) {
             continue;
         }
         let Some(pred_sid) = try_normalize_pred_sid(store, &pred_ref) else {
@@ -230,8 +257,18 @@ fn build_exists_semijoin_cache(
     }
 
     if cache.subjects_by_key.is_empty() {
+        crate::fast_path_outcome::stamp_fast_path(
+            EXISTS_SEMIJOIN_SITE,
+            crate::fast_path_outcome::FastPathOutcome::Fallback(
+                crate::fast_path_outcome::FastPathFallback::GateDeclined,
+            ),
+        );
         Ok(None)
     } else {
+        crate::fast_path_outcome::stamp_fast_path(
+            EXISTS_SEMIJOIN_SITE,
+            crate::fast_path_outcome::FastPathOutcome::Proceed,
+        );
         Ok(Some(cache))
     }
 }
@@ -423,7 +460,17 @@ fn try_eval_simple_exists_semijoin(
     if !tp.p_bound() {
         return Ok(None);
     }
-    if tp.o.is_bound() {
+    // `Term::is_bound()` is `!is_var()` — a plan-time syntactic test. It rejects
+    // a constant object but says nothing about a variable the current row has
+    // already bound, and the cache key carries no object at all, so a
+    // correlated object would silently be answered as "any object".
+    let Some(object_var) = tp.o.as_var() else {
+        return Ok(None);
+    };
+    if batch
+        .get(row_idx, object_var)
+        .is_some_and(Binding::is_matchable)
+    {
         return Ok(None);
     }
     let Some(pred_sid) = try_normalize_pred_sid(store, &tp.p) else {
@@ -849,6 +896,40 @@ mod tests {
         ))];
         let schema = &[VarId(0), VarId(1)];
         assert!(is_uncorrelated_exists(&patterns, schema));
+    }
+
+    /// The semijoin key carries no object, so the object var has to travel out
+    /// of the collector for the caller to test it against the batch schema.
+    #[test]
+    fn simple_exists_key_carries_object_var() {
+        let expr = Expression::Exists {
+            patterns: vec![Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Sid(Sid::new(100, "member")),
+                Term::Var(VarId(7)),
+            ))],
+            negated: true,
+        };
+        let mut out = Vec::new();
+        collect_simple_exists_keys(&expr, &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].0, VarId(0));
+        assert_eq!(out[0].2, VarId(7));
+    }
+
+    #[test]
+    fn simple_exists_key_declines_constant_object() {
+        let expr = Expression::Exists {
+            patterns: vec![Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Sid(Sid::new(100, "member")),
+                Term::Value(FlakeValue::Long(1)),
+            ))],
+            negated: true,
+        };
+        let mut out = Vec::new();
+        collect_simple_exists_keys(&expr, &mut out);
+        assert!(out.is_empty());
     }
 
     #[test]

--- a/fluree-db-query/src/filter.rs
+++ b/fluree-db-query/src/filter.rs
@@ -227,11 +227,18 @@ fn build_exists_semijoin_cache(
         if !schema_vars.contains(&sv) {
             continue;
         }
-        // The object var is fed by an outer pattern, so this EXISTS asks about
-        // one specific object rather than "any object". The subject-set key
-        // cannot express that, and the per-row guard in
-        // `try_eval_simple_exists_semijoin` would decline every row anyway —
-        // skip the entry so the PSOT scan below is never paid for.
+        // An object var an outer pattern can bind makes this EXISTS ask about
+        // one specific object, which the subject-set key cannot express.
+        //
+        // This is deliberately more conservative than the per-row guard in
+        // `try_eval_simple_exists_semijoin`, which declines only rows where the
+        // var is actually bound: a var in the schema may still be unbound in a
+        // given row (an unmatched OPTIONAL), and those rows would take the
+        // semijoin. Cache-build time has no per-row bindings to consult, so the
+        // choice is between skipping the entry and speculatively paying a PSOT
+        // scan for rows that may all decline. Skipping is the better trade, and
+        // it costs only performance — the per-row guard is what keeps the
+        // answer right.
         if schema_vars.contains(&ov) {
             continue;
         }
@@ -464,6 +471,13 @@ fn try_eval_simple_exists_semijoin(
     // a constant object but says nothing about a variable the current row has
     // already bound, and the cache key carries no object at all, so a
     // correlated object would silently be answered as "any object".
+    //
+    // Testing the row rather than the schema is not merely permissive, it is
+    // the correct reading: EXISTS substitutes only the bindings the row
+    // actually carries, so a variable left unbound by an unmatched OPTIONAL is
+    // a fresh free variable inside the subpattern. For those rows "does this
+    // subject have any object for this predicate" is exactly the question being
+    // asked, and the semijoin answers it.
     let Some(object_var) = tp.o.as_var() else {
         return Ok(None);
     };

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -620,26 +620,32 @@ impl NestedLoopJoinOperator {
 
         // Determine right pattern output vars (vars that are still unbound after substitution),
         // filtered by the emission mask. This allows plan-time pruning of unused vars.
+        //
+        // A variable repeated across positions (`?x <p> ?x`, `?x ?x ?o`) is one
+        // output column, not two: the right scan's own schema folds the repeat
+        // into a single slot (`schema_from_pattern_with_emit`) and enforces the
+        // implied equality per row (`within_row_var_equality_ok`), so emitting
+        // it twice here would only build a batch schema that names the same
+        // VarId in two columns — which `Batch::new` rejects outright.
         let mut right_output_vars: Vec<VarId> = Vec::new();
+        let push_right_var = |out: &mut Vec<VarId>, v: VarId| {
+            if !left_var_positions.contains_key(&v) && !out.contains(&v) {
+                out.push(v);
+            }
+        };
         if right_emit.s {
             if let Ref::Var(v) = &right_pattern.s {
-                if !left_var_positions.contains_key(v) {
-                    right_output_vars.push(*v);
-                }
+                push_right_var(&mut right_output_vars, *v);
             }
         }
         if right_emit.p {
             if let Ref::Var(v) = &right_pattern.p {
-                if !left_var_positions.contains_key(v) {
-                    right_output_vars.push(*v);
-                }
+                push_right_var(&mut right_output_vars, *v);
             }
         }
         if right_emit.o {
             if let Term::Var(v) = &right_pattern.o {
-                if !left_var_positions.contains_key(v) {
-                    right_output_vars.push(*v);
-                }
+                push_right_var(&mut right_output_vars, *v);
             }
         }
 


### PR DESCRIPTION
Six related cases where an indexed-lane fast path answered a question its metadata can't actually answer, each returning a plausible wrong number (or a spurious error) with HTTP 200. All of the fixes are eligibility narrowings — the declined query falls through to the general pipeline, which computes the correct answer in every case — so no currently-correct query changes behavior.

The EXISTS semijoin keyed on `(subject_var, pred)` and gated on a plan-time `Term::is_bound()`, which is blind to a variable an outer pattern binds at runtime — so `NOT EXISTS { ?s2 :member ?x }` with `?x` correlated was answered as "does `?s2` have any member" on the indexed lane (the W3C `subset-02` negation query returned 25 rows where 11 is correct). The COUNT/COUNT DISTINCT/AVG/MIN-MAX detectors never compared subject to object, so a repeated-variable triple like `{ ?x :rel ?x }` counted the predicate's full cardinality instead of the self-loops. The fused SUM detectors never read the subject position at all, so a constant-subject `SUM(?v)` returned the ledger-wide sum for a per-entity question. Routing those SUM detectors through the shared triple validator also picked up its datatype-constraint decline, which they never had of their own — so a datatype-constrained `SUM` no longer takes the fused scan and sums the predicate's whole object column across every datatype under it. A repeated-variable triple joined to a second same-subject pattern failed outright with `Duplicate VarId` (the nested-loop join widened the same variable into two schema columns; the scan layer already folds it). And the whole-graph `COUNT(DISTINCT ?o)` grouped on the OPST `(o_type, o_key)` lead, which for NumBig objects is a per-predicate arena handle rather than a global identity — two different decimals under two predicates share a lead, so distinct counts collapsed toward the largest single predicate's count (every `xsd:decimal` and any `xsd:integer` beyond i64 is arena-routed). That last gate declines on directory metadata alone; an exact NumBig-aware counter is tracked as #1638 so decimal-heavy graphs eventually get the fast path back.

The regression suite asserts both directions via the span-capture harness: must-not-fire (no `proceed` stamp, correct value) for every broken shape, and must-fire (positive stamp) for the shapes that should keep their fast path — including on decimal-bearing ledgers, so an over-broad gate fails loudly. One note for reviewers: these tests wait for background index application and probe the lane before asserting, since a lost indexer race otherwise downgrades an "indexed" test to novelty and it passes vacuously.

