### PR TITLE
Name terms and the failed constraint in SHACL violation messages

### DIFF
--- a/docs/guides/cookbook-shacl.md
+++ b/docs/guides/cookbook-shacl.md
@@ -606,7 +606,19 @@ become part of permanent ledger state.
 
 ## Validation modes
 
-- **`f:ValidationReject`** (default): on any violation, the transaction fails with `ShaclViolation(report)`. The formatted report lists each violation's focus node, property path, and message.
+- **`f:ValidationReject`** (default): on any violation, the transaction fails with `ShaclViolation(report)`. The formatted report lists each violation's focus node, property path, failed constraint component, and message:
+
+  ```
+  SHACL validation failed with 1 violation(s):
+    1. Expected at least 1 value(s) but found 0
+       Focus node: ex:alex
+       Path: schema:name
+       Constraint: sh:MinCountConstraintComponent
+  ```
+
+  The constraint component matters when one `sh:message` covers several constraints on the same property — it is what distinguishes a value that was absent from one that was repeated or the wrong datatype.
+
+  Identifiers are compacted against the transaction's own `@context`, using its explicit prefixes and `@base` (never `@vocab`), so a violation names the terms you wrote. Where there is no context to compact against — a Turtle insert, or commit replay — the same fields report full IRIs instead.
 - **`f:ValidationWarn`**: violations are logged via `tracing::warn!` and the transaction proceeds. Any **non-violation** error from the SHACL pipeline (compile failure, range-scan failure) still propagates — Warn mode never silently admits a broken validation pipeline.
 
 ## Working with shapes across write surfaces

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -463,6 +463,10 @@ impl Fluree {
                         // re-validate same-ledger only.
                         cross_ledger_shapes: None,
                         staged_ns: None,
+                        // Replay carries no `opts` payload, so there is no
+                        // authoring context to compact against — violations
+                        // here name full IRIs.
+                        txn_context: None,
                         cross_ledger_schema: None,
                         // Inline shapes are an authoring-time
                         // construct; commit replay carries no

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -384,9 +384,21 @@ impl Fluree {
             PushError::Invalid(format!("base snapshot namespace corruption: {e}")).into_api_error()
         })?;
 
+        // The namespaces these commits introduce, which reach the snapshot only
+        // in `apply_pushed_commits_to_state` — after validation. Kept as a plain
+        // map so a rejected commit's violation can name the terms it brought in,
+        // including ones an earlier commit of the same push introduced.
+        let mut pushed_namespaces: HashMap<u16, String> = HashMap::new();
+
         for c in &decoded {
             // Current state is base db + evolving novelty.
             let current_t = base_state.snapshot.t.max(evolving_novelty.t);
+            pushed_namespaces.extend(
+                c.commit
+                    .namespace_delta
+                    .iter()
+                    .map(|(code, prefix)| (*code, prefix.clone())),
+            );
 
             // 4.0.1 Cross-commit namespace validation: namespace delta must be
             // conflict-free against the accumulated namespace table from parent + prior commits.
@@ -463,6 +475,11 @@ impl Fluree {
                         // re-validate same-ledger only.
                         cross_ledger_shapes: None,
                         staged_ns: None,
+                        // These commits' own namespaces do not reach the
+                        // snapshot until after validation, so a violation on a
+                        // term they introduce resolves through here or not at
+                        // all.
+                        uncommitted_namespaces: Some(&pushed_namespaces),
                         // Replay carries no `opts` payload, so there is no
                         // authoring context to compact against — violations
                         // here name full IRIs.

--- a/fluree-db-api/src/shacl_tests.rs
+++ b/fluree-db-api/src/shacl_tests.rs
@@ -253,6 +253,62 @@ async fn violation_message_distinguishes_constraints_sharing_one_message() {
     }
 }
 
+/// A Turtle insert declares its prefixes in the document, so a namespace it
+/// introduces reaches validation through the staging registry and nowhere
+/// else — the snapshot has never seen it. Without that registry the focus node
+/// has no IRI to report and falls back to naming the raw namespace code.
+///
+/// Turtle carries no JSON-LD context, so the message reports full IRIs; there
+/// are no author-declared terms to compact against.
+#[tokio::test]
+async fn turtle_violation_resolves_a_namespace_the_document_introduced() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let context = shacl_context();
+    let shape_txn = json!({
+        "@context": context.clone(),
+        "@id": "ex:UserShape",
+        "@type": "sh:NodeShape",
+        "sh:targetClass": {"@id": "ex:User"},
+        "sh:property": [{
+            "@id": "ex:pshape1",
+            "sh:path": {"@id": "schema:name"},
+            "sh:minCount": 1
+        }]
+    });
+
+    let ledger = fluree
+        .create_ledger("shacl/turtle-violation:main")
+        .await
+        .unwrap();
+    let ledger = fluree.upsert(ledger, &shape_txn).await.unwrap().ledger;
+
+    // `fresh:` appears nowhere in the ledger, so its code is allocated during
+    // this parse and lives only in the staging registry.
+    let turtle = r"
+        @prefix ex: <http://example.org/ns/> .
+        @prefix fresh: <http://brand-new.example/ns/> .
+        fresh:alex a ex:User .
+    ";
+    // `StageResult` is not `Debug`, so match rather than `unwrap_err`.
+    let Err(err) = fluree
+        .stage_turtle_insert(ledger, turtle, None, None, None)
+        .await
+    else {
+        panic!("expected the Turtle insert to be rejected");
+    };
+    let ApiError::Transact(TransactError::ShaclViolation(message)) = err else {
+        panic!("expected SHACL violation, got {err:?}");
+    };
+    assert!(
+        message.contains("Focus node: http://brand-new.example/ns/alex"),
+        "a namespace the document introduced should still resolve: {message}"
+    );
+    assert!(
+        !message.contains("unresolved namespace"),
+        "nothing should fall back to a raw namespace code: {message}"
+    );
+}
+
 #[tokio::test]
 async fn shacl_datatype_constraints() {
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/src/shacl_tests.rs
+++ b/fluree-db-api/src/shacl_tests.rs
@@ -19,6 +19,24 @@ fn shacl_context() -> JsonValue {
     json!([default_context(), {"ex": "http://example.org/ns/"}])
 }
 
+/// The violation text from a rejected transaction, or a panic naming what came
+/// back instead.
+///
+/// Two variants carry it, because the tracked/policy entry point converts its
+/// errors to a `TrackedErrorResponse` and the violation arrives already
+/// stringified as an HTTP 400 rather than as the typed `ShaclViolation`. The
+/// text is identical either way, and the text is what these tests are about.
+fn shacl_violation_message(err: ApiError) -> String {
+    match err {
+        ApiError::Transact(TransactError::ShaclViolation(message)) => message,
+        ApiError::Http {
+            status: 400,
+            message,
+        } if message.contains("SHACL validation failed") => message,
+        other => panic!("expected SHACL violation, got {other:?}"),
+    }
+}
+
 fn assert_shacl_violation(err: ApiError, expected: &str) {
     match err {
         ApiError::Transact(TransactError::ShaclViolation(message)) => {
@@ -178,6 +196,103 @@ async fn violation_message_names_terms_and_constraint() {
 
     // The shape of the old output: a namespace code run together with a local
     // name, indistinguishable from a corrupt identifier.
+    assert!(
+        !message.contains("Focus node: 13"),
+        "raw namespace codes must not reach the message: {message}"
+    );
+}
+
+/// The same transaction, the same shape, the same `@context` — but with a policy
+/// attached, which is the normal configuration on a deployed server.
+///
+/// Policy-bearing writes go through `stage_transaction_tracked_with_policy`, and
+/// that path used to pass `txn_context: None` on the claim that a "Txn-based
+/// entry" has no source document to compact against. It does: the same
+/// `input.txn_json` it parsed a few lines earlier. So the fix for #1615 landed
+/// everywhere EXCEPT the path most rejected writes actually take — the tracked
+/// server write entry routes through here too — and an author with policy on saw
+/// `http://example.org/ns/alex` where the identical policy-free transaction
+/// reported `ex:alex`.
+///
+/// The policy here is permissive on purpose. It has to admit the write so the
+/// transaction reaches SHACL and fails THERE; a denying policy would reject it
+/// first and never produce a violation message to inspect.
+#[tokio::test]
+async fn violation_message_compacts_terms_on_the_policy_path() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let context = shacl_context();
+    let shape_txn = json!({
+        "@context": context.clone(),
+        "@id": "ex:UserShape",
+        "@type": "sh:NodeShape",
+        "sh:targetClass": {"@id": "ex:User"},
+        "sh:property": [{
+            "@id": "ex:pshape1",
+            "sh:path": {"@id": "schema:name"},
+            "sh:minCount": 1
+        }]
+    });
+
+    let ledger = fluree
+        .create_ledger("shacl/violation-message-policy:main")
+        .await
+        .unwrap();
+    let ledger = fluree.upsert(ledger, &shape_txn).await.unwrap().ledger;
+
+    // Allow-all, so the write is admitted and SHACL is what rejects it.
+    let policy = json!([{
+        "@id": "ex:allowAll",
+        "f:action": [{"@id": "f:view"}, {"@id": "f:modify"}],
+        "f:allow": true
+    }]);
+    let qc_opts = crate::GovernanceOptions {
+        policy: Some(policy),
+        default_allow: Some(true),
+        ..Default::default()
+    };
+    let policy_ctx = crate::policy_builder::build_policy_context_from_opts(
+        &ledger.snapshot,
+        ledger.novelty.as_ref(),
+        Some(ledger.novelty.as_ref()),
+        ledger.t(),
+        &qc_opts,
+        &[0],
+    )
+    .await
+    .expect("build policy context");
+
+    let data = json!({
+        "@context": context.clone(),
+        "@id": "ex:alex",
+        "@type": "ex:User"
+    });
+    let err = fluree
+        .stage_owned(ledger)
+        .upsert(&data)
+        .policy(policy_ctx)
+        .execute()
+        .await
+        .unwrap_err();
+
+    let message = shacl_violation_message(err);
+
+    assert!(
+        message.contains("Focus node: ex:alex"),
+        "a policy on the transaction must not cost the author their own terms: {message}"
+    );
+    assert!(
+        message.contains("Path: schema:name"),
+        "a policy on the transaction must not cost the author their own terms: {message}"
+    );
+    assert!(
+        message.contains("Constraint: sh:MinCountConstraintComponent"),
+        "the violated constraint component should be reported: {message}"
+    );
+    // The regression this guards is the un-compacted full IRI, not the raw code.
+    assert!(
+        !message.contains("http://example.org/ns/alex"),
+        "the focus node should be compacted, not a full IRI: {message}"
+    );
     assert!(
         !message.contains("Focus node: 13"),
         "raw namespace codes must not reach the message: {message}"

--- a/fluree-db-api/src/shacl_tests.rs
+++ b/fluree-db-api/src/shacl_tests.rs
@@ -115,6 +115,144 @@ async fn shacl_cardinality_constraints() {
     assert_shacl_violation(err, "Expected at most 1 value(s) but found 2");
 }
 
+/// A rejected transaction must name the focus node and path as terms the
+/// author would recognise, and say which constraint failed.
+///
+/// Regression for #1615: these were printed as a namespace code concatenated
+/// onto a local name (`13name`), which reads as corrupted data — the reporter
+/// spent their time hunting a serialization bug that did not exist. The
+/// constraint component was omitted entirely, so a shape whose single
+/// `sh:message` covers minCount, maxCount and datatype could not say which of
+/// them rejected the transaction.
+#[tokio::test]
+async fn violation_message_names_terms_and_constraint() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let context = shacl_context();
+    let shape_txn = json!({
+        "@context": context.clone(),
+        "@id": "ex:UserShape",
+        "@type": "sh:NodeShape",
+        "sh:targetClass": {"@id": "ex:User"},
+        "sh:property": [{
+            "@id": "ex:pshape1",
+            "sh:path": {"@id": "schema:name"},
+            "sh:minCount": 1
+        }]
+    });
+
+    let ledger = fluree
+        .create_ledger("shacl/violation-message:main")
+        .await
+        .unwrap();
+    let ledger = fluree.upsert(ledger, &shape_txn).await.unwrap().ledger;
+    let err = fluree
+        .upsert(
+            ledger,
+            &json!({
+                "@context": context.clone(),
+                "@id": "ex:alex",
+                "@type": "ex:User"
+            }),
+        )
+        .await
+        .unwrap_err();
+
+    let ApiError::Transact(TransactError::ShaclViolation(message)) = err else {
+        panic!("expected SHACL violation, got {err:?}");
+    };
+
+    // Compacted against the transaction's own context, so the message uses the
+    // prefixes the author declared.
+    assert!(
+        message.contains("Focus node: ex:alex"),
+        "focus node should name the term the transaction used: {message}"
+    );
+    assert!(
+        message.contains("Path: schema:name"),
+        "path should name the term the transaction used: {message}"
+    );
+    assert!(
+        message.contains("Constraint: sh:MinCountConstraintComponent"),
+        "the violated constraint component should be reported: {message}"
+    );
+
+    // The shape of the old output: a namespace code run together with a local
+    // name, indistinguishable from a corrupt identifier.
+    assert!(
+        !message.contains("Focus node: 13"),
+        "raw namespace codes must not reach the message: {message}"
+    );
+}
+
+/// The second half of #1615: one `sh:message` can cover several constraints on
+/// the same property, so the message alone cannot say which of them rejected
+/// the transaction. The reported component has to distinguish them.
+#[tokio::test]
+async fn violation_message_distinguishes_constraints_sharing_one_message() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let context = shacl_context();
+    // One property, three constraints, a single message for all of them.
+    let shape_txn = json!({
+        "@context": context.clone(),
+        "@id": "ex:UserShape",
+        "@type": "sh:NodeShape",
+        "sh:targetClass": {"@id": "ex:User"},
+        "sh:property": [{
+            "@id": "ex:pshape1",
+            "sh:path": {"@id": "schema:name"},
+            "sh:minCount": 1,
+            "sh:maxCount": 1,
+            "sh:datatype": {"@id": "xsd:string"},
+            "sh:message": "name is invalid"
+        }]
+    });
+
+    // Each case violates a different constraint on that one property.
+    let cases = [
+        (
+            "missing",
+            json!({"@id": "ex:alex", "@type": "ex:User"}),
+            "sh:MinCountConstraintComponent",
+        ),
+        (
+            "repeated",
+            json!({"@id": "ex:bri", "@type": "ex:User", "schema:name": ["Bri", "Brian"]}),
+            "sh:MaxCountConstraintComponent",
+        ),
+        (
+            "wrong-datatype",
+            json!({"@id": "ex:cass", "@type": "ex:User", "schema:name": 42}),
+            "sh:DatatypeConstraintComponent",
+        ),
+    ];
+
+    for (label, mut node, expected_component) in cases {
+        let ledger = fluree
+            .create_ledger(&format!("shacl/constraint-{label}:main"))
+            .await
+            .unwrap();
+        let ledger = fluree.upsert(ledger, &shape_txn).await.unwrap().ledger;
+        node.as_object_mut()
+            .unwrap()
+            .insert("@context".into(), context.clone());
+
+        let err = fluree.upsert(ledger, &node).await.unwrap_err();
+        let ApiError::Transact(TransactError::ShaclViolation(message)) = err else {
+            panic!("expected SHACL violation for {label}, got {err:?}");
+        };
+
+        assert!(
+            message.contains(&format!("Constraint: {expected_component}")),
+            "{label} should report {expected_component}: {message}"
+        );
+        // The shared message is what made these indistinguishable before.
+        assert!(
+            message.contains("name is invalid"),
+            "{label} should still carry the shape's message: {message}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn shacl_datatype_constraints() {
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -3166,7 +3166,10 @@ impl crate::Fluree {
                 // resolve_cross_ledger_shapes_for_tx here when
                 // the use case lands.
                 cross_ledger_shapes: None,
-                staged_ns: None,
+                // Carries the prefixes this document declared, which the
+                // snapshot has not seen yet — without it a violation on a
+                // predicate the document introduces has no IRI to report.
+                staged_ns: Some(&ns_registry),
                 // Turtle carries its prefixes in the document, not as a
                 // JSON-LD context the API sees, so violations name full IRIs.
                 txn_context: None,

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -1141,7 +1141,7 @@ fn format_violations(
     // and saying so beats emitting something that looks like an IRI.
     let render = |sid: &Sid| {
         compactor.compact_id_sid(sid).unwrap_or_else(|_| {
-            format!("<unresolved namespace {}>{}", sid.namespace_code, sid.name)
+            format!("[unresolved namespace {}]{}", sid.namespace_code, sid.name)
         })
     };
 

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -572,11 +572,19 @@ pub(crate) struct StagedShaclContext<'a> {
 
     /// Staged `NamespaceRegistry` — D's snapshot namespaces plus
     /// any IRIs the in-flight transaction has registered. Required
-    /// when `cross_ledger_shapes` is `Some`, where it is the term
-    /// context for compiling M's wire-form shapes against D. Also
-    /// resolves identifiers in violation messages, so a property the
-    /// transaction itself introduced still renders as an IRI.
+    /// when `cross_ledger_shapes` is `Some`; consulted as the term
+    /// context for compiling M's wire-form shapes against D.
     pub staged_ns: Option<&'a fluree_db_transact::namespace::NamespaceRegistry>,
+
+    /// Namespace codes this operation introduced, which the snapshot will not
+    /// carry until it commits. Violation messages resolve against these on top
+    /// of the snapshot's, so a term the operation itself brought in still has
+    /// an IRI to report rather than a bare code.
+    ///
+    /// Every path holds these somewhere of its own — a staging registry's
+    /// delta, or the namespace deltas of the commits being replayed — so this
+    /// is the map rather than any one path's carrier for it.
+    pub uncommitted_namespaces: Option<&'a HashMap<u16, String>>,
 
     /// The JSON-LD context the transaction supplied, used to compact
     /// identifiers in violation messages to the terms the author wrote.
@@ -1091,10 +1099,14 @@ fn violation_iri_compactor(
     use crate::format::IriCompactor;
 
     let base = view.base().snapshot.shared_namespaces();
-    let namespace_codes = match ctx.staged_ns.map(NamespaceRegistry::delta) {
-        Some(delta) if !delta.is_empty() => {
+    let namespace_codes = match ctx.uncommitted_namespaces {
+        Some(uncommitted) if !uncommitted.is_empty() => {
             let mut merged = (*base).clone();
-            merged.extend(delta.iter().map(|(code, prefix)| (*code, prefix.clone())));
+            merged.extend(
+                uncommitted
+                    .iter()
+                    .map(|(code, prefix)| (*code, prefix.clone())),
+            );
             std::sync::Arc::new(merged)
         }
         _ => base,
@@ -1345,7 +1357,8 @@ async fn stage_with_config_shacl(
                     crate::cross_ledger::GovernanceArtifact::Shapes(wire) => Some(wire),
                     _ => None,
                 }),
-            staged_ns: Some(&ns_registry),
+            staged_ns: cross_ledger_shapes.as_deref().map(|_| &ns_registry),
+            uncommitted_namespaces: Some(ns_registry.delta()),
             txn_context,
             inline_shape_bundle,
             cross_ledger_schema,
@@ -3171,10 +3184,11 @@ impl crate::Fluree {
                 // resolve_cross_ledger_shapes_for_tx here when
                 // the use case lands.
                 cross_ledger_shapes: None,
-                // Carries the prefixes this document declared, which the
-                // snapshot has not seen yet — without it a violation on a
-                // predicate the document introduces has no IRI to report.
-                staged_ns: Some(&ns_registry),
+                staged_ns: None,
+                // The prefixes this document declared, which the snapshot has
+                // not seen yet — without them a violation on a predicate the
+                // document introduces has no IRI to report.
+                uncommitted_namespaces: Some(ns_registry.delta()),
                 // Turtle carries its prefixes in the document, not as a
                 // JSON-LD context the API sees, so violations name full IRIs.
                 txn_context: None,

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -572,9 +572,17 @@ pub(crate) struct StagedShaclContext<'a> {
 
     /// Staged `NamespaceRegistry` — D's snapshot namespaces plus
     /// any IRIs the in-flight transaction has registered. Required
-    /// when `cross_ledger_shapes` is `Some`; consulted as the term
-    /// context for compiling M's wire-form shapes against D.
+    /// when `cross_ledger_shapes` is `Some`, where it is the term
+    /// context for compiling M's wire-form shapes against D. Also
+    /// resolves identifiers in violation messages, so a property the
+    /// transaction itself introduced still renders as an IRI.
     pub staged_ns: Option<&'a fluree_db_transact::namespace::NamespaceRegistry>,
+
+    /// The JSON-LD context the transaction supplied, used to compact
+    /// identifiers in violation messages to the terms the author wrote.
+    /// `None` where the request carries no context — Turtle inserts and
+    /// commit replay — and those messages carry full IRIs instead.
+    pub txn_context: Option<&'a serde_json::Value>,
 
     /// Inline shape bundle parsed from `txn.opts.shapes` against the
     /// staged namespace registry. When `Some`, the bundle attaches
@@ -1044,27 +1052,87 @@ pub(crate) async fn apply_shacl_policy_to_staged_view(
     .await?;
 
     // 6. Apply per-graph mode: warn violations log, reject violations fail.
+    //    The compactor is built only when there is something to report — it
+    //    merges namespace maps and parses the context, neither of which the
+    //    conforming path should pay for.
+    if outcome.conforms() {
+        return Ok(());
+    }
+    let compactor = violation_iri_compactor(view, &ctx);
+
     if !outcome.warn_violations.is_empty() {
         tracing::warn!(
             count = outcome.warn_violations.len(),
-            report = %format_violations(&outcome.warn_violations),
+            report = %format_violations(&outcome.warn_violations, &compactor),
             "SHACL violations (warn-mode graph, continuing)"
         );
     }
     if !outcome.reject_violations.is_empty() {
         return Err(fluree_db_transact::TransactError::ShaclViolation(
-            format_violations(&outcome.reject_violations),
+            format_violations(&outcome.reject_violations, &compactor),
         ));
     }
     Ok(())
 }
 
+/// Build the compactor that renders identifiers in violation messages.
+///
+/// Namespaces come from the snapshot plus anything this transaction registered,
+/// so a property the transaction itself introduced still resolves. The
+/// transaction's own context supplies the prefixes, which is what lets the
+/// message name terms the way the author wrote them; without one the compactor
+/// falls back to full IRIs rather than inventing prefixes the reader has no way
+/// to resolve.
+#[cfg(feature = "shacl")]
+fn violation_iri_compactor(
+    view: &StagedLedger,
+    ctx: &StagedShaclContext<'_>,
+) -> crate::format::IriCompactor {
+    use crate::format::IriCompactor;
+
+    let base = view.base().snapshot.shared_namespaces();
+    let namespace_codes = match ctx.staged_ns.map(NamespaceRegistry::delta) {
+        Some(delta) if !delta.is_empty() => {
+            let mut merged = (*base).clone();
+            merged.extend(delta.iter().map(|(code, prefix)| (*code, prefix.clone())));
+            std::sync::Arc::new(merged)
+        }
+        _ => base,
+    };
+
+    match ctx
+        .txn_context
+        .and_then(|raw| crate::ParsedContext::parse(None, raw).ok())
+    {
+        Some(parsed) => IriCompactor::new(namespace_codes, &parsed),
+        None => IriCompactor::from_namespaces(namespace_codes),
+    }
+}
+
 /// Format SHACL violations as a human-readable string, matching the shape of
 /// the prior `TransactError::ShaclViolation` payload so test assertions and
 /// log readers that look for familiar phrasing keep working.
+///
+/// Identifiers are rendered through `compactor`, so a focus node and path read
+/// as the terms the transaction was written with — or as full IRIs where it
+/// declared no context. Printing the raw Sid parts instead concatenates a
+/// namespace code onto a local name (`13address`), which reads as corrupt data
+/// rather than as the property it names.
 #[cfg(feature = "shacl")]
-fn format_violations(violations: &[fluree_db_shacl::ValidationResult]) -> String {
+fn format_violations(
+    violations: &[fluree_db_shacl::ValidationResult],
+    compactor: &crate::format::IriCompactor,
+) -> String {
     use std::fmt::Write;
+
+    // A Sid that will not decode has no better rendering than its own parts,
+    // and saying so beats emitting something that looks like an IRI.
+    let render = |sid: &Sid| {
+        compactor.compact_id_sid(sid).unwrap_or_else(|_| {
+            format!("<unresolved namespace {}>{}", sid.namespace_code, sid.name)
+        })
+    };
+
     let mut out = String::new();
     let _ = writeln!(
         out,
@@ -1073,10 +1141,22 @@ fn format_violations(violations: &[fluree_db_shacl::ValidationResult]) -> String
     );
     for (i, v) in violations.iter().enumerate() {
         let _ = writeln!(out, "  {}. {}", i + 1, v.message);
-        let _ = writeln!(out, "     Focus node: {}", v.focus_node);
+        let focus = match &v.focus_node {
+            fluree_db_shacl::FocusNode::Node(sid) => render(sid),
+            fluree_db_shacl::FocusNode::Literal(lit) => lit.value.to_string(),
+        };
+        let _ = writeln!(out, "     Focus node: {focus}");
         if let Some(path) = &v.result_path {
-            let _ = writeln!(out, "     Path: {}{}", path.namespace_code, path.name);
+            let _ = writeln!(out, "     Path: {}", render(path));
         }
+        // Which constraint failed. One `sh:message` often covers several
+        // constraints on the same property, so the message alone cannot say
+        // whether the value was absent, repeated, or the wrong datatype.
+        let _ = writeln!(
+            out,
+            "     Constraint: {}",
+            compactor.compact_vocab_iri(v.constraint_component)
+        );
     }
     out
 }
@@ -1096,6 +1176,7 @@ async fn stage_with_config_shacl(
     ns_registry: NamespaceRegistry,
     options: StageOptions<'_>,
     resolve_ctx: &mut crate::cross_ledger::ResolveCtx<'_>,
+    txn_context: Option<&JsonValue>,
 ) -> std::result::Result<(StagedLedger, NamespaceRegistry), fluree_db_transact::TransactError> {
     // Capture graph_delta + tracker before stage_txn consumes the options/txn.
     // graph_delta is used both for per-graph config lookup and for rebuilding
@@ -1259,7 +1340,8 @@ async fn stage_with_config_shacl(
                     crate::cross_ledger::GovernanceArtifact::Shapes(wire) => Some(wire),
                     _ => None,
                 }),
-            staged_ns: cross_ledger_shapes.as_deref().map(|_| &ns_registry),
+            staged_ns: Some(&ns_registry),
+            txn_context,
             inline_shape_bundle,
             cross_ledger_schema,
             cross_ledger_membership,
@@ -2130,8 +2212,15 @@ impl crate::Fluree {
         let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(&ledger_id_owned, self);
 
         #[cfg(feature = "shacl")]
-        let (view, ns_registry) =
-            stage_with_config_shacl(ledger, txn, ns_registry, options, &mut resolve_ctx).await?;
+        let (view, ns_registry) = stage_with_config_shacl(
+            ledger,
+            txn,
+            ns_registry,
+            options,
+            &mut resolve_ctx,
+            txn_json.get("@context"),
+        )
+        .await?;
         #[cfg(not(feature = "shacl"))]
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
@@ -2251,8 +2340,17 @@ impl crate::Fluree {
         let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(&ledger_id_owned, self);
 
         #[cfg(feature = "shacl")]
-        let (view, ns_registry) =
-            stage_with_config_shacl(ledger, txn, ns_registry, options, &mut resolve_ctx).await?;
+        let (view, ns_registry) = stage_with_config_shacl(
+            ledger,
+            txn,
+            ns_registry,
+            options,
+            &mut resolve_ctx,
+            // Txn-based entry: no source document, so no authoring
+            // context to compact violation messages against.
+            None,
+        )
+        .await?;
         #[cfg(not(feature = "shacl"))]
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
@@ -2458,10 +2556,18 @@ impl crate::Fluree {
         let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(&ledger_id_owned, self);
 
         #[cfg(feature = "shacl")]
-        let (view, ns_registry) =
-            stage_with_config_shacl(ledger, txn, ns_registry, options, &mut resolve_ctx)
-                .await
-                .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
+        let (view, ns_registry) = stage_with_config_shacl(
+            ledger,
+            txn,
+            ns_registry,
+            options,
+            &mut resolve_ctx,
+            // Txn-based entry: no source document, so no authoring
+            // context to compact violation messages against.
+            None,
+        )
+        .await
+        .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;
         #[cfg(not(feature = "shacl"))]
         let (view, ns_registry) = stage_txn(ledger, txn, ns_registry, options)
             .await
@@ -3061,6 +3167,9 @@ impl crate::Fluree {
                 // the use case lands.
                 cross_ledger_shapes: None,
                 staged_ns: None,
+                // Turtle carries its prefixes in the document, not as a
+                // JSON-LD context the API sees, so violations name full IRIs.
+                txn_context: None,
                 cross_ledger_schema: None,
                 // Turtle insert API has no `opts.shapes` surface
                 // today — inline SHACL flows in over the JSON

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -2553,9 +2553,14 @@ impl crate::Fluree {
             ns_registry,
             options,
             &mut resolve_ctx,
-            // Txn-based entry: no source document, so no authoring
-            // context to compact violation messages against.
-            None,
+            // The source document IS available here — `parse_transaction` above
+            // borrows it — so violations compact against the author's own terms.
+            // This entry point is where policy-bearing writes land, including the
+            // tracked server write path, so passing `None` here meant that on a
+            // deployed server with policy on, essentially every rejected write
+            // reported full IRIs while the same transaction without a policy
+            // reported `ex:alex`.
+            input.txn_json.get("@context"),
         )
         .await
         .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), tracker.tally()))?;

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -1085,12 +1085,12 @@ pub(crate) async fn apply_shacl_policy_to_staged_view(
 
 /// Build the compactor that renders identifiers in violation messages.
 ///
-/// Namespaces come from the snapshot plus anything this transaction registered,
-/// so a property the transaction itself introduced still resolves. The
-/// transaction's own context supplies the prefixes, which is what lets the
-/// message name terms the way the author wrote them; without one the compactor
-/// falls back to full IRIs rather than inventing prefixes the reader has no way
-/// to resolve.
+/// Namespaces come from the snapshot plus whatever the operation introduced
+/// and has not committed yet, so a term it brought in itself still resolves.
+/// An authoring context, where the request carried one, supplies the prefixes
+/// that let the message name terms the way their author wrote them. Without
+/// one — a Turtle insert, a replayed commit — the compactor reports full IRIs
+/// rather than inventing prefixes the reader has no way to resolve.
 #[cfg(feature = "shacl")]
 fn violation_iri_compactor(
     view: &StagedLedger,
@@ -1126,10 +1126,10 @@ fn violation_iri_compactor(
 /// log readers that look for familiar phrasing keep working.
 ///
 /// Identifiers are rendered through `compactor`, so a focus node and path read
-/// as the terms the transaction was written with — or as full IRIs where it
-/// declared no context. Printing the raw Sid parts instead concatenates a
-/// namespace code onto a local name (`13address`), which reads as corrupt data
-/// rather than as the property it names.
+/// as the terms their author wrote — or as full IRIs where the operation
+/// carried no context to compact against. Printing the raw Sid parts instead
+/// concatenates a namespace code onto a local name (`13address`), which reads
+/// as corrupt data rather than as the property it names.
 #[cfg(feature = "shacl")]
 fn format_violations(
     violations: &[fluree_db_shacl::ValidationResult],

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -1125,57 +1125,30 @@ fn violation_iri_compactor(
 /// the prior `TransactError::ShaclViolation` payload so test assertions and
 /// log readers that look for familiar phrasing keep working.
 ///
-/// Identifiers are rendered through `compactor`, so a focus node and path read
-/// as the terms their author wrote — or as full IRIs where the operation
-/// carried no context to compact against. Printing the raw Sid parts instead
-/// concatenates a namespace code onto a local name (`13address`), which reads
-/// as corrupt data rather than as the property it names.
+/// Supplies the resolution the shared layout cannot do for itself: identifiers
+/// go through `compactor`, so a focus node and path read as the terms their
+/// author wrote — or as full IRIs where the operation carried no context to
+/// compact against.
 #[cfg(feature = "shacl")]
 fn format_violations(
     violations: &[fluree_db_shacl::ValidationResult],
     compactor: &crate::format::IriCompactor,
 ) -> String {
-    use std::fmt::Write;
+    let violations: Vec<&fluree_db_shacl::ValidationResult> = violations.iter().collect();
 
-    // A Sid that will not decode has no better rendering than its own parts,
-    // and saying so beats emitting something that looks like an IRI.
-    let render = |sid: &Sid| {
-        compactor.compact_id_sid(sid).unwrap_or_else(|_| {
-            format!("[unresolved namespace {}]{}", sid.namespace_code, sid.name)
-        })
-    };
-
-    let mut out = String::new();
-    let _ = writeln!(
-        out,
-        "SHACL validation failed with {} violation(s):",
-        violations.len()
-    );
-    for (i, v) in violations.iter().enumerate() {
-        let _ = writeln!(out, "  {}. {}", i + 1, v.message);
-        let focus = match &v.focus_node {
-            fluree_db_shacl::FocusNode::Node(sid) => render(sid),
-            fluree_db_shacl::FocusNode::Literal(lit) => lit.value.to_string(),
-        };
-        let _ = writeln!(out, "     Focus node: {focus}");
-        if let Some(path) = &v.result_path {
-            let _ = writeln!(out, "     Path: {}", render(path));
-        }
-        // Which constraint failed. One `sh:message` often covers several
-        // constraints on the same property, so the message alone cannot say
-        // whether the value was absent, repeated, or the wrong datatype.
-        //
+    fluree_db_shacl::format_violations(
+        &violations,
+        |sid| {
+            compactor
+                .compact_id_sid(sid)
+                .unwrap_or_else(|_| fluree_db_shacl::unresolved_sid(sid))
+        },
         // Compacted the same way as the focus node and path — explicit
         // prefixes only. `@vocab` compaction would render this one line as a
         // bare term where the others never can, and a bare word in an error
         // does not read as the identifier it is.
-        let _ = writeln!(
-            out,
-            "     Constraint: {}",
-            compactor.compact_id_iri(v.constraint_component)
-        );
-    }
-    out
+        |iri| compactor.compact_id_iri(iri),
+    )
 }
 
 /// Perform staging followed by config-aware SHACL validation.

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -1152,10 +1152,15 @@ fn format_violations(
         // Which constraint failed. One `sh:message` often covers several
         // constraints on the same property, so the message alone cannot say
         // whether the value was absent, repeated, or the wrong datatype.
+        //
+        // Compacted the same way as the focus node and path — explicit
+        // prefixes only. `@vocab` compaction would render this one line as a
+        // bare term where the others never can, and a bare word in an error
+        // does not read as the identifier it is.
         let _ = writeln!(
             out,
             "     Constraint: {}",
-            compactor.compact_vocab_iri(v.constraint_component)
+            compactor.compact_id_iri(v.constraint_component)
         );
     }
     out

--- a/fluree-db-shacl/src/error.rs
+++ b/fluree-db-shacl/src/error.rs
@@ -36,15 +36,4 @@ pub enum ShaclError {
     /// Circular shape reference detected
     #[error("Circular shape reference detected involving {shape_id}")]
     CircularReference { shape_id: Sid },
-
-    /// SHACL validation failed
-    ///
-    /// Contains a summary of the validation failures.
-    #[error("SHACL validation failed: {violation_count} violation(s), {warning_count} warning(s)")]
-    ValidationFailed {
-        violation_count: usize,
-        warning_count: usize,
-        /// Detailed messages for each violation (truncated if too many)
-        details: Vec<String>,
-    },
 }

--- a/fluree-db-shacl/src/lib.rs
+++ b/fluree-db-shacl/src/lib.rs
@@ -102,6 +102,7 @@ pub mod compile;
 pub mod constraints;
 pub mod error;
 pub mod path;
+pub mod report_text;
 pub mod validate;
 
 pub use cache::{ShaclCache, ShaclCacheKey};
@@ -109,6 +110,7 @@ pub use compile::{CompiledShape, LiteralTarget, PropertyShape, Severity, ShapeId
 pub use constraints::Constraint;
 pub use error::{Result, ShaclError};
 pub use path::PropertyPath;
+pub use report_text::{format_violations, unresolved_sid, violations_of};
 pub use validate::{
     CrossLedgerMembership, FocusNode, ShaclEngine, ValidationReport, ValidationResult,
 };

--- a/fluree-db-shacl/src/report_text.rs
+++ b/fluree-db-shacl/src/report_text.rs
@@ -1,0 +1,89 @@
+//! Human-readable rendering of validation results.
+//!
+//! Enforcement rejects a write with a plain-text report, and the layout of
+//! that report is the same wherever the write came from. What differs is how
+//! each caller turns a [`Sid`] into something a reader recognises: the api
+//! layer compacts against the transaction's JSON-LD context, while callers
+//! below it, which cannot see a context, decode to full IRIs. Those callers
+//! supply the rendering; the layout lives here.
+//!
+//! Resolution has to be supplied rather than derived. A `Sid` is a namespace
+//! code plus a local name, and the code means nothing without the ledger's
+//! namespace map — which this crate has no handle on. Rendering the parts
+//! bare produces `13address` for `…/ns/address`, which reads as corrupt data
+//! (#1615).
+
+use std::fmt::Write;
+
+use fluree_db_core::Sid;
+
+use crate::compile::Severity;
+use crate::validate::{FocusNode, ValidationResult};
+
+/// Render a `Sid` no namespace map could resolve.
+///
+/// Reached only when a namespace code is absent from both the snapshot and
+/// whatever the operation has yet to commit, which means corruption or a bug
+/// rather than a missing prefix. Says so, rather than emitting something a
+/// reader would mistake for an identifier.
+pub fn unresolved_sid(sid: &Sid) -> String {
+    format!("[unresolved namespace {}]{}", sid.namespace_code, sid.name)
+}
+
+/// Every result in `results` carrying [`Severity::Violation`].
+///
+/// Callers holding a whole report use this to select what
+/// [`format_violations`] renders.
+pub fn violations_of(results: &[ValidationResult]) -> Vec<&ValidationResult> {
+    results
+        .iter()
+        .filter(|r| r.severity == Severity::Violation)
+        .collect()
+}
+
+/// Format violations as the report a rejected write carries.
+///
+/// `render_node` resolves focus nodes and property paths; `render_component`
+/// renders the constraint component's IRI. Both are the caller's, because
+/// only the caller knows which namespaces and prefixes are in reach.
+pub fn format_violations<N, C>(
+    violations: &[&ValidationResult],
+    render_node: N,
+    render_component: C,
+) -> String
+where
+    N: Fn(&Sid) -> String,
+    C: Fn(&str) -> String,
+{
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "SHACL validation failed with {} violation(s):",
+        violations.len()
+    );
+
+    for (i, violation) in violations.iter().enumerate() {
+        let _ = writeln!(out, "  {}. {}", i + 1, violation.message);
+
+        let focus = match &violation.focus_node {
+            FocusNode::Node(sid) => render_node(sid),
+            FocusNode::Literal(literal) => literal.value.to_string(),
+        };
+        let _ = writeln!(out, "     Focus node: {focus}");
+
+        if let Some(path) = &violation.result_path {
+            let _ = writeln!(out, "     Path: {}", render_node(path));
+        }
+
+        // Which constraint failed. One `sh:message` often covers several
+        // constraints on the same property, so the message alone cannot say
+        // whether the value was absent, repeated, or the wrong datatype.
+        let _ = writeln!(
+            out,
+            "     Constraint: {}",
+            render_component(violation.constraint_component)
+        );
+    }
+
+    out
+}

--- a/fluree-db-shacl/src/validate.rs
+++ b/fluree-db-shacl/src/validate.rs
@@ -3045,10 +3045,21 @@ impl FocusNode {
     }
 }
 
+/// Renders the node's internal parts, **not** an IRI.
+///
+/// A `Sid` is a namespace code plus a local name, and resolving the code to a
+/// prefix needs the ledger's namespace map — which a `Display` impl cannot
+/// reach. Anything user-facing must resolve the Sid itself; see
+/// `fluree-db-api`'s violation formatter, which decodes against the snapshot
+/// and the staged registry and compacts against the transaction's context.
+///
+/// The bracketed form is [`Sid`]'s own, chosen so the output cannot be
+/// mistaken for an identifier. Concatenating the parts bare renders
+/// `13address` for `…/ns/address`, which reads as corrupt data (#1615).
 impl std::fmt::Display for FocusNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FocusNode::Node(sid) => write!(f, "{}{}", sid.namespace_code, sid.name),
+            FocusNode::Node(sid) => write!(f, "{sid}"),
             FocusNode::Literal(lit) => write!(f, "{}", lit.value),
         }
     }

--- a/fluree-db-shacl/src/validate.rs
+++ b/fluree-db-shacl/src/validate.rs
@@ -588,48 +588,6 @@ impl ShaclEngine {
             results: all_results,
         })
     }
-
-    /// Validate staged changes, returning an error if validation fails
-    ///
-    /// This is a convenience wrapper around `validate_staged` that converts
-    /// validation failures into errors, suitable for use in transaction staging.
-    pub async fn validate_staged_or_error(
-        &self,
-        db: GraphDbRef<'_>,
-        modified_subjects: &HashSet<Sid>,
-    ) -> Result<()> {
-        let report = self.validate_staged(db, modified_subjects).await?;
-
-        // Enforcement rejects on violations only — spec-level `conforms`
-        // is also false for warnings/infos, which must not block a commit.
-        if report.violation_count() == 0 {
-            Ok(())
-        } else {
-            // Build detailed error messages (limit to first 10 to avoid huge errors)
-            let details: Vec<String> = report
-                .results
-                .iter()
-                .filter(|r| r.severity == Severity::Violation)
-                .take(10)
-                .map(|r| {
-                    if let Some(ref path) = r.result_path {
-                        format!(
-                            "Node {}: property {}: {}",
-                            r.focus_node, path.name, r.message
-                        )
-                    } else {
-                        format!("Node {}: {}", r.focus_node, r.message)
-                    }
-                })
-                .collect();
-
-            Err(crate::error::ShaclError::ValidationFailed {
-                violation_count: report.violation_count(),
-                warning_count: report.warning_count(),
-                details,
-            })
-        }
-    }
 }
 
 /// Get focus nodes for a shape based on its targeting declarations
@@ -3041,26 +2999,6 @@ impl FocusNode {
         match self {
             FocusNode::Node(sid) => Some(sid),
             FocusNode::Literal(_) => None,
-        }
-    }
-}
-
-/// Renders the node's internal parts, **not** an IRI.
-///
-/// A `Sid` is a namespace code plus a local name, and resolving the code to a
-/// prefix needs the ledger's namespace map — which a `Display` impl cannot
-/// reach. Anything user-facing must resolve the Sid itself; see
-/// `fluree-db-api`'s violation formatter, which decodes against the snapshot
-/// and the staged registry and compacts against the transaction's context.
-///
-/// The bracketed form is [`Sid`]'s own, chosen so the output cannot be
-/// mistaken for an identifier. Concatenating the parts bare renders
-/// `13address` for `…/ns/address`, which reads as corrupt data (#1615).
-impl std::fmt::Display for FocusNode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FocusNode::Node(sid) => write!(f, "{sid}"),
-            FocusNode::Literal(lit) => write!(f, "{}", lit.value),
         }
     }
 }

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -3333,70 +3333,36 @@ async fn validate_staged_nodes(
 
 /// Format a SHACL validation report as a human-readable string.
 ///
-/// Identifiers are decoded to IRIs against the snapshot's namespaces, falling
-/// back to `ns_registry` for prefixes this transaction registered — a property
-/// the transaction itself introduced is absent from the snapshot until it
-/// commits. Printing the raw Sid parts instead concatenates a namespace code
-/// onto a local name (`13address`), which reads as corrupt data rather than as
-/// the property it names.
+/// Supplies the resolution the shared layout cannot do for itself: Sids decode
+/// against the snapshot's namespaces, falling back to `ns_registry` for
+/// prefixes this transaction registered — a property the transaction itself
+/// introduced is absent from the snapshot until it commits.
 ///
-/// Unlike the api layer's equivalent, this reports full IRIs: the crate has no
-/// access to the transaction's JSON-LD context, so there are no author-supplied
-/// prefixes to compact against.
+/// Reports full IRIs, unlike the api layer's caller: this crate cannot see the
+/// transaction's JSON-LD context, so there are no author-supplied prefixes to
+/// compact against.
 #[cfg(feature = "shacl")]
 fn format_shacl_report(
     report: &ValidationReport,
     snapshot: &fluree_db_core::LedgerSnapshot,
     ns_registry: &NamespaceRegistry,
 ) -> String {
-    use std::fmt::Write;
+    let violations = fluree_db_shacl::violations_of(&report.results);
 
-    let render = |sid: &Sid| {
-        snapshot
-            .decode_sid(sid)
-            .or_else(|| {
-                ns_registry
-                    .get_prefix(sid.namespace_code)
-                    .map(|prefix| format!("{prefix}{}", sid.name))
-            })
-            .unwrap_or_else(|| format!("<unresolved namespace {}>{}", sid.namespace_code, sid.name))
-    };
-
-    let mut output = String::new();
-    writeln!(
-        &mut output,
-        "SHACL validation failed with {} violation(s):",
-        report.violation_count()
+    fluree_db_shacl::format_violations(
+        &violations,
+        |sid| {
+            snapshot
+                .decode_sid(sid)
+                .or_else(|| {
+                    ns_registry
+                        .get_prefix(sid.namespace_code)
+                        .map(|prefix| format!("{prefix}{}", sid.name))
+                })
+                .unwrap_or_else(|| fluree_db_shacl::unresolved_sid(sid))
+        },
+        str::to_string,
     )
-    .ok();
-
-    for (i, result) in report
-        .results
-        .iter()
-        .filter(|r| r.severity == fluree_db_shacl::Severity::Violation)
-        .enumerate()
-    {
-        writeln!(&mut output, "  {}. {}", i + 1, result.message).ok();
-        let focus = match &result.focus_node {
-            fluree_db_shacl::FocusNode::Node(sid) => render(sid),
-            fluree_db_shacl::FocusNode::Literal(lit) => lit.value.to_string(),
-        };
-        writeln!(&mut output, "     Focus node: {focus}").ok();
-        if let Some(path) = &result.result_path {
-            writeln!(&mut output, "     Path: {}", render(path)).ok();
-        }
-        // Which constraint failed. One `sh:message` often covers several
-        // constraints on the same property, so the message alone cannot say
-        // whether the value was absent, repeated, or the wrong datatype.
-        writeln!(
-            &mut output,
-            "     Constraint: {}",
-            result.constraint_component
-        )
-        .ok();
-    }
-
-    output
 }
 
 #[cfg(test)]

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -3058,7 +3058,11 @@ pub async fn stage_with_shacl(
     // Reject on violations only — spec-level `conforms` is also false for
     // warnings/infos, which must not block a commit.
     if report.violation_count() > 0 {
-        return Err(TransactError::ShaclViolation(format_shacl_report(&report)));
+        return Err(TransactError::ShaclViolation(format_shacl_report(
+            &report,
+            &base.snapshot,
+            &ns_registry,
+        )));
     }
 
     Ok((view, ns_registry))
@@ -3327,10 +3331,36 @@ async fn validate_staged_nodes(
     })
 }
 
-/// Format a SHACL validation report as a human-readable string
+/// Format a SHACL validation report as a human-readable string.
+///
+/// Identifiers are decoded to IRIs against the snapshot's namespaces, falling
+/// back to `ns_registry` for prefixes this transaction registered — a property
+/// the transaction itself introduced is absent from the snapshot until it
+/// commits. Printing the raw Sid parts instead concatenates a namespace code
+/// onto a local name (`13address`), which reads as corrupt data rather than as
+/// the property it names.
+///
+/// Unlike the api layer's equivalent, this reports full IRIs: the crate has no
+/// access to the transaction's JSON-LD context, so there are no author-supplied
+/// prefixes to compact against.
 #[cfg(feature = "shacl")]
-fn format_shacl_report(report: &ValidationReport) -> String {
+fn format_shacl_report(
+    report: &ValidationReport,
+    snapshot: &fluree_db_core::LedgerSnapshot,
+    ns_registry: &NamespaceRegistry,
+) -> String {
     use std::fmt::Write;
+
+    let render = |sid: &Sid| {
+        snapshot
+            .decode_sid(sid)
+            .or_else(|| {
+                ns_registry
+                    .get_prefix(sid.namespace_code)
+                    .map(|prefix| format!("{prefix}{}", sid.name))
+            })
+            .unwrap_or_else(|| format!("<unresolved namespace {}>{}", sid.namespace_code, sid.name))
+    };
 
     let mut output = String::new();
     writeln!(
@@ -3347,15 +3377,23 @@ fn format_shacl_report(report: &ValidationReport) -> String {
         .enumerate()
     {
         writeln!(&mut output, "  {}. {}", i + 1, result.message).ok();
-        writeln!(&mut output, "     Focus node: {}", result.focus_node).ok();
+        let focus = match &result.focus_node {
+            fluree_db_shacl::FocusNode::Node(sid) => render(sid),
+            fluree_db_shacl::FocusNode::Literal(lit) => lit.value.to_string(),
+        };
+        writeln!(&mut output, "     Focus node: {focus}").ok();
         if let Some(path) = &result.result_path {
-            writeln!(
-                &mut output,
-                "     Path: {}{}",
-                path.namespace_code, path.name
-            )
-            .ok();
+            writeln!(&mut output, "     Path: {}", render(path)).ok();
         }
+        // Which constraint failed. One `sh:message` often covers several
+        // constraints on the same property, so the message alone cannot say
+        // whether the value was absent, repeated, or the wrong datatype.
+        writeln!(
+            &mut output,
+            "     Constraint: {}",
+            result.constraint_component
+        )
+        .ok();
     }
 
     output


### PR DESCRIPTION
## Problem

A rejected transaction reported its focus node and property path by concatenating a Sid's namespace code onto its local name — `13address` for `https://ixfabric.ai/ns/address`. Nothing was wrong with the data; the formatter printed two unrelated values with no separator between them. The reporter read it as corruption and spent their time hunting a serialization bug that did not exist.

The same message never said which constraint failed. `ValidationResult` has carried `constraint_component` all along, derived per violation from the specific constraint, but no formatter printed it. One `sh:message` commonly covers several constraints on a property, so the message alone cannot distinguish a value that was absent from one that was repeated or the wrong datatype.

## Scope is narrower than the issue reads, and wider than one call site

`/validate` was never affected. It already resolved identifiers through `resolve_sid` and already emitted `sh:sourceConstraintComponent`; so does the CLI's `fluree validate`, which consumes the same resolved report. The defect was confined to *transaction enforcement*.

But four enforcement paths carried it, not one: the JSON transaction path, Turtle inserts, commit replay in `prepare_push`, and `fluree-db-transact::stage_with_shacl` — a public entry point with no in-workspace callers that external embedders reach. All four are fixed.

## Changes

**Identifiers resolve, and compact where there is a context to compact against.** The api layer renders through `IriCompactor::compact_id_sid` using the transaction's own `@context`, so a violation reads `Focus node: ex:alex` / `Path: schema:name` / `Constraint: sh:MinCountConstraintComponent`. Paths below that layer cannot see a context and report full IRIs, matching `/validate`. All three lines compact by the same rule — explicit prefixes and `@base`, never `@vocab` — so no line can emit a bare term where the others cannot.

**Namespaces an operation introduced now resolve.** A property the operation itself brought in is absent from the snapshot until it commits, so it had no IRI to report. `StagedShaclContext` gained `uncommitted_namespaces: Option<&HashMap<u16, String>>`, which each path fills from what it holds: a staging registry's delta for JSON and Turtle, the pushed commits' `namespace_delta`s for replay. Replay accumulates across the decoded commits rather than reading each in isolation, because a later commit's flakes can reference a namespace an earlier one introduced within the same push.

**One layout, per-caller resolution.** `fluree-db-api` and `fluree-db-transact` had near-identical formatters, and `fluree-db-api → fluree-db-transact` is one-directional, so neither could host the shared code. Both depend on `fluree-db-shacl`, which also owns `ValidationResult` and `FocusNode`, so the layout moved there as `report_text::format_violations`, parameterised by the two things only a caller can know: how to resolve a Sid, and how to render the component IRI. `unresolved_sid` moved with it, so the `[unresolved namespace 13]address` fallback has one definition rather than two string literals to keep in step.

**Dead code removed.** `validate_staged_or_error` had no callers anywhere and formatted violations its own way; with it gone, `ShaclError::ValidationFailed` was constructed nowhere and `FocusNode`'s `Display` — which could only ever render `13address`, since a `Display` impl cannot reach the ledger's namespace map — had no users. All three are removed, so nothing left in the tree can render an unresolved Sid to a reader.

## Breaking changes

Three removals from `fluree-db-shacl`'s public surface. Nothing in this workspace used any of them, but external consumers might:

- `ShaclEngine::validate_staged_or_error`
- `ShaclError::ValidationFailed`
- `impl Display for FocusNode` — code formatting a `FocusNode` with `{}` will stop compiling, which is the intended outcome: it was emitting `13address`. Resolve the Sid against a namespace map instead.

## Testing

- `violation_message_names_terms_and_constraint` — the compacted path end to end: focus node, path and constraint component, plus an assertion that a raw namespace code cannot reappear.
- `violation_message_distinguishes_constraints_sharing_one_message` — the reporter's shape exactly: one property carrying minCount, maxCount and datatype under a single `sh:message`, asserting each violation reports its own component while all three carry the identical message. That last assertion is the point — it proves the message stays ambiguous and the component is what disambiguates.
- `turtle_violation_resolves_a_namespace_the_document_introduced` — a Turtle insert declaring a prefix that appears nowhere in the ledger, asserting the focus node resolves rather than falling back.

Each was verified to fail without its fix: removing the `Constraint:` line fails the first two, and reverting the Turtle wiring reproduces `Focus node: [unresolved namespace 15]alex`.

`cargo fmt --check`, `cargo clippy --workspace --all-targets`, and `cargo check --workspace --all-targets` are clean with the `shacl` feature enabled. Suites: api SHACL 78, transact 304, shacl 59.

## Notes for reviewers

**`cargo check -p fluree-db-api` does not cover this.** `shacl` is off by default in that crate, so the code compiles green while broken. A third `StagedShaclContext` construction site in `commit_transfer.rs` only surfaced once the feature was enabled — enable it, or check the workspace.

**Warn-mode violations now log resolved IRIs.** `tracing::warn!` previously carried the opaque `13address`; it now carries subject IRIs, which can encode customer identifiers. That is the intended improvement, but it puts them into log sinks rather than only into the response to a caller who already had the data.

**Commit replay has no test of its own.** Reaching `prepare_push` needs a follower holding decoded commits with a namespace delta plus a shape that rejects one — considerable scaffolding for the same resolution path the Turtle test already pins. The wiring is one field at one call site.

**`[unresolved namespace 13]address` should be unreachable.** It means a namespace code is absent from both the snapshot and whatever the operation has yet to commit, which is corruption or a bug rather than a missing prefix. It is deliberately not IRI-shaped.

Fixes #1615 