### PR TITLE
emit absolute iris in w3c result formats

### DIFF
--- a/docs/api/headers.md
+++ b/docs/api/headers.md
@@ -285,6 +285,23 @@ X-Response-Time: 45
 
 ## Content Type Details
 
+### IRI form: absolute vs. abbreviated
+
+Response formats fall into two families, and they treat IRIs differently.
+
+**W3C result serializations** — `application/sparql-results+json`, `application/sparql-results+xml`,
+`text/csv`, `text/tab-separated-values` — always emit **absolute** IRIs. A query's `PREFIX` and `BASE`
+declarations do not shorten them. These formats carry no prefix map and no base slot, so an abbreviated
+IRI in one of them could not be expanded back by the consumer; the specs define the value as the
+absolute IRI.
+
+**JSON-LD-flavored formats** — `application/ld+json`, `application/json`,
+`application/vnd.fluree.agent+json`, typed JSON, NDJSON, and the `fluree` CLI's display output —
+abbreviate IRIs against the query's `@context` / `PREFIX` prologue. That is intentional: the consumer
+either receives the context alongside the data or is a human reading a terminal.
+
+If you need absolute IRIs from a SPARQL query, request `application/sparql-results+json`.
+
 ### JSON-LD (application/json, application/ld+json)
 
 **Request Example:**
@@ -367,7 +384,9 @@ Plain text SPARQL query in the request body.
 }
 ```
 
-Follows W3C SPARQL 1.1 Query Results JSON Format specification.
+Follows W3C SPARQL 1.1 Query Results JSON Format specification. `uri` values are always absolute
+IRIs, and a literal carries its `datatype` unless it is an `xsd:string` — see
+[IRI form](#iri-form-absolute-vs-abbreviated).
 
 ### Turtle (text/turtle)
 

--- a/fluree-db-api/src/format/config.rs
+++ b/fluree-db-api/src/format/config.rs
@@ -183,12 +183,13 @@ pub struct FormatterConfig {
     /// recover the term (SPARQL Results JSON §3.2.2, and the CSV/TSV spec, all
     /// define the value as the absolute IRI).
     ///
-    /// The same switch tightens the `datatype` rule for string-backed literals:
-    /// only `xsd:string` may be omitted, because these formats encode every
-    /// value as text and nothing about the datatype is recoverable from the
-    /// serialized form. See `datatype::omit_datatype_for_string_literal`.
+    /// The same switch tightens the `datatype` rule: only `xsd:string` may be
+    /// omitted, because these formats encode every value as text and nothing
+    /// about the datatype is recoverable from the serialized form. See
+    /// `datatype::may_omit_datatype`.
     ///
-    /// True for [`Self::sparql_json`], [`Self::csv`] and [`Self::tsv`]; false for
+    /// True for [`Self::sparql_json`], [`Self::sparql_xml`], [`Self::csv`] and
+    /// [`Self::tsv`]; false for
     /// the JSON-LD-flavored formats (JSON-LD, TypedJson, AgentJson, CypherJson,
     /// NDJSON), whose consumers receive the `@context` or are a human reading a
     /// terminal — that compaction is intentional and governed by #1466. Call
@@ -213,9 +214,15 @@ impl FormatterConfig {
     }
 
     /// Create a SPARQL XML config
+    ///
+    /// `absolute_iris` is set for the datatype half of the W3C profile: the XML
+    /// writer never compacted node IRIs to begin with (`write_sid_ref` streams
+    /// namespace prefix + name and never consults the compactor), so the flag is
+    /// inert for IRIs here and only tightens the `datatype` rule.
     pub fn sparql_xml() -> Self {
         Self {
             format: OutputFormat::SparqlXml,
+            absolute_iris: true,
             ..Default::default()
         }
     }

--- a/fluree-db-api/src/format/config.rs
+++ b/fluree-db-api/src/format/config.rs
@@ -173,6 +173,28 @@ pub struct FormatterConfig {
 
     /// Additional context for AgentJson formatting
     pub agent_json_context: Option<AgentJsonContext>,
+
+    /// Serialize in the strict W3C result-format profile.
+    ///
+    /// Named for its headline effect: a node reference is written as the
+    /// **absolute** IRI, never a CURIE and never a `@base`-relative reference.
+    /// The W3C result serializations carry no prefix map and no `@base` slot, so
+    /// a compacted IRI in one of them is lossy — the consumer has no way to
+    /// recover the term (SPARQL Results JSON §3.2.2, and the CSV/TSV spec, all
+    /// define the value as the absolute IRI).
+    ///
+    /// The same switch tightens the `datatype` rule for string-backed literals:
+    /// only `xsd:string` may be omitted, because these formats encode every
+    /// value as text and nothing about the datatype is recoverable from the
+    /// serialized form. See `datatype::omit_datatype_for_string_literal`.
+    ///
+    /// True for [`Self::sparql_json`], [`Self::csv`] and [`Self::tsv`]; false for
+    /// the JSON-LD-flavored formats (JSON-LD, TypedJson, AgentJson, CypherJson,
+    /// NDJSON), whose consumers receive the `@context` or are a human reading a
+    /// terminal — that compaction is intentional and governed by #1466. Call
+    /// [`Self::with_compact_iris`] to opt a W3C format back into compaction; the
+    /// CLI display paths do exactly that.
+    pub absolute_iris: bool,
 }
 
 impl FormatterConfig {
@@ -185,6 +207,7 @@ impl FormatterConfig {
     pub fn sparql_json() -> Self {
         Self {
             format: OutputFormat::SparqlJson,
+            absolute_iris: true,
             ..Default::default()
         }
     }
@@ -217,6 +240,7 @@ impl FormatterConfig {
     pub fn tsv() -> Self {
         Self {
             format: OutputFormat::Tsv,
+            absolute_iris: true,
             ..Default::default()
         }
     }
@@ -225,6 +249,7 @@ impl FormatterConfig {
     pub fn csv() -> Self {
         Self {
             format: OutputFormat::Csv,
+            absolute_iris: true,
             ..Default::default()
         }
     }
@@ -270,6 +295,19 @@ impl FormatterConfig {
     /// Set AgentJson context (SPARQL text, FROM count, ISO timestamp)
     pub fn with_agent_json_context(mut self, context: AgentJsonContext) -> Self {
         self.agent_json_context = Some(context);
+        self
+    }
+
+    /// Opt a W3C result format back into `@context` / PREFIX IRI compaction.
+    ///
+    /// Clears [`absolute_iris`](Self::absolute_iris), so `uri` values are
+    /// CURIE-compacted and the looser `is_inferable_datatype` omission applies.
+    /// This is the Fluree-flavored display profile that #1466 established for the
+    /// CLI, and the CLI is its only caller: on a wire format, compaction is
+    /// lossy. Use it only where the consumer also gets the prefix mappings — or
+    /// is a human reading a terminal.
+    pub fn with_compact_iris(mut self) -> Self {
+        self.absolute_iris = false;
         self
     }
 }

--- a/fluree-db-api/src/format/datatype.rs
+++ b/fluree-db-api/src/format/datatype.rs
@@ -48,6 +48,28 @@ pub fn is_inferable_datatype(dt_iri: &str) -> bool {
     )
 }
 
+/// Whether a **string-backed** literal may be serialized without its `datatype`.
+///
+/// `w3c_strict` selects the rule for the W3C result serializations (SPARQL
+/// Results JSON, CSV, TSV — see [`crate::FormatterConfig::absolute_iris`]).
+/// There, only `xsd:string` may be dropped: those formats encode every value as
+/// text, so nothing about the datatype is recoverable from the serialized form,
+/// and SPARQL Results JSON §3.2.2 defines a literal with neither `datatype` nor
+/// `xml:lang` as a *simple literal* — i.e. an `xsd:string`. Dropping the tag off
+/// anything else changes which RDF term the document denotes: `STRDT("2",
+/// xsd:integer)` would come back as `"2"^^xsd:string`.
+///
+/// Otherwise the looser [`is_inferable_datatype`] rule applies, which is sound
+/// for the JSON-LD-flavored outputs: those render the value as a native JSON
+/// number / boolean, so the datatype really is recoverable from the JSON.
+pub fn omit_datatype_for_string_literal(dt_iri: &str, w3c_strict: bool) -> bool {
+    if w3c_strict {
+        matches!(dt_iri, xsd::STRING | "xsd:string")
+    } else {
+        is_inferable_datatype(dt_iri)
+    }
+}
+
 // Note: is_reference_datatype is NOT needed - Binding::Sid already indicates references.
 // The Rust invariant (Binding::Lit never contains FlakeValue::Ref) eliminates the need
 // for datatype checks to identify references.
@@ -74,5 +96,34 @@ mod tests {
         assert!(!is_inferable_datatype(rdf::LANG_STRING));
         assert!(!is_inferable_datatype(jsonld::JSON));
         assert!(!is_inferable_datatype("http://example.org/customType"));
+    }
+
+    /// Issue #45 (b): under the W3C profile only `xsd:string` may lose its
+    /// datatype tag; the other "inferable" types must keep theirs because a
+    /// SPARQL-Results-JSON `value` is always a JSON string.
+    #[test]
+    fn test_omit_datatype_for_string_literal() {
+        assert!(omit_datatype_for_string_literal(xsd::STRING, true));
+        assert!(omit_datatype_for_string_literal("xsd:string", true));
+        for dt in [
+            xsd::INTEGER,
+            xsd::LONG,
+            xsd::DOUBLE,
+            xsd::DECIMAL,
+            xsd::BOOLEAN,
+            fluree::EMBEDDING_VECTOR,
+        ] {
+            assert!(
+                !omit_datatype_for_string_literal(dt, true),
+                "{dt} must keep its datatype in W3C output"
+            );
+            assert!(
+                omit_datatype_for_string_literal(dt, false),
+                "{dt} stays inferable for JSON-LD-flavored output"
+            );
+        }
+        // Non-inferable types are emitted under either profile.
+        assert!(!omit_datatype_for_string_literal(xsd::DATE, true));
+        assert!(!omit_datatype_for_string_literal(xsd::DATE, false));
     }
 }

--- a/fluree-db-api/src/format/datatype.rs
+++ b/fluree-db-api/src/format/datatype.rs
@@ -48,21 +48,26 @@ pub fn is_inferable_datatype(dt_iri: &str) -> bool {
     )
 }
 
-/// Whether a **string-backed** literal may be serialized without its `datatype`.
+/// Whether a literal may be serialized without its `datatype`.
 ///
-/// `w3c_strict` selects the rule for the W3C result serializations (SPARQL
-/// Results JSON, CSV, TSV — see [`crate::FormatterConfig::absolute_iris`]).
-/// There, only `xsd:string` may be dropped: those formats encode every value as
-/// text, so nothing about the datatype is recoverable from the serialized form,
-/// and SPARQL Results JSON §3.2.2 defines a literal with neither `datatype` nor
-/// `xml:lang` as a *simple literal* — i.e. an `xsd:string`. Dropping the tag off
-/// anything else changes which RDF term the document denotes: `STRDT("2",
-/// xsd:integer)` would come back as `"2"^^xsd:string`.
+/// `w3c_strict` selects the rule for the W3C result serializations — SPARQL
+/// Results JSON, SPARQL Results **XML**, CSV and TSV (see
+/// [`crate::FormatterConfig::absolute_iris`]). There, only `xsd:string` may be
+/// dropped: all four encode every value as text, so nothing about the datatype
+/// is recoverable from the serialized form, and SPARQL Results JSON §3.2.2
+/// defines a literal with neither `datatype` nor `xml:lang` as a *simple
+/// literal* — i.e. an `xsd:string`. Dropping the tag off anything else changes
+/// which RDF term the document denotes: `STRDT("2", xsd:integer)` would come
+/// back as `"2"^^xsd:string`.
 ///
 /// Otherwise the looser [`is_inferable_datatype`] rule applies, which is sound
 /// for the JSON-LD-flavored outputs: those render the value as a native JSON
 /// number / boolean, so the datatype really is recoverable from the JSON.
-pub fn omit_datatype_for_string_literal(dt_iri: &str, w3c_strict: bool) -> bool {
+///
+/// Applies to every value kind, not just string-backed literals: the XML writer
+/// gates all of them through one call, and an `xsd:long` in a `<literal>` is
+/// exactly as un-inferable as a string-backed one.
+pub fn may_omit_datatype(dt_iri: &str, w3c_strict: bool) -> bool {
     if w3c_strict {
         matches!(dt_iri, xsd::STRING | "xsd:string")
     } else {
@@ -102,9 +107,9 @@ mod tests {
     /// datatype tag; the other "inferable" types must keep theirs because a
     /// SPARQL-Results-JSON `value` is always a JSON string.
     #[test]
-    fn test_omit_datatype_for_string_literal() {
-        assert!(omit_datatype_for_string_literal(xsd::STRING, true));
-        assert!(omit_datatype_for_string_literal("xsd:string", true));
+    fn test_may_omit_datatype() {
+        assert!(may_omit_datatype(xsd::STRING, true));
+        assert!(may_omit_datatype("xsd:string", true));
         for dt in [
             xsd::INTEGER,
             xsd::LONG,
@@ -114,16 +119,16 @@ mod tests {
             fluree::EMBEDDING_VECTOR,
         ] {
             assert!(
-                !omit_datatype_for_string_literal(dt, true),
+                !may_omit_datatype(dt, true),
                 "{dt} must keep its datatype in W3C output"
             );
             assert!(
-                omit_datatype_for_string_literal(dt, false),
+                may_omit_datatype(dt, false),
                 "{dt} stays inferable for JSON-LD-flavored output"
             );
         }
         // Non-inferable types are emitted under either profile.
-        assert!(!omit_datatype_for_string_literal(xsd::DATE, true));
-        assert!(!omit_datatype_for_string_literal(xsd::DATE, false));
+        assert!(!may_omit_datatype(xsd::DATE, true));
+        assert!(!may_omit_datatype(xsd::DATE, false));
     }
 }

--- a/fluree-db-api/src/format/delimited.rs
+++ b/fluree-db-api/src/format/delimited.rs
@@ -2,7 +2,14 @@
 //!
 //! Bypasses JSON DOM construction and JSON serialization entirely.
 //! Resolves bindings directly to bytes in a pre-allocated buffer.
-//! IRIs are compacted via `IriCompactor` using the query's `@context`.
+//!
+//! W3C SPARQL 1.1 Query Results CSV and TSV are spec'd formats with no prefix
+//! map, so IRIs come out **absolute** (issue #45) — that is what the plain
+//! `format_csv` / `format_tsv` entry points and [`FormatterConfig::csv`] /
+//! [`FormatterConfig::tsv`] do. A caller rendering for human display can pass a
+//! [`FormatterConfig::with_compact_iris`] config to [`format_bytes`] /
+//! [`format_limited`] to compact against the query's `@context` instead; the CLI
+//! is the only such caller (#1466).
 //!
 //! # Performance
 //!
@@ -18,6 +25,7 @@
 //! - **CSV**: Comma-separated. RFC 4180 quoting (values containing `,`, `"`, or
 //!   newlines are wrapped in double-quotes; internal `"` doubled).
 
+use super::config::{FormatterConfig, OutputFormat};
 use super::iri::IriCompactor;
 use super::{FormatError, Result};
 use crate::QueryResult;
@@ -55,7 +63,20 @@ impl Delimiter {
             Delimiter::Comma => "CSV",
         }
     }
+
+    /// The delimiter a `FormatterConfig` selects, or `None` for a non-delimited
+    /// output format.
+    pub fn from_format(format: OutputFormat) -> Option<Self> {
+        match format {
+            OutputFormat::Tsv => Some(Delimiter::Tab),
+            OutputFormat::Csv => Some(Delimiter::Comma),
+            _ => None,
+        }
+    }
 }
+
+/// The W3C profile these entry points serialize under: absolute IRIs.
+const ABSOLUTE: bool = true;
 
 // ---------------------------------------------------------------------------
 // Public API — TSV
@@ -63,12 +84,12 @@ impl Delimiter {
 
 /// Format query results as TSV bytes.
 pub fn format_tsv_bytes(result: &QueryResult, snapshot: &LedgerSnapshot) -> Result<Vec<u8>> {
-    format_delimited_bytes(result, snapshot, Delimiter::Tab)
+    format_delimited_bytes(result, snapshot, Delimiter::Tab, ABSOLUTE)
 }
 
 /// Format query results as a TSV string.
 pub fn format_tsv(result: &QueryResult, snapshot: &LedgerSnapshot) -> Result<String> {
-    format_delimited(result, snapshot, Delimiter::Tab)
+    format_delimited(result, snapshot, Delimiter::Tab, ABSOLUTE)
 }
 
 /// Format TSV with a row limit. Returns `(tsv_bytes, total_row_count)`.
@@ -77,7 +98,7 @@ pub fn format_tsv_bytes_limited(
     snapshot: &LedgerSnapshot,
     limit: usize,
 ) -> Result<(Vec<u8>, usize)> {
-    format_delimited_bytes_limited(result, snapshot, Delimiter::Tab, limit)
+    format_delimited_bytes_limited(result, snapshot, Delimiter::Tab, limit, ABSOLUTE)
 }
 
 /// Format TSV string with a row limit. Returns `(tsv_string, total_row_count)`.
@@ -86,7 +107,7 @@ pub fn format_tsv_limited(
     snapshot: &LedgerSnapshot,
     limit: usize,
 ) -> Result<(String, usize)> {
-    format_delimited_limited(result, snapshot, Delimiter::Tab, limit)
+    format_delimited_limited(result, snapshot, Delimiter::Tab, limit, ABSOLUTE)
 }
 
 // ---------------------------------------------------------------------------
@@ -95,12 +116,12 @@ pub fn format_tsv_limited(
 
 /// Format query results as CSV bytes.
 pub fn format_csv_bytes(result: &QueryResult, snapshot: &LedgerSnapshot) -> Result<Vec<u8>> {
-    format_delimited_bytes(result, snapshot, Delimiter::Comma)
+    format_delimited_bytes(result, snapshot, Delimiter::Comma, ABSOLUTE)
 }
 
 /// Format query results as a CSV string.
 pub fn format_csv(result: &QueryResult, snapshot: &LedgerSnapshot) -> Result<String> {
-    format_delimited(result, snapshot, Delimiter::Comma)
+    format_delimited(result, snapshot, Delimiter::Comma, ABSOLUTE)
 }
 
 /// Format CSV with a row limit. Returns `(csv_bytes, total_row_count)`.
@@ -109,7 +130,7 @@ pub fn format_csv_bytes_limited(
     snapshot: &LedgerSnapshot,
     limit: usize,
 ) -> Result<(Vec<u8>, usize)> {
-    format_delimited_bytes_limited(result, snapshot, Delimiter::Comma, limit)
+    format_delimited_bytes_limited(result, snapshot, Delimiter::Comma, limit, ABSOLUTE)
 }
 
 /// Format CSV string with a row limit. Returns `(csv_string, total_row_count)`.
@@ -118,7 +139,50 @@ pub fn format_csv_limited(
     snapshot: &LedgerSnapshot,
     limit: usize,
 ) -> Result<(String, usize)> {
-    format_delimited_limited(result, snapshot, Delimiter::Comma, limit)
+    format_delimited_limited(result, snapshot, Delimiter::Comma, limit, ABSOLUTE)
+}
+
+// ---------------------------------------------------------------------------
+// Public API — config-driven (lets a caller opt out of the W3C profile)
+// ---------------------------------------------------------------------------
+
+/// Format query results as delimited bytes under an explicit config.
+///
+/// The only reason to reach for this over [`format_csv_bytes`] /
+/// [`format_tsv_bytes`] is to render for human display, where
+/// [`FormatterConfig::with_compact_iris`] restores `@context` compaction.
+pub fn format_bytes(
+    result: &QueryResult,
+    snapshot: &LedgerSnapshot,
+    delimiter: Delimiter,
+    config: &FormatterConfig,
+) -> Result<Vec<u8>> {
+    format_delimited_bytes(result, snapshot, delimiter, config.absolute_iris)
+}
+
+/// Format query results as a delimited string, taking both the delimiter and
+/// the IRI profile from `config`. The dispatch entry used by
+/// [`super::format_results_string`]; errors for a non-delimited `config.format`.
+pub fn format_string_for(
+    result: &QueryResult,
+    snapshot: &LedgerSnapshot,
+    config: &FormatterConfig,
+) -> Result<String> {
+    let delimiter = Delimiter::from_format(config.format).ok_or_else(|| {
+        FormatError::InvalidBinding(format!("{:?} is not a delimited format", config.format))
+    })?;
+    format_delimited(result, snapshot, delimiter, config.absolute_iris)
+}
+
+/// Row-limited [`format_bytes`], as a string. Returns `(text, total_row_count)`.
+pub fn format_limited(
+    result: &QueryResult,
+    snapshot: &LedgerSnapshot,
+    delimiter: Delimiter,
+    limit: usize,
+    config: &FormatterConfig,
+) -> Result<(String, usize)> {
+    format_delimited_limited(result, snapshot, delimiter, limit, config.absolute_iris)
 }
 
 // ---------------------------------------------------------------------------
@@ -129,10 +193,12 @@ fn format_delimited_bytes(
     result: &QueryResult,
     snapshot: &LedgerSnapshot,
     delimiter: Delimiter,
+    absolute_iris: bool,
 ) -> Result<Vec<u8>> {
     reject_non_tabular(result, delimiter)?;
 
-    let compactor = IriCompactor::new(snapshot.shared_namespaces(), &result.context);
+    let compactor = IriCompactor::new(snapshot.shared_namespaces(), &result.context)
+        .with_absolute_iris(absolute_iris);
     let gv = result.binary_graph.as_ref();
     let select_vars = resolve_select_vars(result);
 
@@ -161,8 +227,9 @@ fn format_delimited(
     result: &QueryResult,
     snapshot: &LedgerSnapshot,
     delimiter: Delimiter,
+    absolute_iris: bool,
 ) -> Result<String> {
-    let bytes = format_delimited_bytes(result, snapshot, delimiter)?;
+    let bytes = format_delimited_bytes(result, snapshot, delimiter, absolute_iris)?;
     #[cfg(debug_assertions)]
     {
         Ok(String::from_utf8(bytes).expect("delimited output should always be valid UTF-8"))
@@ -182,10 +249,12 @@ fn format_delimited_bytes_limited(
     snapshot: &LedgerSnapshot,
     delimiter: Delimiter,
     limit: usize,
+    absolute_iris: bool,
 ) -> Result<(Vec<u8>, usize)> {
     reject_non_tabular(result, delimiter)?;
 
-    let compactor = IriCompactor::new(snapshot.shared_namespaces(), &result.context);
+    let compactor = IriCompactor::new(snapshot.shared_namespaces(), &result.context)
+        .with_absolute_iris(absolute_iris);
     let gv = result.binary_graph.as_ref();
     let select_vars = resolve_select_vars(result);
     let total = result.row_count();
@@ -216,8 +285,10 @@ fn format_delimited_limited(
     snapshot: &LedgerSnapshot,
     delimiter: Delimiter,
     limit: usize,
+    absolute_iris: bool,
 ) -> Result<(String, usize)> {
-    let (bytes, total) = format_delimited_bytes_limited(result, snapshot, delimiter, limit)?;
+    let (bytes, total) =
+        format_delimited_bytes_limited(result, snapshot, delimiter, limit, absolute_iris)?;
     #[cfg(debug_assertions)]
     let s = String::from_utf8(bytes).expect("delimited output should always be valid UTF-8");
     #[cfg(not(debug_assertions))]
@@ -376,12 +447,12 @@ fn write_binding_cell(
             write_compacted_sid(cell, compactor, sid)?;
         }
         Binding::IriMatch { iri, .. } => {
-            let compacted = compactor.compact_vocab_iri(iri);
-            cell.extend_from_slice(compacted.as_bytes());
+            let rendered = compactor.render_vocab_iri(iri);
+            cell.extend_from_slice(rendered.as_bytes());
         }
         Binding::Iri(iri) => {
-            let compacted = compactor.compact_vocab_iri(iri);
-            cell.extend_from_slice(compacted.as_bytes());
+            let rendered = compactor.render_vocab_iri(iri);
+            cell.extend_from_slice(rendered.as_bytes());
         }
         Binding::Lit { val, .. } => {
             write_flake_value(cell, val, compactor);
@@ -393,8 +464,8 @@ fn write_binding_cell(
                     "Failed to resolve subject IRI for s_id {s_id}: {e}"
                 ))
             })?;
-            let compacted = compactor.compact_vocab_iri(&iri);
-            cell.extend_from_slice(compacted.as_bytes());
+            let rendered = compactor.render_vocab_iri(&iri);
+            cell.extend_from_slice(rendered.as_bytes());
         }
         Binding::EncodedPid { p_id } => {
             let gv = require_graph_view(gv)?;
@@ -404,8 +475,8 @@ fn write_binding_cell(
                     "Failed to resolve predicate IRI for p_id {p_id}"
                 ))
             })?;
-            let compacted = compactor.compact_vocab_iri(iri);
-            cell.extend_from_slice(compacted.as_bytes());
+            let rendered = compactor.render_vocab_iri(iri);
+            cell.extend_from_slice(rendered.as_bytes());
         }
         Binding::EncodedLit {
             o_kind,
@@ -437,8 +508,8 @@ fn write_binding_cell(
                         "Failed to resolve ref IRI for s_id {o_key}: {e}"
                     ))
                 })?;
-                let compacted = compactor.compact_vocab_iri(&iri);
-                cell.extend_from_slice(compacted.as_bytes());
+                let rendered = compactor.render_vocab_iri(&iri);
+                cell.extend_from_slice(rendered.as_bytes());
             } else {
                 let val = gv
                     .decode_value_from_kind(*o_kind, *o_key, *p_id, *dt_id, *lang_id)
@@ -511,8 +582,8 @@ fn require_graph_view(gv: Option<&BinaryGraphView>) -> Result<&BinaryGraphView> 
 
 /// Write a compacted Sid IRI to the cell buffer.
 fn write_compacted_sid(cell: &mut Vec<u8>, compactor: &IriCompactor, sid: &Sid) -> Result<()> {
-    let compacted = compactor.compact_sid(sid)?;
-    cell.extend_from_slice(compacted.as_bytes());
+    let rendered = compactor.render_vocab_sid(sid)?;
+    cell.extend_from_slice(rendered.as_bytes());
     Ok(())
 }
 
@@ -521,9 +592,9 @@ fn write_flake_value(cell: &mut Vec<u8>, val: &FlakeValue, compactor: &IriCompac
     match val {
         FlakeValue::String(s) => cell.extend_from_slice(s.as_bytes()),
         FlakeValue::Ref(sid) => {
-            // Best-effort: if compaction fails (unknown namespace), write raw
-            match compactor.compact_sid(sid) {
-                Ok(compacted) => cell.extend_from_slice(compacted.as_bytes()),
+            // Best-effort: if the namespace is unknown, write raw
+            match compactor.render_vocab_sid(sid) {
+                Ok(rendered) => cell.extend_from_slice(rendered.as_bytes()),
                 Err(_) => {
                     // Fallback: code:name
                     let mut buf = itoa::Buffer::new();
@@ -709,9 +780,11 @@ mod tests {
         assert_eq!(tsv, "s\nhttp://example.org/alice\n");
     }
 
+    /// W3C `text/tab-separated-values` has no prefix map, so a declared `ex:`
+    /// prefix must NOT shorten the IRI (issue #45) — even though the same result
+    /// under the display profile does compact (next test).
     #[test]
     fn test_tsv_sid_binding_with_context() {
-        // With @context that maps "ex" -> "http://example.org/", IRIs should be compacted
         let snapshot = make_test_snapshot();
         let result = make_result_with_context(
             &["?s"],
@@ -719,6 +792,25 @@ mod tests {
             make_test_context(),
         );
         let tsv = format_tsv(&result, &snapshot).unwrap();
+        assert_eq!(tsv, "s\nhttp://example.org/alice\n");
+    }
+
+    /// The CLI display profile (#1466): `with_compact_iris` restores compaction
+    /// against the query's `@context`.
+    #[test]
+    fn test_tsv_sid_binding_with_context_compacting_profile() {
+        let snapshot = make_test_snapshot();
+        let result = make_result_with_context(
+            &["?s"],
+            vec![vec![Binding::sid(Sid::new(100, "alice"))]],
+            make_test_context(),
+        );
+        let tsv = format_string_for(
+            &result,
+            &snapshot,
+            &FormatterConfig::tsv().with_compact_iris(),
+        )
+        .unwrap();
         assert_eq!(tsv, "s\nex:alice\n");
     }
 
@@ -855,6 +947,7 @@ mod tests {
         assert_eq!(tsv, "g\nhttp://example.org/graph1\n");
     }
 
+    /// A raw `Binding::Iri` obeys the same W3C rule as `Binding::Sid`.
     #[test]
     fn test_tsv_iri_binding_with_context() {
         let snapshot = make_test_snapshot();
@@ -864,7 +957,14 @@ mod tests {
             make_test_context(),
         );
         let tsv = format_tsv(&result, &snapshot).unwrap();
-        assert_eq!(tsv, "g\nex:graph1\n");
+        assert_eq!(tsv, "g\nhttp://example.org/graph1\n");
+        let display = format_string_for(
+            &result,
+            &snapshot,
+            &FormatterConfig::tsv().with_compact_iris(),
+        )
+        .unwrap();
+        assert_eq!(display, "g\nex:graph1\n");
     }
 
     #[test]
@@ -951,6 +1051,8 @@ mod tests {
         assert_eq!(csv, "val\n\"line1\nline2\"\n");
     }
 
+    /// W3C `text/csv`, same rule as TSV (issue #45), with the display profile
+    /// pinned alongside it.
     #[test]
     fn test_csv_sid_with_context() {
         let snapshot = make_test_snapshot();
@@ -960,7 +1062,14 @@ mod tests {
             make_test_context(),
         );
         let csv = format_csv(&result, &snapshot).unwrap();
-        assert_eq!(csv, "s\nex:alice\n");
+        assert_eq!(csv, "s\nhttp://example.org/alice\n");
+        let display = format_string_for(
+            &result,
+            &snapshot,
+            &FormatterConfig::csv().with_compact_iris(),
+        )
+        .unwrap();
+        assert_eq!(display, "s\nex:alice\n");
     }
 
     #[test]

--- a/fluree-db-api/src/format/iri.rs
+++ b/fluree-db-api/src/format/iri.rs
@@ -10,6 +10,7 @@
 use fluree_db_core::Sid;
 use fluree_graph_json_ld::{ContextCompactor, ParsedContext};
 use fluree_vocab::namespaces;
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
@@ -67,6 +68,23 @@ pub struct IriCompactor {
     /// formatter (JSON-LD/XML/typed/delimited) leaves it false and keeps raw
     /// graph-source IRIs (that consistency follow-up is register entry F16).
     compact_graph_source_iris: bool,
+
+    /// When true the writer is rendering one of the W3C result serializations
+    /// (SPARQL Results JSON / CSV / TSV), so every node reference must come out
+    /// as the absolute IRI: those formats carry no prefix map and no `@base` slot,
+    /// so a CURIE or a relative reference in one of them cannot be expanded back
+    /// by the consumer (issue #45).
+    ///
+    /// Carried on the compactor rather than passed alongside it because the
+    /// term-rendering helpers (`sparql::write_term`, `delimited::write_binding_cell`)
+    /// receive the compactor and nothing else — including on the NDJSON streaming
+    /// path, which has no `FormatterConfig` in scope.
+    ///
+    /// Defaults **false** (compact), matching every JSON-LD-flavored formatter.
+    /// [`crate::FormatterConfig::absolute_iris`] is what sets it and documents
+    /// where the boundary sits; it also governs the strict `datatype` rule for
+    /// string-backed literals.
+    absolute_iris: bool,
 }
 
 impl IriCompactor {
@@ -90,6 +108,7 @@ impl IriCompactor {
             // Lazily built on first display-compaction call — see field docs.
             fallback_prefixes: OnceLock::new(),
             compact_graph_source_iris: false,
+            absolute_iris: false,
         }
     }
 
@@ -108,6 +127,7 @@ impl IriCompactor {
             // Empty default context → lazy build yields no fallbacks (unchanged behavior).
             fallback_prefixes: OnceLock::new(),
             compact_graph_source_iris: false,
+            absolute_iris: false,
         }
     }
 
@@ -123,6 +143,65 @@ impl IriCompactor {
     /// graph-source `Binding::Iri` node references (see the field docs).
     pub fn compacts_graph_source_iris(&self) -> bool {
         self.compact_graph_source_iris
+    }
+
+    /// Select the strict W3C result-format profile: absolute IRIs, and the
+    /// tightened `datatype` rule for string-backed literals. Builder-style; see
+    /// the `absolute_iris` field docs and [`crate::FormatterConfig::absolute_iris`].
+    pub fn with_absolute_iris(mut self, enabled: bool) -> Self {
+        self.absolute_iris = enabled;
+        self
+    }
+
+    /// True when this render must emit absolute IRIs (a W3C result format).
+    pub fn emits_absolute_iris(&self) -> bool {
+        self.absolute_iris
+    }
+
+    /// Render a Sid as a node identifier **for the current output profile**.
+    ///
+    /// The `render_*` family is what result writers should call: it applies the
+    /// profile, where the `compact_*` family is the raw compaction mechanism and
+    /// always compacts. Under [`emits_absolute_iris`](Self::emits_absolute_iris)
+    /// this is [`decode_sid`](Self::decode_sid); otherwise it is
+    /// [`compact_id_sid`](Self::compact_id_sid).
+    pub fn render_id_sid(&self, sid: &Sid) -> Result<String> {
+        if self.absolute_iris {
+            self.decode_sid(sid)
+        } else {
+            self.compact_id_sid(sid)
+        }
+    }
+
+    /// Render an already-decoded IRI as a node identifier for the current
+    /// output profile. See [`render_id_sid`](Self::render_id_sid).
+    pub fn render_id_iri<'a>(&self, iri: &'a str) -> Cow<'a, str> {
+        if self.absolute_iris {
+            Cow::Borrowed(iri)
+        } else {
+            Cow::Owned(self.compact_id_iri(iri))
+        }
+    }
+
+    /// Render an IRI in a predicate / `@type` position for the current output
+    /// profile — the vocab-rules counterpart of
+    /// [`render_id_iri`](Self::render_id_iri), used by the delimited writers.
+    pub fn render_vocab_iri<'a>(&self, iri: &'a str) -> Cow<'a, str> {
+        if self.absolute_iris {
+            Cow::Borrowed(iri)
+        } else {
+            Cow::Owned(self.compact_vocab_iri(iri))
+        }
+    }
+
+    /// Render a Sid in a predicate / `@type` position for the current output
+    /// profile. See [`render_vocab_iri`](Self::render_vocab_iri).
+    pub fn render_vocab_sid(&self, sid: &Sid) -> Result<String> {
+        if self.absolute_iris {
+            self.decode_sid(sid)
+        } else {
+            self.compact_sid(sid)
+        }
     }
 
     /// Lazily-built auto-derived fallback prefixes (see the `fallback_prefixes` field).

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -275,8 +275,14 @@ fn curie_align_enabled() -> bool {
 /// XML, typed, delimited) shares this compactor but receives `false` here and so
 /// keeps raw graph-source IRIs — that cross-format consistency work is register
 /// entry F16, deliberately out of scope for the corpus-gated F9 fix.
+/// Never true under [`FormatterConfig::absolute_iris`]: F9's job is to make
+/// virtual output match native, and under the W3C profile native emits the
+/// absolute IRI, which the `Binding::Iri` arm already does verbatim. So the
+/// alignment holds at the absolute end and this flag only fires on the
+/// compacting (CLI display) profile.
 fn graph_source_iri_compaction(result: &QueryResult, config: &FormatterConfig) -> bool {
     result.from_graph_source
+        && !config.absolute_iris
         && curie_align_enabled()
         && matches!(config.format, OutputFormat::SparqlJson)
 }
@@ -315,7 +321,8 @@ pub fn format_results(
     }
 
     let compactor = IriCompactor::new(snapshot.shared_namespaces(), context)
-        .with_graph_source_iri_compaction(graph_source_iri_compaction(result, config));
+        .with_graph_source_iri_compaction(graph_source_iri_compaction(result, config))
+        .with_absolute_iris(config.absolute_iris);
 
     // CONSTRUCT / DESCRIBE produce a graph, not a binding table, so the only
     // sensible JSON rendering is JSON-LD. Any JSON-producing format request
@@ -420,8 +427,9 @@ pub fn format_results_string(
 ) -> Result<String> {
     // Delimited-text fast-path: skip JSON DOM and JSON serialization entirely
     match config.format {
-        OutputFormat::Tsv => return delimited::format_tsv(result, snapshot),
-        OutputFormat::Csv => return delimited::format_csv(result, snapshot),
+        OutputFormat::Tsv | OutputFormat::Csv => {
+            return delimited::format_string_for(result, snapshot, config)
+        }
         OutputFormat::SparqlXml => {
             let compactor = IriCompactor::new(snapshot.shared_namespaces(), context);
             return sparql_xml::format(result, &compactor, config);
@@ -437,7 +445,8 @@ pub fn format_results_string(
     // serde_json::Value DOM and its second serialization pass.
     if json_stream_eligible(result, config) {
         let compactor = IriCompactor::new(snapshot.shared_namespaces(), context)
-            .with_graph_source_iri_compaction(graph_source_iri_compaction(result, config));
+            .with_graph_source_iri_compaction(graph_source_iri_compaction(result, config))
+            .with_absolute_iris(config.absolute_iris);
         return stream_json(result, &compactor, config);
     }
 
@@ -512,7 +521,8 @@ pub async fn format_results_async(
     }
 
     let compactor = IriCompactor::new(db.snapshot.shared_namespaces(), context)
-        .with_graph_source_iri_compaction(graph_source_iri_compaction(result, config));
+        .with_graph_source_iri_compaction(graph_source_iri_compaction(result, config))
+        .with_absolute_iris(config.absolute_iris);
 
     // CONSTRUCT / DESCRIBE produce a graph (sync, no DB access needed); coerce
     // any JSON-producing format to JSON-LD rather than rejecting it. RDF/XML and
@@ -666,8 +676,9 @@ pub async fn format_results_string_async(
 ) -> Result<String> {
     // Delimited-text fast-path: skip JSON DOM and JSON serialization entirely
     match config.format {
-        OutputFormat::Tsv => return delimited::format_tsv(result, db.snapshot),
-        OutputFormat::Csv => return delimited::format_csv(result, db.snapshot),
+        OutputFormat::Tsv | OutputFormat::Csv => {
+            return delimited::format_string_for(result, db.snapshot, config)
+        }
         OutputFormat::SparqlXml => {
             let compactor = IriCompactor::new(db.snapshot.shared_namespaces(), context);
             return sparql_xml::format(result, &compactor, config);
@@ -712,8 +723,9 @@ pub async fn format_results_string_async_dataset(
     })?;
     let primary_db = primary.as_graph_db_ref();
     match config.format {
-        OutputFormat::Tsv => return delimited::format_tsv(result, primary_db.snapshot),
-        OutputFormat::Csv => return delimited::format_csv(result, primary_db.snapshot),
+        OutputFormat::Tsv | OutputFormat::Csv => {
+            return delimited::format_string_for(result, primary_db.snapshot, config)
+        }
         OutputFormat::SparqlXml => {
             let compactor = IriCompactor::new(primary_db.snapshot.shared_namespaces(), context);
             return sparql_xml::format(result, &compactor, config);

--- a/fluree-db-api/src/format/mod.rs
+++ b/fluree-db-api/src/format/mod.rs
@@ -431,7 +431,8 @@ pub fn format_results_string(
             return delimited::format_string_for(result, snapshot, config)
         }
         OutputFormat::SparqlXml => {
-            let compactor = IriCompactor::new(snapshot.shared_namespaces(), context);
+            let compactor = IriCompactor::new(snapshot.shared_namespaces(), context)
+                .with_absolute_iris(config.absolute_iris);
             return sparql_xml::format(result, &compactor, config);
         }
         OutputFormat::RdfXml => {

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -1196,6 +1196,133 @@ mod tests {
         assert_parity(&r, &c);
     }
 
+    // ------------------------------------------------------------------
+    // Issue #45: the W3C profile emits absolute IRIs and keeps datatypes.
+    // ------------------------------------------------------------------
+
+    /// A context declaring `ex:` (as a `PREFIX ex:` prologue lowers to) plus a
+    /// `@base` — the two things that shortened `uri` cells on main.
+    fn prefixed_context() -> crate::ParsedContext {
+        crate::ParsedContext::parse(
+            None,
+            &json!({ "ex": "http://example.org/", "@base": "http://base.example/" }),
+        )
+        .unwrap()
+    }
+
+    fn w3c_compactor(ctx: &crate::ParsedContext) -> IriCompactor {
+        IriCompactor::new(std::sync::Arc::new(make_test_namespaces()), ctx).with_absolute_iris(true)
+    }
+
+    fn make_test_namespaces() -> HashMap<u16, String> {
+        let mut m = HashMap::new();
+        m.insert(2, "http://www.w3.org/2001/XMLSchema#".to_string());
+        m.insert(100, "http://example.org/".to_string());
+        m.insert(101, "http://base.example/".to_string());
+        m
+    }
+
+    /// Every node-reference binding kind renders the absolute IRI under the W3C
+    /// profile, through BOTH the DOM and the streaming entry point. `?based` is
+    /// the `@base` case: on main a `BASE`-only prologue produced a bare relative
+    /// reference, which SRJ cannot express at all.
+    #[test]
+    fn w3c_profile_emits_absolute_iris_for_every_node_binding() {
+        let ctx = prefixed_context();
+        let c = w3c_compactor(&ctx);
+        let r = make_result(
+            &["?sid", "?match", "?raw", "?based"],
+            vec![vec![
+                Binding::sid(Sid::new(100, "s2")),
+                Binding::IriMatch {
+                    iri: std::sync::Arc::from("http://example.org/s3"),
+                    primary_sid: Sid::new(100, "s3"),
+                    ledger_alias: std::sync::Arc::from("test:main"),
+                },
+                Binding::iri("http://example.org/s4"),
+                Binding::sid(Sid::new(101, "thing")),
+            ]],
+        );
+
+        let dom = serde_json::to_string(&format(&r, &c, &FormatterConfig::sparql_json()).unwrap())
+            .unwrap();
+        let streamed = format_string(&r, &c, &FormatterConfig::sparql_json()).unwrap();
+        assert_eq!(dom, streamed, "DOM and streaming must agree");
+
+        for want in [
+            "http://example.org/s2",
+            "http://example.org/s3",
+            "http://example.org/s4",
+            "http://base.example/thing",
+        ] {
+            assert!(dom.contains(want), "missing {want} in {dom}");
+        }
+        for forbidden in [r#""ex:s2""#, r#""ex:s3""#, r#""ex:s4""#, r#""thing""#] {
+            assert!(!dom.contains(forbidden), "leaked {forbidden} in {dom}");
+        }
+    }
+
+    /// The same bindings under the Fluree display profile still compact — so the
+    /// test above is measuring the flag, not the absence of a usable context.
+    #[test]
+    fn display_profile_still_compacts_node_bindings() {
+        let ctx = prefixed_context();
+        let c = IriCompactor::new(std::sync::Arc::new(make_test_namespaces()), &ctx);
+        let r = make_result(
+            &["?sid", "?based"],
+            vec![vec![
+                Binding::sid(Sid::new(100, "s2")),
+                Binding::sid(Sid::new(101, "thing")),
+            ]],
+        );
+        assert_parity(&r, &c);
+        let dom = serde_json::to_string(&format(&r, &c, &FormatterConfig::sparql_json()).unwrap())
+            .unwrap();
+        assert!(dom.contains(r#""ex:s2""#), "{dom}");
+        assert!(dom.contains(r#""value":"thing""#), "{dom}");
+    }
+
+    /// Issue #45 (b): a string-backed literal carrying an "inferable" datatype —
+    /// what `STRDT("2", xsd:integer)` produces — must keep its `datatype` in the
+    /// W3C profile. Dropping it makes the cell denote `"2"^^xsd:string`, a
+    /// different RDF term. `xsd:string` itself stays bare (a simple literal).
+    #[test]
+    fn w3c_profile_keeps_datatype_on_string_backed_literals() {
+        let ctx = crate::ParsedContext::default();
+        let c = w3c_compactor(&ctx);
+        let r = make_result(
+            &["?i", "?b", "?d", "?s"],
+            vec![vec![
+                Binding::lit(FlakeValue::String("2".into()), Sid::new(2, "integer")),
+                Binding::lit(FlakeValue::String("true".into()), Sid::new(2, "boolean")),
+                Binding::lit(FlakeValue::String("2".into()), Sid::new(2, "decimal")),
+                Binding::lit(FlakeValue::String("hi".into()), Sid::new(2, "string")),
+            ]],
+        );
+
+        let dom = format(&r, &c, &FormatterConfig::sparql_json()).unwrap();
+        let streamed = format_string(&r, &c, &FormatterConfig::sparql_json()).unwrap();
+        assert_eq!(serde_json::to_string(&dom).unwrap(), streamed);
+
+        let row = &dom["results"]["bindings"][0];
+        for (var, dt) in [("i", "integer"), ("b", "boolean"), ("d", "decimal")] {
+            assert_eq!(
+                row[var]["datatype"],
+                json!(format!("http://www.w3.org/2001/XMLSchema#{dt}")),
+                "xsd:{dt} lost its datatype: {row}"
+            );
+        }
+        assert!(
+            row["s"]["datatype"].is_null(),
+            "xsd:string stays bare: {row}"
+        );
+
+        // The display profile keeps today's looser behavior.
+        let display = IriCompactor::new(std::sync::Arc::new(make_test_namespaces()), &ctx);
+        let loose = format(&r, &display, &FormatterConfig::sparql_json()).unwrap();
+        assert!(loose["results"]["bindings"][0]["i"]["datatype"].is_null());
+    }
+
     #[test]
     fn test_format_binding_double_special_values() {
         let compactor = make_test_compactor();

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -18,7 +18,7 @@
 //! - Disaggregation: `Binding::Grouped` explodes into multiple rows (cartesian product)
 
 use super::config::FormatterConfig;
-use super::datatype::omit_datatype_for_string_literal;
+use super::datatype::may_omit_datatype;
 use super::iri::IriCompactor;
 use super::json_write::{push_json_string, push_value};
 use super::{materialize, FormatError, Result};
@@ -396,7 +396,7 @@ fn write_literal(
             if let Some(lang) = lang {
                 out.push_str(r#","xml:lang":"#);
                 push_json_string(out, lang);
-            } else if !omit_datatype_for_string_literal(dt_iri, w3c_strict) {
+            } else if !may_omit_datatype(dt_iri, w3c_strict) {
                 out.push_str(r#","datatype":"#);
                 push_json_string(out, dt_iri);
             }
@@ -539,10 +539,7 @@ fn format_binding(
                             "value": s,
                             "xml:lang": lang_tag
                         })))
-                    } else if omit_datatype_for_string_literal(
-                        &dt_iri,
-                        compactor.emits_absolute_iris(),
-                    ) {
+                    } else if may_omit_datatype(&dt_iri, compactor.emits_absolute_iris()) {
                         // Omittable - a bare value denotes exactly this term
                         Ok(Some(json!({
                             "type": "literal",

--- a/fluree-db-api/src/format/sparql.rs
+++ b/fluree-db-api/src/format/sparql.rs
@@ -18,7 +18,7 @@
 //! - Disaggregation: `Binding::Grouped` explodes into multiple rows (cartesian product)
 
 use super::config::FormatterConfig;
-use super::datatype::is_inferable_datatype;
+use super::datatype::omit_datatype_for_string_literal;
 use super::iri::IriCompactor;
 use super::json_write::{push_json_string, push_value};
 use super::{materialize, FormatError, Result};
@@ -328,10 +328,11 @@ fn write_cell(
 /// Write the `{"type":...,"value":...}` term object for a (non-omitted) binding.
 fn write_term(out: &mut String, binding: &Binding, compactor: &IriCompactor) -> Result<()> {
     match binding {
-        Binding::Sid { sid, .. } => write_node(out, &compactor.compact_id_sid(sid)?),
-        Binding::IriMatch { iri, .. } => write_node(out, &compactor.compact_id_iri(iri)),
+        Binding::Sid { sid, .. } => write_node(out, &compactor.render_id_sid(sid)?),
+        Binding::IriMatch { iri, .. } => write_node(out, &compactor.render_id_iri(iri)),
         // Raw graph-source IRI: CURIE-compacted for sparql_json of a graph-source
-        // result so virtual output matches native (F9); otherwise emitted verbatim.
+        // result so virtual output matches native (F9); otherwise emitted verbatim
+        // — which is also the absolute form the W3C profile requires.
         Binding::Iri(iri) => {
             if compactor.compacts_graph_source_iris() {
                 write_node(out, &compactor.compact_id_iri(iri));
@@ -341,7 +342,13 @@ fn write_term(out: &mut String, binding: &Binding, compactor: &IriCompactor) -> 
         }
         Binding::Lit { val, dtc, .. } => {
             let dt_iri = compactor.decode_sid(dtc.datatype())?;
-            write_literal(out, val, dtc.lang_tag(), &dt_iri)?;
+            write_literal(
+                out,
+                val,
+                dtc.lang_tag(),
+                &dt_iri,
+                compactor.emits_absolute_iris(),
+            )?;
         }
         Binding::Grouped(_) => {
             return Err(FormatError::InvalidBinding(
@@ -380,6 +387,7 @@ fn write_literal(
     val: &FlakeValue,
     lang: Option<&str>,
     dt_iri: &str,
+    w3c_strict: bool,
 ) -> Result<()> {
     match val {
         FlakeValue::String(s) => {
@@ -388,7 +396,7 @@ fn write_literal(
             if let Some(lang) = lang {
                 out.push_str(r#","xml:lang":"#);
                 push_json_string(out, lang);
-            } else if !is_inferable_datatype(dt_iri) {
+            } else if !omit_datatype_for_string_literal(dt_iri, w3c_strict) {
                 out.push_str(r#","datatype":"#);
                 push_json_string(out, dt_iri);
             }
@@ -457,10 +465,11 @@ fn format_binding(
 
         // Reference (IRI or blank node)
         Binding::Sid { sid, .. } => {
-            // SPARQL JSON output uses compact IRIs where possible (not full IRIs).
-            // A `uri` value names a node, so it's an `@id`-position identifier:
-            // compact via `@base` + explicit prefixes, never `@vocab` (issue #1280).
-            let iri = compactor.compact_id_sid(sid)?;
+            // A `uri` value names a node, so it's an `@id`-position identifier.
+            // Under the W3C profile it is the absolute IRI (issue #45); under the
+            // Fluree display profile it compacts via `@base` + explicit prefixes,
+            // never `@vocab` (issue #1280).
+            let iri = compactor.render_id_sid(sid)?;
             // Check if it's a blank node (starts with _:)
             if iri.starts_with("_:") {
                 Ok(Some(json!({
@@ -475,9 +484,9 @@ fn format_binding(
             }
         }
 
-        // IriMatch: use canonical IRI, then compact (multi-ledger mode)
+        // IriMatch: canonical IRI, rendered for the output profile (multi-ledger mode)
         Binding::IriMatch { iri, .. } => {
-            let compacted = compactor.compact_id_iri(iri);
+            let compacted = compactor.render_id_iri(iri);
             if compacted.starts_with("_:") {
                 Ok(Some(json!({
                     "type": "bnode",
@@ -530,14 +539,17 @@ fn format_binding(
                             "value": s,
                             "xml:lang": lang_tag
                         })))
-                    } else if is_inferable_datatype(&dt_iri) {
-                        // Inferable type - omit datatype
+                    } else if omit_datatype_for_string_literal(
+                        &dt_iri,
+                        compactor.emits_absolute_iris(),
+                    ) {
+                        // Omittable - a bare value denotes exactly this term
                         Ok(Some(json!({
                             "type": "literal",
                             "value": s
                         })))
                     } else {
-                        // Non-inferable type - include datatype
+                        // Everything else carries its datatype
                         Ok(Some(json!({
                             "type": "literal",
                             "value": s,

--- a/fluree-db-api/src/format/sparql_xml.rs
+++ b/fluree-db-api/src/format/sparql_xml.rs
@@ -11,7 +11,7 @@
 use crate::QueryResult;
 
 use super::config::FormatterConfig;
-use super::datatype::is_inferable_datatype;
+use super::datatype::may_omit_datatype;
 use super::iri::IriCompactor;
 use super::xml_escape::{escape_attr_into, escape_text_into};
 use super::{materialize, FormatError, Result};
@@ -327,7 +327,10 @@ fn write_literal(
         out.push('"');
     } else {
         let dt_iri = compactor.decode_sid(dtc.datatype())?;
-        if !is_inferable_datatype(&dt_iri) {
+        // `<literal>` content is text, so nothing about the datatype survives
+        // into the serialized form — under the W3C profile only `xsd:string`
+        // may go untagged (issue #45 (b), same rule as the SRJ writer).
+        if !may_omit_datatype(&dt_iri, compactor.emits_absolute_iris()) {
             out.push_str(r#" datatype=""#);
             escape_attr_into(&dt_iri, out);
             out.push('"');
@@ -447,7 +450,15 @@ mod tests {
         // BLANK_NODE (code 10) is registered with the "_:" prefix in production
         // (default_namespace_codes); mirror that so blank-node Sids resolve.
         namespaces.insert(fluree_vocab::namespaces::BLANK_NODE, "_:".to_string());
-        IriCompactor::from_namespaces(std::sync::Arc::new(namespaces))
+        // `format_results_string` builds the XML compactor with the W3C profile
+        // (`FormatterConfig::sparql_xml().absolute_iris`); mirror it, or these
+        // tests measure a render path production never takes.
+        IriCompactor::from_namespaces(std::sync::Arc::new(namespaces)).with_absolute_iris(true)
+    }
+
+    /// The pre-#45 profile, for asserting that a rule is actually flag-driven.
+    fn make_loose_compactor() -> IriCompactor {
+        make_test_compactor().with_absolute_iris(false)
     }
 
     fn make_test_result() -> QueryResult {
@@ -540,15 +551,20 @@ mod tests {
             )]],
         );
         let xml = fmt(&r, &c);
-        // xsd:string is inferable → no datatype attribute, just the value.
+        // A literal with no datatype and no xml:lang IS an xsd:string, so
+        // omitting the tag here is exact, not lossy — the one omission the W3C
+        // profile keeps.
         assert!(xml.contains("<literal>Alice</literal>"), "{xml}");
     }
 
+    /// Issue #45 (b), XML half. This test previously pinned the OPPOSITE: XML
+    /// dropped the datatype for every "inferable" type, so an `xsd:long` came
+    /// back as a bare `<literal>42</literal>` — a plain literal, which is
+    /// `xsd:string`, not the term the query produced. `<literal>` content is
+    /// text; nothing is inferable from it.
     #[test]
-    fn inferable_datatype_omitted_long() {
+    fn w3c_profile_keeps_datatype_on_inferable_types() {
         let c = make_test_compactor();
-        // xsd:long is inferable, so XML omits the datatype (value-type agnostic,
-        // unlike SPARQL-JSON which always carries datatype on numerics).
         let r = make_result(
             &["?v"],
             vec![vec![Binding::lit(
@@ -557,7 +573,36 @@ mod tests {
             )]],
         );
         let xml = fmt(&r, &c);
-        assert!(xml.contains("<literal>42</literal>"), "{xml}");
+        assert!(
+            xml.contains(
+                r#"<literal datatype="http://www.w3.org/2001/XMLSchema#long">42</literal>"#
+            ),
+            "{xml}"
+        );
+
+        // A string-backed literal with an inferable type — the STRDT shape — is
+        // the same rule.
+        let r = make_result(
+            &["?v"],
+            vec![vec![Binding::lit(
+                FlakeValue::String("2".to_string()),
+                Sid::new(2, "integer"),
+            )]],
+        );
+        assert!(
+            fmt(&r, &c).contains(
+                r#"<literal datatype="http://www.w3.org/2001/XMLSchema#integer">2</literal>"#
+            ),
+            "{}",
+            fmt(&r, &c)
+        );
+
+        // ...and it is flag-driven, not unconditional: the loose profile still
+        // omits, so this test measures the profile rather than a constant.
+        assert!(
+            fmt(&r, &make_loose_compactor()).contains("<literal>2</literal>"),
+            "loose profile should still omit"
+        );
     }
 
     #[test]

--- a/fluree-db-api/src/query/mod.rs
+++ b/fluree-db-api/src/query/mod.rs
@@ -252,6 +252,10 @@ impl QueryResult {
     /// Format as SPARQL 1.1 Query Results JSON
     ///
     /// Returns W3C standard format with `{"head": {"vars": [...]}, "results": {"bindings": [...]}}`.
+    /// `uri` values are absolute IRIs — the format carries no prefix map, so a
+    /// CURIE in one could not be expanded back (issue #45). A display caller that
+    /// wants compaction formats with
+    /// `FormatterConfig::sparql_json().with_compact_iris()` instead.
     pub fn to_sparql_json(&self, snapshot: &LedgerSnapshot) -> format::Result<JsonValue> {
         let config = FormatterConfig::sparql_json();
         format::format_results(self, &self.context, snapshot, &config)
@@ -428,6 +432,47 @@ impl QueryResult {
     /// Format as CSV bytes with a row limit (for server benchmark/preview).
     ///
     /// Returns `(csv_bytes, total_row_count)`.
+    /// Format as TSV or CSV bytes under an explicit config (`config.format`
+    /// selects the delimiter).
+    ///
+    /// [`Self::to_csv_bytes`] and friends serialize the W3C `text/csv` /
+    /// `text/tab-separated-values` profile, with absolute IRIs. Reach for this
+    /// only to render for human display, passing
+    /// [`FormatterConfig::with_compact_iris`] to restore `@context` compaction
+    /// (the CLI's #1466 contract).
+    pub fn to_delimited_bytes(
+        &self,
+        snapshot: &LedgerSnapshot,
+        config: &FormatterConfig,
+    ) -> format::Result<Vec<u8>> {
+        let delimiter =
+            format::delimited::Delimiter::from_format(config.format).ok_or_else(|| {
+                format::FormatError::InvalidBinding(format!(
+                    "{:?} is not a delimited format",
+                    config.format
+                ))
+            })?;
+        format::delimited::format_bytes(self, snapshot, delimiter, config)
+    }
+
+    /// Row-limited [`Self::to_delimited_bytes`], as a string. Returns
+    /// `(text, total_row_count)`.
+    pub fn to_delimited_limited(
+        &self,
+        snapshot: &LedgerSnapshot,
+        limit: usize,
+        config: &FormatterConfig,
+    ) -> format::Result<(String, usize)> {
+        let delimiter =
+            format::delimited::Delimiter::from_format(config.format).ok_or_else(|| {
+                format::FormatError::InvalidBinding(format!(
+                    "{:?} is not a delimited format",
+                    config.format
+                ))
+            })?;
+        format::delimited::format_limited(self, snapshot, delimiter, limit, config)
+    }
+
     pub fn to_csv_bytes_limited(
         &self,
         snapshot: &LedgerSnapshot,

--- a/fluree-db-api/tests/grp_query_sparql.rs
+++ b/fluree-db-api/tests/grp_query_sparql.rs
@@ -33,3 +33,5 @@ mod it_query_subselect_correlation;
 mod it_query_unwind;
 #[path = "it_query_values.rs"]
 mod it_query_values;
+#[path = "it_w3c_result_formats.rs"]
+mod it_w3c_result_formats;

--- a/fluree-db-api/tests/it_decimal_exactness.rs
+++ b/fluree-db-api/tests/it_decimal_exactness.rs
@@ -220,7 +220,10 @@ async fn sparql_decimal_constant_matches_stored_decimal() {
     let sparql_json = result
         .to_sparql_json(&ledger.snapshot)
         .expect("to_sparql_json");
-    assert_eq!(binding_values(&sparql_json, "s"), vec!["ex:a"]);
+    assert_eq!(
+        binding_values(&sparql_json, "s"),
+        vec!["http://example.org/a"]
+    );
 
     // FILTER equality with a decimal constant.
     let query = r"
@@ -233,7 +236,10 @@ async fn sparql_decimal_constant_matches_stored_decimal() {
     let sparql_json = result
         .to_sparql_json(&ledger.snapshot)
         .expect("to_sparql_json");
-    assert_eq!(binding_values(&sparql_json, "s"), vec!["ex:b"]);
+    assert_eq!(
+        binding_values(&sparql_json, "s"),
+        vec!["http://example.org/b"]
+    );
 }
 
 #[tokio::test]
@@ -264,7 +270,10 @@ async fn jsonld_number_decimal_matches_sparql_constant_across_paths() {
     let sparql_json = result
         .to_sparql_json(&ledger.snapshot)
         .expect("to_sparql_json");
-    assert_eq!(binding_values(&sparql_json, "s"), vec!["ex:item"]);
+    assert_eq!(
+        binding_values(&sparql_json, "s"),
+        vec!["http://example.org/item"]
+    );
 
     // SPARQL DELETE DATA retracts the JSON-LD-ingested fact.
     let result = run_sparql_update(
@@ -394,7 +403,10 @@ async fn integer_beyond_i64_round_trips_exactly() {
     let sparql_json = result
         .to_sparql_json(&ledger.snapshot)
         .expect("to_sparql_json");
-    assert_eq!(binding_values(&sparql_json, "s"), vec!["ex:item"]);
+    assert_eq!(
+        binding_values(&sparql_json, "s"),
+        vec!["http://example.org/item"]
+    );
 
     // Typed lexical form via SPARQL UPDATE round-trips and is queryable by
     // the typed constant (both previously degraded through i64 paths).
@@ -429,7 +441,7 @@ async fn integer_beyond_i64_round_trips_exactly() {
     subjects.sort();
     assert_eq!(
         subjects,
-        vec!["ex:item", "ex:typed"],
+        vec!["http://example.org/item", "http://example.org/typed"],
         "typed xsd:integer constant must match both bare- and typed-ingested values"
     );
 
@@ -455,7 +467,7 @@ async fn integer_beyond_i64_round_trips_exactly() {
     subjects.sort();
     assert_eq!(
         subjects,
-        vec!["ex:item", "ex:typed"],
+        vec!["http://example.org/item", "http://example.org/typed"],
         "typed VALUES constant must join against stored values"
     );
 }
@@ -738,7 +750,7 @@ async fn scale_variant_decimal_retracts_indexed_fact() {
                 .expect("to_sparql_json");
             assert_eq!(
                 binding_values(&sparql_json, "s"),
-                vec!["ex:item"],
+                vec!["http://example.org/item"],
                 "1.5 constant must match indexed 1.50"
             );
 

--- a/fluree-db-api/tests/it_minmax_string_fast_path.rs
+++ b/fluree-db-api/tests/it_minmax_string_fast_path.rs
@@ -333,7 +333,11 @@ async fn min_max_value_ordered_alongside_group_concat() {
 
             for (pred, expect_min, expect_max) in [
                 ("ex:word", json!("apple"), json!("zebra")),
-                ("ex:link", json!("ex:aaa"), json!("ex:zzz")),
+                (
+                    "ex:link",
+                    json!("http://example.org/ns/aaa"),
+                    json!("http://example.org/ns/zzz"),
+                ),
             ] {
                 let q = format!(
                     r#"PREFIX ex: <http://example.org/ns/>

--- a/fluree-db-api/tests/it_mixed_representation.rs
+++ b/fluree-db-api/tests/it_mixed_representation.rs
@@ -161,7 +161,7 @@ async fn mixed_representation_count_distinct_and_group_counts() {
     .await;
     let a_count = groups
         .iter()
-        .find(|g| g["x"]["value"] == "ex:a")
+        .find(|g| g["x"]["value"] == "http://example.org/ns/a")
         .expect("ex:a group");
     assert_eq!(a_count["c"]["value"], "2", "ex:a rows merge into one group");
 }

--- a/fluree-db-api/tests/it_query_owl2rl.rs
+++ b/fluree-db-api/tests/it_query_owl2rl.rs
@@ -1190,7 +1190,10 @@ SELECT ?x WHERE { ex:person-b ex:livesWith ?x }";
         1,
         "pragma owl2rl: expected derived symmetric edge, got {bindings:?}"
     );
-    assert_eq!(bindings[0]["x"]["value"], json!("ex:person-a"));
+    assert_eq!(
+        bindings[0]["x"]["value"],
+        json!("http://example.org/person-a")
+    );
 
     // Control: without the pragma only auto-RDFS applies — no symmetric edge.
     let without_pragma = "\

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -7,7 +7,7 @@ use crate::support::{
     assert_index_defaults, genesis_ledger, normalize_rows, normalize_sparql_bindings, MemoryFluree,
     MemoryLedger,
 };
-use fluree_db_api::FlureeBuilder;
+use fluree_db_api::{FlureeBuilder, FormatterConfig};
 use serde_json::{json, Value as JsonValue};
 use std::sync::Arc;
 
@@ -366,7 +366,8 @@ async fn sparql_basic_query_outputs_jsonld_and_sparql_json() {
     let jsonld = result.to_jsonld(&ledger.snapshot).expect("to_jsonld");
     assert_eq!(jsonld, json!([["ex:jdoe", "Jane Doe"]]));
 
-    // SPARQL JSON output uses compact IRIs.
+    // SPARQL Results JSON carries the ABSOLUTE IRI even though the query
+    // declared `ex:` — the format has no prefix map to expand it with (#45).
     let sparql_json = result
         .to_sparql_json(&ledger.snapshot)
         .expect("to_sparql_json");
@@ -376,11 +377,24 @@ async fn sparql_basic_query_outputs_jsonld_and_sparql_json() {
             "head": {"vars": ["fullName", "person"]},
             "results": {"bindings": [
                 {
-                    "person": {"type": "uri", "value": "ex:jdoe"},
+                    "person": {"type": "uri", "value": "http://example.org/ns/jdoe"},
                     "fullName": {"type": "literal", "value": "Jane Doe"}
                 }
             ]}
         })
+    );
+
+    // The Fluree display profile (#1466) still compacts the same result.
+    let display = fluree_db_api::format::format_results(
+        &result,
+        &result.context,
+        &ledger.snapshot,
+        &FormatterConfig::sparql_json().with_compact_iris(),
+    )
+    .expect("compacting sparql_json");
+    assert_eq!(
+        display["results"]["bindings"][0]["person"]["value"],
+        json!("ex:jdoe")
     );
 }
 

--- a/fluree-db-api/tests/it_query_sparql_indexed.rs
+++ b/fluree-db-api/tests/it_query_sparql_indexed.rs
@@ -9291,7 +9291,7 @@ async fn indexed_exists_graph_var_decodes_encoded_bindings() {
                 "exactly ex:s1's graph is populated: {json}"
             );
             assert_eq!(
-                bindings[0]["s"]["value"], "ex:s1",
+                bindings[0]["s"]["value"], "http://example.org/ns/s1",
                 "EXISTS must seed the row's own ?g, decoded from EncodedSid: {json}"
             );
             assert_eq!(

--- a/fluree-db-api/tests/it_w3c_result_formats.rs
+++ b/fluree-db-api/tests/it_w3c_result_formats.rs
@@ -1,0 +1,236 @@
+//! Issue #45: the W3C result serializations must emit absolute IRIs.
+//!
+//! `application/sparql-results+json`, `text/csv` and `text/tab-separated-values`
+//! carry no prefix map and no `@base` slot, so a CURIE or a relative reference in
+//! one of them is lossy — the consumer cannot recover the term. On main, a query
+//! prologue of `PREFIX ex:` produced `ex:s2` in all three, and a `BASE`-only
+//! prologue produced the bare relative reference `s2`.
+//!
+//! These tests drive the real query engine end to end (prologue -> lowered
+//! `@context` -> writer), which is what makes them a gate on the whole path
+//! rather than on the writer in isolation. The JSON-LD writer is included as the
+//! control: it carries an `@context`, so it still compacts (#1466).
+
+#![cfg(feature = "native")]
+
+use crate::support;
+use fluree_db_api::{
+    format, FlureeBuilder, FormatterConfig, IndexConfig, LedgerManagerConfig, QueryInput,
+};
+use fluree_db_transact::{CommitOpts, TxnOpts};
+use serde_json::json;
+use support::genesis_ledger_for_fluree;
+
+const S2: &str = "http://example.org/s2";
+
+fn seed_data() -> serde_json::Value {
+    json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": S2,
+             "http://example.org/p": {"@value": "2", "@type": "http://www.w3.org/2001/XMLSchema#integer"}}
+        ]
+    })
+}
+
+async fn seeded_view(ledger_id: &str) -> (fluree_db_api::Fluree, fluree_db_api::GraphDb) {
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let index_cfg = IndexConfig {
+        reindex_min_bytes: 0,
+        reindex_max_bytes: 10_000_000,
+    };
+    let ledger = genesis_ledger_for_fluree(&fluree, ledger_id);
+    fluree
+        .insert_with_opts(
+            ledger,
+            &seed_data(),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_cfg,
+        )
+        .await
+        .expect("insert");
+    let view = fluree.db(ledger_id).await.expect("view");
+    (fluree, view)
+}
+
+/// The four prologue forms that reach the writer as four different lowered
+/// contexts. `BASE` is the worst case: it lowers to `@base`, which shortens
+/// `@id`-position IRIs to a bare relative reference.
+const PROLOGUES: [(&str, &str); 4] = [
+    (
+        "PREFIX ex:",
+        "PREFIX ex: <http://example.org/> SELECT ?s ?o WHERE { ?s ex:p ?o }",
+    ),
+    (
+        "PREFIX :",
+        "PREFIX : <http://example.org/> SELECT ?s ?o WHERE { ?s :p ?o }",
+    ),
+    (
+        "no prologue",
+        "SELECT ?s ?o WHERE { ?s <http://example.org/p> ?o }",
+    ),
+    (
+        "BASE only",
+        "BASE <http://example.org/> SELECT ?s ?o WHERE { ?s <http://example.org/p> ?o }",
+    ),
+];
+
+#[tokio::test]
+async fn w3c_result_formats_emit_absolute_iris_under_every_prologue() {
+    let (fluree, view) = seeded_view("w3cfmt/iris:main").await;
+
+    for (label, query) in PROLOGUES {
+        let result = fluree
+            .query(&view, QueryInput::Sparql(query))
+            .await
+            .unwrap_or_else(|e| panic!("{label}: query failed: {e}"));
+
+        // SRJ through the DOM path...
+        let srj = format::format_results(
+            &result,
+            &result.context,
+            &view.snapshot,
+            &FormatterConfig::sparql_json(),
+        )
+        .unwrap_or_else(|e| panic!("{label}: sparql_json: {e}"));
+        assert_eq!(
+            srj["results"]["bindings"][0]["s"],
+            json!({"type": "uri", "value": S2}),
+            "{label}: SRJ (DOM) must carry the absolute IRI"
+        );
+
+        // ...and through the streaming path the server actually uses. These are
+        // separate writers; a fix applied to only one ships half-broken.
+        let srj_stream = format::format_results_string(
+            &result,
+            &result.context,
+            &view.snapshot,
+            &FormatterConfig::sparql_json(),
+        )
+        .unwrap_or_else(|e| panic!("{label}: sparql_json string: {e}"));
+        assert_eq!(
+            srj_stream,
+            serde_json::to_string(&srj).unwrap(),
+            "{label}: streaming SRJ diverged from the DOM"
+        );
+
+        // SPARQL Results XML was already correct; it stays correct.
+        let srx = format::format_results_string(
+            &result,
+            &result.context,
+            &view.snapshot,
+            &FormatterConfig::sparql_xml(),
+        )
+        .unwrap_or_else(|e| panic!("{label}: sparql_xml: {e}"));
+        assert!(
+            srx.contains(&format!("<uri>{S2}</uri>")),
+            "{label}: SRX must carry the absolute IRI: {srx}"
+        );
+
+        // CSV and TSV carry the identical defect on main.
+        let csv = result.to_csv(&view.snapshot).expect("csv");
+        let tsv = result.to_tsv(&view.snapshot).expect("tsv");
+        for (name, text) in [("CSV", &csv), ("TSV", &tsv)] {
+            assert!(
+                text.contains(S2),
+                "{label}: {name} must carry the absolute IRI: {text}"
+            );
+        }
+
+        // Control: the JSON-LD writer ships the `@context` that expands a CURIE,
+        // so it still compacts wherever the prologue gives it one. This is what
+        // keeps the assertions above measuring the W3C profile rather than a
+        // context that never reached the formatter.
+        let jsonld = result.to_jsonld(&view.snapshot).expect("jsonld");
+        let jsonld_s = serde_json::to_string(&jsonld).unwrap();
+        let expected_compact = match label {
+            "PREFIX ex:" => Some("ex:s2"),
+            "PREFIX :" => Some(":s2"),
+            "BASE only" => Some("s2"),
+            _ => None, // no prologue: nothing to compact against
+        };
+        match expected_compact {
+            Some(compact) => assert!(
+                jsonld_s.contains(&format!("\"{compact}\"")),
+                "{label}: JSON-LD should still compact to {compact}: {jsonld_s}"
+            ),
+            None => assert!(
+                jsonld_s.contains(S2),
+                "{label}: JSON-LD without a prologue keeps the full IRI: {jsonld_s}"
+            ),
+        }
+    }
+}
+
+/// Issue #45 (b). `is_inferable_datatype` drops the `datatype` tag off any
+/// string-backed literal whose type is on its allow-list. Stored integers escape
+/// it only because ingest lands them as `FlakeValue::Long`; `STRDT` builds a
+/// string-backed literal with an "inferable" type at query time, and on main the
+/// tag was dropped — so `STRDT("2", xsd:integer)` serialized as a *different* RDF
+/// term (a simple literal, i.e. `xsd:string`).
+#[tokio::test]
+async fn w3c_sparql_json_keeps_datatype_on_constructed_literals() {
+    let (fluree, view) = seeded_view("w3cfmt/strdt:main").await;
+
+    // The first three were dropped on main; the last two are the control group
+    // (never on the allow-list, so they were always emitted).
+    for dt in [
+        "http://www.w3.org/2001/XMLSchema#integer",
+        "http://www.w3.org/2001/XMLSchema#boolean",
+        "http://www.w3.org/2001/XMLSchema#decimal",
+        "http://www.w3.org/2001/XMLSchema#float",
+        "http://www.w3.org/2001/XMLSchema#date",
+    ] {
+        let lex = if dt.ends_with("boolean") {
+            "true"
+        } else if dt.ends_with("date") {
+            "2020-01-01"
+        } else {
+            "2"
+        };
+        let q = format!(
+            "SELECT (STRDT(\"{lex}\", <{dt}>) AS ?v) WHERE {{ ?s <http://example.org/p> ?o }}"
+        );
+        let result = fluree
+            .query(&view, QueryInput::Sparql(&q))
+            .await
+            .unwrap_or_else(|e| panic!("STRDT({lex}, {dt}): {e}"));
+        let srj = format::format_results(
+            &result,
+            &result.context,
+            &view.snapshot,
+            &FormatterConfig::sparql_json(),
+        )
+        .expect("sparql_json");
+        assert_eq!(
+            srj["results"]["bindings"][0]["v"],
+            json!({"type": "literal", "value": lex, "datatype": dt}),
+            "STRDT({lex}, {dt}) must round-trip its datatype"
+        );
+    }
+
+    // A plain string literal stays bare: no `datatype` and no `xml:lang` IS
+    // `xsd:string` per SRJ §3.2.2, so emitting the tag would be noise, not a fix.
+    let result = fluree
+        .query(
+            &view,
+            QueryInput::Sparql("SELECT (\"plain\" AS ?v) WHERE { ?s <http://example.org/p> ?o }"),
+        )
+        .await
+        .expect("plain literal query");
+    let srj = format::format_results(
+        &result,
+        &result.context,
+        &view.snapshot,
+        &FormatterConfig::sparql_json(),
+    )
+    .expect("sparql_json");
+    assert_eq!(
+        srj["results"]["bindings"][0]["v"],
+        json!({"type": "literal", "value": "plain"}),
+        "a simple literal stays bare"
+    );
+}

--- a/fluree-db-api/tests/it_w3c_result_formats.rs
+++ b/fluree-db-api/tests/it_w3c_result_formats.rs
@@ -129,6 +129,10 @@ async fn w3c_result_formats_emit_absolute_iris_under_every_prologue() {
             srx.contains(&format!("<uri>{S2}</uri>")),
             "{label}: SRX must carry the absolute IRI: {srx}"
         );
+        assert!(
+            srx.contains(r#"datatype="http://www.w3.org/2001/XMLSchema#integer""#),
+            "{label}: SRX must carry the literal's datatype: {srx}"
+        );
 
         // CSV and TSV carry the identical defect on main.
         let csv = result.to_csv(&view.snapshot).expect("csv");
@@ -210,6 +214,21 @@ async fn w3c_sparql_json_keeps_datatype_on_constructed_literals() {
             json!({"type": "literal", "value": lex, "datatype": dt}),
             "STRDT({lex}, {dt}) must round-trip its datatype"
         );
+
+        // SPARQL Results XML carries the identical rule: `<literal>` content is
+        // text, so nothing is inferable from it either. On main the XML writer
+        // dropped the tag for EVERY value kind, not just string-backed ones.
+        let srx = format::format_results_string(
+            &result,
+            &result.context,
+            &view.snapshot,
+            &FormatterConfig::sparql_xml(),
+        )
+        .expect("sparql_xml");
+        assert!(
+            srx.contains(&format!(r#"<literal datatype="{dt}">{lex}</literal>"#)),
+            "STRDT({lex}, {dt}) must round-trip its datatype in XML: {srx}"
+        );
     }
 
     // A plain string literal stays bare: no `datatype` and no `xml:lang` IS
@@ -232,5 +251,16 @@ async fn w3c_sparql_json_keeps_datatype_on_constructed_literals() {
         srj["results"]["bindings"][0]["v"],
         json!({"type": "literal", "value": "plain"}),
         "a simple literal stays bare"
+    );
+    let srx = format::format_results_string(
+        &result,
+        &result.context,
+        &view.snapshot,
+        &FormatterConfig::sparql_xml(),
+    )
+    .expect("sparql_xml");
+    assert!(
+        srx.contains("<literal>plain</literal>"),
+        "a simple literal stays bare in XML too: {srx}"
     );
 }

--- a/fluree-db-cli/src/commands/query.rs
+++ b/fluree-db-cli/src/commands/query.rs
@@ -975,7 +975,7 @@ pub async fn run(
                         } else {
                             // Rare fallback: GROUP BY produces grouped bindings requiring
                             // disaggregation, so fall back to the existing JSON-based formatter.
-                            let formatted_json = result.to_sparql_json(&view.snapshot)?;
+                            let formatted_json = cli_sparql_json(&result, &view.snapshot)?;
                             let output = output::format_result(
                                 &formatted_json,
                                 OutputFormatKind::Table,
@@ -988,8 +988,11 @@ pub async fn run(
                     }
                     detect::QueryFormat::JsonLd => {
                         // JSON-LD can be nested; keep bench output in the lightweight TSV form.
-                        let (text, total_rows) =
-                            result.to_tsv_limited(&view.snapshot, BENCH_ROWS)?;
+                        let (text, total_rows) = result.to_delimited_limited(
+                            &view.snapshot,
+                            BENCH_ROWS,
+                            &cli_delimited_config(OutputFormatKind::Tsv),
+                        )?;
                         print!("{text}");
                         print_footer(total_rows, Some(BENCH_ROWS), elapsed);
                     }
@@ -998,11 +1001,8 @@ pub async fn run(
                 // Delimited fast path: write bytes directly to stdout (no JSON intermediate).
                 let total_rows = result.row_count();
                 let fmt_timer = Instant::now();
-                let bytes = if output_format == OutputFormatKind::Tsv {
-                    result.to_tsv_bytes(&view.snapshot)?
-                } else {
-                    result.to_csv_bytes(&view.snapshot)?
-                };
+                let bytes = result
+                    .to_delimited_bytes(&view.snapshot, &cli_delimited_config(output_format))?;
                 let fmt_elapsed = fmt_timer.elapsed();
                 use std::io::Write;
                 std::io::stdout().write_all(&bytes)?;
@@ -1096,7 +1096,7 @@ pub async fn run(
                     result.format_async(view.as_graph_db_ref(), &config).await?
                 } else {
                     match query_format {
-                        detect::QueryFormat::Sparql => result.to_sparql_json(&view.snapshot)?,
+                        detect::QueryFormat::Sparql => cli_sparql_json(&result, &view.snapshot)?,
                         detect::QueryFormat::JsonLd => {
                             result.to_jsonld_async(view.as_graph_db_ref()).await?
                         }
@@ -1460,11 +1460,8 @@ async fn run_cypher_query(
     // Delimited fast path mirrors the SPARQL/JSON-LD handler.
     if matches!(output_format, OutputFormatKind::Tsv | OutputFormatKind::Csv) {
         let total_rows = result.row_count();
-        let bytes = if output_format == OutputFormatKind::Tsv {
-            result.to_tsv_bytes(&view.snapshot)?
-        } else {
-            result.to_csv_bytes(&view.snapshot)?
-        };
+        let bytes =
+            result.to_delimited_bytes(&view.snapshot, &cli_delimited_config(output_format))?;
         use std::io::Write;
         std::io::stdout().write_all(&bytes)?;
         eprintln!(
@@ -1697,6 +1694,46 @@ fn reject_graph_source_unsupported(
     Ok(())
 }
 
+/// The SPARQL-JSON config the CLI renders with.
+///
+/// The CLI is a display surface: its output is read by a human in a terminal or
+/// piped into a shell one-liner, and the query's own PREFIX declarations are
+/// right there on screen to expand a CURIE with. So it deliberately opts out of
+/// the W3C absolute-IRI profile that the HTTP/API surfaces serialize under
+/// (issue #45) and keeps the abbreviated form issue #1466 established.
+///
+/// Every CLI call site that reaches a W3C writer goes through this (or
+/// [`cli_delimited_config`]) so the deviation is a visible decision, not a
+/// default it inherited.
+fn cli_sparql_json_config() -> fluree_db_api::FormatterConfig {
+    fluree_db_api::FormatterConfig::sparql_json().with_compact_iris()
+}
+
+/// The CSV/TSV config the CLI renders with — same rationale as
+/// [`cli_sparql_json_config`].
+fn cli_delimited_config(output_format: OutputFormatKind) -> fluree_db_api::FormatterConfig {
+    let config = if output_format == OutputFormatKind::Csv {
+        fluree_db_api::FormatterConfig::csv()
+    } else {
+        fluree_db_api::FormatterConfig::tsv()
+    };
+    config.with_compact_iris()
+}
+
+/// Format a result as SPARQL JSON for CLI display (compacted; see
+/// [`cli_sparql_json_config`]).
+fn cli_sparql_json(
+    result: &fluree_db_api::QueryResult,
+    snapshot: &fluree_db_core::LedgerSnapshot,
+) -> Result<serde_json::Value, CliError> {
+    Ok(fluree_db_api::format::format_results(
+        result,
+        &result.context,
+        snapshot,
+        &cli_sparql_json_config(),
+    )?)
+}
+
 /// Build the formatter config for the JSON-returning graph-source / connection
 /// paths from the requested output format.
 fn json_path_formatter_config(
@@ -1707,7 +1744,7 @@ fn json_path_formatter_config(
     match output_format {
         OutputFormatKind::TypedJson => fluree_db_api::FormatterConfig::typed_json(),
         _ => match query_format {
-            detect::QueryFormat::Sparql => fluree_db_api::FormatterConfig::sparql_json(),
+            detect::QueryFormat::Sparql => cli_sparql_json_config(),
             detect::QueryFormat::JsonLd => {
                 let config = fluree_db_api::FormatterConfig::jsonld();
                 if normalize_arrays {
@@ -1923,12 +1960,32 @@ async fn connection_query_local(
 #[cfg(test)]
 mod tests {
     use super::{
-        attach_time_suffix_preserving_fragment, base_ledger_id, inject_sparql_from_before_where,
-        json_path_display_format, jsonld_from_targets, query_targets_foreign_source,
+        attach_time_suffix_preserving_fragment, base_ledger_id, cli_delimited_config,
+        cli_sparql_json_config, inject_sparql_from_before_where, json_path_display_format,
+        json_path_formatter_config, jsonld_from_targets, query_targets_foreign_source,
         reject_graph_source_unsupported,
     };
     use crate::detect::QueryFormat;
     use crate::output::OutputFormatKind;
+
+    /// #1466: the CLI renders SPARQL results with CURIEs, opting out of the
+    /// W3C absolute-IRI profile the API/HTTP surfaces use (#45). Pinned here so
+    /// the deviation cannot be lost to a default change.
+    #[test]
+    fn cli_display_configs_compact_iris() {
+        assert!(!cli_sparql_json_config().absolute_iris);
+        for fmt in [OutputFormatKind::Csv, OutputFormatKind::Tsv] {
+            assert!(!cli_delimited_config(fmt).absolute_iris, "{fmt}");
+        }
+        // ...including the graph-source / connection path, which builds its
+        // config separately.
+        assert!(
+            !json_path_formatter_config(QueryFormat::Sparql, OutputFormatKind::Json, false)
+                .absolute_iris
+        );
+        // The W3C constructors themselves are unchanged (absolute).
+        assert!(fluree_db_api::FormatterConfig::sparql_json().absolute_iris);
+    }
 
     #[test]
     fn attach_time_suffix_preserves_fragment() {

--- a/fluree-db-cli/tests/integration.rs
+++ b/fluree-db-cli/tests/integration.rs
@@ -262,6 +262,58 @@ fn query_and_insert_accept_ledger_flag() {
         .stdout(predicate::str::contains("Carol"));
 }
 
+/// #1466 end to end: `--format json` on a SPARQL query prints the abbreviated
+/// IRI the query's own PREFIX declares. The W3C result writers emit absolute
+/// IRIs (#45); the CLI is a display surface and deliberately does not, so this
+/// pins the deviation against the real rendered bytes rather than the config.
+#[test]
+fn query_sparql_json_output_keeps_compact_iris() {
+    let tmp = TempDir::new().unwrap();
+    seed_named_people(&tmp, "curiedb");
+
+    let assertion = fluree_cmd(&tmp)
+        .args([
+            "query",
+            "--ledger",
+            "curiedb",
+            "--sparql",
+            "--format",
+            "json",
+            "-e",
+            "PREFIX ex: <http://example.org/> SELECT ?s WHERE { ?s ex:name \"Alice\" }",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ex:alice"));
+    let stdout = String::from_utf8(assertion.get_output().stdout.clone()).unwrap();
+    assert!(
+        !stdout.contains("http://example.org/alice"),
+        "CLI json output should stay compacted, got: {stdout}"
+    );
+}
+
+/// Same contract for the delimited display formats.
+#[test]
+fn query_csv_output_keeps_compact_iris() {
+    let tmp = TempDir::new().unwrap();
+    seed_named_people(&tmp, "curiecsv");
+
+    fluree_cmd(&tmp)
+        .args([
+            "query",
+            "--ledger",
+            "curiecsv",
+            "--sparql",
+            "--format",
+            "csv",
+            "-e",
+            "PREFIX ex: <http://example.org/> SELECT ?s WHERE { ?s ex:name \"Alice\" }",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ex:alice"));
+}
+
 #[test]
 fn query_ledger_flag_rejects_extra_positional() {
     let tmp = TempDir::new().unwrap();

--- a/testsuite-sparql/src/query_handler.rs
+++ b/testsuite-sparql/src/query_handler.rs
@@ -6,8 +6,7 @@ use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use fluree_db_api::{
-    format, Fluree, FlureeBuilder, FormatterConfig, GraphDb, LedgerState, ParsedContext,
-    QueryOutput,
+    format, Fluree, FlureeBuilder, FormatterConfig, GraphDb, LedgerState, QueryOutput,
 };
 
 use crate::files::read_file_to_string;
@@ -278,10 +277,14 @@ async fn read_graph_triples(
         .await
         .with_context(|| format!("Reading back graph {graph:?}"))?;
 
-    let empty_context = ParsedContext::new();
     let config = FormatterConfig::sparql_json();
-    let json = format::format_results(&query_result, &empty_context, &ledger.snapshot, &config)
-        .map_err(|e| anyhow::anyhow!("Formatting readback results: {e}"))?;
+    let json = format::format_results(
+        &query_result,
+        &query_result.context,
+        &ledger.snapshot,
+        &config,
+    )
+    .map_err(|e| anyhow::anyhow!("Formatting readback results: {e}"))?;
     let results = fluree_json_to_sparql_results(&json)
         .context("Converting readback results to SparqlResults")?;
 
@@ -330,10 +333,14 @@ async fn list_named_graphs(fluree: &Fluree, ledger: &LedgerState) -> Result<Vec<
         .await
         .context("Enumerating named graphs")?;
 
-    let empty_context = ParsedContext::new();
     let config = FormatterConfig::sparql_json();
-    let json = format::format_results(&query_result, &empty_context, &ledger.snapshot, &config)
-        .map_err(|e| anyhow::anyhow!("Formatting graph enumeration: {e}"))?;
+    let json = format::format_results(
+        &query_result,
+        &query_result.context,
+        &ledger.snapshot,
+        &config,
+    )
+    .map_err(|e| anyhow::anyhow!("Formatting graph enumeration: {e}"))?;
     let results = fluree_json_to_sparql_results(&json)?;
 
     let SparqlResults::Solutions { solutions, .. } = results else {
@@ -471,12 +478,21 @@ pub async fn run_eval_test(
         fluree_construct_to_sparql_results(&construct_json)
             .context("Converting CONSTRUCT output to graph")?
     } else {
-        // SELECT/ASK path: format as SPARQL JSON
-        let empty_context = ParsedContext::new();
+        // SELECT/ASK path: format as SPARQL JSON, through the SAME context the
+        // HTTP surface passes. Substituting an empty context here made IRI
+        // compaction structurally invisible to this suite: every test rendered
+        // as if it had no prologue, so a `PREFIX`-declaring test could never
+        // surface a CURIE and the harness's prepended `BASE` could never surface
+        // a relative reference (issue #45). The writers emit absolute IRIs for
+        // the W3C formats now, so this is a live gate on that.
         let config = FormatterConfig::sparql_json();
-        let actual_json =
-            format::format_results(&query_result, &empty_context, &ledger.snapshot, &config)
-                .map_err(|e| anyhow::anyhow!("Formatting SPARQL JSON: {e}"))?;
+        let actual_json = format::format_results(
+            &query_result,
+            &query_result.context,
+            &ledger.snapshot,
+            &config,
+        )
+        .map_err(|e| anyhow::anyhow!("Formatting SPARQL JSON: {e}"))?;
         fluree_json_to_sparql_results(&actual_json)
             .context("Converting Fluree results to SparqlResults")?
     };

--- a/testsuite-sparql/tests/registers/mod.rs
+++ b/testsuite-sparql/tests/registers/mod.rs
@@ -209,17 +209,14 @@ pub const SPARQL10_QUERY_EVAL: &[&str] = &[
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-02",
     // open-eq-04 greened (D5 datatype-aware `=`/`!=`). open-eq-05/06 need BOTH the
     // scan-path EncodedLit datatype-carry (bench-sensitive, D5b class) AND typed-
-    // literal *constants* to carry their datatype (lower_typed_literal drops it);
-    // open-eq-07/08/10/11/12 now select the correct 12/42/52/52/10-row set but
-    // stay non-isomorphic on blank-node OUTPUT identity (the same object bnode is
-    // re-minted per binding) — orthogonal to the equality lattice.
+    // literal *constants* to carry their datatype (lower_typed_literal drops it).
+    // open-eq-07/08/10/11/12 greened by issue #45 (b): they already selected the
+    // correct 12/42/52/52/10-row set, and the residual mismatch was the SPARQL-JSON
+    // writer dropping the `datatype` off string-backed literals with an "inferable"
+    // type — so a typed object compared as a plain string and no bnode mapping was
+    // consistent. With the datatype emitted, the isomorphism resolves.
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-05",
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-06",
-    "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-07",
-    "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-08",
-    "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-10",
-    "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-11",
-    "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/open-world/manifest#open-eq-12",
     // optional cluster (3): all three optional-complex-* use GRAPH ?x/?g and
     // are gated on PR-G1 (GRAPH-variable semantics). dawg-optional-filter-005's
     // doubly-nested `OPTIONAL { { ... FILTER } }` scope leak is fixed (PR-W1


### PR DESCRIPTION
When a SPARQL query declares a prefix, the lowerer builds a JSON-LD-style context from the prologue and the formatters compact against it. That's the intended behavior for our JSON-LD-flavored outputs and CLI display — but it also reached `application/sparql-results+json`, CSV, and TSV, where the specs define a `uri` value as the absolute IRI and the formats carry no prefix map for a consumer to expand with. A `BASE`-only prologue was worse still: relative IRIs in the output. SPARQL-XML was already correct on this half — it never compacted node IRIs.

`FormatterConfig` grows an `absolute_iris` profile, true for the W3C-format constructors and threaded into the compactor as a suppress flag (same pattern as the existing graph-source flag). The CLI's SPARQL display paths explicitly construct the compacting variant, so `--format json`/csv/tsv keep today's output — that contract is now pinned by a CLI test rather than being emergent. In the same profile, datatype omission is narrowed to `xsd:string`: the old allow-list dropped tags from string-backed typed literals (e.g. `STRDT` results), which changes term identity in a format whose values are always text.

That datatype rule applies to **all four** W3C result formats, XML included. SPARQL-XML gated on the same `is_inferable_datatype` allow-list, and more broadly than SRJ did — its single gate covered every value kind, so a stored `xsd:long` serialized as a bare `<literal>42</literal>`. `<literal>` content is text, so nothing about the datatype survives serialization there either, and its own test pinned the wrong behavior. Both writers now route through `may_omit_datatype`, so the four formats are genuinely consistent.

The W3C harness previously rendered results with an empty context, so compaction was invisible to it; it now renders with the query's own context and the full suite stays green against the fixed writer — and the datatype change greened five equality tests whose register entries had misattributed the failures. Behavior note for release: SRJ/CSV/TSV consumers that had adapted to compacted output will see absolute IRIs, and SRJ/XML consumers will see `datatype` on typed literals that previously arrived bare; every consumer that handles the fuller form is unaffected.
