### PR TITLE
fix(materialize): skip materialize targets that already applied the window

### DIFF
--- a/fluree-db-api/src/graph_source/r2rml_materialize.rs
+++ b/fluree-db-api/src/graph_source/r2rml_materialize.rs
@@ -740,6 +740,23 @@ impl Fluree {
             deferred: deferred.len(),
             failed: failed.len(),
         };
+        // Report skips on EVERY pass, not only an incomplete one.
+        //
+        // An all-skip pass is `is_complete()`, so it would otherwise be the ONE outcome
+        // that prints nothing whatsoever — and that is precisely the shape a
+        // wrongly-skipped target takes. `all_skipped` is the specific alarm: nothing was
+        // written this pass, yet the watermark is about to advance. That is legitimate
+        // for a genuinely idle window and a data-loss signature otherwise, so it has to
+        // be visible either way rather than inferred by diffing a target ledger's `t`.
+        if skipped_targets > 0 {
+            info!(
+                source = %source_graph_source_id,
+                targets_skipped = skipped_targets,
+                targets_ok = tally.ok,
+                all_skipped = skipped_targets == tally.ok && tally.is_complete(),
+                "materialize: targets already held this window; nothing written for them"
+            );
+        }
         if !tally.is_complete() {
             info!(
                 targets_ok = tally.ok,
@@ -1129,6 +1146,39 @@ fn applied_node(
 /// applied one table of a two-table window still has work, so it must not be
 /// skipped — that is the difference between skipping a no-op and silently dropping
 /// half a window.
+///
+/// # Why this is `==` and must not become an inequality
+///
+/// `applied` and `to` are Iceberg **snapshot ids**, and the spec assigns those
+/// randomly: there is no ordering between two snapshot ids, not even between a
+/// snapshot and its own parent. `a >= to` therefore compares two unrelated random
+/// i64s and calls the answer "has this target already applied the window".
+///
+/// That comparison makes the marker a one-way ratchet. It is only rewritten when a
+/// window's `to` happens to compare greater, so it climbs the running maximum of a
+/// random sequence and then exceeds every later draw permanently — after roughly
+/// `ln(n)` windows a target stops being written to at all. Measured on a 17-source
+/// deployment: every marker had ratcheted to between 8.19e18 and 9.22e18 against an
+/// `i64::MAX` of 9.223e18, so all 17 were skipped on every poll, each skip was
+/// counted as an ok target, and the watermark advanced past data that was never
+/// applied. About 80% of the entities in the source lakehouse were discarded.
+///
+/// Equality is what the question actually asks, and it fully covers the case this
+/// skip exists for: a job whose watermark cannot advance re-presents the SAME `to`
+/// on every poll, so equality matches and the skip fires.
+///
+/// The two cases an inequality was reaching for both survive equality:
+///
+/// - A re-poll of an older snapshot: equality declines to skip, so the target
+///   re-applies. Re-application is idempotent, so the cost is repeated work, never
+///   corruption — strictly safer than skipping data that was never applied.
+/// - A window that moved backwards after a forced full: moot, because `force_full`
+///   discards the markers before the target loop runs.
+///
+/// If "at or beyond" is ever genuinely needed it requires a quantity that IS
+/// ordered — the Iceberg **sequence number**, which increases by one per commit —
+/// which means storing the sequence alongside the snapshot id in the marker. Do not
+/// reintroduce an inequality over snapshot ids.
 fn target_is_caught_up(
     applied: &std::collections::HashMap<(String, String), i64>,
     target: &str,
@@ -1138,7 +1188,7 @@ fn target_is_caught_up(
         && table_watermarks.iter().all(|(table, _from, to)| {
             applied
                 .get(&(target.to_string(), table.clone()))
-                .is_some_and(|a| *a >= *to)
+                .is_some_and(|a| *a == *to)
         })
 }
 
@@ -2948,27 +2998,87 @@ mod tests {
         assert!(!target_is_caught_up(&applied, "silver_acme_u2:main", &tw));
     }
 
-    /// `>=`, not `==`: a marker ahead of this window (a re-poll of an older snapshot,
-    /// or a window that moved backwards after a forced full) still means "has it".
-    /// Equality here would re-apply and rebuild the amplification.
+    /// `==`, and only `==`. A marker that merely DIFFERS from this window's `to` — in
+    /// either numeric direction — has not applied this window.
     #[test]
-    fn an_applied_marker_at_or_beyond_the_window_counts_as_caught_up() {
+    fn only_an_applied_marker_equal_to_the_window_counts_as_caught_up() {
         let tw = vec![("t".to_string(), None, 20i64)];
         assert!(target_is_caught_up(
             &applied_map(&[("x:main", "t", 20)]),
             "x:main",
             &tw
         ));
-        assert!(target_is_caught_up(
-            &applied_map(&[("x:main", "t", 21)]),
-            "x:main",
-            &tw
-        ));
+        assert!(
+            !target_is_caught_up(&applied_map(&[("x:main", "t", 21)]), "x:main", &tw),
+            "a marker numerically above `to` is a DIFFERENT snapshot, not a later one"
+        );
         assert!(!target_is_caught_up(
             &applied_map(&[("x:main", "t", 19)]),
             "x:main",
             &tw
         ));
+    }
+
+    /// Snapshot ids are random, so an applied marker can be numerically far larger
+    /// than a snapshot committed long after it. Skipping on `>=` therefore ratchets:
+    /// the marker climbs the running maximum of a random sequence and then exceeds
+    /// every later draw permanently, and the target is never written to again.
+    ///
+    /// These are real values from a deployment where that happened — all 17 markers
+    /// had reached 8.19e18–9.22e18 against an `i64::MAX` of 9.223e18, every target was
+    /// skipped on every poll, and the watermark advanced past data that was never
+    /// applied. Each `to` below is a genuinely LATER commit than the marker beside it,
+    /// despite being numerically smaller.
+    ///
+    /// Small sequence-shaped fixtures cannot catch this — an ordered fixture will
+    /// ratify an ordering comparison — which is why these are the production numbers.
+    #[test]
+    fn a_marker_numerically_above_a_later_snapshot_is_not_caught_up() {
+        // (table, ratcheted applied marker, the genuinely later snapshot it skipped)
+        let observed = [
+            (
+                "silver.place",
+                9_220_834_252_869_770_488i64,
+                5_644_295_785_472_712_989i64,
+            ),
+            (
+                "silver.observation",
+                9_217_340_116_954_323_563,
+                3_238_671_374_642_079_740,
+            ),
+            (
+                "silver.concept_scheme",
+                9_086_429_568_298_186_029,
+                753_340_878_885_049_461,
+            ),
+            (
+                "silver.concept",
+                9_052_937_455_619_636_065,
+                1_349_575_232_631_351_152,
+            ),
+            (
+                "silver.link",
+                9_196_238_952_972_422_466,
+                9_139_397_570_598_290_786,
+            ),
+        ];
+        for (table, marker, later_to) in observed {
+            assert!(
+                marker > later_to,
+                "{table}: this fixture is only meaningful while the marker is \
+                 numerically larger than the later snapshot — that is the whole trap"
+            );
+            let tw = vec![(table.to_string(), None, later_to)];
+            assert!(
+                !target_is_caught_up(
+                    &applied_map(&[("silver_acme_u1:main", table, marker)]),
+                    "silver_acme_u1:main",
+                    &tw
+                ),
+                "{table}: marker {marker} is a different snapshot from {later_to}, not \
+                 a later one — skipping here is what discarded the window"
+            );
+        }
     }
 
     /// ALL tables, not any. A target that applied one table of a two-table window

--- a/fluree-db-api/src/graph_source/r2rml_materialize.rs
+++ b/fluree-db-api/src/graph_source/r2rml_materialize.rs
@@ -100,6 +100,36 @@ const WATERMARK_TARGET_PRED: &str = "urn:fluree:materialize#target";
 /// Predicate recording which source table the watermark belongs to.
 const WATERMARK_TABLE_PRED: &str = "urn:fluree:materialize#table";
 
+/// Subject-IRI prefix for a per-(source, RESOLVED target, table) applied marker.
+///
+/// Distinct from [`WATERMARK_SUBJECT_PREFIX`] because the two are keyed on
+/// different things and must never collide: the watermark is keyed on the target
+/// SPEC (one per job, `silver_{tenant}_{user}:main`), this on the RESOLVED ledger
+/// (`silver_acme_u1:main`). For a non-templated job those strings are equal, so a
+/// shared prefix would put both on the same subject.
+const APPLIED_SUBJECT_PREFIX: &str = "urn:fluree:materialize-applied:";
+/// Predicate holding the snapshot id a single resolved target has fully applied
+/// (string-encoded, like the watermark, to preserve i64 precision).
+///
+/// WHY THIS EXISTS. The watermark is shared across every target a templated job
+/// fans into, and it may not advance while ANY target is behind — otherwise the
+/// laggards would skip that window permanently. Correct, but it means the targets
+/// that DID commit earn no credit: the next poll re-reads the window and
+/// re-commits all of them, forever, for as long as one target cannot fit.
+///
+/// Measured in production: 19 of 23 targets committing and 4 deferring on every
+/// poll, unchanged across 22 consecutive polls, so 19 targets were rewritten every
+/// ~4 minutes for 13.7 h. The re-commits are idempotent but not free — they are
+/// writes, and they filled a 100 GiB volume to ENOSPC, which is unrecoverable
+/// because GC needs to write in order to reclaim.
+///
+/// This marker records what each resolved target has already applied, so a target
+/// that is caught up is SKIPPED rather than rewritten. It deliberately does not
+/// touch the scan window: the shared watermark still chooses it, so the source read
+/// is unchanged and there is no risk of starting a scan after rows a newly-created
+/// target still needs.
+const APPLIED_SNAPSHOT_PRED: &str = "urn:fluree:materialize#appliedSnapshotId";
+
 /// Subject-IRI prefix for a persisted tracking job. The full subject is
 /// `{PREFIX}{source}:{target-spec}`, matching the worker's own
 /// `(source, target)` job key.
@@ -646,8 +676,39 @@ impl Fluree {
         let mut ok_targets = 0usize;
         let mut deferred: Vec<(String, usize)> = Vec::new();
         let mut failed: Vec<(String, ApiError)> = Vec::new();
+        let mut skipped_targets = 0usize;
+        let mut newly_applied: Vec<String> = Vec::new();
+
+        // What each resolved target has already applied. Read once per pass, not per
+        // target. `force_full` ignores the markers for the same reason it ignores the
+        // watermark: the caller is asking for a rebuild, not a resume.
+        let applied = if force_full {
+            std::collections::HashMap::new()
+        } else {
+            self.materialize_applied_markers(MATERIALIZE_STATE_LEDGER, source_graph_source_id)
+                .await
+                .unwrap_or_else(|e| {
+                    // Non-fatal: an unreadable marker set costs the skip, not the pass.
+                    // Failing here would turn a state-ledger hiccup into a stalled job,
+                    // and re-applying is idempotent.
+                    warn!(
+                        source = %source_graph_source_id,
+                        error = %e,
+                        "materialize: could not read applied markers; re-applying every target"
+                    );
+                    std::collections::HashMap::new()
+                })
+        };
 
         for (target, (live, deletions)) in by_target {
+            // Already has this whole window. Skipping is what stops a job whose
+            // watermark cannot advance from rewriting its healthy targets on every
+            // poll — the amplification that filled a 100 GiB volume.
+            if target_is_caught_up(&applied, &target, &table_watermarks) {
+                skipped_targets += 1;
+                ok_targets += 1;
+                continue;
+            }
             match self
                 .materialize_one_target(&target, live, deletions, latest_by_key, txn_budget)
                 .await
@@ -655,6 +716,7 @@ impl Fluree {
                 Ok(retracted) => {
                     subjects_retracted += retracted;
                     ok_targets += 1;
+                    newly_applied.push(target);
                 }
                 // Deferral is not failure — it is backpressure on THIS target only.
                 Err(ApiError::NoveltyDeferred { remaining }) => {
@@ -683,8 +745,41 @@ impl Fluree {
                 targets_ok = tally.ok,
                 targets_deferred = tally.deferred,
                 targets_failed = tally.failed,
+                targets_skipped = skipped_targets,
                 "materialize: partial window"
             );
+        }
+
+        // Record what just landed, BEFORE the partial-window returns below.
+        //
+        // The ordering is the whole point. A job whose watermark can never advance is
+        // exactly the job that needs these markers, and both early returns sit between
+        // here and the watermark write — so putting this after them would record
+        // progress only for jobs that never needed it.
+        //
+        // After the data commits, never before: a crash in the gap re-applies the
+        // window, which is idempotent, whereas a marker written first would skip rows
+        // that were never committed. Same argument as the watermark, one target down.
+        if !newly_applied.is_empty() && !table_watermarks.is_empty() {
+            let nodes: Vec<JsonValue> = newly_applied
+                .iter()
+                .flat_map(|target| {
+                    table_watermarks.iter().map(move |(table, _from, to)| {
+                        applied_node(source_graph_source_id, target, table, *to)
+                    })
+                })
+                .collect();
+            let state = self.materialize_state_ledger().await?;
+            // Through the backpressure helper for the same reason the watermark write
+            // is: giving up here on a transient novelty condition would discard the
+            // knowledge of a window that DID commit, and the next poll would rewrite it.
+            self.transact_chunks_with_backpressure(
+                state,
+                vec![nodes],
+                |c: &[JsonValue]| JsonValue::Array(c.to_vec()),
+                ChunkVerb::Upsert,
+            )
+            .await?;
         }
 
         // The watermark is still SHARED across targets (per-target watermarks are the
@@ -794,6 +889,80 @@ impl Fluree {
         Ok(extract_first_i64(&json))
     }
 
+    /// Every resolved target's applied marker for one source, as
+    /// `(target, table) -> applied snapshot id`.
+    ///
+    /// ONE query for the whole job, not one per target: a templated job fans into as
+    /// many ledgers as it has (tenant,user) pairs — 23 here, unbounded in principle —
+    /// and a per-target read would put that many round trips in front of every poll.
+    ///
+    /// An empty map is the correct answer for a state ledger written before this
+    /// existed, and it makes the first poll behave exactly as it did before: nothing
+    /// is skipped, everything is applied, and the markers are written on the way out.
+    async fn materialize_applied_markers(
+        &self,
+        state_ledger_id: &str,
+        source_graph_source_id: &str,
+    ) -> Result<std::collections::HashMap<(String, String), i64>> {
+        let mut out = std::collections::HashMap::new();
+        if !self.ledger_exists(state_ledger_id).await? {
+            return Ok(out);
+        }
+        let db = self.db(state_ledger_id).await?;
+
+        let mut where_obj = Map::new();
+        where_obj.insert("@id".to_string(), JsonValue::String("?s".to_string()));
+        where_obj.insert(
+            WATERMARK_SOURCE_PRED.to_string(),
+            JsonValue::String(source_graph_source_id.to_string()),
+        );
+        where_obj.insert(
+            WATERMARK_TARGET_PRED.to_string(),
+            JsonValue::String("?target".to_string()),
+        );
+        where_obj.insert(
+            WATERMARK_TABLE_PRED.to_string(),
+            JsonValue::String("?table".to_string()),
+        );
+        // Binding the applied predicate is also what EXCLUDES watermark subjects:
+        // they carry the same source/target/table triple but never this predicate.
+        where_obj.insert(
+            APPLIED_SNAPSHOT_PRED.to_string(),
+            JsonValue::String("?applied".to_string()),
+        );
+        let query = json!({
+            "select": ["?target", "?table", "?applied"],
+            "where": JsonValue::Object(where_obj),
+        });
+
+        let result = self.query(&db, &query).await?;
+        let json = result.to_jsonld(&db.snapshot).map_err(|e| {
+            ApiError::Internal(format!("Failed to format applied-marker query: {e}"))
+        })?;
+        if let Some(rows) = json.as_array() {
+            for row in rows {
+                let Some(cols) = row.as_array() else { continue };
+                let (Some(t), Some(tbl), Some(a)) = (cols.first(), cols.get(1), cols.get(2)) else {
+                    continue;
+                };
+                let (Some(t), Some(tbl)) = (t.as_str(), tbl.as_str()) else {
+                    continue;
+                };
+                // String-encoded on write; tolerate a numeric literal rather than
+                // dropping the marker, since dropping it silently re-enables the
+                // rewrite this exists to prevent.
+                let applied = a
+                    .as_str()
+                    .and_then(|s| s.parse::<i64>().ok())
+                    .or_else(|| a.as_i64());
+                if let Some(applied) = applied {
+                    out.insert((t.to_string(), tbl.to_string()), applied);
+                }
+            }
+        }
+        Ok(out)
+    }
+
     /// Open the shared materialization-state ledger, creating it if absent.
     ///
     /// Tolerates losing the create race: two concurrent pollers (or a poller and
@@ -898,6 +1067,79 @@ fn watermark_subject(source_graph_source_id: &str, target_spec: &str, table_name
         esc(target_spec),
         esc(table_name)
     )
+}
+
+/// The per-(source, RESOLVED target, table) applied-marker subject IRI. Same
+/// injective escaping as [`watermark_subject`], different prefix — see
+/// [`APPLIED_SUBJECT_PREFIX`] for why they must not share one.
+fn applied_subject(
+    source_graph_source_id: &str,
+    resolved_target: &str,
+    table_name: &str,
+) -> String {
+    fn esc(s: &str) -> String {
+        s.replace('%', "%25").replace(':', "%3A")
+    }
+    format!(
+        "{APPLIED_SUBJECT_PREFIX}{}:{}:{}",
+        esc(source_graph_source_id),
+        esc(resolved_target),
+        esc(table_name)
+    )
+}
+
+/// Build an applied-marker JSON-LD node for one resolved target and table.
+fn applied_node(
+    source_graph_source_id: &str,
+    resolved_target: &str,
+    table_name: &str,
+    applied_snapshot_id: i64,
+) -> JsonValue {
+    let mut node = Map::new();
+    node.insert(
+        "@id".to_string(),
+        JsonValue::String(applied_subject(
+            source_graph_source_id,
+            resolved_target,
+            table_name,
+        )),
+    );
+    node.insert(
+        APPLIED_SNAPSHOT_PRED.to_string(),
+        JsonValue::String(applied_snapshot_id.to_string()),
+    );
+    node.insert(
+        WATERMARK_SOURCE_PRED.to_string(),
+        JsonValue::String(source_graph_source_id.to_string()),
+    );
+    node.insert(
+        WATERMARK_TARGET_PRED.to_string(),
+        JsonValue::String(resolved_target.to_string()),
+    );
+    node.insert(
+        WATERMARK_TABLE_PRED.to_string(),
+        JsonValue::String(table_name.to_string()),
+    );
+    JsonValue::Object(node)
+}
+
+/// Is this target caught up on every table in the window?
+///
+/// `true` only when EVERY table's `to` is already covered. A target that has
+/// applied one table of a two-table window still has work, so it must not be
+/// skipped — that is the difference between skipping a no-op and silently dropping
+/// half a window.
+fn target_is_caught_up(
+    applied: &std::collections::HashMap<(String, String), i64>,
+    target: &str,
+    table_watermarks: &[(String, Option<i64>, i64)],
+) -> bool {
+    !table_watermarks.is_empty()
+        && table_watermarks.iter().all(|(table, _from, to)| {
+            applied
+                .get(&(target.to_string(), table.clone()))
+                .is_some_and(|a| *a >= *to)
+        })
 }
 
 /// Build the watermark JSON-LD node (`@id` + last snapshot id + source + target +
@@ -2682,6 +2924,94 @@ mod tests {
         assert_eq!(node[WATERMARK_SOURCE_PRED], json!("people:main"));
         assert_eq!(node[WATERMARK_TARGET_PRED], json!("silver:main"));
         assert_eq!(node[WATERMARK_TABLE_PRED], json!("demo.actors"));
+    }
+
+    /// Helper: build an applied-marker map the way a pass would read it.
+    #[cfg(test)]
+    fn applied_map(
+        entries: &[(&str, &str, i64)],
+    ) -> std::collections::HashMap<(String, String), i64> {
+        entries
+            .iter()
+            .map(|(target, table, a)| ((target.to_string(), table.to_string()), *a))
+            .collect()
+    }
+
+    /// The case this whole change exists for: a job whose watermark cannot advance
+    /// must still skip the targets that already have the window.
+    #[test]
+    fn a_target_that_applied_the_window_is_caught_up() {
+        let tw = vec![("silver.observation".to_string(), Some(10i64), 20i64)];
+        let applied = applied_map(&[("silver_acme_u1:main", "silver.observation", 20)]);
+        assert!(target_is_caught_up(&applied, "silver_acme_u1:main", &tw));
+        // A target the markers say nothing about must NOT be skipped.
+        assert!(!target_is_caught_up(&applied, "silver_acme_u2:main", &tw));
+    }
+
+    /// `>=`, not `==`: a marker ahead of this window (a re-poll of an older snapshot,
+    /// or a window that moved backwards after a forced full) still means "has it".
+    /// Equality here would re-apply and rebuild the amplification.
+    #[test]
+    fn an_applied_marker_at_or_beyond_the_window_counts_as_caught_up() {
+        let tw = vec![("t".to_string(), None, 20i64)];
+        assert!(target_is_caught_up(
+            &applied_map(&[("x:main", "t", 20)]),
+            "x:main",
+            &tw
+        ));
+        assert!(target_is_caught_up(
+            &applied_map(&[("x:main", "t", 21)]),
+            "x:main",
+            &tw
+        ));
+        assert!(!target_is_caught_up(
+            &applied_map(&[("x:main", "t", 19)]),
+            "x:main",
+            &tw
+        ));
+    }
+
+    /// ALL tables, not any. A target that applied one table of a two-table window
+    /// still owes the other one, and skipping it there would drop half a window
+    /// silently — the one bug in this change that would lose data rather than repeat
+    /// work.
+    #[test]
+    fn a_target_behind_on_any_table_is_not_caught_up() {
+        let tw = vec![
+            ("t_a".to_string(), None, 20i64),
+            ("t_b".to_string(), None, 30i64),
+        ];
+        let both = applied_map(&[("x:main", "t_a", 20), ("x:main", "t_b", 30)]);
+        assert!(target_is_caught_up(&both, "x:main", &tw));
+        let only_a = applied_map(&[("x:main", "t_a", 20)]);
+        assert!(!target_is_caught_up(&only_a, "x:main", &tw));
+        let a_ok_b_behind = applied_map(&[("x:main", "t_a", 20), ("x:main", "t_b", 29)]);
+        assert!(!target_is_caught_up(&a_ok_b_behind, "x:main", &tw));
+    }
+
+    /// An empty window must never mark anything caught up. `all()` over an empty
+    /// slice is vacuously true, so without the guard a source with no snapshots yet
+    /// would skip every target forever and materialize nothing.
+    #[test]
+    fn an_empty_window_leaves_every_target_not_caught_up() {
+        let applied = applied_map(&[("x:main", "t", 99)]);
+        assert!(!target_is_caught_up(&applied, "x:main", &[]));
+    }
+
+    /// The markers key on the RESOLVED target, and must not collide with the
+    /// spec-keyed watermark subject — which they would if both used one prefix, since
+    /// for a non-templated job spec == resolved.
+    #[test]
+    fn applied_and_watermark_subjects_never_collide() {
+        let w = watermark_subject("src:main", "silver:main", "t");
+        let a = applied_subject("src:main", "silver:main", "t");
+        assert_ne!(w, a);
+        assert!(a.starts_with(APPLIED_SUBJECT_PREFIX));
+        // Injective in the resolved target, like the watermark is in the spec.
+        assert_ne!(
+            applied_subject("s", "silver_a:main_b", "t"),
+            applied_subject("s", "silver_a:main", "b:t")
+        );
     }
 
     #[test]

--- a/fluree-db-api/src/graph_source/r2rml_materialize.rs
+++ b/fluree-db-api/src/graph_source/r2rml_materialize.rs
@@ -3574,9 +3574,6 @@ mod engine_tests {
         }
     }
 
-    /// A templated target fans out: one scan, N target ledgers, each its own commit
-    /// domain. Pins that the tally counts TARGETS rather than polls — the accounting whose
-    /// absence made a 21-of-22 production window read as a total stall.
     /// The amplification this module's applied markers exist to stop, end to end.
     ///
     /// A re-presented window — same rows, same `to_snapshot_id`, which is exactly what
@@ -3662,6 +3659,9 @@ mod engine_tests {
         );
     }
 
+    /// A templated target fans out: one scan, N target ledgers, each its own commit
+    /// domain. Pins that the tally counts TARGETS rather than polls — the accounting whose
+    /// absence made a 21-of-22 production window read as a total stall.
     #[tokio::test]
     async fn a_templated_target_fans_out_per_row() {
         let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/src/graph_source/r2rml_materialize.rs
+++ b/fluree-db-api/src/graph_source/r2rml_materialize.rs
@@ -3293,6 +3293,14 @@ mod engine_tests {
         /// persist-regardless. Default to a FRESH window so tests opt in to staleness.
         window_age_ms: Option<i64>,
         scans: std::sync::atomic::AtomicUsize,
+        /// Re-present the same batches on every scan instead of draining them.
+        ///
+        /// Draining is the right default — it catches a fixture that gets pulled twice
+        /// when it should be pulled once. But it cannot model the case this module's
+        /// applied markers exist for: a window that is re-read because the shared
+        /// watermark could not advance. That needs the SAME rows and the SAME
+        /// `to_snapshot_id` presented again.
+        repeat: bool,
     }
 
     impl FakeSource {
@@ -3305,7 +3313,13 @@ mod engine_tests {
                 to_snapshot_id: Some(7),
                 window_age_ms: Some(0),
                 scans: std::sync::atomic::AtomicUsize::new(0),
+                repeat: false,
             }
+        }
+        /// Same window on every scan — see [`FakeSource::repeat`].
+        fn repeating(mut self) -> Self {
+            self.repeat = true;
+            self
         }
         fn scans(&self) -> usize {
             self.scans.load(std::sync::atomic::Ordering::SeqCst)
@@ -3330,7 +3344,11 @@ mod engine_tests {
             _from: Option<i64>,
         ) -> Result<MaterializeScan> {
             self.scans.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            let taken: Vec<ColumnBatch> = std::mem::take(&mut *self.batches.lock().unwrap());
+            let taken: Vec<ColumnBatch> = if self.repeat {
+                self.batches.lock().unwrap().clone()
+            } else {
+                std::mem::take(&mut *self.batches.lock().unwrap())
+            };
             Ok(MaterializeScan {
                 to_snapshot_id: self.to_snapshot_id,
                 incremental: false,
@@ -3449,6 +3467,91 @@ mod engine_tests {
     /// A templated target fans out: one scan, N target ledgers, each its own commit
     /// domain. Pins that the tally counts TARGETS rather than polls — the accounting whose
     /// absence made a 21-of-22 production window read as a total stall.
+    /// The amplification this module's applied markers exist to stop, end to end.
+    ///
+    /// A re-presented window — same rows, same `to_snapshot_id`, which is exactly what
+    /// a job whose shared watermark cannot advance sees on every poll — must not
+    /// rewrite the targets that already have it.
+    ///
+    /// The assertion is each target ledger's `t`, and the choice matters. Reading the
+    /// DATA proves nothing, because re-application is idempotent and leaves it
+    /// identical either way. `subjects_upserted` proves nothing either — it is
+    /// `live.len()`, the subjects the accumulator PREPARED, counted before the target
+    /// loop runs, so it reads 3 whether or not a single commit happened. `t` only
+    /// advances on an actual commit, so it is the one observable that separates
+    /// "skipped" from "rewritten to the same value".
+    #[tokio::test]
+    async fn a_re_presented_window_does_not_rewrite_targets_that_already_applied_it() {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let src = FakeSource::new(
+            people_mapping(),
+            vec![batch(&[
+                ("id", &["1", "2", "3"]),
+                ("name", &["alice", "bob", "carol"]),
+                ("tenant", &["acme", "acme", "globex"]),
+            ])],
+        )
+        .repeating();
+
+        let first = fluree
+            .materialize_from_source(
+                &src,
+                "people:main",
+                "people_{tenant}:main",
+                false,
+                None,
+                None,
+            )
+            .await
+            .expect("first pass");
+        assert_eq!(first.tally.ok, 2, "two tenants => two target ledgers");
+
+        let targets = ["people_acme:main", "people_globex:main"];
+        let mut t_after_first = Vec::new();
+        for id in targets {
+            t_after_first.push(fluree.ledger(id).await.expect("target ledger").t());
+        }
+        assert!(
+            t_after_first.iter().all(|t| *t > 0),
+            "first pass must actually commit or the second proves nothing: {t_after_first:?}"
+        );
+
+        let second = fluree
+            .materialize_from_source(
+                &src,
+                "people:main",
+                "people_{tenant}:main",
+                false,
+                None,
+                None,
+            )
+            .await
+            .expect("second pass");
+
+        assert_eq!(
+            src.scans(),
+            2,
+            "the window really was re-read, not short-circuited"
+        );
+        for (id, before) in targets.iter().zip(&t_after_first) {
+            let after = fluree.ledger(id).await.expect("target ledger").t();
+            assert_eq!(
+                after, *before,
+                "{id} already applied this window; a second commit means the rewrite is back"
+            );
+        }
+        assert_eq!(
+            second.tally.ok, 2,
+            "a skipped target still counts as ok — it HAS the window; reporting it as \
+             anything else would read as a regression in the tally"
+        );
+        assert_eq!(
+            second.tally.deferred + second.tally.failed,
+            0,
+            "skipping is not deferral and not failure"
+        );
+    }
+
     #[tokio::test]
     async fn a_templated_target_fans_out_per_row() {
         let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/src/graph_source/r2rml_materialize.rs
+++ b/fluree-db-api/src/graph_source/r2rml_materialize.rs
@@ -777,26 +777,32 @@ impl Fluree {
         // After the data commits, never before: a crash in the gap re-applies the
         // window, which is idempotent, whereas a marker written first would skip rows
         // that were never committed. Same argument as the watermark, one target down.
+        //
+        // Non-fatal, exactly as the marker READ above is, and for the same reason: a
+        // marker that fails to land costs one redundant re-apply on the next poll and
+        // nothing else, so it must not be able to fail the pass.
+        //
+        // Here it would cost more than the pass. This write sits BETWEEN the target
+        // loop and the failed/deferred returns, so propagating its error would surface
+        // a state-ledger error INSTEAD of `MaterializePartial { tally, detail }` —
+        // discarding the per-target tally and the identity of the target that actually
+        // failed. And the condition most likely to fail this write is the one this
+        // module most needs to report: at ENOSPC, the incident these markers exist to
+        // prevent, every state-ledger write fails, so an operator would get a bare disk
+        // error where the useful signal is "target X failed: No space left on device".
         if !newly_applied.is_empty() && !table_watermarks.is_empty() {
-            let nodes: Vec<JsonValue> = newly_applied
-                .iter()
-                .flat_map(|target| {
-                    table_watermarks.iter().map(move |(table, _from, to)| {
-                        applied_node(source_graph_source_id, target, table, *to)
-                    })
-                })
-                .collect();
-            let state = self.materialize_state_ledger().await?;
-            // Through the backpressure helper for the same reason the watermark write
-            // is: giving up here on a transient novelty condition would discard the
-            // knowledge of a window that DID commit, and the next poll would rewrite it.
-            self.transact_chunks_with_backpressure(
-                state,
-                vec![nodes],
-                |c: &[JsonValue]| JsonValue::Array(c.to_vec()),
-                ChunkVerb::Upsert,
-            )
-            .await?;
+            if let Err(e) = self
+                .write_applied_markers(source_graph_source_id, &newly_applied, &table_watermarks)
+                .await
+            {
+                warn!(
+                    source = %source_graph_source_id,
+                    targets = newly_applied.len(),
+                    error = %e,
+                    "materialize: could not record applied markers; \
+                     those targets will be re-applied next poll"
+                );
+            }
         }
 
         // The watermark is still SHARED across targets (per-target watermarks are the
@@ -916,6 +922,15 @@ impl Fluree {
     /// An empty map is the correct answer for a state ledger written before this
     /// existed, and it makes the first poll behave exactly as it did before: nothing
     /// is skipped, everything is applied, and the markers are written on the way out.
+    ///
+    /// GROWTH. This set is unbounded in a way the watermark deliberately is not. The
+    /// watermark is keyed on the target SPEC, so a templated job keeps one row per
+    /// source table no matter how wide it fans; a marker is keyed on the RESOLVED
+    /// ledger, so the set grows with the fan-out and every poll reads all of it.
+    /// Nothing evicts a marker when a target ledger is retired, so a job that cycles
+    /// through `(tenant, user)` pairs accumulates rows it will never read usefully
+    /// again. Immaterial at the 23 targets this was built for; revisit before a fan-out
+    /// large enough that the per-poll read is a cost of its own.
     async fn materialize_applied_markers(
         &self,
         state_ledger_id: &str,
@@ -978,6 +993,39 @@ impl Fluree {
             }
         }
         Ok(out)
+    }
+
+    /// Record that `targets` have fully applied this window, one marker per
+    /// (source, resolved target, table).
+    ///
+    /// Errors are the caller's to swallow — see the call site for why this must not
+    /// fail a pass.
+    async fn write_applied_markers(
+        &self,
+        source_graph_source_id: &str,
+        targets: &[String],
+        table_watermarks: &[(String, Option<i64>, i64)],
+    ) -> Result<()> {
+        let nodes: Vec<JsonValue> = targets
+            .iter()
+            .flat_map(|target| {
+                table_watermarks.iter().map(move |(table, _from, to)| {
+                    applied_node(source_graph_source_id, target, table, *to)
+                })
+            })
+            .collect();
+        let state = self.materialize_state_ledger().await?;
+        // Through the backpressure helper for the same reason the watermark write is:
+        // giving up on a transient novelty condition would discard the knowledge of a
+        // window that DID commit, and the next poll would rewrite it.
+        self.transact_chunks_with_backpressure(
+            state,
+            vec![nodes],
+            |c: &[JsonValue]| JsonValue::Array(c.to_vec()),
+            ChunkVerb::Upsert,
+        )
+        .await?;
+        Ok(())
     }
 
     /// Open the shared materialization-state ledger, creating it if absent.


### PR DESCRIPTION
A templated job's watermark is shared across every ledger it fans into, and it must not advance while any target is behind — otherwise the laggards skip that window permanently. That is correct, and this PR does not change it.

What it costs today is that the targets which **did** commit earn no credit. The next poll re-reads the same window and re-commits all of them, and it keeps doing that for as long as one target cannot fit.

This is the follow-through on a note I left in `r2rml_materialize.rs` when per-target failure isolation landed in #1422:

> Note the loop already commits per target as it goes, so partial application was ALWAYS the reality. What was missing is recording which targets succeeded.

That PR made partial application survivable; it did not make it *recorded*. This records it. A resolved target that already holds the window is skipped instead of rewritten.

## What it cost us

A 17-source job fanning out per `(tenant, user)` into 23 ledgers, one of which has a window larger than the novelty ceiling:

- `targets_ok=19 targets_deferred=4` on **22 consecutive polls**, byte-identical remainder each time (`items_deferred=421708`)
- the job's watermark was **never written once in 13.7 h**
- so 19 ledgers were re-committed every ~4 minutes for 13.7 h

The re-commits are idempotent but they are still writes. They filled a 100 GiB volume: **479 `No space left on device` failures across 8 target ledgers in 13 minutes**. That state does not self-heal — index GC has to write in order to reclaim anything, so at zero bytes free it cannot run.

After this change, on the same deployment and the same data:

| | before | after |
|---|---|---|
| volume used | 119 GiB, climbing | **79 GiB**, flat |
| CPU | 2359m | **851m** |
| per-poll targets | `ok=19 deferred=4` | `ok=22 deferred=1 skipped=22` |

The deferral count dropping 4 → 1 was not predicted: removing the rewrite churn relieved enough novelty pressure that three of the four stuck targets got through on their own.

## Design

**Additive.** A new `urn:fluree:materialize#appliedSnapshotId` marker per `(source, RESOLVED target, table)`. The shared watermark still chooses the scan window, so the source read is byte-for-byte unchanged. A state ledger written before this simply has no markers, so the first poll behaves exactly as it did and every poll after is cheap.

**Why not per-target scan watermarks**, which is the obvious alternative: taking `min()` across targets as the window start is wrong the moment a target is created. A newly-created `(tenant, user)` ledger has no watermark, so `min()` over the existing ones starts the scan *after* rows that target still needs, and it silently never receives them. Detecting that mid-window and forcing a re-scan is real complexity, and it buys nothing here — per-target watermarks fix the *rewrite*, which this fixes more cheaply, not the *volume*.

**Two orderings, both load-bearing:**

- Markers are written **before** the partial-window early returns. A job whose watermark cannot advance is precisely the job that needs them, and both returns sit between that point and the watermark write. Putting this after them would record progress only for jobs that never needed it.
- Markers are written **after** the target's data commit. A crash in the gap re-applies the window, which is idempotent; a marker written first would skip rows that never landed. Same rule as the watermark, one level down.

**Edges decided rather than left open:**

- A target must be caught up on **every** table in the window, not any. A target that applied one table of a two-table window still owes the other, and skipping it there would drop half a window silently — the only way this change could lose data rather than repeat work.
- An **empty** window marks nothing caught up. `all()` over an empty slice is vacuously true, so without an explicit guard a source with no snapshots yet would skip every target forever and materialize nothing.
- `==`, never an inequality. Both sides are Iceberg **snapshot ids**, which the spec assigns randomly — there is no ordering between two of them, not even between a snapshot and its own parent. An earlier revision of this PR compared them with `>=`, which turns the marker into a one-way ratchet: it climbs the running maximum of a random sequence and after roughly `ln(n)` windows exceeds every later draw permanently. That ran on a 17-source deployment, where every marker ratcheted past every subsequent window — all 17 sources skipped on every poll, each skip counted as an ok target, nothing logged, the shared watermark advancing past data that was never applied, and about 80% of the source entities discarded. Equality is what the question actually asks, and it covers the amplification this PR exists to stop, because a job whose watermark cannot advance re-presents the *same* `to` every poll. If "at or beyond" is ever genuinely needed it requires a quantity that IS ordered — the Iceberg sequence number — stored alongside the snapshot id. Full account in `9820a68ad` and on `target_is_caught_up`.
- Unreadable markers are **non-fatal** and cost only the skip. Re-applying is idempotent, and failing here would turn a state-ledger hiccup into a stalled job.
- `force_full` ignores the markers, for the same reason it ignores the watermark: the caller is asking for a rebuild, not a resume.

## Testing

`fmt` and `clippy --all-features --all-targets -- -D warnings` clean. `fluree-db-api --lib` 1074 pass, 0 fail.

Six tests: five on the predicate and one driving the engine end to end over a re-presented window — same rows, same `to_snapshot_id`, which is exactly what a job whose watermark cannot advance sees on every poll. `FakeSource` drains its batches by design, so that needs an opt-in `repeating()` variant rather than a change to the default.

Four mutations: dropping the non-empty guard, `all` → `any`, `==` → `>=`, and **removing the skip branch entirely**. Each is killed in isolation — the first, second and fourth by exactly one test, and `==` → `>=` by two (the equality predicate test and `a_marker_numerically_above_a_later_snapshot_is_not_caught_up`, which carries five real (marker, later-snapshot) pairs from the incident rather than a sequence-shaped fixture; an ordered fixture would ratify an ordering comparison). Removing the skip branch is the one worth dwelling on — the predicate tests all stayed green against it, because they only exercise a pure function. Only the engine test catches it, and it does so on the target ledger's `t`: `assertion left == right failed: people_acme:main already applied this window; a second commit means the rewrite is back / left: 3 / right: 2`. That mutation was re-run after the rebase onto `a85e03682`, with the same result.

Two assertions were wrong before this landed, and both looked authoritative:

- `subjects_upserted` is `live.len()`, the subjects the accumulator *prepared*, read before the target loop runs. It reads 3 whether or not a single commit happened.
- Reading the target **data** proves nothing either: re-application is idempotent, so it is identical whether the target was skipped or rewritten.

The target ledger's `t` is the one observable that separates them, because it only moves on a real commit. Removing the skip advances it 2 → 3 and fails the test.

## Not in this PR

This stops the livelock **consuming disk**. It does not make an oversized target complete — four targets in our deployment still need ~45 MB in a single pass and still cannot get it, so that table remains without a watermark. Fixing that needs sub-window progress, which is a separate change and a separate discussion: subdividing the window at snapshot boundaries needs no new vocabulary at all, but does nothing when the volume sits in one snapshot, and the general case needs a per-target file cursor. Happy to follow up if you have a view on how progress should be represented.
