### PR TITLE
release v4.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,11 +2422,11 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-bench-alloc"
-version = "4.1.5"
+version = "4.1.6"
 
 [[package]]
 name = "fluree-bench-support"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "chrono",
  "rand 0.8.5",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-bench-virtual"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-api"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2573,14 +2573,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-bolt"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-db-cli"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-consensus"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cypher"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-docs"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "pulldown-cmark",
  "rust-embed",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-iceberg"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-mcp"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-db-docs",
  "fluree-db-memory",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-memory"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "chrono",
  "fluree-db-api",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice-sync"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-peer"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-server"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-aws"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-storage-ipfs"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "cid",
@@ -3275,14 +3275,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-vocab",
  "pretty_assertions",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-httpd"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-service"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -3426,14 +3426,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-sse"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "fluree-vocab"
-version = "4.1.5"
+version = "4.1.6"
 
 [[package]]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ members = [
 exclude = ["testsuite-sparql", "testsuite-shacl", "scripts/local/load"]
 
 [workspace.package]
-version = "4.1.5"
+version = "4.1.6"
 edition = "2021"
 license = "BUSL-1.1"
 repository = "https://github.com/fluree/db"

--- a/testsuite-shacl/Cargo.lock
+++ b/testsuite-shacl/Cargo.lock
@@ -668,7 +668,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-db-api"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "bigdecimal 0.4.10",
  "chrono",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "base64",
  "bs58",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cypher"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-shacl"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -1083,14 +1083,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-graph-ir",
  "serde",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-vocab",
  "serde",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-vocab"
-version = "4.1.5"
+version = "4.1.6"
 
 [[package]]
 name = "foldhash"
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "testsuite-shacl"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "anyhow",
  "fluree-db-api",

--- a/testsuite-shacl/Cargo.toml
+++ b/testsuite-shacl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testsuite-shacl"
-version = "4.1.5"
+version = "4.1.6"
 edition = "2021"
 publish = false
 

--- a/testsuite-sparql/Cargo.lock
+++ b/testsuite-sparql/Cargo.lock
@@ -662,7 +662,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fluree-db-api"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "base64",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-binary-index"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "bigdecimal 0.4.10",
  "chrono",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-connection"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-core"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-credential"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "base64",
  "bs58",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-crypto"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-cypher"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-db-core",
  "fluree-db-query",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-indexer"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-ledger"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-nameservice"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-core",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-novelty"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-policy"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-db-core",
  "fluree-vocab",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-query"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-r2rml"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "fluree-db-tabular",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-reasoner"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-sparql"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "bigdecimal 0.4.10",
  "fluree-db-core",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-spatial"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "crc32fast",
@@ -1063,14 +1063,14 @@ dependencies = [
 
 [[package]]
 name = "fluree-db-tabular"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "fluree-db-transact"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "async-trait",
  "bigdecimal 0.4.10",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-format"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-graph-ir",
  "serde",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-ir"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-vocab",
  "serde",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-json-ld"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-graph-turtle"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "fluree-graph-ir",
  "fluree-vocab",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-search-protocol"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "fluree-vocab"
-version = "4.1.5"
+version = "4.1.6"
 
 [[package]]
 name = "foldhash"
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "testsuite-sparql"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "anyhow",
  "fluree-db-api",

--- a/testsuite-sparql/Cargo.toml
+++ b/testsuite-sparql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testsuite-sparql"
-version = "4.1.5"
+version = "4.1.6"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Bumps the workspace to 4.1.6.

Six files, version lines only — no dependency drift:

- `Cargo.toml` / `Cargo.lock`
- `testsuite-sparql/Cargo.toml` / `Cargo.lock`
- `testsuite-shacl/Cargo.toml` / `Cargo.lock`

The two testsuite crates are `[workspace] exclude`d, so the workspace version
does not reach them and they carry their own.

Based on `perf/absent-subject-scan-narrowing` (#1659) rather than `main`, so
this PR shows only the bump. Tag `v4.1.6` after both land on `main`.