### PR TITLE
fix: don't fail open when a subject's namespace code is undecodable

### DIFF
--- a/docs/design/namespace-allocation.md
+++ b/docs/design/namespace-allocation.md
@@ -119,4 +119,14 @@ Implementation: `NamespaceRegistry::from_db` and `NamespaceRegistry::sid_for_iri
   (one per host), but it prevents deeper fragmentation that is common in path-heavy IRIs.
 - The `OVERFLOW` namespace code is a sentinel used when `u16` codes are exhausted; it is not a
   fallback mode. Overflow SIDs store the **full IRI** as the SID name.
+- **High-cardinality trailing segments allocate one namespace per subject.** Under `MostGranular`,
+  an opaque IRI splits at its *last* `/`, `#` or `:`, so a shape like
+  `urn:example:record:<id>:rev:<hash>` yields the prefix `urn:example:record:<id>:rev:` — unique to
+  that one subject. A dataset built this way allocates a namespace code per node rather than per
+  family, which has two consequences: the user code space (`USER_START`..`OVERFLOW`, ~65.5k codes)
+  can be exhausted by a few hundred thousand subjects, and per-transaction work that keys off
+  namespace codes degrades. The streaming preflight above only covers **bulk import** — ordinary
+  transactions get no such detection, so this is a data-modelling concern for write workloads.
+  Prefer moving the high-cardinality part into the *suffix* (`urn:example:record:<id>-rev-<hash>`)
+  or setting `HostPlusN(n)` on the ledger.
 

--- a/fluree-db-api/tests/it_transact_upsert_indexed.rs
+++ b/fluree-db-api/tests/it_transact_upsert_indexed.rs
@@ -193,6 +193,117 @@ async fn upsert_mixed_persisted_novelty_new_subjects() {
         .await;
 }
 
+/// Subjects whose IRI shape mints a **fresh namespace code per subject**.
+///
+/// Under `MostGranular` splitting, `urn:…:<id>:r:<sig>` splits at the last
+/// `:`, so every such subject gets its own namespace prefix. The pre-check
+/// resolves a subject's IRI in order to run the store's full-IRI lookup; when
+/// the pre-transaction snapshot cannot decode the namespace code it falls back
+/// to the store's own namespace table, and only reports "absent" when NEITHER
+/// can decode it (a code neither knows cannot name a row in the base index).
+///
+/// This pins both directions of that decision: subjects of this shape that
+/// already exist must still have their old values retracted, and brand-new
+/// ones must still be skipped rather than dragging the whole transaction
+/// through a per-(subject, predicate) scan.
+#[tokio::test]
+async fn upsert_indexed_replaces_values_for_per_subject_namespaces() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let index_cfg = IndexConfig {
+        reindex_min_bytes: 0,
+        reindex_max_bytes: 1_000_000,
+    };
+
+    let mut fluree = FlureeBuilder::file(path).build().expect("build");
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .publisher_arc()
+            .expect("test setup requires ReadWrite nameservice mode"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/upsert-indexed-ns-per-subject:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            // `base` shares one namespace; `rev` mints its own.
+            let base = "urn:it:ev:aaaa";
+            let rev = "urn:it:ev:aaaa:r:sig1";
+            let fresh = "urn:it:ev:bbbb:r:sig2";
+
+            let r1 = fluree
+                .upsert_with_opts(
+                    ledger,
+                    &json!({
+                        "@context": ctx(),
+                        "@graph": [
+                            {"@id": base, "ex:name": ["V1a", "V1b"]},
+                            {"@id": rev, "ex:name": "R1"}
+                        ]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .unwrap();
+
+            trigger_index_and_wait_outcome(&handle, ledger_id, r1.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(ledger.snapshot.range_provider.is_some());
+
+            // Re-upsert the persisted subjects, plus a brand-new one that also
+            // mints its own namespace (the skip path).
+            let r2 = fluree
+                .upsert_with_opts(
+                    ledger,
+                    &json!({
+                        "@context": ctx(),
+                        "@graph": [
+                            {"@id": base, "ex:name": "V2"},
+                            {"@id": rev, "ex:name": "R2"},
+                            {"@id": fresh, "ex:name": "N1"}
+                        ]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .unwrap();
+
+            let expect = |v: &str| vec![json!([v])];
+            assert_eq!(
+                name_values(&fluree, &r2.ledger, base).await,
+                expect("V2"),
+                "persisted subject on a shared namespace: both old values replaced"
+            );
+            assert_eq!(
+                name_values(&fluree, &r2.ledger, rev).await,
+                expect("R2"),
+                "persisted subject on a per-subject namespace: old value replaced"
+            );
+            assert_eq!(
+                name_values(&fluree, &r2.ledger, fresh).await,
+                expect("N1"),
+                "brand-new per-subject-namespace subject inserted"
+            );
+
+            // Retractions must be staged, not merely masked by novelty.
+            trigger_index_and_wait_outcome(&handle, ledger_id, r2.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(name_values(&fluree, &ledger, base).await, expect("V2"));
+            assert_eq!(name_values(&fluree, &ledger, rev).await, expect("R2"));
+            assert_eq!(name_values(&fluree, &ledger, fresh).await, expect("N1"));
+        })
+        .await;
+}
+
 /// Post-index named-graph upsert. The subject pre-check keys its novelty set
 /// per ledger graph while `subject_in_base` is graph-agnostic, and the
 /// txn-graph → ledger-graph translation is hoisted out of the subject loop —

--- a/fluree-db-api/tests/it_transact_upsert_indexed.rs
+++ b/fluree-db-api/tests/it_transact_upsert_indexed.rs
@@ -8,11 +8,16 @@
 //! that the skip never drops retractions for subjects that DO exist:
 //! persisted (base index), novelty-only (committed after the last index), and
 //! brand-new subjects all in one transaction.
+//!
+//! Correctness assertions alone cannot see the skip switching *off* — failing
+//! open is conservatively correct, costing only extra queries — so
+//! `upsert_indexed_skip_fires_for_per_subject_namespace_subjects` asserts on
+//! the `skipped_subjects` / `pattern_queries` counters instead.
 
 #![cfg(feature = "native")]
 
 use crate::support::{
-    normalize_rows, query_jsonld_formatted, start_background_indexer_local,
+    normalize_rows, query_jsonld_formatted, span_capture, start_background_indexer_local,
     trigger_index_and_wait_outcome,
 };
 use fluree_db_api::{FlureeBuilder, IndexConfig};
@@ -300,6 +305,108 @@ async fn upsert_indexed_replaces_values_for_per_subject_namespaces() {
             assert_eq!(name_values(&fluree, &ledger, base).await, expect("V2"));
             assert_eq!(name_values(&fluree, &ledger, rev).await, expect("R2"));
             assert_eq!(name_values(&fluree, &ledger, fresh).await, expect("N1"));
+        })
+        .await;
+}
+
+/// The skip must actually *fire*, not merely stay correct.
+///
+/// `upsert_indexed_replaces_values_for_per_subject_namespaces` pins that the
+/// pre-check never drops a real retraction — but it passes against the old
+/// `decode_sid` fail-open too, because reporting "present" was conservatively
+/// correct: it only cost extra queries and produced identical results. A
+/// results-only assertion therefore cannot see the skip switching off, which
+/// is the regression that matters. `generate_upsert_deletions` reports
+/// `skipped_subjects` and `pattern_queries`; asserting on those is what makes
+/// it detectable.
+#[tokio::test(flavor = "current_thread")]
+async fn upsert_indexed_skip_fires_for_per_subject_namespace_subjects() {
+    let (spans, _guard) = span_capture::init_test_tracing();
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().to_string_lossy().to_string();
+    let index_cfg = IndexConfig {
+        reindex_min_bytes: 0,
+        reindex_max_bytes: 1_000_000,
+    };
+
+    let mut fluree = FlureeBuilder::file(path).build().expect("build");
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .publisher_arc()
+            .expect("test setup requires ReadWrite nameservice mode"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/upsert-indexed-skip-fires:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            // Seed an unrelated subject so a base index exists to probe.
+            let r1 = fluree
+                .upsert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "urn:it:seed:aaaa", "ex:name": "S1"}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .unwrap();
+            trigger_index_and_wait_outcome(&handle, ledger_id, r1.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(ledger.snapshot.range_provider.is_some());
+
+            // Three brand-new subjects, each minting its own namespace code.
+            fluree
+                .upsert_with_opts(
+                    ledger,
+                    &json!({
+                        "@context": ctx(),
+                        "@graph": [
+                            {"@id": "urn:it:ev:aaaa:r:s1", "ex:name": "R1"},
+                            {"@id": "urn:it:ev:bbbb:r:s2", "ex:name": "R2"},
+                            {"@id": "urn:it:ev:cccc:r:s3", "ex:name": "R3"}
+                        ]
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .unwrap();
+
+            let events = spans.find_events("upsert deletion subject pre-check");
+            let last = events.last().expect(
+                "generate_upsert_deletions must report its pre-check outcome; \
+                 if this event was renamed or removed, update this assertion",
+            );
+            let field = |k: &str| -> u64 {
+                last.fields
+                    .get(k)
+                    .unwrap_or_else(|| panic!("pre-check event missing field `{k}`"))
+                    .parse()
+                    .unwrap_or_else(|_| panic!("field `{k}` is not a number"))
+            };
+
+            assert_eq!(field("subject_count"), 3, "all three subjects are grouped");
+            // The load-bearing assertions: absent subjects must be proven
+            // absent and skipped, so no existing-value query is issued at all.
+            assert_eq!(
+                field("skipped_subjects"),
+                3,
+                "every absent subject must be skipped — a namespace code the \
+                 snapshot cannot decode is not grounds to assume presence"
+            );
+            assert_eq!(
+                field("pattern_queries"),
+                0,
+                "a skipped subject must issue no existing-value lookups"
+            );
         })
         .await;
 }

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -1562,39 +1562,48 @@ impl BinaryScanOperator {
         let from_t = ctx.from_t;
         let cmp = self.index.comparator();
 
-        // Collect all overlay flakes for this graph+index (novelty is expected to be small),
-        // then narrow by equality match.
+        // Collect overlay flakes for this graph+index, applying the bound-term
+        // equality match INSIDE the walk.
+        //
+        // Filtering before the copy (rather than `retain`ing afterwards) is
+        // what keeps this path cheap: this fallback is reached once per probe
+        // of a subject/predicate/value that is absent from the persisted
+        // dictionaries, and callers such as upsert's existing-value lookup
+        // issue thousands of such probes per transaction. Cloning and sorting
+        // the whole graph's novelty on each one is O(novelty log novelty) per
+        // call; matching first makes it a comparison-only walk with no
+        // allocation for the (overwhelmingly common) non-matching flakes.
+        //
+        // Equivalent to the previous filter-after-resolve order:
+        // `resolve_overlay_retractions` decides each distinct fact
+        // `(s, p, o, dt, m)` independently, and an (s, p, o) equality filter
+        // either keeps or drops a fact's entries as a whole — so it can never
+        // separate an assertion from the retraction that cancels it.
         let mut flakes: Vec<Flake> = Vec::new();
         overlay.for_each_overlay_flake(self.g_id, self.index, None, None, true, to_t, &mut |f| {
-            if f.t <= to_t && from_t.is_none_or(|ft| f.t >= ft) {
-                flakes.push(f.clone());
+            if f.t > to_t || from_t.is_some_and(|ft| f.t < ft) {
+                return;
             }
+            if let Some(s) = s_sid.as_ref() {
+                if &f.s != s {
+                    return;
+                }
+            }
+            if let Some(p) = p_sid.as_ref() {
+                if &f.p != p {
+                    return;
+                }
+            }
+            if let Some(o) = self.bound_o.as_ref() {
+                if &f.o != o {
+                    return;
+                }
+            }
+            flakes.push(f.clone());
         });
 
         flakes.sort_by(cmp);
         flakes = resolve_overlay_retractions(flakes);
-
-        // Apply equality match (subject/predicate/object).
-        if s_sid.is_some() || p_sid.is_some() || self.bound_o.is_some() {
-            flakes.retain(|f| {
-                if let Some(s) = s_sid.as_ref() {
-                    if &f.s != s {
-                        return false;
-                    }
-                }
-                if let Some(p) = p_sid.as_ref() {
-                    if &f.p != p {
-                        return false;
-                    }
-                }
-                if let Some(o) = self.bound_o.as_ref() {
-                    if &f.o != o {
-                        return false;
-                    }
-                }
-                true
-            });
-        }
 
         // Apply object bounds (post-filter) when present.
         if let Some(bounds) = self.object_bounds.as_ref() {

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -2766,8 +2766,14 @@ async fn generate_upsert_deletions(
     // system RAM when indexing lags — which is why it runs at most once per
     // graph, and only on demand. It is authoritative in Sid space, needing
     // no dictionary translation.
+    // A snapshot with no range provider at all has no base index (genesis, or
+    // nothing indexed yet), so novelty is the only place a subject can exist
+    // and the presence check below is authoritative on its own.
+    let base_index_absent = ledger.snapshot.range_provider.is_none();
+    let can_decide_absence = binary_store.is_some() || base_index_absent;
+
     let mut per_g_subjects: HashMap<u16, HashSet<&Sid>> = HashMap::new();
-    if binary_store.is_some() {
+    if can_decide_absence {
         for (subject, txn_g) in subject_groups.keys() {
             if let Some(Some(ledger_g)) = ledger_g_for_txn_g.get(txn_g) {
                 per_g_subjects.entry(*ledger_g).or_default().insert(subject);
@@ -2783,7 +2789,8 @@ async fn generate_upsert_deletions(
     // per-predicate query surfaces the real failure.
     let subject_in_base = |subject: &Sid| -> bool {
         let Some(store) = binary_store.as_deref() else {
-            return true;
+            // Nothing to consult: absent iff there is no base index at all.
+            return !base_index_absent;
         };
         if matches!(
             store.find_subject_id_by_parts(subject.namespace_code, &subject.name),
@@ -2791,14 +2798,31 @@ async fn generate_upsert_deletions(
         ) {
             return true;
         }
-        match ledger.snapshot.decode_sid(subject) {
+        // Resolve the subject IRI so the store's full-IRI fallback can run. The
+        // snapshot is consulted first; when it cannot decode the namespace code
+        // the store's own namespace table is tried. A code that NEITHER knows
+        // was minted after the base index was written, so the subject provably
+        // has no rows in it — report absent rather than failing open.
+        //
+        // Reporting "present" here instead defeats the skip for every IRI shape
+        // that mints a namespace per subject — `MostGranular` splits
+        // `urn:…:<id>:r:<sig>` at the last `:` — sending each one down a
+        // per-(subject, predicate) degraded scan. Novelty presence is still
+        // checked by the caller, so a subject that exists only in unindexed
+        // commits is never wrongly skipped.
+        match ledger
+            .snapshot
+            .decode_sid(subject)
+            .or_else(|| store.sid_to_iri(subject))
+        {
             Some(iri) => !matches!(store.find_subject_id(&iri), Ok(None)),
-            None => true,
+            None => false,
         }
     };
 
     let mut retractions = Vec::new();
     let mut skipped_subjects = 0usize;
+    let mut pattern_queries = 0usize;
 
     // Query existing values for each (subject, predicate, graph) tuple
     let mut query_vars = VarRegistry::new();
@@ -2831,7 +2855,7 @@ async fn generate_upsert_deletions(
         // Skip subjects with no persisted or novelty presence entirely. The
         // base dictionary is a point probe, so it is consulted first; the
         // per-graph novelty set is built on the first dictionary miss only.
-        if binary_store.is_some() && !subject_in_base(subject) {
+        if can_decide_absence && !subject_in_base(subject) {
             let present = novelty_present.entry(effective_g_id).or_insert_with(|| {
                 let mut set = HashSet::new();
                 if let Some(subjects) = per_g_subjects.get(&effective_g_id) {
@@ -2870,6 +2894,7 @@ async fn generate_upsert_deletions(
         });
 
         for predicate in predicates {
+            pattern_queries += 1;
             // Query: <subject> <predicate> ?o
             let pattern = TriplePattern::new(
                 Ref::Sid(subject.clone()),
@@ -2932,6 +2957,7 @@ async fn generate_upsert_deletions(
     tracing::debug!(
         subject_count = subject_groups.len(),
         skipped_subjects,
+        pattern_queries,
         "upsert deletion subject pre-check"
     );
 


### PR DESCRIPTION
## Problem

Upsert against subjects with **new IRIs** was dramatically slower than against existing ones, and the cost grew with ledger size. A customer's 547-transaction / 1.55M-flake identity persist took **823.1s** of transactor time in production, with 93 transactions at a median of 6.7s each.

`generate_upsert_deletions` already skips existing-value lookups for subjects absent from both the persisted dictionary and novelty (#8ae18197b, `bb2a042f8`) — and that skip works. Instrumenting it showed it firing for exactly **151 of 302** subjects per transaction. The other half went down the slow path.

## Root cause

Proving a subject absent requires resolving its IRI. The guard's last line reported "present" whenever the pre-transaction snapshot could not decode the subject's namespace code:

```rust
match ledger.snapshot.decode_sid(subject) {
    Some(iri) => !matches!(store.find_subject_id(&iri), Ok(None)),
    None => true,     // <-- assume present
}
```

That defeats the skip for every IRI shape that allocates a namespace **per subject**. Under `MostGranular`, an opaque IRI splits at its last `:`, so `urn:…:evidence:<hex>:r:<sig>` gives each revision node its own prefix — 151 new codes per transaction, none of them in the pre-transaction snapshot. Each of those subjects' predicates then issued a point query that could not build a bound-subject filter and degraded into cloning and sorting the entire novelty set.

Measured per transaction: `subject_count=302 skipped_subjects=151 pattern_queries=1510`, and those 1,510 queries were **10.9s of an 11s staging**. Commit itself was 33ms; background indexing 137ms and fully overlapped. Replaying the same payloads through `insert` instead of `upsert` took 42ms each, flat.

## Changes

- **`stage.rs`** — resolve the IRI through the snapshot, then fall back to the store's own namespace table; report absent only when *neither* can decode the code. A code neither knows cannot name a base-index row. Novelty presence still backstops, so a subject that exists only in unindexed commits is never wrongly skipped.
- **`stage.rs`** — allow the skip before any index exists, where the absence of a range provider makes novelty authoritative on its own. That case alone cost 2.6s/txn.
- **`binary_scan.rs`** — apply the bound `(s,p,o)` match *inside* the overlay walk in `open_overlay_only_fallback` instead of cloning every overlay flake, sorting, and then `retain`ing. It was O(novelty) clones plus an O(n log n) sort **per call**. Safe because `resolve_overlay_retractions` decides each `(s,p,o,dt,m)` fact independently, so the filter drops whole facts and can never separate an assertion from its retraction.
- **`docs/design/namespace-allocation.md`** — the doc's namespace-explosion preflight covers bulk import only; ordinary transactions get no such detection. Notes the hazard, which also burns the u16 code space (~151 codes/txn ≈ 48k for this dataset against ~65.5k available).

## Measurements

Apple M4 Max, local file storage, default config, applied serially over HTTP to a fresh ledger.

| | 547 transactions |
|---|---|
| production, as reported | 823.1 s |
| this branch | 32–76 s |

Matched 20-upsert subset, identical payloads and machine:

| build | IRI shape | 20 upserts |
|---|---|---|
| v4.1.5 | `…evidence:<hex>:r:<sig>` | 273.8 s |
| v4.1.5 | revision IRIs share a prefix | 3.4 s |
| this branch | `…evidence:<hex>:r:<sig>` | 1.0 s |

The middle row is worth noting on its own: **IRI shape alone was an 80× penalty on the unmodified binary.** The customer has since normalized their IRIs, which independently confirmed the diagnosis in production — staging median 148ms → 22ms, p90 6,392ms → 447ms. On already-normalized data this branch is worth a further ~1.45× (34.9s → 24.1s), concentrated in four transactions where subjects exist as *objects* but not as subjects and still land in the overlay fallback. Its main value is removing the engine's sensitivity to IRI shape.

## Testing

- 4,986 tests pass across `fluree-db-transact`, `fluree-db-query`, `fluree-db-ledger`, `fluree-db-novelty` and `fluree-db-api`.
- New regression test `upsert_indexed_replaces_values_for_per_subject_namespaces` pins **both** directions: per-subject-namespace subjects that already exist still have their old values retracted (before and after a subsequent index build, so retractions are staged rather than masked by novelty), and brand-new ones are still skipped.
- Rebuilt ledger contains exactly 1,548,373 triples across 365,406 subjects, matching the source manifest.

## Not addressed

- Those benchmarks were taken with `--profile dev-fast`, not `--release`; before/after ratios are from matched builds.
- Remaining hot spot: a window of transactions where ~1,440 subjects per transaction genuinely exist and are probed one `(subject, predicate)` at a time. `batched_subject_probe_binary` (`join.rs:3208`) is the primitive that would collapse them.
- Overlay walks still scan the whole graph's novelty per call: `for_each_overlay_flake` supports a bounded seek that no leaf caller uses. Tracked in #1648.
- A profile of the fixed build shows `DictTreeReader::reverse_lookup` spending ~10% of CPU purely in clock reads (moka cache bookkeeping per leaf access). Separate issue, worth a look.

