### PR TITLE
feat(nameservice): add NameServiceLookup::heads for cheap head reads

### DIFF
--- a/.fluree-memory/repo.ttl
+++ b/.fluree-memory/repo.ttl
@@ -2045,6 +2045,20 @@ mem:fact-01kwsmdy5pms38yy81d0bdxprb a mem:Fact ;
     mem:branch "feature/merge-preview-changes" ;
     mem:createdAt "2026-07-05T17:15:17.046896+00:00"^^xsd:dateTime .
 
+mem:fact-01m0cs8ax1gv4kedajb8ff9yj2 a mem:Fact ;
+    mem:content "NameServiceLookup has three read depths, all backend-agnostic: get_ref(id, RefKind) → RefValue (one head; Dynamo = 1 GetItem, file = main JSON only), heads(id) → LedgerHeads{commit,index} (Dynamo = 1 projected Query over sk BETWEEN head AND index; file/S3 = main+index file via ns_format::merge_heads; Raft/Memory = 1 lock), lookup(id) → full NsRecord (4 Dynamo items + config/context parsing). Use the shallowest that answers the question. `None` from get_ref/heads = unknown, and on Raft also retracted (tombstone); only lookup surfaces retracted:true. LedgerHeads converts into NsRecordSnapshot for rollback capture." ;
+    mem:tag "api" ;
+    mem:tag "dynamodb" ;
+    mem:tag "nameservice" ;
+    mem:tag "performance" ;
+    mem:scope mem:repo ;
+    mem:artifactRef "fluree-db-nameservice/src/lib.rs" ;
+    mem:artifactRef "fluree-db-nameservice/src/ns_format.rs" ;
+    mem:artifactRef "fluree-db-storage-aws/src/dynamodb/mod.rs" ;
+    mem:branch "feature/nameservice-heads-read" ;
+    mem:createdAt "2026-08-19T10:32:16.033424+00:00"^^xsd:dateTime ;
+    mem:rationale "External callers (Lambda query backend etc.) asked for the cheapest head read; the answer is the existing trait, not a new type or HTTP endpoint." .
+
 mem:decision-01kx0v325fhgme9a3yfn7cjqtq a mem:Decision ;
     mem:content "Policy condition unification (user-decided 2026-07): state graph IRIs are f:preState/f:postState (NOT f:pre/f:post); every f:query condition is an ASK contract regardless of language — JSON-LD gains the existing `{\"ask\": ...}` query form as preferred spelling (parse/mod.rs already parses ask; policy parser must accept it), SPARQL ASK/SELECT as-is, Cypher reserved via f:cypher datatype (read-only MATCH, ≥1 row = allow, $this/$identity/$value as native Cypher parameters). Per-policy f:queryState selector = whole-condition state switch for graph-less languages; SPARQL GRAPH f:postState for in-query mixing. Design doc: docs/design/policy-condition-languages.md." ;
     mem:tag "ask" ;

--- a/docs/concepts/ledgers-and-nameservice.md
+++ b/docs/concepts/ledgers-and-nameservice.md
@@ -151,6 +151,21 @@ let record = nameservice.lookup("mydb:main").await?;
 // Returns: NsRecord with commit_id, index_id, timestamps, etc.
 ```
 
+Three read depths exist on every backend, all on `NameServiceLookup`. Pick the
+shallowest that answers the question — the deeper reads cost extra items on
+DynamoDB and extra files plus config/context parsing on file and S3:
+
+| Call | Returns | Use when |
+|------|---------|----------|
+| `get_ref(id, RefKind::CommitHead)` | `RefValue { id, t }` | "has this ledger moved?" — one head |
+| `heads(id)` | `LedgerHeads { commit, index }` | both heads; converts to `NsRecordSnapshot` for rollback |
+| `lookup(id)` | full `NsRecord` | branch metadata, config, retraction flag |
+
+`heads` is one round trip on DynamoDB (a projected query over the two ref
+items), the main + index file on file/S3, and a single lock on the in-memory
+and Raft backends. `None` means unknown (and, on Raft, retracted) — the same
+rule as `get_ref`; only `lookup` surfaces `retracted: true`.
+
 #### Publishing
 
 Record new commits and indexes:

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -612,6 +612,16 @@ impl fluree_db_nameservice::NameServiceLookup for NameServiceMode {
     > {
         self.reader().all_records().await
     }
+
+    async fn heads(
+        &self,
+        ledger_id: &str,
+    ) -> std::result::Result<
+        Option<fluree_db_nameservice::LedgerHeads>,
+        fluree_db_nameservice::NameServiceError,
+    > {
+        self.reader().heads(ledger_id).await
+    }
 }
 
 // No `BranchLifecycle` impl for `NameServiceMode`: read-only modes can't

--- a/fluree-db-connection/tests/aws_testcontainers_test.rs
+++ b/fluree-db-connection/tests/aws_testcontainers_test.rs
@@ -10,8 +10,9 @@ use fluree_db_core::{ContentId, ContentKind, StorageRead, StorageWrite};
 use fluree_db_nameservice::{
     AdminPublisher, CasResult, ConfigCasResult, ConfigLookup, ConfigPayload, ConfigPublisher,
     ConfigValue, GraphSourceLookup, GraphSourcePublisher, GraphSourceType, IndexPublisher,
-    LedgerLifecycle, NameServiceLookup, NsLookupResult, RefKind, RefLookup, RefPublisher, RefValue,
-    StatusCasResult, StatusLookup, StatusPayload, StatusPublisher, StatusValue,
+    LedgerHeads, LedgerLifecycle, NameServiceLookup, NsLookupResult, RefKind, RefLookup,
+    RefPublisher, RefValue, StatusCasResult, StatusLookup, StatusPayload, StatusPublisher,
+    StatusValue,
 };
 use fluree_db_storage_aws::DynamoDbNameService;
 use fs2::FileExt;
@@ -548,12 +549,13 @@ async fn nameservice_ref_publisher() {
 
     let alias = "ref-test:main";
 
-    // get_ref before init → None
+    // get_ref / heads before init → None
     assert!(ns
         .get_ref(alias, RefKind::CommitHead)
         .await
         .unwrap()
         .is_none());
+    assert!(ns.heads(alias).await.unwrap().is_none());
 
     ns.init(alias).await.unwrap();
 
@@ -565,6 +567,9 @@ async fn nameservice_ref_publisher() {
         .expect("exists after init");
     assert!(ref_val.id.is_none());
     assert_eq!(ref_val.t, 0);
+    let heads = ns.heads(alias).await.unwrap().expect("exists after init");
+    assert_eq!(heads.commit, ref_val);
+    assert_eq!(heads.index, RefValue { id: None, t: 0 });
 
     // CAS: unborn → first commit
     let commit_id_1 = test_commit_id("commit:1");
@@ -642,6 +647,13 @@ async fn nameservice_ref_publisher() {
         .await
         .unwrap();
     assert!(matches!(result, CasResult::Updated));
+
+    // heads() = one projected query; must agree with lookup() and get_ref().
+    let heads = ns.heads(alias).await.unwrap().unwrap();
+    let rec = ns.lookup(alias).await.unwrap().unwrap();
+    assert_eq!(heads, LedgerHeads::from_record(&rec));
+    assert_eq!(heads.commit.id.as_ref(), Some(&commit_id_2));
+    assert_eq!(heads.index, new_idx);
 
     // ── CAS expected=None creates ledger (matches StorageNameService) ────
     let new_alias = "cas-create-test:main";

--- a/fluree-db-consensus/src/raft/nameservice.rs
+++ b/fluree-db-consensus/src/raft/nameservice.rs
@@ -67,9 +67,9 @@ use fluree_db_core::ContentId;
 use fluree_db_nameservice::{
     AdminPublisher, BranchLifecycle, CasResult, CommitPublisher, ConfigCasResult, ConfigLookup,
     ConfigPublisher, ConfigValue, GraphSourceLookup, GraphSourcePublisher, GraphSourceRecord,
-    GraphSourceType, IndexPublisher, LedgerLifecycle, NameServiceError, NameServiceLookup,
-    NsLookupResult, NsRecord, NsRecordSnapshot, RefKind, RefLookup, RefPublisher, RefValue, Result,
-    StatusCasResult, StatusLookup, StatusPublisher, StatusValue,
+    GraphSourceType, IndexPublisher, LedgerHeads, LedgerLifecycle, NameServiceError,
+    NameServiceLookup, NsLookupResult, NsRecord, NsRecordSnapshot, RefKind, RefLookup,
+    RefPublisher, RefValue, Result, StatusCasResult, StatusLookup, StatusPublisher, StatusValue,
 };
 use openraft::error::{ClientWriteError, RaftError};
 use openraft::Raft;
@@ -292,6 +292,32 @@ impl NameServiceLookup for RaftNameService {
         let (name, branch) = split_ledger_id(ledger_id)?;
         let state = self.state.read().await;
         Ok(record_from_state(&state, &name, &branch))
+    }
+
+    /// One lock, two field reads. Mirrors `get_ref`: retracted branches are
+    /// tombstoned here (`None`) even though `lookup` still returns them.
+    async fn heads(&self, ledger_id: &str) -> Result<Option<LedgerHeads>> {
+        let (name, branch) = split_ledger_id(ledger_id)?;
+        let state = self.state.read().await;
+        if !state.ledgers.contains_key(&name) {
+            return Ok(None);
+        }
+        let ref_key = RefKey::new(&name, &branch);
+        if state.retracted.contains(&ref_key) {
+            return Ok(None);
+        }
+        let entry = state.refs.get(&ref_key);
+        let index = entry.and_then(|e| e.index.as_ref());
+        Ok(Some(LedgerHeads {
+            commit: RefValue {
+                id: entry.map(|e| e.head.clone()),
+                t: entry.map(|e| e.t).unwrap_or(0),
+            },
+            index: RefValue {
+                id: index.map(|i| i.head.clone()),
+                t: index.map(|i| i.t).unwrap_or(0),
+            },
+        }))
     }
 
     async fn all_records(&self) -> Result<Vec<NsRecord>> {
@@ -3085,6 +3111,25 @@ mod tests {
             .expect("index ref");
         assert!(index_ref.id.is_none());
         assert_eq!(index_ref.t, 0);
+    }
+
+    #[tokio::test]
+    async fn heads_matches_get_ref_and_tombstones_unknown() {
+        let state = fresh_state();
+        apply_cmd(&state, init_cmd("test/db", "main"), 1).await;
+        seed_head(&state, "test/db", "main", cid(9), 3).await;
+
+        let ns = RaftNameService::new(state, stub_raft().await);
+        let heads = ns.heads("test/db:main").await.unwrap().expect("heads");
+        assert_eq!(
+            heads.commit,
+            RefValue {
+                id: Some(cid(9)),
+                t: 3
+            }
+        );
+        assert_eq!(heads.index, RefValue { id: None, t: 0 });
+        assert!(ns.heads("test/other:main").await.unwrap().is_none());
     }
 
     /// Convenience for the index-head tests: create a ledger and

--- a/fluree-db-nameservice-sync/src/proxy_nameservice.rs
+++ b/fluree-db-nameservice-sync/src/proxy_nameservice.rs
@@ -139,26 +139,52 @@ impl ProxyNameService {
     }
 }
 
+/// Project a fetched record onto one head ref.
+///
+/// A retracted branch yields `None`, matching the raft nameservice: `lookup`
+/// keeps serving the record so admin tooling can see the `retracted` flag, but
+/// this is the active-read surface and must not resolve a head for a branch the
+/// operator soft-deleted. The remote endpoint projects `lookup`, so without
+/// this the proxy would resurrect branches its own raft-backed origin reports
+/// as gone.
+fn project_ref(
+    record: Option<NsRecord>,
+    kind: fluree_db_nameservice::RefKind,
+) -> Option<fluree_db_nameservice::RefValue> {
+    use fluree_db_nameservice::{RefKind, RefValue};
+    let r = record.filter(|r| !r.retracted)?;
+    Some(match kind {
+        RefKind::CommitHead => RefValue {
+            id: r.commit_head_id,
+            t: r.commit_t,
+        },
+        RefKind::IndexHead => RefValue {
+            id: r.index_head_id,
+            t: r.index_t,
+        },
+    })
+}
+
+/// Project a fetched record onto both head refs. Tombstones retracted
+/// branches for the same reason as [`project_ref`].
+fn project_heads(record: Option<NsRecord>) -> Option<fluree_db_nameservice::LedgerHeads> {
+    record
+        .filter(|r| !r.retracted)
+        .map(|r| fluree_db_nameservice::LedgerHeads::from_record(&r))
+}
+
 #[async_trait]
 impl fluree_db_nameservice::RefLookup for ProxyNameService {
     /// The proxy endpoint serves whole records, so a single-ref read is a
-    /// projection of `lookup` — still one HTTP round trip.
+    /// projection of `lookup` — still one HTTP round trip. Retracted branches
+    /// report `None`; see [`project_ref`].
     async fn get_ref(
         &self,
         ledger_id: &str,
         kind: fluree_db_nameservice::RefKind,
     ) -> Result<Option<fluree_db_nameservice::RefValue>> {
-        use fluree_db_nameservice::{NameServiceLookup, RefKind, RefValue};
-        Ok(self.lookup(ledger_id).await?.map(|r| match kind {
-            RefKind::CommitHead => RefValue {
-                id: r.commit_head_id,
-                t: r.commit_t,
-            },
-            RefKind::IndexHead => RefValue {
-                id: r.index_head_id,
-                t: r.index_t,
-            },
-        }))
+        use fluree_db_nameservice::NameServiceLookup;
+        Ok(project_ref(self.lookup(ledger_id).await?, kind))
     }
 }
 
@@ -224,11 +250,9 @@ impl fluree_db_nameservice::NameServiceLookup for ProxyNameService {
         }
     }
 
+    /// Retracted branches report `None` — see [`project_heads`].
     async fn heads(&self, ledger_id: &str) -> Result<Option<fluree_db_nameservice::LedgerHeads>> {
-        Ok(self
-            .lookup(ledger_id)
-            .await?
-            .map(|r| fluree_db_nameservice::LedgerHeads::from_record(&r)))
+        Ok(project_heads(self.lookup(ledger_id).await?))
     }
 
     async fn all_records(&self) -> Result<Vec<NsRecord>> {
@@ -277,6 +301,8 @@ impl fluree_db_nameservice::GraphSourceLookup for ProxyNameService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fluree_db_core::{ContentId, ContentKind};
+    use fluree_db_nameservice::{RefKind, RefValue};
 
     #[test]
     fn test_proxy_nameservice_debug() {
@@ -343,6 +369,79 @@ mod tests {
         assert!(!record.retracted);
         // default_context is not exposed via proxy API
         assert!(record.default_context.is_none());
+    }
+
+    fn record(retracted: bool) -> NsRecord {
+        NsRecordResponse {
+            name: Some("books".to_string()),
+            branch: "main".to_string(),
+            commit_head_id: Some(ContentId::new(ContentKind::Commit, b"c").to_string()),
+            commit_t: 42,
+            index_head_id: Some(ContentId::new(ContentKind::IndexRoot, b"i").to_string()),
+            index_t: 40,
+            default_context: None,
+            retracted,
+            config_id: None,
+            source_branch: None,
+            branches: 0,
+        }
+        .into_ns_record("books:main")
+    }
+
+    #[test]
+    fn projections_carry_both_heads() {
+        let r = record(false);
+        let commit = project_ref(Some(r.clone()), RefKind::CommitHead).expect("commit ref");
+        assert_eq!(commit.id, Some(ContentId::new(ContentKind::Commit, b"c")));
+        assert_eq!(commit.t, 42);
+
+        let index = project_ref(Some(r.clone()), RefKind::IndexHead).expect("index ref");
+        assert_eq!(index.id, Some(ContentId::new(ContentKind::IndexRoot, b"i")));
+        assert_eq!(index.t, 40);
+
+        // `heads` must agree with the two single-ref reads, not drift from them.
+        let heads = project_heads(Some(r)).expect("heads");
+        assert_eq!(heads.commit, commit);
+        assert_eq!(heads.index, index);
+    }
+
+    /// A retracted branch is tombstoned on the active-read surface even though
+    /// the remote endpoint keeps serving its record (with the flag set) through
+    /// `lookup`. Without this the proxy resurrects branches a raft-backed
+    /// origin reports as gone — see `project_ref`.
+    #[test]
+    fn projections_tombstone_a_retracted_branch() {
+        let r = record(true);
+        assert!(r.retracted, "the record itself still carries the flag");
+        assert_eq!(project_ref(Some(r.clone()), RefKind::CommitHead), None);
+        assert_eq!(project_ref(Some(r.clone()), RefKind::IndexHead), None);
+        assert_eq!(project_heads(Some(r)), None);
+    }
+
+    /// An unknown ledger (the endpoint's 404) is `None`, distinct from a
+    /// known-but-unborn branch, which projects zeroed refs.
+    #[test]
+    fn projections_distinguish_unknown_from_unborn() {
+        assert_eq!(project_ref(None, RefKind::CommitHead), None);
+        assert_eq!(project_heads(None), None);
+
+        let unborn = NsRecordResponse {
+            name: Some("books".to_string()),
+            branch: "main".to_string(),
+            commit_head_id: None,
+            commit_t: 0,
+            index_head_id: None,
+            index_t: 0,
+            default_context: None,
+            retracted: false,
+            config_id: None,
+            source_branch: None,
+            branches: 0,
+        }
+        .into_ns_record("books:main");
+        let heads = project_heads(Some(unborn)).expect("unborn branch is known");
+        assert_eq!(heads.commit, RefValue { id: None, t: 0 });
+        assert_eq!(heads.index, RefValue { id: None, t: 0 });
     }
 
     /// Regression for finding #11: `source_branch` and `branches`

--- a/fluree-db-nameservice-sync/src/proxy_nameservice.rs
+++ b/fluree-db-nameservice-sync/src/proxy_nameservice.rs
@@ -141,14 +141,24 @@ impl ProxyNameService {
 
 #[async_trait]
 impl fluree_db_nameservice::RefLookup for ProxyNameService {
+    /// The proxy endpoint serves whole records, so a single-ref read is a
+    /// projection of `lookup` — still one HTTP round trip.
     async fn get_ref(
         &self,
-        _ledger_id: &str,
-        _kind: fluree_db_nameservice::RefKind,
+        ledger_id: &str,
+        kind: fluree_db_nameservice::RefKind,
     ) -> Result<Option<fluree_db_nameservice::RefValue>> {
-        Err(NameServiceError::storage(
-            "get_ref not supported in proxy mode".to_string(),
-        ))
+        use fluree_db_nameservice::{NameServiceLookup, RefKind, RefValue};
+        Ok(self.lookup(ledger_id).await?.map(|r| match kind {
+            RefKind::CommitHead => RefValue {
+                id: r.commit_head_id,
+                t: r.commit_t,
+            },
+            RefKind::IndexHead => RefValue {
+                id: r.index_head_id,
+                t: r.index_t,
+            },
+        }))
     }
 }
 
@@ -212,6 +222,13 @@ impl fluree_db_nameservice::NameServiceLookup for ProxyNameService {
                 "Nameservice proxy unexpected status {status} for {ledger_id}"
             ))),
         }
+    }
+
+    async fn heads(&self, ledger_id: &str) -> Result<Option<fluree_db_nameservice::LedgerHeads>> {
+        Ok(self
+            .lookup(ledger_id)
+            .await?
+            .map(|r| fluree_db_nameservice::LedgerHeads::from_record(&r)))
     }
 
     async fn all_records(&self) -> Result<Vec<NsRecord>> {

--- a/fluree-db-nameservice/src/file.rs
+++ b/fluree-db-nameservice/src/file.rs
@@ -24,15 +24,16 @@
 //! - A database with transactions
 
 use crate::ns_format::{
-    ns_context, BranchPointRef, IndexRef, LedgerRef, NsFileV2, NsIndexFileV2, NS_VERSION,
+    merge_heads, ns_context, BranchPointRef, IndexRef, LedgerRef, NsFileV2, NsIndexFileV2,
+    NS_VERSION,
 };
 use crate::{
     check_cas_expectation, deserialize_json, parse_default_context_value, ref_values_match,
     serialize_json, AdminPublisher, CasResult, CommitPublisher, ConfigCasResult, ConfigLookup,
     ConfigPublisher, ConfigValue, GraphSourceLookup, GraphSourcePublisher, GraphSourceRecord,
-    GraphSourceType, IndexPublisher, LedgerLifecycle, NameServiceError, NsLookupResult, NsRecord,
-    RefKind, RefLookup, RefPublisher, RefValue, Result, StatusCasResult, StatusLookup,
-    StatusPublisher, StatusValue,
+    GraphSourceType, IndexPublisher, LedgerHeads, LedgerLifecycle, NameServiceError,
+    NsLookupResult, NsRecord, RefKind, RefLookup, RefPublisher, RefValue, Result, StatusCasResult,
+    StatusLookup, StatusPublisher, StatusValue,
 };
 use async_trait::async_trait;
 use fluree_db_core::ledger_id::{format_ledger_id, normalize_ledger_id, split_ledger_id};
@@ -349,6 +350,26 @@ impl FileNameService {
         Ok(Some(record))
     }
 
+    /// Head pointers only: same files and merge rule as `load_record`, minus
+    /// the config/context/status fields.
+    async fn load_heads(&self, ledger_name: &str, branch: &str) -> Result<Option<LedgerHeads>> {
+        use fluree_db_core::StorageRead;
+        let main_address = Self::ns_address(ledger_name, branch);
+        let main_bytes = match self.storage.read_bytes(&main_address).await {
+            Ok(bytes) => bytes,
+            Err(fluree_db_core::Error::NotFound(_)) => return Ok(None),
+            Err(e) => return Err(NameServiceError::from(e)),
+        };
+        if Self::is_graph_source_from_bytes(&main_bytes) {
+            return Ok(None);
+        }
+        let main: NsFileV2 = serde_json::from_slice(&main_bytes)?;
+        let index_file: Option<NsIndexFileV2> = self
+            .read_json_from_address(&Self::index_address(ledger_name, branch))
+            .await?;
+        Ok(Some(merge_heads(&main, index_file.as_ref())))
+    }
+
     /// Check if a record file is a graph source record (based on @type).
     /// Matches "f:IndexSource"/"f:MappedSource" compact prefixes and full IRIs.
     async fn is_graph_source_record(&self, name: &str, branch: &str) -> Result<bool> {
@@ -462,6 +483,11 @@ impl crate::NameServiceLookup for FileNameService {
         // A graph-source record is not a ledger (#1369). `load_record` reports it
         // as Ok(None) so the caller can fall back to the graph-source path.
         self.load_record(&ledger_name, &branch).await
+    }
+
+    async fn heads(&self, ledger_id: &str) -> Result<Option<LedgerHeads>> {
+        let (ledger_name, branch) = split_ledger_id(ledger_id)?;
+        self.load_heads(&ledger_name, &branch).await
     }
 
     async fn list_branches(&self, ledger_name: &str) -> Result<Vec<NsRecord>> {
@@ -2321,6 +2347,50 @@ mod tests {
             .unwrap();
         assert_eq!(index.id, Some(index_cid));
         assert_eq!(index.t, 3);
+    }
+
+    #[tokio::test]
+    async fn test_file_heads_unknown_and_graph_source() {
+        let (_dir, ns) = setup().await;
+        assert_eq!(ns.heads("nonexistent:main").await.unwrap(), None);
+
+        ns.publish_graph_source("search", "main", GraphSourceType::Bm25, "{}", &[])
+            .await
+            .unwrap();
+        assert_eq!(ns.heads("search:main").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_file_heads_matches_lookup() {
+        let (_dir, ns) = setup().await;
+        let commit_cid = test_cid("commit-1");
+        let index_cid = ContentId::new(ContentKind::IndexRoot, b"index-1");
+        ns.publish_commit("mydb:main", 5, &commit_cid)
+            .await
+            .unwrap();
+
+        // Commit only: index unborn.
+        let heads = ns.heads("mydb:main").await.unwrap().unwrap();
+        assert_eq!(
+            heads.commit,
+            RefValue {
+                id: Some(commit_cid.clone()),
+                t: 5
+            }
+        );
+        assert_eq!(heads.index, RefValue { id: None, t: 0 });
+
+        // Separate index file merges in; heads agrees with lookup and get_ref.
+        ns.publish_index("mydb:main", 3, &index_cid).await.unwrap();
+        let heads = ns.heads("mydb:main").await.unwrap().unwrap();
+        let record = ns.lookup("mydb:main").await.unwrap().unwrap();
+        assert_eq!(heads, LedgerHeads::from_record(&record));
+        assert_eq!(
+            Some(heads.index.clone()),
+            ns.get_ref("mydb:main", RefKind::IndexHead).await.unwrap()
+        );
+        assert_eq!(heads.index.id, Some(index_cid));
+        assert_eq!(crate::NsRecordSnapshot::from(&heads).index_t, 3);
     }
 
     // =========================================================================

--- a/fluree-db-nameservice/src/file.rs
+++ b/fluree-db-nameservice/src/file.rs
@@ -2393,6 +2393,58 @@ mod tests {
         assert_eq!(crate::NsRecordSnapshot::from(&heads).index_t, 3);
     }
 
+    /// `heads` and `lookup` must apply the SAME index merge rule. The
+    /// interesting boundary is equal `t` with different cids: `load_record`
+    /// takes `>=`, so the separate index file wins, and `merge_heads` claims
+    /// to match. Constructed by writing both ns files directly, since
+    /// `publish_index` only ever writes the separate one.
+    #[tokio::test]
+    async fn test_file_heads_agrees_with_lookup_at_equal_index_t() {
+        let (dir, ns) = setup().await;
+        let inline = ContentId::new(ContentKind::IndexRoot, b"inline");
+        let separate = ContentId::new(ContentKind::IndexRoot, b"separate");
+
+        ns.publish_commit("mydb:main", 9, &test_cid("commit-1"))
+            .await
+            .unwrap();
+
+        // Give the main file an inline index at t=5 ...
+        let main_path = dir.path().join(NS_VERSION).join("mydb").join("main.json");
+        let mut main: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&main_path).unwrap()).unwrap();
+        main["f:ledgerIndex"] = serde_json::json!({
+            "f:cid": inline.to_string(),
+            "f:t": 5,
+        });
+        std::fs::write(&main_path, serde_json::to_vec(&main).unwrap()).unwrap();
+
+        // ... and the separate index file a DIFFERENT cid at the same t.
+        let index_path = dir
+            .path()
+            .join(NS_VERSION)
+            .join("mydb")
+            .join("main.index.json");
+        std::fs::write(
+            &index_path,
+            serde_json::to_vec(&serde_json::json!({
+                "@context": ns_context(),
+                "f:ledgerIndex": { "f:cid": separate.to_string(), "f:t": 5 },
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let heads = ns.heads("mydb:main").await.unwrap().unwrap();
+        let record = ns.lookup("mydb:main").await.unwrap().unwrap();
+        assert_eq!(
+            heads,
+            LedgerHeads::from_record(&record),
+            "heads must not drift from lookup at the equal-t boundary"
+        );
+        assert_eq!(heads.index.id, Some(separate));
+        assert_eq!(heads.index.t, 5);
+    }
+
     // =========================================================================
     // StatusPublisher tests
     // =========================================================================

--- a/fluree-db-nameservice/src/lib.rs
+++ b/fluree-db-nameservice/src/lib.rs
@@ -461,6 +461,15 @@ pub trait NameServiceLookup:
     ///
     /// `None` follows [`RefLookup::get_ref`] on the same backend — an
     /// unknown ledger, and (where the backend tombstones) a retracted one.
+    /// That correspondence is about **existence only**, not values: the file
+    /// backend's `get_ref(IndexHead)` prefers the separate index file
+    /// unconditionally, where this and [`lookup`](Self::lookup) apply the
+    /// read-time `>=` merge, so the two can disagree on a stale index file.
+    /// Where they differ, `heads` sides with `lookup`.
+    ///
+    /// Retraction is not applied uniformly across backends — raft tombstones
+    /// on this surface, file/DynamoDB/memory do not. See #1670.
+    ///
     /// The default reads the two refs separately; backends override when
     /// they can serve both in one read.
     async fn heads(&self, ledger_id: &str) -> Result<Option<LedgerHeads>> {

--- a/fluree-db-nameservice/src/lib.rs
+++ b/fluree-db-nameservice/src/lib.rs
@@ -451,6 +451,28 @@ pub trait NameServiceLookup:
             .filter(|r| r.name == ledger_name && !r.retracted)
             .collect())
     }
+
+    /// Read both head pointers without assembling a full [`NsRecord`].
+    ///
+    /// Prefer this (or [`RefLookup::get_ref`] for a single head) over
+    /// [`lookup`](Self::lookup) whenever only `commit`/`index` identity or
+    /// `t` is needed: the full record costs config/context/status parsing
+    /// and, on remote backends, more items per read.
+    ///
+    /// `None` follows [`RefLookup::get_ref`] on the same backend — an
+    /// unknown ledger, and (where the backend tombstones) a retracted one.
+    /// The default reads the two refs separately; backends override when
+    /// they can serve both in one read.
+    async fn heads(&self, ledger_id: &str) -> Result<Option<LedgerHeads>> {
+        let Some(commit) = self.get_ref(ledger_id, RefKind::CommitHead).await? else {
+            return Ok(None);
+        };
+        let index = self
+            .get_ref(ledger_id, RefKind::IndexHead)
+            .await?
+            .unwrap_or(RefValue { id: None, t: 0 });
+        Ok(Some(LedgerHeads { commit, index }))
+    }
 }
 
 /// Branch lifecycle writes — create, drop, and non-monotonic head reset.
@@ -911,6 +933,49 @@ pub struct RefValue {
     pub id: Option<ContentId>,
     /// Monotonic watermark (transaction time).
     pub t: i64,
+}
+
+/// Both head pointers of a ledger branch, read together.
+///
+/// The cheapest backend-agnostic "where is this ledger" read: every
+/// [`NameServiceLookup`] returns it via [`NameServiceLookup::heads`], and
+/// backends that can fetch both refs in one round trip override the default.
+/// Carries identities (CIDs), not just watermarks, so the values can feed
+/// staleness checks and [`RefPublisher::compare_and_set_ref`] directly.
+///
+/// The two refs are read together but not necessarily atomically (file
+/// backends keep them in separate files), so `index.t > commit.t` is a
+/// transient state callers must tolerate — the same rule as [`NsRecord`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LedgerHeads {
+    pub commit: RefValue,
+    pub index: RefValue,
+}
+
+impl LedgerHeads {
+    pub fn from_record(record: &NsRecord) -> Self {
+        Self {
+            commit: RefValue {
+                id: record.commit_head_id.clone(),
+                t: record.commit_t,
+            },
+            index: RefValue {
+                id: record.index_head_id.clone(),
+                t: record.index_t,
+            },
+        }
+    }
+}
+
+impl From<&LedgerHeads> for NsRecordSnapshot {
+    fn from(heads: &LedgerHeads) -> Self {
+        Self {
+            commit_head_id: heads.commit.id.clone(),
+            commit_t: heads.commit.t,
+            index_head_id: heads.index.id.clone(),
+            index_t: heads.index.t,
+        }
+    }
 }
 
 /// Outcome of a compare-and-set operation.
@@ -1385,6 +1450,10 @@ where
     async fn list_branches(&self, ledger_name: &str) -> Result<Vec<NsRecord>> {
         (**self).list_branches(ledger_name).await
     }
+
+    async fn heads(&self, ledger_id: &str) -> Result<Option<LedgerHeads>> {
+        (**self).heads(ledger_id).await
+    }
 }
 
 #[async_trait]
@@ -1803,5 +1872,66 @@ mod tests {
 
         assert!(matches!(updated, ConfigCasResult::Updated));
         assert!(matches!(conflict, ConfigCasResult::Conflict { .. }));
+    }
+
+    /// Exercises the trait-default `heads()` — only `get_ref` is implemented,
+    /// and the index ref is deliberately reported as unknown.
+    #[derive(Debug)]
+    struct RefOnlyNs;
+
+    #[async_trait]
+    impl RefLookup for RefOnlyNs {
+        async fn get_ref(&self, ledger_id: &str, kind: RefKind) -> Result<Option<RefValue>> {
+            Ok(match (ledger_id, kind) {
+                ("db:main", RefKind::CommitHead) => Some(RefValue {
+                    id: Some(ContentId::new(ContentKind::Commit, b"c")),
+                    t: 7,
+                }),
+                _ => None,
+            })
+        }
+    }
+    #[async_trait]
+    impl GraphSourceLookup for RefOnlyNs {
+        async fn lookup_graph_source(&self, _: &str) -> Result<Option<GraphSourceRecord>> {
+            Ok(None)
+        }
+        async fn lookup_any(&self, _: &str) -> Result<NsLookupResult> {
+            Ok(NsLookupResult::NotFound)
+        }
+        async fn all_graph_source_records(&self) -> Result<Vec<GraphSourceRecord>> {
+            Ok(vec![])
+        }
+    }
+    #[async_trait]
+    impl StatusLookup for RefOnlyNs {
+        async fn get_status(&self, _: &str) -> Result<Option<StatusValue>> {
+            Ok(None)
+        }
+    }
+    #[async_trait]
+    impl ConfigLookup for RefOnlyNs {
+        async fn get_config(&self, _: &str) -> Result<Option<ConfigValue>> {
+            Ok(None)
+        }
+    }
+    #[async_trait]
+    impl NameServiceLookup for RefOnlyNs {
+        async fn lookup(&self, _: &str) -> Result<Option<NsRecord>> {
+            Ok(None)
+        }
+        async fn all_records(&self) -> Result<Vec<NsRecord>> {
+            Ok(vec![])
+        }
+    }
+
+    #[tokio::test]
+    async fn heads_default_composes_get_ref() {
+        let heads = RefOnlyNs.heads("db:main").await.unwrap().unwrap();
+        assert_eq!(heads.commit.t, 7);
+        assert_eq!(heads.index, RefValue { id: None, t: 0 });
+        assert_eq!(RefOnlyNs.heads("other:main").await.unwrap(), None);
+        let snap = NsRecordSnapshot::from(&heads);
+        assert_eq!((snap.commit_t, snap.index_t), (7, 0));
     }
 }

--- a/fluree-db-nameservice/src/memory.rs
+++ b/fluree-db-nameservice/src/memory.rs
@@ -120,6 +120,15 @@ impl crate::NameServiceLookup for MemoryNameService {
             .cloned()
             .collect())
     }
+
+    async fn heads(&self, ledger_id: &str) -> Result<Option<crate::LedgerHeads>> {
+        let key = self.normalize_ledger_id(ledger_id);
+        Ok(self
+            .records
+            .read()
+            .get(&key)
+            .map(crate::LedgerHeads::from_record))
+    }
 }
 
 #[async_trait]
@@ -735,6 +744,27 @@ mod tests {
 
     fn test_index_id(label: &str) -> ContentId {
         ContentId::new(ContentKind::IndexRoot, label.as_bytes())
+    }
+
+    #[tokio::test]
+    async fn test_memory_ns_heads() {
+        let ns = MemoryNameService::new();
+        assert_eq!(ns.heads("mydb:main").await.unwrap(), None);
+
+        ns.publish_commit("mydb:main", 2, &test_commit_id("c2"))
+            .await
+            .unwrap();
+        ns.publish_index("mydb:main", 1, &test_index_id("i1"))
+            .await
+            .unwrap();
+
+        let heads = ns.heads("mydb:main").await.unwrap().unwrap();
+        assert_eq!(heads.commit.id, Some(test_commit_id("c2")));
+        assert_eq!(heads.commit.t, 2);
+        assert_eq!(heads.index.id, Some(test_index_id("i1")));
+        assert_eq!(heads.index.t, 1);
+        let record = ns.lookup("mydb:main").await.unwrap().unwrap();
+        assert_eq!(heads, crate::LedgerHeads::from_record(&record));
     }
 
     #[tokio::test]

--- a/fluree-db-nameservice/src/mount.rs
+++ b/fluree-db-nameservice/src/mount.rs
@@ -22,9 +22,10 @@
 use crate::{
     AdminPublisher, BranchLifecycle, CasResult, CommitPublisher, ConfigCasResult, ConfigLookup,
     ConfigPublisher, ConfigValue, GraphSourceLookup, GraphSourcePublisher, GraphSourceRecord,
-    GraphSourceType, IndexPublisher, LedgerLifecycle, NameServiceError, NameServiceLookup,
-    NameServicePublisher, NsLookupResult, NsRecord, NsRecordSnapshot, RefKind, RefLookup,
-    RefPublisher, RefValue, Result, StatusCasResult, StatusLookup, StatusPublisher, StatusValue,
+    GraphSourceType, IndexPublisher, LedgerHeads, LedgerLifecycle, NameServiceError,
+    NameServiceLookup, NameServicePublisher, NsLookupResult, NsRecord, NsRecordSnapshot, RefKind,
+    RefLookup, RefPublisher, RefValue, Result, StatusCasResult, StatusLookup, StatusPublisher,
+    StatusValue,
 };
 use async_trait::async_trait;
 use fluree_db_core::ContentId;
@@ -185,6 +186,13 @@ impl NameServiceLookup for CompositeNameService {
                 .map(|r| mount.localize_record(r))
                 .collect()),
             None => self.local.list_branches(ledger_name).await,
+        }
+    }
+
+    async fn heads(&self, ledger_id: &str) -> Result<Option<LedgerHeads>> {
+        match self.mount_for(ledger_id) {
+            Some((mount, remote)) => mount.lookup.heads(remote).await,
+            None => self.local.heads(ledger_id).await,
         }
     }
 }

--- a/fluree-db-nameservice/src/notifying.rs
+++ b/fluree-db-nameservice/src/notifying.rs
@@ -12,10 +12,10 @@ use fluree_db_core::ContentId;
 use crate::{
     event_bus::LedgerEventBus, AdminPublisher, BranchLifecycle, CasResult, CommitPublisher,
     ConfigCasResult, ConfigLookup, ConfigPublisher, ConfigValue, GraphSourceLookup,
-    GraphSourcePublisher, GraphSourceRecord, GraphSourceType, IndexPublisher, LedgerLifecycle,
-    NameServiceEvent, NameServiceLookup, NsLookupResult, NsRecord, NsRecordSnapshot, RefKind,
-    RefLookup, RefPublisher, RefValue, Result, StatusCasResult, StatusLookup, StatusPublisher,
-    StatusValue, Subscription, SubscriptionScope,
+    GraphSourcePublisher, GraphSourceRecord, GraphSourceType, IndexPublisher, LedgerHeads,
+    LedgerLifecycle, NameServiceEvent, NameServiceLookup, NsLookupResult, NsRecord,
+    NsRecordSnapshot, RefKind, RefLookup, RefPublisher, RefValue, Result, StatusCasResult,
+    StatusLookup, StatusPublisher, StatusValue, Subscription, SubscriptionScope,
 };
 
 /// Decorator that wraps a nameservice and emits events on a [`LedgerEventBus`]
@@ -80,6 +80,10 @@ where
 
     async fn list_branches(&self, ledger_name: &str) -> Result<Vec<NsRecord>> {
         self.inner.list_branches(ledger_name).await
+    }
+
+    async fn heads(&self, ledger_id: &str) -> Result<Option<LedgerHeads>> {
+        self.inner.heads(ledger_id).await
     }
 }
 

--- a/fluree-db-nameservice/src/ns_format.rs
+++ b/fluree-db-nameservice/src/ns_format.rs
@@ -6,7 +6,8 @@
 //! so they are defined once here to ensure consistency.
 
 use crate::{
-    is_zero, parse_default_context_value, ConfigPayload, ConfigValue, StatusPayload, StatusValue,
+    is_zero, parse_default_context_value, ConfigPayload, ConfigValue, LedgerHeads, RefValue,
+    StatusPayload, StatusValue,
 };
 use fluree_db_core::ContentId;
 use serde::{Deserialize, Serialize};
@@ -172,6 +173,32 @@ impl NsFileV2 {
             cid: Some(id.to_string()),
             t: snapshot.index_t,
         });
+    }
+}
+
+/// Head pointers from a main ns@v2 file plus its optional index-only file,
+/// using the read-time merge rule shared by `load_record`: the separate
+/// index file wins when its `t` is equal or higher.
+pub(crate) fn merge_heads(main: &NsFileV2, index_file: Option<&NsIndexFileV2>) -> LedgerHeads {
+    let parse = |s: Option<&str>| s.and_then(|s| s.parse::<ContentId>().ok());
+    let mut index = RefValue {
+        id: parse(main.index.as_ref().and_then(|i| i.cid.as_deref())),
+        t: main.index.as_ref().map(|i| i.t).unwrap_or(0),
+    };
+    if let Some(f) = index_file {
+        if f.index.t >= index.t {
+            index = RefValue {
+                id: parse(f.index.cid.as_deref()),
+                t: f.index.t,
+            };
+        }
+    }
+    LedgerHeads {
+        commit: RefValue {
+            id: parse(main.commit_cid.as_deref()),
+            t: main.t,
+        },
+        index,
     }
 }
 

--- a/fluree-db-nameservice/src/ns_format.rs
+++ b/fluree-db-nameservice/src/ns_format.rs
@@ -241,3 +241,95 @@ pub(crate) struct BranchPointRef {
     #[serde(rename = "f:t")]
     pub t: i64,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_db_core::ContentKind;
+
+    fn cid(label: &str) -> ContentId {
+        ContentId::new(ContentKind::IndexRoot, label.as_bytes())
+    }
+
+    fn main_file(inline_index: Option<IndexRef>) -> NsFileV2 {
+        NsFileV2 {
+            context: ns_context(),
+            id: "mydb:main".to_string(),
+            record_type: vec!["f:LedgerSource".to_string()],
+            ledger: LedgerRef {
+                id: "mydb".to_string(),
+            },
+            branch: "main".to_string(),
+            commit_cid: Some(ContentId::new(ContentKind::Commit, b"c").to_string()),
+            t: 9,
+            index: inline_index,
+            status: "ready".to_string(),
+            default_context_cid: None,
+            status_v: None,
+            status_meta: None,
+            config_v: None,
+            config_meta: None,
+            config_cid: None,
+            source_branch: None,
+            branch_point: None,
+            branches: 0,
+        }
+    }
+
+    fn index_file(c: &ContentId, t: i64) -> NsIndexFileV2 {
+        NsIndexFileV2 {
+            context: ns_context(),
+            index: IndexRef {
+                cid: Some(c.to_string()),
+                t,
+            },
+        }
+    }
+
+    /// The separate index file wins at EQUAL `t`, not only when strictly
+    /// higher — `load_record` uses `>=` and `merge_heads` claims to match it
+    /// byte for byte. Flipping the comparison to `>` passes every other test
+    /// in this crate, so this is the only thing pinning the boundary.
+    #[test]
+    fn merge_heads_index_file_wins_at_equal_t() {
+        let inline = IndexRef {
+            cid: Some(cid("inline").to_string()),
+            t: 5,
+        };
+        let separate = index_file(&cid("separate"), 5);
+
+        let heads = merge_heads(&main_file(Some(inline)), Some(&separate));
+        assert_eq!(heads.index.t, 5);
+        assert_eq!(
+            heads.index.id,
+            Some(cid("separate")),
+            "at equal t the separate index file must win, matching load_record"
+        );
+    }
+
+    #[test]
+    fn merge_heads_keeps_the_higher_t_either_way() {
+        let inline = IndexRef {
+            cid: Some(cid("inline").to_string()),
+            t: 7,
+        };
+        // Stale separate file: the inline index is ahead and must survive.
+        let heads = merge_heads(
+            &main_file(Some(inline.clone())),
+            Some(&index_file(&cid("separate"), 3)),
+        );
+        assert_eq!((heads.index.id, heads.index.t), (Some(cid("inline")), 7));
+
+        // Separate file ahead: it wins.
+        let heads = merge_heads(
+            &main_file(Some(inline)),
+            Some(&index_file(&cid("separate"), 11)),
+        );
+        assert_eq!((heads.index.id, heads.index.t), (Some(cid("separate")), 11));
+
+        // No separate file at all, and no inline index at all.
+        let heads = merge_heads(&main_file(None), None);
+        assert_eq!(heads.index, RefValue { id: None, t: 0 });
+        assert_eq!(heads.commit.t, 9);
+    }
+}

--- a/fluree-db-nameservice/src/storage_ns.rs
+++ b/fluree-db-nameservice/src/storage_ns.rs
@@ -18,15 +18,16 @@
 //! Under contention, operations will retry with exponential backoff.
 
 use crate::ns_format::{
-    ns_context, BranchPointRef, IndexRef, LedgerRef, NsFileV2, NsIndexFileV2, NS_VERSION,
+    merge_heads, ns_context, BranchPointRef, IndexRef, LedgerRef, NsFileV2, NsIndexFileV2,
+    NS_VERSION,
 };
 use crate::{
     deserialize_json, parse_default_context_value, serialize_json, AdminPublisher, BranchLifecycle,
     CasResult, CommitPublisher, ConfigCasResult, ConfigLookup, ConfigPublisher, ConfigValue,
     GraphSourceLookup, GraphSourcePublisher, GraphSourceRecord, GraphSourceType, IndexPublisher,
-    LedgerLifecycle, NameServiceError, NameServiceLookup, NsLookupResult, NsRecord, RefKind,
-    RefLookup, RefPublisher, RefValue, Result, StatusCasResult, StatusLookup, StatusPublisher,
-    StatusValue,
+    LedgerHeads, LedgerLifecycle, NameServiceError, NameServiceLookup, NsLookupResult, NsRecord,
+    RefKind, RefLookup, RefPublisher, RefValue, Result, StatusCasResult, StatusLookup,
+    StatusPublisher, StatusValue,
 };
 use async_trait::async_trait;
 use fluree_db_core::ledger_id::{format_ledger_id, normalize_ledger_id, split_ledger_id};
@@ -326,6 +327,28 @@ where
         }
     }
 
+    /// Head pointers only: same keys and merge rule as `load_record`, minus
+    /// the config/context/status fields.
+    async fn load_heads(&self, ledger_name: &str, branch: &str) -> Result<Option<LedgerHeads>> {
+        let main_key = self.ns_key(ledger_name, branch);
+        let main_bytes = match self.storage.read_bytes(&main_key).await {
+            Ok(bytes) => bytes,
+            Err(CoreError::NotFound(_)) => return Ok(None),
+            Err(e) => {
+                return Err(NameServiceError::storage(format!(
+                    "Failed to read {main_key}: {e}"
+                )))
+            }
+        };
+        if Self::is_graph_source_from_bytes(&main_bytes) {
+            return Ok(None);
+        }
+        let main: NsFileV2 = serde_json::from_slice(&main_bytes)?;
+        let index_file: Option<NsIndexFileV2> =
+            self.read_json(&self.index_key(ledger_name, branch)).await?;
+        Ok(Some(merge_heads(&main, index_file.as_ref())))
+    }
+
     /// Load and merge main record with index file
     async fn load_record(&self, ledger_name: &str, branch: &str) -> Result<Option<NsRecord>> {
         let main_key = self.ns_key(ledger_name, branch);
@@ -497,6 +520,11 @@ where
         // A graph-source record is not a ledger (#1369). `load_record` reports it
         // as Ok(None) so the caller can fall back to the graph-source path.
         self.load_record(&ledger_name, &branch).await
+    }
+
+    async fn heads(&self, ledger_id: &str) -> Result<Option<LedgerHeads>> {
+        let (ledger_name, branch) = split_ledger_id(ledger_id)?;
+        self.load_heads(&ledger_name, &branch).await
     }
 
     async fn list_branches(&self, ledger_name: &str) -> Result<Vec<NsRecord>> {
@@ -2273,6 +2301,26 @@ mod tests {
             .unwrap();
         assert_eq!(index.id, Some(dummy_cid("index-1")));
         assert_eq!(index.t, 3);
+    }
+
+    #[tokio::test]
+    async fn test_storage_heads_matches_lookup() {
+        let ns = make_storage_ns();
+        assert_eq!(ns.heads("mydb:main").await.unwrap(), None);
+
+        publish_commit(&ns, "mydb:main", 5, &dummy_cid("commit-1")).await;
+        let heads = ns.heads("mydb:main").await.unwrap().unwrap();
+        assert_eq!(heads.commit.t, 5);
+        assert_eq!(heads.index, RefValue { id: None, t: 0 });
+
+        ns.publish_index("mydb:main", 3, &dummy_cid("index-1"))
+            .await
+            .unwrap();
+        let heads = ns.heads("mydb:main").await.unwrap().unwrap();
+        let record = ns.lookup("mydb:main").await.unwrap().unwrap();
+        assert_eq!(heads, LedgerHeads::from_record(&record));
+        assert_eq!(heads.index.id, Some(dummy_cid("index-1")));
+        assert_eq!(heads.index.t, 3);
     }
 
     #[tokio::test]

--- a/fluree-db-storage-aws/src/dynamodb/mod.rs
+++ b/fluree-db-storage-aws/src/dynamodb/mod.rs
@@ -24,9 +24,10 @@ use fluree_db_core::ContentId;
 use fluree_db_nameservice::{
     AdminPublisher, BranchLifecycle, CasResult, CommitPublisher, ConfigCasResult, ConfigLookup,
     ConfigPayload, ConfigPublisher, ConfigValue, GraphSourceLookup, GraphSourcePublisher,
-    GraphSourceRecord, GraphSourceType, IndexPublisher, LedgerLifecycle, NameServiceError,
-    NameServiceLookup, NsLookupResult, NsRecord, RefKind, RefLookup, RefPublisher, RefValue,
-    StatusCasResult, StatusLookup, StatusPayload, StatusPublisher, StatusValue,
+    GraphSourceRecord, GraphSourceType, IndexPublisher, LedgerHeads, LedgerLifecycle,
+    NameServiceError, NameServiceLookup, NsLookupResult, NsRecord, RefKind, RefLookup,
+    RefPublisher, RefValue, StatusCasResult, StatusLookup, StatusPayload, StatusPublisher,
+    StatusValue,
 };
 use schema::*;
 use std::collections::HashMap;
@@ -597,6 +598,61 @@ impl fluree_db_nameservice::NameServiceLookup for DynamoDbNameService {
         let pk = Self::normalize(ledger_id);
         let items = self.query_metadata_items(&pk).await?;
         Ok(Self::items_to_ns_record(&pk, &items))
+    }
+
+    /// One consistent Query over the `head..=index` sort-key range, projected
+    /// to the four ref attributes — a single round trip and a single RCU,
+    /// versus a GetItem per ref or the full 4-item `lookup` query.
+    async fn heads(
+        &self,
+        ledger_id: &str,
+    ) -> std::result::Result<Option<LedgerHeads>, NameServiceError> {
+        let pk = Self::normalize(ledger_id);
+        let response = self
+            .client
+            .query()
+            .table_name(&self.table_name)
+            .key_condition_expression("#pk = :pk AND #sk BETWEEN :head AND :index")
+            .projection_expression("#sk, #cid, #ct, #iid, #it")
+            .expression_attribute_names("#pk", ATTR_PK)
+            .expression_attribute_names("#sk", ATTR_SK)
+            .expression_attribute_names("#cid", ATTR_COMMIT_ID)
+            .expression_attribute_names("#ct", ATTR_COMMIT_T)
+            .expression_attribute_names("#iid", ATTR_INDEX_ID)
+            .expression_attribute_names("#it", ATTR_INDEX_T)
+            .expression_attribute_values(":pk", AttributeValue::S(pk.clone()))
+            .expression_attribute_values(":head", AttributeValue::S(SK_HEAD.to_string()))
+            .expression_attribute_values(":index", AttributeValue::S(SK_INDEX.to_string()))
+            .consistent_read(true)
+            .send()
+            .await
+            .map_err(|e| NameServiceError::storage(format!("DynamoDB Query failed: {e}")))?;
+
+        let items = response.items();
+        let ref_from = |sk: &str, id_attr: &str, t_attr: &str| {
+            Self::find_item_by_sk(items, sk).map(|item| RefValue {
+                id: item
+                    .get(id_attr)
+                    .and_then(|v| v.as_s().ok())
+                    .and_then(|s| s.parse::<ContentId>().ok()),
+                t: item
+                    .get(t_attr)
+                    .and_then(|v| v.as_n().ok())
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0),
+            })
+        };
+        let commit = ref_from(SK_HEAD, ATTR_COMMIT_ID, ATTR_COMMIT_T);
+        let index = ref_from(SK_INDEX, ATTR_INDEX_ID, ATTR_INDEX_T);
+        // No ref items at all: unborn (meta exists) or unknown — same rule as `get_ref`.
+        if commit.is_none() && index.is_none() && !self.meta_exists(&pk).await? {
+            return Ok(None);
+        }
+        let unborn = || RefValue { id: None, t: 0 };
+        Ok(Some(LedgerHeads {
+            commit: commit.unwrap_or_else(unborn),
+            index: index.unwrap_or_else(unborn),
+        }))
     }
 
     async fn all_records(&self) -> std::result::Result<Vec<NsRecord>, NameServiceError> {

--- a/fluree-db-storage-aws/src/dynamodb/schema.rs
+++ b/fluree-db-storage-aws/src/dynamodb/schema.rs
@@ -41,6 +41,11 @@ pub const SK_META: &str = "meta";
 pub const SK_HEAD: &str = "head";
 pub const SK_INDEX: &str = "index";
 pub const SK_CONFIG: &str = "config";
+// NOTE: `NameServiceLookup::heads` range-scans `SK_HEAD..=SK_INDEX` to fetch
+// both ref items in one Query. A new sort key landing lexically between them
+// is read and discarded (`find_item_by_sk` matches exactly, so the result
+// cannot be corrupted) — but it costs RCU on every head read. Keep new keys
+// outside that range where practical.
 pub const SK_STATUS: &str = "status";
 
 // ── Meta item attributes ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

External callers (e.g. a Lambda query backend over DynamoDB, or a standalone deployment over the file nameservice) want the cheapest possible "where is this ledger" read without depending on which backend is configured. `lookup()` returns the full `NsRecord` — on DynamoDB that is a 4-item query plus record assembly; on file/S3 it is main + index file plus config/context/status parsing.

This adds a middle read depth on `NameServiceLookup`, so every backend now offers three levels behind the same `&dyn NameServiceLookup`:

| Call | Returns | Cost |
|------|---------|------|
| `get_ref(id, RefKind)` | `RefValue { id, t }` | one head (already existed) |
| **`heads(id)`** | `LedgerHeads { commit, index }` | both heads, one round trip where the backend allows |
| `lookup(id)` | full `NsRecord` | everything |

## Changes

- `LedgerHeads { commit: RefValue, index: RefValue }` + `NameServiceLookup::heads(ledger_id)`, default-implemented over two `get_ref` calls. `From<&LedgerHeads> for NsRecordSnapshot` so rollback capture can use it.
- Single-read overrides:
  - **DynamoDB** — one consistent `Query` over `sk BETWEEN head AND index`, projected to the four ref attributes (1 RCU vs two GetItems or the 4-item lookup query).
  - **File / StorageNameService** — main + index file via a shared `ns_format::merge_heads` (same read-time merge rule as `load_record`, graph-source guard preserved).
  - **Memory / Raft** — one lock; Raft tombstones retracted branches the same way `get_ref` does.
  - Forwarding in `NotifyingNameService`, `CompositeNameService`, `Arc<T>`, and api's `NameServiceMode`.
- `ProxyNameService::get_ref` was an `Err("not supported")` stub; it and `heads` now project `lookup()` (still one HTTP round trip), so the proxy backend honors the full read surface.
- Docs: `docs/concepts/ledgers-and-nameservice.md` gains the read-depth table.

## Semantics

`None` from `heads` follows `get_ref` on the same backend: unknown ledger, and on Raft also retracted. Only `lookup` surfaces `retracted: true`. The two refs are read together but not atomically on file backends, so `index.t > commit.t` remains a transient state callers must tolerate — same as `NsRecord`.

## Testing

- Unit tests for the trait default, Memory, File (unknown / graph-source → `None`; merge agrees with `lookup` and `get_ref`), StorageNameService, Raft.
- `heads()` assertions added to the LocalStack test `nameservice_ref_publisher` in `fluree-db-connection/tests/aws_testcontainers_test.rs` (requires Docker; `--features aws-testcontainers`).
- `cargo clippy --all --all-features --all-targets -- -D warnings` clean.