### PR TITLE
apply rdf set semantics to construct results

### DIFF
--- a/docs/contributing/sparql-compliance.md
+++ b/docs/contributing/sparql-compliance.md
@@ -430,6 +430,8 @@ SPARQL, JSON-LD query, and Cypher (`fluree-db-cypher`) all compile to the **same
 
 **Regression-test rule:** a compliance fix is not done when the W3C test goes green — it is done when the register entry is removed AND an equivalent JSON-LD test exists for behavior that JSON-LD can express.
 
+**Known corpus blind spot — CONSTRUCT result-graph serialization.** The W3C CONSTRUCT suites do run through the JSON-LD serializer (`query_handler.rs` formats the result with `to_construct`, then compares graphs for isomorphism), so a serializer defect is *reachable* by the suite — but the corpus contains no test where one subject carries the **same object under two different predicates**. A formatter that deduplicated objects per subject instead of per predicate therefore dropped a distinct triple while all 1,420 tests stayed green. Isomorphism comparison also cannot see a triple emitted twice, so neither direction of an RDF-set-semantics bug is corpus-guarded. Serialization changes that touch the CONSTRUCT/DESCRIBE graph path need engine-side regression tests regardless of a green suite: `fluree-graph-format/tests/construct_value_dedup.rs` (serializer alone) and the set-semantics block in `fluree-db-api/tests/it_query_construct.rs` (both graph serializations, novelty and indexed).
+
 ### Where to add parity tests
 
 | Language | Test files |

--- a/fluree-db-api/src/format/construct.rs
+++ b/fluree-db-api/src/format/construct.rs
@@ -40,8 +40,14 @@ pub fn format(result: &QueryResult, compactor: &IriCompactor) -> Result<JsonValu
     // 1. Build Graph from template instantiation
     let mut graph = instantiate_construct_graph(result, compactor)?;
 
-    // Sort for deterministic output
-    graph.sort();
+    // Sort for deterministic output, and apply RDF set semantics: a CONSTRUCT
+    // result is a graph, so a template instantiated to the same (s, p, o) by
+    // several solution rows contributes one triple (SPARQL 1.1 §16.2).
+    // `Term`'s equality compares value, datatype AND language, so this is real
+    // RDF term identity — `"1"^^xsd:integer` and `"1"^^xsd:string` stay
+    // distinct. Caveat: a NaN `xsd:double` object never compares equal to
+    // itself, so repeated NaN triples are not collapsed.
+    graph.canonicalize();
 
     // 2. Format to JSON-LD using CONSTRUCT parity settings.
     //    Use the precomputed ContextCompactor so we don't rebuild the

--- a/fluree-db-api/src/format/rdf_xml.rs
+++ b/fluree-db-api/src/format/rdf_xml.rs
@@ -27,7 +27,10 @@ pub fn format(
     }
 
     let mut graph = instantiate_construct_graph(result, compactor)?;
-    graph.sort();
+    // Sort for deterministic output, and apply RDF set semantics — see the
+    // matching call in `construct::format`. Without the dedupe this serializer
+    // emitted a repeated triple once per contributing solution row.
+    graph.canonicalize();
     format_graph(&graph)
 }
 

--- a/fluree-db-api/tests/it_query_construct.rs
+++ b/fluree-db-api/tests/it_query_construct.rs
@@ -770,3 +770,96 @@ async fn sparql_construct_duplicate_rows_mint_distinct_blanks() {
          template blanks — per-row, not per-distinct-binding: {out:#}"
     );
 }
+
+// =============================================================================
+// RDF set semantics for CONSTRUCT / DESCRIBE results
+// =============================================================================
+//
+// A CONSTRUCT result is an RDF graph, so triple identity is the full
+// `(s, p, o)` tuple and the result is a SET union of the instantiated
+// templates (SPARQL 1.1 §16.2). Both graph serializations are pinned here so
+// they cannot drift apart on that rule.
+
+/// Seed the two-predicate fixture. `same_value` selects the shape where one
+/// literal is shared by both predicates, or the distinct-value control.
+async fn seed_shared_object(
+    ledger_id: &str,
+    same_value: bool,
+) -> (fluree_db_api::Fluree, LedgerState) {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = support::genesis_ledger(&fluree, ledger_id);
+    let (v1, v2) = if same_value {
+        ("same", "same")
+    } else {
+        ("alpha", "beta")
+    };
+    let tx = json!({
+        "@graph": [{
+            "@id": "http://ex/s",
+            "http://ex/p1": v1,
+            "http://ex/p2": v2
+        }]
+    });
+    let committed = fluree.insert(ledger0, &tx).await.expect("insert fixture");
+    (fluree, committed.ledger)
+}
+
+/// Count object values across every `@graph` node, excluding `@id`/`@context`.
+fn count_graph_values(v: &JsonValue) -> usize {
+    let count_node = |o: &Map<String, JsonValue>| -> usize {
+        o.iter()
+            .filter(|(k, _)| k.as_str() != "@id" && k.as_str() != "@context")
+            .map(|(_, val)| match val {
+                JsonValue::Array(a) => a.len(),
+                _ => 1,
+            })
+            .sum()
+    };
+    match v.get("@graph").and_then(JsonValue::as_array) {
+        Some(graph) => graph
+            .iter()
+            .filter_map(JsonValue::as_object)
+            .map(count_node)
+            .sum(),
+        None => v.as_object().map_or(0, count_node),
+    }
+}
+
+const CONSTRUCT_ALL: &str = "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }";
+
+/// A constant template instantiated once per solution row yields the SAME
+/// triple N times; the result graph holds it once. Asserted in BOTH graph
+/// serializations — the JSON-LD formatter's value dedupe used to be the only
+/// thing collapsing it, which left RDF/XML emitting the duplicate.
+#[tokio::test]
+async fn sparql_construct_repeated_triple_collapses_in_both_serializations() {
+    // Two solution rows x one constant template triple.
+    let (fluree, ledger) = seed_shared_object("it/construct:repeat", false).await;
+    let db = support::graphdb_from_ledger(&ledger);
+    let sparql = "CONSTRUCT { <http://ex/s> <http://ex/pc> \"dup\" } WHERE { ?s ?p ?o }";
+
+    let jsonld = db
+        .query(&fluree)
+        .sparql(sparql)
+        .execute_formatted()
+        .await
+        .expect("CONSTRUCT must execute");
+    assert_eq!(
+        count_graph_values(&jsonld),
+        1,
+        "JSON-LD collapses the repeated triple: {jsonld:#}"
+    );
+
+    let rdfxml = db
+        .query(&fluree)
+        .sparql(sparql)
+        .format(fluree_db_api::FormatterConfig::rdf_xml())
+        .execute_formatted_string()
+        .await
+        .expect("RDF/XML must execute");
+    assert_eq!(
+        rdfxml.matches("<ns0:pc>").count(),
+        1,
+        "RDF/XML applies the same set semantics: {rdfxml}"
+    );
+}

--- a/fluree-db-api/tests/it_query_construct.rs
+++ b/fluree-db-api/tests/it_query_construct.rs
@@ -863,3 +863,133 @@ async fn sparql_construct_repeated_triple_collapses_in_both_serializations() {
         "RDF/XML applies the same set semantics: {rdfxml}"
     );
 }
+
+/// One subject, one literal, two predicates: two distinct RDF triples. The
+/// JSON-LD formatter's object dedupe once tracked seen values per SUBJECT and
+/// dropped the second. The SELECT row path is the oracle.
+#[tokio::test]
+async fn sparql_construct_shared_object_across_predicates_novelty() {
+    let (fluree, ledger) = seed_shared_object("it/construct:shared-obj", true).await;
+    let db = support::graphdb_from_ledger(&ledger);
+
+    let rows = support::query_sparql(&fluree, &ledger, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }")
+        .await
+        .expect("select");
+    let row_count: usize = rows.batches.iter().map(fluree_db_api::Batch::len).sum();
+    assert_eq!(row_count, 2, "SELECT oracle sees both triples");
+
+    let out = db
+        .query(&fluree)
+        .sparql(CONSTRUCT_ALL)
+        .execute_formatted()
+        .await
+        .expect("CONSTRUCT must execute");
+    assert_eq!(
+        count_graph_values(&out),
+        2,
+        "same literal under p1 and p2 are distinct triples: {out:#}"
+    );
+}
+
+/// Same assertion on the indexed read path: the binary index feeds a different
+/// scan operator, and the reported reproduction reindexed before querying.
+#[tokio::test]
+async fn sparql_construct_shared_object_across_predicates_indexed() {
+    let ledger_id = "it/construct:shared-obj-idx";
+    let (fluree, _ledger) = seed_shared_object(ledger_id, true).await;
+    support::rebuild_and_publish_index(&fluree, ledger_id).await;
+    let db = fluree.db(ledger_id).await.expect("indexed view");
+
+    let out = db
+        .query(&fluree)
+        .sparql(CONSTRUCT_ALL)
+        .execute_formatted()
+        .await
+        .expect("CONSTRUCT must execute");
+    assert_eq!(
+        count_graph_values(&out),
+        2,
+        "indexed lane must agree with novelty: {out:#}"
+    );
+}
+
+/// Control: distinct objects were never affected. Guards against a "fix" that
+/// simply disables deduplication.
+#[tokio::test]
+async fn sparql_construct_distinct_objects_across_predicates() {
+    let (fluree, ledger) = seed_shared_object("it/construct:distinct-obj", false).await;
+    let db = support::graphdb_from_ledger(&ledger);
+
+    let out = db
+        .query(&fluree)
+        .sparql(CONSTRUCT_ALL)
+        .execute_formatted()
+        .await
+        .expect("CONSTRUCT must execute");
+    assert_eq!(count_graph_values(&out), 2, "control: {out:#}");
+}
+
+/// DESCRIBE lowers to the same `QueryOutput::Construct`, so it shares the
+/// result-graph contract.
+#[tokio::test]
+async fn sparql_describe_shared_object_across_predicates() {
+    let (fluree, ledger) = seed_shared_object("it/construct:describe-obj", true).await;
+    let db = support::graphdb_from_ledger(&ledger);
+
+    let out = db
+        .query(&fluree)
+        .sparql("DESCRIBE <http://ex/s>")
+        .execute_formatted()
+        .await
+        .expect("DESCRIBE must execute");
+    assert_eq!(
+        count_graph_values(&out),
+        2,
+        "DESCRIBE must emit both triples: {out:#}"
+    );
+}
+
+/// Three-surface parity: the FQL `construct` form shares the same formatter and
+/// must agree with the SPARQL surface.
+#[tokio::test]
+async fn fql_construct_shared_object_across_predicates() {
+    let (fluree, ledger) = seed_shared_object("it/construct:fql-obj", true).await;
+
+    let query = json!({
+        "where": [{"@id": "?s", "?p": "?o"}],
+        "construct": [{"@id": "?s", "?p": "?o"}]
+    });
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("FQL construct must execute");
+    let out = result
+        .to_jsonld_async(support::graphdb_from_ledger(&ledger).as_graph_db_ref())
+        .await
+        .expect("format");
+    assert_eq!(
+        count_graph_values(&out),
+        2,
+        "FQL construct must agree with SPARQL: {out:#}"
+    );
+}
+
+/// RDF/XML must carry both predicates for the shared-object shape. Pins the
+/// serializer that was already correct, so the dedupe-scope change cannot
+/// over-correct it into the JSON-LD failure mode.
+#[tokio::test]
+async fn sparql_construct_shared_object_rdfxml_keeps_both_predicates() {
+    let (fluree, ledger) = seed_shared_object("it/construct:shared-obj-xml", true).await;
+    let db = support::graphdb_from_ledger(&ledger);
+
+    let rdfxml = db
+        .query(&fluree)
+        .sparql(CONSTRUCT_ALL)
+        .format(fluree_db_api::FormatterConfig::rdf_xml())
+        .execute_formatted_string()
+        .await
+        .expect("RDF/XML must execute");
+    assert!(
+        rdfxml.contains("p1") && rdfxml.contains("p2"),
+        "RDF/XML must carry both predicates: {rdfxml}"
+    );
+}

--- a/fluree-graph-format/src/jsonld.rs
+++ b/fluree-graph-format/src/jsonld.rs
@@ -353,10 +353,13 @@ impl SubjectData {
         let mut node = Map::new();
         node.insert("@id".to_string(), JsonValue::String(self.id.clone()));
 
-        // Track seen values for deduplication
-        let mut seen_values: HashSet<String> = HashSet::new();
-
         for (pred_iri, triples) in self.predicates {
+            // Track seen objects for deduplication, scoped to THIS predicate.
+            // RDF triple identity is (s, p, o), so the same object reached
+            // through a different predicate is a different triple and must
+            // still be emitted; a subject-wide set would drop it.
+            let mut seen_values: HashSet<String> = HashSet::new();
+
             // Check if this predicate is a list (any triple has list_index)
             let is_list = triples.iter().any(|(idx, _)| idx.is_some());
 

--- a/fluree-graph-format/src/jsonld.rs
+++ b/fluree-graph-format/src/jsonld.rs
@@ -6,7 +6,7 @@ use crate::policy::{BlankNodePolicy, ContextPolicy, TypeHandling};
 use fluree_graph_ir::datatype::iri as dt_iri;
 use fluree_graph_ir::{BlankId, Datatype, Graph, LiteralValue, Term};
 use serde_json::{json, Map, Value as JsonValue};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 /// Type alias for IRI compaction functions used in JSON-LD formatting.
@@ -30,12 +30,6 @@ pub struct JsonLdFormatConfig {
     /// When false (default), single values are scalars, multiple values are arrays.
     pub multicardinal_arrays: bool,
 
-    /// Deduplicate identical values within a property (CONSTRUCT parity)
-    ///
-    /// When true, duplicate values for the same predicate are removed.
-    /// When false (default), duplicates are preserved.
-    pub dedupe_values: bool,
-
     /// Optional IRI compaction function for vocab positions (predicates and @type values)
     ///
     /// If None, IRIs are output in expanded form.
@@ -54,7 +48,6 @@ impl std::fmt::Debug for JsonLdFormatConfig {
             .field("blank_node_policy", &self.blank_node_policy)
             .field("type_handling", &self.type_handling)
             .field("multicardinal_arrays", &self.multicardinal_arrays)
-            .field("dedupe_values", &self.dedupe_values)
             .field(
                 "compactor_vocab",
                 &self.compactor_vocab.as_ref().map(|_| "<fn>"),
@@ -94,12 +87,6 @@ impl JsonLdFormatConfig {
         self
     }
 
-    /// Enable value deduplication
-    pub fn with_dedupe_values(mut self, enabled: bool) -> Self {
-        self.dedupe_values = enabled;
-        self
-    }
-
     /// Set the IRI compactor function
     pub fn with_compactor<F>(mut self, compactor: F) -> Self
     where
@@ -123,8 +110,12 @@ impl JsonLdFormatConfig {
     /// This convenience builder encapsulates all CONSTRUCT-specific settings:
     /// - `rdf:type` → `@type` conversion
     /// - Singleton values unwrapped (arrays only for multi-values)
-    /// - Value deduplication (duplicate values removed)
     /// - Deterministic blank node IDs
+    ///
+    /// It does NOT deduplicate: a CONSTRUCT result is an RDF graph, and set
+    /// semantics belong to the graph, not the rendering. Call
+    /// [`Graph::canonicalize`](fluree_graph_ir::Graph::canonicalize) before
+    /// formatting.
     ///
     /// # Arguments
     ///
@@ -138,7 +129,6 @@ impl JsonLdFormatConfig {
     ///
     /// let config = JsonLdFormatConfig::construct_parity(None, |iri| iri.to_string());
     /// assert!(config.multicardinal_arrays);
-    /// assert!(config.dedupe_values);
     /// ```
     pub fn construct_parity<F>(orig_context: Option<JsonValue>, compactor: F) -> Self
     where
@@ -156,7 +146,6 @@ impl JsonLdFormatConfig {
             // For CONSTRUCT (JSON-LD): always use arrays for values.
             // (The API layer may override this for SPARQL CONSTRUCT output.)
             .with_multicardinal_arrays(true)
-            .with_dedupe_values(true)
             .with_compactor(compactor)
     }
 
@@ -354,12 +343,6 @@ impl SubjectData {
         node.insert("@id".to_string(), JsonValue::String(self.id.clone()));
 
         for (pred_iri, triples) in self.predicates {
-            // Track seen objects for deduplication, scoped to THIS predicate.
-            // RDF triple identity is (s, p, o), so the same object reached
-            // through a different predicate is a different triple and must
-            // still be emitted; a subject-wide set would drop it.
-            let mut seen_values: HashSet<String> = HashSet::new();
-
             // Check if this predicate is a list (any triple has list_index)
             let is_list = triples.iter().any(|(idx, _)| idx.is_some());
 
@@ -378,19 +361,17 @@ impl SubjectData {
                 let list_value = format_list_value(&triples, config, bnode_renamer);
                 node.insert(pred_key, list_value);
             } else {
-                // Normal multi-valued predicate
+                // Normal multi-valued predicate. Every triple reaching this
+                // point is emitted: the graph is the unit of RDF set
+                // semantics, so callers that need uniqueness apply
+                // `Graph::canonicalize()` before formatting. Deduplicating
+                // here instead would have to compare rendered JSON, and
+                // rendering is lossy — the inferable datatypes all collapse to
+                // bare scalars, so `"1"^^xsd:integer` and `"1"^^xsd:long` are
+                // indistinguishable once rendered despite being distinct RDF
+                // terms.
                 for (_, triple) in triples {
                     let obj_val = term_to_object(&triple.o, config, bnode_renamer);
-
-                    // Dedupe check
-                    if config.dedupe_values {
-                        let value_str = obj_val.to_string();
-                        if seen_values.contains(&value_str) {
-                            continue; // Skip duplicate
-                        }
-                        seen_values.insert(value_str);
-                    }
-
                     add_property(&mut node, &pred_key, obj_val);
                 }
             }
@@ -975,8 +956,10 @@ mod tests {
         assert_eq!(name[0], "Alice");
     }
 
+    /// Duplicate triples are collapsed by `Graph::canonicalize()` — the graph
+    /// is the unit of RDF set semantics. The formatter emits what it is given.
     #[test]
-    fn test_dedupe_values() {
+    fn test_canonicalized_graph_has_no_duplicate_values() {
         let mut graph = Graph::new();
 
         // Add duplicate values
@@ -998,9 +981,9 @@ mod tests {
             Term::string("Ali"),
         );
 
-        graph.sort();
+        graph.canonicalize();
 
-        let config = JsonLdFormatConfig::default().with_dedupe_values(true);
+        let config = JsonLdFormatConfig::default();
         let result = format_jsonld(&graph, &config);
 
         let nicks = &result["@graph"][0]["http://xmlns.com/foaf/0.1/nick"];
@@ -1032,12 +1015,10 @@ mod tests {
             Term::string("Al"), // duplicate
         );
 
-        graph.sort();
+        graph.canonicalize();
 
-        // Construct mode: singletons unwrapped + dedupe
-        let config = JsonLdFormatConfig::default()
-            .with_multicardinal_arrays(false)
-            .with_dedupe_values(true);
+        // Construct mode: singletons unwrapped; uniqueness from canonicalize
+        let config = JsonLdFormatConfig::default().with_multicardinal_arrays(false);
 
         let result = format_jsonld(&graph, &config);
         let node = &result["@graph"][0];
@@ -1191,8 +1172,9 @@ mod tests {
 
         graph.sort();
 
-        // Even with dedupe_values enabled, list indices should preserve duplicates
-        let config = JsonLdFormatConfig::default().with_dedupe_values(true);
+        // List items are index-distinguished, so a repeated value is a
+        // distinct triple and survives canonicalization.
+        let config = JsonLdFormatConfig::default();
         let result = format_jsonld(&graph, &config);
         let node = &result["@graph"][0];
 

--- a/fluree-graph-format/tests/construct_value_dedup.rs
+++ b/fluree-graph-format/tests/construct_value_dedup.rs
@@ -1,0 +1,166 @@
+//! Regression corpus: CONSTRUCT value dedup must key on RDF triple identity.
+//!
+//! A CONSTRUCT result is an RDF graph, so triple identity is the full
+//! `(s, p, o)` tuple (SPARQL 1.1 §16.2 — set union of instantiated templates).
+//! The JSON-LD formatter's `dedupe_values` pass once tracked seen objects per
+//! SUBJECT, which silently dropped `<s> <p2> "x"` whenever `<s> <p1> "x"` had
+//! already been emitted. These tests pin the object-dedup scope to a single
+//! predicate, and pin the cases that must still collapse.
+//!
+//! Each test builds the Graph by hand, so a failure here is unambiguously a
+//! serializer defect — no query engine involved.
+
+use fluree_graph_format::{format_jsonld, JsonLdFormatConfig};
+use fluree_graph_ir::{Datatype, Graph, Term};
+use serde_json::Value as JsonValue;
+
+/// Count object values across every `@graph` node, excluding `@id`/`@context`.
+fn count_values(v: &JsonValue) -> usize {
+    let graph = v
+        .get("@graph")
+        .and_then(JsonValue::as_array)
+        .expect("@graph");
+    graph
+        .iter()
+        .filter_map(JsonValue::as_object)
+        .flat_map(serde_json::Map::iter)
+        .filter(|(k, _)| k.as_str() != "@id" && k.as_str() != "@context")
+        .map(|(_, val)| match val {
+            JsonValue::Array(a) => a.len(),
+            _ => 1,
+        })
+        .sum()
+}
+
+fn render(graph: &mut Graph) -> JsonValue {
+    graph.sort();
+    format_jsonld(
+        graph,
+        &JsonLdFormatConfig::construct_parity(None, std::string::ToString::to_string),
+    )
+}
+
+fn triple(g: &mut Graph, s: &str, p: &str, o: Term) {
+    g.add_triple(Term::iri(s), Term::iri(p), o);
+}
+
+/// The reported shape: one subject, one literal, two predicates. Two distinct
+/// RDF triples — both must survive.
+#[test]
+fn same_literal_under_two_predicates_both_survive() {
+    let mut g = Graph::new();
+    triple(&mut g, "http://ex/s", "http://ex/p1", Term::string("same"));
+    triple(&mut g, "http://ex/s", "http://ex/p2", Term::string("same"));
+    assert_eq!(g.len(), 2, "graph must hold both triples pre-serialization");
+
+    let out = render(&mut g);
+    assert_eq!(count_values(&out), 2, "p1 and p2 must both emit: {out}");
+}
+
+/// The defect was never literal-specific: IRI objects drop the same way.
+#[test]
+fn same_iri_object_under_two_predicates_both_survive() {
+    let mut g = Graph::new();
+    triple(
+        &mut g,
+        "http://ex/s",
+        "http://ex/p1",
+        Term::iri("http://ex/o"),
+    );
+    triple(
+        &mut g,
+        "http://ex/s",
+        "http://ex/p2",
+        Term::iri("http://ex/o"),
+    );
+
+    let out = render(&mut g);
+    assert_eq!(count_values(&out), 2, "IRI objects: {out}");
+}
+
+/// Loss grows with predicate fan-out, not linearly: this collapsed to ONE.
+#[test]
+fn many_predicates_sharing_one_value_all_survive() {
+    let mut g = Graph::new();
+    for i in 0..10 {
+        triple(
+            &mut g,
+            "http://ex/s",
+            &format!("http://ex/p{i}"),
+            Term::string("same"),
+        );
+    }
+
+    let out = render(&mut g);
+    assert_eq!(count_values(&out), 10, "10 predicates, one value: {out}");
+}
+
+/// Control: distinct values were never affected. Guards against a fix that
+/// disables dedup wholesale.
+#[test]
+fn distinct_values_under_two_predicates_both_survive() {
+    let mut g = Graph::new();
+    triple(&mut g, "http://ex/s", "http://ex/p1", Term::string("alpha"));
+    triple(&mut g, "http://ex/s", "http://ex/p2", Term::string("beta"));
+
+    let out = render(&mut g);
+    assert_eq!(count_values(&out), 2, "control: {out}");
+}
+
+/// The behavior the fix must PRESERVE: an identical `(s, p, o)` appearing twice
+/// is one RDF triple and must be emitted once.
+#[test]
+fn identical_triple_still_collapses() {
+    let mut g = Graph::new();
+    for _ in 0..2 {
+        triple(&mut g, "http://ex/s", "http://ex/p1", Term::string("same"));
+    }
+
+    let out = render(&mut g);
+    assert_eq!(count_values(&out), 1, "true duplicate must collapse: {out}");
+}
+
+/// Dedup is per-subject as well as per-predicate: the same value on a different
+/// subject is a different triple. Bounds the blast radius of the scope change.
+#[test]
+fn same_value_on_different_subjects_both_survive() {
+    let mut g = Graph::new();
+    triple(&mut g, "http://ex/s1", "http://ex/p1", Term::string("same"));
+    triple(&mut g, "http://ex/s2", "http://ex/p1", Term::string("same"));
+
+    let out = render(&mut g);
+    assert_eq!(count_values(&out), 2, "distinct subjects: {out}");
+}
+
+/// RDF term identity includes the datatype: `"1"^^xsd:integer` and
+/// `"1"^^xsd:string` share a lexical form but are distinct terms.
+#[test]
+fn equal_lexical_form_different_datatype_both_survive() {
+    let mut g = Graph::new();
+    triple(&mut g, "http://ex/s", "http://ex/p1", Term::integer(1));
+    triple(
+        &mut g,
+        "http://ex/s",
+        "http://ex/p1",
+        Term::typed("1", Datatype::xsd_string()),
+    );
+
+    let out = render(&mut g);
+    assert_eq!(count_values(&out), 2, "datatypes must not collapse: {out}");
+}
+
+/// Term identity also includes the language tag.
+#[test]
+fn language_tagged_and_plain_literal_both_survive() {
+    let mut g = Graph::new();
+    triple(&mut g, "http://ex/s", "http://ex/p1", Term::string("same"));
+    triple(
+        &mut g,
+        "http://ex/s",
+        "http://ex/p2",
+        Term::lang_string("same", "en"),
+    );
+
+    let out = render(&mut g);
+    assert_eq!(count_values(&out), 2, "lang tag vs plain: {out}");
+}

--- a/fluree-graph-format/tests/construct_value_dedup.rs
+++ b/fluree-graph-format/tests/construct_value_dedup.rs
@@ -1,17 +1,19 @@
-//! Regression corpus: CONSTRUCT value dedup must key on RDF triple identity.
+//! Regression corpus: CONSTRUCT uniqueness is RDF triple identity, applied to
+//! the graph — never to the rendered JSON.
 //!
 //! A CONSTRUCT result is an RDF graph, so triple identity is the full
 //! `(s, p, o)` tuple (SPARQL 1.1 §16.2 — set union of instantiated templates).
-//! The JSON-LD formatter's `dedupe_values` pass once tracked seen objects per
-//! SUBJECT, which silently dropped `<s> <p2> "x"` whenever `<s> <p1> "x"` had
-//! already been emitted. These tests pin the object-dedup scope to a single
-//! predicate, and pin the cases that must still collapse.
+//! The JSON-LD formatter used to carry its own `dedupe_values` pass keyed on
+//! the *rendered* object, which was wrong twice over: it tracked seen objects
+//! per SUBJECT (dropping `<s> <p2> "x"` after `<s> <p1> "x"`), and rendering is
+//! lossy, so distinct terms that render alike collapsed. Uniqueness now comes
+//! from `Graph::canonicalize()` and the formatter emits what it is given.
 //!
 //! Each test builds the Graph by hand, so a failure here is unambiguously a
-//! serializer defect — no query engine involved.
+//! serializer/graph defect — no query engine involved.
 
 use fluree_graph_format::{format_jsonld, JsonLdFormatConfig};
-use fluree_graph_ir::{Datatype, Graph, Term};
+use fluree_graph_ir::{Datatype, Graph, LiteralValue, Term};
 use serde_json::Value as JsonValue;
 
 /// Count object values across every `@graph` node, excluding `@id`/`@context`.
@@ -32,8 +34,11 @@ fn count_values(v: &JsonValue) -> usize {
         .sum()
 }
 
+/// Mirrors `fluree-db-api`'s `construct::format`: canonicalize the graph (RDF
+/// set semantics), then render. Uniqueness is the graph's job, not the
+/// formatter's.
 fn render(graph: &mut Graph) -> JsonValue {
-    graph.sort();
+    graph.canonicalize();
     format_jsonld(
         graph,
         &JsonLdFormatConfig::construct_parity(None, std::string::ToString::to_string),
@@ -147,6 +152,42 @@ fn equal_lexical_form_different_datatype_both_survive() {
 
     let out = render(&mut g);
     assert_eq!(count_values(&out), 2, "datatypes must not collapse: {out}");
+}
+
+/// The sharper case: BOTH datatypes are in the inferable family, so both
+/// render as the bare JSON scalar `1` and the rendered forms are identical.
+/// `"1"^^xsd:integer` and `"1"^^xsd:long` are still distinct RDF terms under
+/// one predicate, so both triples must survive — a dedupe keyed on the
+/// rendered JSON rather than the term drops the second.
+#[test]
+fn equal_rendering_different_datatype_same_predicate_both_survive() {
+    let mut g = Graph::new();
+    g.add_triple(
+        Term::iri("http://ex/s"),
+        Term::iri("http://ex/p1"),
+        Term::Literal {
+            value: LiteralValue::Integer(1),
+            datatype: Datatype::xsd_integer(),
+            language: None,
+        },
+    );
+    g.add_triple(
+        Term::iri("http://ex/s"),
+        Term::iri("http://ex/p1"),
+        Term::Literal {
+            value: LiteralValue::Integer(1),
+            datatype: Datatype::xsd_long(),
+            language: None,
+        },
+    );
+    assert_eq!(g.len(), 2, "two distinct RDF terms");
+
+    let out = render(&mut g);
+    assert_eq!(
+        count_values(&out),
+        2,
+        "xsd:integer and xsd:long both render as `1` but are distinct terms: {out}"
+    );
 }
 
 /// Term identity also includes the language tag.


### PR DESCRIPTION
Two mirror-image defects in CONSTRUCT result handling, one root cause: RDF set semantics were applied in a serializer instead of at the graph layer.

The JSON-LD writer deduplicated object values with one set per *subject*, keyed on the serialized object alone — the predicate never entered the key. So `<s> <p1> "same" . <s> <p2> "same"` serialized as one triple, the first predicate claiming the value and every later same-valued predicate on that subject dropping silently; IRI objects dropped the same way, `DESCRIBE` and the JSON-LD `construct` surface share the path, and the loss scales with fan-out (ten predicates carrying one value collapse to one). Meanwhile RDF/XML had no dedup at all and the construct graph was only sorted, never canonicalized — so genuinely duplicate instantiations (a constant template over multiple solutions) were emitted twice, violating the same §16.2 set-union clause from the other direction.

`instantiate_construct_graph` now canonicalizes (sort + dedupe on full `(s, p, o)` term identity — the existing `Term` equality already compares value, datatype, and language), which fixes the RDF/XML leak and makes both serializers agree.

With uniqueness established at the graph layer, the JSON-LD writer's own dedup pass is gone rather than merely rescoped. Keying it per-predicate fixed the reported bug but left it keyed on the *rendered* JSON, and rendering is lossy: the inferable datatypes all collapse to bare scalars, so `"1"^^xsd:integer` and `"1"^^xsd:long` under one predicate are indistinguishable once rendered and the second was dropped — the same class of loss this PR is fixing, on a narrower input. Post-canonicalization a correctly term-keyed dedup could never fire, so the pass was redundant *and* lossy; `dedupe_values` had exactly one setter (`construct_parity`) and that one production consumer, so the flag is retired outright rather than left as a footgun a future caller could re-enable. Set semantics now live in exactly one place, `Graph::canonicalize()`.

Behavior note: JSON-LD CONSTRUCT/DESCRIBE output now includes previously-dropped triples, and RDF/XML no longer repeats duplicates.

Regression tests cover both serializations: same-value-across-predicates for literals and IRIs, true duplicates still collapsing, equal lexical forms with different datatypes staying distinct (including the sharper case where *both* datatypes are inferable and render identically), the fan-out shape, and the DESCRIBE/FQL surfaces. Zero regressions in the existing corpus — nothing had baked in the old behavior — and a note in the compliance doc records that no W3C CONSTRUCT test covers this shape (isomorphism comparison also can't see a doubled triple), which is how it survived.
