### PR TITLE
fix(policy): alias the class-cache type (clippy type_complexity, red on main)

### DIFF
--- a/fluree-db-policy/src/evaluate.rs
+++ b/fluree-db-policy/src/evaluate.rs
@@ -56,6 +56,10 @@ impl<'a> FlakeEvalParams<'a> {
     }
 }
 
+/// Shared (graph, subject) -> classes cache for runtime class-membership
+/// checks. See the `class_cache` field docs for why the graph is in the key.
+type ClassCache = Arc<RwLock<std::collections::HashMap<(GraphId, Sid), Vec<Sid>>>>;
+
 /// Policy context for evaluation
 ///
 /// Holds the policy wrapper, grounded identity, and class cache.
@@ -72,7 +76,7 @@ pub struct PolicyContext {
     /// different `rdf:type` values in different named graphs, and an `f:onClass`
     /// decision made against another graph's classes is simply wrong. Keying on
     /// `Sid` alone made the result depend on which graph populated the entry first.
-    class_cache: Arc<RwLock<std::collections::HashMap<(GraphId, Sid), Vec<Sid>>>>,
+    class_cache: ClassCache,
 }
 
 impl PolicyContext {


### PR DESCRIPTION
Unbreak-main: #1580's graph-keyed class cache — the fix itself is right — widened `PolicyContext.class_cache`'s type past clippy's `type_complexity` threshold, and with `-D warnings` that turned main's clippy job red (first failing run: 31954057339, at 3ce13529d). Every open PR inherits the red through the merge-ref checkout, which is how we noticed on #1654.

One `ClassCache` type alias — clippy's own suggested shape — no behavior change. `cargo clippy -p fluree-db-policy --all-targets -- -D warnings` clean locally, policy suite 39/39, fmt clean.