### PR TITLE
fix(query): correct three fast paths that diverged from the generic pipeline

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -2989,8 +2989,22 @@ mem:fact-01m0bre5qrbr1kfpxvq97hhy7p a mem:Fact ;
     mem:updatedAt "2026-08-19T02:42:45.324959+00:00"^^xsd:dateTime ;
     mem:rationale "Any streaming group iterator over leaflet batches must carry the open group across refills — PsotSubjectCountIter/CursorSubjectCountStream are the reference pattern. Repro trick: reindex with IndexerConfig::with_leaflet_rows(3) forces boundary-straddling groups at tiny scale." .
 
+mem:fact-01m0dazrcw355c6c1dkpdsgr8z a mem:Fact ;
+    mem:content "#1652 follow-up: detect_group_by_object_star_topk (execute/operator_tree.rs) now requires filter object vars to be PAIRWISE DISTINCT. The operator folds filters as a product of per-subject counts, which is the join multiplicity only when they range independently — two filter triples sharing an object var join on it, so the true multiplicity is their per-subject value INTERSECTION. Shared var returned inflated counts plus phantom groups (subjects whose filter values are disjoint drop out generically). Distinct vars over the SAME predicate stay eligible: that product is correct. Probed both ways in it_fastpath_1652_regression.rs (must-not-fire + must-fire)." ;
+    mem:tag "correctness" ;
+    mem:tag "count" ;
+    mem:tag "fast-path" ;
+    mem:tag "group-by" ;
+    mem:tag "star-topk" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/tests/it_fastpath_1652_regression.rs" ;
+    mem:artifactRef "fluree-db-query/src/execute/operator_tree.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-08-19T15:12:04.000000+00:00"^^xsd:dateTime ;
+    mem:rationale "The detector destructured (sv, pred, ov) but pushed only pred into filter_preds, discarding ov — so nothing ever compared filter object vars to each other. The pre-existing existence semantics mis-answered this shape too; the product fold made it a certified-lane divergence, which is why the fix is a decline, not a new counting rule." .
+
 mem:fact-01m0bredy3qtxvftbwass43qkc a mem:Fact ;
-    mem:content "#1652 case 3 FIXED: count_composite_join_pairs now gates via predicate_unsafe_for_cross_predicate_o_key_join (fast_path_common) — declines when either predicate's POST leaflets hold NUM_BIG_OVERFLOW objects (per-predicate arena handles, not value identity) OR list rows (HAS_O_I flag; generic list-element join semantics: list elems never match plain refs, aligned duplicate lists pair per-row — not expressible in an (s,o_type,o_key) key). Metadata-first: o_type_const point check, key-range bound for mixed leaflets, exact o_type-column decode ONLY when the range straddles 0x800B (inline numerics sort below, langstrings above — range alone over-declines). Overlay lane: CursorSoIter declines row-level on live o_i (novelty lists). Pinned in it_fastpath_1652_regression.rs incl. must-fire on clean data." ;
+    mem:content "#1652 case 3 FIXED: count_composite_join_pairs now gates via predicate_unsafe_for_cross_predicate_o_key_join (fast_path_common) — declines when either predicate's POST leaflets hold NUM_BIG_OVERFLOW objects (per-predicate arena handles, not value identity) OR list rows (HAS_O_I flag; list elems never match plain refs, aligned duplicate lists pair per-row — not expressible in an (s,o_type,o_key) key). Metadata-first: o_type_const point check, key-range bound for mixed leaflets, exact o_type-column decode ONLY when the range straddles 0x800B. Overlay lane: CursorSoIter declines row-level on live o_i (novelty lists). Pinned in it_fastpath_1652_regression.rs incl. must-fire on clean data." ;
     mem:tag "composite-join" ;
     mem:tag "correctness" ;
     mem:tag "count" ;

--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -2957,6 +2957,54 @@ mem:fact-01kzdveh3fna6wddbkmkeabmxn a mem:Fact ;
     mem:branch "main" ;
     mem:createdAt "2026-08-07T10:14:08.751291+00:00"^^xsd:dateTime .
 
+mem:fact-01m0brdwgvvsnqtd63q7nt2qx9 a mem:Fact ;
+    mem:content "#1652 case 1 FIXED: GroupByObjectStarTopKOperator now carries bag multiplicity — the merge-join lane consumes whole filter-subject runs into (s, count) groups, the multi-pred lane folds filter predicates into a subject→product-of-counts FxHashMap, and AggStateStar::observe takes a mult param (COUNT += mult; MIN/MAX/SAMPLE stay duplicate-insensitive). The operator also stamps fast-path outcomes at site \"group_by_object_star_topk\" (proceed/gate_declined). Pinned by it_fastpath_1652_regression.rs (must-fire + hand-pinned values) and a group_by_object_star_topk case in the differential harness." ;
+    mem:tag "bag-semantics" ;
+    mem:tag "correctness" ;
+    mem:tag "count" ;
+    mem:tag "fast-path" ;
+    mem:tag "group-by" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/tests/it_differential_fastpath.rs" ;
+    mem:artifactRef "fluree-db-api/tests/it_fastpath_1652_regression.rs" ;
+    mem:artifactRef "fluree-db-query/src/fast_group_count_firsts.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-08-19T00:58:34.907610+00:00"^^xsd:dateTime ;
+    mem:updatedAt "2026-08-19T02:42:34.108217+00:00"^^xsd:dateTime ;
+    mem:rationale "Original bug: filter triples treated as existence semi-join (subject dedup/set intersection), losing the star join's multiplicity — fast 2 vs generic 5 on 20 triples. Any change to this operator must keep bag multiplicity of every non-group star triple." .
+
+mem:fact-01m0bre5qrbr1kfpxvq97hhy7p a mem:Fact ;
+    mem:content "#1652 case 2 FIXED: PostObjectGroupCountIter now carries an object group across POST leaflet/batch boundaries (cur_key/cur_count, mirroring PsotSubjectCountIter) so each o_key is emitted once with its full count — execute_chain's forward-only PSOT seek no longer drops the second fragment. Homogeneous non-IRI leaflets are now SKIPPED instead of terminating the stream (the old early-None cut off every IRI group sorting after them; POST o_type order is inline(<0x8000) < STRING 0x8000 < IRI 0x8007 < NUM_BIG 0x800B < langstring 0xC000+). Overlay chain lane (psot_weighted_*) always carried correctly. Pinned at leaflet_rows=3 in it_fastpath_1652_regression.rs." ;
+    mem:tag "chain-fold" ;
+    mem:tag "correctness" ;
+    mem:tag "count" ;
+    mem:tag "fast-path" ;
+    mem:tag "leaflet-boundary" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/tests/it_fastpath_1652_regression.rs" ;
+    mem:artifactRef "fluree-db-query/src/count_plan_exec.rs" ;
+    mem:artifactRef "fluree-db-query/src/fast_path_common.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-08-19T00:58:44.344326+00:00"^^xsd:dateTime ;
+    mem:updatedAt "2026-08-19T02:42:45.324959+00:00"^^xsd:dateTime ;
+    mem:rationale "Any streaming group iterator over leaflet batches must carry the open group across refills — PsotSubjectCountIter/CursorSubjectCountStream are the reference pattern. Repro trick: reindex with IndexerConfig::with_leaflet_rows(3) forces boundary-straddling groups at tiny scale." .
+
+mem:fact-01m0bredy3qtxvftbwass43qkc a mem:Fact ;
+    mem:content "#1652 case 3 FIXED: count_composite_join_pairs now gates via predicate_unsafe_for_cross_predicate_o_key_join (fast_path_common) — declines when either predicate's POST leaflets hold NUM_BIG_OVERFLOW objects (per-predicate arena handles, not value identity) OR list rows (HAS_O_I flag; generic list-element join semantics: list elems never match plain refs, aligned duplicate lists pair per-row — not expressible in an (s,o_type,o_key) key). Metadata-first: o_type_const point check, key-range bound for mixed leaflets, exact o_type-column decode ONLY when the range straddles 0x800B (inline numerics sort below, langstrings above — range alone over-declines). Overlay lane: CursorSoIter declines row-level on live o_i (novelty lists). Pinned in it_fastpath_1652_regression.rs incl. must-fire on clean data." ;
+    mem:tag "composite-join" ;
+    mem:tag "correctness" ;
+    mem:tag "count" ;
+    mem:tag "fast-path" ;
+    mem:tag "numbig" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/tests/it_fastpath_1652_regression.rs" ;
+    mem:artifactRef "fluree-db-query/src/count_plan_exec.rs" ;
+    mem:artifactRef "fluree-db-query/src/fast_path_common.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-08-19T00:58:52.739403+00:00"^^xsd:dateTime ;
+    mem:updatedAt "2026-08-19T02:42:56.706679+00:00"^^xsd:dateTime ;
+    mem:rationale "Two traps for any cross-predicate o_key comparison: NumBig handles are per-predicate, and o_i list rows join by rules the composite key can't express. The exact-membership decode matters — a plain int+string+langstring mixed leaflet straddles NUM_BIG's o_type range without containing one, and a range-only gate silently loses the fast path." .
+
 mem:constraint-01kp8yczz09ndt54ztchbheeyb a mem:Constraint ;
     mem:content "JSON-LD transaction parsing does NOT auto-promote bare string values to IRI references. User data becomes an IRI only when wrapped in `{\"@id\": \"...\"}` or when the property has `@type: \"@id\"` in `@context`. The former `looks_like_iri` heuristic (three sites in parse/jsonld.rs) was removed — it silently promoted strings starting with `http://`/`https://`/`did:`/`fluree:`/`urn:` to IRIs, which violated the JSON-LD spec (especially for `{\"@value\": \"...\"}`, explicitly a literal)." ;
     mem:tag "iri" ;

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -218,6 +218,11 @@ path = "tests/grp_transact.rs"
 name = "it_count_datatype_pin"
 path = "tests/it_count_datatype_pin.rs"
 
+# Own binary for the same reason (kill switch + routing assertions).
+[[test]]
+name = "it_fastpath_1652_regression"
+path = "tests/it_fastpath_1652_regression.rs"
+
 # Own binary: asserts fast-path routing via process-scoped tracing capture.
 [[test]]
 name = "it_exists_semijoin_correlation"

--- a/fluree-db-api/tests/it_differential_fastpath.rs
+++ b/fluree-db-api/tests/it_differential_fastpath.rs
@@ -414,6 +414,19 @@ fn catalog() -> Vec<Case> {
             known_divergence: None,
             sparql: "SELECT ?o (COUNT(?s) AS ?c) WHERE { ?s bsbm:productType ?o } GROUP BY ?o ORDER BY DESC(?c) LIMIT 10",
         },
+        // detect_group_by_object_star_topk (GroupByObjectStarTopKOperator) —
+        // GROUP BY ?o top-k with a same-subject filter star (#1652 case 1:
+        // COUNT must carry the filter predicates' bag multiplicity, not just
+        // subject existence). Churn renames five labels, so in the overlay
+        // condition the subject->multiplicity map must be overlay-correct.
+        // LIMIT exceeds the five product types; count ties make only the row
+        // SET stable (compared unordered).
+        Case {
+            name: "group_by_object_star_topk",
+            ordered: false,
+            known_divergence: None,
+            sparql: "SELECT ?o (COUNT(?s) AS ?c) WHERE { ?s bsbm:productType ?o . ?s bsbm:label ?l } GROUP BY ?o ORDER BY DESC(?c) LIMIT 10",
+        },
         // detect_stats_count_by_predicate — FD-3 fixed (PR-1 L2): now counted
         // exactly from POST leaf directories (base), or declined to the generic
         // pipeline (overlay/novelty), never from StatsView estimates. Enforced.

--- a/fluree-db-api/tests/it_fastpath_1652_regression.rs
+++ b/fluree-db-api/tests/it_fastpath_1652_regression.rs
@@ -60,6 +60,12 @@ const N_B: usize = 25;
 /// (0–2 string objects) as filter-star predicates. Subjects with `i % 4 == 0`
 /// have a type but NO signatures, pinning that they drop out of the
 /// signature-star group counts entirely.
+///
+/// `refA` / `refB` are the shared-object-variable probe: every subject carries
+/// two of each with exactly one value in common, so a filter pair joined on one
+/// variable has per-subject multiplicity 1 while the product of counts is 4.
+/// Every 17th subject gets disjoint values instead — generically it drops out
+/// of the join, while a product of counts still credits it.
 fn star_turtle() -> String {
     let mut buf = String::from(
         "@prefix ex: <http://example.org/ns/> .\n\
@@ -87,6 +93,13 @@ fn star_turtle() -> String {
         }
         if i % 11 == 0 {
             buf.push_str("; ex:bibtexType ex:Misc ");
+        }
+        if i % 17 == 0 {
+            // Disjoint refA/refB: the generic join drops these subjects
+            // entirely, where a product of counts still contributes.
+            buf.push_str("; ex:refA ex:r-0 ; ex:refB ex:r-2 ");
+        } else {
+            buf.push_str("; ex:refA ex:r-0, ex:r-1 ; ex:refB ex:r-1, ex:r-2 ");
         }
         buf.push_str(" .\n");
     }
@@ -302,6 +315,42 @@ fn cases() -> Vec<Case> {
                 "[\"ex:Book\",15,\"ex:pub-0001\",\"ex:pub-0057\"]",
                 "[\"ex:Incollection\",30,\"ex:pub-0002\",\"ex:pub-0058\"]",
                 "[\"ex:Misc\",9,\"ex:pub-0011\",\"ex:pub-0055\"]",
+            ],
+            routing: MustFire(STAR_SITE),
+        },
+        // Two filter triples sharing an object variable are a join on it, so
+        // the per-subject multiplicity is the size of the refA/refB value
+        // intersection (1), not the product of their counts (4). The operator
+        // has no way to express that, so the detector must decline.
+        Case {
+            name: "star topk shared filter object var declines",
+            ledger: Star,
+            sparql: "SELECT ?o1 (COUNT(?s) AS ?count) WHERE {\n\
+                     ?s ex:bibtexType ?o1 . ?s ex:refA ?x . ?s ex:refB ?x .\n\
+                     } GROUP BY ?o1 ORDER BY DESC(?count) LIMIT 10",
+            expected: &[
+                "[\"ex:Article\",14]",
+                "[\"ex:Book\",14]",
+                "[\"ex:Incollection\",14]",
+                "[\"ex:Inproceedings\",14]",
+                "[\"ex:Misc\",5]",
+            ],
+            routing: MustNotFire(STAR_SITE),
+        },
+        // Distinct object vars over filter predicates stay eligible — there the
+        // product of per-subject counts IS the join multiplicity.
+        Case {
+            name: "star topk distinct filter object vars keep the lane",
+            ledger: Star,
+            sparql: "SELECT ?o1 (COUNT(?s) AS ?count) WHERE {\n\
+                     ?s ex:bibtexType ?o1 . ?s ex:refA ?x . ?s ex:refB ?y .\n\
+                     } GROUP BY ?o1 ORDER BY DESC(?count) LIMIT 10",
+            expected: &[
+                "[\"ex:Article\",57]",
+                "[\"ex:Book\",57]",
+                "[\"ex:Incollection\",57]",
+                "[\"ex:Inproceedings\",57]",
+                "[\"ex:Misc\",21]",
             ],
             routing: MustFire(STAR_SITE),
         },

--- a/fluree-db-api/tests/it_fastpath_1652_regression.rs
+++ b/fluree-db-api/tests/it_fastpath_1652_regression.rs
@@ -1,0 +1,623 @@
+//! Regression pins for issue #1652: three indexed-lane fast paths that
+//! returned plausible wrong numbers where the generic pipeline (the
+//! `FLUREE_DISABLE_QUERY_FAST_PATHS` kill-switch reference) is correct.
+//!
+//! * **Star top-k bag multiplicity** — `GroupByObjectStarTopKOperator`
+//!   treated the star's filter triples as an existence semi-join, so
+//!   `GROUP BY ?o (COUNT(?s))` lost the filter predicates' join
+//!   multiplicity (a subject with 3 signatures contributed 1, not 3).
+//! * **Chain-fold POST group split** — `PostObjectGroupCountIter` restarted
+//!   an object group at every leaflet boundary; `execute_chain`'s
+//!   forward-only PSOT seek then dropped the second fragment's rows.
+//!   Layout-dependent, so this file's chain ledger is indexed with 3-row
+//!   leaflets to force boundary-straddling groups at test scale.
+//! * **Composite `(s,o)` join identity** — `count_composite_join_pairs`
+//!   merge-joined on `(s_id, o_type, o_key)`, but a `NUM_BIG_OVERFLOW`
+//!   `o_key` is a per-predicate arena handle (every `xsd:decimal`, any
+//!   `xsd:integer` beyond i64), so equal big values under the two
+//!   predicates never matched. Now declined by directory metadata (list
+//!   rows too — their generic join semantics depend on `o_i`).
+//!
+//! Each case asserts three things: the fast lane's answer, the generic
+//! pipeline's answer (both against a hand-pinned value, so a generic
+//! regression is caught as loudly as a fast-path one), and the engine's
+//! `fast-path outcome` stamps — the fixed shapes must still `proceed` on
+//! their site (the fix must not silently disable the lane), and the
+//! NumBig/list composite shapes must NOT proceed on `count-plan`.
+//!
+//! Own test binary: toggles the process-global kill switch AND asserts
+//! fast-path routing via span capture, so it must not share a process with
+//! other tests.
+
+#![cfg(feature = "native")]
+
+#[path = "support/span_capture.rs"]
+mod span_capture;
+
+use fluree_db_api::admin::ReindexOptions;
+use fluree_db_api::{
+    set_fast_paths_disabled, CommitOpts, Fluree, FlureeBuilder, FormatterConfig, IndexConfig,
+    TxnOpts,
+};
+use fluree_db_indexer::IndexerConfig;
+use serde_json::Value;
+
+const PREFIX: &str = "PREFIX ex: <http://example.org/ns/>\n\
+                      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n\
+                      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n\
+                      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n";
+
+// ---------------------------------------------------------------------------
+// Datasets
+// ---------------------------------------------------------------------------
+
+const N_PUB: usize = 60;
+const N_A: usize = 40;
+const N_B: usize = 25;
+
+/// Star ledger: `bibtexType` (group pred, 4 rotating classes + a second value
+/// on every 11th subject) with `hasSignature` (0–3 IRI objects) and `hasTag`
+/// (0–2 string objects) as filter-star predicates. Subjects with `i % 4 == 0`
+/// have a type but NO signatures, pinning that they drop out of the
+/// signature-star group counts entirely.
+fn star_turtle() -> String {
+    let mut buf = String::from(
+        "@prefix ex: <http://example.org/ns/> .\n\
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n",
+    );
+    for i in 0..N_PUB {
+        let ty = match i % 4 {
+            0 => "ex:Inproceedings",
+            1 => "ex:Book",
+            2 => "ex:Incollection",
+            _ => "ex:Article",
+        };
+        buf.push_str(&format!("ex:pub-{i:04} ex:bibtexType {ty} "));
+        let sigs = i % 4;
+        if sigs > 0 {
+            buf.push_str("; ex:hasSignature ");
+            let list: Vec<String> = (0..sigs).map(|k| format!("ex:sig-{i:04}-{k}")).collect();
+            buf.push_str(&list.join(", "));
+        }
+        let tags = i % 3;
+        if tags > 0 {
+            buf.push_str("; ex:hasTag ");
+            let list: Vec<String> = (0..tags).map(|k| format!("\"tag-{i:04}-{k}\"")).collect();
+            buf.push_str(&list.join(", "));
+        }
+        if i % 11 == 0 {
+            buf.push_str("; ex:bibtexType ex:Misc ");
+        }
+        buf.push_str(" .\n");
+    }
+    buf
+}
+
+/// Chain ledger: `?a ex:sigPub ?b . ?b rdf:type ?c` with a `rdfs:subClassOf`
+/// tail on `?c` (classes c-0/c-1 have 2/1 superclasses, the rest none), plus a
+/// mixed-object `ex:kind` second hop and literal objects sprinkled into
+/// `sigPub` itself. Indexed with 3-row leaflets so object groups of the POST
+/// walk straddle leaflet boundaries — the shape that lost rows.
+fn chain_turtle() -> String {
+    let mut buf = String::from(
+        "@prefix ex: <http://example.org/ns/> .\n\
+         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\
+         @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\n",
+    );
+    buf.push_str(
+        "ex:c-0 rdfs:subClassOf ex:Top1, ex:Top2 .\n\
+         ex:c-1 rdfs:subClassOf ex:Top1 .\n\n",
+    );
+    for j in 0..N_B {
+        buf.push_str(&format!("ex:b-{j:04} rdf:type ex:c-{} ", j % 8));
+        if j % 5 == 0 {
+            buf.push_str(&format!(", ex:c-{} ", (j + 3) % 8));
+        }
+        buf.push_str(&format!("; ex:kind \"kind-{}\" ", j % 6));
+        if j % 7 == 0 {
+            buf.push_str(&format!("; ex:kind ex:c-{} ", j % 8));
+        }
+        buf.push_str(" .\n");
+    }
+    for i in 0..N_A {
+        buf.push_str(&format!("ex:a-{i:04} ex:sigPub ex:b-{:04} ", i % N_B));
+        if i % 6 == 0 {
+            buf.push_str(&format!(", ex:b-{:04} ", (i + 5) % N_B));
+        }
+        if i % 9 == 0 {
+            buf.push_str(&format!(", \"lit-{i}\" "));
+        }
+        buf.push_str(" .\n");
+    }
+    buf
+}
+
+/// Composite-join ledger WITHOUT arena-routed values: the `(s, o)` merge-join
+/// stays on its fast path and must count matching pairs across IRIs, strings,
+/// inline integers/decimals, and language-tagged strings (`@en` vs `@fr` must
+/// NOT match).
+fn composite_clean_turtle() -> String {
+    String::from(
+        "@prefix ex: <http://example.org/ns/> .\n\
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n\
+         ex:d-0 ex:createdBy ex:p-1 ; ex:authoredBy ex:p-1 .\n\
+         ex:d-1 ex:createdBy ex:p-1, ex:p-2 ; ex:authoredBy ex:p-2 .\n\
+         ex:d-2 ex:createdBy \"alice\" ; ex:authoredBy \"alice\" .\n\
+         ex:d-3 ex:createdBy \"7\"^^xsd:integer ; ex:authoredBy \"7\"^^xsd:integer .\n\
+         ex:d-4 ex:createdBy \"bob\"@en ; ex:authoredBy \"bob\"@en .\n\
+         ex:d-5 ex:createdBy \"bob\"@en ; ex:authoredBy \"bob\"@fr .\n\
+         ex:d-6 ex:createdBy ex:p-3 ; ex:authoredBy ex:p-4 .\n",
+    )
+}
+
+/// Composite-join ledger WITH arena-routed values (`xsd:decimal`, overflow
+/// `xsd:integer`), where `createdBy` carries a wider big-value set than
+/// `authoredBy` so the per-predicate arena handles for the shared values
+/// disagree. The fast lane must decline; the counted answer includes every
+/// big-value match.
+fn composite_numbig_turtle() -> String {
+    let mut buf = String::from(
+        "@prefix ex: <http://example.org/ns/> .\n\
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n",
+    );
+    let bigs = [
+        "10000000000000000000.1",
+        "20000000000000000000.2",
+        "30000000000000000000.3",
+        "40000000000000000000.4",
+        "50000000000000000000.5",
+        "60000000000000000000.6",
+    ];
+    // createdBy-only extras widen createdBy's arena so shared values land on
+    // different handles.
+    for (i, v) in bigs.iter().enumerate().take(3) {
+        buf.push_str(&format!("ex:x-{i} ex:createdBy \"{v}\"^^xsd:decimal .\n"));
+    }
+    for (i, v) in bigs.iter().enumerate().skip(3) {
+        buf.push_str(&format!(
+            "ex:x-{i} ex:createdBy \"{v}\"^^xsd:decimal ; ex:authoredBy \"{v}\"^^xsd:decimal .\n"
+        ));
+    }
+    let ints = [
+        "100000000000000000000",
+        "200000000000000000000",
+        "300000000000000000000",
+    ];
+    buf.push_str(&format!(
+        "ex:y-0 ex:createdBy \"{}\"^^xsd:integer .\n",
+        ints[0]
+    ));
+    for (i, v) in ints.iter().enumerate().skip(1) {
+        buf.push_str(&format!(
+            "ex:y-{i} ex:createdBy \"{v}\"^^xsd:integer ; ex:authoredBy \"{v}\"^^xsd:integer .\n"
+        ));
+    }
+    buf.push_str(
+        "ex:z-0 ex:createdBy ex:p-1 ; ex:authoredBy ex:p-1 .\n\
+         ex:z-1 ex:createdBy \"7\"^^xsd:integer ; ex:authoredBy \"7\"^^xsd:integer .\n\
+         ex:z-2 ex:createdBy \"1.5\"^^xsd:decimal ; ex:authoredBy \"1.5\"^^xsd:decimal .\n\
+         ex:z-3 ex:createdBy \"abc\" ; ex:authoredBy \"abc\" .\n",
+    );
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// Cases
+// ---------------------------------------------------------------------------
+
+/// Which ledger a case runs against.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Ledger {
+    Star,
+    Chain,
+    CompositeClean,
+    CompositeNumBig,
+    CompositeList,
+}
+
+/// Routing assertion against the engine's `fast-path outcome` stamps.
+#[derive(Clone, Copy)]
+enum Routing {
+    /// This site must `proceed` — the fix must keep the lane, not disable it.
+    MustFire(&'static str),
+    /// This site must NOT `proceed` — the shape is one the lane cannot answer.
+    MustNotFire(&'static str),
+}
+
+struct Case {
+    name: &'static str,
+    ledger: Ledger,
+    sparql: &'static str,
+    /// Hand-pinned rows as `normalize` renders them (sorted JSON row strings).
+    /// Both the fast lane and the generic pipeline must produce exactly this.
+    expected: &'static [&'static str],
+    routing: Routing,
+}
+
+fn cases() -> Vec<Case> {
+    use Ledger::{Chain, CompositeClean, CompositeList, CompositeNumBig, Star};
+    use Routing::{MustFire, MustNotFire};
+    const STAR_SITE: &str = "group_by_object_star_topk";
+    const PLAN_SITE: &str = "count-plan";
+    vec![
+        // ---- Case 1: star top-k bag multiplicity ---------------------------
+        // Inproceedings subjects (i % 4 == 0) have no signatures: absent.
+        // Counts are sums of per-subject signature counts, not subject counts.
+        Case {
+            name: "star topk COUNT over signature star",
+            ledger: Star,
+            sparql: "SELECT ?o1 (COUNT(?s) AS ?count) WHERE {\n\
+                     ?s ex:bibtexType ?o1 . ?s ex:hasSignature ?o2 .\n\
+                     } GROUP BY ?o1 ORDER BY DESC(?count) LIMIT 10",
+            expected: &[
+                "[\"ex:Article\",45]",
+                "[\"ex:Book\",15]",
+                "[\"ex:Incollection\",30]",
+                "[\"ex:Misc\",9]",
+            ],
+            routing: MustFire(STAR_SITE),
+        },
+        Case {
+            name: "star topk COUNT over string-tag star",
+            ledger: Star,
+            sparql: "SELECT ?o1 (COUNT(?s) AS ?count) WHERE {\n\
+                     ?s ex:bibtexType ?o1 . ?s ex:hasTag ?o2 .\n\
+                     } GROUP BY ?o1 ORDER BY DESC(?count) LIMIT 10",
+            expected: &[
+                "[\"ex:Article\",15]",
+                "[\"ex:Book\",15]",
+                "[\"ex:Incollection\",15]",
+                "[\"ex:Inproceedings\",15]",
+                "[\"ex:Misc\",6]",
+            ],
+            routing: MustFire(STAR_SITE),
+        },
+        // Two filter predicates: multiplicity is the PRODUCT of per-subject
+        // counts (signatures x tags), exercising the intersection-map lane.
+        Case {
+            name: "star topk COUNT over two-predicate star",
+            ledger: Star,
+            sparql: "SELECT ?o1 (COUNT(?s) AS ?count) WHERE {\n\
+                     ?s ex:bibtexType ?o1 . ?s ex:hasSignature ?o2 . ?s ex:hasTag ?o3 .\n\
+                     } GROUP BY ?o1 ORDER BY DESC(?count) LIMIT 10",
+            expected: &[
+                "[\"ex:Article\",45]",
+                "[\"ex:Book\",15]",
+                "[\"ex:Incollection\",30]",
+                "[\"ex:Misc\",11]",
+            ],
+            routing: MustFire(STAR_SITE),
+        },
+        // Multi-aggregate: MIN/MAX stay subject-level (duplicate-insensitive)
+        // while COUNT carries the multiplicity — the mixed-correctness shape
+        // from the report (wrong counts, right min/max).
+        Case {
+            name: "star topk COUNT+MIN+MAX",
+            ledger: Star,
+            sparql: "SELECT ?o1 (COUNT(?s) AS ?count) (MIN(?s) AS ?mn) (MAX(?s) AS ?mx) WHERE {\n\
+                     ?s ex:bibtexType ?o1 . ?s ex:hasSignature ?o2 .\n\
+                     } GROUP BY ?o1 ORDER BY DESC(?count) LIMIT 10",
+            expected: &[
+                "[\"ex:Article\",45,\"ex:pub-0003\",\"ex:pub-0059\"]",
+                "[\"ex:Book\",15,\"ex:pub-0001\",\"ex:pub-0057\"]",
+                "[\"ex:Incollection\",30,\"ex:pub-0002\",\"ex:pub-0058\"]",
+                "[\"ex:Misc\",9,\"ex:pub-0011\",\"ex:pub-0055\"]",
+            ],
+            routing: MustFire(STAR_SITE),
+        },
+        // ---- Case 2: chain fold across leaflet boundaries ------------------
+        // The inner join loses rows too when a POST object group straddles a
+        // leaflet — the OPTIONAL/MINUS asymmetry in the report was downstream
+        // of the same split.
+        Case {
+            name: "chain COUNT(*) plain",
+            ledger: Chain,
+            sparql: "SELECT (COUNT(*) AS ?count) WHERE { ?a ex:sigPub ?b . ?b rdf:type ?c . }",
+            expected: &["[57]"],
+            routing: MustFire(PLAN_SITE),
+        },
+        Case {
+            name: "chain COUNT(*) OPTIONAL tail",
+            ledger: Chain,
+            sparql: "SELECT (COUNT(*) AS ?count) WHERE { ?a ex:sigPub ?b . ?b rdf:type ?c .\n\
+                     OPTIONAL { ?c rdfs:subClassOf ?d . } }",
+            expected: &["[67]"],
+            routing: MustFire(PLAN_SITE),
+        },
+        Case {
+            name: "chain COUNT(*) MINUS tail",
+            ledger: Chain,
+            sparql: "SELECT (COUNT(*) AS ?count) WHERE { ?a ex:sigPub ?b . ?b rdf:type ?c .\n\
+                     MINUS { ?c rdfs:subClassOf ?d . } }",
+            expected: &["[41]"],
+            routing: MustFire(PLAN_SITE),
+        },
+        Case {
+            name: "chain COUNT(*) EXISTS tail",
+            ledger: Chain,
+            sparql: "SELECT (COUNT(*) AS ?count) WHERE { ?a ex:sigPub ?b . ?b rdf:type ?c .\n\
+                     FILTER EXISTS { ?c rdfs:subClassOf ?d . } }",
+            expected: &["[16]"],
+            routing: MustFire(PLAN_SITE),
+        },
+        // Mixed-object second hop (`ex:kind` holds strings AND IRIs): with
+        // 3-row leaflets some are homogeneous non-IRI, which the POST walk
+        // must SKIP, not treat as end-of-stream.
+        Case {
+            name: "chain COUNT(*) mixed-object hop",
+            ledger: Chain,
+            sparql: "SELECT (COUNT(*) AS ?count) WHERE { ?a ex:sigPub ?b . ?b ex:kind ?c . }",
+            expected: &["[54]"],
+            routing: MustFire(PLAN_SITE),
+        },
+        Case {
+            name: "chain COUNT(*) mixed-object hop, OPTIONAL tail",
+            ledger: Chain,
+            sparql: "SELECT (COUNT(*) AS ?count) WHERE { ?a ex:sigPub ?b . ?b ex:kind ?c .\n\
+                     OPTIONAL { ?c rdfs:subClassOf ?d . } }",
+            expected: &["[56]"],
+            routing: MustFire(PLAN_SITE),
+        },
+        Case {
+            name: "chain COUNT(*) mixed-object hop, MINUS tail",
+            ledger: Chain,
+            sparql: "SELECT (COUNT(*) AS ?count) WHERE { ?a ex:sigPub ?b . ?b ex:kind ?c .\n\
+                     MINUS { ?c rdfs:subClassOf ?d . } }",
+            expected: &["[52]"],
+            routing: MustFire(PLAN_SITE),
+        },
+        // ---- Case 3: composite (s,o) join ---------------------------------
+        // d-0 (IRI), d-1 (p-2 of two createdBy), d-2 (string), d-3 (inline
+        // int), d-4 (@en/@en). d-5 (@en/@fr) and d-6 (different IRIs) must not
+        // match.
+        Case {
+            name: "composite join, no arena values (keeps fast path)",
+            ledger: CompositeClean,
+            sparql:
+                "SELECT (COUNT(*) AS ?count) WHERE { ?s ex:createdBy ?o . ?s ex:authoredBy ?o }",
+            expected: &["[5]"],
+            routing: MustFire(PLAN_SITE),
+        },
+        // 9 = 3 big decimals + 2 big ints + z-0..z-3's four matches; the six
+        // big-value matches are exactly what the per-predicate arena handles
+        // missed (fast said 3).
+        Case {
+            name: "composite join, arena values (declines to generic)",
+            ledger: CompositeNumBig,
+            sparql:
+                "SELECT (COUNT(*) AS ?count) WHERE { ?s ex:createdBy ?o . ?s ex:authoredBy ?o }",
+            expected: &["[9]"],
+            routing: MustNotFire(PLAN_SITE),
+        },
+        // List rows (`o_i`): the generic pipeline's list-element join
+        // semantics are not expressible in an (s, o_type, o_key) key, so the
+        // lane must decline and agree with whatever the generic join yields.
+        Case {
+            name: "composite join, list rows (declines to generic)",
+            ledger: CompositeList,
+            sparql:
+                "SELECT (COUNT(*) AS ?count) WHERE { ?s ex:createdBy ?o . ?s ex:authoredBy ?o }",
+            expected: &["[3]"],
+            routing: MustNotFire(PLAN_SITE),
+        },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Setup + runner
+// ---------------------------------------------------------------------------
+
+/// Insert + reindex with an explicit leaflet size. `leaflet_rows = 3` forces
+/// multi-leaflet predicates at test scale (the chain ledger's boundary-split
+/// shape); the default keeps single-leaflet layout.
+async fn setup_turtle(
+    alias: &str,
+    turtle: &str,
+    leaflet_rows: Option<usize>,
+) -> (tempfile::TempDir, Fluree) {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let path = dir.path().to_string_lossy().to_string();
+    let fluree = FlureeBuilder::file(path).build().expect("build Fluree");
+    let ledger = fluree.create_ledger(alias).await.expect("create_ledger");
+    // Thresholds high enough that no commit self-indexes; the explicit
+    // reindex below is the only index point.
+    let index_config = IndexConfig {
+        reindex_min_bytes: 5_000_000_000,
+        reindex_max_bytes: 5_000_000_000,
+    };
+    let _ = fluree
+        .insert_turtle_with_opts(
+            ledger,
+            turtle,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config,
+            None,
+        )
+        .await
+        .expect("insert");
+    let mut opts = ReindexOptions::default();
+    if let Some(rows) = leaflet_rows {
+        opts = opts.with_indexer_config(IndexerConfig::default().with_leaflet_rows(rows));
+    }
+    fluree.reindex(alias, opts).await.expect("reindex");
+    (dir, fluree)
+}
+
+/// The list ledger needs JSON-LD (`@list` has no Turtle surface for `o_i`).
+/// s1: list-vs-plain (generic: no match). s2: aligned duplicate lists
+/// (generic: 2). s3: same value at different positions (generic: 1).
+async fn setup_list_ledger(alias: &str) -> (tempfile::TempDir, Fluree) {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let path = dir.path().to_string_lossy().to_string();
+    let fluree = FlureeBuilder::file(path).build().expect("build Fluree");
+    let ledger0 = fluree.create_ledger(alias).await.expect("create_ledger");
+    let insert1 = serde_json::json!({
+        "@context": [
+            {"ex": "http://example.org/ns/"},
+            {"ex:createdBy": {"@container": "@list"}}
+        ],
+        "@id": "ex:s1",
+        "ex:createdBy": ["ex:p-1", "ex:p-1"],
+        "ex:authoredBy": {"@id": "ex:p-1"}
+    });
+    let insert2 = serde_json::json!({
+        "@context": [
+            {"ex": "http://example.org/ns/"},
+            {"ex:createdBy": {"@container": "@list"}, "ex:authoredBy": {"@container": "@list"}}
+        ],
+        "@id": "ex:s2",
+        "ex:createdBy": ["ex:q-1", "ex:q-1"],
+        "ex:authoredBy": ["ex:q-1", "ex:q-1"]
+    });
+    let insert3 = serde_json::json!({
+        "@context": [
+            {"ex": "http://example.org/ns/"},
+            {"ex:createdBy": {"@container": "@list"}, "ex:authoredBy": {"@container": "@list"}}
+        ],
+        "@id": "ex:s3",
+        "ex:createdBy": ["ex:r-other", "ex:r-1"],
+        "ex:authoredBy": ["ex:r-1", "ex:r-x"]
+    });
+    let r1 = fluree.insert(ledger0, &insert1).await.expect("insert s1");
+    let r2 = fluree.insert(r1.ledger, &insert2).await.expect("insert s2");
+    let _ = fluree.insert(r2.ledger, &insert3).await.expect("insert s3");
+    fluree
+        .reindex(alias, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    (dir, fluree)
+}
+
+async fn run_query(fluree: &Fluree, alias: &str, sparql: &str) -> Value {
+    let full = format!("{PREFIX}{sparql}");
+    let snapshot = fluree.graph(alias).load().await.expect("load");
+    snapshot
+        .query()
+        .sparql(&full)
+        .format(FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .unwrap_or_else(|e| panic!("query {sparql}: {e}"))
+}
+
+fn normalize(rows: &Value) -> Vec<String> {
+    let mut out: Vec<String> = rows
+        .as_array()
+        .expect("array of rows")
+        .iter()
+        .map(|r| serde_json::to_string(r).expect("serialize row"))
+        .collect();
+    out.sort();
+    out
+}
+
+/// RAII restore of the process-global kill switch, including on panic.
+struct FastPathGuard;
+impl Drop for FastPathGuard {
+    fn drop(&mut self) {
+        set_fast_paths_disabled(false);
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn issue_1652_shapes_match_generic_and_keep_their_fast_paths() {
+    // The kill switch OR's with this env var; with it set, the fast phase
+    // below runs generically and every assertion is vacuous.
+    assert!(
+        std::env::var_os("FLUREE_DISABLE_QUERY_FAST_PATHS").is_none(),
+        "FLUREE_DISABLE_QUERY_FAST_PATHS is set — the fast-path phase of this \
+         test would run generically and pin nothing. Unset it."
+    );
+    let _guard = FastPathGuard;
+
+    let (_d1, star) = setup_turtle("r1652:star", &star_turtle(), None).await;
+    let (_d2, chain) = setup_turtle("r1652:chain", &chain_turtle(), Some(3)).await;
+    let (_d3, clean) = setup_turtle("r1652:clean", &composite_clean_turtle(), None).await;
+    let (_d4, numbig) = setup_turtle("r1652:numbig", &composite_numbig_turtle(), None).await;
+    let (_d5, list) = setup_list_ledger("r1652:list").await;
+    let env = |l: Ledger| -> (&Fluree, &'static str) {
+        match l {
+            Ledger::Star => (&star, "r1652:star"),
+            Ledger::Chain => (&chain, "r1652:chain"),
+            Ledger::CompositeClean => (&clean, "r1652:clean"),
+            Ledger::CompositeNumBig => (&numbig, "r1652:numbig"),
+            Ledger::CompositeList => (&list, "r1652:list"),
+        }
+    };
+    let cases = cases();
+
+    // Phase 1 — fast paths on, under span capture so each answer can be
+    // attributed to the site that served it.
+    let (store, tracing_guard) = span_capture::init_test_tracing();
+    set_fast_paths_disabled(false);
+    let mut fast: Vec<Vec<String>> = Vec::new();
+    let mut proceeded: Vec<Vec<String>> = Vec::new();
+    for c in &cases {
+        let (fluree, alias) = env(c.ledger);
+        let before = store.find_events("fast-path outcome").len();
+        fast.push(normalize(&run_query(fluree, alias, c.sparql).await));
+        proceeded.push(
+            store.find_events("fast-path outcome")[before..]
+                .iter()
+                .filter(|e| e.fields.get("outcome").map(String::as_str) == Some("proceed"))
+                .filter_map(|e| e.fields.get("site").cloned())
+                .collect(),
+        );
+    }
+    drop(tracing_guard);
+
+    // Phase 2 — generic pipeline (the kill-switch reference).
+    set_fast_paths_disabled(true);
+    let mut generic: Vec<Vec<String>> = Vec::new();
+    for c in &cases {
+        let (fluree, alias) = env(c.ledger);
+        generic.push(normalize(&run_query(fluree, alias, c.sparql).await));
+    }
+    set_fast_paths_disabled(false);
+
+    let mut failures: Vec<String> = Vec::new();
+    for (i, c) in cases.iter().enumerate() {
+        let expected: Vec<String> = c.expected.iter().map(|s| (*s).to_string()).collect();
+        if fast[i] != expected {
+            failures.push(format!(
+                "{}: fast lane returned {:?}, expected {:?} [proceeded: {:?}]",
+                c.name, fast[i], expected, proceeded[i]
+            ));
+        }
+        if generic[i] != expected {
+            failures.push(format!(
+                "{}: generic pipeline returned {:?}, expected {:?} — the \
+                 hand-pinned answer is wrong or the general pipeline regressed",
+                c.name, generic[i], expected
+            ));
+        }
+        match c.routing {
+            Routing::MustFire(site) => {
+                if !proceeded[i].iter().any(|s| s == site) {
+                    failures.push(format!(
+                        "{}: expected site `{site}` to proceed — the fix must \
+                         keep the fast path, not disable it [proceeded: {:?}]",
+                        c.name, proceeded[i]
+                    ));
+                }
+            }
+            Routing::MustNotFire(site) => {
+                if proceeded[i].iter().any(|s| s == site) {
+                    failures.push(format!(
+                        "{}: site `{site}` proceeded on a shape it cannot \
+                         answer [proceeded: {:?}]",
+                        c.name, proceeded[i]
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "issue #1652 regression pins found {} failure(s):\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+}

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -3502,11 +3502,12 @@ fn execute_optional_chain_head(
         return Ok(Some(0));
     };
 
-    // This lane drives the IRI-only `PostObjectGroupCountIter`, which terminates
-    // on a homogeneous non-IRI leaflet (and POST orders such leaflets before
-    // `IRI_REF`). A literal-valued `?b` still survives the OPTIONAL with
-    // multiplier 1, so rather than undercount we defer any non-all-IRI `p1` to
-    // the generic pipeline.
+    // This lane drives the IRI-only `PostObjectGroupCountIter`, which drops
+    // non-IRI rows — row-wise in a mixed leaflet, whole-leaflet for a
+    // homogeneous non-IRI one. A literal-valued `?b` has no inner-chain
+    // continuation but still survives the OPTIONAL with multiplier 1, so those
+    // dropped rows would undercount; defer any non-all-IRI `p1` to the generic
+    // pipeline instead.
     if !predicate_objects_all_iri(store, g_id, p1_id)? {
         return Ok(None);
     }

--- a/fluree-db-query/src/count_plan_exec.rs
+++ b/fluree-db-query/src/count_plan_exec.rs
@@ -3732,10 +3732,17 @@ impl<'a> PsotSoIter<'a> {
 
 /// Streams `SoKey { s, o_type, o_key }` rows from an overlay-merged PSOT cursor,
 /// in `(s, o_type, o_key)` order (matching `SoKey`'s ordering and `PsotSoIter`).
+///
+/// A **list row** (live `o_i`) sets `declined` and ends the stream: the
+/// directory gate keeps base list predicates off this lane, but novelty can
+/// introduce list rows the directories haven't seen, and `SoKey` drops the
+/// `o_i` the generic pipeline's list-element join semantics depend on. The
+/// caller must treat `declined` as "bail to the generic fallback".
 struct CursorSoIter {
     cursor: BinaryCursor,
     current: Option<fluree_db_binary_index::ColumnBatch>,
     row: usize,
+    declined: bool,
 }
 
 impl CursorSoIter {
@@ -3744,10 +3751,15 @@ impl CursorSoIter {
             cursor,
             current: None,
             row: 0,
+            declined: false,
         }
     }
 
     fn next_row(&mut self) -> Result<Option<SoKey>> {
+        use fluree_db_binary_index::format::run_record::LIST_INDEX_NONE;
+        if self.declined {
+            return Ok(None);
+        }
         loop {
             if self.current.is_none() {
                 self.current = self
@@ -3763,6 +3775,14 @@ impl CursorSoIter {
             if self.row >= batch.row_count {
                 self.current = None;
                 continue;
+            }
+            // `o_i` is absent from the narrow no-overlay projection (base list
+            // predicates never reach this lane — the directory gate declines
+            // them first), and forced into the projection whenever overlay ops
+            // merge — exactly when novelty list rows could appear.
+            if batch.o_i.get_or(self.row, LIST_INDEX_NONE) != LIST_INDEX_NONE {
+                self.declined = true;
+                return Ok(None);
             }
             let key = SoKey {
                 s: batch.s_id.get(self.row),
@@ -3791,6 +3811,12 @@ impl SoRows<'_> {
             SoRows::Meta(it) => it.next_row(),
             SoRows::Cursor(c) => c.next_row(),
         }
+    }
+
+    /// True when the stream ended early on a novelty list row (see
+    /// [`CursorSoIter`]); the composite-join count must bail to its fallback.
+    fn declined(&self) -> bool {
+        matches!(self, SoRows::Cursor(c) if c.declined)
     }
 }
 
@@ -3826,12 +3852,36 @@ fn so_rows<'a>(ec: &ExecCtx<'a, '_>, pred: &Ref) -> Result<Option<SoRows<'a>>> {
     }
 }
 
-/// Count `(s, o)` pairs present in BOTH predicate relations via a streaming
-/// merge-join on the composite `(s_id, o_type, o_key)` key. Each shared pair is
-/// counted once (intersection cardinality), NOT the product of per-subject counts.
-/// `Ok(None)` bails the plan (overlay present but a predicate is absent from the
-/// base index, or an overlay flake failed to translate).
+/// Count join rows of `?s <p1> ?o . ?s <p2> ?o` via a streaming merge-join on
+/// the composite `(s_id, o_type, o_key)` key. Each shared key is counted once:
+/// the eligibility gates below make the key a full live-fact identity (no list
+/// rows survive them, and without `o_i` a live fact appears exactly once per
+/// predicate), so per-key multiplicity is always 1×1.
+///
+/// `Ok(None)` bails the plan:
+/// - overlay present but a predicate is absent from the base index, or an
+///   overlay flake failed to translate;
+/// - either predicate fails
+///   [`predicate_unsafe_for_cross_predicate_o_key_join`] (#1652): a
+///   `NUM_BIG_OVERFLOW` object's `o_key` is a per-predicate arena handle, so
+///   cross-predicate `o_key` equality is not value equality — equal big
+///   decimals under the two predicates would never match; list rows join by
+///   rules `SoKey` cannot express. Directory-metadata gate; ledgers without
+///   decimals/overflow-integers/lists under these predicates keep the fast
+///   path;
+/// - a novelty list row surfaced in the overlay lane (`SoRows::declined`).
 fn count_composite_join_pairs(ec: &ExecCtx<'_, '_>, p1: &Ref, p2: &Ref) -> Result<Option<u64>> {
+    for pred in [p1, p2] {
+        let sid = normalize_pred_sid(ec.store, pred)?;
+        if let Some(p_id) = ec.store.sid_to_p_id(&sid) {
+            if crate::fast_path_common::predicate_unsafe_for_cross_predicate_o_key_join(
+                ec.store, ec.g_id, p_id,
+            )? {
+                return Ok(None);
+            }
+        }
+    }
+
     let Some(mut it1) = so_rows(ec, p1)? else {
         return Ok(None);
     };
@@ -3853,6 +3903,10 @@ fn count_composite_join_pairs(ec: &ExecCtx<'_, '_>, p1: &Ref, p2: &Ref) -> Resul
                 b = it2.next_row()?;
             }
         }
+    }
+
+    if it1.declined() || it2.declined() {
+        return Ok(None);
     }
 
     Ok(Some(count))

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -764,6 +764,12 @@ fn detect_predicate_group_by_object_count_topk(
 /// Detect `GROUP BY ?o` top-k where WHERE is a same-subject star join:
 /// `?s <p_group> ?o . ?s <p_filter1> ?x1 . ...`
 ///
+/// The filter object vars must be pairwise distinct, as written: the operator
+/// folds them as a product of per-subject counts, which is the join
+/// multiplicity only when they range independently. Sharing one makes the
+/// filters a join on it, whose multiplicity is their value intersection —
+/// not expressible in the fold, so the shape declines.
+///
 /// Supports subject aggregates: MIN(?s), MAX(?s), SAMPLE(?s) in addition to COUNT.
 #[allow(clippy::type_complexity)]
 fn detect_group_by_object_star_topk(

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -811,6 +811,7 @@ fn detect_group_by_object_star_topk(
     let mut subj_var: Option<VarId> = None;
     let mut group_tp: Option<&TriplePattern> = None;
     let mut filter_preds: Vec<Ref> = Vec::new();
+    let mut filter_obj_vars: Vec<VarId> = Vec::new();
     for p in &query.patterns {
         let Pattern::Triple(tp) = p else {
             return None;
@@ -827,6 +828,16 @@ fn detect_group_by_object_star_topk(
             }
             group_tp = Some(tp);
         } else {
+            // Filter object vars must be pairwise distinct. The operator folds
+            // filters as a product of per-subject counts, which is the join
+            // multiplicity only when they range independently; two filters
+            // sharing an object var join on it, and the true multiplicity is
+            // the size of their value intersection. Distinct vars over the
+            // same predicate stay eligible — that product is correct.
+            if filter_obj_vars.contains(&ov) {
+                return None;
+            }
+            filter_obj_vars.push(ov);
             filter_preds.push(pred);
         }
     }

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -27,7 +27,7 @@ use fluree_db_binary_index::{
 use fluree_db_core::o_type::OType;
 use fluree_db_core::subject_id::SubjectId;
 use fluree_db_core::{FlakeValue, GraphId, LedgerSnapshot, QueryCancellation, Sid};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::sync::Arc;
@@ -1074,8 +1074,13 @@ impl AggStateStar {
         }
     }
 
-    fn observe(&mut self, s_id: u64, want_min: bool, want_max: bool, want_sample: bool) {
-        self.count = self.count.saturating_add(1);
+    /// Fold one group-predicate row for subject `s_id`, joined against `mult`
+    /// filter-star rows (the product of the filter predicates' per-subject row
+    /// counts). SPARQL bag semantics: the join multiplies each group row by
+    /// `mult`, so COUNT adds `mult`; MIN/MAX/SAMPLE over `?s` are
+    /// duplicate-insensitive and ignore it.
+    fn observe(&mut self, s_id: u64, mult: u64, want_min: bool, want_max: bool, want_sample: bool) {
+        self.count = self.count.saturating_add(mult);
         if want_sample && self.sample_s.is_none() {
             self.sample_s = Some(s_id);
         }
@@ -1095,6 +1100,10 @@ impl AggStateStar {
 /// `GROUP BY ?o ORDER BY DESC(?count) LIMIT k`
 ///
 /// Optionally also computes MIN/MAX/SAMPLE on `?s`.
+///
+/// COUNT honors SPARQL bag semantics: each group-predicate row is multiplied
+/// by the product of the filter predicates' per-subject row counts (the star
+/// join's multiplicity), not merely gated on subject existence (#1652).
 pub struct GroupByObjectStarTopKOperator {
     group_pred: crate::ir::triple::Ref,
     filter_preds: Vec<crate::ir::triple::Ref>,
@@ -1163,6 +1172,9 @@ impl Operator for GroupByObjectStarTopKOperator {
             return Err(QueryError::OperatorAlreadyOpened);
         }
 
+        use crate::fast_path_outcome::{stamp_fast_path, FastPathFallback, FastPathOutcome};
+        const SITE: &str = "group_by_object_star_topk";
+
         if allow_cursor_fast_path(ctx) {
             if let Some(store) = ctx.binary_store.as_ref() {
                 let Some(batch) = compute_group_by_object_star_topk(
@@ -1182,6 +1194,10 @@ impl Operator for GroupByObjectStarTopKOperator {
                 else {
                     // Fast-path unavailable under this execution context (e.g., overlay requires fallback).
                     // Fall through to the provided fallback operator.
+                    stamp_fast_path(
+                        SITE,
+                        FastPathOutcome::Fallback(FastPathFallback::GateDeclined),
+                    );
                     let Some(fallback) = &mut self.fallback else {
                         return Err(QueryError::Internal(
                             "group-by-object star topk fast-path unavailable and no fallback provided".into(),
@@ -1191,6 +1207,7 @@ impl Operator for GroupByObjectStarTopKOperator {
                     self.state = OperatorState::Open;
                     return Ok(());
                 };
+                stamp_fast_path(SITE, FastPathOutcome::Proceed);
                 self.result = Some(batch);
                 self.emitted = false;
                 self.fallback = None;
@@ -1199,6 +1216,10 @@ impl Operator for GroupByObjectStarTopKOperator {
             }
         }
 
+        stamp_fast_path(
+            SITE,
+            FastPathOutcome::Fallback(FastPathFallback::GateDeclined),
+        );
         let Some(fallback) = &mut self.fallback else {
             return Err(QueryError::Internal(
                 "group-by-object star topk fast-path unavailable and no fallback provided".into(),
@@ -1240,13 +1261,19 @@ impl Operator for GroupByObjectStarTopKOperator {
     }
 }
 
-fn collect_subject_set_for_predicate_group(
+/// Stream one filter predicate's PSOT rows and fold them into a
+/// `subject -> multiplicity` map. With `restrict_to` set (the running product
+/// over earlier filter predicates), a subject survives only if present there,
+/// and its new multiplicity is `restrict_to[s] * row_count(s)` — the star
+/// join's bag multiplicity across filter predicates. Without it, the
+/// multiplicity is this predicate's row count alone.
+fn collect_subject_counts_for_predicate_group(
     store: &Arc<BinaryIndexStore>,
     ctx: &ExecutionContext<'_>,
     g_id: GraphId,
     pred: &crate::ir::triple::Ref,
-    restrict_to: Option<&FxHashSet<u64>>,
-) -> Result<Option<FxHashSet<u64>>> {
+    restrict_to: Option<&FxHashMap<u64, u64>>,
+) -> Result<Option<FxHashMap<u64, u64>>> {
     let overlay_has_rows = ctx
         .overlay
         .map(fluree_db_core::OverlayProvider::epoch)
@@ -1257,7 +1284,7 @@ fn collect_subject_set_for_predicate_group(
         return if overlay_has_rows {
             Ok(None)
         } else {
-            Ok(Some(FxHashSet::default()))
+            Ok(Some(FxHashMap::default()))
         };
     };
     let mut out = ColumnSet::EMPTY;
@@ -1272,8 +1299,19 @@ fn collect_subject_set_for_predicate_group(
         return Ok(None);
     };
 
-    let mut set: FxHashSet<u64> = FxHashSet::default();
-    let mut last_s: Option<u64> = None;
+    let mut map: FxHashMap<u64, u64> = FxHashMap::default();
+    let flush = |s: u64, n: u64, map: &mut FxHashMap<u64, u64>| match restrict_to {
+        Some(r) => {
+            if let Some(&m) = r.get(&s) {
+                map.insert(s, m.saturating_mul(n));
+            }
+        }
+        None => {
+            map.insert(s, n);
+        }
+    };
+    let mut cur_s: Option<u64> = None;
+    let mut cur_n: u64 = 0;
     while let Some(batch) = cursor
         .next_batch()
         .map_err(|e| QueryError::Internal(format!("cursor batch: {e}")))?
@@ -1281,19 +1319,21 @@ fn collect_subject_set_for_predicate_group(
         ctx.check_cancelled()?;
         for i in 0..batch.row_count {
             let s = batch.s_id.get(i);
-            if last_s == Some(s) {
-                continue;
-            }
-            last_s = Some(s);
-            if let Some(r) = restrict_to {
-                if !r.contains(&s) {
-                    continue;
+            if cur_s == Some(s) {
+                cur_n += 1;
+            } else {
+                if let Some(prev) = cur_s {
+                    flush(prev, cur_n, &mut map);
                 }
+                cur_s = Some(s);
+                cur_n = 1;
             }
-            set.insert(s);
         }
     }
-    Ok(Some(set))
+    if let Some(prev) = cur_s {
+        flush(prev, cur_n, &mut map);
+    }
+    Ok(Some(map))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1372,13 +1412,14 @@ fn compute_group_by_object_star_topk(
         let mut g_i: usize = 0;
         let mut f_batch: Option<ColumnBatch> = None;
         let mut f_i: usize = 0;
-        let mut f_last: Option<u64> = None;
 
-        let next_filter_subject = |fcur: &mut BinaryCursor,
-                                   f_batch: &mut Option<ColumnBatch>,
-                                   f_i: &mut usize,
-                                   f_last: &mut Option<u64>|
-         -> Result<Option<u64>> {
+        // Next `(subject, row_count)` group of the filter predicate. The whole
+        // run is consumed (across batch refills) before returning, so filter
+        // subjects arrive strictly increasing with their bag multiplicity.
+        let next_filter_group = |fcur: &mut BinaryCursor,
+                                 f_batch: &mut Option<ColumnBatch>,
+                                 f_i: &mut usize|
+         -> Result<Option<(u64, u64)>> {
             loop {
                 if f_batch.is_none() || *f_i >= f_batch.as_ref().unwrap().row_count {
                     ctx.check_cancelled()?;
@@ -1389,16 +1430,31 @@ fn compute_group_by_object_star_topk(
                     if f_batch.is_none() {
                         return Ok(None);
                     }
-                }
-                let b = f_batch.as_ref().unwrap();
-                let s = b.s_id.get(*f_i);
-                *f_i += 1;
-                if *f_last == Some(s) {
                     continue;
                 }
-                *f_last = Some(s);
-                return Ok(Some(s));
+                break;
             }
+            let s = f_batch.as_ref().unwrap().s_id.get(*f_i);
+            let mut n: u64 = 0;
+            loop {
+                let b = f_batch.as_ref().unwrap();
+                while *f_i < b.row_count && b.s_id.get(*f_i) == s {
+                    n += 1;
+                    *f_i += 1;
+                }
+                if *f_i < b.row_count {
+                    break; // group ended within this batch
+                }
+                ctx.check_cancelled()?;
+                *f_batch = fcur
+                    .next_batch()
+                    .map_err(|e| QueryError::Internal(format!("cursor batch: {e}")))?;
+                *f_i = 0;
+                if f_batch.is_none() {
+                    break; // stream ended; group is complete
+                }
+            }
+            Ok(Some((s, n)))
         };
 
         let peek_group_subject = |cursor: &mut BinaryCursor,
@@ -1419,8 +1475,8 @@ fn compute_group_by_object_star_topk(
             Ok(Some(b.s_id.get(*g_i)))
         };
 
-        let mut fs = next_filter_subject(&mut fcur, &mut f_batch, &mut f_i, &mut f_last)?;
-        while let (Some(gs), Some(cur_fs)) =
+        let mut fs = next_filter_group(&mut fcur, &mut f_batch, &mut f_i)?;
+        while let (Some(gs), Some((cur_fs, f_mult))) =
             (peek_group_subject(&mut cursor, &mut g_batch, &mut g_i)?, fs)
         {
             match gs.cmp(&cur_fs) {
@@ -1437,7 +1493,7 @@ fn compute_group_by_object_star_topk(
                     }
                 }
                 Ordering::Greater => {
-                    fs = next_filter_subject(&mut fcur, &mut f_batch, &mut f_i, &mut f_last)?;
+                    fs = next_filter_group(&mut fcur, &mut f_batch, &mut f_i)?;
                 }
                 Ordering::Equal => {
                     let s = gs;
@@ -1454,40 +1510,43 @@ fn compute_group_by_object_star_topk(
                         };
                         aggs.entry(k).or_insert_with(AggStateStar::new).observe(
                             s,
+                            f_mult,
                             want_min,
                             want_max,
                             want_sample,
                         );
                         g_i += 1;
                     }
-                    fs = next_filter_subject(&mut fcur, &mut f_batch, &mut f_i, &mut f_last)?;
+                    fs = next_filter_group(&mut fcur, &mut f_batch, &mut f_i)?;
                 }
             }
         }
     } else {
-        // General path: build subject set S by intersecting filter predicates.
-        let mut s_set: Option<FxHashSet<u64>> = None;
+        // General path: fold the filter predicates into a subject -> bag
+        // multiplicity map (the product of per-subject row counts; a subject
+        // absent from any filter predicate drops out).
+        let mut s_counts: Option<FxHashMap<u64, u64>> = None;
         for p in filter_preds {
-            let Some(next) = collect_subject_set_for_predicate_group(
+            let Some(next) = collect_subject_counts_for_predicate_group(
                 store,
                 ctx,
                 g_id,
                 p,
-                s_set.as_ref().map(|s| s as &FxHashSet<u64>),
+                s_counts.as_ref().map(|s| s as &FxHashMap<u64, u64>),
             )?
             else {
                 return Ok(None);
             };
-            s_set = Some(next);
-            if s_set
+            s_counts = Some(next);
+            if s_counts
                 .as_ref()
-                .is_some_and(std::collections::HashSet::is_empty)
+                .is_some_and(std::collections::HashMap::is_empty)
             {
                 break;
             }
         }
-        let s_set = s_set.unwrap_or_default();
-        if s_set.is_empty() {
+        let s_counts = s_counts.unwrap_or_default();
+        if s_counts.is_empty() {
             return Ok(Some(crate::binding::Batch::empty(schema)?));
         }
 
@@ -1498,15 +1557,16 @@ fn compute_group_by_object_star_topk(
             ctx.check_cancelled()?;
             for i in 0..batch.row_count {
                 let s = batch.s_id.get(i);
-                if !s_set.contains(&s) {
+                let Some(&mult) = s_counts.get(&s) else {
                     continue;
-                }
+                };
                 let k = ObjGroupKey {
                     o_type: batch.o_type.get(i),
                     o_key: batch.o_key.get(i),
                 };
                 aggs.entry(k).or_insert_with(AggStateStar::new).observe(
                     s,
+                    mult,
                     want_min,
                     want_max,
                     want_sample,

--- a/fluree-db-query/src/fast_group_count_firsts.rs
+++ b/fluree-db-query/src/fast_group_count_firsts.rs
@@ -1102,8 +1102,10 @@ impl AggStateStar {
 /// Optionally also computes MIN/MAX/SAMPLE on `?s`.
 ///
 /// COUNT honors SPARQL bag semantics: each group-predicate row is multiplied
-/// by the product of the filter predicates' per-subject row counts (the star
-/// join's multiplicity), not merely gated on subject existence (#1652).
+/// by the product of the filter predicates' per-subject row counts, not merely
+/// gated on subject existence (#1652). That product is the star join's
+/// multiplicity only because the filter object vars are pairwise distinct —
+/// `detect_group_by_object_star_topk` declines when they are not.
 pub struct GroupByObjectStarTopKOperator {
     group_pred: crate::ir::triple::Ref,
     filter_preds: Vec<crate::ir::triple::Ref>,

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -15,7 +15,9 @@ use async_trait::async_trait;
 use fluree_db_binary_index::format::branch::LeafEntry;
 use fluree_db_binary_index::format::column_block::ColumnId;
 use fluree_db_binary_index::format::run_record::RunSortOrder;
-use fluree_db_binary_index::format::run_record_v2::{cmp_v2_for_order, RunRecordV2};
+use fluree_db_binary_index::format::run_record_v2::{
+    cmp_v2_for_order, read_ordered_key_v2, RunRecordV2,
+};
 use fluree_db_binary_index::read::column_loader::load_columns_cached_via_handle;
 use fluree_db_binary_index::{
     BinaryCursor, BinaryFilter, BinaryIndexStore, ColumnBatch, ColumnProjection, ColumnSet,
@@ -352,6 +354,86 @@ pub fn leaf_entries_for_predicate(
     let (min_key, max_key) = predicate_range_keys(p_id, g_id);
     let leaf_range = branch.find_leaves_in_range(&min_key, &max_key, cmp);
     &branch.leaves[leaf_range]
+}
+
+/// Whether `p_id`'s stored rows make `(s_id, o_type, o_key)` unreliable as a
+/// join key **across two different predicates** (#1652 case 3). True when any
+/// POST leaflet shows either hazard:
+///
+/// - a `NUM_BIG_OVERFLOW` object: its `o_key` is a handle into a
+///   **per-predicate** arena (see [`OType::o_key_is_globally_identifying`]),
+///   so equal big decimals under two predicates carry unrelated handles and
+///   never compare equal;
+/// - a list row (`HAS_O_I`): the generic pipeline's list-element bindings join
+///   neither like plain values nor purely by value, so a key that drops `o_i`
+///   diverges from it on multiplicity.
+///
+/// Per-predicate consumers need neither check — their key fixes the `p_id`
+/// that scopes the arena handle, and within one predicate `o_i` only splits a
+/// group it fully contains.
+///
+/// Metadata-first: `HAS_O_I` is a leaflet flag, and a homogeneous leaflet's
+/// o_type is answered by `o_type_const` — no payload touched. A mixed leaflet
+/// is bounded by the o_type of its first/last keys (exact bounds — POST orders
+/// `o_type` immediately after `p_id`); only when that range straddles a
+/// non-identifying o_type is the leaflet's o_type column decoded for an exact
+/// membership check, because the range alone over-declines (inline numerics
+/// sort below `NUM_BIG_OVERFLOW` and langstrings above it, so a plain
+/// int+string+langstring leaflet straddles it without containing one).
+///
+/// Covers the base index only — novelty NumBig values get query-scoped
+/// ephemeral handles that ARE value-deduped across predicates
+/// (`DictOverlay::assign_numbig_handle`), a novelty value reuses a base arena
+/// handle only when the predicate's base arena is non-empty (already reported
+/// here), and novelty *list* rows need a row-level check in the overlay lane.
+pub(crate) fn predicate_unsafe_for_cross_predicate_o_key_join(
+    store: &BinaryIndexStore,
+    g_id: GraphId,
+    p_id: u32,
+) -> Result<bool> {
+    use fluree_db_binary_index::format::leaflet::flags::HAS_O_I;
+    for leaf_entry in leaf_entries_for_predicate(store, g_id, RunSortOrder::Post, p_id) {
+        let handle = store
+            .open_leaf_handle(&leaf_entry.leaf_cid, leaf_entry.sidecar_cid.as_ref(), false)
+            .map_err(|e| QueryError::Internal(format!("leaf open: {e}")))?;
+        let dir = handle.dir();
+        for (idx, entry) in dir.entries.iter().enumerate() {
+            if entry.row_count == 0 || entry.p_const != Some(p_id) {
+                continue;
+            }
+            if entry.flags & HAS_O_I != 0 {
+                return Ok(true);
+            }
+            match entry.o_type_const {
+                Some(ot) => {
+                    if !OType::from_u16(ot).o_key_is_globally_identifying() {
+                        return Ok(true);
+                    }
+                }
+                None => {
+                    let lo = read_ordered_key_v2(RunSortOrder::Post, &entry.first_key).o_type;
+                    let hi = read_ordered_key_v2(RunSortOrder::Post, &entry.last_key).o_type;
+                    if !OType::range_holds_non_globally_identifying(
+                        OType::from_u16(lo),
+                        OType::from_u16(hi),
+                    ) {
+                        continue;
+                    }
+                    // Range straddles a non-identifying o_type: decode this
+                    // leaflet's o_type column and check exact membership.
+                    let batch = handle
+                        .load_columns(idx, &projection_otype_only(), RunSortOrder::Post)
+                        .map_err(|e| QueryError::Internal(format!("load columns: {e}")))?;
+                    for i in 0..batch.row_count {
+                        if !OType::from_u16(batch.o_type.get(i)).o_key_is_globally_identifying() {
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(false)
 }
 
 /// Minimum total predicate rows before a parallel leaf-chunk scan is worth its
@@ -1135,8 +1217,15 @@ impl<'a> PsotSubjectSeek<'a> {
 /// Streaming iterator over POST leaflets for a predicate that yields
 /// `(object_key, row_count)` groups in POST order, restricted to IRI_REF objects.
 ///
-/// Returns `Ok(None)` from `next_group` if a non-IRI_REF leaflet is encountered
-/// (unless it's a mixed-type leaflet, in which case non-IRI rows are skipped).
+/// Non-IRI rows contribute nothing: mixed-type leaflets skip them row-wise and
+/// homogeneous non-IRI leaflets are skipped whole (POST sorts `o_type` before
+/// `o_key`, so the IRI rows form one contiguous run either way).
+///
+/// Groups span leaflet/leaf boundaries — an `o_key` whose rows straddle two
+/// leaflets is emitted ONCE with its full count (`cur_key`/`cur_count` carry,
+/// mirroring [`PsotSubjectCountIter`]). Callers rely on strictly increasing
+/// group keys: `execute_chain`'s forward-only PSOT seek treats a repeated key
+/// as "absent" and would silently drop the second fragment's rows (#1652).
 pub struct PostObjectGroupCountIter<'a> {
     store: &'a BinaryIndexStore,
     p_id: u32,
@@ -1147,6 +1236,9 @@ pub struct PostObjectGroupCountIter<'a> {
     handle: Option<Box<dyn fluree_db_binary_index::read::leaf_access::LeafHandle>>,
     batch: Option<ColumnBatch>,
     mixed: bool,
+    /// Accumulated object key for a group that may span leaflet boundaries.
+    cur_key: Option<u64>,
+    cur_count: u64,
 }
 
 impl<'a> PostObjectGroupCountIter<'a> {
@@ -1161,6 +1253,8 @@ impl<'a> PostObjectGroupCountIter<'a> {
             handle: None,
             batch: None,
             mixed: false,
+            cur_key: None,
+            cur_count: 0,
         }))
     }
 
@@ -1199,7 +1293,10 @@ impl<'a> PostObjectGroupCountIter<'a> {
                 }
                 let mixed = entry.o_type_const.is_none();
                 if !mixed && entry.o_type_const != Some(OType::IRI_REF.as_u16()) {
-                    return Ok(None);
+                    // Homogeneous non-IRI leaflet: no IRI rows in it, skip it.
+                    // (Terminating here instead — the pre-#1652 behavior — cut
+                    // off every IRI group sorting after the leaflet's o_type.)
+                    continue;
                 }
                 let batch = if let Some(cache) = self.store.leaflet_cache() {
                     let idx_u32: u32 = idx
@@ -1237,12 +1334,19 @@ impl<'a> PostObjectGroupCountIter<'a> {
 
     /// Return the next `(object_key, count)` group.
     ///
-    /// Only counts IRI_REF objects. Mixed-type leaflets are handled by filtering
-    /// to IRI rows. Returns `None` when exhausted or if a non-IRI homogeneous
-    /// leaflet is encountered.
+    /// Only counts IRI_REF objects (mixed-type leaflets filter to IRI rows;
+    /// homogeneous non-IRI leaflets are skipped in `load_next_batch`). Groups
+    /// accumulate across leaflet/leaf boundaries — each distinct `o_key` is
+    /// emitted exactly once, with its complete count.
     pub fn next_group(&mut self) -> Result<Option<(u64, u64)>> {
         loop {
+            // Load a batch if needed. If there are no more, flush any group
+            // carried across the last boundary.
             if self.batch.is_none() && self.load_next_batch()?.is_none() {
+                if let Some(k) = self.cur_key.take() {
+                    let n = std::mem::take(&mut self.cur_count);
+                    return Ok(Some((k, n)));
+                }
                 return Ok(None);
             }
             let batch = self.batch.as_ref().unwrap();
@@ -1250,37 +1354,35 @@ impl<'a> PostObjectGroupCountIter<'a> {
                 self.batch = None;
                 continue;
             }
-            if !self.mixed {
-                let b = batch.o_key.get(self.row);
-                let mut count: u64 = 0;
-                while self.row < batch.row_count && batch.o_key.get(self.row) == b {
-                    count += 1;
-                    self.row += 1;
-                }
-                return Ok(Some((b, count)));
-            }
-
-            // Mixed-type leaflet: skip non-IRI_REF rows and group by o_key.
-            while self.row < batch.row_count
-                && batch.o_type.get(self.row) != OType::IRI_REF.as_u16()
-            {
+            if self.mixed && batch.o_type.get(self.row) != OType::IRI_REF.as_u16() {
                 self.row += 1;
-            }
-            if self.row >= batch.row_count {
-                self.batch = None;
                 continue;
             }
 
-            let b = batch.o_key.get(self.row);
-            let mut count: u64 = 0;
+            let key = batch.o_key.get(self.row);
+            match self.cur_key {
+                None => {
+                    self.cur_key = Some(key);
+                    self.cur_count = 0;
+                }
+                Some(cur) if cur != key => {
+                    // New group starts; emit the previous one without
+                    // consuming this row.
+                    self.cur_key = Some(key);
+                    let n = std::mem::take(&mut self.cur_count);
+                    return Ok(Some((cur, n)));
+                }
+                Some(_) => {}
+            }
+
+            // Accumulate the current group's run within this batch.
             while self.row < batch.row_count
-                && batch.o_type.get(self.row) == OType::IRI_REF.as_u16()
-                && batch.o_key.get(self.row) == b
+                && (!self.mixed || batch.o_type.get(self.row) == OType::IRI_REF.as_u16())
+                && batch.o_key.get(self.row) == key
             {
-                count += 1;
+                self.cur_count += 1;
                 self.row += 1;
             }
-            return Ok(Some((b, count)));
         }
     }
 }


### PR DESCRIPTION
Closes #1652.

All three reported shapes reproduce as `fast != generic` under the
`FLUREE_DISABLE_QUERY_FAST_PATHS` kill switch, on small indexed ledgers — no
DBLP-scale data needed. Two of the three fixes are arithmetic/carry corrections
that keep the lane; the third is an eligibility narrowing in the style of #1628.

### 1. Star top-k dropped join multiplicity

`GroupByObjectStarTopKOperator` treated the star's filter triples as an
existence semi-join — the merge-join lane deduplicated filter subjects, the
multi-predicate lane intersected them into a set — so

```sparql
SELECT ?o1 (COUNT(?s) AS ?count) {
  ?s :bibtexType ?o1 .
  ?s :hasSignature ?o2 .
} GROUP BY ?o1 ORDER BY DESC(?count) LIMIT 10
```

counted qualifying *subjects* instead of joined rows. On a 20-triple ledger
(one publication with three signatures, one with two): fast 2, generic 5.
Reproduces at any leaflet size, no overlay required.

The merge-join lane now consumes a whole filter-subject run into an
`(s, count)` group, the multi-predicate lane folds filter predicates into a
`subject -> product-of-counts` map, and `AggStateStar::observe` takes that
multiplicity — COUNT adds it, MIN/MAX/SAMPLE ignore it (duplicate-insensitive,
and they were already correct, which is why only the count column was wrong).

### 2. Chain fold lost rows at POST leaflet boundaries

Not the tail-weight machinery the issue suspected. `PostObjectGroupCountIter`
restarted an object group at every leaflet boundary, emitting the same `o_key`
twice with partial counts; `execute_chain` seeks PSOT forward-only, so the
repeated (non-increasing) key read as absent and **every row of the second
fragment was dropped**. Confirmed by instrumentation — a
`duplicate POST object group emitted` immediately followed by a seek miss.

Two consequences worth noting against the report:

* it hits the **plain** inner-join chain too, so "plain is correct" there was
  layout luck — a 6-row chain gives fast 5 vs generic 6 at 3-row leaflets;
* OPTIONAL, MINUS and EXISTS inherit it from the shared driver, which is why
  their deltas were identical (-434).

The iterator now carries the open group across leaflet and batch refills, the
way `PsotSubjectCountIter` already did. Found alongside: a homogeneous non-IRI
leaflet *terminated* the stream instead of being skipped, and since POST sorts
non-IRI o_types below `IRI_REF`, that truncated every IRI group behind one on a
mixed-object predicate.

### 3. Composite (s,o) join compared non-identifying keys

`count_composite_join_pairs` merge-joins `?s <p1> ?o . ?s <p2> ?o` on
`(s_id, o_type, o_key)` **across two different predicates**. A
`NUM_BIG_OVERFLOW` `o_key` is a handle into a per-predicate arena, not a term
identity, so equal `xsd:decimal`s and overflow integers under the two
predicates never matched — the same trap #1628 gated for the whole-graph
`COUNT(DISTINCT ?o)`; this lane never had it. A 20-row ledger where `createdBy`
carries a wider big-value set than `authoredBy`: **fast 3, generic 9**.

Probing the fix surfaced a second hazard in the same key: **list rows**. The
generic pipeline's list-element join semantics (a list element does not match a
plain ref; aligned duplicate lists pair per-row) are not expressible in a key
that drops `o_i`.

Both now decline through `predicate_unsafe_for_cross_predicate_o_key_join`,
which answers from leaflet directory metadata (`HAS_O_I` flag, `o_type_const`)
and decodes an o_type column only for a mixed leaflet whose key range straddles
`NUM_BIG_OVERFLOW` — inline numerics sort below it and langstrings above, so
the range test alone over-declines ordinary int+string+langstring predicates
(the must-fire assertion caught exactly that). The overlay lane declines
row-wise on a live `o_i`, covering novelty list rows the directories have not
seen.

### Testing

New standalone binary `it_fastpath_1652_regression.rs` (own process: it toggles
the global kill switch and asserts routing): 16 cases over 5 ledgers, with the
chain ledger indexed at three-row leaflets to force boundary-straddling groups
at test scale. Every case pins three things — the fast lane's answer, the
generic pipeline's answer (both against hand-computed values, so a generic
regression fails as loudly as a fast-path one), and the engine's `fast-path
outcome` stamps: **must-fire** for every shape that keeps its lane, so a fix
cannot silently degrade into a disable, and **must-not-fire** for the composite
shapes that now decline.

The differential harness gains a `group_by_object_star_topk` case across base,
overlay and novelty.

Green locally: 1440 `fluree-db-query` unit tests, all 422 `grp_query` tests
(differential harness included), #1628's `it_repeated_var_fast_path_guards` and
`it_count_datatype_pin`, `it_query_explain`, `it_distinct_object_numbig_gate`,
plus clippy `--all-features --all-targets -D warnings` and `cargo fmt --check`.



### Follow-up in this PR

Review surfaced a fourth divergence in the same operator: `detect_group_by_object_star_topk`
admitted star shapes whose filter triples share an object variable. It destructured
`(sv, pred, ov)` but pushed only `pred` into `filter_preds`, so filter object vars were never
compared to each other — and for a shared var the product of per-subject counts is not the join
multiplicity, it's the size of the value intersection.

`?s ex:bibtexType ?o1 . ?s ex:refA ?x . ?s ex:refB ?x` returned `57/57/57/57/21` against the
generic pipeline's `14/14/14/14/5`, lane stamped `proceed`. The admission predates this PR (the
base's existence semantics mis-answers the shape differently), but the product fold made it a
certified-lane divergence, so filter object vars must now be pairwise distinct and the shape
declines. Distinct vars over the same predicate stay eligible — there the product *is* the
multiplicity — pinned by a must-fire companion case. Both probes ride on the star ledger, whose
`refA`/`refB` include every-17th-subject disjoint values so the generic row-drop is covered too.

Also trims the case-3 memory fact to the 750-char cap `repo_memory_lint` enforces (was 806,
the sole red job); the o_type-ordering detail it drops is already in that fact's `rationale`.
