### PR TITLE
forward the query prologue to remote service sub-queries

### DIFF
--- a/fluree-db-api/src/remote_service.rs
+++ b/fluree-db-api/src/remote_service.rs
@@ -154,9 +154,12 @@ impl RemoteServiceExecutor for HttpRemoteService {
     }
 }
 
-/// Mock remote executor for testing — returns pre-programmed SPARQL Results JSON responses.
+/// Mock remote executor for testing — returns pre-programmed SPARQL Results JSON
+/// responses, and records the SPARQL text it was asked to execute so a test can
+/// assert on the query the engine actually ships.
 pub struct MockRemoteService {
     responses: std::sync::Mutex<HashMap<String, serde_json::Value>>,
+    last_sparql: std::sync::Mutex<Option<String>>,
 }
 
 impl fmt::Debug for MockRemoteService {
@@ -175,7 +178,16 @@ impl MockRemoteService {
     pub fn new() -> Self {
         Self {
             responses: std::sync::Mutex::new(HashMap::new()),
+            last_sparql: std::sync::Mutex::new(None),
         }
+    }
+
+    /// The SPARQL text of the most recent `execute_remote_sparql` call, if any.
+    ///
+    /// Recorded before the canned-response lookup, so it is available even when
+    /// the call goes on to fail.
+    pub fn last_sparql(&self) -> Option<String> {
+        self.last_sparql.lock().unwrap().clone()
     }
 
     /// Register a canned SPARQL Results JSON response for a given connection+ledger.
@@ -191,9 +203,11 @@ impl RemoteServiceExecutor for MockRemoteService {
         &self,
         connection_name: &str,
         ledger: &str,
-        _sparql: &str,
+        sparql: &str,
     ) -> fluree_db_query::error::Result<RemoteQueryResult> {
         use fluree_db_query::error::QueryError;
+
+        *self.last_sparql.lock().unwrap() = Some(sparql.to_string());
 
         let key = format!("{connection_name}/{ledger}");
         let guard = self.responses.lock().unwrap();

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -5417,6 +5417,63 @@ async fn sparql_service_remote_returns_mock_data() {
     );
 }
 
+/// End to end: the query the engine ships to a remote SERVICE endpoint carries
+/// the parent query's prologue, so a prefixed name in the SERVICE body means the
+/// same thing there as here. Without it the remote fails with
+/// `Undefined prefix 'ex'` (the local-only lowering tests in
+/// `fluree-db-sparql::lower` cover both failure modes in detail; this one pins
+/// the executor call site).
+#[tokio::test]
+async fn sparql_service_remote_query_carries_query_prologue() {
+    assert_index_defaults();
+    let mut fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people(&fluree, "people:main").await;
+
+    let mock = Arc::new(fluree_db_api::remote_service::MockRemoteService::new());
+    mock.register_response(
+        "acme",
+        "customers:main",
+        json!({
+            "head": {"vars": ["name"]},
+            "results": {"bindings": [{"name": {"type": "literal", "value": "Alice"}}]}
+        }),
+    );
+    fluree.set_remote_service(mock.clone());
+
+    let query = r"
+        PREFIX ex: <http://example.org/>
+        BASE <http://base.example/>
+        SELECT ?name
+        WHERE {
+          SERVICE <fluree:remote:acme/customers:main> {
+            ?s ex:name ?name .
+          }
+        }
+    ";
+    support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("Remote SERVICE should succeed with mock");
+
+    let sent = mock.last_sparql().expect("mock should have been called");
+    assert!(
+        sent.contains("PREFIX ex: <http://example.org/>"),
+        "shipped sub-query must declare ex:, got: {sent}"
+    );
+    assert!(
+        sent.contains("BASE <http://base.example/>"),
+        "shipped sub-query must declare the base, got: {sent}"
+    );
+    assert!(
+        sent.contains("ex:name"),
+        "body must ship verbatim, got: {sent}"
+    );
+    // The prologue has to precede the query form to be legal SPARQL.
+    assert!(
+        sent.find("PREFIX ex:") < sent.find("SELECT"),
+        "prologue must precede SELECT, got: {sent}"
+    );
+}
+
 #[tokio::test]
 async fn sparql_service_remote_unknown_connection_errors() {
     assert_index_defaults();

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -4648,6 +4648,7 @@ mod tests {
                 patterns: vec![Pattern::Triple(make_pattern(VarId(10), "q", VarId(11)))],
             }],
             source_body: None,
+            source_prologue: None,
         })];
 
         let strategy = choose_exists_strategy(&outer_schema, &inner);
@@ -4733,6 +4734,7 @@ mod tests {
                 },
             ],
             source_body: None,
+            source_prologue: None,
         })];
 
         let strategy = choose_exists_strategy(&outer_schema, &inner);

--- a/fluree-db-query/src/ir/pattern.rs
+++ b/fluree-db-query/src/ir/pattern.rs
@@ -250,6 +250,21 @@ pub struct ServicePattern {
     /// Used by `ServiceOperator` to send the body verbatim to remote endpoints
     /// without needing an IR-to-SPARQL serializer.
     pub source_body: Option<Arc<str>>,
+    /// The parent query's prologue, re-rendered as SPARQL, to prepend to the
+    /// outgoing sub-query.
+    ///
+    /// Because `source_body` is a verbatim slice of the SERVICE block, any
+    /// prefixed name or relative IRI in it is only meaningful under the parent
+    /// query's `PREFIX` / `BASE` declarations — which live outside that slice.
+    /// Shipping the body without them changes what the query means: a prefixed
+    /// name fails at the remote with "Undefined prefix", and a relative IRI
+    /// silently resolves against a different base and matches a different term.
+    ///
+    /// Rendered from the lowerer's already-resolved prefix map rather than
+    /// sliced out of the source, so relative `PREFIX` IRIs arrive base-resolved
+    /// and no literal in the body is ever rewritten. Empty string when the query
+    /// declared no prologue; `None` for JSON-LD originated queries.
+    pub source_prologue: Option<Arc<str>>,
 }
 
 impl ServicePattern {
@@ -260,22 +275,43 @@ impl ServicePattern {
             endpoint,
             patterns,
             source_body: None,
+            source_prologue: None,
         }
     }
 
-    /// Create a new SERVICE pattern with captured source body text
+    /// Create a new SERVICE pattern with captured source body text and the
+    /// prologue that body's prefixed names and relative IRIs resolve under.
+    ///
+    /// The two are captured together because the body is only interpretable
+    /// under that prologue — see [`source_prologue`](Self::source_prologue).
     pub fn with_source_body(
         silent: bool,
         endpoint: ServiceEndpoint,
         patterns: Vec<Pattern>,
         source_body: Arc<str>,
+        source_prologue: Arc<str>,
     ) -> Self {
         Self {
             silent,
             endpoint,
             patterns,
             source_body: Some(source_body),
+            source_prologue: Some(source_prologue),
         }
+    }
+
+    /// The complete SPARQL query text to send to a remote endpoint for this
+    /// SERVICE block, or `None` when no source body was captured.
+    ///
+    /// Prologue first, so the body's prefixed names and relative IRIs resolve
+    /// remotely to exactly the IRIs they resolve to locally. The body is wrapped
+    /// in braces unconditionally: `parse_group_graph_pattern` unwraps a
+    /// single-pattern group, so the slice may or may not carry its own, and
+    /// double braces are legal SPARQL.
+    pub fn remote_query_text(&self) -> Option<String> {
+        let body = self.source_body.as_deref()?;
+        let prologue = self.source_prologue.as_deref().unwrap_or("");
+        Some(format!("{prologue}SELECT * WHERE {{ {body} }}"))
     }
 
     /// Variables this service pattern adds to the row's binding set: the

--- a/fluree-db-query/src/service.rs
+++ b/fluree-db-query/src/service.rs
@@ -284,18 +284,15 @@ impl ServiceOperator {
             ))
         })?;
 
-        let source_body = self.service.source_body.as_deref().ok_or_else(|| {
+        // Build the complete SPARQL query from the captured body, prefixed by the
+        // parent query's prologue so prefixed names and relative IRIs in the body
+        // mean the same thing remotely as they do locally.
+        let sparql = self.service.remote_query_text().ok_or_else(|| {
             QueryError::InvalidQuery(
                 "Remote SERVICE requires SPARQL source text (not available for JSON-LD queries)"
                     .into(),
             )
         })?;
-
-        // Build a complete SPARQL query from the captured body.
-        // The source_body may or may not include braces depending on whether
-        // parse_group_graph_pattern unwrapped a single-pattern group. Always
-        // wrap in braces to ensure valid SPARQL (double-braces are legal).
-        let sparql = format!("SELECT * WHERE {{ {source_body} }}");
 
         let result = match executor
             .execute_remote_sparql(connection_name, ledger, &sparql)

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -739,22 +739,72 @@ mod tests {
     // against a different base and matched a different predicate.
     // ------------------------------------------------------------------
 
-    /// Lower `sparql` and return its single SERVICE pattern.
-    fn lower_one_service(sparql: &str) -> fluree_db_query::ir::ServicePattern {
+    /// Collect every SERVICE pattern reachable from `patterns`, at any depth.
+    ///
+    /// Walks the nesting containers, not just the top level: the prologue lives
+    /// on `LoweringContext` so it *should* reach a nested SERVICE identically —
+    /// but "should" is what let the original bug survive, since the body slice
+    /// was captured correctly in every position too. Ordered outermost-first,
+    /// then in pattern order, so a two-SERVICE query has a stable [0]/[1].
+    fn collect_services(patterns: &[Pattern]) -> Vec<fluree_db_query::ir::ServicePattern> {
+        let mut found = Vec::new();
+        for p in patterns {
+            match p {
+                Pattern::Service(s) => {
+                    found.push(s.clone());
+                    found.extend(collect_services(&s.patterns));
+                }
+                Pattern::Optional(inner)
+                | Pattern::Minus(inner)
+                | Pattern::Exists(inner)
+                | Pattern::NotExists(inner)
+                | Pattern::Graph {
+                    patterns: inner, ..
+                } => found.extend(collect_services(inner)),
+                Pattern::Union(branches) => {
+                    for branch in branches {
+                        found.extend(collect_services(branch));
+                    }
+                }
+                Pattern::Subquery(sub) => found.extend(collect_services(&sub.patterns)),
+                _ => {}
+            }
+        }
+        found
+    }
+
+    /// Lower `sparql` and return every SERVICE pattern in it, at any depth.
+    fn lower_services(sparql: &str) -> Vec<fluree_db_query::ir::ServicePattern> {
         let ast = parse_sparql(sparql).ast.expect("parse");
         let mut vars = VarRegistry::new();
         let query = lower_sparql_with_source(&ast, &test_encoder(), &mut vars, Some(sparql))
             .expect("lower");
-        let mut services: Vec<_> = query
-            .patterns
-            .iter()
-            .filter_map(|p| match p {
-                Pattern::Service(s) => Some(s.clone()),
-                _ => None,
-            })
-            .collect();
+        collect_services(&query.patterns)
+    }
+
+    /// Lower `sparql` and return its single SERVICE pattern (at any depth).
+    fn lower_one_service(sparql: &str) -> fluree_db_query::ir::ServicePattern {
+        let mut services = lower_services(sparql);
         assert_eq!(services.len(), 1, "expected exactly one SERVICE pattern");
         services.pop().unwrap()
+    }
+
+    /// Assert a SERVICE ships a sub-query whose body resolves to `expected`
+    /// predicates and that carries the prologue those names need.
+    fn assert_prologue_reaches(
+        service: &fluree_db_query::ir::ServicePattern,
+        expected: &[Ref],
+        what: &str,
+    ) {
+        let sent = service
+            .remote_query_text()
+            .unwrap_or_else(|| panic!("{what}: no remote query text"));
+        assert_eq!(
+            predicates_of(&sent),
+            predicate_refs(&service.patterns),
+            "{what}: remote must resolve the body to the same predicates we do"
+        );
+        assert_eq!(predicates_of(&sent), expected, "{what}: {sent}");
     }
 
     /// The predicate `Ref`s of every triple in a pattern list, in order.
@@ -853,6 +903,91 @@ mod tests {
             sent.contains("\"ex:p is not a curie\""),
             "literal text must survive verbatim: {sent}"
         );
+    }
+
+    /// `SERVICE SILENT` is the shape that converts the loud remote failure into a
+    /// quiet one — a dropped prologue there yields an empty result instead of an
+    /// error, so it is the position where the bug is *least* visible and most
+    /// worth pinning.
+    #[test]
+    fn remote_service_silent_query_forwards_prologue() {
+        let service = lower_one_service(
+            "PREFIX ex: <http://example.org/>\n\
+             SELECT * WHERE { \
+             SERVICE SILENT <fluree:remote:conn/db:main> { ?s ex:p ?o } }",
+        );
+        assert!(service.silent, "expected SERVICE SILENT");
+        assert_prologue_reaches(&service, &[Ref::Sid(Sid::new(100, "p"))], "SERVICE SILENT");
+    }
+
+    /// A SERVICE nested inside OPTIONAL / UNION / a sub-SELECT gets the same
+    /// prologue: it comes off the lowering context, not off the position.
+    #[test]
+    fn nested_remote_service_query_forwards_prologue() {
+        let cases = [
+            (
+                "OPTIONAL",
+                "PREFIX ex: <http://example.org/>\n\
+                 SELECT * WHERE { ?s ex:local ?x . \
+                 OPTIONAL { SERVICE <fluree:remote:conn/db:main> { ?s ex:p ?o } } }",
+            ),
+            (
+                "UNION",
+                "PREFIX ex: <http://example.org/>\n\
+                 SELECT * WHERE { { ?s ex:local ?x } UNION \
+                 { SERVICE <fluree:remote:conn/db:main> { ?s ex:p ?o } } }",
+            ),
+            (
+                "sub-SELECT",
+                "PREFIX ex: <http://example.org/>\n\
+                 SELECT * WHERE { { SELECT ?s ?o WHERE { \
+                 SERVICE <fluree:remote:conn/db:main> { ?s ex:p ?o } } } }",
+            ),
+            (
+                "GRAPH",
+                "PREFIX ex: <http://example.org/>\n\
+                 SELECT * WHERE { GRAPH <http://example.org/g> { \
+                 SERVICE <fluree:remote:conn/db:main> { ?s ex:p ?o } } }",
+            ),
+        ];
+        for (label, src) in cases {
+            let service = lower_one_service(src);
+            assert_prologue_reaches(&service, &[Ref::Sid(Sid::new(100, "p"))], label);
+        }
+    }
+
+    /// Two SERVICE clauses in one query: both ship, and both carry the prologue.
+    #[test]
+    fn multiple_remote_services_each_forward_prologue() {
+        let services = lower_services(
+            "PREFIX ex: <http://example.org/>\n\
+             PREFIX other: <http://other.example/>\n\
+             SELECT * WHERE { \
+             SERVICE <fluree:remote:conn/a:main> { ?s ex:p ?o } . \
+             SERVICE <fluree:remote:conn/b:main> { ?o other:q ?z } }",
+        );
+        assert_eq!(services.len(), 2, "expected two SERVICE patterns");
+        assert_prologue_reaches(
+            &services[0],
+            &[Ref::Sid(Sid::new(100, "p"))],
+            "first SERVICE",
+        );
+        // `other:` resolves through a namespace the test encoder does not know,
+        // so it lands in the overflow/unregistered namespace — what matters is
+        // that BOTH sub-queries resolve identically to their local lowering.
+        assert_prologue_reaches(
+            &services[1],
+            &predicate_refs(&services[1].patterns),
+            "second SERVICE",
+        );
+        for (i, s) in services.iter().enumerate() {
+            let sent = s.remote_query_text().unwrap();
+            assert!(
+                sent.contains("PREFIX ex: <http://example.org/>")
+                    && sent.contains("PREFIX other: <http://other.example/>"),
+                "SERVICE {i} must carry the full prologue: {sent}"
+            );
+        }
     }
 
     /// A query with no prologue ships exactly what it shipped before: the fix

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -622,6 +622,40 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
         }
     }
 
+    /// Re-render the query's prologue as SPARQL declaration text, for prepending
+    /// to a remote SERVICE sub-query (see `ServicePattern::source_prologue`).
+    ///
+    /// Rendered from the resolved environment, not sliced from the source, which
+    /// buys three things: a relative `PREFIX` IRI arrives already resolved against
+    /// `BASE` (`prologue_environment` does that), the body's own bytes are never
+    /// touched so a literal that merely *looks* like a CURIE is safe, and the
+    /// output is independent of how the author spaced or cased the original.
+    ///
+    /// Prefixes are emitted in sorted order so the outgoing query text is
+    /// deterministic — `self.prefixes` is a `HashMap`. Every declared prefix is
+    /// forwarded, not just the ones the body uses: an unused `PREFIX` is legal
+    /// SPARQL, and deciding "used" would mean parsing the body slice again.
+    ///
+    /// Returns an empty string when the query declared no prologue.
+    fn render_prologue_sparql(&self) -> String {
+        let mut out = String::new();
+        if let Some(base) = &self.base {
+            out.push_str("BASE <");
+            out.push_str(base);
+            out.push_str(">\n");
+        }
+        let mut prefixes: Vec<(&Arc<str>, &Arc<str>)> = self.prefixes.iter().collect();
+        prefixes.sort_by(|(a, _), (b, _)| a.as_ref().cmp(b.as_ref()));
+        for (prefix, iri) in prefixes {
+            out.push_str("PREFIX ");
+            out.push_str(prefix);
+            out.push_str(": <");
+            out.push_str(iri);
+            out.push_str(">\n");
+        }
+        out
+    }
+
     /// Build a JSON-LD context object from the SPARQL prologue.
     fn build_jsonld_context_value(&self) -> serde_json::Value {
         use serde_json::{Map, Value as JsonValue};
@@ -656,6 +690,7 @@ impl<'a, E: IriEncoder> LoweringContext<'a, E> {
 mod tests {
     use super::*;
     use crate::parse::parse_sparql;
+    use fluree_db_core::Sid;
     use fluree_db_query::ir::triple::{Ref, Term};
     use fluree_db_query::ir::{AggregateFn, AggregateSpec, InputSemantics};
     use fluree_db_query::ir::{Expression, Grouping, PathModifier, Pattern};
@@ -692,6 +727,168 @@ mod tests {
         encoder.add_namespace("http://schema.org/", 101);
         encoder.add_namespace("http://xmlns.com/foaf/0.1/", 102);
         encoder
+    }
+
+    // ------------------------------------------------------------------
+    // Remote SERVICE prologue forwarding.
+    //
+    // `ServicePattern::source_body` is a verbatim slice of the SERVICE block, so
+    // it stops short of the query's PREFIX / BASE declarations. Shipping it bare
+    // changed what the query meant at the remote — loudly for a prefixed name
+    // ("Undefined prefix"), and silently for a relative IRI, which resolved
+    // against a different base and matched a different predicate.
+    // ------------------------------------------------------------------
+
+    /// Lower `sparql` and return its single SERVICE pattern.
+    fn lower_one_service(sparql: &str) -> fluree_db_query::ir::ServicePattern {
+        let ast = parse_sparql(sparql).ast.expect("parse");
+        let mut vars = VarRegistry::new();
+        let query = lower_sparql_with_source(&ast, &test_encoder(), &mut vars, Some(sparql))
+            .expect("lower");
+        let mut services: Vec<_> = query
+            .patterns
+            .iter()
+            .filter_map(|p| match p {
+                Pattern::Service(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(services.len(), 1, "expected exactly one SERVICE pattern");
+        services.pop().unwrap()
+    }
+
+    /// The predicate `Ref`s of every triple in a pattern list, in order.
+    fn predicate_refs(patterns: &[Pattern]) -> Vec<Ref> {
+        patterns
+            .iter()
+            .filter_map(|p| match p {
+                Pattern::Triple(t) => Some(t.p.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Lower a standalone query and return its triple predicates.
+    fn predicates_of(sparql: &str) -> Vec<Ref> {
+        let ast = parse_sparql(sparql).ast.expect("remote parse");
+        let mut vars = VarRegistry::new();
+        let q = lower_sparql_with_source(&ast, &test_encoder(), &mut vars, Some(sparql))
+            .expect("remote lower");
+        predicate_refs(&q.patterns)
+    }
+
+    /// A prefixed name in a SERVICE body must arrive at the remote with the
+    /// declaration that defines it. Without the prologue the remote rejects the
+    /// sub-query outright: `Undefined prefix 'ex'`.
+    #[test]
+    fn remote_service_query_forwards_prefix_declarations() {
+        let service = lower_one_service(
+            "PREFIX ex: <http://example.org/>\n\
+             SELECT * WHERE { ?s ex:local ?o . \
+             SERVICE <fluree:remote:conn/db:main> { ?s ex:p ?o . ?o ex:q \"x\" } }",
+        );
+        let sent = service.remote_query_text().expect("remote query text");
+
+        // Meaning first: the remote must be able to lower what we send, and must
+        // land on the same predicates we did. This is the loud failure mode —
+        // without the prologue `predicates_of` panics with `Undefined prefix
+        // 'ex'` (the LOWERER rejects it; the parser accepts it silently).
+        assert_eq!(
+            predicates_of(&sent),
+            predicate_refs(&service.patterns),
+            "remote must resolve the body to the same predicates we do"
+        );
+        assert!(
+            sent.contains("PREFIX ex: <http://example.org/>"),
+            "prologue must be forwarded: {sent}"
+        );
+        // ...and those are real encoded SIDs, not an accidental both-sides-broken
+        // match: `ex:` maps to namespace 100 in `test_encoder`.
+        assert_eq!(
+            predicates_of(&sent),
+            vec![Ref::Sid(Sid::new(100, "p")), Ref::Sid(Sid::new(100, "q"))]
+        );
+    }
+
+    /// The silent half: a relative IRI resolves against the parent's BASE. With
+    /// the prologue dropped it fell back to the empty namespace (code 0) — no
+    /// error, just a different predicate and therefore wrong results.
+    #[test]
+    fn remote_service_query_forwards_base_for_relative_iris() {
+        let service = lower_one_service(
+            "BASE <http://example.org/>\n\
+             SELECT * WHERE { ?s <local> ?o . \
+             SERVICE <fluree:remote:conn/db:main> { ?s <p> ?o } }",
+        );
+        let sent = service.remote_query_text().expect("remote query text");
+
+        // Meaning first. This is the SILENT failure mode: without BASE the remote
+        // still lowers cleanly, but `<p>` lands in namespace 0 (the empty
+        // namespace) instead of 100 (`http://example.org/`) — a different
+        // predicate, no error, wrong results.
+        assert_eq!(
+            predicates_of(&sent),
+            predicate_refs(&service.patterns),
+            "remote must resolve <p> against the same base we do"
+        );
+        assert_eq!(predicates_of(&sent), vec![Ref::Sid(Sid::new(100, "p"))]);
+        assert!(
+            sent.contains("BASE <http://example.org/>"),
+            "BASE must be forwarded: {sent}"
+        );
+    }
+
+    /// Why the fix forwards declarations instead of rewriting the body: the body
+    /// is shipped byte-for-byte, so a literal whose *text* looks like a CURIE or
+    /// a relative IRI is untouched. A naive string expansion would corrupt these.
+    #[test]
+    fn remote_service_query_does_not_rewrite_literals() {
+        let service = lower_one_service(
+            "PREFIX ex: <http://example.org/>\n\
+             SELECT * WHERE { \
+             SERVICE <fluree:remote:conn/db:main> { ?s ex:p \"ex:p is not a curie\" } }",
+        );
+        let sent = service.remote_query_text().expect("remote query text");
+        assert!(
+            sent.contains("\"ex:p is not a curie\""),
+            "literal text must survive verbatim: {sent}"
+        );
+    }
+
+    /// A query with no prologue ships exactly what it shipped before: the fix
+    /// adds declarations, it does not restructure the sub-query.
+    #[test]
+    fn remote_service_query_without_prologue_is_unchanged() {
+        let service = lower_one_service(
+            "SELECT * WHERE { SERVICE <fluree:remote:conn/db:main> { ?s <http://example.org/p> ?o } }",
+        );
+        assert_eq!(
+            service.remote_query_text().unwrap(),
+            "SELECT * WHERE { ?s <http://example.org/p> ?o }"
+        );
+    }
+
+    /// Multiple declarations are forwarded, in a deterministic (sorted) order —
+    /// `prefixes` is a HashMap, so unsorted output would make the outgoing query
+    /// text vary run to run.
+    #[test]
+    fn remote_service_query_prologue_is_deterministic() {
+        let src = "PREFIX zz: <http://example.org/z/>\n\
+                   PREFIX aa: <http://example.org/a/>\n\
+                   BASE <http://base.example/>\n\
+                   SELECT * WHERE { SERVICE <fluree:remote:conn/db:main> { ?s aa:p ?o } }";
+        let first = lower_one_service(src).remote_query_text().unwrap();
+        for _ in 0..4 {
+            assert_eq!(lower_one_service(src).remote_query_text().unwrap(), first);
+        }
+        assert!(
+            first.starts_with(
+                "BASE <http://base.example/>\n\
+                 PREFIX aa: <http://example.org/a/>\n\
+                 PREFIX zz: <http://example.org/z/>\n"
+            ),
+            "{first}"
+        );
     }
 
     #[test]

--- a/fluree-db-sparql/src/lower/pattern.rs
+++ b/fluree-db-sparql/src/lower/pattern.rs
@@ -288,10 +288,18 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             src.get(span.start..span.end).map(std::sync::Arc::from)
         });
 
+        // The body slice stops at the SERVICE block's braces, so the PREFIX /
+        // BASE declarations its prefixed names and relative IRIs resolve under
+        // are NOT in it. Capture them alongside, or the remote sees a different
+        // query than the one the user wrote.
         let service = match source_body {
-            Some(body) => {
-                ServicePattern::with_source_body(silent, ir_endpoint, inner_patterns, body)
-            }
+            Some(body) => ServicePattern::with_source_body(
+                silent,
+                ir_endpoint,
+                inner_patterns,
+                body,
+                std::sync::Arc::from(self.render_prologue_sparql()),
+            ),
             None => ServicePattern::new(silent, ir_endpoint, inner_patterns),
         };
 


### PR DESCRIPTION
The outgoing `SERVICE` sub-query was built from the body source slice alone — no `PREFIX`, no `BASE`. A body written with prefixed names fails loudly at the remote ("Undefined prefix"), which at least surfaces; a body with relative IRIs under a query-level `BASE` is the quiet one — it parses cleanly at the remote, resolves against nothing, and matches a different predicate than the user wrote, returning wrong or empty results as a success. `SERVICE SILENT` converts the loud mode into the quiet presentation too.

The prologue is now rendered from the lowerer's already-resolved prefix map and base (not re-sliced from source), so body bytes are never touched — a literal like `"ex:p is not a curie"` is safe by construction — relative prefix IRIs arrive base-resolved, and the output is deterministic (sorted). `ServicePattern` carries it and one function builds the shipped string.

Tests pin both failure modes red-to-green (the prefixed body now lowers at the remote to the same predicate refs as the parent's own patterns; the `BASE` body resolves to the same absolute IRIs locally and remotely), plus an executor-level mock asserting the exact sub-query text `service.rs` ships, literal safety, the no-prologue case unchanged, and determinism.
