### PR TITLE
refuse graph-source patterns the plan cannot route

### DIFF
--- a/docs/graph-sources/iceberg.md
+++ b/docs/graph-sources/iceberg.md
@@ -884,6 +884,18 @@ A failed gate drops the twin so nothing unverified stays announced. See the [`fl
    merge-on-read semantics (e.g. Athena `DELETE`, Flink/CDC upserts, Snowflake v3
    deletion vectors, or Snowflake v2 once `ENABLE_ICEBERG_MERGE_ON_READ` is on).
    See the switch below to override.
+5. **No transitive traversal (fail-closed):** Property-path quantifiers (`p+`,
+   `p*`, `p?`, and quantified combinations like `^p+` or `(a|b)+`),
+   `shortestPath`, and subqueries need a native index to walk and cannot be
+   evaluated over an Iceberg source. A query using one is **refused** with HTTP
+   400 `err:db/InvalidQuery` naming the pattern, rather than returning the empty
+   result it would otherwise produce as a success. Fixed-length patterns (`p`,
+   `p/p`, …) and unquantified `a|b` / `^p` scan the tables normally. Bound the
+   traversal to a known depth (see [Graph Sources Overview → Query Patterns a
+   Graph Source Cannot
+   Evaluate](overview.md#query-patterns-a-graph-source-cannot-evaluate)) or
+   [materialize a native twin](#materializing-a-native-twin), which evaluates
+   all of them.
 
 ### Environment switches
 

--- a/docs/graph-sources/overview.md
+++ b/docs/graph-sources/overview.md
@@ -245,6 +245,28 @@ Pick that maximum depth deliberately and state it wherever the query is document
 
 For genuinely unbounded traversal, materialize the graph source into a native ledger first — see [Materializing a Native Twin](iceberg.md#materializing-a-native-twin). A native ledger evaluates all of these patterns normally.
 
+### Patterns Must Be Inside the GRAPH Block
+
+Patterns reach a graph source only inside a `GRAPH <gs_id> { … }` block. Fluree adds that block automatically when you address a graph source directly — but **not** to a query that already contains a `GRAPH` block of its own, since that is taken as explicit scoping. In a query that mixes the two, any triple pattern left at the top level has nothing to route it, and it returns **HTTP 400 `err:db/InvalidQuery`**:
+
+```sparql
+-- Refused: `?order ex:total ?total` is outside every GRAPH block
+SELECT ?total ?item FROM <warehouse-orders:main> WHERE {
+  ?order ex:total ?total .
+  GRAPH <warehouse-items:main> { ?order ex:item ?item }
+}
+
+-- Correct: every pattern is scoped
+SELECT ?total ?item FROM <warehouse-orders:main> WHERE {
+  GRAPH <warehouse-orders:main> { ?order ex:total ?total }
+  GRAPH <warehouse-items:main> { ?order ex:item ?item }
+}
+```
+
+Either move the pattern inside a `GRAPH` block naming the source it belongs to, or drop the explicit `GRAPH` block so the whole query is scoped automatically.
+
+One gap remains here: a top-level pattern inside `OPTIONAL`, `MINUS`, `UNION`, or `EXISTS` is **not** refused, because refusing it would reject queries that do return rows today. Such a block is evaluated against an empty index, so it matches nothing — a top-level `OPTIONAL` never binds, and a top-level `MINUS` excludes nothing. Scope those blocks with `GRAPH` as well.
+
 ### Search Indexes (BM25, Vector)
 
 Search indexes use the `f:graphSource` pattern:

--- a/docs/graph-sources/overview.md
+++ b/docs/graph-sources/overview.md
@@ -219,6 +219,32 @@ SELECT ?s ?p ?o FROM <execution-log:main> WHERE { ?s ?p ?o } LIMIT 10
 
 Iceberg graph sources use R2RML mappings to define how table rows become RDF triples. See [Iceberg / Parquet](iceberg.md) and [R2RML](r2rml.md) for details.
 
+### Query Patterns a Graph Source Cannot Evaluate
+
+A graph source has no native RDF index. Its triples are materialized per query from the backing table or index, which is enough for triple patterns but not for the constructs that need an index to walk. Three of them are refused rather than answered:
+
+- **Property-path quantifiers** — `p+`, `p*`, `p?`, and any quantified combination such as `^p+`, `(a|b)+`, or `(a/b)+`
+- **`shortestPath` / `allShortestPaths`**
+- **Subqueries** — a nested SPARQL `SELECT`, or a JSON-LD sub-`select`
+
+A query using one against a graph source returns **HTTP 400 `err:db/InvalidQuery`**, naming the pattern kind. The refusal is deliberate: these patterns would otherwise read the graph source's empty native index and return a wrong answer as a success — nothing at all for `p+`, and the starting node alone for `p*` and `p?`. Unquantified alternation (`a|b`) and inverse (`^p`) are unaffected; they lower to ordinary triple patterns and run normally.
+
+**Workaround: bounded fixed-length paths.** Sequence paths do lower to table scans, so a traversal whose maximum depth you know can be written as a union of explicit hops:
+
+```sparql
+PREFIX ex: <http://example.org/ns/>
+
+SELECT ?boss FROM <warehouse-hr:main> WHERE {
+  { ex:emp1 ex:manager ?boss }
+  UNION { ex:emp1 ex:manager/ex:manager ?boss }
+  UNION { ex:emp1 ex:manager/ex:manager/ex:manager ?boss }
+}
+```
+
+Pick that maximum depth deliberately and state it wherever the query is documented: results are silently incomplete beyond the depth you enumerate, and nothing in the response marks the truncation.
+
+For genuinely unbounded traversal, materialize the graph source into a native ledger first — see [Materializing a Native Twin](iceberg.md#materializing-a-native-twin). A native ledger evaluates all of these patterns normally.
+
 ### Search Indexes (BM25, Vector)
 
 Search indexes use the `f:graphSource` pattern:

--- a/docs/graph-sources/r2rml.md
+++ b/docs/graph-sources/r2rml.md
@@ -353,6 +353,17 @@ An R2RML graph source is *virtual* — every query re-reads the underlying table
 1. **Read-Only:** R2RML graph sources are read-only (no writes via Fluree)
 2. **Performance:** Complex joins across Fluree + Iceberg may be slow
 3. **Schema Changes:** Requires mapping updates when referenced columns change
+4. **No index-walking query patterns (fail-closed):** Property-path quantifiers
+   (`p+`, `p*`, `p?`, and quantified combinations like `^p+` or `(a|b)+`),
+   `shortestPath`, and subqueries cannot be evaluated over a mapped source — it
+   has no native index for them to walk. A query using one is **refused** with
+   HTTP 400 `err:db/InvalidQuery` naming the pattern, rather than returning the
+   empty result it would otherwise produce as a success. Fixed-length patterns
+   (`p`, `p/p`, …) and unquantified `a|b` / `^p` lower to table scans and run
+   normally. See [Graph Sources Overview → Query Patterns a Graph Source Cannot
+   Evaluate](overview.md#query-patterns-a-graph-source-cannot-evaluate) for the
+   bounded workaround, or materialize a native twin (below) for unbounded
+   traversal.
 
 ## Troubleshooting
 

--- a/docs/query/graph-crawl.md
+++ b/docs/query/graph-crawl.md
@@ -2,6 +2,8 @@
 
 Graph crawl enables recursive traversal of relationships — following links between entities to discover connected data. This is built on **property paths**, which provide operators for transitive, inverse, and multi-predicate traversal.
 
+> **Native ledgers only.** Everything on this page evaluates against a ledger's own indexes. A [graph source](../graph-sources/overview.md) — Iceberg/R2RML, BM25, or vector — has no native index, so quantified property paths (`+`, `*`, `?`), `shortestPath`, and subqueries are refused there with HTTP 400 `err:db/InvalidQuery` rather than answered. Fixed-length paths (`ex:knows`, `ex:knows/ex:name`) and unquantified `|` / `^` work against both. See [Query Patterns a Graph Source Cannot Evaluate](../graph-sources/overview.md#query-patterns-a-graph-source-cannot-evaluate) for the bounded-depth workaround and how to crawl a graph source by materializing it into a native ledger first.
+
 ## Overview
 
 Graph crawl queries traverse relationships in the graph, following links from one entity to another. Common use cases:

--- a/fluree-db-api/src/view/dataset_query.rs
+++ b/fluree-db-api/src/view/dataset_query.rs
@@ -167,7 +167,11 @@ impl Fluree {
         // 1b. Auto-wrap for graph source context, then refuse whatever the wrap
         // could not put on the provider's path.
         super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
-        super::query::guard_dataset_graph_source_patterns(dataset, &parsed)?;
+        super::query::guard_dataset_graph_source_patterns(
+            dataset,
+            &parsed,
+            super::query::QuerySyntax::of(&input),
+        )?;
 
         // 2. Build executable with optional reasoning override from primary view
         let executable = self.build_executable_for_dataset(dataset, &parsed).await?;
@@ -268,7 +272,11 @@ impl Fluree {
         // 1b. Auto-wrap for graph source context, then refuse whatever the wrap
         // could not put on the provider's path.
         super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
-        super::query::guard_dataset_graph_source_patterns(dataset, &parsed)?;
+        super::query::guard_dataset_graph_source_patterns(
+            dataset,
+            &parsed,
+            super::query::QuerySyntax::of(&input),
+        )?;
 
         // 2. Build executable with optional reasoning override from primary view
         let executable = self.build_executable_for_dataset(dataset, &parsed).await?;
@@ -393,7 +401,12 @@ impl Fluree {
         if let Some(primary) = dataset.primary() {
             super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
         }
-        super::query::guard_dataset_graph_source_patterns(dataset, &parsed).map_err(|e| {
+        super::query::guard_dataset_graph_source_patterns(
+            dataset,
+            &parsed,
+            super::query::QuerySyntax::of(&input),
+        )
+        .map_err(|e| {
             crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
         })?;
 
@@ -509,7 +522,12 @@ impl Fluree {
         if let Some(primary) = dataset.primary() {
             super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
         }
-        super::query::guard_dataset_graph_source_patterns(dataset, &parsed).map_err(|e| {
+        super::query::guard_dataset_graph_source_patterns(
+            dataset,
+            &parsed,
+            super::query::QuerySyntax::of(&input),
+        )
+        .map_err(|e| {
             crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
         })?;
 

--- a/fluree-db-api/src/view/dataset_query.rs
+++ b/fluree-db-api/src/view/dataset_query.rs
@@ -164,8 +164,10 @@ impl Fluree {
             }
         };
 
-        // 1b. Auto-wrap for graph source context
+        // 1b. Auto-wrap for graph source context, then refuse whatever the wrap
+        // could not put on the provider's path.
         super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
+        super::query::guard_dataset_graph_source_patterns(dataset, &parsed)?;
 
         // 2. Build executable with optional reasoning override from primary view
         let executable = self.build_executable_for_dataset(dataset, &parsed).await?;
@@ -263,8 +265,10 @@ impl Fluree {
             }
         };
 
-        // 1b. Auto-wrap for graph source context
+        // 1b. Auto-wrap for graph source context, then refuse whatever the wrap
+        // could not put on the provider's path.
         super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
+        super::query::guard_dataset_graph_source_patterns(dataset, &parsed)?;
 
         // 2. Build executable with optional reasoning override from primary view
         let executable = self.build_executable_for_dataset(dataset, &parsed).await?;
@@ -384,10 +388,14 @@ impl Fluree {
             }
         };
 
-        // Auto-wrap for graph source context
+        // Auto-wrap for graph source context, then refuse whatever the wrap
+        // could not put on the provider's path.
         if let Some(primary) = dataset.primary() {
             super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
         }
+        super::query::guard_dataset_graph_source_patterns(dataset, &parsed).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
+        })?;
 
         // Build executable
         let executable = self
@@ -496,10 +504,14 @@ impl Fluree {
             }
         };
 
-        // Auto-wrap for graph source context
+        // Auto-wrap for graph source context, then refuse whatever the wrap
+        // could not put on the provider's path.
         if let Some(primary) = dataset.primary() {
             super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
         }
+        super::query::guard_dataset_graph_source_patterns(dataset, &parsed).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
+        })?;
 
         let executable = self
             .build_executable_for_dataset(dataset, &parsed)

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -56,10 +56,22 @@ pub(crate) fn maybe_wrap_for_graph_source(db: &GraphDb, parsed: &mut fluree_db_q
 /// match only — as HTTP 200. This check makes the refusal independent of the
 /// query's `GRAPH` structure.
 ///
+/// A plain triple stranded out there is refused too, by
+/// [`unroutable_top_level_error`]. It is scoped deliberately to triples in
+/// *conjunctive* top-level position, where an empty match provably zeroes the
+/// whole result and no query can be returning correct rows today. It does not
+/// descend into `OPTIONAL`, `MINUS`, `UNION`, or `EXISTS` bodies: those degrade
+/// rather than zero (a vacuous `OPTIONAL` still emits its left side, a vacuous
+/// `MINUS` excludes nothing), and a `UNION` branch may carry a nested `GRAPH`
+/// block that routes and contributes real rows — so refusing there would reject
+/// queries that answer today. Those shapes stay silently degraded pending the
+/// routing work; see the graph-source docs.
+///
 /// Call it *after* the wrap: everything the wrap moved into the graph scope is
 /// then already covered by the rewrite guard, so a query with no `GRAPH` block
 /// of its own keeps refusing on exactly the route it refuses on today, with the
-/// same message.
+/// same message. It also means a surviving top-level triple is itself proof the
+/// wrap declined — no separate flag needed.
 pub(crate) fn guard_graph_source_patterns(
     db: &GraphDb,
     parsed: &fluree_db_query::ir::Query,
@@ -68,11 +80,43 @@ pub(crate) fn guard_graph_source_patterns(
         return Ok(());
     };
     let unsupported = fluree_db_query::r2rml::unsupported_outside_graph_scopes(&parsed.patterns);
-    if unsupported.is_empty() {
-        return Ok(());
+    if !unsupported.is_empty() {
+        return Err(ApiError::Query(
+            fluree_db_query::r2rml::unsupported_subscope_error(gs_id, &unsupported),
+        ));
     }
-    Err(ApiError::Query(
-        fluree_db_query::r2rml::unsupported_subscope_error(gs_id, &unsupported),
+    let unroutable = parsed
+        .patterns
+        .iter()
+        .filter(|p| matches!(p, Pattern::Triple(_)))
+        .count();
+    if unroutable > 0 {
+        return Err(ApiError::Query(unroutable_top_level_error(
+            gs_id, unroutable,
+        )));
+    }
+    Ok(())
+}
+
+/// The refusal for a triple pattern the wrap left stranded at the top level of a
+/// graph-source query.
+///
+/// Unlike the property-path family this is *lowerable* — it would convert to an
+/// R2RML scan perfectly well — but only inside a `GRAPH` scope, and on this plan
+/// it is not in one. "Lowerable in principle" is no comfort to a user whose
+/// pattern will not be lowered on the plan actually running, so it refuses for
+/// the same reason: it would otherwise read the graph source's empty native
+/// index and return no rows as a success. The wording names the workaround
+/// rather than the internals, because both fixes are entirely in the user's
+/// hands.
+fn unroutable_top_level_error(gs_id: &str, count: usize) -> fluree_db_query::QueryError {
+    fluree_db_query::QueryError::InvalidQuery(format!(
+        "graph source '{gs_id}' cannot evaluate {count} top-level triple pattern(s) in this \
+         query. Patterns reach a graph source only inside a `GRAPH <{gs_id}>` block; Fluree \
+         adds that block automatically, but not to a query that already contains a GRAPH \
+         block of its own — so these patterns would read an empty index and silently return \
+         no rows. Move them inside a `GRAPH <{gs_id}>` block, or drop the explicit GRAPH \
+         block so the whole query is scoped to the graph source."
     ))
 }
 
@@ -1838,6 +1882,57 @@ mod graph_source_guard_tests {
         assert!(
             msg.contains(SCAN_MARKER),
             "a fixed-length pattern must reach the R2RML scan, not a guard: {msg}"
+        );
+    }
+
+    /// A plain triple stranded at the top level by the same bypass is refused
+    /// too. It is lowerable in principle, but not on this plan — nothing routes
+    /// it to the provider, so it reads the empty genesis index and zeroes the
+    /// whole conjunction. Verified before implementing: it returns HTTP 200 with
+    /// 0 rows today.
+    #[tokio::test]
+    async fn top_level_triple_beside_an_explicit_graph_block_is_refused() {
+        let msg = query_err(&format!(
+            "SELECT ?o WHERE {{ <{N1}> <{EDGE_PRED}> ?o . \
+             GRAPH <{GS_ID}> {{ ?a <{EDGE_PRED}> ?c }} }}"
+        ))
+        .await;
+        assert!(
+            msg.contains("top-level triple pattern") && msg.contains("Move them inside"),
+            "expected the unroutable-top-level refusal naming the workaround, got: {msg}"
+        );
+    }
+
+    /// Scope guard: the refusal is for *conjunctive* top-level triples only. A
+    /// vacuous `OPTIONAL` still emits its left side, so refusing it would reject
+    /// a query that returns rows today — those stay out of scope until the
+    /// patterns can actually be routed.
+    #[tokio::test]
+    async fn a_top_level_optional_beside_a_graph_block_is_not_refused() {
+        let msg = query_err(&format!(
+            "SELECT ?o WHERE {{ GRAPH <{GS_ID}> {{ <{N1}> <{EDGE_PRED}> ?o }} \
+             OPTIONAL {{ ?o <{EDGE_PRED}> ?x }} }}"
+        ))
+        .await;
+        assert!(
+            msg.contains(SCAN_MARKER),
+            "an OPTIONAL body must not be refused — the GRAPH block still scans: {msg}"
+        );
+    }
+
+    /// Scope guard: patterns that never read this view's index — `VALUES`,
+    /// `BIND`, `FILTER`, and the search adapters, which carry their own graph
+    /// source and route independently — must survive at the top level.
+    #[tokio::test]
+    async fn top_level_values_beside_a_graph_block_is_not_refused() {
+        let msg = query_err(&format!(
+            "SELECT ?o ?v WHERE {{ VALUES ?v {{ 1 }} \
+             GRAPH <{GS_ID}> {{ <{N1}> <{EDGE_PRED}> ?o }} }}"
+        ))
+        .await;
+        assert!(
+            msg.contains(SCAN_MARKER),
+            "VALUES reads no index and must not be refused: {msg}"
         );
     }
 

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -75,14 +75,25 @@ pub(crate) fn maybe_wrap_for_graph_source(db: &GraphDb, parsed: &mut fluree_db_q
 pub(crate) fn guard_graph_source_patterns(
     db: &GraphDb,
     parsed: &fluree_db_query::ir::Query,
+    syntax: QuerySyntax,
 ) -> Result<()> {
     let Some(gs_id) = db.graph_source_id.as_deref() else {
         return Ok(());
     };
+    guard_graph_source_patterns_for(&[gs_id], parsed, syntax)
+}
+
+/// [`guard_graph_source_patterns`] over an explicit source list, so a dataset
+/// can name every graph source it is querying rather than just the primary's.
+fn guard_graph_source_patterns_for(
+    gs_ids: &[&str],
+    parsed: &fluree_db_query::ir::Query,
+    syntax: QuerySyntax,
+) -> Result<()> {
     let unsupported = fluree_db_query::r2rml::unsupported_outside_graph_scopes(&parsed.patterns);
     if !unsupported.is_empty() {
         return Err(ApiError::Query(
-            fluree_db_query::r2rml::unsupported_subscope_error(gs_id, &unsupported),
+            fluree_db_query::r2rml::unsupported_subscope_error(gs_ids, &unsupported),
         ));
     }
     let unroutable = parsed
@@ -92,36 +103,105 @@ pub(crate) fn guard_graph_source_patterns(
         .count();
     if unroutable > 0 {
         return Err(ApiError::Query(unroutable_top_level_error(
-            gs_id, unroutable,
+            gs_ids, unroutable, syntax,
         )));
     }
     Ok(())
+}
+
+/// Which surface a query arrived on, so a refusal can name a scoping construct
+/// the user could actually have typed.
+///
+/// The three surfaces spell graph scoping differently, and one of them cannot
+/// spell it at all — see [`unroutable_top_level_error`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum QuerySyntax {
+    Sparql,
+    JsonLd,
+    Cypher,
+}
+
+impl QuerySyntax {
+    pub(crate) fn of(input: &QueryInput<'_>) -> Self {
+        match input {
+            QueryInput::Sparql(_) => Self::Sparql,
+            QueryInput::JsonLd(_) => Self::JsonLd,
+        }
+    }
 }
 
 /// The refusal for a triple pattern the wrap left stranded at the top level of a
 /// graph-source query.
 ///
 /// Unlike the property-path family this is *lowerable* — it would convert to an
-/// R2RML scan perfectly well — but only inside a `GRAPH` scope, and on this plan
+/// R2RML scan perfectly well — but only inside a graph scope, and on this plan
 /// it is not in one. "Lowerable in principle" is no comfort to a user whose
 /// pattern will not be lowered on the plan actually running, so it refuses for
 /// the same reason: it would otherwise read the graph source's empty native
-/// index and return no rows as a success. The wording names the workaround
-/// rather than the internals, because both fixes are entirely in the user's
-/// hands.
-fn unroutable_top_level_error(gs_id: &str, count: usize) -> fluree_db_query::QueryError {
+/// index and return no rows as a success.
+///
+/// The wording names the workaround rather than the internals, because both
+/// fixes are entirely in the user's hands — which means it has to be spelled in
+/// the language the user is actually writing. SPARQL scopes with
+/// `GRAPH <iri> { … }` and JSON-LD with a `"graph"` object; telling a JSON-LD
+/// user to write SPARQL is the same defect as telling them nothing.
+///
+/// The `Cypher` arm is defensive, not reachable today: Cypher lowering emits no
+/// `Pattern::Graph`, so `maybe_wrap_for_graph_source` always wraps a Cypher
+/// query whole and never leaves a top-level triple behind (pinned by
+/// `cypher_over_a_graph_source_cannot_reach_the_graph_block_advice`). If Cypher
+/// ever gains a graph-scoping construct, this must stop claiming there is none.
+///
+/// With several sources in play the "drop the explicit block" escape is omitted
+/// deliberately: dropping it would scope the whole query to one source and
+/// silently drop the rest, which is not what the user asked for.
+fn unroutable_top_level_error(
+    gs_ids: &[&str],
+    count: usize,
+    syntax: QuerySyntax,
+) -> fluree_db_query::QueryError {
+    let names = gs_ids
+        .iter()
+        .map(|id| format!("'{id}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let subject = if gs_ids.len() == 1 {
+        format!("graph source {names}")
+    } else {
+        format!("graph sources {names}")
+    };
+    let scope_syntax = match syntax {
+        QuerySyntax::Sparql => "a `GRAPH <source> { … }` block",
+        QuerySyntax::JsonLd => "a `{\"graph\": \"source\", \"where\": [ … ]}` block",
+        QuerySyntax::Cypher => "a graph-scoping block",
+    };
+    let advice = match (syntax, gs_ids.len()) {
+        // Cypher has no way to scope a pattern to one graph, so there is no
+        // rewrite to suggest — only a different way to address the source.
+        (QuerySyntax::Cypher, _) => {
+            "Cypher has no graph-scoping syntax, so these patterns cannot be routed from a \
+             query that also addresses another graph — query the graph source on its own."
+                .to_string()
+        }
+        (_, 1) => format!(
+            "Move them inside {scope_syntax} naming {names}, or drop the explicit block so \
+             the whole query is scoped to the graph source."
+        ),
+        (_, _) => format!(
+            "Move each pattern inside {scope_syntax} naming the source it belongs to \
+             ({names}). Dropping the explicit block is not an option here: it would scope \
+             the whole query to one source and silently exclude the others."
+        ),
+    };
     fluree_db_query::QueryError::InvalidQuery(format!(
-        "graph source '{gs_id}' cannot evaluate {count} top-level triple pattern(s) in this \
-         query. Patterns reach a graph source only inside a `GRAPH <{gs_id}>` block; Fluree \
-         adds that block automatically, but not to a query that already contains a GRAPH \
-         block of its own — so these patterns would read an empty index and silently return \
-         no rows. Move them inside a `GRAPH <{gs_id}>` block, or drop the explicit GRAPH \
-         block so the whole query is scoped to the graph source."
+        "{subject} cannot evaluate {count} top-level triple pattern(s) in this query. \
+         Patterns reach a graph source only inside {scope_syntax}; Fluree adds that block \
+         automatically, but not to a query that already scopes a block of its own — so these \
+         patterns would read an empty index and silently return no rows. {advice}"
     ))
 }
 
-/// [`guard_graph_source_patterns`] for a dataset query, applied through the
-/// primary view.
+/// [`guard_graph_source_patterns`] for a dataset query.
 ///
 /// Gated on *every* default graph being a graph source. A dataset that mixes a
 /// graph source with a native ledger (`from: ["sales:main", "warehouse-gs"]`)
@@ -129,22 +209,44 @@ fn unroutable_top_level_error(gs_id: &str, count: usize) -> fluree_db_query::Que
 /// out there has a real index to traverse and refusing it would reject a query
 /// that works. With no native member in the union there is no such index, and
 /// the single-view reasoning applies unchanged.
+///
+/// Every default graph's source id is passed to the refusal, not just the
+/// primary's. The message tells the user where to move a stranded pattern, and
+/// a message naming one id out of several would be advice to silently exclude
+/// the rest.
+///
+/// # Empty default set
+///
+/// An empty `default` returns `Ok` — the query is not refused. This is the
+/// `fromNamed`-only shape, and post-#1631 (which stopped injecting the ledger as
+/// a default graph for such bodies) it is the *correct* answer rather than a gap
+/// in the gate. SPARQL §13.2 gives a `FROM NAMED`-only query an empty default
+/// graph, so its top-level patterns are supposed to match nothing: an empty
+/// result is the specified answer, not the silent-wrong one this guard exists to
+/// catch. Refusing here would reject a conformant query. Pinned by
+/// `a_named_only_body_leaves_the_default_graph_empty` and its end-to-end
+/// companion `a_named_only_graph_source_query_is_answered_not_refused`.
 pub(crate) fn guard_dataset_graph_source_patterns(
     dataset: &DataSetDb,
     parsed: &fluree_db_query::ir::Query,
+    syntax: QuerySyntax,
 ) -> Result<()> {
-    if dataset.default.is_empty()
-        || dataset
-            .default
-            .iter()
-            .any(|view| view.graph_source_id.is_none())
-    {
+    if dataset.default.is_empty() {
         return Ok(());
     }
-    match dataset.primary() {
-        Some(primary) => guard_graph_source_patterns(primary, parsed),
-        None => Ok(()),
+    let mut gs_ids = Vec::with_capacity(dataset.default.len());
+    for view in &dataset.default {
+        match view.graph_source_id.as_deref() {
+            Some(id) => {
+                if !gs_ids.contains(&id) {
+                    gs_ids.push(id);
+                }
+            }
+            // A native member can answer top-level patterns — see above.
+            None => return Ok(()),
+        }
     }
+    guard_graph_source_patterns_for(&gs_ids, parsed, syntax)
 }
 
 // ============================================================================
@@ -251,7 +353,7 @@ impl Fluree {
         // 1b. Auto-wrap for graph source context, then refuse whatever the wrap
         // could not put on the provider's path.
         maybe_wrap_for_graph_source(db, &mut parsed);
-        guard_graph_source_patterns(db, &parsed)?;
+        guard_graph_source_patterns(db, &parsed, QuerySyntax::of(&input))?;
 
         // 2. Build executable with optional reasoning override
         let plan_start = std::time::Instant::now();
@@ -317,7 +419,7 @@ impl Fluree {
         let parse_ms = parse_start.elapsed().as_secs_f64() * 1000.0;
 
         maybe_wrap_for_graph_source(db, &mut parsed);
-        guard_graph_source_patterns(db, &parsed)?;
+        guard_graph_source_patterns(db, &parsed, QuerySyntax::Cypher)?;
 
         self.execute_cypher_ir(db, vars, parsed, parse_ms).await
     }
@@ -338,7 +440,7 @@ impl Fluree {
             db.policy_enforcer().map(|e| &**e),
         )?;
         maybe_wrap_for_graph_source(db, &mut parsed);
-        guard_graph_source_patterns(db, &parsed)?;
+        guard_graph_source_patterns(db, &parsed, QuerySyntax::Cypher)?;
         self.execute_cypher_ir(db, vars, parsed, 0.0).await
     }
 
@@ -402,7 +504,7 @@ impl Fluree {
         }
 
         maybe_wrap_for_graph_source(db, &mut parsed);
-        guard_graph_source_patterns(db, &parsed)?;
+        guard_graph_source_patterns(db, &parsed, QuerySyntax::Cypher)?;
         self.execute_cypher_ir(db, vars, parsed, 0.0).await
     }
 
@@ -498,7 +600,7 @@ impl Fluree {
         // 1b. Auto-wrap for graph source context, then refuse whatever the wrap
         // could not put on the provider's path.
         maybe_wrap_for_graph_source(db, &mut parsed);
-        guard_graph_source_patterns(db, &parsed)?;
+        guard_graph_source_patterns(db, &parsed, QuerySyntax::of(&input))?;
 
         // 2. Build executable with optional reasoning override
         let executable = self.build_executable_for_view(db, &parsed).await?;
@@ -677,7 +779,7 @@ impl Fluree {
         // Auto-wrap for graph source context, then refuse whatever the wrap
         // could not put on the provider's path.
         maybe_wrap_for_graph_source(db, &mut parsed);
-        guard_graph_source_patterns(db, &parsed).map_err(|e| {
+        guard_graph_source_patterns(db, &parsed, QuerySyntax::of(&input)).map_err(|e| {
             crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
         })?;
 
@@ -839,7 +941,7 @@ impl Fluree {
         // Auto-wrap for graph source context, then refuse whatever the wrap
         // could not put on the provider's path.
         maybe_wrap_for_graph_source(db, &mut parsed);
-        guard_graph_source_patterns(db, &parsed).map_err(|e| {
+        guard_graph_source_patterns(db, &parsed, QuerySyntax::of(&input)).map_err(|e| {
             crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
         })?;
 
@@ -1934,6 +2036,270 @@ mod graph_source_guard_tests {
             msg.contains(SCAN_MARKER),
             "VALUES reads no index and must not be refused: {msg}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // The refusal has to be spelled in the language the user is writing
+    // -----------------------------------------------------------------------
+
+    /// SPARQL scopes with `GRAPH <iri> { … }`, so that is what a SPARQL user is
+    /// told to write.
+    #[tokio::test]
+    async fn a_sparql_refusal_names_sparql_scoping_syntax() {
+        let msg = query_err(&format!(
+            "SELECT ?o WHERE {{ <{N1}> <{EDGE_PRED}> ?o . \
+             GRAPH <{GS_ID}> {{ ?a <{EDGE_PRED}> ?c }} }}"
+        ))
+        .await;
+        assert!(
+            msg.contains("`GRAPH <source> { … }` block") && msg.contains(GS_ID),
+            "a SPARQL user must be shown SPARQL scoping syntax: {msg}"
+        );
+        assert!(
+            !msg.contains("\"graph\""),
+            "and must not be shown the JSON-LD form: {msg}"
+        );
+    }
+
+    /// JSON-LD scopes with a `"graph"` object, not a `GRAPH` keyword. Telling a
+    /// JSON-LD user to write SPARQL is the same defect as telling them nothing —
+    /// this is the reachable half of the review's query-language finding.
+    #[tokio::test]
+    async fn a_jsonld_refusal_names_jsonld_scoping_syntax() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let db = graph_source_view();
+        let stub = StubProvider::new();
+        let q = serde_json::json!({
+            "select": ["?o"],
+            "where": [
+                {"@id": N1, EDGE_PRED: "?o"},
+                ["graph", GS_ID, {"@id": "?a", EDGE_PRED: "?c"}]
+            ]
+        });
+        let msg = fluree
+            .query_view_with_r2rml_options(&db, &q, &stub, &stub, QueryExecutionOptions::default())
+            .await
+            .expect_err("the stranded top-level pattern is refused")
+            .to_string();
+        assert!(
+            msg.contains("\"graph\": \"source\"") && msg.contains("\"where\""),
+            "a JSON-LD user must be shown the JSON-LD scoping form: {msg}"
+        );
+        assert!(
+            !msg.contains("GRAPH <source>"),
+            "and must not be shown SPARQL syntax: {msg}"
+        );
+    }
+
+    /// The review asked whether a Cypher user can be told to write `GRAPH { }`,
+    /// which is not Cypher syntax. They cannot: Cypher lowering emits no
+    /// `Pattern::Graph`, so `maybe_wrap_for_graph_source` always wraps a Cypher
+    /// query whole and never strands a top-level pattern for the guard to find.
+    /// This pins that structurally — if Cypher ever gains a graph-scoping
+    /// construct, this test fails and the Cypher wording stops being hypothetical.
+    #[tokio::test]
+    async fn cypher_over_a_graph_source_cannot_reach_the_graph_block_advice() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let db = graph_source_view().with_default_context(Some(
+            serde_json::json!({"@vocab": "http://fs3.example/vocab#"}),
+        ));
+
+        for cypher in [
+            "MATCH (a)-[:edge]->(b) RETURN b",
+            // A variable-length pattern, which lowers to Pattern::PropertyPath —
+            // the kind the other guard refuses when it sits outside a scope.
+            "MATCH (a)-[:edge*1..3]->(b) RETURN b",
+        ] {
+            let result = fluree.query_cypher(&db, cypher).await;
+            let msg = match &result {
+                Ok(_) => String::new(),
+                Err(e) => e.to_string(),
+            };
+            assert!(
+                !msg.contains("cannot evaluate") && !msg.contains("Move them inside"),
+                "Cypher must not be handed graph-block advice for `{cypher}`: {msg}"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Dataset shapes
+    // -----------------------------------------------------------------------
+
+    /// A hand-built IR query: one stranded top-level triple beside a scoped
+    /// block. Built directly so the dataset gates can be exercised without
+    /// standing up a resolvable multi-source dataset.
+    fn stranded_query() -> fluree_db_query::ir::Query {
+        use fluree_db_query::ir::triple::{Ref, Term, TriplePattern};
+        use fluree_db_query::ir::{GraphName, Pattern, Query, QueryOutput};
+
+        let mut vars = fluree_db_query::VarRegistry::new();
+        let o = vars.get_or_insert("?o");
+        let mut query = Query::new(fluree_graph_json_ld::ParsedContext::default());
+        query.patterns = vec![
+            Pattern::Triple(TriplePattern::new(Ref::Var(o), Ref::Var(o), Term::Var(o))),
+            Pattern::Graph {
+                name: GraphName::Iri(GS_ID.into()),
+                patterns: vec![],
+            },
+        ];
+        query.output = QueryOutput::select_all(vec![o]);
+        query
+    }
+
+    fn graph_source_view_named(gs_id: &str) -> GraphDb {
+        let mut db = graph_source_view();
+        db.graph_source_id = Some(gs_id.into());
+        db
+    }
+
+    /// With several *different* sources in the default set, the refusal must
+    /// name all of them: "move it into `GRAPH <primary>`" would be advice to
+    /// silently exclude the rest.
+    #[test]
+    fn a_multi_source_dataset_refusal_names_every_source() {
+        let dataset = crate::view::DataSetDb::new()
+            .with_default(graph_source_view_named("warehouse-a:main"))
+            .with_default(graph_source_view_named("warehouse-b:main"));
+
+        let err = super::guard_dataset_graph_source_patterns(
+            &dataset,
+            &stranded_query(),
+            super::QuerySyntax::Sparql,
+        )
+        .expect_err("all defaults are graph sources, so the stranded triple is refused");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("warehouse-a:main") && msg.contains("warehouse-b:main"),
+            "every source in the default set must be named: {msg}"
+        );
+        assert!(
+            msg.contains("graph sources"),
+            "and the subject must be plural: {msg}"
+        );
+        assert!(
+            !msg.contains("drop the explicit block"),
+            "the drop-the-block escape must be withheld — it would scope the query to one \
+             source and exclude the others: {msg}"
+        );
+    }
+
+    /// A `fromNamed`-only dataset arrives with an empty default set — the shape
+    /// #1631 settled on when it stopped injecting the ledger as a default graph.
+    /// Returning `Ok` here is correct, not a gap: SPARQL §13.2 gives such a query
+    /// an empty default graph, so its top-level patterns are *supposed* to match
+    /// nothing. That empty result is the specified answer, and refusing it would
+    /// reject a conformant query — unlike the silent-empty this guard exists to
+    /// catch, which is an unroutable pattern over a source that does hold data.
+    ///
+    /// #1631 reached the same conclusion from the other side: rather than refuse
+    /// this shape it *warns* on it ("`fromNamed` without `from` leaves the
+    /// default graph empty"). Refusing here would have overridden that warning
+    /// with a 400 on a conformant query.
+    ///
+    /// Asserted where the semantics are actually decided — the dataset spec
+    /// parsed from a real `fromNamed`-only body — rather than assuming the
+    /// dataset shape it produces.
+    #[test]
+    fn a_named_only_body_leaves_the_default_graph_empty() {
+        let body = serde_json::json!({
+            "fromNamed": [GS_ID],
+            "select": ["?o"],
+            "where": [
+                {"@id": N1, EDGE_PRED: "?o"},
+                ["graph", GS_ID, {"@id": "?a", EDGE_PRED: "?c"}]
+            ]
+        });
+        let (spec, _) = crate::dataset::DatasetSpec::from_query_json(&body)
+            .expect("a fromNamed-only body parses");
+        assert!(
+            spec.default_graphs.is_empty(),
+            "fromNamed without from leaves the default graph empty (SPARQL 1.1 §13.2)"
+        );
+        assert_eq!(
+            spec.named_graphs.len(),
+            1,
+            "the source is a named graph only"
+        );
+
+        let dataset =
+            crate::view::DataSetDb::new().with_named(GS_ID, graph_source_view_named(GS_ID));
+        assert!(dataset.default.is_empty(), "which is this dataset shape");
+
+        super::guard_dataset_graph_source_patterns(
+            &dataset,
+            &stranded_query(),
+            super::QuerySyntax::JsonLd,
+        )
+        .expect("an empty default graph makes an empty result the spec answer, not a defect");
+    }
+
+    /// The same combination driven end-to-end through the real connection-query
+    /// path against a registered graph source: body → dataset spec → dataset →
+    /// guard → execution. The `where` clause deliberately mixes a stranded
+    /// top-level pattern with a `["graph", …]` block, the shape that suppresses
+    /// the auto-wrap and reaches the guard, so an accidental refusal would
+    /// surface here as an error rather than as an empty result.
+    #[tokio::test]
+    async fn a_named_only_graph_source_query_is_answered_not_refused() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let ledger = fluree.create_ledger("gsguard-src").await.unwrap();
+        let txn = serde_json::json!({
+            "@context": {"ex": "http://example.org/ns/"},
+            "insert": [{"@id": "ex:a1", "@type": "ex:Article", "ex:title": "Graph sources"}]
+        });
+        let _ledger = fluree.insert(ledger, &txn).await.unwrap().ledger;
+
+        // A BM25 source registers in the nameservice without the iceberg
+        // feature, so the dataset resolves a real graph-source view.
+        let index_query = serde_json::json!({
+            "@context": {"ex": "http://example.org/ns/"},
+            "where": [{"@id": "?x", "@type": "ex:Article"}],
+            "select": {"?x": ["@id", "ex:title"]}
+        });
+        let gs = fluree
+            .create_full_text_index(crate::Bm25CreateConfig::new(
+                "gsguard-search",
+                "gsguard-src:main",
+                index_query,
+            ))
+            .await
+            .expect("register the BM25 graph source");
+
+        let body = serde_json::json!({
+            "@context": {"ex": "http://example.org/ns/"},
+            "fromNamed": [gs.graph_source_id],
+            "select": ["?title"],
+            "where": [
+                {"@id": "?s", "ex:title": "?title"},
+                ["graph", gs.graph_source_id, {"@id": "?x", "ex:title": "?t"}]
+            ]
+        });
+        let result = fluree.query_connection(&body).await;
+        assert!(
+            result.is_ok(),
+            "a fromNamed-only query must be answered (empty, per §13.2), not refused: {:?}",
+            result.err()
+        );
+    }
+
+    /// The complement: a native member in the default set means top-level
+    /// patterns have a real index to read, so nothing is refused.
+    #[test]
+    fn a_dataset_with_a_native_member_is_not_refused() {
+        let mut native = graph_source_view();
+        native.graph_source_id = None;
+        let dataset = crate::view::DataSetDb::new()
+            .with_default(graph_source_view_named("warehouse-a:main"))
+            .with_default(native);
+
+        super::guard_dataset_graph_source_patterns(
+            &dataset,
+            &stranded_query(),
+            super::QuerySyntax::Sparql,
+        )
+        .expect("a native default graph can answer top-level patterns");
     }
 
     /// The guard is gated on the view being a graph source. A native ledger has

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -24,7 +24,8 @@ use serde_json::Value as JsonValue;
 /// in `GRAPH <gs_id> { ... }` so the R2RML provider handles them.
 ///
 /// Skips wrapping if the query already contains a top-level GRAPH pattern
-/// (the user explicitly scoped it).
+/// (the user explicitly scoped it). Whatever is left outside a `GRAPH` scope
+/// after this runs is covered by [`guard_graph_source_patterns`].
 pub(crate) fn maybe_wrap_for_graph_source(db: &GraphDb, parsed: &mut fluree_db_query::ir::Query) {
     if let Some(ref gs_id) = db.graph_source_id {
         let has_graph_pattern = parsed
@@ -38,6 +39,67 @@ pub(crate) fn maybe_wrap_for_graph_source(db: &GraphDb, parsed: &mut fluree_db_q
                 patterns: inner,
             }];
         }
+    }
+}
+
+/// Refuse the patterns a graph source cannot evaluate, on the route where the
+/// per-scope guard inside `GraphOperator` can never see them.
+///
+/// A graph-source view is a `LedgerSnapshot::genesis` — zero flakes — because
+/// its data lives behind a provider that only the `GRAPH <gs_id>` execution path
+/// consults. `maybe_wrap_for_graph_source` puts the query on that path, but it
+/// bails out for the *whole* query when the user wrote any `GRAPH` block of
+/// their own, leaving the remaining top-level patterns to read the empty native
+/// index. Property paths, shortest paths, and subqueries are the patterns the
+/// R2RML rewrite cannot lower, so out there they answer with silently-wrong
+/// results — `p+` with nothing at all, `p*`/`p?` with the zero-length identity
+/// match only — as HTTP 200. This check makes the refusal independent of the
+/// query's `GRAPH` structure.
+///
+/// Call it *after* the wrap: everything the wrap moved into the graph scope is
+/// then already covered by the rewrite guard, so a query with no `GRAPH` block
+/// of its own keeps refusing on exactly the route it refuses on today, with the
+/// same message.
+pub(crate) fn guard_graph_source_patterns(
+    db: &GraphDb,
+    parsed: &fluree_db_query::ir::Query,
+) -> Result<()> {
+    let Some(gs_id) = db.graph_source_id.as_deref() else {
+        return Ok(());
+    };
+    let unsupported = fluree_db_query::r2rml::unsupported_outside_graph_scopes(&parsed.patterns);
+    if unsupported.is_empty() {
+        return Ok(());
+    }
+    Err(ApiError::Query(
+        fluree_db_query::r2rml::unsupported_subscope_error(gs_id, &unsupported),
+    ))
+}
+
+/// [`guard_graph_source_patterns`] for a dataset query, applied through the
+/// primary view.
+///
+/// Gated on *every* default graph being a graph source. A dataset that mixes a
+/// graph source with a native ledger (`from: ["sales:main", "warehouse-gs"]`)
+/// evaluates its top-level patterns over the union of both, so a property path
+/// out there has a real index to traverse and refusing it would reject a query
+/// that works. With no native member in the union there is no such index, and
+/// the single-view reasoning applies unchanged.
+pub(crate) fn guard_dataset_graph_source_patterns(
+    dataset: &DataSetDb,
+    parsed: &fluree_db_query::ir::Query,
+) -> Result<()> {
+    if dataset.default.is_empty()
+        || dataset
+            .default
+            .iter()
+            .any(|view| view.graph_source_id.is_none())
+    {
+        return Ok(());
+    }
+    match dataset.primary() {
+        Some(primary) => guard_graph_source_patterns(primary, parsed),
+        None => Ok(()),
     }
 }
 
@@ -142,8 +204,10 @@ impl Fluree {
         };
         let parse_ms = parse_start.elapsed().as_secs_f64() * 1000.0;
 
-        // 1b. Auto-wrap for graph source context
+        // 1b. Auto-wrap for graph source context, then refuse whatever the wrap
+        // could not put on the provider's path.
         maybe_wrap_for_graph_source(db, &mut parsed);
+        guard_graph_source_patterns(db, &parsed)?;
 
         // 2. Build executable with optional reasoning override
         let plan_start = std::time::Instant::now();
@@ -209,6 +273,7 @@ impl Fluree {
         let parse_ms = parse_start.elapsed().as_secs_f64() * 1000.0;
 
         maybe_wrap_for_graph_source(db, &mut parsed);
+        guard_graph_source_patterns(db, &parsed)?;
 
         self.execute_cypher_ir(db, vars, parsed, parse_ms).await
     }
@@ -229,6 +294,7 @@ impl Fluree {
             db.policy_enforcer().map(|e| &**e),
         )?;
         maybe_wrap_for_graph_source(db, &mut parsed);
+        guard_graph_source_patterns(db, &parsed)?;
         self.execute_cypher_ir(db, vars, parsed, 0.0).await
     }
 
@@ -292,6 +358,7 @@ impl Fluree {
         }
 
         maybe_wrap_for_graph_source(db, &mut parsed);
+        guard_graph_source_patterns(db, &parsed)?;
         self.execute_cypher_ir(db, vars, parsed, 0.0).await
     }
 
@@ -384,8 +451,10 @@ impl Fluree {
             }
         };
 
-        // 1b. Auto-wrap for graph source context
+        // 1b. Auto-wrap for graph source context, then refuse whatever the wrap
+        // could not put on the provider's path.
         maybe_wrap_for_graph_source(db, &mut parsed);
+        guard_graph_source_patterns(db, &parsed)?;
 
         // 2. Build executable with optional reasoning override
         let executable = self.build_executable_for_view(db, &parsed).await?;
@@ -561,8 +630,12 @@ impl Fluree {
             }
         };
 
-        // Auto-wrap for graph source context
+        // Auto-wrap for graph source context, then refuse whatever the wrap
+        // could not put on the provider's path.
         maybe_wrap_for_graph_source(db, &mut parsed);
+        guard_graph_source_patterns(db, &parsed).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
+        })?;
 
         // Build executable with reasoning.
         //
@@ -719,8 +792,12 @@ impl Fluree {
             }
         };
 
-        // Auto-wrap for graph source context
+        // Auto-wrap for graph source context, then refuse whatever the wrap
+        // could not put on the provider's path.
         maybe_wrap_for_graph_source(db, &mut parsed);
+        guard_graph_source_patterns(db, &parsed).map_err(|e| {
+            crate::query::TrackedErrorResponse::new(400, e.to_string(), tracker.tally())
+        })?;
 
         let executable = self
             .build_executable_for_view(db, &parsed)
@@ -1573,5 +1650,221 @@ mod tests {
         let db = fluree.db_at_t("testdb:main", 1).await.unwrap();
         let result = fluree.query(&db, &query).await.unwrap();
         assert!(!result.batches.is_empty());
+    }
+}
+
+/// End-to-end routing coverage for the graph-source pattern guard.
+///
+/// The rewrite-level unit test in `fluree-db-query` (`rewrite.rs`,
+/// `non_lowered_subscopes_are_flagged_unsupported`) exercises the rewriter in
+/// isolation and would keep passing if the routing that feeds it broke — which
+/// is exactly how the `GRAPH`-block bypass survived. These drive the real query
+/// entry point against a real graph-source view instead, so the four routes a
+/// query can take to a graph source stay pinned together: with the auto-wrap,
+/// with the user's own `GRAPH` block, with both, and with neither pattern kind
+/// involved.
+#[cfg(test)]
+mod graph_source_guard_tests {
+    use crate::view::GraphDb;
+    use crate::{FlureeBuilder, QueryExecutionOptions};
+    use async_trait::async_trait;
+    use fluree_db_query::r2rml::{
+        ColumnBatchStream, R2rmlProvider, R2rmlTableProvider, ScanFilter, ScanTopK,
+    };
+    use fluree_db_r2rml::mapping::CompiledR2rmlMapping;
+    use std::sync::Arc;
+
+    const GS_ID: &str = "fs3repro:main";
+    const NS_CODE: u16 = 9_999;
+    const NS_IRI: &str = "http://fs3.example/";
+    const EDGE_PRED: &str = "http://fs3.example/vocab#edge";
+    const N1: &str = "http://fs3.example/node/n1";
+
+    /// Marker the stub errors with, so a test can prove a pattern reached the
+    /// R2RML scan layer rather than being refused on the way there.
+    const SCAN_MARKER: &str = "GSGUARD-SCAN-REACHED";
+
+    /// Reports a mapping for the graph source — all the rewrite decision needs —
+    /// and fails loudly if anything gets as far as scanning a table.
+    #[derive(Debug)]
+    struct StubProvider {
+        mapping: Arc<CompiledR2rmlMapping>,
+    }
+
+    impl StubProvider {
+        fn new() -> Self {
+            use fluree_db_r2rml::mapping::{
+                ObjectMap, PredicateMap, PredicateObjectMap, TriplesMap,
+            };
+            let tm = TriplesMap::new("#Edge", "fs3.edge")
+                .with_subject_template("http://fs3.example/node/{src}")
+                .with_predicate_object(PredicateObjectMap {
+                    predicate_map: PredicateMap::constant(EDGE_PRED),
+                    object_map: ObjectMap::column("dst"),
+                });
+            Self {
+                mapping: Arc::new(CompiledR2rmlMapping::new(vec![tm])),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl R2rmlProvider for StubProvider {
+        async fn has_r2rml_mapping(&self, _graph_source_id: &str) -> bool {
+            true
+        }
+
+        async fn compiled_mapping(
+            &self,
+            _graph_source_id: &str,
+            _as_of_t: Option<i64>,
+        ) -> fluree_db_query::Result<Arc<CompiledR2rmlMapping>> {
+            Ok(Arc::clone(&self.mapping))
+        }
+    }
+
+    #[async_trait]
+    impl R2rmlTableProvider for StubProvider {
+        async fn scan_table(
+            &self,
+            _graph_source_id: &str,
+            _table_name: &str,
+            _projection: &[String],
+            _filters: &[ScanFilter],
+            _topk: Option<&ScanTopK>,
+            _as_of_t: Option<i64>,
+        ) -> fluree_db_query::Result<ColumnBatchStream> {
+            Err(fluree_db_query::QueryError::Internal(
+                SCAN_MARKER.to_string(),
+            ))
+        }
+    }
+
+    /// The view `resolve_graph_source` hands back for a registered graph source:
+    /// a genesis (zero-flake) snapshot named for the source and tagged with its
+    /// id, with the fixture's namespace registered so IRIs encode. Built the
+    /// same way here so no nameservice registration (and no `iceberg` feature)
+    /// is needed to exercise the routing.
+    fn graph_source_view() -> GraphDb {
+        let mut snapshot = fluree_db_core::LedgerSnapshot::genesis(GS_ID);
+        snapshot
+            .insert_namespace_code(NS_CODE, NS_IRI.to_string())
+            .expect("namespace registration");
+        let state =
+            fluree_db_ledger::LedgerState::new(snapshot, fluree_db_novelty::Novelty::new(0));
+        let mut db = GraphDb::from_ledger_state(&state);
+        db.graph_source_id = Some(GS_ID.into());
+        db
+    }
+
+    /// Run `sparql` against a graph-source view through the R2RML query entry
+    /// point, returning the error message (every arm here ends in an error: a
+    /// refusal, or the stub's scan marker).
+    async fn query_err(sparql: &str) -> String {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let db = graph_source_view();
+        let stub = StubProvider::new();
+        fluree
+            .query_view_with_r2rml_options(
+                &db,
+                sparql,
+                &stub,
+                &stub,
+                QueryExecutionOptions::default(),
+            )
+            .await
+            .expect_err("every arm of this matrix ends in an error")
+            .to_string()
+    }
+
+    fn assert_refused(msg: &str, context: &str) {
+        assert!(
+            msg.contains("property path") && msg.contains("cannot be evaluated"),
+            "{context}: expected the unsupported-pattern refusal, got: {msg}"
+        );
+    }
+
+    /// The bypass. A quantifier at the top level next to the user's own `GRAPH`
+    /// block: the auto-wrap declines the whole query, so nothing routes the path
+    /// to `GraphOperator` and its guard never sees it. Before the pre-execution
+    /// check this returned HTTP 200 with zero rows.
+    #[tokio::test]
+    async fn quantifier_beside_an_explicit_graph_block_is_refused() {
+        for label in ["+", "*", "?"] {
+            let msg = query_err(&format!(
+                "SELECT ?o WHERE {{ <{N1}> <{EDGE_PRED}>{label} ?o . \
+                 GRAPH <{GS_ID}> {{ ?a <{EDGE_PRED}> ?c }} }}"
+            ))
+            .await;
+            assert_refused(&msg, &format!("`edge{label}` beside a GRAPH block"));
+        }
+    }
+
+    /// The route that already worked, unchanged: with no `GRAPH` block of its
+    /// own the query is auto-wrapped, and the rewrite guard refuses it inside
+    /// the scope. Pinned so the pre-execution check cannot quietly become the
+    /// only thing holding this up.
+    #[tokio::test]
+    async fn quantifier_with_no_graph_block_is_still_refused() {
+        for label in ["+", "*", "?"] {
+            let msg = query_err(&format!(
+                "SELECT ?o WHERE {{ <{N1}> <{EDGE_PRED}>{label} ?o }}"
+            ))
+            .await;
+            assert_refused(&msg, &format!("bare `edge{label}`"));
+        }
+    }
+
+    /// Also unchanged: a quantifier the user scoped into a `GRAPH` block itself.
+    #[tokio::test]
+    async fn quantifier_inside_an_explicit_graph_block_is_still_refused() {
+        let msg = query_err(&format!(
+            "SELECT ?o WHERE {{ GRAPH <{GS_ID}> {{ <{N1}> <{EDGE_PRED}>+ ?o }} }}"
+        ))
+        .await;
+        assert_refused(&msg, "`edge+` inside a GRAPH block");
+    }
+
+    /// No over-refusal: a fixed-length pattern in a legitimately scoped `GRAPH`
+    /// block still lowers to an R2RML scan and reaches the provider. This is the
+    /// contrast the original reporter measured, and the property the guard must
+    /// not break.
+    #[tokio::test]
+    async fn fixed_length_pattern_in_a_graph_block_still_reaches_the_provider() {
+        let msg = query_err(&format!(
+            "SELECT ?o WHERE {{ GRAPH <{GS_ID}> {{ <{N1}> <{EDGE_PRED}> ?o }} }}"
+        ))
+        .await;
+        assert!(
+            msg.contains(SCAN_MARKER),
+            "a fixed-length pattern must reach the R2RML scan, not a guard: {msg}"
+        );
+    }
+
+    /// The guard is gated on the view being a graph source. A native ledger has
+    /// a real index, so its property paths must keep executing — including on
+    /// the plain `query` path, which shares the check.
+    #[tokio::test]
+    async fn a_native_ledger_still_evaluates_property_paths() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let ledger = fluree.create_ledger("pathdb").await.unwrap();
+        let txn = serde_json::json!({
+            "insert": [
+                {"@id": "http://example.org/n1", "http://example.org/edge": {"@id": "http://example.org/n2"}},
+                {"@id": "http://example.org/n2", "http://example.org/edge": {"@id": "http://example.org/n3"}}
+            ]
+        });
+        let _ledger = fluree.update(ledger, &txn).await.unwrap().ledger;
+
+        let db = fluree.db("pathdb:main").await.unwrap();
+        let result = fluree
+            .query(
+                &db,
+                "SELECT ?o WHERE { <http://example.org/n1> <http://example.org/edge>+ ?o }",
+            )
+            .await
+            .expect("a native ledger must still evaluate `edge+`");
+        let rows: usize = result.batches.iter().map(fluree_db_query::Batch::len).sum();
+        assert_eq!(rows, 2, "`edge+` from n1 reaches n2 and n3");
     }
 }

--- a/fluree-db-api/src/view/stream_query.rs
+++ b/fluree-db-api/src/view/stream_query.rs
@@ -104,6 +104,7 @@ impl Fluree {
         };
 
         super::query::maybe_wrap_for_graph_source(db, &mut parsed);
+        super::query::guard_graph_source_patterns(db, &parsed)?;
 
         ensure_streamable(&parsed.output)?;
 
@@ -321,6 +322,7 @@ impl Fluree {
         };
 
         super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
+        super::query::guard_dataset_graph_source_patterns(dataset, &parsed)?;
         ensure_streamable(&parsed.output)?;
 
         let executable = self.build_executable_for_dataset(dataset, &parsed).await?;

--- a/fluree-db-api/src/view/stream_query.rs
+++ b/fluree-db-api/src/view/stream_query.rs
@@ -104,7 +104,11 @@ impl Fluree {
         };
 
         super::query::maybe_wrap_for_graph_source(db, &mut parsed);
-        super::query::guard_graph_source_patterns(db, &parsed)?;
+        super::query::guard_graph_source_patterns(
+            db,
+            &parsed,
+            super::query::QuerySyntax::of(&input),
+        )?;
 
         ensure_streamable(&parsed.output)?;
 
@@ -322,7 +326,11 @@ impl Fluree {
         };
 
         super::query::maybe_wrap_for_graph_source(primary, &mut parsed);
-        super::query::guard_dataset_graph_source_patterns(dataset, &parsed)?;
+        super::query::guard_dataset_graph_source_patterns(
+            dataset,
+            &parsed,
+            super::query::QuerySyntax::of(&input),
+        )?;
         ensure_streamable(&parsed.output)?;
 
         let executable = self.build_executable_for_dataset(dataset, &parsed).await?;

--- a/fluree-db-query/src/graph.rs
+++ b/fluree-db-query/src/graph.rs
@@ -312,7 +312,7 @@ impl GraphOperator {
             // empty native index and silently return no rows — fail loudly.
             if !rewrite_result.unsupported.is_empty() {
                 return Err(unsupported_subscope_error(
-                    &graph_iri,
+                    &[&graph_iri],
                     &rewrite_result.unsupported,
                 ));
             }
@@ -528,7 +528,7 @@ impl GraphOperator {
         // index — fail loudly rather than return a wrong empty result.
         if !rewrite_result.unsupported.is_empty() {
             return Err(unsupported_subscope_error(
-                &graph_iri,
+                &[&graph_iri],
                 &rewrite_result.unsupported,
             ));
         }

--- a/fluree-db-query/src/r2rml/mod.rs
+++ b/fluree-db-query/src/r2rml/mod.rs
@@ -34,7 +34,7 @@ pub use provider::{
 };
 pub use rewrite::{
     convert_triple_to_r2rml, r2rml_unsupported_pattern_error, rewrite_patterns_for_r2rml,
-    unsupported_subscope_error, R2rmlRewriteResult,
+    unsupported_outside_graph_scopes, unsupported_subscope_error, R2rmlRewriteResult,
 };
 
 /// Read an on/off environment switch that defaults to **on**. Only `0`, `false`,

--- a/fluree-db-query/src/r2rml/rewrite.rs
+++ b/fluree-db-query/src/r2rml/rewrite.rs
@@ -59,10 +59,12 @@ pub struct R2rmlRewriteResult {
 /// Build the loud-refuse error for [`R2rmlRewriteResult::unsupported`].
 ///
 /// Shared by every GRAPH execution path that consumes a rewrite result (the
-/// seeded and batched operators in `graph.rs`) so the user-facing message
-/// cannot drift between them. Kind names are deduplicated preserving first
-/// occurrence: two property paths in one scope read "property path", not
-/// "property path, property path".
+/// seeded and batched operators in `graph.rs`) and by the API-layer check that
+/// covers the same kinds *outside* a GRAPH scope
+/// ([`unsupported_outside_graph_scopes`]), so the user-facing message cannot
+/// drift between them. Kind names are deduplicated preserving first occurrence:
+/// two property paths in one scope read "property path", not "property path,
+/// property path".
 pub fn unsupported_subscope_error(graph_iri: &str, kinds: &[&str]) -> crate::error::QueryError {
     let mut unique: Vec<&str> = Vec::with_capacity(kinds.len());
     for &kind in kinds {
@@ -71,13 +73,82 @@ pub fn unsupported_subscope_error(graph_iri: &str, kinds: &[&str]) -> crate::err
         }
     }
     crate::error::QueryError::InvalidQuery(format!(
-        "R2RML graph source '{}' contains pattern(s) that cannot be evaluated over a \
-         virtual dataset (an R2RML source has no native index, so these would silently \
-         return no rows): {}. Rewrite them as basic triple patterns or move them outside \
-         the GRAPH block.",
+        "graph source '{}' contains pattern(s) that cannot be evaluated over a \
+         virtual dataset (a graph source has no native index, so these would silently \
+         return no rows): {}. Rewrite them as fixed-length triple patterns \
+         (`p`, `p/p`, …), or run them against a native ledger.",
         graph_iri,
         unique.join(", ")
     ))
+}
+
+/// The kinds of pattern a graph source cannot evaluate, collected from the
+/// patterns that sit **outside** every `GRAPH` scope.
+///
+/// [`rewrite_patterns_for_r2rml`] records the same three kinds for the patterns
+/// *inside* one graph-source scope, and `GraphOperator` refuses on them. But a
+/// query addressed to a graph source can carry them at the top level too, where
+/// no `GRAPH` scope — and so no rewrite, and no refusal — ever sees them. There
+/// they evaluate against the graph source's view, which is a zero-flake genesis
+/// snapshot, and return silently-wrong results: `p+` nothing at all, `p*`/`p?`
+/// the zero-length identity match only. The API layer calls this before
+/// execution and refuses with [`unsupported_subscope_error`], so the refusal
+/// does not depend on whether the query happens to contain a `GRAPH` block.
+///
+/// Recursion mirrors the rewriter's, descending into the containers whose
+/// bodies evaluate against this view and stopping where they do not:
+/// - `GRAPH` is its own scope — already covered by the rewrite guard;
+/// - `SERVICE` targets another ledger or endpoint, which may have a native
+///   index, so refusing on its body would reject a query that works;
+/// - the RDF-star `EdgeAnnotation`/`AnnotationTarget` bodies are left untouched
+///   here exactly as the rewriter leaves them (RDF-star over a graph source is
+///   undefined rather than confirmed silently-empty).
+pub fn unsupported_outside_graph_scopes(patterns: &[Pattern]) -> Vec<&'static str> {
+    let mut kinds = Vec::new();
+    collect_unsupported_outside_graph_scopes(patterns, &mut kinds);
+    kinds
+}
+
+fn collect_unsupported_outside_graph_scopes(patterns: &[Pattern], kinds: &mut Vec<&'static str>) {
+    for pattern in patterns {
+        match pattern {
+            // The three kinds the rewriter flags, named identically so one
+            // query reads the same whichever guard refuses it.
+            Pattern::PropertyPath(_) => kinds.push("property path"),
+            Pattern::ShortestPath(_) => kinds.push("shortest path"),
+            Pattern::Subquery(_) => kinds.push("subquery"),
+            // Containers whose bodies evaluate against this view.
+            Pattern::Optional(inner)
+            | Pattern::Minus(inner)
+            | Pattern::Exists(inner)
+            | Pattern::NotExists(inner)
+            | Pattern::DefaultGraphSource { patterns: inner } => {
+                collect_unsupported_outside_graph_scopes(inner, kinds);
+            }
+            Pattern::Union(branches) => {
+                for branch in branches {
+                    collect_unsupported_outside_graph_scopes(branch, kinds);
+                }
+            }
+            // Everything else is either a leaf, routed elsewhere, or its own
+            // scope — see the doc comment. Listed exhaustively so a new pattern
+            // variant that reads this view's index forces a decision here.
+            Pattern::Triple(_)
+            | Pattern::Filter(_)
+            | Pattern::Bind { .. }
+            | Pattern::Unwind { .. }
+            | Pattern::Values { .. }
+            | Pattern::IndexSearch(_)
+            | Pattern::VectorSearch(_)
+            | Pattern::R2rml(_)
+            | Pattern::GeoSearch(_)
+            | Pattern::S2Search(_)
+            | Pattern::Graph { .. }
+            | Pattern::Service(_)
+            | Pattern::EdgeAnnotation { .. }
+            | Pattern::AnnotationTarget { .. } => {}
+        }
+    }
 }
 
 /// The typed refusal for an R2RML graph-source query carrying `unconverted`
@@ -2668,6 +2739,58 @@ mod tests {
             "first-seen order must be preserved: {msg}"
         );
         assert!(msg.contains("gs:main"), "names the graph source: {msg}");
+    }
+
+    /// The out-of-scope scan flags the same kinds this rewriter flags inside a
+    /// scope, wherever a body evaluates against the graph source's own (empty)
+    /// index — and stops at the two scopes that are somebody else's problem: a
+    /// `GRAPH` block, which the rewrite guard already refuses, and a `SERVICE`
+    /// block, whose body runs against another ledger or endpoint that may well
+    /// have a native index.
+    #[test]
+    fn out_of_scope_scan_covers_bodies_this_view_evaluates() {
+        use crate::ir::path::{PathModifier, PropertyPathPattern};
+        use crate::ir::{GraphName, ServiceEndpoint, ServicePattern};
+
+        let path = || {
+            Pattern::PropertyPath(PropertyPathPattern::new(
+                Ref::Sid(Sid::new(100, "n1")),
+                Sid::new(100, "edge"),
+                PathModifier::OneOrMore,
+                Ref::Var(VarId(0)),
+            ))
+        };
+
+        assert_eq!(
+            unsupported_outside_graph_scopes(&[path()]),
+            vec!["property path"],
+            "a top-level path is exactly the bypass this scan exists to close"
+        );
+        assert_eq!(
+            unsupported_outside_graph_scopes(&[
+                Pattern::Optional(vec![path()]),
+                Pattern::Union(vec![vec![path()], vec![]]),
+            ]),
+            vec!["property path", "property path"],
+            "OPTIONAL and UNION bodies evaluate against this view"
+        );
+        assert!(
+            unsupported_outside_graph_scopes(&[Pattern::Graph {
+                name: GraphName::Iri("gs:main".into()),
+                patterns: vec![path()],
+            }])
+            .is_empty(),
+            "a GRAPH scope is the rewrite guard's to refuse, not this scan's"
+        );
+        assert!(
+            unsupported_outside_graph_scopes(&[Pattern::Service(ServicePattern::new(
+                false,
+                ServiceEndpoint::Iri("fluree:ledger:other:main".into()),
+                vec![path()],
+            ))])
+            .is_empty(),
+            "a SERVICE body runs elsewhere and may have a native index"
+        );
     }
 
     #[test]

--- a/fluree-db-query/src/r2rml/rewrite.rs
+++ b/fluree-db-query/src/r2rml/rewrite.rs
@@ -65,19 +65,32 @@ pub struct R2rmlRewriteResult {
 /// drift between them. Kind names are deduplicated preserving first occurrence:
 /// two property paths in one scope read "property path", not "property path,
 /// property path".
-pub fn unsupported_subscope_error(graph_iri: &str, kinds: &[&str]) -> crate::error::QueryError {
+/// `graph_iris` names every graph source the refusal covers. `GraphOperator`
+/// always has exactly one (it is refusing inside one scope); the API-layer
+/// check can be guarding a dataset whose default graphs are several *different*
+/// sources, and naming only one of them would misdescribe the query.
+pub fn unsupported_subscope_error(graph_iris: &[&str], kinds: &[&str]) -> crate::error::QueryError {
     let mut unique: Vec<&str> = Vec::with_capacity(kinds.len());
     for &kind in kinds {
         if !unique.contains(&kind) {
             unique.push(kind);
         }
     }
+    let (subject, verb) = if graph_iris.len() == 1 {
+        ("graph source", "contains")
+    } else {
+        ("graph sources", "contain")
+    };
+    let names = graph_iris
+        .iter()
+        .map(|iri| format!("'{iri}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
     crate::error::QueryError::InvalidQuery(format!(
-        "graph source '{}' contains pattern(s) that cannot be evaluated over a \
+        "{subject} {names} {verb} pattern(s) that cannot be evaluated over a \
          virtual dataset (a graph source has no native index, so these would silently \
-         return no rows): {}. Rewrite them as fixed-length triple patterns \
-         (`p`, `p/p`, …), or run them against a native ledger.",
-        graph_iri,
+         return no rows): {}. Rewrite them as fixed-length steps between nodes, or run \
+         them against a native ledger.",
         unique.join(", ")
     ))
 }
@@ -2726,8 +2739,10 @@ mod tests {
     /// order is preserved.
     #[test]
     fn unsupported_subscope_error_dedups_kinds() {
-        let err =
-            unsupported_subscope_error("gs:main", &["property path", "property path", "subquery"]);
+        let err = unsupported_subscope_error(
+            &["gs:main"],
+            &["property path", "property path", "subquery"],
+        );
         let msg = err.to_string();
         assert_eq!(
             msg.matches("property path").count(),

--- a/fluree-db-query/tests/graph_source_property_path.rs
+++ b/fluree-db-query/tests/graph_source_property_path.rs
@@ -360,7 +360,7 @@ async fn outside_a_graph_scope_the_pre_execution_scan_flags_every_quantifier() {
 /// graph source and the pattern kind.
 #[test]
 fn the_refusal_is_the_shared_unsupported_subscope_error() {
-    let err = unsupported_subscope_error(GS_ID, &["property path"]);
+    let err = unsupported_subscope_error(&[GS_ID], &["property path"]);
     assert!(
         matches!(err, fluree_db_query::QueryError::InvalidQuery(_)),
         "must be the 400-mapped variant, got: {err:?}"

--- a/fluree-db-query/tests/graph_source_property_path.rs
+++ b/fluree-db-query/tests/graph_source_property_path.rs
@@ -1,0 +1,373 @@
+//! SPARQL path quantifiers (`+`, `*`, `?`) over an Iceberg/R2RML graph source.
+//!
+//! Grown out of the triage of fluree/azure-chat#56. The reporter's graph is
+//! `n1 -edge-> n2 -edge-> n3`, queried from `n1` over a graph source. On Fluree
+//! 4.1.3/4.1.4 they measured `edge+` -> empty, `edge*` -> `{n1}`, `edge?` ->
+//! `{n1}` (identity only), while fixed-length `edge` and `edge/edge` were
+//! correct — all with HTTP 200.
+//!
+//! Three arms:
+//!
+//! * `prefix_*` reproduces the MECHANISM of the reported behavior. A
+//!   graph-source view is a `LedgerSnapshot::genesis(gs_id)` — an EMPTY native
+//!   snapshot (see `fluree-db-api/src/view/fluree_ext.rs`). `PropertyPathOperator`
+//!   reads edges only through `range_with_overlay` over that snapshot's SPOT/POST/PSOT
+//!   indexes (`fluree-db-query/src/property_path.rs`), so it sees zero edges. The
+//!   arm asserts the exact reported matrix falls out of running the path operator
+//!   against a genesis snapshot: `+` empty, `*`/`?` identity-only.
+//!
+//! * `guard_*` asserts what the engine does on the same route: the R2RML
+//!   rewrite flags a residual `Pattern::PropertyPath` as an unsupported sub-scope
+//!   (`fluree-db-query/src/r2rml/rewrite.rs`) and `GraphOperator` refuses the
+//!   query (`fluree-db-query/src/graph.rs`), instead of returning the silent
+//!   wrong answer. A fixed-length triple in the same block still lowers to an
+//!   R2RML scan and reaches the provider.
+//!
+//! * `outside_a_graph_scope_*` covers the residual the triage found: that guard
+//!   lives on the `GRAPH`-block path, so a path pattern the auto-wrap left at the
+//!   top level never reaches it. `unsupported_outside_graph_scopes` is the scan
+//!   the API layer runs before execution to refuse those; here we pin both that
+//!   it flags them and that the executor alone does not, which is why the check
+//!   has to exist at all. The end-to-end routing assertions live in
+//!   `fluree-db-api/src/view/query.rs`, where the graph-source view is built.
+
+use async_trait::async_trait;
+use fluree_db_core::{GraphDbRef, LedgerSnapshot, NoOverlay, Sid, Tracker};
+use fluree_db_query::ir::path::{PathModifier, PropertyPathPattern};
+use fluree_db_query::ir::triple::{Ref, Term, TriplePattern};
+use fluree_db_query::ir::{GraphName, Pattern, Query, QueryOutput};
+use fluree_db_query::r2rml::{
+    unsupported_outside_graph_scopes, unsupported_subscope_error, ColumnBatchStream, R2rmlProvider,
+    R2rmlTableProvider, ScanFilter, ScanTopK,
+};
+use fluree_db_query::{execute, ContextConfig, ExecutableQuery, VarRegistry};
+use fluree_db_r2rml::mapping::CompiledR2rmlMapping;
+use fluree_graph_json_ld::ParsedContext;
+use std::sync::Arc;
+
+const GS_ID: &str = "fs3repro:main";
+const NS_CODE: u16 = 9_999;
+const NS_IRI: &str = "http://fs3.example/";
+const EDGE_PRED: &str = "http://fs3.example/vocab#edge";
+const N1: &str = "http://fs3.example/node/n1";
+
+/// Marker the stub provider errors with, so a test can prove a pattern actually
+/// reached the R2RML scan layer rather than being refused during the rewrite.
+const SCAN_MARKER: &str = "AUDIT56-SCAN-REACHED";
+
+/// Minimal stub standing in for `FlureeR2rmlProvider`: it reports a mapping for
+/// the graph source (which is all the rewrite decision needs) and fails loudly
+/// with `SCAN_MARKER` if a pattern gets as far as scanning a table.
+#[derive(Debug)]
+struct StubProvider {
+    mapping: Arc<CompiledR2rmlMapping>,
+}
+
+impl StubProvider {
+    fn new() -> Self {
+        use fluree_db_r2rml::mapping::{ObjectMap, PredicateMap, PredicateObjectMap, TriplesMap};
+        let tm = TriplesMap::new("#Edge", "fs3.edge")
+            .with_subject_template("http://fs3.example/node/{src}")
+            .with_predicate_object(PredicateObjectMap {
+                predicate_map: PredicateMap::constant(EDGE_PRED),
+                object_map: ObjectMap::column("dst"),
+            });
+        Self {
+            mapping: Arc::new(CompiledR2rmlMapping::new(vec![tm])),
+        }
+    }
+}
+
+#[async_trait]
+impl R2rmlProvider for StubProvider {
+    async fn has_r2rml_mapping(&self, _graph_source_id: &str) -> bool {
+        true
+    }
+
+    async fn compiled_mapping(
+        &self,
+        _graph_source_id: &str,
+        _as_of_t: Option<i64>,
+    ) -> fluree_db_query::Result<Arc<CompiledR2rmlMapping>> {
+        Ok(Arc::clone(&self.mapping))
+    }
+}
+
+#[async_trait]
+impl R2rmlTableProvider for StubProvider {
+    async fn scan_table(
+        &self,
+        _graph_source_id: &str,
+        _table_name: &str,
+        _projection: &[String],
+        _filters: &[ScanFilter],
+        _topk: Option<&ScanTopK>,
+        _as_of_t: Option<i64>,
+    ) -> fluree_db_query::Result<ColumnBatchStream> {
+        Err(fluree_db_query::QueryError::Internal(
+            SCAN_MARKER.to_string(),
+        ))
+    }
+}
+
+/// The snapshot a graph-source-addressed query actually runs against: a genesis
+/// (zero-flake) `LedgerSnapshot` named for the graph source, with the fixture's
+/// namespace registered so IRIs encode to `Sid`s.
+fn graph_source_snapshot() -> LedgerSnapshot {
+    let mut snapshot = LedgerSnapshot::genesis(GS_ID);
+    snapshot
+        .insert_namespace_code(NS_CODE, NS_IRI.to_string())
+        .expect("namespace registration");
+    snapshot
+}
+
+fn encode(snapshot: &LedgerSnapshot, iri: &str) -> Sid {
+    snapshot
+        .encode_iri(iri)
+        .unwrap_or_else(|| panic!("{iri} should encode against the registered namespace"))
+}
+
+/// `<n1> edge{modifier} ?o` as a bare top-level pattern — the shape the path
+/// operator sees when nothing lowered it to an R2RML scan.
+fn path_query(snapshot: &LedgerSnapshot, modifier: PathModifier) -> (VarRegistry, Query) {
+    let mut vars = VarRegistry::new();
+    let o = vars.get_or_insert("?o");
+    let pattern = Pattern::PropertyPath(PropertyPathPattern::new(
+        Ref::Sid(encode(snapshot, N1)),
+        encode(snapshot, EDGE_PRED),
+        modifier,
+        Ref::Var(o),
+    ));
+    let mut query = Query::new(ParsedContext::default());
+    query.patterns = vec![pattern];
+    query.output = QueryOutput::select_all(vec![o]);
+    (vars, query)
+}
+
+/// Wrap `inner` in `GRAPH <fs3repro:main> { … }`, exactly as
+/// `maybe_wrap_for_graph_source` does for a query addressed to a graph source
+/// (`fluree-db-api/src/view/query.rs`).
+fn wrap_in_graph(query: &mut Query) {
+    let inner = std::mem::take(&mut query.patterns);
+    query.patterns = vec![Pattern::Graph {
+        name: GraphName::Iri(GS_ID.into()),
+        patterns: inner,
+    }];
+}
+
+async fn run(
+    snapshot: &LedgerSnapshot,
+    vars: &VarRegistry,
+    query: Query,
+    provider: Option<&StubProvider>,
+) -> fluree_db_query::Result<usize> {
+    let tracker = Tracker::disabled();
+    let executable = ExecutableQuery::simple(query);
+    let config = ContextConfig {
+        tracker: Some(&tracker),
+        r2rml: provider.map(|p| (p as &dyn R2rmlProvider, p as &dyn R2rmlTableProvider)),
+        ..Default::default()
+    };
+    let batches = execute(
+        GraphDbRef::new(snapshot, 0, &NoOverlay, 0),
+        vars,
+        &executable,
+        config,
+    )
+    .await?;
+    Ok(batches.iter().map(fluree_db_query::Batch::len).sum())
+}
+
+// ---------------------------------------------------------------------------
+// Arm 1 — the reported (pre-fix) behavior falls out of the empty genesis snapshot
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn prefix_plus_is_empty_over_a_graph_source_snapshot() {
+    let snapshot = graph_source_snapshot();
+    let (vars, query) = path_query(&snapshot, PathModifier::OneOrMore);
+    let rows = run(&snapshot, &vars, query, None)
+        .await
+        .expect("path over a genesis snapshot executes without error");
+    assert_eq!(
+        rows, 0,
+        "reported behavior: `edge+` returns NOTHING over a graph source \
+         (expected {{n2, n3}} per SPARQL 1.1 §9.1)"
+    );
+}
+
+#[tokio::test]
+async fn prefix_star_is_identity_only_over_a_graph_source_snapshot() {
+    let snapshot = graph_source_snapshot();
+    let (vars, query) = path_query(&snapshot, PathModifier::ZeroOrMore);
+    let rows = run(&snapshot, &vars, query, None)
+        .await
+        .expect("path over a genesis snapshot executes without error");
+    assert_eq!(
+        rows, 1,
+        "reported behavior: `edge*` returns ONLY the zero-length identity match \
+         (expected {{n1, n2, n3}} per SPARQL 1.1 §9.1)"
+    );
+}
+
+#[tokio::test]
+async fn prefix_question_is_identity_only_over_a_graph_source_snapshot() {
+    let snapshot = graph_source_snapshot();
+    let (vars, query) = path_query(&snapshot, PathModifier::ZeroOrOne);
+    let rows = run(&snapshot, &vars, query, None)
+        .await
+        .expect("path over a genesis snapshot executes without error");
+    assert_eq!(
+        rows, 1,
+        "reported behavior: `edge?` returns ONLY the zero-length identity match \
+         (expected {{n1, n2}} per SPARQL 1.1 §9.1)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Arm 2 — origin/main refuses the same query instead of answering it wrongly
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn guard_refuses_every_quantifier_over_an_r2rml_graph_source() {
+    let snapshot = graph_source_snapshot();
+    let provider = StubProvider::new();
+
+    for (label, modifier) in [
+        ("edge+", PathModifier::OneOrMore),
+        ("edge*", PathModifier::ZeroOrMore),
+        ("edge?", PathModifier::ZeroOrOne),
+    ] {
+        let (vars, mut query) = path_query(&snapshot, modifier);
+        wrap_in_graph(&mut query);
+        let err = run(&snapshot, &vars, query, Some(&provider))
+            .await
+            .expect_err(&format!(
+                "{label} over an R2RML graph source must be REFUSED, not answered"
+            ));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("property path") && msg.contains("cannot be evaluated"),
+            "{label}: expected the unsupported-sub-scope refusal, got: {msg}"
+        );
+    }
+}
+
+/// The contrast the reporter observed: a fixed-length pattern in the same block
+/// is NOT refused — it lowers to an R2RML scan and reaches the provider (here,
+/// the stub's `SCAN_MARKER`). So the guard is specific to quantified paths.
+#[tokio::test]
+async fn guard_does_not_refuse_a_fixed_length_pattern() {
+    let snapshot = graph_source_snapshot();
+    let provider = StubProvider::new();
+
+    let mut vars = VarRegistry::new();
+    let o = vars.get_or_insert("?o");
+    let mut query = Query::new(ParsedContext::default());
+    query.patterns = vec![Pattern::Triple(TriplePattern::new(
+        Ref::Sid(encode(&snapshot, N1)),
+        Ref::Sid(encode(&snapshot, EDGE_PRED)),
+        Term::Var(o),
+    ))];
+    query.output = QueryOutput::select_all(vec![o]);
+    wrap_in_graph(&mut query);
+
+    let err = run(&snapshot, &vars, query, Some(&provider))
+        .await
+        .expect_err("the stub provider fails the scan on purpose");
+    let msg = err.to_string();
+    assert!(
+        msg.contains(SCAN_MARKER),
+        "a fixed-length pattern must reach the R2RML scan (not the path guard), got: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Arm 3 — the same pattern OUTSIDE a GRAPH scope, which that guard cannot see
+// ---------------------------------------------------------------------------
+
+/// The mixed shape: a top-level quantifier next to the user's own `GRAPH` block.
+/// `maybe_wrap_for_graph_source` skips the auto-wrap for the whole query once any
+/// `GRAPH` block is present, so the path stays at the top level — outside every
+/// scope the rewrite guard inspects.
+fn mixed_shape(snapshot: &LedgerSnapshot, modifier: PathModifier) -> (VarRegistry, Query) {
+    let (mut vars, mut query) = path_query(snapshot, modifier);
+    let a = vars.get_or_insert("?a");
+    let c = vars.get_or_insert("?c");
+    query.patterns.push(Pattern::Graph {
+        name: GraphName::Iri(GS_ID.into()),
+        patterns: vec![Pattern::Triple(TriplePattern::new(
+            Ref::Var(a),
+            Ref::Sid(encode(snapshot, EDGE_PRED)),
+            Term::Var(c),
+        ))],
+    });
+    (vars, query)
+}
+
+/// Executing the mixed shape does NOT refuse: the path is outside the `GRAPH`
+/// block, so no rewrite ever inspects it and it reads the empty genesis index
+/// instead. It succeeds with the reporter's wrong answer — and it never even
+/// reaches the R2RML scan, because the empty path result leaves the correlated
+/// `GRAPH` block with no parent row to scan for. This is the bypass, and the
+/// reason the check has to run before execution rather than as another guard
+/// inside `GraphOperator`.
+#[tokio::test]
+async fn outside_a_graph_scope_the_executor_guard_never_fires() {
+    let snapshot = graph_source_snapshot();
+    let provider = StubProvider::new();
+    let (vars, query) = mixed_shape(&snapshot, PathModifier::OneOrMore);
+
+    let rows = run(&snapshot, &vars, query, Some(&provider))
+        .await
+        .expect("the mixed shape is answered, not refused — that is the bug");
+    assert_eq!(
+        rows, 0,
+        "`edge+` beside a GRAPH block still returns the silent-empty wrong answer"
+    );
+}
+
+/// What the API layer runs before execution to close that bypass: every
+/// quantifier at the top level is flagged, under the same kind name the rewrite
+/// guard uses, whether or not the query also carries a `GRAPH` block.
+#[tokio::test]
+async fn outside_a_graph_scope_the_pre_execution_scan_flags_every_quantifier() {
+    let snapshot = graph_source_snapshot();
+
+    for (label, modifier) in [
+        ("edge+", PathModifier::OneOrMore),
+        ("edge*", PathModifier::ZeroOrMore),
+        ("edge?", PathModifier::ZeroOrOne),
+    ] {
+        let (_, mixed) = mixed_shape(&snapshot, modifier);
+        assert_eq!(
+            unsupported_outside_graph_scopes(&mixed.patterns),
+            vec!["property path"],
+            "{label} beside a GRAPH block must be flagged"
+        );
+
+        let (_, bare) = path_query(&snapshot, modifier);
+        assert_eq!(
+            unsupported_outside_graph_scopes(&bare.patterns),
+            vec!["property path"],
+            "{label} alone must be flagged the same way"
+        );
+    }
+}
+
+/// The refusal the API layer raises from that scan is the same
+/// `QueryError::InvalidQuery` (HTTP 400) the rewrite guard raises, naming the
+/// graph source and the pattern kind.
+#[test]
+fn the_refusal_is_the_shared_unsupported_subscope_error() {
+    let err = unsupported_subscope_error(GS_ID, &["property path"]);
+    assert!(
+        matches!(err, fluree_db_query::QueryError::InvalidQuery(_)),
+        "must be the 400-mapped variant, got: {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains(GS_ID) && msg.contains("property path"),
+        "names the graph source and the kind: {msg}"
+    );
+}


### PR DESCRIPTION
Non-lowerable patterns over a graph source (property-path quantifiers, `shortestPath`, subqueries) are refused with a 400 since #1507 — but the guard lived inside the `GRAPH`-scope rewrite, and `maybe_wrap_for_graph_source` skips the auto-wrap for the whole query once it contains any explicit `GRAPH` block. A query mixing a top-level quantifier with a `GRAPH` block therefore left that path reading the graph source's genesis (zero-flake) snapshot and answered HTTP 200 with nothing. The check now also runs after the wrap, over whatever remains outside every `GRAPH` scope, raising the same typed refusal.

The same bail-out strands ordinary top-level triples, which are lowerable in principle but not lowered on that plan — nothing routes them to the provider, so they read the empty genesis index and zero the whole conjunction. Those are now refused too, scoped to conjunctive top-level position where an empty match provably zeroes the result. `OPTIONAL`/`MINUS`/`UNION`/`EXISTS` bodies are deliberately left alone — they degrade rather than zero, and a `UNION` branch can carry a nested `GRAPH` block that routes and contributes real rows, so refusing there would reject queries that answer today; tests pin those exclusions so the guard doesn't widen casually. Dataset queries are guarded only when every default graph is a graph source, since a native member gives a top-level pattern a real index.

Also documents the limitation user-facing for the first time (graph-sources overview + r2rml/iceberg pages, and a scoping note in graph-crawl.md, which promoted property paths for recursive traversal without saying they're native-ledger-only). Tests drive the real query entry point against a graph-source view — the pre-existing rewrite unit test passes whether or not routing reaches it, which is how the bypass survived.
