### PR TITLE
perf: fold a one-row VALUES into its object and cost nested UNION honestly

### DIFF
--- a/docs/design/performance.md
+++ b/docs/design/performance.md
@@ -211,6 +211,38 @@ generic RDF cardinality math gets badly wrong:
   `MATCH (p {id: $x})-[:KNOWS*1..2]-(f) WITH DISTINCT f` emits its projected
   distinct rows, not its body's join product — the product overestimates by
   ~792 M on a 2-hop `KNOWS`.
+- **Branches made only of compound patterns.** `estimate_branch_cardinality`
+  scales a branch with no triples of its own by the unknown-property-scan
+  default, which is right for a branch it knows nothing about and wrong for one
+  whose single member already reports a row count. A chained
+  `{A} UNION {B} UNION {C}` parses as `Union([[Union([[A],[B]])],[C]])`, so the
+  outer branch holding the inner UNION owns no triples — a 30-row union was
+  costed at 20 M rows and placed behind every real scan. Since `UnionOperator`
+  is correlated (it rebuilds and re-runs each branch per input row), that
+  misplacement is superlinear: 53 s on a 200k-row driver versus 0.1 ms placed
+  first.
+
+### Pre-planning rewrites
+
+Two rewrites run over a pattern list before `reorder_patterns` sees it, so both
+ordering and the scan layer work from the narrower form:
+
+- **Redundant `rdf:type` elision** — drop `?s rdf:type <C>` when stats prove
+  every subject of a co-occurring predicate is a `C` (`elide_redundant_type_filters`).
+- **Single-row VALUES object folding** — `VALUES ?o { <iri> }` *is* the constant
+  `<iri>`, so `?s <p> ?o` in the same inner-join region is folded to `?s <p> <iri>`
+  (`inline_singleton_values_objects`). Without it a VALUES binding a leaf object
+  var is deferred *above* the star, so `PropertyJoinOperator` drives off whatever
+  else is bound and drains that predicate's whole extent before the one-row
+  VALUES filters it — 240 ms versus 0.1 ms for the inlined form on a
+  200k-subject star. The VALUES pattern stays in place, so the variable is still
+  bound for projection and FILTERs. The rewrite is restricted to one-row
+  reference cells in object position within one contiguous
+  Triple/VALUES/BIND/FILTER region: multi-row VALUES is a set rather than a
+  constant, literals carry datatype/language matching rules that belong to the
+  scan layer, subject/predicate positions keep the existing seeding path, and
+  compound patterns are rewrite boundaries because MINUS/EXISTS semantics can
+  change when a shared variable disappears before the retained VALUES binds it.
 
 ### Cost constants are coupled and tested
 

--- a/fluree-db-api/examples/values_object_scan_probe.rs
+++ b/fluree-db-api/examples/values_object_scan_probe.rs
@@ -1,0 +1,226 @@
+//! Repro for the "VALUES-bound object var does not narrow the scan" report.
+//!
+//! Shape (customer): a claim star where the *object* of one predicate is
+//! supplied by `VALUES ?sub { <iri> }` and a second predicate carries a
+//! constant literal. Inlining the same IRI as a constant object is ~10x
+//! faster than the VALUES form, which says the VALUES binding never reaches
+//! the scan.
+//!
+//! ```bash
+//! cargo run --release --example values_object_scan_probe -p fluree-db-api
+//! ```
+
+use std::time::Instant;
+
+use fluree_db_api::{Fluree, FlureeBuilder, ReindexOptions};
+use serde_json::json;
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+const PREFIX: &str = "PREFIX ex: <http://example.org/>\n";
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+async fn main() {
+    let claims = env_usize("PROBE_CLAIMS", 200_000);
+    let subjects = env_usize("PROBE_SUBJECTS", 20_000);
+    let iters = env_usize("PROBE_ITERS", 5);
+    let batch = 20_000;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fluree: Fluree = FlureeBuilder::file(dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("fluree");
+    let mut ledger = fluree.create_ledger("probe:claims").await.expect("ledger");
+
+    let dims = ["legal-control", "financial", "operational"];
+
+    let t_load = Instant::now();
+    let mut start = 0usize;
+    while start < claims {
+        let end = (start + batch).min(claims);
+        let graph: Vec<_> = (start..end)
+            .map(|i| {
+                json!({
+                    "@id": format!("http://example.org/claim{i}"),
+                    "@type": "http://example.org/Claim",
+                    "http://example.org/relSubject": {
+                        "@id": format!("http://example.org/sub{}", i % subjects)
+                    },
+                    "http://example.org/dimension": dims[i % dims.len()],
+                    "http://example.org/status": if i % 7 == 0 { "closed" } else { "open" },
+                    "http://example.org/label": format!("claim {i}"),
+                    "http://example.org/seq": i as i64,
+                })
+            })
+            .collect();
+        ledger = fluree
+            .insert(ledger, &json!({"@graph": graph}))
+            .await
+            .expect("seed")
+            .ledger;
+        start = end;
+    }
+    eprintln!(
+        "loaded {claims} claims in {:.1}s; reindexing…",
+        t_load.elapsed().as_secs_f64()
+    );
+    fluree
+        .reindex("probe:claims", ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let db = fluree.db("probe:claims").await.expect("db");
+
+    // Subject 42 owns claims 42, 42+subjects, … — a handful out of `claims`.
+    let target = "http://example.org/sub42";
+
+    let queries: Vec<(&str, String)> = vec![
+        (
+            "A values_obj + dimension",
+            format!(
+                "{PREFIX}SELECT ?claim WHERE {{ VALUES ?sub {{ <{target}> }} \
+                 ?claim ex:relSubject ?sub . ?claim ex:dimension \"legal-control\" }}"
+            ),
+        ),
+        (
+            "B inlined_const + dimension",
+            format!(
+                "{PREFIX}SELECT ?claim WHERE {{ \
+                 ?claim ex:relSubject <{target}> . ?claim ex:dimension \"legal-control\" }}"
+            ),
+        ),
+        (
+            "C values_obj alone",
+            format!(
+                "{PREFIX}SELECT ?claim WHERE {{ VALUES ?sub {{ <{target}> }} \
+                 ?claim ex:relSubject ?sub }}"
+            ),
+        ),
+        (
+            "D inlined_const alone",
+            format!("{PREFIX}SELECT ?claim WHERE {{ ?claim ex:relSubject <{target}> }}"),
+        ),
+        (
+            "E values_obj + 4 more preds",
+            format!(
+                "{PREFIX}SELECT ?claim ?dim ?st ?lb ?sq WHERE {{ VALUES ?sub {{ <{target}> }} \
+                 ?claim ex:relSubject ?sub . ?claim ex:dimension ?dim . \
+                 ?claim ex:status ?st . ?claim ex:label ?lb . ?claim ex:seq ?sq }}"
+            ),
+        ),
+        (
+            "F inlined + 4 more preds",
+            format!(
+                "{PREFIX}SELECT ?claim ?dim ?st ?lb ?sq WHERE {{ \
+                 ?claim ex:relSubject <{target}> . ?claim ex:dimension ?dim . \
+                 ?claim ex:status ?st . ?claim ex:label ?lb . ?claim ex:seq ?sq }}"
+            ),
+        ),
+        (
+            "G union_3_inlined",
+            format!(
+                "{PREFIX}SELECT ?claim WHERE {{ \
+                 {{ ?claim ex:relSubject <http://example.org/sub42> }} UNION \
+                 {{ ?claim ex:relSubject <http://example.org/sub43> }} UNION \
+                 {{ ?claim ex:relSubject <http://example.org/sub44> }} }}"
+            ),
+        ),
+        (
+            "H values_3_rows + dimension",
+            format!(
+                "{PREFIX}SELECT ?claim WHERE {{ VALUES ?sub {{ \
+                 <http://example.org/sub42> <http://example.org/sub43> \
+                 <http://example.org/sub44> }} \
+                 ?claim ex:relSubject ?sub . ?claim ex:dimension \"legal-control\" }}"
+            ),
+        ),
+        (
+            "I dimension + union_3_inlined",
+            format!(
+                "{PREFIX}SELECT ?claim WHERE {{ ?claim ex:dimension \"legal-control\" . \
+                 {{ ?claim ex:relSubject <http://example.org/sub42> }} UNION \
+                 {{ ?claim ex:relSubject <http://example.org/sub43> }} UNION \
+                 {{ ?claim ex:relSubject <http://example.org/sub44> }} }}"
+            ),
+        ),
+        (
+            "J union_3_full_stars",
+            format!(
+                "{PREFIX}SELECT ?claim ?dim WHERE {{ \
+                 {{ ?claim ex:relSubject <http://example.org/sub42> . ?claim ex:dimension ?dim . \
+                    ?claim ex:status ?st . ?claim ex:label ?lb . ?claim ex:seq ?sq }} UNION \
+                 {{ ?claim ex:relSubject <http://example.org/sub43> . ?claim ex:dimension ?dim . \
+                    ?claim ex:status ?st . ?claim ex:label ?lb . ?claim ex:seq ?sq }} UNION \
+                 {{ ?claim ex:relSubject <http://example.org/sub44> . ?claim ex:dimension ?dim . \
+                    ?claim ex:status ?st . ?claim ex:label ?lb . ?claim ex:seq ?sq }} }}"
+            ),
+        ),
+        (
+            "K union_3_stars_after_scan",
+            format!(
+                "{PREFIX}SELECT ?claim ?st WHERE {{ ?claim ex:status ?st . \
+                 {{ ?claim ex:relSubject <http://example.org/sub42> }} UNION \
+                 {{ ?claim ex:relSubject <http://example.org/sub43> }} UNION \
+                 {{ ?claim ex:relSubject <http://example.org/sub44> }} }}"
+            ),
+        ),
+        (
+            "L values_obj + 4 preds + 2 optional",
+            format!(
+                "{PREFIX}SELECT ?claim ?dim ?st WHERE {{ VALUES ?sub {{ <{target}> }} \
+                 ?claim ex:relSubject ?sub . ?claim ex:dimension ?dim . ?claim ex:status ?st . \
+                 OPTIONAL {{ ?claim ex:label ?lb }} OPTIONAL {{ ?claim ex:seq ?sq }} }}"
+            ),
+        ),
+    ];
+
+    let only = std::env::var("PROBE_ONLY").ok();
+
+    for (name, text) in &queries {
+        if let Some(only) = &only {
+            if !name.contains(only.as_str()) {
+                continue;
+            }
+        }
+        // Warm the caches once, and record the row count for a sanity check.
+        let warm = fluree.query(&db, text.as_str()).await.expect("warmup");
+        let rows = warm.row_count();
+
+        let mut times = Vec::with_capacity(iters);
+        for _ in 0..iters {
+            let t0 = Instant::now();
+            let r = fluree.query(&db, text.as_str()).await.expect("query");
+            std::hint::black_box(&r);
+            times.push(t0.elapsed().as_secs_f64() * 1000.0);
+        }
+        times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        eprintln!(
+            "{name:<30} rows={rows:<6} median={:.1}ms  min={:.1}ms  max={:.1}ms",
+            times[times.len() / 2],
+            times[0],
+            times[times.len() - 1]
+        );
+    }
+
+    if std::env::var("PROBE_EXPLAIN").is_ok() {
+        for (name, text) in &queries {
+            if let Some(only) = &only {
+                if !name.contains(only.as_str()) {
+                    continue;
+                }
+            }
+            let plan = fluree
+                .explain_sparql(&db, text.as_str())
+                .await
+                .expect("explain");
+            eprintln!(
+                "\n=== EXPLAIN {name} ===\n{}",
+                serde_json::to_string_pretty(&plan).unwrap()
+            );
+        }
+    }
+}

--- a/fluree-db-api/tests/it_join_batched_overlay.rs
+++ b/fluree-db-api/tests/it_join_batched_overlay.rs
@@ -508,30 +508,47 @@ async fn batched_object_join_merges_novelty() {
         .await
         .expect("novelty asserts");
 
-    let queries: &[(&str, &str, usize)] = &[
+    // (name, query, expected rows, must route through the batched-object lane)
+    let queries: &[(&str, &str, usize, bool)] = &[
         (
             "object-probe-mixed",
             r"PREFIX ex: <http://example.org/ns/>
               SELECT ?b ?x WHERE { ex:alice ex:knows ?b . ?x ex:author ?b }
               ORDER BY ?b ?x",
             2, // (bob, b3 injected) + (grace novelty-only, b4 injected);
-               // b2 retracted, b1/d1 authors not known by alice
+            // b2 retracted, b1/d1 authors not known by alice
+            true,
         ),
         (
             "object-probe-list-retract",
+            // Two rows on purpose: a SINGLE-row VALUES is folded into the
+            // object position by the planner (`inline_singleton_values_objects`)
+            // and takes the plain bound-object scan instead of this lane.
+            // `ex:dave` has no `ex:authors` edge, so the answer is unchanged.
             r"PREFIX ex: <http://example.org/ns/>
-              SELECT ?x WHERE { VALUES ?b { ex:bob } ?x ex:authors ?b }
+              SELECT ?x WHERE { VALUES ?b { ex:bob ex:dave } ?x ex:authors ?b }
               ORDER BY ?x",
             1, // the delete's WHERE dedupes the repeated @list value to one
-               // binding, so exactly ONE of the two o_i entries is retracted:
-               // the fate check must discriminate the entries by o_i (a
-               // default-read o_i would either resurrect both or drop both)
+            // binding, so exactly ONE of the two o_i entries is retracted:
+            // the fate check must discriminate the entries by o_i (a
+            // default-read o_i would either resurrect both or drop both)
+            true,
+        ),
+        (
+            // The folded form of the same `@list` retraction, which is what a
+            // one-row VALUES now plans as. Same answer, different lane.
+            "object-const-list-retract",
+            r"PREFIX ex: <http://example.org/ns/>
+              SELECT ?x WHERE { ?x ex:authors ex:bob }
+              ORDER BY ?x",
+            1,
+            false,
         ),
     ];
 
     let view = fluree.db(ledger_id).await.expect("novelty view");
     let mut novelty_results = Vec::new();
-    for (name, query, expected_len) in queries {
+    for (name, query, expected_len, expect_lane) in queries {
         let (spans, guard) = span_capture::init_test_tracing();
         let rows = run_query(&fluree, &view, query).await;
         drop(guard);
@@ -540,15 +557,17 @@ async fn batched_object_join_merges_novelty() {
             *expected_len,
             "{name}: row count under novelty; got {rows:?}"
         );
-        assert!(
-            spans.has_span("join_flush_batched_object_binary"),
-            "{name}: bound-object lane should engage under novelty; spans: {:?}",
-            spans.span_names()
-        );
-        assert!(
-            spans.has_event("join batched object flush merged novelty overlay"),
-            "{name}: object flush should merge the overlay"
-        );
+        if *expect_lane {
+            assert!(
+                spans.has_span("join_flush_batched_object_binary"),
+                "{name}: bound-object lane should engage under novelty; spans: {:?}",
+                spans.span_names()
+            );
+            assert!(
+                spans.has_event("join batched object flush merged novelty overlay"),
+                "{name}: object flush should merge the overlay"
+            );
+        }
         novelty_results.push(rows);
     }
 
@@ -557,7 +576,7 @@ async fn batched_object_join_merges_novelty() {
         .await
         .expect("reindex ground truth");
     let view = fluree.db(ledger_id).await.expect("indexed view");
-    for ((name, query, _), novelty_rows) in queries.iter().zip(&novelty_results) {
+    for ((name, query, _, _), novelty_rows) in queries.iter().zip(&novelty_results) {
         let indexed_rows = run_query(&fluree, &view, query).await;
         assert_eq!(
             &indexed_rows, novelty_rows,

--- a/fluree-db-api/tests/it_query_values.rs
+++ b/fluree-db-api/tests/it_query_values.rs
@@ -392,3 +392,248 @@ async fn values_federated_query_connection_from_two_ledgers() {
         normalize_rows(&json!(["Khris", "Nikola"]))
     );
 }
+
+// --- single-row VALUES folded into a bound object -------------------------
+//
+// `VALUES ?o { <iri> }` is the constant `<iri>`, so the planner rewrites the
+// object position of the triples it constrains (see
+// `where_plan::inline_singleton_values_objects`). These tests pin the result
+// equivalence that licenses the rewrite, and the shapes deliberately left out
+// of it.
+
+const VALUES_PREFIXES: &str = "PREFIX ex: <http://example.com/>\n\
+     PREFIX schema: <http://schema.org/>\n";
+
+async fn sparql_rows(
+    fluree: &MemoryFluree,
+    ledger: &MemoryLedger,
+    body: &str,
+) -> Vec<serde_json::Value> {
+    let query = format!("{VALUES_PREFIXES}{body}");
+    let result = support::query_sparql(fluree, ledger, &query)
+        .await
+        .expect("sparql query should succeed");
+    normalize_rows(&result.to_jsonld(&ledger.snapshot).expect("to_jsonld"))
+}
+
+#[tokio::test]
+async fn values_object_iri_matches_inlined_constant() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    let with_values = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s ?name WHERE { VALUES ?f { ex:brian } \
+         ?s ex:friend ?f . ?s schema:name ?name }",
+    )
+    .await;
+    let inlined = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s ?name WHERE { ?s ex:friend ex:brian . ?s schema:name ?name }",
+    )
+    .await;
+
+    assert_eq!(with_values, inlined);
+    assert_eq!(
+        with_values,
+        normalize_rows(&json!([
+            ["ex:alice", "Alice"],
+            ["ex:cam", "Cam"],
+            ["ex:liam", "Liam"]
+        ]))
+    );
+}
+
+#[tokio::test]
+async fn values_object_var_stays_projectable_after_inlining() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    // ?f no longer appears in any triple once the constant is folded in, so it
+    // has to come back from the retained VALUES pattern.
+    let rows = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s ?f WHERE { VALUES ?f { ex:brian } \
+         ?s ex:friend ?f . ?s schema:age ?age }",
+    )
+    .await;
+
+    assert_eq!(
+        rows,
+        normalize_rows(&json!([
+            ["ex:alice", "ex:brian"],
+            ["ex:cam", "ex:brian"],
+            ["ex:liam", "ex:brian"]
+        ]))
+    );
+}
+
+#[tokio::test]
+async fn values_object_iri_still_filters_a_wide_star() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    let with_values = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s ?name ?age WHERE { VALUES ?f { ex:alice } \
+         ?s ex:friend ?f . ?s schema:name ?name . ?s schema:age ?age . \
+         OPTIONAL { ?s schema:email ?email } }",
+    )
+    .await;
+    let inlined = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s ?name ?age WHERE { ?s ex:friend ex:alice . \
+         ?s schema:name ?name . ?s schema:age ?age . \
+         OPTIONAL { ?s schema:email ?email } }",
+    )
+    .await;
+
+    assert_eq!(with_values, inlined);
+    assert_eq!(
+        with_values,
+        normalize_rows(&json!([["ex:cam", "Cam", 34], ["ex:liam", "Liam", 13]]))
+    );
+}
+
+#[tokio::test]
+async fn values_object_iri_keeps_minus_sharing_the_variable() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    // MINUS is scoped by the variables it shares with the left side. Folding
+    // the constant into the MINUS group would remove ?f from it and turn the
+    // MINUS into a no-op, so nested groups are left alone.
+    let rows = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s WHERE { VALUES ?f { ex:brian } ?s ex:friend ?f . \
+         MINUS { ?other ex:friend ?f } }",
+    )
+    .await;
+
+    assert_eq!(rows, normalize_rows(&json!([])));
+}
+
+#[tokio::test]
+async fn multi_row_values_object_is_a_set_not_a_constant() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    let rows = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s ?f WHERE { VALUES ?f { ex:brian ex:cam } \
+         ?s ex:friend ?f . ?s schema:name ?name }",
+    )
+    .await;
+
+    assert_eq!(
+        rows,
+        normalize_rows(&json!([
+            ["ex:alice", "ex:brian"],
+            ["ex:cam", "ex:brian"],
+            ["ex:liam", "ex:brian"],
+            ["ex:liam", "ex:cam"]
+        ]))
+    );
+}
+
+#[tokio::test]
+async fn values_object_literal_matches_inlined_literal() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    // Literal cells are NOT folded (datatype/language matching stays with the
+    // scan layer); the answer must still match the inlined form.
+    let with_values = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s WHERE { VALUES ?age { 50 } ?s schema:age ?age . ?s schema:name ?name }",
+    )
+    .await;
+    let inlined = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s WHERE { ?s schema:age 50 . ?s schema:name ?name }",
+    )
+    .await;
+
+    assert_eq!(with_values, inlined);
+    assert_eq!(
+        with_values,
+        normalize_rows(&json!([["ex:alice"], ["ex:brian"]]))
+    );
+}
+
+#[tokio::test]
+async fn chained_union_after_a_broad_scan_returns_every_branch() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    // A 3-way UNION nests as Union([[Union([[A],[B]])],[C]]); the outer branch
+    // holding the inner UNION has no triples of its own, and used to be costed
+    // as an unknown property scan. Ordering must not change the answer.
+    let rows = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s ?name WHERE { ?s schema:name ?name . \
+         { ?s ex:friend ex:brian } UNION { ?s ex:friend ex:alice } \
+         UNION { ?s ex:friend ex:cam } }",
+    )
+    .await;
+
+    assert_eq!(
+        rows,
+        normalize_rows(&json!([
+            ["ex:alice", "Alice"],
+            ["ex:cam", "Cam"],
+            ["ex:cam", "Cam"],
+            ["ex:liam", "Liam"],
+            ["ex:liam", "Liam"],
+            ["ex:liam", "Liam"]
+        ]))
+    );
+}
+
+#[tokio::test]
+async fn trailing_values_keeps_minus_correlated() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    // A VALUES written AFTER the MINUS still binds ?f for the whole group, so
+    // the anti-join is correlated on ?f and removes every row. Folding the
+    // constant into the triple would take ?f out of the MINUS's order-
+    // preservation set, letting it float ahead of the VALUES and degenerate
+    // into a disjoint-domain no-op.
+    let rows = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s WHERE { ?s ex:friend ?f . \
+         MINUS { ?other ex:friend ?f } VALUES ?f { ex:brian } }",
+    )
+    .await;
+
+    assert_eq!(rows, normalize_rows(&json!([])));
+}
+
+#[tokio::test]
+async fn trailing_values_keeps_not_exists_correlated() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    let rows = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s WHERE { ?s ex:friend ?f . \
+         FILTER NOT EXISTS { ?other ex:friend ?f . FILTER(?other != ?s) } \
+         VALUES ?f { ex:brian } }",
+    )
+    .await;
+
+    assert_eq!(rows, normalize_rows(&json!([])));
+}

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1805,6 +1805,134 @@ fn elide_redundant_type_filters(
     )
 }
 
+/// The constant term a single-row VALUES cell stands for, when it is a reference.
+///
+/// Only reference bindings convert: a literal cell would have to reproduce the
+/// datatype/language matching rules that `TriplePattern::dtc` and the scan layer
+/// apply to `Term::Value`, and getting that subtly wrong changes results rather
+/// than timings.
+fn values_cell_as_ref_term(binding: &crate::binding::Binding) -> Option<Term> {
+    match binding {
+        crate::binding::Binding::Sid { sid, .. } => Some(Term::Sid(sid.clone())),
+        crate::binding::Binding::IriMatch { iri, .. } => Some(Term::Iri(iri.clone())),
+        _ => None,
+    }
+}
+
+/// Substitute a single-row VALUES' IRI into the object position of the triples
+/// it constrains, keeping the VALUES pattern itself.
+///
+/// `VALUES ?o { <iri> }` *is* the constant `<iri>` — one row, one binding — so a
+/// sibling `?s <p> ?o` is the same pattern as `?s <p> <iri>`. Only the constant
+/// form narrows anything, though: a VALUES binding a leaf object var is deferred
+/// above the star (see [`split_values_seeding_star`] and
+/// [`build_property_join_block`]), so `PropertyJoinOperator` drives off whatever
+/// else is bound, drains that predicate's whole extent, and only then does the
+/// one-row VALUES filter it. Measured on a 200k-claim ledger: 54 ms versus 0.0 ms
+/// for the same query with the IRI written inline, and 240 ms versus 0.1 ms once
+/// the star widens to five predicates.
+///
+/// The VALUES stays in the list, so the variable is still bound for projection,
+/// FILTERs, and later patterns — it just no longer has to do the narrowing.
+///
+/// Deliberately narrow, because each relaxation reaches code with its own gates:
+/// - **one row only** — a multi-row VALUES is a set, not a constant;
+/// - **reference cells only** — see [`values_cell_as_ref_term`];
+/// - **object position only** — a var used as subject or predicate keeps today's
+///   behaviour ([`split_values_seeding_star`] already seeds the subject case, and
+///   the fixed-subject scan fast paths carry their own absent-subject gates);
+/// - **one inner-join region only** — substitution never crosses a compound
+///   pattern such as UNION/OPTIONAL/MINUS/EXISTS/NOT EXISTS/subquery. MINUS in
+///   particular changes meaning when a shared variable stops appearing before
+///   it; keeping each VALUES and rewritten triple in the same contiguous
+///   Triple/VALUES/BIND/FILTER region preserves that variable-domain boundary.
+///
+/// Returns `None` when nothing was substituted, so callers keep borrowing the
+/// original slice.
+fn inline_singleton_values_objects(patterns: &[Pattern]) -> Option<Vec<Pattern>> {
+    // Preserve the existing subject/predicate seeding paths everywhere in this
+    // list. This is intentionally more conservative than checking per region:
+    // one variable keeps one planning role throughout the enclosing group.
+    let mut non_object_vars: HashSet<VarId> = HashSet::new();
+    for p in patterns {
+        if let Pattern::Triple(tp) = p {
+            if let Ref::Var(v) = &tp.s {
+                non_object_vars.insert(*v);
+            }
+            if let Ref::Var(v) = &tp.p {
+                non_object_vars.insert(*v);
+            }
+        }
+    }
+
+    let is_inner_join_member = |p: &Pattern| {
+        matches!(
+            p,
+            Pattern::Triple(_) | Pattern::Values { .. } | Pattern::Bind { .. } | Pattern::Filter(_)
+        )
+    };
+
+    let mut replacements: Vec<(usize, Term)> = Vec::new();
+    let mut start = 0;
+    while start < patterns.len() {
+        if !is_inner_join_member(&patterns[start]) {
+            start += 1;
+            continue;
+        }
+
+        let mut end = start + 1;
+        while end < patterns.len() && is_inner_join_member(&patterns[end]) {
+            end += 1;
+        }
+
+        // Constants are local to this contiguous inner-join region. In
+        // particular, a VALUES after MINUS cannot rewrite a triple before the
+        // MINUS: doing so removes the shared variable from the anti-join's
+        // order-preservation set before the VALUES has bound it.
+        let mut constants: HashMap<VarId, Term> = HashMap::new();
+        for p in &patterns[start..end] {
+            if let Pattern::Values { vars, rows } = p {
+                let [row] = rows.as_slice() else { continue };
+                for (var, cell) in vars.iter().zip(row) {
+                    if !non_object_vars.contains(var) {
+                        if let Some(term) = values_cell_as_ref_term(cell) {
+                            constants.insert(*var, term);
+                        }
+                    }
+                }
+            }
+        }
+
+        for (offset, p) in patterns[start..end].iter().enumerate() {
+            let Pattern::Triple(tp) = p else { continue };
+            if tp.dtc.is_some() {
+                continue;
+            }
+            let Some(object_var) = tp.o.as_var() else {
+                continue;
+            };
+            if let Some(term) = constants.get(&object_var) {
+                replacements.push((start + offset, term.clone()));
+            }
+        }
+
+        start = end;
+    }
+
+    if replacements.is_empty() {
+        return None;
+    }
+
+    let mut rewritten = patterns.to_vec();
+    for (idx, term) in replacements {
+        let Pattern::Triple(tp) = &mut rewritten[idx] else {
+            unreachable!("replacement indices only come from triple patterns")
+        };
+        tp.o = term;
+    }
+    Some(rewritten)
+}
+
 /// Build WHERE operators with an optional initial seed operator and explicit needed-vars + GROUP BY keys.
 ///
 /// Handles all pattern types: Triple, VALUES, BIND, FILTER, OPTIONAL, UNION,
@@ -1869,6 +1997,12 @@ pub fn build_where_operators_seeded_with_needed(
     // removes no rows when stats prove the predicate's subjects are all `C`.
     let elided_storage = elide_redundant_type_filters(patterns, stats.as_deref(), planning);
     let patterns: &[Pattern] = elided_storage.as_deref().unwrap_or(patterns);
+
+    // Within each inner-join region, fold a single-row VALUES' IRI into the
+    // object position it constrains, so reordering and the scan layer both see
+    // a constant instead of a variable the VALUES wrapper only filters later.
+    let inlined_storage = inline_singleton_values_objects(patterns);
+    let patterns: &[Pattern] = inlined_storage.as_deref().unwrap_or(patterns);
 
     // Apply generalized pattern reordering upfront for all pattern lists.
     //
@@ -3434,6 +3568,237 @@ mod tests {
         assert!(
             !ops.contains(&"PropertyJoinOperator"),
             "the seeded star must not drain the class extent: {ops:?}"
+        );
+    }
+
+    // --- single-row VALUES object inlining --------------------------------
+
+    fn object_terms(patterns: &[Pattern]) -> Vec<Term> {
+        patterns
+            .iter()
+            .filter_map(|p| match p {
+                Pattern::Triple(tp) => Some(tp.o.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// A one-row IRI VALUES becomes a constant object, and the VALUES stays.
+    #[test]
+    fn singleton_iri_values_inlines_into_object_position() {
+        use crate::binding::Binding;
+
+        // VALUES ?sub { <ex:sub42> } . ?claim <relSubject> ?sub . ?claim <dimension> ?dim
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(1)],
+                rows: vec![vec![Binding::sid(Sid::new(13, "sub42"))]],
+            },
+            Pattern::Triple(make_pattern(VarId(0), "relSubject", VarId(1))),
+            Pattern::Triple(make_pattern(VarId(0), "dimension", VarId(2))),
+        ];
+
+        let rewritten = inline_singleton_values_objects(&patterns).expect("should inline");
+        assert_eq!(
+            object_terms(&rewritten),
+            vec![Term::Sid(Sid::new(13, "sub42")), Term::Var(VarId(2))],
+            "only the VALUES-bound object becomes a constant"
+        );
+        assert!(
+            matches!(rewritten[0], Pattern::Values { .. }),
+            "the VALUES must stay so the variable is still bound downstream"
+        );
+    }
+
+    /// A var used as a subject keeps its variable form everywhere, so the
+    /// existing subject-seeding path (`split_values_seeding_star`) still fires.
+    #[test]
+    fn singleton_values_skips_var_used_as_subject() {
+        use crate::binding::Binding;
+
+        // VALUES ?s { <ex:thing1> } . ?s <name> ?n . ?other <friend> ?s
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(0)],
+                rows: vec![vec![Binding::sid(Sid::new(13, "thing1"))]],
+            },
+            Pattern::Triple(make_pattern(VarId(0), "name", VarId(1))),
+            Pattern::Triple(make_pattern(VarId(2), "friend", VarId(0))),
+        ];
+
+        assert!(inline_singleton_values_objects(&patterns).is_none());
+    }
+
+    /// Multi-row VALUES is a set, not a constant.
+    #[test]
+    fn multi_row_values_is_not_inlined() {
+        use crate::binding::Binding;
+
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(1)],
+                rows: vec![
+                    vec![Binding::sid(Sid::new(13, "a"))],
+                    vec![Binding::sid(Sid::new(13, "b"))],
+                ],
+            },
+            Pattern::Triple(make_pattern(VarId(0), "relSubject", VarId(1))),
+        ];
+
+        assert!(inline_singleton_values_objects(&patterns).is_none());
+    }
+
+    /// Literal cells keep the datatype/language matching rules of the scan
+    /// layer instead of being folded into a bare constant term.
+    #[test]
+    fn literal_and_undef_values_cells_are_not_inlined() {
+        use crate::binding::Binding;
+
+        let literal = vec![
+            Pattern::Values {
+                vars: vec![VarId(1)],
+                rows: vec![vec![Binding::lit(
+                    FlakeValue::String("x".into()),
+                    Sid::new(1, "string"),
+                )]],
+            },
+            Pattern::Triple(make_pattern(VarId(0), "name", VarId(1))),
+        ];
+        assert!(inline_singleton_values_objects(&literal).is_none());
+
+        let undef = vec![
+            Pattern::Values {
+                vars: vec![VarId(1)],
+                rows: vec![vec![Binding::Unbound]],
+            },
+            Pattern::Triple(make_pattern(VarId(0), "name", VarId(1))),
+        ];
+        assert!(inline_singleton_values_objects(&undef).is_none());
+    }
+
+    /// A VALUES written AFTER an order-sensitive pattern must not fold.
+    ///
+    /// `reorder_patterns` places MINUS/EXISTS/NOT EXISTS on the set of vars
+    /// their predecessors PRODUCE. Folding shrinks a triple's produced set, so
+    /// a trailing VALUES would let the anti-join float ahead of the VALUES that
+    /// binds the shared variable and degenerate into a disjoint-domain no-op.
+    #[test]
+    fn values_after_an_order_sensitive_pattern_is_not_folded() {
+        use crate::binding::Binding;
+
+        let values = || Pattern::Values {
+            vars: vec![VarId(1)],
+            rows: vec![vec![Binding::sid(Sid::new(13, "brian"))]],
+        };
+        let inner = || vec![Pattern::Triple(make_pattern(VarId(3), "friend", VarId(1)))];
+
+        for blocker in [
+            Pattern::Minus(inner()),
+            Pattern::Exists(inner()),
+            Pattern::NotExists(inner()),
+        ] {
+            let patterns = vec![
+                Pattern::Triple(make_pattern(VarId(0), "friend", VarId(1))),
+                blocker.clone(),
+                values(),
+            ];
+            assert!(
+                inline_singleton_values_objects(&patterns).is_none(),
+                "a VALUES behind {blocker:?} must not fold"
+            );
+        }
+    }
+
+    /// A compound-pattern boundary limits substitution; it does not disable
+    /// independent regions that follow it.
+    #[test]
+    fn values_after_minus_only_folds_triples_in_its_own_region() {
+        use crate::binding::Binding;
+
+        let patterns = vec![
+            Pattern::Triple(make_pattern(VarId(0), "friend", VarId(1))),
+            Pattern::Minus(vec![Pattern::Triple(make_pattern(
+                VarId(3),
+                "blocked",
+                VarId(1),
+            ))]),
+            Pattern::Values {
+                vars: vec![VarId(1)],
+                rows: vec![vec![Binding::sid(Sid::new(13, "brian"))]],
+            },
+            Pattern::Triple(make_pattern(VarId(4), "author", VarId(1))),
+        ];
+
+        let rewritten = inline_singleton_values_objects(&patterns).expect("later region folds");
+        assert_eq!(
+            object_terms(&rewritten),
+            vec![Term::Var(VarId(1)), Term::Sid(Sid::new(13, "brian"))],
+            "the pre-MINUS triple keeps the shared var; only the post-MINUS triple folds"
+        );
+    }
+
+    /// The same shapes DO fold when the VALUES comes first: its own
+    /// `produced_vars` keeps the variable in the anti-join's ordering set.
+    #[test]
+    fn values_before_an_order_sensitive_pattern_still_folds() {
+        use crate::binding::Binding;
+
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(1)],
+                rows: vec![vec![Binding::sid(Sid::new(13, "brian"))]],
+            },
+            Pattern::Triple(make_pattern(VarId(0), "friend", VarId(1))),
+            Pattern::Minus(vec![Pattern::Triple(make_pattern(
+                VarId(3),
+                "friend",
+                VarId(1),
+            ))]),
+        ];
+
+        let rewritten = inline_singleton_values_objects(&patterns).expect("should fold");
+        assert_eq!(
+            object_terms(&rewritten),
+            vec![Term::Sid(Sid::new(13, "brian"))],
+            "the required triple folds"
+        );
+        let Pattern::Minus(inner) = &rewritten[2] else {
+            panic!("MINUS must survive the rewrite");
+        };
+        assert_eq!(
+            object_terms(inner),
+            vec![Term::Var(VarId(1))],
+            "the MINUS group keeps sharing the variable"
+        );
+    }
+
+    /// Nested groups are left alone: MINUS changes meaning when a shared
+    /// variable stops appearing in it.
+    #[test]
+    fn singleton_values_does_not_reach_into_nested_groups() {
+        use crate::binding::Binding;
+
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(1)],
+                rows: vec![vec![Binding::sid(Sid::new(13, "sub42"))]],
+            },
+            Pattern::Triple(make_pattern(VarId(0), "relSubject", VarId(1))),
+            Pattern::Minus(vec![Pattern::Triple(make_pattern(
+                VarId(3),
+                "blocked",
+                VarId(1),
+            ))]),
+        ];
+
+        let rewritten = inline_singleton_values_objects(&patterns).expect("should inline");
+        let Pattern::Minus(inner) = &rewritten[2] else {
+            panic!("MINUS must survive the rewrite");
+        };
+        assert_eq!(
+            object_terms(inner),
+            vec![Term::Var(VarId(1))],
+            "the MINUS group must keep sharing the variable"
         );
     }
 

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1865,6 +1865,16 @@ fn inline_singleton_values_objects(patterns: &[Pattern]) -> Option<Vec<Pattern>>
         }
     }
 
+    // Coupled with the order-sensitive classification in
+    // `planner::reorder_patterns` (see its `order_sensitive` match): a
+    // variable-free FILTER and a `BIND(BNODE(..))` are ordered against
+    // everything their predecessors produce, yet both are inner-join members
+    // here. Folding is safe for them today because the rewrite REPLACES ONLY
+    // triple objects and keeps every pattern — the retained one-row VALUES goes
+    // on producing its variable, so no preceding-produced set shrinks. A new
+    // order-sensitive classification that is also an inner-join member would
+    // break that, which `fold_survives_a_variable_free_filter_in_its_region`
+    // pins.
     let is_inner_join_member = |p: &Pattern| {
         matches!(
             p,
@@ -3769,6 +3779,64 @@ mod tests {
             object_terms(inner),
             vec![Term::Var(VarId(1))],
             "the MINUS group keeps sharing the variable"
+        );
+    }
+
+    /// A variable-free FILTER sits in the fold's region while
+    /// `planner::reorder_patterns` treats it as order-sensitive, ordering it
+    /// against everything produced before it. The fold must keep firing (it is
+    /// a row-independent predicate, so nothing about it depends on the object
+    /// term) AND must leave the VALUES pattern in place — the retained VALUES
+    /// is the whole reason the coupling is benign, because it goes on producing
+    /// the variable that the ordering set is built from.
+    ///
+    /// If a future order-sensitive classification is added that IS an
+    /// inner-join member, this pin is the one that should be revisited: see the
+    /// comment on `is_inner_join_member`.
+    #[test]
+    fn fold_survives_a_variable_free_filter_in_its_region() {
+        use crate::binding::Binding;
+        use crate::ir::Expression;
+        use fluree_db_core::FlakeValue;
+
+        // `FILTER(true)` references no variable, so `reorder_patterns` marks it
+        // order-sensitive and pins it against its predecessors' produced vars.
+        let variable_free_filter = Pattern::Filter(Expression::Const(FlakeValue::Boolean(true)));
+        assert!(
+            variable_free_filter.referenced_vars().is_empty(),
+            "the pinned coupling only applies to a FILTER with no variables"
+        );
+
+        let patterns = vec![
+            Pattern::Values {
+                vars: vec![VarId(1)],
+                rows: vec![vec![Binding::sid(Sid::new(13, "brian"))]],
+            },
+            variable_free_filter,
+            Pattern::Triple(make_pattern(VarId(0), "friend", VarId(1))),
+        ];
+
+        let rewritten = inline_singleton_values_objects(&patterns)
+            .expect("a variable-free FILTER must not block the fold");
+        assert_eq!(
+            object_terms(&rewritten),
+            vec![Term::Sid(Sid::new(13, "brian"))],
+            "the triple still folds across the filter"
+        );
+        assert_eq!(
+            rewritten.len(),
+            patterns.len(),
+            "the rewrite replaces triple objects only; it never drops a pattern"
+        );
+        assert!(
+            matches!(&rewritten[0], Pattern::Values { vars, rows }
+                if vars == &[VarId(1)] && rows.len() == 1),
+            "the VALUES must survive: it keeps producing the variable that the \
+             order-sensitive FILTER is ordered against"
+        );
+        assert!(
+            matches!(&rewritten[1], Pattern::Filter(_)),
+            "the FILTER must survive in place"
         );
     }
 

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -1064,6 +1064,13 @@ pub fn estimate_branch_cardinality(patterns: &[Pattern], stats: Option<&StatsVie
     let mut non_triple_estimate: f64 = HIGHLY_SELECTIVE;
     // Did any non-triple pattern contribute a real row count (as opposed to an
     // Expander/Deferred that says nothing about absolute cardinality)?
+    //
+    // `Service` is excluded on purpose. Its `DEFAULT_SERVICE_ROW_COUNT` is a
+    // placement sentinel — `FULL_SCAN`, chosen to sort remote calls last — not
+    // knowledge of how many rows the endpoint returns. Counting it here would
+    // read "unknown, and expensive" as "known to be big" and let a triple-free
+    // SERVICE branch skip the unknown-scan default, which is the opposite of
+    // what that constant is for.
     let mut has_sized_source = false;
 
     for p in patterns {
@@ -1077,7 +1084,9 @@ pub fn estimate_branch_cardinality(patterns: &[Pattern], stats: Option<&StatsVie
                 match card {
                     PatternEstimate::Source { row_count } => {
                         non_triple_estimate *= row_count.max(HIGHLY_SELECTIVE);
-                        has_sized_source = true;
+                        if !matches!(other, Pattern::Service(_)) {
+                            has_sized_source = true;
+                        }
                     }
                     PatternEstimate::Reducer { multiplier } => {
                         non_triple_estimate *= multiplier;
@@ -1395,6 +1404,12 @@ pub fn reorder_patterns(
                 //
                 // All other filters/binds keep the existing dependency
                 // placement byte-identically.
+                //
+                // Coupled with `where_plan::inline_singleton_values_objects`:
+                // both classifications below are also inner-join members of its
+                // fold region (see the comment on its `is_inner_join_member`),
+                // so a new order-sensitive arm here that is likewise an
+                // inner-join member must be checked against that fold.
                 let order_sensitive = match pattern {
                     Pattern::Filter(_) => required_vars.is_empty(),
                     Pattern::Bind { expr, .. } => expr.contains_bnode(),
@@ -3614,6 +3629,76 @@ mod tests {
 
         // Single triple: should be the triple's selectivity (count = 1000)
         assert!((est - 1000.0).abs() < f64::EPSILON);
+    }
+
+    /// A triple-free branch whose only sized member is a nested UNION knows its
+    /// own cardinality, so the unknown-scan default must not be multiplied in
+    /// on top of it — that is the chained-UNION shape whose 20M-row estimate
+    /// pushed a 30-row union behind every real scan.
+    #[test]
+    fn triple_free_branch_with_a_nested_union_is_not_scaled_by_the_unknown_default() {
+        let mut stats = StatsView::default();
+        stats.properties.insert(
+            Sid::new(100, "name"),
+            PropertyStatData {
+                count: 1000,
+                ndv_values: 500,
+                ndv_subjects: 1000,
+            },
+        );
+
+        let branch = vec![Pattern::Union(vec![
+            vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
+            vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(2)))],
+        ])];
+        let est = estimate_branch_cardinality(&branch, Some(&stats));
+
+        assert!(
+            est < DEFAULT_PROPERTY_SCAN_SELECTIVITY,
+            "a sized branch must keep its own estimate ({est}), not be scaled by \
+             the unknown-scan default"
+        );
+    }
+
+    /// SERVICE is the one `Source` whose row count is a placement sentinel
+    /// (`FULL_SCAN`, to sort remote calls last) rather than knowledge of the
+    /// endpoint's cardinality. A triple-free SERVICE branch therefore knows
+    /// nothing, and must keep the unknown-scan default — otherwise "unknown and
+    /// expensive" would be read as "known to be big" and the branch could sort
+    /// ahead of local work.
+    #[test]
+    fn triple_free_service_branch_keeps_the_unknown_scan_default() {
+        let service = || {
+            Pattern::Service(crate::ir::ServicePattern {
+                silent: false,
+                endpoint: crate::ir::ServiceEndpoint::Iri(Arc::from("http://example.org/sparql")),
+                patterns: vec![Pattern::Triple(make_pattern(VarId(0), "name", VarId(1)))],
+                source_body: None,
+                source_prologue: None,
+            })
+        };
+
+        let est = estimate_branch_cardinality(&[service()], None);
+        assert!(
+            est >= DEFAULT_PROPERTY_SCAN_SELECTIVITY * DEFAULT_SERVICE_ROW_COUNT,
+            "a SERVICE-only branch must stay at the unknown-scan default \
+             ({est}), so a remote call is not promoted ahead of local scans"
+        );
+
+        // The exclusion is specific to SERVICE: a branch that also holds a
+        // genuinely sized member still escapes the default.
+        let sized = vec![
+            service(),
+            Pattern::Values {
+                vars: vec![VarId(5)],
+                rows: vec![vec![crate::binding::Binding::sid(Sid::new(13, "a"))]],
+            },
+        ];
+        assert!(
+            estimate_branch_cardinality(&sized, None)
+                < DEFAULT_PROPERTY_SCAN_SELECTIVITY * DEFAULT_SERVICE_ROW_COUNT,
+            "a sized member alongside the SERVICE still sizes the branch"
+        );
     }
 
     // =========================================================================

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -1062,6 +1062,9 @@ pub fn estimate_branch_cardinality(patterns: &[Pattern], stats: Option<&StatsVie
     // Separate triples from non-triples
     let mut triples: Vec<&TriplePattern> = Vec::new();
     let mut non_triple_estimate: f64 = HIGHLY_SELECTIVE;
+    // Did any non-triple pattern contribute a real row count (as opposed to an
+    // Expander/Deferred that says nothing about absolute cardinality)?
+    let mut has_sized_source = false;
 
     for p in patterns {
         match p {
@@ -1074,6 +1077,7 @@ pub fn estimate_branch_cardinality(patterns: &[Pattern], stats: Option<&StatsVie
                 match card {
                     PatternEstimate::Source { row_count } => {
                         non_triple_estimate *= row_count.max(HIGHLY_SELECTIVE);
+                        has_sized_source = true;
                     }
                     PatternEstimate::Reducer { multiplier } => {
                         non_triple_estimate *= multiplier;
@@ -1088,7 +1092,22 @@ pub fn estimate_branch_cardinality(patterns: &[Pattern], stats: Option<&StatsVie
     }
 
     if triples.is_empty() {
-        return (DEFAULT_PROPERTY_SCAN_SELECTIVITY) * non_triple_estimate;
+        // A branch made ONLY of sized sources already knows its own cardinality —
+        // multiplying by the unknown-scan default would invent rows that are not
+        // there. This is the common shape of a chained UNION: `{A} UNION {B} UNION
+        // {C}` nests as `Union([[Union([[A],[B]])], [C]])`, so the outer branch
+        // holding the inner UNION has no triples of its own. Scaling it by
+        // DEFAULT_PROPERTY_SCAN_SELECTIVITY put a 30-row union at 20M rows, which
+        // pushed it behind every real scan; the correlated UnionOperator then
+        // rebuilt and re-ran all three branches once per driving row.
+        //
+        // With no sized source (only OPTIONAL/MINUS/FILTER/BIND) nothing is known,
+        // so the unknown-scan default still applies.
+        return if has_sized_source {
+            non_triple_estimate.max(HIGHLY_SELECTIVE)
+        } else {
+            DEFAULT_PROPERTY_SCAN_SELECTIVITY * non_triple_estimate
+        };
     }
 
     // Sort triples by standalone row count for initial ordering (most selective first)
@@ -3343,6 +3362,63 @@ mod tests {
         };
         // Sum of branch estimates: 100 + 200 = 300
         assert!((row_count - 300.0).abs() < f64::EPSILON);
+    }
+
+    /// A chained `{A} UNION {B} UNION {C}` nests as `Union([[Union([[A],[B]])],
+    /// [C]])`, so the outer branch holding the inner UNION owns no triples of
+    /// its own. Scaling such a branch by the unknown-property-scan default put
+    /// a 30-row union at 20M rows, which pushed it behind every real scan and
+    /// left the correlated `UnionOperator` rebuilding all three branches once
+    /// per driving row (measured: 53 s on a 200k-row driver).
+    #[test]
+    fn test_estimate_nested_union_is_not_scaled_by_unknown_scan_default() {
+        let mut stats = StatsView::default();
+        stats.properties.insert(
+            Sid::new(100, "a"),
+            PropertyStatData {
+                count: 100,
+                ndv_values: 10,
+                ndv_subjects: 100,
+            },
+        );
+
+        let branch = |o: &str| {
+            vec![Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Sid(Sid::new(100, "a")),
+                Term::Iri(Arc::from(o)),
+            ))]
+        };
+        // Each bound-object branch is count/ndv = 10 rows.
+        let nested = Pattern::Union(vec![
+            vec![Pattern::Union(vec![branch("ex:x"), branch("ex:y")])],
+            branch("ex:z"),
+        ]);
+
+        let card = estimate_pattern(&nested, &HashSet::new(), Some(&stats));
+        let PatternEstimate::Source { row_count } = card else {
+            panic!("expected Source")
+        };
+        assert!(
+            (row_count - 30.0).abs() < f64::EPSILON,
+            "nested union should cost its branches (10+10+10), got {row_count}"
+        );
+    }
+
+    /// With nothing sized to go on, the unknown-scan default still applies.
+    #[test]
+    fn test_estimate_branch_with_no_sized_source_keeps_scan_default() {
+        let optional_only = vec![Pattern::Optional(vec![Pattern::Triple(make_pattern(
+            VarId(0),
+            "opt",
+            VarId(1),
+        ))])];
+
+        let card = estimate_branch_cardinality(&optional_only, None);
+        assert!(
+            (card - DEFAULT_PROPERTY_SCAN_SELECTIVITY).abs() < f64::EPSILON,
+            "expected the unknown-scan default, got {card}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two independent planner defects, reported together: a bound-subject claim
lookup ran ~500x slower than the identical query with the IRI written inline,
and UNION-ing three inlined IRIs instead timed out at the gateway.

Both reproduce on a synthetic 200k-claim ledger — see the added
`values_object_scan_probe` example.

## A VALUES binding a leaf object var never reached the scan

`split_values_seeding_star` only seeds a VALUES that binds the **star's
subject**; everything else defers, and `build_property_join_block` defers
unconditionally. So `PropertyJoinOperator` drove off whatever else was bound,
drained that predicate's whole extent, and only then let the one-row VALUES
filter it. Explain showed it plainly: `Project -> Values -> PropertyJoin`.

That deferral was deliberate — seeding a leaf-object VALUES costs the star
fusion. The fix isn't to seed it: a one-row VALUES **is** a constant, so
`inline_singleton_values_objects` folds it into the object position of
same-list triples and keeps the VALUES pattern, leaving the variable bound for
projection and FILTERs.

Gated to one row, reference cells, object position, and a single contiguous
inner-join region. The region boundary is what makes it sound: compound
patterns are not inner-join members, so no region straddles a
MINUS/EXISTS/NOT EXISTS. A folded triple's donor VALUES is therefore always on
the same side of every order-sensitive boundary, which leaves those patterns'
order-preservation sets (built from *preceding* `produced_vars`) unchanged —
and covers `subquery_correlation_vars`, which reads the same thing. Without
that gate a trailing VALUES could shrink the set and let an anti-join float
ahead of the binding that correlates it, degenerating into a disjoint-domain
no-op.

## Chained UNION was costed 1e6x too high

`{A} UNION {B} UNION {C}` parses as `Union([[Union([[A],[B]])],[C]])`, so the
outer branch holding the inner UNION owns no triples of its own.
`estimate_branch_cardinality` scaled every triple-free branch by the
unknown-property-scan default, so a 30-row union costed **20,000,010** against
a 20,000-row triple and was placed behind every real scan. A 4-way union
compounds to 1e12.

That misplacement is superlinear because `UnionOperator` is correlated — it
rebuilds and re-runs each branch once per input row. A branch whose non-triple
members report sized `Source` estimates now costs those; the default still
applies when only Expander/Deferred patterns (OPTIONAL/MINUS/FILTER/BIND) are
present, where nothing is known.

## Measured

200k claims, 20k subjects. Row counts identical before and after in every case.

| Query | Before | After |
|---|---|---|
| `VALUES ?sub` + dimension | 54.3 ms | 0.0 ms |
| inlined constant + dimension (control) | 0.0 ms | 0.0 ms |
| `VALUES ?sub` + 4 more predicates | 239.3 ms | 0.1 ms |
| inlined + 4 more predicates (control) | 0.1 ms | 0.1 ms |
| `VALUES` + 4 preds + 2 OPTIONAL | 147.7 ms | 0.1 ms |
| broad triple, then 3-way UNION | 8,185 ms | 0.1 ms |
| 200k-row triple, then 3-way UNION | 53,016 ms | 0.1 ms |

## Deliberately not covered

- **Multi-row VALUES on an object var** (~92 ms, unchanged). Seeding it is a
  genuine cost decision, and blanket seeding regressed a 21k-row Cypher UNWIND
  previously. It needs a stats-driven gate, not a threshold guess.
- **`UnionOperator` re-planning per input row.** The estimator fix keeps unions
  early, which is where the 53 s came from, but a union that legitimately runs
  second still rebuilds its operator tree per driving row.

## Note for reviewers

Two patterns are classified order-sensitive in `reorder_patterns`
(planner.rs:1398-1402) but *are* inner-join members, so they do not break a
region: a variable-free FILTER and `BIND(BNODE(..))`. Folding can shrink their
preceding-produced-vars set. It is benign today — a variable-free filter is
row-independent, and the retained one-row VALUES removes no rows, so both see
an identical solution set either way — but it is a coupling across two files
worth knowing about if another order-sensitive classification is ever added.

`batched_object_join_merges_novelty` asserted the batched-object lane for a
one-row VALUES, which now folds to a constant scan. It gets a two-row VALUES to
keep exercising the lane, plus the folded form as a third case so the `@list`
retraction fate check covers both plans.

## Validation

`fmt --check` and `clippy --all --all-features --all-targets` clean;
`fluree-db-query` 1501/1501, `grp_query_sparql` 349/349, batched-overlay green.
The full workspace suite (11,140) and the W3C SPARQL suite (36 suites, 0
failures) last ran green immediately *before* the final region rewrite of
`inline_singleton_values_objects` and have not been re-run locally since —
leaving that to CI.