### PR TITLE
fix(query): answer unbound for a calendar field the value does not carry

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -3003,6 +3003,21 @@ mem:fact-01m0dazrcw355c6c1dkpdsgr8z a mem:Fact ;
     mem:createdAt "2026-08-19T15:12:04.000000+00:00"^^xsd:dateTime ;
     mem:rationale "The detector destructured (sv, pred, ov) but pushed only pred into filter_preds, discarding ov — so nothing ever compared filter object vars to each other. The pre-existing existence semantics mis-answered this shape too; the product fold made it a certified-lane divergence, which is why the fix is a decline, not a new counting rule." .
 
+mem:fact-01m0fxp7rvjkyvvkvka3dd24zh a mem:Fact ;
+    mem:content "Fast-path routing is observable for ANY operator built on FastPathOperator: its open() stamps `fast-path outcome` with the operator label as the `site` (fast_path_common.rs), so grepping a file for stamp_fast_path UNDERSTATES coverage — fast_predicate_scalar_agg has zero direct calls yet its lanes stamp as `SUM(DAY)`, `SUM(YEAR)`, `AVG numeric`, `COUNT(DISTINCT)`. Assert routing in tests via span_capture find_events(`fast-path outcome`) filtered on outcome=proceed. This matters because a silently disabled fast lane produces the SAME answer via its fallback: value assertions cannot see it, only the stamp can." ;
+    mem:tag "fast-path" ;
+    mem:tag "instrumentation" ;
+    mem:tag "routing-stamp" ;
+    mem:tag "testing" ;
+    mem:tag "tracing" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-api/tests/it_datetime_component_presence.rs" ;
+    mem:artifactRef "fluree-db-query/src/fast_path_common.rs" ;
+    mem:artifactRef "fluree-db-query/src/fast_path_outcome.rs" ;
+    mem:branch "main" ;
+    mem:createdAt "2026-08-20T10:14:02.000000+00:00"^^xsd:dateTime ;
+    mem:rationale "A #1667 review item asked to add a stamp to the fused scalar-agg operator on the basis that it had none; the stamp already existed one layer up, so the fix was a test-side assertion and no production change. Check the FastPathOperator layer before concluding a lane is unstamped." .
+
 mem:fact-01m0bredy3qtxvftbwass43qkc a mem:Fact ;
     mem:content "#1652 case 3 FIXED: count_composite_join_pairs now gates via predicate_unsafe_for_cross_predicate_o_key_join (fast_path_common) — declines when either predicate's POST leaflets hold NUM_BIG_OVERFLOW objects (per-predicate arena handles, not value identity) OR list rows (HAS_O_I flag; list elems never match plain refs, aligned duplicate lists pair per-row — not expressible in an (s,o_type,o_key) key). Metadata-first: o_type_const point check, key-range bound for mixed leaflets, exact o_type-column decode ONLY when the range straddles 0x800B. Overlay lane: CursorSoIter declines row-level on live o_i (novelty lists). Pinned in it_fastpath_1652_regression.rs incl. must-fire on clean data." ;
     mem:tag "composite-join" ;

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -223,6 +223,11 @@ path = "tests/it_count_datatype_pin.rs"
 name = "it_fastpath_1652_regression"
 path = "tests/it_fastpath_1652_regression.rs"
 
+# Own binary: toggles the process-global fast-path kill switch.
+[[test]]
+name = "it_datetime_component_presence"
+path = "tests/it_datetime_component_presence.rs"
+
 # Own binary: asserts fast-path routing via process-scoped tracing capture.
 [[test]]
 name = "it_exists_semijoin_correlation"

--- a/fluree-db-api/tests/it_datetime_component_presence.rs
+++ b/fluree-db-api/tests/it_datetime_component_presence.rs
@@ -1,0 +1,299 @@
+//! A calendar field a value does not carry must answer unbound, not filler.
+//!
+//! `xsd:gYear` has a year and nothing else, so `DAY("2005"^^xsd:gYear)` has no
+//! answer in the data. The engine used to promote every temporal value to a
+//! whole instant and read the field off the promoted result, so absent fields
+//! came back as the promotion's filler — day 1, month 1, and (from the Unix
+//! epoch) year 1970 — indistinguishable in the answer from a real value.
+//!
+//! The filler is close to harmless on a predicate that is entirely year-only
+//! (the shape reported as a side observation on #1652: a nonsense query getting
+//! a nonsense number). It is not harmless on a predicate mixing `xsd:date` with
+//! `xsd:gYear`, which is ordinary in bibliographic data where some records are
+//! dated and some are year-only. There the year-only rows contributed a
+//! fabricated day 1 each, so `AVG(DAY(?o))` was dragged toward 1,
+//! `COUNT(DAY(?o))` counted rows that have no day, and — worst — a
+//! `FILTER(DAY(?o) < 15)` selected exactly the rows with no day at all and
+//! excluded every row that had one.
+//!
+//! `xsd:date` keeps its time-of-day fields at the midnight the XSD timeline
+//! maps it to: that one is a documented convention rather than invented data,
+//! and it is pinned below so the narrowing cannot quietly widen.
+//!
+//! Every case also runs under the fast-path kill switch, because three separate
+//! lanes read these fields — the per-row evaluator, its no-chrono fast
+//! extractor, and the fused `SUM(DAY(?o))` scan that folds a homogeneous
+//! leaflet with no column IO. They previously each carried their own copy of
+//! the defaults; the point of the shared table in `fluree-db-core::temporal` is
+//! that they cannot drift, and fast-vs-generic agreement here is what proves it.
+//!
+//! Own test binary: toggles the process-global fast-path kill switch.
+
+#![cfg(feature = "native")]
+
+use fluree_db_api::admin::ReindexOptions;
+use fluree_db_api::{
+    set_fast_paths_disabled, CommitOpts, Fluree, FlureeBuilder, FormatterConfig, IndexConfig,
+    TxnOpts,
+};
+use serde_json::Value;
+
+const PREFIX: &str = "PREFIX ex: <http://example.org/ns/>\n\
+                      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n";
+
+const DATA: &str = r#"
+@prefix ex: <http://example.org/ns/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:a ex:gyear "2005"^^xsd:gYear .
+ex:b ex:gyearmonth "2005-07"^^xsd:gYearMonth .
+ex:c ex:gmonth "--03"^^xsd:gMonth .
+ex:d ex:gday "---17"^^xsd:gDay .
+ex:e ex:gmonthday "--03-17"^^xsd:gMonthDay .
+ex:f ex:date "2005-07-17"^^xsd:date .
+ex:g ex:datetime "2005-07-17T13:45:00Z"^^xsd:dateTime .
+ex:h ex:time "13:45:00"^^xsd:time .
+
+# Mixed predicate: three dated records, three year-only ones. The dated days
+# are 17, 20 and 30 — all >= 15, so a `DAY(?o) < 15` filter must select none.
+ex:m1 ex:pubdate "2005-07-17"^^xsd:date .
+ex:m2 ex:pubdate "2005-08-20"^^xsd:date .
+ex:m3 ex:pubdate "2005-09-30"^^xsd:date .
+ex:m4 ex:pubdate "2005"^^xsd:gYear .
+ex:m5 ex:pubdate "2006"^^xsd:gYear .
+ex:m6 ex:pubdate "2007"^^xsd:gYear .
+"#;
+
+struct Case {
+    name: &'static str,
+    sparql: &'static str,
+    /// Rows as `normalize` renders them. `null` is an unbound field.
+    expected: &'static str,
+}
+
+fn cases() -> Vec<Case> {
+    vec![
+        // ---- carried fields stay exactly as they were ----------------------
+        Case {
+            name: "YEAR(gYear) is carried",
+            sparql: "SELECT (YEAR(?o) AS ?v) WHERE { ?s ex:gyear ?o }",
+            expected: "[[2005]]",
+        },
+        Case {
+            name: "YEAR+MONTH(gYearMonth) are carried",
+            sparql: "SELECT (YEAR(?o) AS ?y) (MONTH(?o) AS ?m) WHERE { ?s ex:gyearmonth ?o }",
+            expected: "[[2005,7]]",
+        },
+        Case {
+            name: "MONTH(gMonth) is carried",
+            sparql: "SELECT (MONTH(?o) AS ?v) WHERE { ?s ex:gmonth ?o }",
+            expected: "[[3]]",
+        },
+        Case {
+            name: "DAY(gDay) is carried",
+            sparql: "SELECT (DAY(?o) AS ?v) WHERE { ?s ex:gday ?o }",
+            expected: "[[17]]",
+        },
+        Case {
+            name: "MONTH+DAY(gMonthDay) are carried",
+            sparql: "SELECT (MONTH(?o) AS ?m) (DAY(?o) AS ?d) WHERE { ?s ex:gmonthday ?o }",
+            expected: "[[3,17]]",
+        },
+        Case {
+            name: "YEAR+MONTH+DAY(date) are carried",
+            sparql: "SELECT (YEAR(?o) AS ?y) (MONTH(?o) AS ?m) (DAY(?o) AS ?d) WHERE { ?s ex:date ?o }",
+            expected: "[[2005,7,17]]",
+        },
+        Case {
+            name: "all fields of dateTime are carried",
+            sparql: "SELECT (YEAR(?o) AS ?y) (DAY(?o) AS ?d) (HOURS(?o) AS ?h) (MINUTES(?o) AS ?mi) WHERE { ?s ex:datetime ?o }",
+            expected: "[[2005,17,13,45]]",
+        },
+        Case {
+            name: "HOURS+MINUTES(time) are carried",
+            sparql: "SELECT (HOURS(?o) AS ?h) (MINUTES(?o) AS ?m) WHERE { ?s ex:time ?o }",
+            expected: "[[13,45]]",
+        },
+        // xsd:date -> midnight is a kept convention, pinned so it can't widen.
+        Case {
+            name: "HOURS(date) keeps the midnight convention",
+            sparql: "SELECT (HOURS(?o) AS ?h) (MINUTES(?o) AS ?m) WHERE { ?s ex:date ?o }",
+            expected: "[[0,0]]",
+        },
+        // ---- absent fields are unbound, not filler -------------------------
+        Case {
+            name: "MONTH/DAY(gYear) are absent",
+            sparql: "SELECT (MONTH(?o) AS ?m) (DAY(?o) AS ?d) WHERE { ?s ex:gyear ?o }",
+            expected: "[[null,null]]",
+        },
+        Case {
+            name: "DAY(gYearMonth) is absent",
+            sparql: "SELECT (DAY(?o) AS ?d) WHERE { ?s ex:gyearmonth ?o }",
+            expected: "[[null]]",
+        },
+        // The epoch's 1970 was the most clearly invented of the fillers.
+        Case {
+            name: "YEAR(gMonth) is absent, not 1970",
+            sparql: "SELECT (YEAR(?o) AS ?y) (DAY(?o) AS ?d) WHERE { ?s ex:gmonth ?o }",
+            expected: "[[null,null]]",
+        },
+        Case {
+            name: "YEAR(gDay) is absent, not 1970",
+            sparql: "SELECT (YEAR(?o) AS ?y) (MONTH(?o) AS ?m) WHERE { ?s ex:gday ?o }",
+            expected: "[[null,null]]",
+        },
+        Case {
+            name: "YEAR(gMonthDay) is absent, not 1970",
+            sparql: "SELECT (YEAR(?o) AS ?y) WHERE { ?s ex:gmonthday ?o }",
+            expected: "[[null]]",
+        },
+        Case {
+            name: "date fields of time are absent, not 1970",
+            sparql: "SELECT (YEAR(?o) AS ?y) (MONTH(?o) AS ?m) (DAY(?o) AS ?d) WHERE { ?s ex:time ?o }",
+            expected: "[[null,null,null]]",
+        },
+        // ---- the mixed predicate: what the filler actually cost ------------
+        // Days present: 17, 20, 30. The three year-only rows have none.
+        Case {
+            name: "MIXED AVG(DAY) ignores rows with no day",
+            sparql: "SELECT (AVG(DAY(?o)) AS ?v) WHERE { ?s ex:pubdate ?o }",
+            expected: "[[\"22.33333333333333333333333333333333\"]]",
+        },
+        Case {
+            name: "MIXED SUM(DAY) ignores rows with no day",
+            sparql: "SELECT (SUM(DAY(?o)) AS ?v) WHERE { ?s ex:pubdate ?o }",
+            expected: "[[67]]",
+        },
+        Case {
+            name: "MIXED COUNT(DAY) counts only rows that have one",
+            sparql: "SELECT (COUNT(DAY(?o)) AS ?v) WHERE { ?s ex:pubdate ?o }",
+            expected: "[[3]]",
+        },
+        // The sharpest case: every dated row has a day >= 15, so the honest
+        // answer is zero. The filler used to make this select all three
+        // year-only rows — exactly the rows that cannot satisfy it.
+        Case {
+            name: "MIXED FILTER(DAY < 15) selects no fabricated rows",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?s ex:pubdate ?o FILTER(DAY(?o) < 15) }",
+            expected: "[[0]]",
+        },
+        Case {
+            name: "MIXED YEAR is carried by both datatypes",
+            sparql: "SELECT (SUM(YEAR(?o)) AS ?v) WHERE { ?s ex:pubdate ?o }",
+            expected: "[[12033]]",
+        },
+        // ---- the fused SUM lane, which folds a homogeneous leaflet ---------
+        // Every row is absent, so the fold contributes nothing and SPARQL's
+        // empty-sum identity stands.
+        Case {
+            name: "fused SUM(DAY) over a year-only predicate sums nothing",
+            sparql: "SELECT (SUM(DAY(?o)) AS ?v) WHERE { ?s ex:gyear ?o }",
+            expected: "[[0]]",
+        },
+        Case {
+            name: "fused SUM(YEAR) over a year-only predicate is carried",
+            sparql: "SELECT (SUM(YEAR(?o)) AS ?v) WHERE { ?s ex:gyear ?o }",
+            expected: "[[2005]]",
+        },
+        Case {
+            name: "fused SUM(YEAR) over a month-only predicate sums nothing",
+            sparql: "SELECT (SUM(YEAR(?o)) AS ?v) WHERE { ?s ex:gmonth ?o }",
+            expected: "[[0]]",
+        },
+    ]
+}
+
+async fn setup() -> (tempfile::TempDir, Fluree, String) {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let path = dir.path().to_string_lossy().to_string();
+    let fluree = FlureeBuilder::file(path).build().expect("build Fluree");
+    let alias = "dtpresence:main".to_string();
+    let ledger = fluree.create_ledger(&alias).await.expect("create_ledger");
+    let index_config = IndexConfig {
+        reindex_min_bytes: 5_000_000_000,
+        reindex_max_bytes: 5_000_000_000,
+    };
+    let _ = fluree
+        .insert_turtle_with_opts(
+            ledger,
+            DATA,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config,
+            None,
+        )
+        .await
+        .expect("insert");
+    // Indexed: the fused SUM lane and the encoded-literal extractor only run
+    // against a persisted binary index.
+    fluree
+        .reindex(&alias, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    (dir, fluree, alias)
+}
+
+async fn run_query(fluree: &Fluree, alias: &str, sparql: &str) -> Value {
+    let full = format!("{PREFIX}{sparql}");
+    let snapshot = fluree.graph(alias).load().await.expect("load");
+    snapshot
+        .query()
+        .sparql(&full)
+        .format(FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .unwrap_or_else(|e| panic!("query {sparql}: {e}"))
+}
+
+fn normalize(rows: &Value) -> String {
+    serde_json::to_string(rows).expect("serialize rows")
+}
+
+/// RAII restore of the process-global kill switch, including on panic.
+struct FastPathGuard;
+impl Drop for FastPathGuard {
+    fn drop(&mut self) {
+        set_fast_paths_disabled(false);
+    }
+}
+
+#[tokio::test]
+async fn absent_calendar_fields_answer_unbound_on_every_lane() {
+    assert!(
+        std::env::var_os("FLUREE_DISABLE_QUERY_FAST_PATHS").is_none(),
+        "FLUREE_DISABLE_QUERY_FAST_PATHS is set — the fast-path phase of this \
+         test would run generically and pin nothing. Unset it."
+    );
+    let _guard = FastPathGuard;
+    let (_dir, fluree, alias) = setup().await;
+
+    let mut failures: Vec<String> = Vec::new();
+    for case in cases() {
+        set_fast_paths_disabled(false);
+        let fast = normalize(&run_query(&fluree, &alias, case.sparql).await);
+        set_fast_paths_disabled(true);
+        let generic = normalize(&run_query(&fluree, &alias, case.sparql).await);
+        set_fast_paths_disabled(false);
+
+        if fast != case.expected {
+            failures.push(format!(
+                "{}: fast lane returned {fast}, expected {}",
+                case.name, case.expected
+            ));
+        }
+        if generic != case.expected {
+            failures.push(format!(
+                "{}: generic pipeline returned {generic}, expected {} — the \
+                 hand-computed answer is wrong or the general pipeline regressed",
+                case.name, case.expected
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "calendar-field presence found {} failure(s):\n\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}

--- a/fluree-db-api/tests/it_datetime_component_presence.rs
+++ b/fluree-db-api/tests/it_datetime_component_presence.rs
@@ -38,6 +38,8 @@ use fluree_db_api::{
 };
 use serde_json::Value;
 
+mod support;
+
 const PREFIX: &str = "PREFIX ex: <http://example.org/ns/>\n\
                       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n";
 
@@ -64,93 +66,121 @@ ex:m5 ex:pubdate "2006"^^xsd:gYear .
 ex:m6 ex:pubdate "2007"^^xsd:gYear .
 "#;
 
+/// Routing assertion against the engine's `fast-path outcome` stamps.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Routing {
+    /// No routing claim — the case is about the answer, not the lane.
+    Any,
+    /// This site must `proceed`. Pins that the fused lane still serves the
+    /// shape: its fallback computes the same number, so a silent disable is
+    /// invisible to the value assertions alone.
+    MustFire(&'static str),
+}
+
 struct Case {
     name: &'static str,
     sparql: &'static str,
     /// Rows as `normalize` renders them. `null` is an unbound field.
     expected: &'static str,
+    routing: Routing,
 }
 
 fn cases() -> Vec<Case> {
+    use Routing::{Any, MustFire};
     vec![
         // ---- carried fields stay exactly as they were ----------------------
         Case {
             name: "YEAR(gYear) is carried",
             sparql: "SELECT (YEAR(?o) AS ?v) WHERE { ?s ex:gyear ?o }",
             expected: "[[2005]]",
+            routing: Any,
         },
         Case {
             name: "YEAR+MONTH(gYearMonth) are carried",
             sparql: "SELECT (YEAR(?o) AS ?y) (MONTH(?o) AS ?m) WHERE { ?s ex:gyearmonth ?o }",
             expected: "[[2005,7]]",
+            routing: Any,
         },
         Case {
             name: "MONTH(gMonth) is carried",
             sparql: "SELECT (MONTH(?o) AS ?v) WHERE { ?s ex:gmonth ?o }",
             expected: "[[3]]",
+            routing: Any,
         },
         Case {
             name: "DAY(gDay) is carried",
             sparql: "SELECT (DAY(?o) AS ?v) WHERE { ?s ex:gday ?o }",
             expected: "[[17]]",
+            routing: Any,
         },
         Case {
             name: "MONTH+DAY(gMonthDay) are carried",
             sparql: "SELECT (MONTH(?o) AS ?m) (DAY(?o) AS ?d) WHERE { ?s ex:gmonthday ?o }",
             expected: "[[3,17]]",
+            routing: Any,
         },
         Case {
             name: "YEAR+MONTH+DAY(date) are carried",
             sparql: "SELECT (YEAR(?o) AS ?y) (MONTH(?o) AS ?m) (DAY(?o) AS ?d) WHERE { ?s ex:date ?o }",
             expected: "[[2005,7,17]]",
+            routing: Any,
         },
         Case {
             name: "all fields of dateTime are carried",
             sparql: "SELECT (YEAR(?o) AS ?y) (DAY(?o) AS ?d) (HOURS(?o) AS ?h) (MINUTES(?o) AS ?mi) WHERE { ?s ex:datetime ?o }",
             expected: "[[2005,17,13,45]]",
+            routing: Any,
         },
         Case {
             name: "HOURS+MINUTES(time) are carried",
             sparql: "SELECT (HOURS(?o) AS ?h) (MINUTES(?o) AS ?m) WHERE { ?s ex:time ?o }",
             expected: "[[13,45]]",
+            routing: Any,
         },
         // xsd:date -> midnight is a kept convention, pinned so it can't widen.
         Case {
             name: "HOURS(date) keeps the midnight convention",
             sparql: "SELECT (HOURS(?o) AS ?h) (MINUTES(?o) AS ?m) WHERE { ?s ex:date ?o }",
             expected: "[[0,0]]",
+            routing: Any,
         },
         // ---- absent fields are unbound, not filler -------------------------
         Case {
             name: "MONTH/DAY(gYear) are absent",
             sparql: "SELECT (MONTH(?o) AS ?m) (DAY(?o) AS ?d) WHERE { ?s ex:gyear ?o }",
             expected: "[[null,null]]",
+            routing: Any,
         },
         Case {
             name: "DAY(gYearMonth) is absent",
             sparql: "SELECT (DAY(?o) AS ?d) WHERE { ?s ex:gyearmonth ?o }",
             expected: "[[null]]",
+            routing: Any,
         },
         // The epoch's 1970 was the most clearly invented of the fillers.
         Case {
             name: "YEAR(gMonth) is absent, not 1970",
             sparql: "SELECT (YEAR(?o) AS ?y) (DAY(?o) AS ?d) WHERE { ?s ex:gmonth ?o }",
             expected: "[[null,null]]",
+            routing: Any,
         },
         Case {
             name: "YEAR(gDay) is absent, not 1970",
             sparql: "SELECT (YEAR(?o) AS ?y) (MONTH(?o) AS ?m) WHERE { ?s ex:gday ?o }",
             expected: "[[null,null]]",
+            routing: Any,
         },
         Case {
             name: "YEAR(gMonthDay) is absent, not 1970",
             sparql: "SELECT (YEAR(?o) AS ?y) WHERE { ?s ex:gmonthday ?o }",
             expected: "[[null]]",
+            routing: Any,
         },
         Case {
             name: "date fields of time are absent, not 1970",
             sparql: "SELECT (YEAR(?o) AS ?y) (MONTH(?o) AS ?m) (DAY(?o) AS ?d) WHERE { ?s ex:time ?o }",
             expected: "[[null,null,null]]",
+            routing: Any,
         },
         // ---- the mixed predicate: what the filler actually cost ------------
         // Days present: 17, 20, 30. The three year-only rows have none.
@@ -158,16 +188,19 @@ fn cases() -> Vec<Case> {
             name: "MIXED AVG(DAY) ignores rows with no day",
             sparql: "SELECT (AVG(DAY(?o)) AS ?v) WHERE { ?s ex:pubdate ?o }",
             expected: "[[\"22.33333333333333333333333333333333\"]]",
+            routing: Any,
         },
         Case {
             name: "MIXED SUM(DAY) ignores rows with no day",
             sparql: "SELECT (SUM(DAY(?o)) AS ?v) WHERE { ?s ex:pubdate ?o }",
             expected: "[[67]]",
+            routing: Any,
         },
         Case {
             name: "MIXED COUNT(DAY) counts only rows that have one",
             sparql: "SELECT (COUNT(DAY(?o)) AS ?v) WHERE { ?s ex:pubdate ?o }",
             expected: "[[3]]",
+            routing: Any,
         },
         // The sharpest case: every dated row has a day >= 15, so the honest
         // answer is zero. The filler used to make this select all three
@@ -176,11 +209,50 @@ fn cases() -> Vec<Case> {
             name: "MIXED FILTER(DAY < 15) selects no fabricated rows",
             sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?s ex:pubdate ?o FILTER(DAY(?o) < 15) }",
             expected: "[[0]]",
+            routing: Any,
         },
         Case {
             name: "MIXED YEAR is carried by both datatypes",
             sparql: "SELECT (SUM(YEAR(?o)) AS ?v) WHERE { ?s ex:pubdate ?o }",
             expected: "[[12033]]",
+            routing: Any,
+        },
+        // ---- SECONDS: its own evaluator, its own copy of the gate ---------
+        // `eval_seconds` returns xsd:decimal and so does not route through
+        // `eval_datetime_component`; it repeats the presence check itself.
+        // Without these, an inverted condition there passes every pin above.
+        // The decimal return is why a carried value renders as a JSON string.
+        Case {
+            name: "SECONDS(time) is carried",
+            sparql: "SELECT (SECONDS(?o) AS ?v) WHERE { ?s ex:time ?o }",
+            expected: "[[\"0\"]]",
+            routing: Any,
+        },
+        Case {
+            name: "SECONDS(dateTime) is carried",
+            sparql: "SELECT (SECONDS(?o) AS ?v) WHERE { ?s ex:datetime ?o }",
+            expected: "[[\"0\"]]",
+            routing: Any,
+        },
+        Case {
+            name: "SECONDS(gYear) is absent, not zero",
+            sparql: "SELECT (SECONDS(?o) AS ?v) WHERE { ?s ex:gyear ?o }",
+            expected: "[[null]]",
+            routing: Any,
+        },
+        Case {
+            name: "SECONDS(gMonth) is absent, not zero",
+            sparql: "SELECT (SECONDS(?o) AS ?v) WHERE { ?s ex:gmonth ?o }",
+            expected: "[[null]]",
+            routing: Any,
+        },
+        // The midnight convention for the field the cases above don't cover:
+        // a date carries seconds only in the sense that its instant does.
+        Case {
+            name: "SECONDS(date) keeps the midnight convention",
+            sparql: "SELECT (SECONDS(?o) AS ?v) WHERE { ?s ex:date ?o }",
+            expected: "[[\"0\"]]",
+            routing: Any,
         },
         // ---- the fused SUM lane, which folds a homogeneous leaflet ---------
         // Every row is absent, so the fold contributes nothing and SPARQL's
@@ -189,16 +261,19 @@ fn cases() -> Vec<Case> {
             name: "fused SUM(DAY) over a year-only predicate sums nothing",
             sparql: "SELECT (SUM(DAY(?o)) AS ?v) WHERE { ?s ex:gyear ?o }",
             expected: "[[0]]",
+            routing: MustFire("SUM(DAY)"),
         },
         Case {
             name: "fused SUM(YEAR) over a year-only predicate is carried",
             sparql: "SELECT (SUM(YEAR(?o)) AS ?v) WHERE { ?s ex:gyear ?o }",
             expected: "[[2005]]",
+            routing: MustFire("SUM(YEAR)"),
         },
         Case {
             name: "fused SUM(YEAR) over a month-only predicate sums nothing",
             sparql: "SELECT (SUM(YEAR(?o)) AS ?v) WHERE { ?s ex:gmonth ?o }",
             expected: "[[0]]",
+            routing: MustFire("SUM(YEAR)"),
         },
     ]
 }
@@ -257,7 +332,7 @@ impl Drop for FastPathGuard {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn absent_calendar_fields_answer_unbound_on_every_lane() {
     assert!(
         std::env::var_os("FLUREE_DISABLE_QUERY_FAST_PATHS").is_none(),
@@ -267,10 +342,22 @@ async fn absent_calendar_fields_answer_unbound_on_every_lane() {
     let _guard = FastPathGuard;
     let (_dir, fluree, alias) = setup().await;
 
+    // Span capture attributes each fast-lane answer to the site that served
+    // it. `FastPathOperator::open` stamps `fast-path outcome` under the
+    // operator's label, so the fused scalar-agg lane is observable without any
+    // instrumentation of its own.
+    let (store, tracing_guard) = support::span_capture::init_test_tracing();
+
     let mut failures: Vec<String> = Vec::new();
     for case in cases() {
         set_fast_paths_disabled(false);
+        let before = store.find_events("fast-path outcome").len();
         let fast = normalize(&run_query(&fluree, &alias, case.sparql).await);
+        let proceeded: Vec<String> = store.find_events("fast-path outcome")[before..]
+            .iter()
+            .filter(|e| e.fields.get("outcome").map(String::as_str) == Some("proceed"))
+            .filter_map(|e| e.fields.get("site").cloned())
+            .collect();
         set_fast_paths_disabled(true);
         let generic = normalize(&run_query(&fluree, &alias, case.sparql).await);
         set_fast_paths_disabled(false);
@@ -288,7 +375,18 @@ async fn absent_calendar_fields_answer_unbound_on_every_lane() {
                 case.name, case.expected
             ));
         }
+        if let Routing::MustFire(site) = case.routing {
+            if !proceeded.iter().any(|s| s == site) {
+                failures.push(format!(
+                    "{}: site `{site}` did not proceed — the fused lane stopped \
+                     serving this shape and the fallback answered instead \
+                     [proceeded: {proceeded:?}]",
+                    case.name
+                ));
+            }
+        }
     }
+    drop(tracing_guard);
 
     assert!(
         failures.is_empty(),

--- a/fluree-db-core/src/temporal.rs
+++ b/fluree-db-core/src/temporal.rs
@@ -2263,6 +2263,264 @@ fn compose_components(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Which calendar fields a temporal datatype actually carries
+// ---------------------------------------------------------------------------
+
+/// A calendar field of a temporal value, as the SPARQL accessor functions
+/// (`YEAR`, `MONTH`, `DAY`, `HOURS`, `MINUTES`, `SECONDS`) name them.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum CalendarField {
+    Year,
+    Month,
+    Day,
+    Hour,
+    Minute,
+    Second,
+}
+
+impl CalendarField {
+    /// Filler for a field absent from a value being promoted to a whole
+    /// instant. Year takes the Unix epoch's 1970 and the calendar fields their
+    /// first valid value, matching the XSD timeline mapping the promotion has
+    /// always used.
+    ///
+    /// For whole-value uses only — comparison, ordering, `TZ`/`TIMEZONE`.
+    /// Reading a field OFF a promoted instant must consult
+    /// [`TemporalKind::carries`] first and yield unbound rather than reporting
+    /// one of these as if it came from the data.
+    pub const fn promotion_default(self) -> i64 {
+        match self {
+            Self::Year => 1970,
+            Self::Month | Self::Day => 1,
+            Self::Hour | Self::Minute | Self::Second => 0,
+        }
+    }
+}
+
+/// An XSD temporal datatype, identified from any of the engine's three value
+/// representations: a [`FlakeValue`](crate::value::FlakeValue), an index
+/// [`OType`](crate::o_type::OType), or an encoded
+/// [`ObjKind`](crate::value_id::ObjKind).
+///
+/// Exists for [`Self::carries`] — the single answer to "does this value have
+/// that field at all", which three separate fast/slow paths in
+/// `fluree-db-query` previously each answered with their own hand-rolled
+/// defaults table.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TemporalKind {
+    DateTime,
+    Date,
+    Time,
+    GYear,
+    GYearMonth,
+    GMonth,
+    GDay,
+    GMonthDay,
+}
+
+impl TemporalKind {
+    /// Whether a value of this datatype carries `field` in its lexical form.
+    ///
+    /// `xsd:gYear` has a year and nothing else; `xsd:gMonth` has a month and
+    /// nothing else. Asking for a field the value does not carry —
+    /// `DAY("2005"^^xsd:gYear)`, `YEAR("--03"^^xsd:gMonth)` — has no answer in
+    /// the data, and the caller must yield unbound rather than report the
+    /// promotion's filler (day 1, month 1, or the epoch's year 1970) as though
+    /// it came from the value. That filler is invisible in an answer: on a
+    /// predicate mixing `xsd:date` with `xsd:gYear`, ordinary in bibliographic
+    /// data, it dragged `AVG(DAY(?o))` toward 1 and made `FILTER(DAY(?o) < 15)`
+    /// select precisely the rows with no day at all.
+    ///
+    /// `xsd:date` is treated as carrying the time-of-day fields, at the
+    /// midnight the XSD timeline maps it to. That one is a documented
+    /// convention rather than invented data — a date does begin at midnight,
+    /// and `YEAR`/`MONTH`/`DAY` of a date, the overwhelmingly common uses, are
+    /// genuine either way — so it stays.
+    pub const fn carries(self, field: CalendarField) -> bool {
+        use CalendarField::{Day, Hour, Minute, Month, Second, Year};
+        match self {
+            Self::DateTime | Self::Date => true,
+            Self::Time => matches!(field, Hour | Minute | Second),
+            Self::GYear => matches!(field, Year),
+            Self::GYearMonth => matches!(field, Year | Month),
+            Self::GMonth => matches!(field, Month),
+            Self::GDay => matches!(field, Day),
+            Self::GMonthDay => matches!(field, Month | Day),
+        }
+    }
+
+    /// Identify the datatype of a [`FlakeValue`](crate::value::FlakeValue).
+    ///
+    /// `FlakeValue::Long` carries no datatype of its own; a caller holding one
+    /// under an `xsd:gYear` binding (the numeric gYear encoding) passes
+    /// [`Self::GYear`] itself after checking that datatype.
+    pub fn from_flake_value(val: &crate::value::FlakeValue) -> Option<Self> {
+        use crate::value::FlakeValue;
+        Some(match val {
+            FlakeValue::DateTime(_) => Self::DateTime,
+            FlakeValue::Date(_) => Self::Date,
+            FlakeValue::Time(_) => Self::Time,
+            FlakeValue::GYear(_) => Self::GYear,
+            FlakeValue::GYearMonth(_) => Self::GYearMonth,
+            FlakeValue::GMonth(_) => Self::GMonth,
+            FlakeValue::GDay(_) => Self::GDay,
+            FlakeValue::GMonthDay(_) => Self::GMonthDay,
+            _ => return None,
+        })
+    }
+
+    /// Identify the datatype of an index [`OType`](crate::o_type::OType).
+    pub fn from_o_type(o_type: crate::o_type::OType) -> Option<Self> {
+        use crate::o_type::OType;
+        Some(match o_type {
+            OType::XSD_DATE_TIME => Self::DateTime,
+            OType::XSD_DATE => Self::Date,
+            OType::XSD_TIME => Self::Time,
+            OType::XSD_G_YEAR => Self::GYear,
+            OType::XSD_G_YEAR_MONTH => Self::GYearMonth,
+            OType::XSD_G_MONTH => Self::GMonth,
+            OType::XSD_G_DAY => Self::GDay,
+            OType::XSD_G_MONTH_DAY => Self::GMonthDay,
+            _ => return None,
+        })
+    }
+
+    /// Identify the datatype of an encoded literal's
+    /// [`ObjKind`](crate::value_id::ObjKind).
+    pub fn from_obj_kind(kind: crate::value_id::ObjKind) -> Option<Self> {
+        use crate::value_id::ObjKind;
+        Some(match kind {
+            ObjKind::DATE_TIME => Self::DateTime,
+            ObjKind::DATE => Self::Date,
+            ObjKind::TIME => Self::Time,
+            ObjKind::G_YEAR => Self::GYear,
+            ObjKind::G_YEAR_MONTH => Self::GYearMonth,
+            ObjKind::G_MONTH => Self::GMonth,
+            ObjKind::G_DAY => Self::GDay,
+            ObjKind::G_MONTH_DAY => Self::GMonthDay,
+            _ => return None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod calendar_field_tests {
+    use super::CalendarField::{Day, Hour, Minute, Month, Second, Year};
+    use super::*;
+    use crate::o_type::OType;
+    use crate::value_id::ObjKind;
+
+    /// The fields each datatype genuinely carries, spelled out independently of
+    /// `carries`'s own match arms so a typo there cannot pass by agreeing with
+    /// itself.
+    const CARRIED: &[(TemporalKind, &[CalendarField])] = &[
+        (
+            TemporalKind::DateTime,
+            &[Year, Month, Day, Hour, Minute, Second],
+        ),
+        // xsd:date carries the time fields by the midnight convention.
+        (
+            TemporalKind::Date,
+            &[Year, Month, Day, Hour, Minute, Second],
+        ),
+        (TemporalKind::Time, &[Hour, Minute, Second]),
+        (TemporalKind::GYear, &[Year]),
+        (TemporalKind::GYearMonth, &[Year, Month]),
+        (TemporalKind::GMonth, &[Month]),
+        (TemporalKind::GDay, &[Day]),
+        (TemporalKind::GMonthDay, &[Month, Day]),
+    ];
+
+    #[test]
+    fn carries_matches_the_declared_table() {
+        const ALL: &[CalendarField] = &[Year, Month, Day, Hour, Minute, Second];
+        for (kind, carried) in CARRIED {
+            for field in ALL {
+                assert_eq!(
+                    kind.carries(*field),
+                    carried.contains(field),
+                    "{kind:?}.carries({field:?})"
+                );
+            }
+        }
+    }
+
+    /// The fabrications this table exists to stop: a year-only value has no
+    /// month or day, and a month/day-only value has no year to report.
+    #[test]
+    fn absent_fields_are_not_carried() {
+        assert!(!TemporalKind::GYear.carries(Month));
+        assert!(!TemporalKind::GYear.carries(Day));
+        assert!(!TemporalKind::GYearMonth.carries(Day));
+        assert!(!TemporalKind::GMonth.carries(Year));
+        assert!(!TemporalKind::GDay.carries(Year));
+        assert!(!TemporalKind::GMonthDay.carries(Year));
+        assert!(!TemporalKind::Time.carries(Year));
+    }
+
+    /// The two index representations must classify the same datatype the same
+    /// way, or the fast and generic lanes disagree about what is carried.
+    #[test]
+    fn o_type_and_obj_kind_classify_alike() {
+        for (o_type, obj_kind) in [
+            (OType::XSD_DATE_TIME, ObjKind::DATE_TIME),
+            (OType::XSD_DATE, ObjKind::DATE),
+            (OType::XSD_TIME, ObjKind::TIME),
+            (OType::XSD_G_YEAR, ObjKind::G_YEAR),
+            (OType::XSD_G_YEAR_MONTH, ObjKind::G_YEAR_MONTH),
+            (OType::XSD_G_MONTH, ObjKind::G_MONTH),
+            (OType::XSD_G_DAY, ObjKind::G_DAY),
+            (OType::XSD_G_MONTH_DAY, ObjKind::G_MONTH_DAY),
+        ] {
+            let from_o_type = TemporalKind::from_o_type(o_type);
+            assert!(from_o_type.is_some(), "{o_type:?} unclassified");
+            assert_eq!(
+                from_o_type,
+                TemporalKind::from_obj_kind(obj_kind),
+                "{o_type:?} vs {obj_kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_temporal_types_are_unclassified() {
+        assert_eq!(TemporalKind::from_o_type(OType::XSD_STRING), None);
+        assert_eq!(TemporalKind::from_obj_kind(ObjKind::NUM_BIG), None);
+    }
+
+    #[test]
+    fn flake_values_classify_by_variant() {
+        let gy = GYear::parse("2005").expect("parse gYear");
+        assert_eq!(
+            TemporalKind::from_flake_value(&crate::value::FlakeValue::GYear(Box::new(gy))),
+            Some(TemporalKind::GYear)
+        );
+        assert_eq!(
+            TemporalKind::from_flake_value(&crate::value::FlakeValue::String("x".into())),
+            None
+        );
+        // A bare Long is the numeric gYear encoding; its datatype, not its
+        // value, settles the kind, so this helper declines it.
+        assert_eq!(
+            TemporalKind::from_flake_value(&crate::value::FlakeValue::Long(2005)),
+            None
+        );
+    }
+
+    /// The promotion filler, which is exactly what `carries` keeps out of an
+    /// answer. 1970 is the epoch's year and has no relation to any value.
+    #[test]
+    fn promotion_defaults_are_the_epoch_origin() {
+        assert_eq!(Year.promotion_default(), 1970);
+        assert_eq!(Month.promotion_default(), 1);
+        assert_eq!(Day.promotion_default(), 1);
+        assert_eq!(Hour.promotion_default(), 0);
+        assert_eq!(Minute.promotion_default(), 0);
+        assert_eq!(Second.promotion_default(), 0);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/fluree-db-query/src/eval/datetime.rs
+++ b/fluree-db-query/src/eval/datetime.rs
@@ -8,22 +8,13 @@ use crate::error::{QueryError, Result};
 use crate::ir::Expression;
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Datelike, FixedOffset, SecondsFormat, Timelike, Utc};
-use fluree_db_core::temporal::DateTime as FlureeDateTime;
+use fluree_db_core::temporal::{CalendarField, DateTime as FlureeDateTime, TemporalKind};
 use fluree_db_core::value_id::{ObjKey, ObjKind};
 use std::sync::Arc;
 
 use super::helpers::{check_arity, parse_datetime_from_binding};
 use super::value::ComparableValue;
 use crate::parse::UnresolvedDatatypeConstraint;
-
-#[derive(Copy, Clone, Debug)]
-enum DateComponent {
-    Year,
-    Month,
-    Day,
-    Hour,
-    Minute,
-}
 
 pub fn eval_now(args: &[Expression]) -> Result<Option<ComparableValue>> {
     check_arity(args, 0, "NOW")?;
@@ -47,7 +38,7 @@ pub fn eval_year<R: RowAccess>(
     row: &R,
     ctx: Option<&ExecutionContext<'_>>,
 ) -> Result<Option<ComparableValue>> {
-    eval_datetime_component(args, row, ctx, "YEAR", DateComponent::Year, |dt| {
+    eval_datetime_component(args, row, ctx, "YEAR", CalendarField::Year, |dt| {
         dt.year() as i64
     })
 }
@@ -57,7 +48,7 @@ pub fn eval_month<R: RowAccess>(
     row: &R,
     ctx: Option<&ExecutionContext<'_>>,
 ) -> Result<Option<ComparableValue>> {
-    eval_datetime_component(args, row, ctx, "MONTH", DateComponent::Month, |dt| {
+    eval_datetime_component(args, row, ctx, "MONTH", CalendarField::Month, |dt| {
         dt.month() as i64
     })
 }
@@ -67,7 +58,7 @@ pub fn eval_day<R: RowAccess>(
     row: &R,
     ctx: Option<&ExecutionContext<'_>>,
 ) -> Result<Option<ComparableValue>> {
-    eval_datetime_component(args, row, ctx, "DAY", DateComponent::Day, |dt| {
+    eval_datetime_component(args, row, ctx, "DAY", CalendarField::Day, |dt| {
         dt.day() as i64
     })
 }
@@ -77,7 +68,7 @@ pub fn eval_hours<R: RowAccess>(
     row: &R,
     ctx: Option<&ExecutionContext<'_>>,
 ) -> Result<Option<ComparableValue>> {
-    eval_datetime_component(args, row, ctx, "HOURS", DateComponent::Hour, |dt| {
+    eval_datetime_component(args, row, ctx, "HOURS", CalendarField::Hour, |dt| {
         dt.hour() as i64
     })
 }
@@ -87,7 +78,7 @@ pub fn eval_minutes<R: RowAccess>(
     row: &R,
     ctx: Option<&ExecutionContext<'_>>,
 ) -> Result<Option<ComparableValue>> {
-    eval_datetime_component(args, row, ctx, "MINUTES", DateComponent::Minute, |dt| {
+    eval_datetime_component(args, row, ctx, "MINUTES", CalendarField::Minute, |dt| {
         dt.minute() as i64
     })
 }
@@ -101,20 +92,30 @@ pub fn eval_seconds<R: RowAccess>(
     check_arity(args, 1, "SECONDS")?;
     if let Expression::Var(var) = &args[0] {
         match row.get(*var) {
-            Some(binding) => match parse_datetime_from_binding(binding, ctx) {
-                Some(dt) => {
-                    let secs = dt.second() as i64;
-                    let nanos = dt.nanosecond() as i64;
-                    let decimal = if nanos == 0 {
-                        BigDecimal::from(secs)
-                    } else {
-                        let total_nanos = secs * 1_000_000_000 + nanos;
-                        BigDecimal::new(total_nanos.into(), 9)
-                    };
-                    Ok(Some(ComparableValue::Decimal(Box::new(decimal))))
+            Some(binding) => {
+                // A value that carries no seconds (a bare `xsd:gYear`, say) has
+                // no answer here; report unbound rather than the promotion's
+                // zero. See `eval_datetime_component`.
+                if let Some(kind) = temporal_kind_of_binding(binding) {
+                    if !kind.carries(CalendarField::Second) {
+                        return Ok(None);
+                    }
                 }
-                None => Ok(None),
-            },
+                match parse_datetime_from_binding(binding, ctx) {
+                    Some(dt) => {
+                        let secs = dt.second() as i64;
+                        let nanos = dt.nanosecond() as i64;
+                        let decimal = if nanos == 0 {
+                            BigDecimal::from(secs)
+                        } else {
+                            let total_nanos = secs * 1_000_000_000 + nanos;
+                            BigDecimal::new(total_nanos.into(), 9)
+                        };
+                        Ok(Some(ComparableValue::Decimal(Box::new(decimal))))
+                    }
+                    None => Ok(None),
+                }
+            }
             None => Ok(None),
         }
     } else {
@@ -247,7 +248,7 @@ fn eval_datetime_component<R: RowAccess, F>(
     row: &R,
     ctx: Option<&ExecutionContext<'_>>,
     fn_name: &str,
-    component: DateComponent,
+    component: CalendarField,
     extract: F,
 ) -> Result<Option<ComparableValue>>
 where
@@ -257,18 +258,28 @@ where
     if let Expression::Var(var) = &args[0] {
         match row.get(*var) {
             Some(binding) => {
-                if let Some(v) = fast_datetime_component_from_binding(binding, ctx, component) {
-                    return Ok(Some(ComparableValue::Long(v)));
+                if let Some(kind) = temporal_kind_of_binding(binding) {
+                    // The value's datatype is known. If its lexical form does
+                    // not carry this field there is no answer in the data, so
+                    // report unbound — never the filler the promotion below
+                    // would supply (day 1, month 1, or the epoch's 1970).
+                    // Returning here also keeps such a value away from the
+                    // epoch-millis fallback, which would re-fabricate it.
+                    if !kind.carries(component) {
+                        return Ok(None);
+                    }
+                    if let Some(v) = fast_datetime_component_from_binding(binding, ctx, component) {
+                        return Ok(Some(ComparableValue::Long(v)));
+                    }
+                    if let Some(dt) = parse_datetime_from_binding(binding, ctx) {
+                        return Ok(Some(ComparableValue::Long(extract(&dt))));
+                    }
+                    return Ok(None);
                 }
-                if let Some(dt) = parse_datetime_from_binding(binding, ctx) {
-                    return Ok(Some(ComparableValue::Long(extract(&dt))));
-                }
-                // Fallback: a plain integer is treated as Unix epoch
-                // milliseconds. LDBC-style datasets store dates/datetimes as
-                // epoch-ms longs rather than xsd:dateTime, so `<epochMs>.month`
-                // / `.day` must still resolve. Only reached when the value is
-                // NOT a recognized temporal type (handled above), so this does
-                // not change date/dateTime semantics.
+                // Not a recognized temporal type. A plain integer is treated as
+                // Unix epoch milliseconds: LDBC-style datasets store
+                // dates/datetimes as epoch-ms longs rather than xsd:dateTime, so
+                // `<epochMs>.month` / `.day` must still resolve.
                 if let Some(ms) = binding_epoch_millis(binding, ctx) {
                     if let Some(v) = epoch_millis_component(ms, component) {
                         return Ok(Some(ComparableValue::Long(v)));
@@ -317,63 +328,96 @@ fn binding_epoch_millis(
 }
 
 /// Component of a Unix epoch-millisecond instant, interpreted in UTC.
-fn epoch_millis_component(ms: i64, component: DateComponent) -> Option<i64> {
+fn epoch_millis_component(ms: i64, component: CalendarField) -> Option<i64> {
     let dt = DateTime::<Utc>::from_timestamp_millis(ms)?;
     Some(match component {
-        DateComponent::Year => i64::from(dt.year()),
-        DateComponent::Month => i64::from(dt.month()),
-        DateComponent::Day => i64::from(dt.day()),
-        DateComponent::Hour => i64::from(dt.hour()),
-        DateComponent::Minute => i64::from(dt.minute()),
+        CalendarField::Year => i64::from(dt.year()),
+        CalendarField::Month => i64::from(dt.month()),
+        CalendarField::Day => i64::from(dt.day()),
+        CalendarField::Hour => i64::from(dt.hour()),
+        CalendarField::Minute => i64::from(dt.minute()),
+        // SECONDS is fractional (xsd:decimal) and has its own evaluator.
+        CalendarField::Second => return None,
     })
 }
 
-/// Fast-path extraction for YEAR/MONTH/DAY/HOURS/MINUTES without constructing a chrono DateTime.
+/// The XSD temporal datatype of a binding, or `None` when the value is not a
+/// recognized temporal type (a string, a bare integer, an IRI).
+///
+/// The `FlakeValue::Long` arm is the numeric `xsd:gYear` encoding: the value
+/// alone is indistinguishable from any other integer, so the binding's declared
+/// datatype settles it.
+fn temporal_kind_of_binding(binding: &crate::binding::Binding) -> Option<TemporalKind> {
+    use crate::binding::Binding;
+    use fluree_db_core::FlakeValue;
+    match binding {
+        Binding::Lit { val, dtc, .. } => TemporalKind::from_flake_value(val).or_else(|| {
+            let dts = &*crate::eval::helpers::WELL_KNOWN_DATATYPES;
+            match val {
+                FlakeValue::Long(_) if *dtc.datatype() == dts.xsd_g_year => {
+                    Some(TemporalKind::GYear)
+                }
+                _ => None,
+            }
+        }),
+        Binding::EncodedLit { o_kind, .. } => {
+            TemporalKind::from_obj_kind(ObjKind::from_u8(*o_kind))
+        }
+        _ => None,
+    }
+}
+
+/// Fast-path extraction of a CARRIED calendar field, without constructing a
+/// chrono DateTime.
 ///
 /// This avoids the `parse_datetime_from_binding()` promotion path (gYear→dateTime, etc.) which
 /// is expensive when applied per-row to large scans (e.g. sparqloscope DBLP date-* benchmarks).
+///
+/// Callers must have already established that the value's datatype carries the
+/// field (`TemporalKind::carries`); this function never substitutes a default
+/// for one it does not.
 fn fast_datetime_component_from_binding(
     binding: &crate::binding::Binding,
     _ctx: Option<&ExecutionContext<'_>>,
-    component: DateComponent,
+    component: CalendarField,
 ) -> Option<i64> {
     use crate::binding::Binding;
     use fluree_db_core::FlakeValue;
 
-    // Calendar fragment defaults match `flake_value_to_datetime()` in helpers.rs:
-    // - gYear → Jan 1, 00:00:00
-    // - gYearMonth → day=1
-    // - gMonth/gDay/gMonthDay → year=1970, month/day defaults as appropriate
-    const DEFAULT_YEAR: i64 = 1970;
-    const DEFAULT_MONTH: i64 = 1;
-
-    let extract_from_parts =
-        |year: i64, month: i64, day: i64, hour: i64, minute: i64| match component {
-            DateComponent::Year => Some(year),
-            DateComponent::Month => Some(month),
-            DateComponent::Day => Some(day),
-            DateComponent::Hour => Some(hour),
-            DateComponent::Minute => Some(minute),
-        };
+    // Each arm supplies ONLY the fields its datatype carries. There are no
+    // defaults here on purpose: this used to fill the rest from 1970/1/1 and
+    // hand them back as answers, a third copy of the promotion's defaults
+    // table. `None` now means "not available from this representation", which
+    // sends the caller to the general path rather than inventing a value.
+    let pick = |year: Option<i64>, month: Option<i64>, day: Option<i64>| match component {
+        CalendarField::Year => year,
+        CalendarField::Month => month,
+        CalendarField::Day => day,
+        // A calendar fragment carries no time of day, and SECONDS has its own
+        // evaluator; the datatypes that do carry a time go the general path.
+        CalendarField::Hour | CalendarField::Minute | CalendarField::Second => None,
+    };
 
     match binding {
         Binding::Lit { val, dtc, .. } => match val {
-            FlakeValue::GYear(gy) => extract_from_parts(gy.year() as i64, 1, 1, 0, 0),
-            FlakeValue::GYearMonth(gym) => {
-                extract_from_parts(gym.year() as i64, gym.month() as i64, 1, 0, 0)
-            }
-            FlakeValue::GMonth(gm) => extract_from_parts(DEFAULT_YEAR, gm.month() as i64, 1, 0, 0),
-            FlakeValue::GDay(gd) => {
-                extract_from_parts(DEFAULT_YEAR, DEFAULT_MONTH, gd.day() as i64, 0, 0)
-            }
-            FlakeValue::GMonthDay(gmd) => {
-                extract_from_parts(DEFAULT_YEAR, gmd.month() as i64, gmd.day() as i64, 0, 0)
-            }
-            // Numeric gYear encoding fallback (see helpers.rs::flake_value_to_datetime()).
+            FlakeValue::GYear(gy) => pick(Some(i64::from(gy.year())), None, None),
+            FlakeValue::GYearMonth(gym) => pick(
+                Some(i64::from(gym.year())),
+                Some(i64::from(gym.month())),
+                None,
+            ),
+            FlakeValue::GMonth(gm) => pick(None, Some(i64::from(gm.month())), None),
+            FlakeValue::GDay(gd) => pick(None, None, Some(i64::from(gd.day()))),
+            FlakeValue::GMonthDay(gmd) => pick(
+                None,
+                Some(i64::from(gmd.month())),
+                Some(i64::from(gmd.day())),
+            ),
+            // Numeric gYear encoding: the datatype, not the value, settles it.
             FlakeValue::Long(year) => {
                 let dts = &*crate::eval::helpers::WELL_KNOWN_DATATYPES;
                 if *dtc.datatype() == dts.xsd_g_year {
-                    extract_from_parts(*year, 1, 1, 0, 0)
+                    pick(Some(*year), None, None)
                 } else {
                     None
                 }
@@ -386,21 +430,21 @@ fn fast_datetime_component_from_binding(
             let key = ObjKey::from_u64(*o_key);
             match kind.as_u8() {
                 x if x == ObjKind::G_YEAR.as_u8() => {
-                    extract_from_parts(key.decode_g_year() as i64, 1, 1, 0, 0)
+                    pick(Some(i64::from(key.decode_g_year())), None, None)
                 }
                 x if x == ObjKind::G_YEAR_MONTH.as_u8() => {
                     let (y, m) = key.decode_g_year_month();
-                    extract_from_parts(y as i64, m as i64, 1, 0, 0)
+                    pick(Some(i64::from(y)), Some(i64::from(m)), None)
                 }
                 x if x == ObjKind::G_MONTH.as_u8() => {
-                    extract_from_parts(DEFAULT_YEAR, key.decode_g_month() as i64, 1, 0, 0)
+                    pick(None, Some(i64::from(key.decode_g_month())), None)
                 }
                 x if x == ObjKind::G_DAY.as_u8() => {
-                    extract_from_parts(DEFAULT_YEAR, DEFAULT_MONTH, key.decode_g_day() as i64, 0, 0)
+                    pick(None, None, Some(i64::from(key.decode_g_day())))
                 }
                 x if x == ObjKind::G_MONTH_DAY.as_u8() => {
                     let (m, d) = key.decode_g_month_day();
-                    extract_from_parts(DEFAULT_YEAR, m as i64, d as i64, 0, 0)
+                    pick(None, Some(i64::from(m)), Some(i64::from(d)))
                 }
                 _ => None,
             }

--- a/fluree-db-query/src/eval/helpers.rs
+++ b/fluree-db-query/src/eval/helpers.rs
@@ -8,6 +8,7 @@ use crate::context::WellKnownDatatypes;
 use crate::error::{QueryError, Result};
 use crate::ir::{Expression, Function};
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, TimeZone};
+use fluree_db_core::temporal::CalendarField;
 use fluree_db_core::{FlakeValue, ObjKind};
 use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
@@ -681,6 +682,49 @@ pub fn parse_datetime_from_binding(
     }
 }
 
+/// Promote a calendar fragment (`xsd:gYear` and friends) to a whole instant,
+/// filling the fields it does not carry from [`CalendarField::promotion_default`].
+///
+/// The filler is for whole-value uses only — comparison, ordering,
+/// `TZ`/`TIMEZONE`. Reading a field back off the result is only valid once
+/// [`TemporalKind::carries`] says the value carries it; the SPARQL accessors
+/// check that first (see `eval::datetime`), because reporting a filled field as
+/// data is exactly what made `DAY("2005"^^xsd:gYear)` answer 1.
+/// The date a value carrying no date at all promotes to, from the shared
+/// defaults: the Unix epoch's 1970-01-01.
+fn promotion_default_date() -> Option<NaiveDate> {
+    NaiveDate::from_ymd_opt(
+        i32::try_from(CalendarField::Year.promotion_default()).ok()?,
+        u32::try_from(CalendarField::Month.promotion_default()).ok()?,
+        u32::try_from(CalendarField::Day.promotion_default()).ok()?,
+    )
+}
+
+fn promote_calendar_fragment(
+    tz_offset: Option<FixedOffset>,
+    year: Option<i32>,
+    month: Option<u32>,
+    day: Option<u32>,
+) -> Option<DateTime<FixedOffset>> {
+    let offset = tz_offset.unwrap_or(FixedOffset::east_opt(0)?);
+    let naive = NaiveDate::from_ymd_opt(
+        year.unwrap_or(i32::try_from(CalendarField::Year.promotion_default()).ok()?),
+        month.unwrap_or(u32::try_from(CalendarField::Month.promotion_default()).ok()?),
+        day.unwrap_or(u32::try_from(CalendarField::Day.promotion_default()).ok()?),
+    )?
+    .and_hms_opt(
+        u32::try_from(CalendarField::Hour.promotion_default()).ok()?,
+        u32::try_from(CalendarField::Minute.promotion_default()).ok()?,
+        u32::try_from(CalendarField::Second.promotion_default()).ok()?,
+    )?;
+    Some(
+        offset
+            .from_local_datetime(&naive)
+            .single()
+            .unwrap_or_else(|| offset.from_utc_datetime(&naive)),
+    )
+}
+
 /// Convert a FlakeValue to a DateTime, handling all XSD temporal types.
 ///
 /// The `dt_sid` parameter is used only for the `FlakeValue::Long` fallback
@@ -709,7 +753,8 @@ fn flake_value_to_datetime(
         }
         FlakeValue::Time(t) => {
             let offset = t.tz_offset().unwrap_or(utc);
-            let date = NaiveDate::from_ymd_opt(1970, 1, 1)?;
+            // A time carries no date; fill it from the shared defaults.
+            let date = promotion_default_date()?;
             let naive = NaiveDateTime::new(date, t.time());
             Some(
                 offset
@@ -719,69 +764,26 @@ fn flake_value_to_datetime(
             )
         }
         FlakeValue::GYear(gy) => {
-            let offset = gy.tz_offset().unwrap_or(utc);
-            let naive = NaiveDate::from_ymd_opt(gy.year(), 1, 1)?.and_hms_opt(0, 0, 0)?;
-            Some(
-                offset
-                    .from_local_datetime(&naive)
-                    .single()
-                    .unwrap_or_else(|| offset.from_utc_datetime(&naive)),
-            )
+            promote_calendar_fragment(gy.tz_offset(), Some(gy.year()), None, None)
         }
         FlakeValue::GYearMonth(gym) => {
-            let offset = gym.tz_offset().unwrap_or(utc);
-            let naive =
-                NaiveDate::from_ymd_opt(gym.year(), gym.month(), 1)?.and_hms_opt(0, 0, 0)?;
-            Some(
-                offset
-                    .from_local_datetime(&naive)
-                    .single()
-                    .unwrap_or_else(|| offset.from_utc_datetime(&naive)),
-            )
+            promote_calendar_fragment(gym.tz_offset(), Some(gym.year()), Some(gym.month()), None)
         }
         FlakeValue::GMonth(gm) => {
-            let offset = gm.tz_offset().unwrap_or(utc);
-            let naive = NaiveDate::from_ymd_opt(1970, gm.month(), 1)?.and_hms_opt(0, 0, 0)?;
-            Some(
-                offset
-                    .from_local_datetime(&naive)
-                    .single()
-                    .unwrap_or_else(|| offset.from_utc_datetime(&naive)),
-            )
+            promote_calendar_fragment(gm.tz_offset(), None, Some(gm.month()), None)
         }
         FlakeValue::GDay(gd) => {
-            let offset = gd.tz_offset().unwrap_or(utc);
-            let naive = NaiveDate::from_ymd_opt(1970, 1, gd.day())?.and_hms_opt(0, 0, 0)?;
-            Some(
-                offset
-                    .from_local_datetime(&naive)
-                    .single()
-                    .unwrap_or_else(|| offset.from_utc_datetime(&naive)),
-            )
+            promote_calendar_fragment(gd.tz_offset(), None, None, Some(gd.day()))
         }
         FlakeValue::GMonthDay(gmd) => {
-            let offset = gmd.tz_offset().unwrap_or(utc);
-            let naive =
-                NaiveDate::from_ymd_opt(1970, gmd.month(), gmd.day())?.and_hms_opt(0, 0, 0)?;
-            Some(
-                offset
-                    .from_local_datetime(&naive)
-                    .single()
-                    .unwrap_or_else(|| offset.from_utc_datetime(&naive)),
-            )
+            promote_calendar_fragment(gmd.tz_offset(), None, Some(gmd.month()), Some(gmd.day()))
         }
         FlakeValue::String(s) => DateTime::parse_from_rfc3339(s).ok().or_else(|| {
             let with_time = format!("{s}T00:00:00+00:00");
             DateTime::parse_from_rfc3339(&with_time).ok()
         }),
         FlakeValue::Long(y) if dt_sid == Some(&datatypes.xsd_g_year) => {
-            let year = i32::try_from(*y).ok()?;
-            let naive = NaiveDate::from_ymd_opt(year, 1, 1)?.and_hms_opt(0, 0, 0)?;
-            Some(
-                utc.from_local_datetime(&naive)
-                    .single()
-                    .unwrap_or_else(|| utc.from_utc_datetime(&naive)),
-            )
+            promote_calendar_fragment(None, Some(i32::try_from(*y).ok()?), None, None)
         }
         _ => None,
     }

--- a/fluree-db-query/src/fast_predicate_scalar_agg.rs
+++ b/fluree-db-query/src/fast_predicate_scalar_agg.rs
@@ -30,6 +30,7 @@ use fluree_db_binary_index::format::column_block::ColumnId;
 use fluree_db_binary_index::format::run_record::RunSortOrder;
 use fluree_db_binary_index::{BinaryIndexStore, ColumnProjection, ColumnSet};
 use fluree_db_core::o_type::{DecodeKind, OType};
+use fluree_db_core::temporal::{CalendarField, TemporalKind};
 use fluree_db_core::value_id::ObjKey;
 use fluree_db_core::{FlakeValue, GraphId, Sid};
 use std::sync::Arc;
@@ -66,7 +67,8 @@ impl SumExprI64 {
     fn constant_for_otype(self, o_type: u16) -> Option<i64> {
         match self {
             Self::Identity | Self::AddSelf => None,
-            Self::DateComponent(component) => constant_component_for_otype(o_type, component),
+            Self::DateComponent(component) => constant_component_for_otype(o_type, component)
+                .and_then(ComponentFold::sum_contribution),
             Self::NumericUnary(_) => None,
         }
     }
@@ -91,7 +93,9 @@ impl SumExprI64 {
                 // consistent with the overall overflow strategy.
                 Some(ObjKey::from_u64(o_key).decode_i64().saturating_mul(2))
             }
-            Self::DateComponent(component) => component_from_otype_okey(o_type, o_key, component),
+            Self::DateComponent(component) => {
+                component_from_otype_okey(o_type, o_key, component).sum_contribution()
+            }
             Self::NumericUnary(func) => {
                 let ot = OType::from_u16(o_type);
                 if ot.decode_kind() != DecodeKind::I64 {
@@ -554,69 +558,107 @@ pub(crate) fn scan_predicate_scalar_agg_overlay(
 // Decode helpers
 // ---------------------------------------------------------------------------
 
-fn constant_component_for_otype(o_type: u16, component: DateComponentFn) -> Option<i64> {
-    let ot = OType::from_u16(o_type);
-    match component {
-        DateComponentFn::Year => None,
-        DateComponentFn::Month => {
-            if ot == OType::XSD_G_YEAR || ot == OType::XSD_G_DAY {
-                Some(1)
-            } else {
-                None
-            }
-        }
-        DateComponentFn::Day => {
-            if ot == OType::XSD_G_YEAR || ot == OType::XSD_G_YEAR_MONTH || ot == OType::XSD_G_MONTH
-            {
-                Some(1)
-            } else {
-                None
-            }
+/// What one row contributes to a fused date-component fold.
+///
+/// `Absent` is the case that matters: the value's datatype does not carry the
+/// field (`DAY` of an `xsd:gYear`), so the per-row expression is unbound. SUM
+/// skips unbound, hence [`Self::sum_contribution`] scores it 0 — but any future
+/// non-SUM consumer (an AVG that must not count the row, a COUNT that must not
+/// either) has to make that decision for itself rather than inherit a silent 0.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum ComponentFold {
+    Value(i64),
+    Absent,
+    /// The datatype is not one this fold can read at all — decline the fast path.
+    Unsupported,
+}
+
+impl ComponentFold {
+    /// Contribution to a SUM, or `None` to decline the fast path.
+    fn sum_contribution(self) -> Option<i64> {
+        match self {
+            Self::Value(v) => Some(v),
+            Self::Absent => Some(0),
+            Self::Unsupported => None,
         }
     }
 }
 
-fn component_from_otype_okey(o_type: u16, o_key: u64, component: DateComponentFn) -> Option<i64> {
+impl DateComponentFn {
+    fn field(self) -> CalendarField {
+        match self {
+            Self::Year => CalendarField::Year,
+            Self::Month => CalendarField::Month,
+            Self::Day => CalendarField::Day,
+        }
+    }
+}
+
+/// The fold for a whole leaflet, when its homogeneous `o_type` settles the
+/// field without reading a single column.
+///
+/// A field the datatype does not carry is `Absent` for every row — the whole
+/// leaflet folds to nothing, with no IO. (Before #1652's sibling fix this
+/// returned the promotion's `1` here, which is precisely how a year-only
+/// leaflet came to contribute a day per row.)
+fn constant_component_for_otype(o_type: u16, component: DateComponentFn) -> Option<ComponentFold> {
+    let kind = TemporalKind::from_o_type(OType::from_u16(o_type))?;
+    if !kind.carries(component.field()) {
+        return Some(ComponentFold::Absent);
+    }
+    // Carried fields are constant only where the datatype pins them: a gMonth's
+    // month varies per row, but a gYear has no month to vary.
+    None
+}
+
+fn component_from_otype_okey(o_type: u16, o_key: u64, component: DateComponentFn) -> ComponentFold {
     let ot = OType::from_u16(o_type);
+    let Some(kind) = TemporalKind::from_o_type(ot) else {
+        return ComponentFold::Unsupported;
+    };
+    if !kind.carries(component.field()) {
+        return ComponentFold::Absent;
+    }
     let key = ObjKey::from_u64(o_key);
 
-    // Defaulting semantics match helpers.rs promotion:
-    // - gYear → Jan 1, 00:00:00
-    // - gYearMonth → day=1
-    // - gMonth/gDay/gMonthDay → year=1970, missing parts default to 1
-    const DEFAULT_YEAR: i64 = 1970;
-    const DEFAULT_MONTH: i64 = 1;
-
-    let (year, month, day) = if ot == OType::XSD_G_YEAR {
-        (key.decode_g_year() as i64, 1, 1)
+    let parts = if ot == OType::XSD_G_YEAR {
+        Some((key.decode_g_year() as i64, 0, 0))
     } else if ot == OType::XSD_G_YEAR_MONTH {
         let (y, m) = key.decode_g_year_month();
-        (y as i64, m as i64, 1)
+        Some((y as i64, m as i64, 0))
     } else if ot == OType::XSD_G_MONTH {
-        (DEFAULT_YEAR, key.decode_g_month() as i64, 1)
+        Some((0, key.decode_g_month() as i64, 0))
     } else if ot == OType::XSD_G_DAY {
-        (DEFAULT_YEAR, DEFAULT_MONTH, key.decode_g_day() as i64)
+        Some((0, 0, key.decode_g_day() as i64))
     } else if ot == OType::XSD_G_MONTH_DAY {
         let (m, d) = key.decode_g_month_day();
-        (DEFAULT_YEAR, m as i64, d as i64)
+        Some((0, m as i64, d as i64))
     } else if ot == OType::XSD_DATE {
         // xsd:date: days since Unix epoch (1970-01-01)
-        let days = key.decode_date() as i64;
-        let base = chrono::NaiveDate::from_ymd_opt(1970, 1, 1)?;
-        let dt = base.checked_add_signed(chrono::Duration::days(days))?;
-        (dt.year() as i64, dt.month() as i64, dt.day() as i64)
+        chrono::NaiveDate::from_ymd_opt(1970, 1, 1)
+            .and_then(|base| {
+                base.checked_add_signed(chrono::Duration::days(key.decode_date() as i64))
+            })
+            .map(|dt| (dt.year() as i64, dt.month() as i64, dt.day() as i64))
     } else if ot == OType::XSD_DATE_TIME {
-        // xsd:dateTime: epoch micros; interpret in UTC for component extraction.
-        let micros = key.decode_datetime();
-        let dt = chrono::DateTime::<chrono::Utc>::from_timestamp_micros(micros)?;
-        (dt.year() as i64, dt.month() as i64, dt.day() as i64)
+        // xsd:dateTime: epoch micros. Offsets are normalized to UTC at ingest,
+        // so reading the components in UTC matches the generic pipeline.
+        chrono::DateTime::<chrono::Utc>::from_timestamp_micros(key.decode_datetime())
+            .map(|dt| (dt.year() as i64, dt.month() as i64, dt.day() as i64))
     } else {
-        return None;
+        // xsd:time carries no date fields, and `carries` already returned above
+        // for those; anything else this fold cannot read.
+        None
     };
 
-    match component {
-        DateComponentFn::Year => Some(year),
-        DateComponentFn::Month => Some(month),
-        DateComponentFn::Day => Some(day),
+    // Only carried fields are read, so the zero placeholders above are never
+    // the value selected here.
+    match parts {
+        Some((year, month, day)) => ComponentFold::Value(match component {
+            DateComponentFn::Year => year,
+            DateComponentFn::Month => month,
+            DateComponentFn::Day => day,
+        }),
+        None => ComponentFold::Unsupported,
     }
 }


### PR DESCRIPTION
Follows up the side observation at the end of #1652 — deliberately left out of
#1666, which fixed that issue's three reported shapes. Those were fast-vs-generic
divergences with an unambiguous oracle: make the fast lane match the generic
pipeline and no correct query changes. This one is different in kind. Both lanes
already agree; the question is whether what they agree on is right. It changes
results for queries that return numbers today, so it wants its own review.

Stacked on #1666 (base `fix/fastpath-count-divergences`) — review that one first;
this branch's own commit is the second one.

## The behavior

`xsd:gYear` has a year and nothing else, so `DAY("2005"^^xsd:gYear)` has no answer
in the data. Every temporal value was promoted to a whole instant and the field
read off the promoted result, so absent fields came back as the promotion's
filler — day 1, month 1, and from the Unix epoch year 1970 — indistinguishable in
the answer from a value that was really there:

| expression | was | now |
|---|---|---|
| `YEAR("2005"^^xsd:gYear)` | 2005 | 2005 (carried) |
| `MONTH`/`DAY("2005"^^xsd:gYear)` | **1** | unbound |
| `DAY("2005-07"^^xsd:gYearMonth)` | **1** | unbound |
| `YEAR("--03"^^xsd:gMonth)` | **1970** | unbound |
| `YEAR("---17"^^xsd:gDay)` | **1970** | unbound |
| `YEAR("13:45:00"^^xsd:time)` | **1970** | unbound |
| `DAY("2005-07-17"^^xsd:date)` | 17 | 17 (carried) |

## Why it is worth changing

On a predicate that is entirely year-only — the shape in the report — the filler
is close to harmless: a nonsense query gets a nonsense number.

It is not harmless on a predicate mixing `xsd:date` with `xsd:gYear`, which is
ordinary in bibliographic data where some records are dated and some are
year-only. With three dated rows (days 17, 20, 30) beside three year-only rows:

| query | was | now |
|---|---|---|
| `AVG(DAY(?o))` | **11.67** | 22.33 |
| `COUNT(DAY(?o))` | **6** | 3 |
| `SUM(DAY(?o))` | **70** | 67 |
| `FILTER(DAY(?o) < 15)` | **3 rows** | 0 rows |

The filter is the sharpest one. Every dated row has a day ≥ 15, so the honest
answer is none — and the fabricated day 1 made it select precisely the three rows
with no day at all while excluding all three that had one. The result was not
merely wrong, it was anti-correlated with the question. A `MONTH(?o)` histogram
got a fake January spike sized to however many year-only records existed.

## What changed

Component extraction consults the datatype before promoting, and yields unbound
where the lexical form carries nothing (SPARQL makes the accessor a type error on
such an operand, and this engine already demotes expression errors to unbound in
queries — `DAY("hello")` has always been unbound). Unbound then falls out of the
aggregates for free, since SUM/AVG/COUNT skip it.

The check runs before the epoch-millis fallback as well, so a declined temporal
value cannot be re-fabricated by it. A bare integer is still read as epoch
milliseconds, which LDBC-style datasets depend on.

**One judgment call, flagged for review:** `xsd:date` keeps its time-of-day fields
at the midnight the XSD timeline maps it to. That one reads as a documented
convention rather than invented data — a date does begin at midnight, and
`YEAR`/`MONTH`/`DAY` of a date, the overwhelmingly common uses, are genuine either
way — so it stays, pinned by test so the narrowing cannot quietly widen. The
consistent-purist alternative is to make `HOURS(date)` unbound too; easy to flip
if reviewers prefer it.

## Consolidating the three copies

Three lanes read these fields: the per-row evaluator, its no-chrono fast extractor,
and the fused `SUM(DAY(?o))` scan that folds a homogeneous leaflet with no column
IO. Each carried its own copy of the defaults, and they had already drifted:

* the fast extractor guarded a bare `Long` on `xsd:gYear`, while the generic path
  let the same value reach the epoch-millis fallback instead;
* only the fused lane knew about `xsd:date`;
* the fused lane's constant-fold was the same "which fields are absent" table
  written a third time and inverted.

All three now consult one presence table and one defaults table in
`fluree-db-core::temporal`, beside the temporal types themselves, and none keeps
defaults of its own. The one surviving 1970 outside that table is `xsd:date`'s
storage encoding, which counts days from the epoch.

The fused lane also gains an explicit `Absent` state rather than a bare `Option`,
so a future non-SUM consumer — an AVG that must not count the row, a COUNT that
must not either — has to decide for itself instead of inheriting SUM's silent
zero. That implicit-default pattern is what produced the bug in the first place.
A field the datatype does not carry now folds a whole leaflet to nothing with no
IO, where it previously read a fabricated 1 per row.

## Testing

New `it_datetime_component_presence.rs`, 28 cases, each run twice under the
fast-path kill switch — fast-vs-generic agreement is what proves the three lanes
still share one answer — and each pinned against a hand-computed value on both
lanes, so a generic regression fails as loudly as a fast-path one. Carried fields
are pinned alongside absent ones so the narrowing cannot overshoot, and the
`xsd:date` midnight convention has its own pin. Unit tests in
`fluree-db-core::temporal` check the presence table against an independently
spelled-out table and assert the two index representations classify alike.

Green locally: the full W3C suite (36 suites, 0 failures, including the SPARQL 1.1
accessor tests), the Cypher suite (231 tests — its `.year`/`.month` accessors share
this path), 1440 `fluree-db-query` unit tests, 789 `fluree-db-core` tests, the 764
query-binary tests, clippy `--all-features --all-targets -D warnings`, and
`cargo fmt --check`.



### Review follow-up

**SECONDS pins.** `eval_seconds` returns `xsd:decimal` and so does not route through
`eval_datetime_component` — it repeats the presence check itself, and the suite had no SECONDS
case at all, so removing that gate entirely passed every pin. Five cases now cover it: carried on
`xsd:time` and `xsd:dateTime`, absent on `xsd:gYear` and `xsd:gMonth`, and the midnight convention
on `xsd:date`. Mutation-checked — dropping the gate fails exactly the two absent cases, on both
lanes. (A carried SECONDS renders as a JSON string, being a decimal.)

**Fused-lane routing.** The three fused SUM cases pinned their answer but not the lane, and the
fallback computes the same number, so a silent disable was invisible here. They now assert the
site proceeded.

This needed no production change. `FastPathOperator::open` already stamps `fast-path outcome`
under the operator's label, so the fused lanes stamp as `SUM(DAY)` / `SUM(YEAR)` despite
`fast_predicate_scalar_agg.rs` containing no direct `stamp_fast_path` call — grepping a file for
stamp sites understates coverage for anything built on `FastPathOperator`. Mutation-checked:
forcing the operator to decline fails exactly the three routing assertions **and no value
assertion**, which is precisely the blind spot they close.

The `eval_seconds` / `eval_datetime_component` consistency nit is deliberately not folded in — see
the review thread.
