### PR TITLE
accept legal aggregate and property-path forms below the parser

### DIFF
--- a/fluree-db-api/tests/grp_query_sparql.rs
+++ b/fluree-db-api/tests/grp_query_sparql.rs
@@ -15,6 +15,8 @@ mod it_query_sparql;
 mod it_query_sparql_agg_over_group_key;
 #[path = "it_query_sparql_annotations.rs"]
 mod it_query_sparql_annotations;
+#[path = "it_query_sparql_count_distinct_star.rs"]
+mod it_query_sparql_count_distinct_star;
 #[path = "it_query_sparql_parse_errors.rs"]
 mod it_query_sparql_parse_errors;
 #[path = "it_query_sparql_path_literal_object.rs"]

--- a/fluree-db-api/tests/grp_query_sparql.rs
+++ b/fluree-db-api/tests/grp_query_sparql.rs
@@ -11,6 +11,8 @@ mod it_query_construct;
 mod it_query_negation;
 #[path = "it_query_sparql.rs"]
 mod it_query_sparql;
+#[path = "it_query_sparql_agg_over_group_key.rs"]
+mod it_query_sparql_agg_over_group_key;
 #[path = "it_query_sparql_annotations.rs"]
 mod it_query_sparql_annotations;
 #[path = "it_query_sparql_parse_errors.rs"]

--- a/fluree-db-api/tests/grp_query_sparql.rs
+++ b/fluree-db-api/tests/grp_query_sparql.rs
@@ -17,6 +17,8 @@ mod it_query_sparql_agg_over_group_key;
 mod it_query_sparql_annotations;
 #[path = "it_query_sparql_count_distinct_star.rs"]
 mod it_query_sparql_count_distinct_star;
+#[path = "it_query_sparql_group_concat_iri.rs"]
+mod it_query_sparql_group_concat_iri;
 #[path = "it_query_sparql_parse_errors.rs"]
 mod it_query_sparql_parse_errors;
 #[path = "it_query_sparql_path_literal_object.rs"]

--- a/fluree-db-api/tests/grp_query_sparql.rs
+++ b/fluree-db-api/tests/grp_query_sparql.rs
@@ -15,6 +15,8 @@ mod it_query_sparql;
 mod it_query_sparql_annotations;
 #[path = "it_query_sparql_parse_errors.rs"]
 mod it_query_sparql_parse_errors;
+#[path = "it_query_sparql_path_literal_object.rs"]
+mod it_query_sparql_path_literal_object;
 #[path = "it_query_sparql_setop_subselect.rs"]
 mod it_query_sparql_setop_subselect;
 #[path = "it_query_subquery.rs"]

--- a/fluree-db-api/tests/it_query_sparql_agg_over_group_key.rs
+++ b/fluree-db-api/tests/it_query_sparql_agg_over_group_key.rs
@@ -1,0 +1,296 @@
+//! Aggregates whose input variable is also a GROUP BY key.
+//!
+//! `SELECT ?k (COUNT(?k) AS ?n) … GROUP BY ?k` is legal SPARQL 1.1 (§18.2.4.1
+//! partitions the multiset; §18.5.1.1 counts the argument's values within a
+//! group — nothing excludes an expression that also appears in GROUP BY). It
+//! used to be rejected outright with `err:db/InvalidQuery`.
+//!
+//! Both grouping implementations must be pinned. The streaming
+//! `GroupAggregateOperator` reads the pre-grouping column and was always
+//! correct here; the traditional `GroupByOperator` + `AggregateOperator` pair
+//! collapses key columns to a scalar and would have answered with the key term
+//! itself. A test that only exercises the streaming path would pass even with
+//! the old hazard intact, so the traditional-path test below asserts through
+//! EXPLAIN which operators actually ran.
+
+use crate::support;
+use crate::support::{
+    genesis_ledger, graphdb_from_ledger, normalize_rows, MemoryFluree, MemoryLedger,
+};
+use fluree_db_api::FlureeBuilder;
+use serde_json::{json, Value as JsonValue};
+
+/// 2 makers, 5 models: maker1 has 2, maker2 has 1, and m4/m5 have no maker at
+/// all so an OPTIONAL-bound grouping key produces a genuinely unbound group.
+async fn seed_makers(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    let insert = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:maker1", "@type": "ex:Maker", "ex:name": "Acme"},
+            {"@id": "ex:maker2", "@type": "ex:Maker", "ex:name": "Globex"},
+            {"@id": "ex:m1", "@type": "ex:Model", "ex:ofMaker": {"@id": "ex:maker1"}},
+            {"@id": "ex:m2", "@type": "ex:Model", "ex:ofMaker": {"@id": "ex:maker1"}},
+            {"@id": "ex:m3", "@type": "ex:Model", "ex:ofMaker": {"@id": "ex:maker2"}},
+            {"@id": "ex:m4", "@type": "ex:Model"},
+            {"@id": "ex:m5", "@type": "ex:Model"}
+        ]
+    });
+    fluree.insert(ledger0, &insert).await.unwrap().ledger
+}
+
+/// Recursively search an EXPLAIN `plan.physical` tree for an operator name.
+fn physical_contains_op(node: &JsonValue, name: &str) -> bool {
+    if node["op"] == name {
+        return true;
+    }
+    node["children"]
+        .as_array()
+        .is_some_and(|cs| cs.iter().any(|e| physical_contains_op(&e["node"], name)))
+}
+
+/// The reported case: one solution per maker, so each group counts 1.
+#[tokio::test]
+async fn sparql_count_over_group_by_key() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/agg-key-count:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?c (COUNT(?c) AS ?n) WHERE { ?c a ex:Maker } GROUP BY ?c";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT over a GROUP BY key is legal SPARQL 1.1")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["ex:maker1", 1], ["ex:maker2", 1]]))
+    );
+}
+
+/// Group sizes larger than one, so a wrong answer cannot hide behind a count
+/// that happens to be 1.
+#[tokio::test]
+async fn sparql_count_over_group_by_key_multi_row_groups() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/agg-key-count-multi:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?c (COUNT(?c) AS ?n) WHERE { ?m ex:ofMaker ?c } GROUP BY ?c";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT over a GROUP BY key is legal SPARQL 1.1")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["ex:maker1", 2], ["ex:maker2", 1]]))
+    );
+}
+
+/// HAVING aggregates lower into the same aggregate list, so they take the same
+/// rewrite. Both a passing and a filtering threshold, so the HAVING is doing
+/// real work rather than being trivially true.
+#[tokio::test]
+async fn sparql_having_count_over_group_by_key() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/agg-key-having:main").await;
+
+    let keeps_all = support::query_sparql(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT ?c WHERE { ?m ex:ofMaker ?c } GROUP BY ?c HAVING (COUNT(?c) >= 1)",
+    )
+    .await
+    .expect("HAVING over a GROUP BY key is legal")
+    .to_jsonld(&ledger.snapshot)
+    .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&keeps_all),
+        normalize_rows(&json!([["ex:maker1"], ["ex:maker2"]]))
+    );
+
+    let filters = support::query_sparql(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT ?c WHERE { ?m ex:ofMaker ?c } GROUP BY ?c HAVING (COUNT(?c) >= 2)",
+    )
+    .await
+    .expect("HAVING over a GROUP BY key is legal")
+    .to_jsonld(&ledger.snapshot)
+    .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&filters),
+        normalize_rows(&json!([["ex:maker1"]]))
+    );
+}
+
+/// `COUNT(DISTINCT ?k)` over the key was rejected on the same path — the
+/// reporter's "just add DISTINCT" workaround did not actually work. Every value
+/// in a group is the key, so the distinct count is 1 per group.
+#[tokio::test]
+async fn sparql_count_distinct_over_group_by_key() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/agg-key-count-distinct:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?c (COUNT(DISTINCT ?c) AS ?n) WHERE { ?m ex:ofMaker ?c } GROUP BY ?c";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT(DISTINCT key) over a GROUP BY key is legal")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["ex:maker1", 1], ["ex:maker2", 1]]))
+    );
+}
+
+/// The case that makes the `COUNT(*)` rewrite-workaround wrong, and the reason
+/// the copy is `Expression::Var(k)` rather than a synthetic constant: with an
+/// OPTIONAL-bound key, the unbound group counts 0 solutions for `COUNT(?k)`
+/// while `COUNT(*)` counts its 2 rows.
+#[tokio::test]
+async fn sparql_count_over_optional_bound_group_key() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/agg-key-optional:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?k (COUNT(?k) AS ?nk) (COUNT(*) AS ?nall)
+        WHERE { ?s a ex:Model OPTIONAL { ?s ex:ofMaker ?k } }
+        GROUP BY ?k";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT over an OPTIONAL-bound GROUP BY key is legal")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
+            ["ex:maker1", 2, 2],
+            ["ex:maker2", 1, 1],
+            [null, 0, 2]
+        ]))
+    );
+}
+
+/// Pins the TRADITIONAL grouping path, where the old hazard actually lived:
+/// `GroupByOperator` writes the scalar key into key columns, so an aggregate
+/// reading a key column would have returned the key term instead of a count.
+/// `GROUP_CONCAT` is not streamable, which forces the pair; the EXPLAIN
+/// assertion is the positive marker that it really did.
+#[tokio::test]
+async fn sparql_count_over_group_by_key_traditional_path() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/agg-key-traditional:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?c (COUNT(?c) AS ?n) (GROUP_CONCAT(?nm; SEPARATOR="|") AS ?g)
+        WHERE { ?m ex:ofMaker ?c . ?c ex:name ?nm } GROUP BY ?c"#;
+
+    let db = graphdb_from_ledger(&ledger);
+    let explained = fluree
+        .explain_sparql(&db, query)
+        .await
+        .expect("explain_sparql");
+    let physical = &explained["plan"]["physical"];
+    assert!(
+        physical_contains_op(physical, "GroupByOperator")
+            && physical_contains_op(physical, "AggregateOperator"),
+        "expected the traditional grouping pair, got: {physical}"
+    );
+    assert!(
+        !physical_contains_op(physical, "GroupAggregateOperator"),
+        "GROUP_CONCAT should have forced off the streaming path: {physical}"
+    );
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT over a GROUP BY key is legal on the traditional path")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    // Every row in a group repeats its maker's single name, so the
+    // concatenation is order-independent: maker1's group has two rows,
+    // maker2's has one.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
+            ["ex:maker1", 2, "Acme|Acme"],
+            ["ex:maker2", 1, "Globex"]
+        ]))
+    );
+}
+
+/// Controls: the shapes that already worked must be untouched by the rewrite.
+#[tokio::test]
+async fn sparql_aggregate_over_non_key_var_unchanged() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/agg-key-controls:main").await;
+
+    let non_key = support::query_sparql(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT ?c (COUNT(?m) AS ?n) WHERE { ?m ex:ofMaker ?c } GROUP BY ?c",
+    )
+    .await
+    .expect("COUNT over a non-key variable")
+    .to_jsonld(&ledger.snapshot)
+    .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&non_key),
+        normalize_rows(&json!([["ex:maker1", 2], ["ex:maker2", 1]]))
+    );
+
+    let count_all = support::query_sparql(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT ?c (COUNT(*) AS ?n) WHERE { ?m ex:ofMaker ?c } GROUP BY ?c",
+    )
+    .await
+    .expect("COUNT(*)")
+    .to_jsonld(&ledger.snapshot)
+    .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&count_all),
+        normalize_rows(&json!([["ex:maker1", 2], ["ex:maker2", 1]]))
+    );
+}
+
+/// An aggregate reading a key must not disturb one reading a non-key variable
+/// in the same query, and two aggregates over the same key must share one copy.
+#[tokio::test]
+async fn sparql_mixed_key_and_non_key_aggregates() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/agg-key-mixed:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?c (COUNT(?c) AS ?nk) (COUNT(?m) AS ?nm) (MIN(?c) AS ?mink)
+        WHERE { ?m ex:ofMaker ?c } GROUP BY ?c";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("mixed key and non-key aggregates")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
+            ["ex:maker1", 2, 2, "ex:maker1"],
+            ["ex:maker2", 1, 1, "ex:maker2"]
+        ]))
+    );
+}

--- a/fluree-db-api/tests/it_query_sparql_count_distinct_star.rs
+++ b/fluree-db-api/tests/it_query_sparql_count_distinct_star.rs
@@ -170,6 +170,101 @@ async fn sparql_count_distinct_star_traditional_path() {
     );
 }
 
+/// Two `ex:a/ex:b` routes from `ex:s` to `ex:o` through different middle nodes.
+/// The two solutions agree on `(?s, ?o)` and differ only in the path-join
+/// variable the lowerer synthesized.
+async fn seed_two_paths(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    let insert = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:s", "ex:a": [{"@id": "ex:x1"}, {"@id": "ex:x2"}]},
+            {"@id": "ex:x1", "ex:b": {"@id": "ex:o"}},
+            {"@id": "ex:x2", "ex:b": {"@id": "ex:o"}}
+        ]
+    });
+    fluree.insert(ledger0, &insert).await.unwrap().ledger
+}
+
+/// `*` is the solution mapping, and SPARQL projects the lowerer's property-path
+/// join variable (`?__ppN`) out of it. Two routes give two solutions that are
+/// identical on `(?s, ?o)`, so the answer is 1 — counting the raw executor row
+/// would say 2. `COUNT(*)` still sees both, which is what makes this a
+/// discriminator rather than a tautology.
+#[tokio::test]
+async fn sparql_count_distinct_star_ignores_property_path_join_var() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_two_paths(&fluree, "sparql/cds-path:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/>
+        SELECT (COUNT(*) AS ?all) (COUNT(DISTINCT *) AS ?distinct)
+        WHERE { ?s ex:a/ex:b ?o }";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT(DISTINCT *) over a property path")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([[2, 1]])));
+}
+
+/// Same divergence on the traditional grouping path, which reconstructs the
+/// group's solutions from its `Grouped` columns rather than hashing rows.
+#[tokio::test]
+async fn sparql_count_distinct_star_ignores_path_join_var_traditional_path() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_two_paths(&fluree, "sparql/cds-path-trad:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?s (COUNT(DISTINCT *) AS ?distinct) (GROUP_CONCAT(?nm; SEPARATOR="|") AS ?g)
+        WHERE { ?s ex:a/ex:b ?o . OPTIONAL { ?o ex:name ?nm } } GROUP BY ?s"#;
+
+    let db = graphdb_from_ledger(&ledger);
+    let physical = fluree
+        .explain_sparql(&db, query)
+        .await
+        .expect("explain_sparql")["plan"]["physical"]
+        .clone();
+    assert!(
+        physical_contains_op(&physical, "AggregateOperator")
+            && !physical_contains_op(&physical, "GroupAggregateOperator"),
+        "expected the traditional grouping pair, got: {physical}"
+    );
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT(DISTINCT *) over a property path, traditional path")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["ex:s", 1, null]]))
+    );
+}
+
+/// Blank-node variables are non-distinguished (SPARQL §4.1.4) and likewise
+/// outside the solution mapping: `ex:s` reaches two objects through `ex:a`, but
+/// the only visible variable is `?s`, so there is one distinct solution.
+#[tokio::test]
+async fn sparql_count_distinct_star_ignores_blank_node_var() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_two_paths(&fluree, "sparql/cds-bnode:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/>
+        SELECT (COUNT(*) AS ?all) (COUNT(DISTINCT *) AS ?distinct)
+        WHERE { ?s ex:a _:mid }";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT(DISTINCT *) with a blank-node variable")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([[2, 1]])));
+}
+
 /// HAVING over `COUNT(DISTINCT *)`, and the plain `COUNT(*)` control alongside
 /// it, so the two no-input aggregates cannot be confused for one another.
 #[tokio::test]

--- a/fluree-db-api/tests/it_query_sparql_count_distinct_star.rs
+++ b/fluree-db-api/tests/it_query_sparql_count_distinct_star.rs
@@ -1,0 +1,192 @@
+//! `COUNT(DISTINCT *)` — the count of distinct SOLUTIONS in a group.
+//!
+//! Well-defined in SPARQL 1.1 §18.5.1.1 and exercised by the W3C
+//! `agg-count-rows-distinct` test. The parser accepted it and lowering rejected
+//! it as "not yet implemented", so `SELECT ?s (COUNT(DISTINCT *) AS ?n) …`
+//! returned HTTP 400.
+//!
+//! It is the only aggregate that reads the whole row rather than one column, so
+//! the tests below pin three things a single happy-path test would miss: that
+//! duplicate solutions actually collapse, that projection trimming does not
+//! erase the column that makes two solutions differ, and that the traditional
+//! grouping path computes it as well as the streaming one.
+
+use crate::support;
+use crate::support::{
+    genesis_ledger, graphdb_from_ledger, normalize_rows, MemoryFluree, MemoryLedger,
+};
+use fluree_db_api::FlureeBuilder;
+use serde_json::{json, Value as JsonValue};
+
+/// maker1 carries two properties, maker2 one — so the two makers have
+/// different group sizes and a wrong answer cannot look right by symmetry.
+async fn seed_makers(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    let insert = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:maker1", "@type": "ex:Maker", "ex:name": "Acme"},
+            {"@id": "ex:maker2", "ex:name": "Globex"}
+        ]
+    });
+    fluree.insert(ledger0, &insert).await.unwrap().ledger
+}
+
+fn physical_contains_op(node: &JsonValue, name: &str) -> bool {
+    if node["op"] == name {
+        return true;
+    }
+    node["children"]
+        .as_array()
+        .is_some_and(|cs| cs.iter().any(|e| physical_contains_op(&e["node"], name)))
+}
+
+/// The W3C `agg-count-rows-distinct` shape. Every solution in a group has a
+/// distinct `(?p, ?o)`, so the distinct count equals the group size.
+#[tokio::test]
+async fn sparql_count_distinct_star_grouped() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/cds-grouped:main").await;
+
+    let query = "SELECT ?s (COUNT(DISTINCT *) AS ?n) WHERE { ?s ?p ?o } GROUP BY ?s";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT(DISTINCT *) is well-defined in SPARQL 1.1")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
+            ["http://example.org/maker1", 2],
+            ["http://example.org/maker2", 1]
+        ]))
+    );
+}
+
+/// No GROUP BY: one implicit group over the whole solution sequence.
+#[tokio::test]
+async fn sparql_count_distinct_star_ungrouped() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/cds-ungrouped:main").await;
+
+    let jsonld = support::query_sparql(
+        &fluree,
+        &ledger,
+        "SELECT (COUNT(DISTINCT *) AS ?n) WHERE { ?s ?p ?o }",
+    )
+    .await
+    .expect("COUNT(DISTINCT *) without GROUP BY")
+    .to_jsonld(&ledger.snapshot)
+    .expect("to_jsonld");
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([[3]])));
+}
+
+/// The load-bearing case: duplicate solutions must collapse. A UNION of a
+/// pattern with itself doubles every solution, so `COUNT(*)` counts twice what
+/// `COUNT(DISTINCT *)` does. An implementation that quietly answered `COUNT(*)`
+/// would pass every test above and fail this one.
+#[tokio::test]
+async fn sparql_count_distinct_star_collapses_duplicate_solutions() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/cds-dupes:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/>
+        SELECT (COUNT(*) AS ?all) (COUNT(DISTINCT *) AS ?distinct)
+        WHERE { { ?s ex:name ?n } UNION { ?s ex:name ?n } }";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT(DISTINCT *) alongside COUNT(*)")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([[4, 2]])));
+}
+
+/// Projection trimming must not fire. Nothing here projects `?s` or `?n`, and
+/// `COUNT(DISTINCT *)` reports no input variable — so a trimmed WHERE would
+/// drop both columns and collapse all four solutions into one.
+#[tokio::test]
+async fn sparql_count_distinct_star_survives_projection_trimming() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/cds-trim:main").await;
+
+    let jsonld = support::query_sparql(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT (COUNT(DISTINCT *) AS ?n) WHERE { ?s ex:name ?nm }",
+    )
+    .await
+    .expect("COUNT(DISTINCT *) with nothing else projected")
+    .to_jsonld(&ledger.snapshot)
+    .expect("to_jsonld");
+    assert_eq!(normalize_rows(&jsonld), normalize_rows(&json!([[2]])));
+}
+
+/// The traditional grouping path reconstructs the group's solutions by zipping
+/// its `Grouped` columns, which is a different implementation from the
+/// streaming `HashSet`. `GROUP_CONCAT` forces that path; EXPLAIN is the marker
+/// that it really ran.
+#[tokio::test]
+async fn sparql_count_distinct_star_traditional_path() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/cds-traditional:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?s (COUNT(DISTINCT *) AS ?n) (GROUP_CONCAT(?nm; SEPARATOR="|") AS ?g)
+        WHERE { { ?s ex:name ?nm } UNION { ?s ex:name ?nm } } GROUP BY ?s"#;
+
+    let db = graphdb_from_ledger(&ledger);
+    let explained = fluree
+        .explain_sparql(&db, query)
+        .await
+        .expect("explain_sparql");
+    let physical = &explained["plan"]["physical"];
+    assert!(
+        physical_contains_op(physical, "GroupByOperator")
+            && physical_contains_op(physical, "AggregateOperator"),
+        "expected the traditional grouping pair, got: {physical}"
+    );
+    assert!(
+        !physical_contains_op(physical, "GroupAggregateOperator"),
+        "GROUP_CONCAT should have forced off the streaming path: {physical}"
+    );
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("COUNT(DISTINCT *) on the traditional path")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    // Each maker's group holds its one solution twice: 1 distinct, 2 concatenated.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
+            ["ex:maker1", 1, "Acme|Acme"],
+            ["ex:maker2", 1, "Globex|Globex"]
+        ]))
+    );
+}
+
+/// HAVING over `COUNT(DISTINCT *)`, and the plain `COUNT(*)` control alongside
+/// it, so the two no-input aggregates cannot be confused for one another.
+#[tokio::test]
+async fn sparql_count_distinct_star_with_having_and_count_all() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/cds-having:main").await;
+
+    let query = "SELECT ?s (COUNT(*) AS ?all) (COUNT(DISTINCT *) AS ?d)
+                 WHERE { ?s ?p ?o } GROUP BY ?s HAVING (COUNT(DISTINCT *) > 1)";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("HAVING over COUNT(DISTINCT *)")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["http://example.org/maker1", 2, 2]]))
+    );
+}

--- a/fluree-db-api/tests/it_query_sparql_group_concat_iri.rs
+++ b/fluree-db-api/tests/it_query_sparql_group_concat_iri.rs
@@ -1,0 +1,157 @@
+//! `GROUP_CONCAT` over IRI-valued variables.
+//!
+//! `agg_group_concat` read only `Binding::Lit`, so IRI-valued group members
+//! were silently skipped: an all-IRI group concatenated nothing and returned
+//! Unbound (rendered `null`), and a mixed IRI/literal group dropped its IRI
+//! members from the result without any error. `STR(?s)` on the same term has
+//! always produced the full IRI, so the two disagreed.
+
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+
+/// maker1 has two models, maker2 one. `ex:tag` gives maker1 a group whose
+/// members are an IRI and a string, for the mixed case.
+async fn seed(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    let insert = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:maker1", "@type": "ex:Maker", "ex:name": "Acme"},
+            {"@id": "ex:maker2", "@type": "ex:Maker", "ex:name": "Globex"},
+            {"@id": "ex:m1", "ex:ofMaker": {"@id": "ex:maker1"}},
+            {"@id": "ex:m2", "ex:ofMaker": {"@id": "ex:maker1"}},
+            {"@id": "ex:m3", "ex:ofMaker": {"@id": "ex:maker2"}}
+        ]
+    });
+    fluree.insert(ledger0, &insert).await.unwrap().ledger
+}
+
+/// A non-key IRI variable: the group's models must concatenate as their IRIs
+/// rather than collapsing to null.
+#[tokio::test]
+async fn sparql_group_concat_over_non_key_iri_var() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed(&fluree, "sparql/gc-iri-nonkey:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?c (GROUP_CONCAT(?m; SEPARATOR="|") AS ?g)
+        WHERE { ?m ex:ofMaker ?c } GROUP BY ?c"#;
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("GROUP_CONCAT over an IRI variable")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    // maker1's two models arrive in an unspecified order (SPARQL §18.5.1.7).
+    let rows = normalize_rows(&jsonld);
+    assert_eq!(rows.len(), 2, "one row per maker: {rows:?}");
+    let maker1 = rows
+        .iter()
+        .find(|r| r[0] == "ex:maker1")
+        .expect("maker1 row");
+    let g = maker1[1].as_str().expect("maker1 concat is a string");
+    assert!(
+        g == "http://example.org/m1|http://example.org/m2"
+            || g == "http://example.org/m2|http://example.org/m1",
+        "expected both model IRIs, got {g:?}"
+    );
+    let maker2 = rows
+        .iter()
+        .find(|r| r[0] == "ex:maker2")
+        .expect("maker2 row");
+    assert_eq!(maker2[1], json!("http://example.org/m3"));
+}
+
+/// The grouping key itself, read as an aggregate input. This rides on the
+/// GROUP-BY-key copy, so it exercises a different column than the case above.
+#[tokio::test]
+async fn sparql_group_concat_over_key_iri_var() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed(&fluree, "sparql/gc-iri-key:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?c (GROUP_CONCAT(?c; SEPARATOR="|") AS ?g)
+        WHERE { ?m ex:ofMaker ?c } GROUP BY ?c"#;
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("GROUP_CONCAT over the grouping key")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    // Every row in a group repeats the key, so this is order-independent.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([
+            [
+                "ex:maker1",
+                "http://example.org/maker1|http://example.org/maker1"
+            ],
+            ["ex:maker2", "http://example.org/maker2"]
+        ]))
+    );
+}
+
+/// A mixed group: the IRI member used to vanish from the result while the
+/// string member survived, which is the silent-wrong-answer half of this bug.
+#[tokio::test]
+async fn sparql_group_concat_over_mixed_iri_and_literal() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed(&fluree, "sparql/gc-iri-mixed:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT (GROUP_CONCAT(?v; SEPARATOR="|") AS ?g)
+        WHERE { { ex:maker1 ex:name ?v } UNION { ex:m1 ex:ofMaker ?v } }"#;
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("GROUP_CONCAT over mixed IRI and literal values")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    let rows = normalize_rows(&jsonld);
+    let g = rows[0][0].as_str().expect("concat is a string");
+    let parts: std::collections::HashSet<&str> = g.split('|').collect();
+    assert_eq!(
+        parts,
+        ["Acme", "http://example.org/maker1"].into_iter().collect(),
+        "both members must appear, got {g:?}"
+    );
+}
+
+/// `GROUP_CONCAT(?s)` and `GROUP_CONCAT(STR(?s))` must agree — the explicit
+/// coercion was the workaround, and it is now redundant rather than required.
+#[tokio::test]
+async fn sparql_group_concat_iri_agrees_with_explicit_str() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed(&fluree, "sparql/gc-iri-str:main").await;
+
+    let bare = support::query_sparql(
+        &fluree,
+        &ledger,
+        r#"PREFIX ex: <http://example.org/>
+           SELECT ?c (GROUP_CONCAT(?c; SEPARATOR="|") AS ?g)
+           WHERE { ?m ex:ofMaker ?c } GROUP BY ?c"#,
+    )
+    .await
+    .expect("bare IRI form")
+    .to_jsonld(&ledger.snapshot)
+    .expect("to_jsonld");
+
+    let via_str = support::query_sparql(
+        &fluree,
+        &ledger,
+        r#"PREFIX ex: <http://example.org/>
+           SELECT ?c (GROUP_CONCAT(STR(?c); SEPARATOR="|") AS ?g)
+           WHERE { ?m ex:ofMaker ?c } GROUP BY ?c"#,
+    )
+    .await
+    .expect("explicit STR form")
+    .to_jsonld(&ledger.snapshot)
+    .expect("to_jsonld");
+
+    assert_eq!(normalize_rows(&bare), normalize_rows(&via_str));
+}

--- a/fluree-db-api/tests/it_query_sparql_group_concat_iri.rs
+++ b/fluree-db-api/tests/it_query_sparql_group_concat_iri.rs
@@ -8,7 +8,7 @@
 
 use crate::support;
 use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
-use fluree_db_api::FlureeBuilder;
+use fluree_db_api::{DatasetSpec, FlureeBuilder, GraphSource};
 use serde_json::json;
 
 /// maker1 has two models, maker2 one. `ex:tag` gives maker1 a group whose
@@ -154,4 +154,78 @@ async fn sparql_group_concat_iri_agrees_with_explicit_str() {
     .expect("to_jsonld");
 
     assert_eq!(normalize_rows(&bare), normalize_rows(&via_str));
+}
+
+/// One subject under a prefix unique to this ledger. Two such ledgers allocate
+/// namespace codes independently and in the same order, so the two prefixes end
+/// up behind the *same* code — which is what makes the dataset test below able
+/// to see an expansion against the wrong table.
+async fn seed_single_prefix(
+    fluree: &MemoryFluree,
+    ledger_id: &str,
+    prefix: &str,
+    local: &str,
+) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    let insert = json!({
+        "@context": {"p": prefix},
+        "@graph": [{"@id": format!("p:{local}"), "p:tag": "shared"}]
+    });
+    fluree.insert(ledger0, &insert).await.unwrap().ledger
+}
+
+/// GROUP_CONCAT over a multi-ledger dataset.
+///
+/// `apply_aggregate` expands IRIs with `ctx.active_snapshot`'s namespace table,
+/// which is one ledger's. That is only sound because `DatasetOperator` stamps
+/// every cross-ledger `Binding::Sid` into `Binding::IriMatch` — carrying the
+/// IRI already decoded in its OWN ledger — before the batch leaves the member
+/// (`dataset_operator.rs::stamp_provenance`), and the expansion reads that
+/// canonical IRI rather than re-expanding a foreign SID.
+///
+/// The two ledgers here use different prefixes that were allocated the same
+/// namespace code, so expanding one ledger's SID against the other's table
+/// would emit a well-formed but WRONG IRI (`http://alpha.example/b1`) — the
+/// #1259 failure mode, and worse than the dropped member this fix removed.
+/// Asserting both absolute IRIs pins that it does not happen.
+#[tokio::test]
+async fn sparql_group_concat_iri_across_multi_ledger_dataset() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let _alpha =
+        seed_single_prefix(&fluree, "gcns-alpha:main", "http://alpha.example/", "a1").await;
+    let _beta = seed_single_prefix(&fluree, "gcns-beta:main", "http://beta.example/", "b1").await;
+
+    let spec = DatasetSpec::new()
+        .with_default(GraphSource::new("gcns-alpha:main"))
+        .with_default(GraphSource::new("gcns-beta:main"));
+    let dataset = fluree
+        .build_dataset_view(&spec)
+        .await
+        .expect("build_dataset_view");
+
+    let sparql = r#"
+        SELECT (GROUP_CONCAT(?s; SEPARATOR="|") AS ?g)
+        WHERE { ?s ?p "shared" }"#;
+
+    let result = fluree
+        .query_dataset(&dataset, sparql)
+        .await
+        .expect("multi-ledger GROUP_CONCAT should succeed");
+    let primary = dataset.primary().unwrap();
+    let jsonld = result
+        .to_jsonld(primary.snapshot.as_ref())
+        .expect("to_jsonld");
+
+    let rows = normalize_rows(&jsonld);
+    let g = rows[0][0]
+        .as_str()
+        .expect("concat is a string, not null — both members are IRIs");
+    let parts: std::collections::HashSet<&str> = g.split('|').collect();
+    assert_eq!(
+        parts,
+        ["http://alpha.example/a1", "http://beta.example/b1"]
+            .into_iter()
+            .collect(),
+        "each subject must expand against its OWN ledger's namespace table, got {g:?}"
+    );
 }

--- a/fluree-db-api/tests/it_query_sparql_path_literal_object.rs
+++ b/fluree-db-api/tests/it_query_sparql_path_literal_object.rs
@@ -1,0 +1,308 @@
+//! Property paths whose object is a literal.
+//!
+//! SPARQL 1.1 §19.8 reaches a path's object through `GraphNodePath`, which
+//! admits `RDFLiteral` / `NumericLiteral` / `BooleanLiteral`, so
+//! `?s ex:ofMaker/ex:name "Acme"` is an ordinary matchable shape. Lowering used
+//! to force every path object through `Ref`, rejecting all of them with
+//! `err:db/InvalidQuery`.
+//!
+//! These are execution tests on purpose. The W3C syntax suite only parses
+//! (`evaluate_positive_syntax_test` never calls `lower_sparql`), so it is
+//! structurally unable to see a lowering-time rejection — `syn-pp-in-collection`
+//! was green the whole time this was broken.
+
+use crate::support;
+use crate::support::{genesis_ledger, normalize_rows, MemoryFluree, MemoryLedger};
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+
+/// 2 makers, 3 models (maker1 has 2, maker2 has 1). `ex:alias` gives the
+/// alternative-path tests a second branch that also ends at `"Acme"`.
+async fn seed_makers(fluree: &MemoryFluree, ledger_id: &str) -> MemoryLedger {
+    let ledger0 = genesis_ledger(fluree, ledger_id);
+    let insert = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:maker1", "@type": "ex:Maker", "ex:name": "Acme", "ex:foundedYear": 1990},
+            {"@id": "ex:maker2", "@type": "ex:Maker", "ex:name": "Globex", "ex:alias": "Acme"},
+            {"@id": "ex:m1", "@type": "ex:Model", "ex:ofMaker": {"@id": "ex:maker1"}},
+            {"@id": "ex:m2", "@type": "ex:Model", "ex:ofMaker": {"@id": "ex:maker1"}},
+            {"@id": "ex:m3", "@type": "ex:Model", "ex:ofMaker": {"@id": "ex:maker2"}}
+        ]
+    });
+    fluree.insert(ledger0, &insert).await.unwrap().ledger
+}
+
+/// The headline case: a sequence path ending at a string literal.
+#[tokio::test]
+async fn sparql_path_sequence_string_literal_object() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-seq:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?s WHERE { ?s ex:ofMaker/ex:name "Acme" }"#;
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("a sequence path with a literal object is legal SPARQL 1.1")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["ex:m1"], ["ex:m2"]]))
+    );
+}
+
+/// Same shape with a numeric literal — the W3C `syn-pp-in-collection` form
+/// (`:p*/:q 123`) puts an integer in exactly this position.
+#[tokio::test]
+async fn sparql_path_sequence_numeric_literal_object() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-num:main").await;
+
+    let query = r"
+        PREFIX ex: <http://example.org/>
+        SELECT ?s WHERE { ?s ex:ofMaker/ex:foundedYear 1990 }";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("a numeric literal is a legal path object")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["ex:m1"], ["ex:m2"]]))
+    );
+}
+
+/// A transitive *leading* step still works when the final hop carries the
+/// literal — only the path's own endpoint has to be a `Ref`.
+#[tokio::test]
+async fn sparql_path_transitive_step_then_literal_object() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-star-seq:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?s WHERE { ?s ex:ofMaker*/ex:name "Acme" }"#;
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("transitive first hop, literal final hop")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    // maker1 via the zero-length prefix, m1/m2 via one ex:ofMaker hop.
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["ex:m1"], ["ex:m2"], ["ex:maker1"]]))
+    );
+}
+
+/// Both branches of an alternative feed the literal into the object slot.
+#[tokio::test]
+async fn sparql_path_alternative_literal_object() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-alt:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?s WHERE { ?s ex:name|ex:alias "Acme" }"#;
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("an alternative path with a literal object is legal")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(
+        normalize_rows(&jsonld),
+        normalize_rows(&json!([["ex:maker1"], ["ex:maker2"]]))
+    );
+}
+
+/// `^p` with a literal object puts the literal in *subject* position. RDF has
+/// no literal subjects, so the answer is the empty solution sequence — not an
+/// error. This is the `[ ^:r "hello" ]` half of `syn-pp-in-collection`.
+#[tokio::test]
+async fn sparql_path_inverse_literal_object_matches_nothing() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-inv:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?s WHERE { ?s ^ex:name "Acme" }"#;
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("inverse-onto-literal is zero solutions, not an error")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(normalize_rows(&jsonld), Vec::<serde_json::Value>::new());
+}
+
+/// The same statically-empty lowering with a constant subject, where the arm
+/// contributes no variables at all.
+#[tokio::test]
+async fn sparql_path_inverse_literal_object_constant_subject() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-inv-const:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?n WHERE { ex:maker1 ex:name ?n . ex:maker1 ^ex:name "Acme" }"#;
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("inverse-onto-literal is zero solutions, not an error")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(normalize_rows(&jsonld), Vec::<serde_json::Value>::new());
+}
+
+/// A sequence whose *final* hop is an inverse onto a literal: same
+/// zero-solutions outcome, reached through the sequence-chain arm.
+#[tokio::test]
+async fn sparql_path_sequence_trailing_inverse_literal_matches_nothing() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-seq-inv:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?s WHERE { ?s ex:ofMaker/^ex:name "Acme" }"#;
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("trailing inverse onto a literal is zero solutions, not an error")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(normalize_rows(&jsonld), Vec::<serde_json::Value>::new());
+}
+
+/// W3C `syn-pp-in-collection` (`sparql11/syntax-query`, `mf:PositiveSyntaxTest11`)
+/// EXECUTED rather than merely parsed. It combines both halves: `:p*/:q 123`
+/// (sequence ending at a numeric literal) and `^:r "hello"` (inverse onto a
+/// literal). Nothing in the ledger matches, so the contract is 200/empty.
+#[tokio::test]
+async fn sparql_path_in_collection_executes() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-coll:main").await;
+
+    let query = "PREFIX : <http://example.org/>\n\
+        SELECT * WHERE {\n\
+        \t?s ?p ( [:p*/:q 123 ] [ ^:r \"hello\"] )\n\
+        }";
+
+    let jsonld = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("syn-pp-in-collection must execute, not just parse")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    assert_eq!(normalize_rows(&jsonld), Vec::<serde_json::Value>::new());
+}
+
+/// Interim divergence, pinned deliberately: the path IR's own endpoints are
+/// typed `Ref`, so a transitive path cannot end at a literal. `?s ex:p+ "lit"`
+/// and `?s ex:p* "lit"` are both evaluable under SPARQL 1.1 (the latter via the
+/// zero-length path, which binds `?s` to the literal), so this must fail with a
+/// message that says the limitation is ours — not with the old blanket
+/// "Property path object cannot be a literal value".
+#[tokio::test]
+async fn sparql_path_transitive_literal_object_narrow_error() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-transitive:main").await;
+
+    for path in ["ex:name+", "ex:name*", "ex:name?", "^ex:name+"] {
+        let query = format!(
+            r#"PREFIX ex: <http://example.org/>
+               SELECT ?s WHERE {{ ?s {path} "Acme" }}"#
+        );
+        let err = support::query_sparql(&fluree, &ledger, &query)
+            .await
+            .err()
+            .unwrap_or_else(|| panic!("{path} onto a literal is still unsupported"))
+            .to_string();
+        assert!(
+            err.contains("Transitive property paths") && err.contains("not yet supported"),
+            "{path} should name the unsupported sub-case, got: {err}"
+        );
+    }
+}
+
+/// Same divergence inside a sequence step, which reaches the limitation through
+/// a different arm.
+#[tokio::test]
+async fn sparql_path_sequence_transitive_tail_literal_narrow_error() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-seq-transitive:main").await;
+
+    for path in ["ex:ofMaker/ex:name+", "ex:ofMaker/^ex:name+"] {
+        let query = format!(
+            r#"PREFIX ex: <http://example.org/>
+               SELECT ?s WHERE {{ ?s {path} "Acme" }}"#
+        );
+        let err = support::query_sparql(&fluree, &ledger, &query)
+            .await
+            .err()
+            .unwrap_or_else(|| panic!("{path} onto a literal is still unsupported"))
+            .to_string();
+        assert!(
+            err.contains("Transitive property paths") && err.contains("not yet supported"),
+            "{path} should name the unsupported sub-case, got: {err}"
+        );
+    }
+}
+
+/// Negated property sets split into a forward and an inverse branch, so their
+/// endpoint must be a `Ref` too. Also a deliberate divergence, also narrow.
+#[tokio::test]
+async fn sparql_path_negated_set_literal_object_narrow_error() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-nps:main").await;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/>
+        SELECT ?s WHERE { ?s !(ex:alias) "Acme" }"#;
+
+    let err = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .err()
+        .expect("negated set onto a literal is still unsupported")
+        .to_string();
+    assert!(
+        err.contains("Negated property sets") && err.contains("not yet supported"),
+        "should name the unsupported sub-case, got: {err}"
+    );
+}
+
+/// A path with a literal object must agree with the hand-written triple chain
+/// it is shorthand for — including how loosely the literal's datatype is
+/// matched.
+#[tokio::test]
+async fn sparql_path_literal_object_agrees_with_triple_chain() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_makers(&fluree, "sparql/path-lit-parity:main").await;
+
+    let via_path = support::query_sparql(
+        &fluree,
+        &ledger,
+        r#"PREFIX ex: <http://example.org/>
+           SELECT ?s WHERE { ?s ex:ofMaker/ex:name "Acme" }"#,
+    )
+    .await
+    .expect("path form")
+    .to_jsonld(&ledger.snapshot)
+    .expect("to_jsonld");
+
+    let via_triples = support::query_sparql(
+        &fluree,
+        &ledger,
+        r#"PREFIX ex: <http://example.org/>
+           SELECT ?s WHERE { ?s ex:ofMaker ?mk . ?mk ex:name "Acme" }"#,
+    )
+    .await
+    .expect("triple form")
+    .to_jsonld(&ledger.snapshot)
+    .expect("to_jsonld");
+
+    assert_eq!(normalize_rows(&via_path), normalize_rows(&via_triples));
+}

--- a/fluree-db-api/tests/it_query_sparql_path_literal_object.rs
+++ b/fluree-db-api/tests/it_query_sparql_path_literal_object.rs
@@ -266,7 +266,7 @@ async fn sparql_path_negated_set_literal_object_narrow_error() {
     let err = support::query_sparql(&fluree, &ledger, query)
         .await
         .err()
-        .expect("negated set onto a literal is still unsupported")
+        .unwrap_or_else(|| panic!("negated set onto a literal is still unsupported"))
         .to_string();
     assert!(
         err.contains("Negated property sets") && err.contains("not yet supported"),

--- a/fluree-db-query/src/aggregate.rs
+++ b/fluree-db-query/src/aggregate.rs
@@ -254,6 +254,15 @@ impl Operator for AggregateOperator {
                                 )
                             })
                             .collect(),
+                        // COUNT(DISTINCT *): the number of distinct solutions in
+                        // the group, composed across every child column.
+                        None if matches!(spec.function, AggregateFn::CountDistinctAll) => (0
+                            ..batch.len())
+                            .map(|row_idx| {
+                                let n = distinct_group_rows(&batch, row_idx, self.child_col_count);
+                                Binding::lit(FlakeValue::Long(n), xsd_integer())
+                            })
+                            .collect(),
                         None => {
                             let sizes = group_sizes.get_or_insert_with(|| {
                                 (0..batch.len())
@@ -410,6 +419,18 @@ impl AggregateFn {
         match self {
             Self::Count(_) => agg_count(values),
             Self::CountAll => agg_count_all(values),
+            // Unreachable by construction: `CountDistinctAll` has no input
+            // variable, so it never gets a column and never reaches `apply`.
+            // `AggregateOperator` computes it from every child column instead
+            // (see `distinct_group_rows`). Assert in debug so a future wiring
+            // change is caught rather than silently answering Unbound.
+            Self::CountDistinctAll => {
+                debug_assert!(
+                    false,
+                    "COUNT(DISTINCT *) must be computed over the whole row, not one column"
+                );
+                Binding::Unbound
+            }
             Self::CountDistinct(_) => agg_count_distinct(values),
             Self::Sum { .. } => agg_sum(values),
             Self::Avg { .. } => agg_avg(values),
@@ -733,6 +754,32 @@ fn agg_count_all(values: &[Binding]) -> Binding {
 }
 
 /// COUNT(DISTINCT) - count distinct non-Unbound values
+/// Number of distinct solutions in one group of a `GroupByOperator` output row.
+///
+/// `GroupByOperator` emits one row per group: key columns carry the single key
+/// value, every other column carries `Grouped(Vec<Binding>)` with one entry per
+/// solution in the group. Zipping the grouped columns index-wise reconstructs
+/// the group's solutions. Key columns are constant within a group, so they
+/// cannot change which solutions are distinct — and a group with no grouped
+/// column at all is a set of rows agreeing on every column, i.e. exactly one
+/// distinct solution.
+fn distinct_group_rows(batch: &Batch, row_idx: usize, child_col_count: usize) -> i64 {
+    let grouped: Vec<&[Binding]> = (0..child_col_count)
+        .filter_map(|col_idx| match batch.get_by_col(row_idx, col_idx) {
+            Binding::Grouped(values) => Some(values.as_slice()),
+            _ => None,
+        })
+        .collect();
+    let Some(group_size) = grouped.iter().map(|col| col.len()).min() else {
+        return 1;
+    };
+    let mut seen: HashSet<Vec<&Binding>> = HashSet::with_capacity(group_size);
+    for i in 0..group_size {
+        seen.insert(grouped.iter().map(|col| &col[i]).collect());
+    }
+    seen.len() as i64
+}
+
 fn agg_count_distinct(values: &[Binding]) -> Binding {
     let distinct: HashSet<_> = values
         .iter()

--- a/fluree-db-query/src/aggregate.rs
+++ b/fluree-db-query/src/aggregate.rs
@@ -29,7 +29,7 @@ use bigdecimal::{BigDecimal, ToPrimitive};
 use fluree_db_core::{FlakeValue, Sid};
 use num_bigint::BigInt;
 use num_traits::{Signed, Zero};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::Instrument;
@@ -225,6 +225,8 @@ impl Operator for AggregateOperator {
 
             let num_cols = self.in_schema.len();
             let mut output_columns: Vec<Vec<Binding>> = Vec::with_capacity(num_cols);
+            // Namespace table for expanding IRI-valued GROUP_CONCAT members.
+            let namespaces = ctx.active_snapshot.namespaces();
             ctx.check_cancelled()?;
 
             // Process child columns (regular aggregates and pass-through)
@@ -239,7 +241,12 @@ impl Operator for AggregateOperator {
                         Some(agg_idx) => {
                             // This column needs aggregation
                             let spec = &self.aggregates[agg_idx];
-                            apply_aggregate(&spec.function, input_binding, self.graph_view.as_ref())
+                            apply_aggregate(
+                                &spec.function,
+                                input_binding,
+                                self.graph_view.as_ref(),
+                                Some(namespaces),
+                            )
                         }
                         None => {
                             // Pass through unchanged
@@ -268,6 +275,7 @@ impl Operator for AggregateOperator {
                                     &spec.function,
                                     input_binding,
                                     self.graph_view.as_ref(),
+                                    Some(namespaces),
                                 )
                             })
                             .collect(),
@@ -344,10 +352,14 @@ impl Operator for AggregateOperator {
 ///
 /// Count variants and the numeric accumulator handle encoded bindings
 /// natively, so they skip the decode.
+///
+/// GROUP_CONCAT additionally needs IRI-valued bindings expanded to their IRI
+/// string (`namespaces`); see [`group_concat_expand_iris`].
 fn apply_aggregate(
     func: &AggregateFn,
     binding: &Binding,
     gv: Option<&fluree_db_binary_index::BinaryGraphView>,
+    namespaces: Option<&HashMap<u16, String>>,
 ) -> Binding {
     let needs_decoded_values = matches!(
         func,
@@ -370,7 +382,23 @@ fn apply_aggregate(
                 .iter()
                 .map(|b| crate::group_aggregate::materialize_encoded(b, gv))
                 .collect();
+            // Decoding turns an encoded ref into `Binding::Sid`, which
+            // GROUP_CONCAT still cannot read — expand those too.
+            let decoded = match func {
+                AggregateFn::GroupConcat { .. } => group_concat_expand_iris(&decoded, namespaces),
+                _ => decoded,
+            };
             return func.apply(&Binding::Grouped(decoded));
+        }
+    }
+    // No graph view (memory ledgers): bindings arrive already decoded, but an
+    // IRI-valued one is still a `Sid`/`IriMatch`/`Iri` that GROUP_CONCAT drops.
+    if matches!(func, AggregateFn::GroupConcat { .. }) {
+        if let Binding::Grouped(values) = binding {
+            if values.iter().any(is_iri_binding) {
+                let expanded = group_concat_expand_iris(values, namespaces);
+                return func.apply(&Binding::Grouped(expanded));
+            }
         }
     }
     // SUM/AVG accumulate inline NUM_INT/NUM_F64 encodings natively, but
@@ -775,6 +803,49 @@ fn agg_count_all(values: &[Binding]) -> Binding {
 }
 
 /// COUNT(DISTINCT) - count distinct non-Unbound values
+/// Whether a binding denotes an IRI (any of the three representations).
+fn is_iri_binding(b: &Binding) -> bool {
+    matches!(
+        b,
+        Binding::Sid { .. } | Binding::IriMatch { .. } | Binding::Iri(_)
+    )
+}
+
+/// Expand IRI-valued bindings to `xsd:string` literals holding the full IRI,
+/// leaving everything else untouched.
+///
+/// `agg_group_concat` reads only `Binding::Lit`, so an IRI-valued group member
+/// was silently skipped: an all-IRI group concatenated nothing and returned
+/// Unbound (rendered `null`), and a mixed group dropped its IRI members from
+/// the result. Expanding here matches what `STR()` already does for the same
+/// term (`eval::string::eval_str`), so `GROUP_CONCAT(?s)` and
+/// `GROUP_CONCAT(STR(?s))` agree.
+///
+/// A `Sid` whose namespace code is missing from `namespaces` cannot be
+/// expanded; it stays as-is and is skipped downstream, exactly as before.
+fn group_concat_expand_iris(
+    values: &[Binding],
+    namespaces: Option<&HashMap<u16, String>>,
+) -> Vec<Binding> {
+    values
+        .iter()
+        .map(|b| {
+            let iri: Option<String> = match b {
+                Binding::Sid { sid, .. } => namespaces
+                    .and_then(|ns| ns.get(&sid.namespace_code))
+                    .map(|prefix| format!("{prefix}{}", sid.name)),
+                Binding::IriMatch { iri, .. } => Some(iri.to_string()),
+                Binding::Iri(iri) => Some(iri.to_string()),
+                _ => None,
+            };
+            match iri {
+                Some(iri) => Binding::lit(FlakeValue::String(iri), xsd_string()),
+                None => b.clone(),
+            }
+        })
+        .collect()
+}
+
 /// Number of distinct solutions in one group of a `GroupByOperator` output row.
 ///
 /// `GroupByOperator` emits one row per group: key columns carry the single key

--- a/fluree-db-query/src/aggregate.rs
+++ b/fluree-db-query/src/aggregate.rs
@@ -56,6 +56,9 @@ pub struct AggregateOperator {
     group_size_col: Option<usize>,
     /// Number of columns from child schema (before extra additions)
     child_col_count: usize,
+    /// Child columns each `COUNT(DISTINCT *)` composes its solution from,
+    /// parallel to `aggregates`; `None` for every other aggregate.
+    row_distinct_cols: Vec<Option<Vec<usize>>>,
     /// Variables required by downstream operators; if set, output is trimmed.
     out_schema: Option<Arc<[VarId]>>,
     /// Graph view for materializing encoded bindings before value-folding
@@ -128,6 +131,19 @@ impl AggregateOperator {
 
         let schema: Arc<[VarId]> = Arc::from(output_vars.into_boxed_slice());
 
+        // Resolve each COUNT(DISTINCT *)'s visible variables to child columns.
+        let row_distinct_cols: Vec<Option<Vec<usize>>> = aggregates
+            .iter()
+            .map(|spec| match &spec.function {
+                AggregateFn::CountDistinctAll(vars) => Some(
+                    vars.iter()
+                        .filter_map(|v| child_schema.iter().position(|sv| sv == v))
+                        .collect(),
+                ),
+                _ => None,
+            })
+            .collect();
+
         Self {
             child,
             aggregates,
@@ -137,6 +153,7 @@ impl AggregateOperator {
             extra_specs,
             group_size_col,
             child_col_count,
+            row_distinct_cols,
             out_schema: None,
             graph_view: None,
         }
@@ -255,14 +272,18 @@ impl Operator for AggregateOperator {
                             })
                             .collect(),
                         // COUNT(DISTINCT *): the number of distinct solutions in
-                        // the group, composed across every child column.
-                        None if matches!(spec.function, AggregateFn::CountDistinctAll) => (0
-                            ..batch.len())
-                            .map(|row_idx| {
-                                let n = distinct_group_rows(&batch, row_idx, self.child_col_count);
-                                Binding::lit(FlakeValue::Long(n), xsd_integer())
-                            })
-                            .collect(),
+                        // the group, composed across the user-visible columns.
+                        None if self.row_distinct_cols[*agg_idx].is_some() => {
+                            let cols = self.row_distinct_cols[*agg_idx]
+                                .as_deref()
+                                .unwrap_or_default();
+                            (0..batch.len())
+                                .map(|row_idx| {
+                                    let n = distinct_group_rows(&batch, row_idx, cols);
+                                    Binding::lit(FlakeValue::Long(n), xsd_integer())
+                                })
+                                .collect()
+                        }
                         None => {
                             let sizes = group_sizes.get_or_insert_with(|| {
                                 (0..batch.len())
@@ -424,7 +445,7 @@ impl AggregateFn {
             // `AggregateOperator` computes it from every child column instead
             // (see `distinct_group_rows`). Assert in debug so a future wiring
             // change is caught rather than silently answering Unbound.
-            Self::CountDistinctAll => {
+            Self::CountDistinctAll(_) => {
                 debug_assert!(
                     false,
                     "COUNT(DISTINCT *) must be computed over the whole row, not one column"
@@ -763,9 +784,13 @@ fn agg_count_all(values: &[Binding]) -> Binding {
 /// cannot change which solutions are distinct — and a group with no grouped
 /// column at all is a set of rows agreeing on every column, i.e. exactly one
 /// distinct solution.
-fn distinct_group_rows(batch: &Batch, row_idx: usize, child_col_count: usize) -> i64 {
-    let grouped: Vec<&[Binding]> = (0..child_col_count)
-        .filter_map(|col_idx| match batch.get_by_col(row_idx, col_idx) {
+///
+/// `cols` restricts the reconstruction to the user-visible columns, matching
+/// what `*` denotes; see [`AggregateFn::CountDistinctAll`].
+fn distinct_group_rows(batch: &Batch, row_idx: usize, cols: &[usize]) -> i64 {
+    let grouped: Vec<&[Binding]> = cols
+        .iter()
+        .filter_map(|&col_idx| match batch.get_by_col(row_idx, col_idx) {
             Binding::Grouped(values) => Some(values.as_slice()),
             _ => None,
         })

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -15,7 +15,7 @@ use std::collections::HashSet;
 /// for all downstream consumers to function correctly.  The sets are
 /// computed once (backward from SELECT) and consulted by each operator to
 /// trim dead columns from its output.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VariableDeps {
     pub required_where_vars: Vec<VarId>,
     pub required_groupby_vars: Vec<VarId>,

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -5,7 +5,7 @@
 //! and GROUP BY. Variables without downstream dependencies are dead and can
 //! be projected away early.
 
-use crate::ir::{Grouping, Pattern, Query};
+use crate::ir::{AggregateFn, Grouping, Pattern, Query};
 use crate::var_registry::VarId;
 use std::collections::HashSet;
 
@@ -36,6 +36,19 @@ pub struct VariableDeps {
 /// - Empty select list (no explicit projection)
 /// - `Construct` without a template
 pub fn compute_variable_deps(query: &Query) -> Option<VariableDeps> {
+    // `COUNT(DISTINCT *)` counts distinct SOLUTIONS, so it reads every column of
+    // the pre-grouping row. It reports no input variable, so the backward walk
+    // below cannot see that dependency — trimming a column would silently
+    // collapse solutions that differ only in it. Disable trimming outright.
+    if query
+        .grouping
+        .iter()
+        .flat_map(Grouping::aggregates)
+        .any(|spec| matches!(spec.function, AggregateFn::CountDistinctAll))
+    {
+        return None;
+    }
+
     // ---- backward walk ----
 
     // Seed deps from the query output requirements.

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -36,19 +36,6 @@ pub struct VariableDeps {
 /// - Empty select list (no explicit projection)
 /// - `Construct` without a template
 pub fn compute_variable_deps(query: &Query) -> Option<VariableDeps> {
-    // `COUNT(DISTINCT *)` counts distinct SOLUTIONS, so it reads every column of
-    // the pre-grouping row. It reports no input variable, so the backward walk
-    // below cannot see that dependency — trimming a column would silently
-    // collapse solutions that differ only in it. Disable trimming outright.
-    if query
-        .grouping
-        .iter()
-        .flat_map(Grouping::aggregates)
-        .any(|spec| matches!(spec.function, AggregateFn::CountDistinctAll(_)))
-    {
-        return None;
-    }
-
     // ---- backward walk ----
 
     // Seed deps from the query output requirements.
@@ -108,8 +95,18 @@ pub fn compute_variable_deps(query: &Query) -> Option<VariableDeps> {
     // Aggregates: replace output vars with input vars.
     for spec in query.grouping.iter().flat_map(Grouping::aggregates) {
         if deps.remove(&spec.output_var) {
-            if let Some(input_var) = spec.function.input_var() {
-                deps.insert(input_var);
+            match &spec.function {
+                // `COUNT(DISTINCT *)` counts distinct SOLUTIONS, so its input is
+                // not one column but every user-visible variable (the list it
+                // carries — see `AggregateFn::CountDistinctAll`). Tracing them
+                // here is what keeps the pre-grouping stages from trimming away
+                // a column that two solutions differ only in; naming them
+                // individually leaves genuinely dead columns still trimmable,
+                // and leaves the post-grouping stages — already recorded above —
+                // untouched. Variables this list names from other scopes simply
+                // never match a schema and drop out.
+                AggregateFn::CountDistinctAll(vars) => deps.extend(vars.iter().copied()),
+                other => deps.extend(other.input_var()),
             }
         }
     }

--- a/fluree-db-query/src/execute/dependency.rs
+++ b/fluree-db-query/src/execute/dependency.rs
@@ -44,7 +44,7 @@ pub fn compute_variable_deps(query: &Query) -> Option<VariableDeps> {
         .grouping
         .iter()
         .flat_map(Grouping::aggregates)
-        .any(|spec| matches!(spec.function, AggregateFn::CountDistinctAll))
+        .any(|spec| matches!(spec.function, AggregateFn::CountDistinctAll(_)))
     {
         return None;
     }

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -3141,7 +3141,7 @@ pub(crate) fn apply_solution_modifiers(
         .into_iter()
         .flat_map(Grouping::group_by_vars)
         .collect();
-    let aggregates_vec: Vec<AggregateSpec> = grouping
+    let mut aggregates_vec: Vec<AggregateSpec> = grouping
         .map(|g| g.aggregates().cloned().collect())
         .unwrap_or_default();
     let post_binds_vec: Vec<(VarId, Expression)> = grouping
@@ -3180,6 +3180,103 @@ pub(crate) fn apply_solution_modifiers(
             }
         }
     }
+    // SPARQL 1.1 §18.5.1 lets an aggregate read a variable that is also a GROUP BY
+    // key: `SELECT ?k (COUNT(?k) AS ?n) … GROUP BY ?k` answers, per group, the
+    // number of solutions in which `?k` is bound.
+    //
+    // The traditional grouping path cannot compute that as written.
+    // `GroupByOperator::build_output_row` puts the *scalar* key value in group-key
+    // columns and only wraps non-key columns as `Binding::Grouped`, and
+    // `AggregateFn::apply` returns its input unchanged when it isn't `Grouped` —
+    // so an aggregate pointed at a key column would answer with the key term
+    // itself. So copy each aggregated key into a fresh non-key column before
+    // grouping and point the aggregate at the copy. `Expression::Var(k)`
+    // reproduces the key's unbound-ness, so an OPTIONAL-bound key keeps
+    // `COUNT(?k)` and `COUNT(*)` differing exactly where the spec says they
+    // should. The streaming path reads the copy as an ordinary upstream column,
+    // so one rewrite serves both operators.
+    let group_by_set: HashSet<VarId> = group_by_vec.iter().copied().collect();
+    let mut aliased_deps: Option<VariableDeps> = None;
+    if aggregates_vec.iter().any(|s| {
+        s.function
+            .input_var()
+            .is_some_and(|v| group_by_set.contains(&v))
+    }) {
+        // Mint copies above every id any stage from here on can name. WHERE-internal
+        // variables that never reached this schema are already consumed, so they
+        // cannot be confused with a copy.
+        let mut named: Vec<VarId> = where_schema_vec.clone();
+        named.extend(group_by_vec.iter().copied());
+        for spec in &aggregates_vec {
+            named.push(spec.output_var);
+            named.extend(spec.function.input_var());
+        }
+        for (var, expr) in post_binds_vec.iter().chain(order_binds.iter()) {
+            named.push(*var);
+            named.extend(expr.referenced_vars());
+        }
+        if let Some(expr) = having_expr {
+            named.extend(expr.referenced_vars());
+        }
+        named.extend(ordering.iter().map(|s| s.var));
+        named.extend(select_vars.into_iter().flatten().copied());
+        if let Some(deps) = variable_deps {
+            named.extend(deps.required_where_vars.iter().copied());
+            named.extend(deps.required_groupby_vars.iter().copied());
+            named.extend(deps.required_aggregate_vars.iter().copied());
+            named.extend(deps.required_having_vars.iter().copied());
+            named.extend(deps.required_sort_vars.iter().copied());
+            named.extend(deps.required_bind_vars.iter().flatten().copied());
+        }
+        let mut next_id = named
+            .iter()
+            .map(|v| v.0)
+            .max()
+            .map_or(0, |m| m.saturating_add(1));
+
+        // One copy per distinct key, however many aggregates read it.
+        let mut copies: Vec<(VarId, VarId)> = Vec::new();
+        for spec in &mut aggregates_vec {
+            let Some(input_var) = spec.function.input_var() else {
+                continue;
+            };
+            if !group_by_set.contains(&input_var) {
+                continue;
+            }
+            let copy = match copies.iter().find(|(key, _)| *key == input_var) {
+                Some((_, copy)) => *copy,
+                None => {
+                    let copy = VarId(next_id);
+                    next_id = next_id.saturating_add(1);
+                    copies.push((input_var, copy));
+                    copy
+                }
+            };
+            spec.function.substitute_var(input_var, copy);
+        }
+
+        for (key, copy) in &copies {
+            operator = Box::new(crate::bind::BindOperator::new(
+                operator,
+                *copy,
+                Expression::Var(*key),
+                Vec::new(),
+            ));
+            where_schema_vec.push(*copy);
+        }
+
+        // `variable_deps` was computed from the pre-rewrite IR, so it does not
+        // know the copies exist. Without this, `GroupByOperator`'s projection
+        // trimming drops the very column the aggregate now reads.
+        if let Some(deps) = variable_deps {
+            let mut deps = deps.clone();
+            deps.required_groupby_vars
+                .extend(copies.iter().map(|(_, copy)| *copy));
+            aliased_deps = Some(deps);
+        }
+    }
+    let variable_deps = aliased_deps.as_ref().or(variable_deps);
+
     // Get the schema after WHERE (before grouping), including any unbound pads.
     let where_schema: Arc<[VarId]> = Arc::from(where_schema_vec.into_boxed_slice());
 
@@ -3196,9 +3293,10 @@ pub(crate) fn apply_solution_modifiers(
             }
         }
 
-        // Validate aggregates
+        // Validate aggregates. No key-reading check here: the copy-before-group
+        // rewrite above has already moved every such aggregate off its key
+        // column, so the hazard it used to guard is unreachable.
         let current_schema = operator.schema();
-        let group_by_set: HashSet<VarId> = group_by_vec.iter().copied().collect();
         let mut seen_output_vars: HashSet<VarId> = HashSet::new();
 
         for spec in &aggregates_vec {
@@ -3206,11 +3304,6 @@ pub(crate) fn apply_solution_modifiers(
                 if !current_schema.contains(&input_var) {
                     return Err(QueryError::VariableNotFound(format!(
                         "Aggregate input variable {input_var:?} not found in schema"
-                    )));
-                }
-                if !group_by_vec.is_empty() && group_by_set.contains(&input_var) {
-                    return Err(QueryError::InvalidQuery(format!(
-                        "Aggregate input variable {input_var:?} is a GROUP BY key and will not be grouped"
                     )));
                 }
                 if spec.output_var != input_var && current_schema.contains(&spec.output_var) {

--- a/fluree-db-query/src/group_aggregate.rs
+++ b/fluree-db-query/src/group_aggregate.rs
@@ -78,6 +78,8 @@ enum AggState {
     Count { n: u64 },
     /// COUNT(DISTINCT) - HashSet of seen values
     CountDistinct { seen: HashSet<GroupKeyOwned> },
+    /// COUNT(DISTINCT *) - HashSet of seen whole solutions
+    CountDistinctAll { seen: HashSet<Vec<GroupKeyOwned>> },
     /// SUM - exact-when-possible numeric accumulator with type promotion
     /// (xsd:integer → xsd:decimal → xsd:double). `poisoned` records a bound
     /// non-numeric member, which makes the whole aggregate a type error.
@@ -224,6 +226,9 @@ impl AggState {
             AggregateFn::CountDistinct(_) => AggState::CountDistinct {
                 seen: HashSet::new(),
             },
+            AggregateFn::CountDistinctAll => AggState::CountDistinctAll {
+                seen: HashSet::new(),
+            },
             AggregateFn::Sum { .. } => AggState::Sum {
                 acc: crate::aggregate::NumericAcc::new(),
                 poisoned: false,
@@ -260,6 +265,9 @@ impl AggState {
                     *n += 1;
                 }
             }
+            // Whole-row state: fed by `update_distinct_row`, never by a single
+            // column (COUNT(DISTINCT *) has no input variable).
+            AggState::CountDistinctAll { .. } => {}
             AggState::CountDistinct { seen } => {
                 if !matches!(binding, Binding::Unbound | Binding::Poisoned) {
                     // Convert binding to owned group key for HashSet,
@@ -350,11 +358,23 @@ impl AggState {
         }
     }
 
+    /// Update with a whole composed solution (`COUNT(DISTINCT *)`).
+    fn update_distinct_row(&mut self, row: &[GroupKeyOwned]) {
+        if let AggState::CountDistinctAll { seen } = self {
+            if !seen.contains(row) {
+                seen.insert(row.to_vec());
+            }
+        }
+    }
+
     /// Finalize the aggregate state into a result binding
     fn finalize(self, func: &AggregateFn) -> Binding {
         match self {
             AggState::Count { n } => Binding::lit(FlakeValue::Long(n as i64), Sid::xsd_integer()),
             AggState::CountDistinct { seen } => {
+                Binding::lit(FlakeValue::Long(seen.len() as i64), Sid::xsd_integer())
+            }
+            AggState::CountDistinctAll { seen } => {
                 Binding::lit(FlakeValue::Long(seen.len() as i64), Sid::xsd_integer())
             }
             AggState::Sum { acc, poisoned } => {
@@ -668,6 +688,12 @@ pub struct GroupAggregateOperator {
     graph_view: Option<BinaryGraphView>,
     /// Variables required by downstream operators; if set, output is trimmed.
     out_schema: Option<Arc<[VarId]>>,
+    /// Number of columns in the child (pre-grouping) batch.
+    child_col_count: usize,
+    /// Whether any aggregate is `COUNT(DISTINCT *)`, which reads the whole
+    /// child row rather than one column. Gates the per-row row-key composition
+    /// so ordinary grouping does no extra work.
+    has_row_distinct: bool,
 }
 
 enum GroupEmitIter {
@@ -712,6 +738,10 @@ impl GroupAggregateOperator {
 
         let schema: Arc<[VarId]> = Arc::from(output_vars.into_boxed_slice());
 
+        let has_row_distinct = agg_specs
+            .iter()
+            .any(|s| matches!(s.function, AggregateFn::CountDistinctAll));
+
         Self {
             child,
             in_schema: schema,
@@ -724,6 +754,8 @@ impl GroupAggregateOperator {
             emit_iter: None,
             graph_view,
             out_schema: None,
+            child_col_count: child_schema.len(),
+            has_row_distinct,
         }
     }
 
@@ -746,6 +778,7 @@ impl GroupAggregateOperator {
             AggregateFn::Count(_)
             | AggregateFn::CountAll
             | AggregateFn::CountDistinct(_)
+            | AggregateFn::CountDistinctAll
             | AggregateFn::Min(_)
             | AggregateFn::Max(_)
             | AggregateFn::Sample(_) => true,
@@ -772,6 +805,20 @@ impl GroupAggregateOperator {
             })
             .collect();
         CompositeGroupKey(keys)
+    }
+
+    /// Compose a whole solution into a hashable key, for `COUNT(DISTINCT *)`.
+    ///
+    /// Every upstream column participates, normalized the same way group keys
+    /// are so a mixed encoded/decoded stream does not double-count.
+    fn extract_row_key(&self, batch: &Batch, row_idx: usize) -> Vec<GroupKeyOwned> {
+        let store = self.graph_view.as_ref().map(BinaryGraphView::store);
+        (0..self.child_col_count)
+            .map(|col_idx| {
+                let binding = batch.get_by_col(row_idx, col_idx);
+                binding_to_group_key_normalized(binding, store, self.graph_view.as_ref())
+            })
+            .collect()
     }
 
     /// Extract original bindings for group key columns (for output)
@@ -910,6 +957,12 @@ impl Operator for GroupAggregateOperator {
                                 });
                             }
 
+                            // COUNT(DISTINCT *) reads the whole solution, so
+                            // compose it before the group state is borrowed.
+                            let row_key = self
+                                .has_row_distinct
+                                .then(|| self.extract_row_key(&batch, row_idx));
+
                             // Update aggregate states for current group.
                             let gv_ref = self.graph_view.as_ref();
                             let group_state = current_state
@@ -921,10 +974,20 @@ impl Operator for GroupAggregateOperator {
                                         let binding = batch.get_by_col(row_idx, col_idx);
                                         group_state.agg_states[agg_idx].update(binding, gv_ref);
                                     }
-                                    None => {
+                                    None => match &row_key {
+                                        // COUNT(DISTINCT *) - count distinct solutions
+                                        Some(row)
+                                            if matches!(
+                                                spec.function,
+                                                AggregateFn::CountDistinctAll
+                                            ) =>
+                                        {
+                                            group_state.agg_states[agg_idx]
+                                                .update_distinct_row(row);
+                                        }
                                         // COUNT(*) - count all rows
-                                        group_state.agg_states[agg_idx].update_count_all();
-                                    }
+                                        _ => group_state.agg_states[agg_idx].update_count_all(),
+                                    },
                                 }
                             }
                         }
@@ -984,6 +1047,12 @@ impl Operator for GroupAggregateOperator {
                         // Extract key bindings BEFORE the mutable borrow to avoid borrow conflict
                         let key_bindings = self.extract_key_bindings(&batch, row_idx);
 
+                        // COUNT(DISTINCT *) reads the whole solution, so compose
+                        // it here too — before the group state is borrowed.
+                        let row_key = self
+                            .has_row_distinct
+                            .then(|| self.extract_row_key(&batch, row_idx));
+
                         // Pre-compute aggregate states initialization
                         let agg_specs_ref = &self.agg_specs;
 
@@ -1005,10 +1074,19 @@ impl Operator for GroupAggregateOperator {
                                     let binding = batch.get_by_col(row_idx, col_idx);
                                     group_state.agg_states[agg_idx].update(binding, gv_ref);
                                 }
-                                None => {
+                                None => match &row_key {
+                                    // COUNT(DISTINCT *) - count distinct solutions
+                                    Some(row)
+                                        if matches!(
+                                            spec.function,
+                                            AggregateFn::CountDistinctAll
+                                        ) =>
+                                    {
+                                        group_state.agg_states[agg_idx].update_distinct_row(row);
+                                    }
                                     // COUNT(*) - count all rows
-                                    group_state.agg_states[agg_idx].update_count_all();
-                                }
+                                    _ => group_state.agg_states[agg_idx].update_count_all(),
+                                },
                             }
                         }
                     }

--- a/fluree-db-query/src/group_aggregate.rs
+++ b/fluree-db-query/src/group_aggregate.rs
@@ -226,7 +226,7 @@ impl AggState {
             AggregateFn::CountDistinct(_) => AggState::CountDistinct {
                 seen: HashSet::new(),
             },
-            AggregateFn::CountDistinctAll => AggState::CountDistinctAll {
+            AggregateFn::CountDistinctAll(_) => AggState::CountDistinctAll {
                 seen: HashSet::new(),
             },
             AggregateFn::Sum { .. } => AggState::Sum {
@@ -688,11 +688,13 @@ pub struct GroupAggregateOperator {
     graph_view: Option<BinaryGraphView>,
     /// Variables required by downstream operators; if set, output is trimmed.
     out_schema: Option<Arc<[VarId]>>,
-    /// Number of columns in the child (pre-grouping) batch.
-    child_col_count: usize,
-    /// Whether any aggregate is `COUNT(DISTINCT *)`, which reads the whole
-    /// child row rather than one column. Gates the per-row row-key composition
-    /// so ordinary grouping does no extra work.
+    /// Child columns each `COUNT(DISTINCT *)` spec composes its solution from,
+    /// parallel to `agg_specs`; `None` for every other aggregate. Resolved once
+    /// from the spec's user-visible variable list, so lowering-internal columns
+    /// never split a solution.
+    row_distinct_cols: Vec<Option<Vec<usize>>>,
+    /// Whether any aggregate is `COUNT(DISTINCT *)`. Gates the per-row solution
+    /// composition so ordinary grouping does no extra work.
     has_row_distinct: bool,
 }
 
@@ -738,9 +740,21 @@ impl GroupAggregateOperator {
 
         let schema: Arc<[VarId]> = Arc::from(output_vars.into_boxed_slice());
 
-        let has_row_distinct = agg_specs
+        // Resolve each COUNT(DISTINCT *)'s visible variables to child columns.
+        // Variables from other scopes, and SELECT aliases, are not in this
+        // schema and drop out here.
+        let row_distinct_cols: Vec<Option<Vec<usize>>> = agg_specs
             .iter()
-            .any(|s| matches!(s.function, AggregateFn::CountDistinctAll));
+            .map(|s| match &s.function {
+                AggregateFn::CountDistinctAll(vars) => Some(
+                    vars.iter()
+                        .filter_map(|v| child_schema.iter().position(|sv| sv == v))
+                        .collect(),
+                ),
+                _ => None,
+            })
+            .collect();
+        let has_row_distinct = row_distinct_cols.iter().any(Option::is_some);
 
         Self {
             child,
@@ -754,7 +768,7 @@ impl GroupAggregateOperator {
             emit_iter: None,
             graph_view,
             out_schema: None,
-            child_col_count: child_schema.len(),
+            row_distinct_cols,
             has_row_distinct,
         }
     }
@@ -778,7 +792,7 @@ impl GroupAggregateOperator {
             AggregateFn::Count(_)
             | AggregateFn::CountAll
             | AggregateFn::CountDistinct(_)
-            | AggregateFn::CountDistinctAll
+            | AggregateFn::CountDistinctAll(_)
             | AggregateFn::Min(_)
             | AggregateFn::Max(_)
             | AggregateFn::Sample(_) => true,
@@ -807,16 +821,32 @@ impl GroupAggregateOperator {
         CompositeGroupKey(keys)
     }
 
-    /// Compose a whole solution into a hashable key, for `COUNT(DISTINCT *)`.
+    /// Compose one solution into a hashable key, for `COUNT(DISTINCT *)`.
     ///
-    /// Every upstream column participates, normalized the same way group keys
-    /// are so a mixed encoded/decoded stream does not double-count.
-    fn extract_row_key(&self, batch: &Batch, row_idx: usize) -> Vec<GroupKeyOwned> {
+    /// Only `cols` participate — the user-visible columns resolved at
+    /// construction — normalized the same way group keys are so a mixed
+    /// encoded/decoded stream does not double-count.
+    fn extract_row_key(&self, batch: &Batch, row_idx: usize, cols: &[usize]) -> Vec<GroupKeyOwned> {
         let store = self.graph_view.as_ref().map(BinaryGraphView::store);
-        (0..self.child_col_count)
-            .map(|col_idx| {
+        cols.iter()
+            .map(|&col_idx| {
                 let binding = batch.get_by_col(row_idx, col_idx);
                 binding_to_group_key_normalized(binding, store, self.graph_view.as_ref())
+            })
+            .collect()
+    }
+
+    /// Per-spec composed solutions for this row, empty when no aggregate needs
+    /// them. Computed before the group state is borrowed.
+    fn extract_row_keys(&self, batch: &Batch, row_idx: usize) -> Vec<Vec<GroupKeyOwned>> {
+        if !self.has_row_distinct {
+            return Vec::new();
+        }
+        self.row_distinct_cols
+            .iter()
+            .map(|cols| match cols {
+                Some(cols) => self.extract_row_key(batch, row_idx, cols),
+                None => Vec::new(),
             })
             .collect()
     }
@@ -957,11 +987,9 @@ impl Operator for GroupAggregateOperator {
                                 });
                             }
 
-                            // COUNT(DISTINCT *) reads the whole solution, so
+                            // COUNT(DISTINCT *) reads a whole solution, so
                             // compose it before the group state is borrowed.
-                            let row_key = self
-                                .has_row_distinct
-                                .then(|| self.extract_row_key(&batch, row_idx));
+                            let row_keys = self.extract_row_keys(&batch, row_idx);
 
                             // Update aggregate states for current group.
                             let gv_ref = self.graph_view.as_ref();
@@ -974,20 +1002,17 @@ impl Operator for GroupAggregateOperator {
                                         let binding = batch.get_by_col(row_idx, col_idx);
                                         group_state.agg_states[agg_idx].update(binding, gv_ref);
                                     }
-                                    None => match &row_key {
-                                        // COUNT(DISTINCT *) - count distinct solutions
-                                        Some(row)
-                                            if matches!(
-                                                spec.function,
-                                                AggregateFn::CountDistinctAll
-                                            ) =>
-                                        {
-                                            group_state.agg_states[agg_idx]
-                                                .update_distinct_row(row);
-                                        }
-                                        // COUNT(*) - count all rows
-                                        _ => group_state.agg_states[agg_idx].update_count_all(),
-                                    },
+                                    // COUNT(DISTINCT *) - count distinct solutions
+                                    None if matches!(
+                                        spec.function,
+                                        AggregateFn::CountDistinctAll(_)
+                                    ) =>
+                                    {
+                                        group_state.agg_states[agg_idx]
+                                            .update_distinct_row(&row_keys[agg_idx]);
+                                    }
+                                    // COUNT(*) - count all rows
+                                    None => group_state.agg_states[agg_idx].update_count_all(),
                                 }
                             }
                         }
@@ -1047,11 +1072,9 @@ impl Operator for GroupAggregateOperator {
                         // Extract key bindings BEFORE the mutable borrow to avoid borrow conflict
                         let key_bindings = self.extract_key_bindings(&batch, row_idx);
 
-                        // COUNT(DISTINCT *) reads the whole solution, so compose
+                        // COUNT(DISTINCT *) reads a whole solution, so compose
                         // it here too — before the group state is borrowed.
-                        let row_key = self
-                            .has_row_distinct
-                            .then(|| self.extract_row_key(&batch, row_idx));
+                        let row_keys = self.extract_row_keys(&batch, row_idx);
 
                         // Pre-compute aggregate states initialization
                         let agg_specs_ref = &self.agg_specs;
@@ -1074,19 +1097,17 @@ impl Operator for GroupAggregateOperator {
                                     let binding = batch.get_by_col(row_idx, col_idx);
                                     group_state.agg_states[agg_idx].update(binding, gv_ref);
                                 }
-                                None => match &row_key {
-                                    // COUNT(DISTINCT *) - count distinct solutions
-                                    Some(row)
-                                        if matches!(
-                                            spec.function,
-                                            AggregateFn::CountDistinctAll
-                                        ) =>
-                                    {
-                                        group_state.agg_states[agg_idx].update_distinct_row(row);
-                                    }
-                                    // COUNT(*) - count all rows
-                                    _ => group_state.agg_states[agg_idx].update_count_all(),
-                                },
+                                // COUNT(DISTINCT *) - count distinct solutions
+                                None if matches!(
+                                    spec.function,
+                                    AggregateFn::CountDistinctAll(_)
+                                ) =>
+                                {
+                                    group_state.agg_states[agg_idx]
+                                        .update_distinct_row(&row_keys[agg_idx]);
+                                }
+                                // COUNT(*) - count all rows
+                                None => group_state.agg_states[agg_idx].update_count_all(),
                             }
                         }
                     }

--- a/fluree-db-query/src/ir/grouping.rs
+++ b/fluree-db-query/src/ir/grouping.rs
@@ -38,6 +38,11 @@ pub enum AggregateFn {
     Count(VarId),
     /// `COUNT(*)` — count all rows in a group regardless of values.
     CountAll,
+    /// `COUNT(DISTINCT *)` — count the *distinct solutions* in a group
+    /// (SPARQL 1.1 §18.5.1.1). Unlike every other variant this reads the whole
+    /// row rather than one column, so it carries no input variable and the
+    /// group operators compose its key from every upstream column.
+    CountDistinctAll,
     /// `COUNT(DISTINCT ?x)` — count distinct non-Unbound values. Separate
     /// variant because its streaming state uses a `HashSet` rather than a
     /// counter.
@@ -77,7 +82,7 @@ impl AggregateFn {
     /// only for [`Self::CountAll`].
     pub fn input_var(&self) -> Option<VarId> {
         match self {
-            Self::CountAll => None,
+            Self::CountAll | Self::CountDistinctAll => None,
             Self::Count(v)
             | Self::CountDistinct(v)
             | Self::Sum(v, _)
@@ -102,6 +107,7 @@ impl AggregateFn {
         matches!(
             self,
             Self::CountDistinct(_)
+                | Self::CountDistinctAll
                 | Self::Sum(_, InputSemantics::Set)
                 | Self::Avg(_, InputSemantics::Set)
                 | Self::Median(_, InputSemantics::Set)
@@ -133,6 +139,12 @@ impl AggregateFn {
         match self {
             Self::Min(_) | Self::Max(_) | Self::Sample(_) => true,
             Self::CountAll | Self::Count(_) => false,
+            // Counting distinct solutions is insensitive to duplicate rows in
+            // principle, but the optimization this gates also *projects away
+            // dead variables* before deduping — and dropping a column changes
+            // which rows are distinct. Classified false so the whole-row read
+            // always sees the full solution.
+            Self::CountDistinctAll => false,
             Self::CountDistinct(_)
             | Self::Sum(..)
             | Self::Avg(..)
@@ -154,7 +166,7 @@ impl AggregateFn {
             }
         };
         match self {
-            Self::CountAll => {}
+            Self::CountAll | Self::CountDistinctAll => {}
             Self::Count(v)
             | Self::CountDistinct(v)
             | Self::Sum(v, _)

--- a/fluree-db-query/src/ir/grouping.rs
+++ b/fluree-db-query/src/ir/grouping.rs
@@ -39,10 +39,19 @@ pub enum AggregateFn {
     /// `COUNT(*)` — count all rows in a group regardless of values.
     CountAll,
     /// `COUNT(DISTINCT *)` — count the *distinct solutions* in a group
-    /// (SPARQL 1.1 §18.5.1.1). Unlike every other variant this reads the whole
-    /// row rather than one column, so it carries no input variable and the
-    /// group operators compose its key from every upstream column.
-    CountDistinctAll,
+    /// (SPARQL 1.1 §18.5.1.1). Unlike every other variant this reads a whole
+    /// row rather than one column, so it carries no input variable.
+    ///
+    /// The payload is the query's **user-visible** variables, in registration
+    /// order. `*` denotes the solution mapping, and SPARQL projects
+    /// lowering-internal variables out of it — property-path join variables
+    /// (`?__ppN`) and non-distinguished blank-node variables (§4.1.4) among
+    /// them. Composing distinctness over the raw upstream row would let those
+    /// split solutions that the spec considers identical, so the group
+    /// operators intersect this list with their input schema and read only
+    /// those columns. Variables from other scopes (or SELECT aliases, which
+    /// never reach the pre-grouping row) drop out in that intersection.
+    CountDistinctAll(Vec<VarId>),
     /// `COUNT(DISTINCT ?x)` — count distinct non-Unbound values. Separate
     /// variant because its streaming state uses a `HashSet` rather than a
     /// counter.
@@ -82,7 +91,7 @@ impl AggregateFn {
     /// only for [`Self::CountAll`].
     pub fn input_var(&self) -> Option<VarId> {
         match self {
-            Self::CountAll | Self::CountDistinctAll => None,
+            Self::CountAll | Self::CountDistinctAll(_) => None,
             Self::Count(v)
             | Self::CountDistinct(v)
             | Self::Sum(v, _)
@@ -107,7 +116,7 @@ impl AggregateFn {
         matches!(
             self,
             Self::CountDistinct(_)
-                | Self::CountDistinctAll
+                | Self::CountDistinctAll(_)
                 | Self::Sum(_, InputSemantics::Set)
                 | Self::Avg(_, InputSemantics::Set)
                 | Self::Median(_, InputSemantics::Set)
@@ -144,7 +153,7 @@ impl AggregateFn {
             // dead variables* before deduping — and dropping a column changes
             // which rows are distinct. Classified false so the whole-row read
             // always sees the full solution.
-            Self::CountDistinctAll => false,
+            Self::CountDistinctAll(_) => false,
             Self::CountDistinct(_)
             | Self::Sum(..)
             | Self::Avg(..)
@@ -166,7 +175,7 @@ impl AggregateFn {
             }
         };
         match self {
-            Self::CountAll | Self::CountDistinctAll => {}
+            Self::CountAll | Self::CountDistinctAll(_) => {}
             Self::Count(v)
             | Self::CountDistinct(v)
             | Self::Sum(v, _)

--- a/fluree-db-query/tests/groupby_aggregate_tests.rs
+++ b/fluree-db-query/tests/groupby_aggregate_tests.rs
@@ -618,14 +618,15 @@ async fn test_order_by_on_grouped_var_errors() {
     );
 }
 
-/// Aggregating a GROUP BY key var should error (it is not Grouped in this model).
+/// Aggregating a GROUP BY key var into a fresh output var is legal SPARQL
+/// (COUNT(?city) counts the rows collapsed into each ?city group).
 #[tokio::test]
-async fn test_aggregate_on_group_by_key_errors() {
+async fn test_aggregate_on_group_by_key() {
     let snapshot = make_test_snapshot();
     let vars = VarRegistry::new();
 
     let mut query = make_query(
-        vec![VarId(0), VarId(1)],
+        vec![VarId(0), VarId(2)],
         vec![Pattern::Values {
             vars: vec![VarId(0), VarId(1)],
             rows: vec![
@@ -641,11 +642,56 @@ async fn test_aggregate_on_group_by_key_errors() {
         }],
     );
 
-    // Attempt to COUNT(?city) while also GROUP BY ?city.
+    // COUNT(?city) AS ?n while also GROUP BY ?city.
     query.grouping = Some(explicit_grouping(
         vec![VarId(0)],
         vec![AggregateSpec {
             function: AggregateFn::Count(VarId(0)), // key var
+            output_var: VarId(2),
+        }],
+    ));
+    let options = ReasoningConfig::default();
+
+    let db = GraphDbRef::new(&snapshot, 0, &NoOverlay, snapshot.t);
+    let executable = ExecutableQuery::new(query, options);
+    let results = execute(db, &vars, &executable, ContextConfig::default())
+        .await
+        .unwrap();
+
+    // One NYC group whose key is bound in both rows -> count 2.
+    let total_rows: usize = results.iter().map(|b| b.rows().count()).sum();
+    assert_eq!(total_rows, 1, "expected a single NYC group");
+    let count = results[0].get_by_col(0, 1);
+    if let Binding::Lit { val, .. } = count {
+        assert_eq!(*val, FlakeValue::Long(2));
+    } else {
+        panic!("Expected Lit binding for count, got {count:?}");
+    }
+}
+
+/// Writing an aggregate's output onto the GROUP BY key itself is still an
+/// error: the key column stays in the schema, so the alias collides.
+#[tokio::test]
+async fn test_aggregate_output_onto_group_by_key_errors() {
+    let snapshot = make_test_snapshot();
+    let vars = VarRegistry::new();
+
+    let mut query = make_query(
+        vec![VarId(0), VarId(1)],
+        vec![Pattern::Values {
+            vars: vec![VarId(0), VarId(1)],
+            rows: vec![vec![
+                Binding::lit(FlakeValue::String("NYC".into()), xsd_string()),
+                Binding::sid(Sid::new(100, "alice")),
+            ]],
+        }],
+    );
+
+    // COUNT(?city) AS ?city while also GROUP BY ?city.
+    query.grouping = Some(explicit_grouping(
+        vec![VarId(0)],
+        vec![AggregateSpec {
+            function: AggregateFn::Count(VarId(0)),
             output_var: VarId(0),
         }],
     ));
@@ -657,7 +703,7 @@ async fn test_aggregate_on_group_by_key_errors() {
         .await
         .unwrap_err();
     assert!(
-        err.to_string().contains("GROUP BY key"),
+        err.to_string().contains("already exists in schema"),
         "unexpected error: {err}"
     );
 }

--- a/fluree-db-sparql/src/lower/aggregate.rs
+++ b/fluree-db-sparql/src/lower/aggregate.rs
@@ -231,7 +231,12 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             // row, so neither carries an input variable.
             (AggregateFunction::Count, None) => {
                 if *distinct {
-                    AggregateFn::CountDistinctAll
+                    // `*` is the solution mapping, so distinctness ranges over
+                    // the user-visible variables — not the lowering-internal
+                    // ones (`?__ppN`, `_:b`) that also sit in the executor's
+                    // row. The WHERE clause is lowered before the solution
+                    // modifiers, so every variable it binds is registered by now.
+                    AggregateFn::CountDistinctAll(self.user_visible_vars())
                 } else {
                     AggregateFn::CountAll
                 }

--- a/fluree-db-sparql/src/lower/aggregate.rs
+++ b/fluree-db-sparql/src/lower/aggregate.rs
@@ -226,12 +226,15 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             InputSemantics::List
         };
         let function = match (function, input_var) {
-            // COUNT(*) — DISTINCT * is not meaningful for COUNT.
+            // COUNT(*) counts solutions in the group; COUNT(DISTINCT *) counts
+            // the DISTINCT solutions (SPARQL 1.1 §18.5.1.1). Both read the whole
+            // row, so neither carries an input variable.
             (AggregateFunction::Count, None) => {
                 if *distinct {
-                    return Err(LowerError::not_implemented("COUNT(DISTINCT *)", *span));
+                    AggregateFn::CountDistinctAll
+                } else {
+                    AggregateFn::CountAll
                 }
-                AggregateFn::CountAll
             }
             // Every non-COUNT aggregate needs an input variable. The caller
             // is responsible for ensuring `expr` is `Some(_)`; reaching this

--- a/fluree-db-sparql/src/lower/annotation.rs
+++ b/fluree-db-sparql/src/lower/annotation.rs
@@ -30,7 +30,8 @@ use fluree_db_query::parse::encode::IriEncoder;
 
 use std::collections::HashMap;
 
-use super::{LowerError, LoweringContext, Result};
+use super::path::PathObject;
+use super::{LoweringContext, Result};
 
 /// Prefix used for registry names of synthetic variables that must
 /// stay invisible to `SELECT *` and unmatchable by user input. `#`
@@ -219,17 +220,14 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                     }));
                 }
                 AnnotationVerb::Path(path) => {
-                    // Same contract as the main property-path surface:
-                    // path objects must be Refs (vars/IRIs/bnodes), not
-                    // literal values.
-                    let (o_term, _dtc) =
+                    // Same contract as the main property-path surface: a
+                    // literal object is legal (`{| :r/:q "x" |}`) and is
+                    // narrowed per-arm by the dispatcher. The datatype
+                    // constraint rides along so a literal endpoint on the
+                    // final hop stays as precise as the `Simple` verb above.
+                    let (o_term, dtc) =
                         self.lower_object_desugared(&entry.object, &mut cache, &mut out, true)?;
-                    let o = Ref::try_from(o_term).map_err(|_| {
-                        LowerError::invalid_property_path(
-                            "Property path object cannot be a literal value",
-                            entry.span,
-                        )
-                    })?;
+                    let o = PathObject::new(o_term, dtc);
                     let pats = self.lower_path_dispatch(annotation, path, &o, entry.span)?;
                     out.extend(pats);
                 }

--- a/fluree-db-sparql/src/lower/path.rs
+++ b/fluree-db-sparql/src/lower/path.rs
@@ -13,9 +13,9 @@ use crate::ast::path::{NegatedPredicate, PropertyPath as SparqlPropertyPath};
 use crate::ast::term::{ObjectTerm, SubjectTerm};
 use crate::span::SourceSpan;
 
-use fluree_db_core::FlakeValue;
+use fluree_db_core::{DatatypeConstraint, FlakeValue};
 use fluree_db_query::ir::path::PathStep;
-use fluree_db_query::ir::triple::{Ref, TriplePattern};
+use fluree_db_query::ir::triple::{Ref, Term, TriplePattern};
 use fluree_db_query::ir::{Expression, Function, PathModifier, Pattern, PropertyPathPattern};
 use fluree_db_query::parse::encode::IriEncoder;
 use fluree_db_query::var_registry::VarId;
@@ -28,6 +28,84 @@ use super::{LowerError, LoweringContext, Result};
 /// `(a|b)/(c|d)/(e|f)/...`.
 const MAX_SEQUENCE_EXPANSION: usize = 64;
 
+/// The object endpoint of a property path.
+///
+/// SPARQL 1.1 §19.8 reaches a path's object through `GraphNodePath`, which
+/// admits `RDFLiteral` / `NumericLiteral` / `BooleanLiteral`, so
+/// `?s ex:ofMaker/ex:name "Acme"` is an ordinary matchable shape. Most path
+/// arms only ever place the endpoint in the *object* slot of a
+/// `TriplePattern`, where a literal is representable; the arms that put it in
+/// subject or `PropertyPathPattern` position narrow it to a [`Ref`] themselves.
+/// Carrying it as a [`Term`] keeps the narrowing per-arm instead of up front.
+#[derive(Clone)]
+pub(super) struct PathObject {
+    term: Term,
+    /// Datatype / language constraint for a literal endpoint. Set only by the
+    /// annotation-block surface, whose objects pin the scan to their exact
+    /// datatype; the plain path surface leaves it `None` so a path's final hop
+    /// matches exactly like the equivalent hand-written triple pattern.
+    dtc: Option<DatatypeConstraint>,
+}
+
+impl PathObject {
+    pub(super) fn new(term: Term, dtc: Option<DatatypeConstraint>) -> Self {
+        Self { term, dtc }
+    }
+
+    /// The endpoint narrowed to a [`Ref`], or `None` when it is a literal.
+    fn to_ref(&self) -> Option<Ref> {
+        Ref::try_from(self.term.clone()).ok()
+    }
+
+    /// Build `s p <endpoint>`, carrying the endpoint's datatype constraint.
+    fn triple(&self, s: Ref, p: Ref) -> TriplePattern {
+        TriplePattern {
+            s,
+            p,
+            o: self.term.clone(),
+            dtc: self.dtc.clone(),
+        }
+    }
+}
+
+impl From<Ref> for PathObject {
+    fn from(r: Ref) -> Self {
+        Self {
+            term: r.into(),
+            dtc: None,
+        }
+    }
+}
+
+/// A pattern that matches nothing while keeping `vars` in scope.
+///
+/// RDF has no literal subjects, so a path arm that would place a literal in
+/// subject position can never match. SPARQL 1.1 asks for the empty solution
+/// sequence there, not an error; an empty `VALUES` gives exactly that and still
+/// declares the arm's variables so `SELECT *` projection is unchanged.
+fn never_matches(vars: impl IntoIterator<Item = VarId>) -> Pattern {
+    Pattern::Values {
+        vars: vars.into_iter().collect(),
+        rows: Vec::new(),
+    }
+}
+
+/// Narrow, deliberate divergence for path forms whose IR endpoints are typed
+/// [`Ref`] and so cannot hold a literal.
+///
+/// These shapes are legal SPARQL 1.1 — the message says so, because the
+/// alternative is a user reading `err:db/InvalidQuery` as "my query is wrong".
+fn literal_endpoint_unsupported(form: &str, example: &str, span: SourceSpan) -> LowerError {
+    LowerError::invalid_property_path(
+        format!(
+            "{form} with a literal object are not yet supported (e.g. `{example}`). This shape is \
+             legal SPARQL 1.1; the restriction is a Fluree limitation, not a spec rule. Rewrite it \
+             with a variable endpoint and a filter, e.g. `?s <path> ?o . FILTER(?o = <literal>)`."
+        ),
+        span,
+    )
+}
+
 impl<E: IriEncoder> LoweringContext<'_, E> {
     pub(super) fn lower_property_path(
         &mut self,
@@ -39,14 +117,9 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         // Lower subject term (already a Ref, so no literal validation needed)
         let s = self.lower_subject(subject)?;
 
-        // Lower object term and convert to Ref (fails on literal values)
-        let o_term = self.lower_object(object)?;
-        let o = Ref::try_from(o_term).map_err(|_| {
-            LowerError::invalid_property_path(
-                "Property path object cannot be a literal value",
-                span,
-            )
-        })?;
+        // The object may legally be a literal (`?s ex:ofMaker/ex:name "Acme"`);
+        // arms that cannot represent one narrow it themselves.
+        let o = PathObject::new(self.lower_object(object)?, None);
 
         self.lower_path_dispatch(&s, path, &o, span)
     }
@@ -59,7 +132,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         &mut self,
         s: &Ref,
         path: &SparqlPropertyPath,
-        o: &Ref,
+        o: &PathObject,
         span: SourceSpan,
     ) -> Result<Vec<Pattern>> {
         // Rewrite complex inverses (^(a/b), ^(a|b), ^(^x)) before dispatching.
@@ -87,6 +160,19 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                 // single modifier over the innermost path before extracting
                 // predicates. `inner` is consumed via `innermost` below.
                 let _ = inner;
+                // `PropertyPathPattern`'s endpoints are `Ref`s, so a literal
+                // endpoint cannot be represented. `?s ex:p+ "lit"` and
+                // `?s ex:p* "lit"` are both evaluable under SPARQL 1.1 (the
+                // latter via the zero-length path, which binds `?s` to the
+                // literal), so this is a divergence, not a spec restriction.
+                let Some(o) = o.to_ref() else {
+                    return Err(literal_endpoint_unsupported(
+                        "Transitive property paths (+, *, ?)",
+                        "?s ex:p+ \"lit\"",
+                        span,
+                    ));
+                };
+                let o = &o;
                 let ((zero, unbounded), innermost) = Self::collapse_modifiers(effective_path);
                 let modifier = match (unbounded, zero) {
                     (true, true) => PathModifier::ZeroOrMore,
@@ -147,6 +233,13 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                 | SparqlPropertyPath::ZeroOrOne { path: tp_inner, .. } => {
                     // Both-constants is a reachability test (handled by the
                     // operator's both-Sid arm), not an error.
+                    let Some(o) = o.to_ref() else {
+                        return Err(literal_endpoint_unsupported(
+                            "Transitive property paths (+, *, ?)",
+                            "?s ^ex:p+ \"lit\"",
+                            span,
+                        ));
+                    };
                     let iri = self.extract_simple_predicate_iri(tp_inner, span)?;
                     let modifier = match inner.as_ref() {
                         SparqlPropertyPath::OneOrMore { .. } => PathModifier::OneOrMore,
@@ -166,8 +259,14 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                 _ => {
                     let iri = self.extract_simple_predicate_iri(inner, span)?;
                     let p = Ref::Iri(Arc::from(iri.as_str()));
+                    // `?s ^ex:p "lit"` puts the literal in subject position:
+                    // zero solutions, not an error (W3C `syn-pp-in-collection`
+                    // writes exactly this as `[ ^:r "hello" ]`).
+                    let Some(o) = o.to_ref() else {
+                        return Ok(vec![never_matches(s.as_var())]);
+                    };
                     Ok(vec![Pattern::Triple(TriplePattern::new(
-                        o.clone(),
+                        o,
                         p,
                         s.clone().into(),
                     ))])
@@ -204,7 +303,17 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             }
             // Negated property set: `!iri`, `!(a|b)`, `!(^p)`, `!(a|^p)`.
             SparqlPropertyPath::NegatedSet { iris, .. } => {
-                self.lower_negated_set(s, iris, o, span)
+                // A negated set's inverse branch reverses subject and object,
+                // so the endpoint must be a `Ref` for the branch split to be
+                // expressible as written.
+                let Some(o) = o.to_ref() else {
+                    return Err(literal_endpoint_unsupported(
+                        "Negated property sets (!)",
+                        "?s !(ex:a) \"lit\"",
+                        span,
+                    ));
+                };
+                self.lower_negated_set(s, iris, &o, span)
             }
 
             // Grouped path - unwrap and recurse
@@ -366,7 +475,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         &mut self,
         s: &Ref,
         steps: &[&SparqlPropertyPath],
-        o: &Ref,
+        o: &PathObject,
         span: SourceSpan,
     ) -> Result<Vec<Pattern>> {
         debug_assert!(
@@ -411,15 +520,18 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
 
         for (i, step) in steps.iter().enumerate() {
             let is_last = i == steps.len() - 1;
-            let next = if is_last {
-                o.clone()
-            } else {
-                let var_name = format!("?__pp{}", self.pp_counter);
-                self.pp_counter += 1;
-                Ref::Var(self.vars.get_or_insert(&var_name))
-            };
+            if is_last {
+                // Only the final hop can carry a literal endpoint; the
+                // intermediate joins are always fresh variables.
+                patterns.push(self.lower_sequence_step_pattern(step, &prev, o, span)?);
+                break;
+            }
 
-            let pat = self.lower_sequence_step_pattern(step, &prev, &next, span)?;
+            let var_name = format!("?__pp{}", self.pp_counter);
+            self.pp_counter += 1;
+            let next = Ref::Var(self.vars.get_or_insert(&var_name));
+
+            let pat = self.lower_sequence_step_pattern(step, &prev, &next.clone().into(), span)?;
             patterns.push(pat);
 
             prev = next;
@@ -663,7 +775,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         &mut self,
         s: &Ref,
         step_choices: &[Vec<&SparqlPropertyPath>],
-        o: &Ref,
+        o: &PathObject,
         span: SourceSpan,
     ) -> Result<Vec<Pattern>> {
         let combos = Self::cartesian_product_sparql(step_choices);
@@ -693,7 +805,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         &mut self,
         s: &Ref,
         steps: &[&SparqlPropertyPath],
-        o: &Ref,
+        o: &PathObject,
         span: SourceSpan,
     ) -> Result<Vec<Pattern>> {
         let mut patterns = Vec::with_capacity(steps.len());
@@ -701,15 +813,16 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
 
         for (i, step) in steps.iter().enumerate() {
             let is_last = i == steps.len() - 1;
-            let next = if is_last {
-                o.clone()
-            } else {
-                let var_name = format!("?__pp{}", self.pp_counter);
-                self.pp_counter += 1;
-                Ref::Var(self.vars.get_or_insert(&var_name))
-            };
+            if is_last {
+                patterns.push(self.lower_sequence_step_pattern(step, &prev, o, span)?);
+                break;
+            }
 
-            let pat = self.lower_sequence_step_pattern(step, &prev, &next, span)?;
+            let var_name = format!("?__pp{}", self.pp_counter);
+            self.pp_counter += 1;
+            let next = Ref::Var(self.vars.get_or_insert(&var_name));
+
+            let pat = self.lower_sequence_step_pattern(step, &prev, &next.clone().into(), span)?;
             patterns.push(pat);
 
             prev = next;
@@ -731,26 +844,18 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         &mut self,
         step: &SparqlPropertyPath,
         prev: &Ref,
-        next: &Ref,
+        next: &PathObject,
         span: SourceSpan,
     ) -> Result<Pattern> {
         match step {
             SparqlPropertyPath::Iri(iri) => {
                 let expanded = self.expand_iri(iri)?;
                 let p = Ref::Iri(Arc::from(expanded.as_str()));
-                Ok(Pattern::Triple(TriplePattern::new(
-                    prev.clone(),
-                    p,
-                    next.clone().into(),
-                )))
+                Ok(Pattern::Triple(next.triple(prev.clone(), p)))
             }
             SparqlPropertyPath::A { .. } => {
                 let p = Ref::Iri(Arc::from(TYPE));
-                Ok(Pattern::Triple(TriplePattern::new(
-                    prev.clone(),
-                    p,
-                    next.clone().into(),
-                )))
+                Ok(Pattern::Triple(next.triple(prev.clone(), p)))
             }
             SparqlPropertyPath::Inverse { path: inner, .. } => {
                 match inner.as_ref() {
@@ -758,6 +863,13 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                     | SparqlPropertyPath::ZeroOrMore { path: tp_inner, .. }
                     | SparqlPropertyPath::ZeroOrOne { path: tp_inner, .. } => {
                         // Inverse-transitive step: ^p+ / ^p* / ^p?
+                        let Some(next) = next.to_ref() else {
+                            return Err(literal_endpoint_unsupported(
+                                "Transitive property paths (+, *, ?)",
+                                "?s ex:a/^ex:p+ \"lit\"",
+                                span,
+                            ));
+                        };
                         if prev.is_bound() && next.is_bound() {
                             return Err(LowerError::invalid_property_path(
                                 "Property path requires at least one variable (cannot have both subject and object as constants)",
@@ -775,7 +887,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                             .encode_iri(&iri)
                             .ok_or_else(|| LowerError::unknown_namespace(&iri, span))?;
                         Ok(Pattern::PropertyPath(PropertyPathPattern::new(
-                            next.clone(),
+                            next,
                             predicate_sid,
                             modifier,
                             prev.clone(),
@@ -785,8 +897,14 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                         // Simple inverse: ^p → Triple with s/o swapped
                         let iri = self.extract_simple_predicate_iri(inner, span)?;
                         let p = Ref::Iri(Arc::from(iri.as_str()));
+                        // A literal endpoint lands in subject position here —
+                        // no RDF triple has a literal subject, so the whole
+                        // chain matches nothing.
+                        let Some(next) = next.to_ref() else {
+                            return Ok(never_matches(prev.as_var()));
+                        };
                         Ok(Pattern::Triple(TriplePattern::new(
-                            next.clone(),
+                            next,
                             p,
                             prev.clone().into(),
                         )))
@@ -796,6 +914,13 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             SparqlPropertyPath::OneOrMore { path: inner, .. }
             | SparqlPropertyPath::ZeroOrMore { path: inner, .. }
             | SparqlPropertyPath::ZeroOrOne { path: inner, .. } => {
+                let Some(next) = next.to_ref() else {
+                    return Err(literal_endpoint_unsupported(
+                        "Transitive property paths (+, *, ?)",
+                        "?s ex:a/ex:p+ \"lit\"",
+                        span,
+                    ));
+                };
                 if prev.is_bound() && next.is_bound() {
                     return Err(LowerError::invalid_property_path(
                         "Property path requires at least one variable (cannot have both subject and object as constants)",
@@ -816,7 +941,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                     prev.clone(),
                     predicate_sid,
                     modifier,
-                    next.clone(),
+                    next,
                 )))
             }
             other => Err(LowerError::invalid_property_path(
@@ -836,7 +961,7 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         &mut self,
         step: &SparqlPropertyPath,
         s: &Ref,
-        o: &Ref,
+        o: &PathObject,
         span: SourceSpan,
     ) -> Result<Vec<Pattern>> {
         let pat = self.lower_sequence_step_pattern(step, s, o, span)?;
@@ -850,32 +975,29 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         &mut self,
         leaf: &SparqlPropertyPath,
         s: &Ref,
-        o: &Ref,
+        o: &PathObject,
         span: SourceSpan,
     ) -> Result<Vec<Pattern>> {
         match leaf {
             SparqlPropertyPath::Iri(iri) => {
                 let expanded = self.expand_iri(iri)?;
                 let p = Ref::Iri(Arc::from(expanded.as_str()));
-                Ok(vec![Pattern::Triple(TriplePattern::new(
-                    s.clone(),
-                    p,
-                    o.clone().into(),
-                ))])
+                Ok(vec![Pattern::Triple(o.triple(s.clone(), p))])
             }
             SparqlPropertyPath::A { .. } => {
                 let p = Ref::Iri(Arc::from(TYPE));
-                Ok(vec![Pattern::Triple(TriplePattern::new(
-                    s.clone(),
-                    p,
-                    o.clone().into(),
-                ))])
+                Ok(vec![Pattern::Triple(o.triple(s.clone(), p))])
             }
             SparqlPropertyPath::Inverse { path: inner, .. } => {
                 let iri = self.extract_simple_predicate_iri(inner, span)?;
                 let p = Ref::Iri(Arc::from(iri.as_str()));
+                // Literal endpoint in subject position: this branch of the
+                // union contributes no solutions.
+                let Some(o) = o.to_ref() else {
+                    return Ok(vec![never_matches(s.as_var())]);
+                };
                 Ok(vec![Pattern::Triple(TriplePattern::new(
-                    o.clone(),
+                    o,
                     p,
                     s.clone().into(),
                 ))])

--- a/fluree-db-sparql/src/lower/select.rs
+++ b/fluree-db-sparql/src/lower/select.rs
@@ -86,32 +86,36 @@ pub(super) struct LoweredModifiers {
 }
 
 impl<E: IriEncoder> LoweringContext<'_, E> {
+    /// The registered variables a user can see, in registration order.
+    ///
+    /// This is what `*` denotes — both in `SELECT *` and in
+    /// `COUNT(DISTINCT *)`, which counts distinct solution *mappings* and so
+    /// must range over the same variables. Three categories are hidden:
+    /// - `?__*` — planner / aggregate / property-path synthetics.
+    /// - `?#*`  — annotation-reifier synthetics
+    ///   (see `annotation::INTERNAL_VAR_PREFIX`).
+    /// - `_:*`  — SPARQL blank-node variables. Per SPARQL §4.1.4 these are
+    ///   non-distinguished and not in SELECT scope, so they don't appear in
+    ///   `SELECT *` results. Hiding them here also covers blank-node-labelled
+    ///   reifiers (`~ _:ann`, `_:ann rdf:reifies …`).
+    ///
+    /// The registry spans the whole query, so this can name variables from
+    /// sibling or nested scopes; consumers intersect it with the scope they
+    /// actually operate on.
+    pub(super) fn user_visible_vars(&self) -> Vec<VarId> {
+        self.vars
+            .iter()
+            .filter(|(name, _)| {
+                !name.starts_with("?__") && !name.starts_with("?#") && !name.starts_with("_:")
+            })
+            .map(|(_, id)| id)
+            .collect()
+    }
+
     /// Lower SELECT clause to a list of VarIds.
     pub(super) fn lower_select_clause(&mut self, clause: &SelectClause) -> Result<Vec<VarId>> {
         match &clause.variables {
-            SelectVariables::Star => {
-                // SELECT * — return user-visible registered variables.
-                //
-                // Hide three categories:
-                // - `?__*` — planner / aggregate / property-path synthetics.
-                // - `?#*`  — annotation-reifier synthetics
-                //   (see `annotation::INTERNAL_VAR_PREFIX`).
-                // - `_:*`  — SPARQL blank-node variables. Per SPARQL §4.1.4
-                //   these are non-distinguished and not in SELECT scope, so
-                //   they don't appear in `SELECT *` results. Hiding them
-                //   here also covers blank-node-labelled reifiers
-                //   (`~ _:ann`, `_:ann rdf:reifies …`).
-                Ok(self
-                    .vars
-                    .iter()
-                    .filter(|(name, _)| {
-                        !name.starts_with("?__")
-                            && !name.starts_with("?#")
-                            && !name.starts_with("_:")
-                    })
-                    .map(|(_, id)| id)
-                    .collect())
-            }
+            SelectVariables::Star => Ok(self.user_visible_vars()),
             SelectVariables::Explicit(vars) => {
                 let mut result = Vec::with_capacity(vars.len());
                 for var in vars {

--- a/testsuite-sparql/tests/registers/mod.rs
+++ b/testsuite-sparql/tests/registers/mod.rs
@@ -88,13 +88,9 @@ pub const SPARQL11_AGGREGATES: &[&str] = &[
     //     memory-backed, so the fast path never fires under it).
     //   * agg-err-01 (SUM/AVG must poison to unbound on a bound non-numeric
     //     group member, §18.5) was greened on main by the same 45d6009bf.
-    // COUNT(DISTINCT *): DEFERRED — the parser accepts it but the lowerer
-    // rejects it (lower/aggregate.rs); greening needs a new CountDistinctAll IR
-    // variant + whole-row group-operator plumbing (the operators feed each
-    // aggregate one input-var column, not the whole solution). Perf-neutral
-    // (per-group, off the per-row hot path); a standalone post-wave-3 follow-up,
-    // NOT X3 — PR-X2 (decision-owner).
-    "http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#agg-count-rows-distinct",
+    //   * agg-count-rows-distinct (COUNT(DISTINCT *)) was greened by the
+    //     CountDistinctAll IR variant plus whole-row plumbing through both
+    //     group operators.
 ];
 
 pub const SPARQL11_BINDINGS: &[&str] = &[


### PR DESCRIPTION
Three cases where the parser accepts a legal SPARQL 1.1 form and a lower layer then rejects it with a 400, plus two aggregate-evaluation fixes found along the way.

Property paths with literal objects: lowering forced every path object through `Ref::try_from`, so `?s ex:ofMaker/ex:name "Acme"` — an ordinary, matchable shape — was rejected wholesale. Endpoints now carry a `Term` and each arm narrows only as far as it must: sequence final hops and alternative branches take the literal directly, a simple inverse onto a literal lowers to a statically-empty pattern (RDF has no literal subjects — zero solutions, not an error), and the transitive arms keep a narrow error naming the sub-case, since their IR endpoints are typed `Ref`.

Aggregates over a `GROUP BY` key: `SELECT ?k (COUNT(?k) AS ?n) … GROUP BY ?k` (and the `HAVING`/`COUNT(DISTINCT ?k)` variants) returned 400. The check was guarding a real hazard on the traditional grouping path — the aggregate would have answered with the key term itself — so rather than delete it, each aggregated key is copied to a fresh non-key column before grouping and the aggregate reads the copy. The copy preserves unboundness, so an `OPTIONAL`-bound key keeps `COUNT(?k)` at 0 where `COUNT(*)` counts rows. The traditional path is pinned explicitly via EXPLAIN (the streaming path alone would have passed even with the old hazard).

`COUNT(DISTINCT *)` is now implemented (count of distinct solutions, §18.5.1.1 — the W3C `agg-count-rows-distinct` test now passes and its register entry is removed), with distinctness scoped to user-visible variables so the lowerer's synthetic path-join and blank-node variables don't split solutions the spec considers identical.

And `GROUP_CONCAT` over IRI-valued variables no longer silently drops them (it only extracted strings from literal bindings, so an all-IRI group returned null): IRIs expand through the same namespace table `STR()` uses, matching Jena. The spec states no coercion for non-literal members, so if we'd rather this be a type error than a concatenation, say so — either beats dropping members silently.
