### PR TITLE
perf: make filtered-DELETE list-meta hydration O(novelty), not O(retractions × novelty)

### DIFF
--- a/docs/design/index-format.md
+++ b/docs/design/index-format.md
@@ -110,6 +110,16 @@ Key properties:
   materializing simple string values during `ORDER BY` comparisons. This flag must be cleared on the first
   post-import write because incremental dictionary appends break the invariant.
   When the flag is absent (older roots) or false, query execution must assume no lexical ordering.
+- **Header flag bytes.** Byte 5 carries section/feature flags (`HAS_STATS`, `HAS_ANNOTATIONS`,
+  `HAS_ANNOTATION_INDEX`, …). Byte 6 is the *extended-flags* byte (low byte of the historically-zero
+  `pad(2)` field; legacy roots wrote `0`):
+  - bit 0 `HAD_ANNOTATION_ARENA` — sticky, see `docs/design/edge-annotations.md`.
+  - bit 1 `LIST_META_TRACKED` + bit 2 `HAS_LIST_META` — three-state `IndexRoot.has_list_meta:
+    Option<bool>`. `Some(false)` (tracked, clear) means the indexer observed every row and none carries
+    an RDF-list position (`o_i == LIST_INDEX_NONE`); filtered-DELETE staging then skips its
+    per-retraction list-meta hydration when novelty agrees. `Some(true)` is sticky. A zero byte decodes
+    to `None` (untracked — legacy roots, bulk import) and consumers must assume lists may exist; a full
+    rebuild, or any incremental pass that sees a list row, moves the root out of that state.
 
 At a high level the root contains:
 

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -448,3 +448,8 @@ harness = false
 [[bench]]
 name = "annotation_planner"
 harness = false
+
+[[test]]
+name = "it_filtered_delete_list_meta"
+path = "tests/it_filtered_delete_list_meta.rs"
+required-features = ["native"]

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -6831,6 +6831,10 @@ where
             // later defensive drop carries the sticky bit forward
             // and stays out of the bootstrap path.
             had_annotation_arena: false,
+            // Bulk import does not observe list positions at root
+            // assembly; leave the flag untracked so the write path keeps
+            // hydrating until the first full rebuild records it exactly.
+            has_list_meta: None,
             ns_split_mode: input.ns_split_mode,
         };
 

--- a/fluree-db-api/src/ledger_manager.rs
+++ b/fluree-db-api/src/ledger_manager.rs
@@ -451,6 +451,7 @@ impl LedgerHandle {
             has_annotations: root.has_annotations,
             annotation_index: root.annotation_index.clone(),
             had_annotation_arena: root.had_annotation_arena,
+            has_list_meta: root.has_list_meta,
         };
         let db = LedgerSnapshot::new_meta(meta)
             .map_err(|e| ApiError::internal(format!("graph registry from root: {e}")))?;

--- a/fluree-db-api/tests/it_filtered_delete_list_meta.rs
+++ b/fluree-db-api/tests/it_filtered_delete_list_meta.rs
@@ -1,0 +1,229 @@
+//! Filtered-DELETE list-meta hydration against the `has_list_meta` flag.
+//!
+//! A `WHERE { ?s p ?o } DELETE { ?s p ?o }` retraction carries no list
+//! position, so staging copies `m.i` from the currently-asserted flake
+//! before the accumulator dedups. That lookup used to cost a full overlay
+//! walk per retracted (subject, predicate) — quadratic in retractions ×
+//! novelty (a 40k-retraction delete over a novelty-heavy ledger never
+//! finished). Now:
+//!
+//! 1. ledgers whose index root AND novelty report no `@list` rows skip the
+//!    lookup entirely (`IndexRoot.has_list_meta == Some(false)`), and
+//! 2. ledgers with lists resolve every group from one overlay walk plus a
+//!    base-only seek per group, merged with the same lifecycle rule
+//!    `range_with_overlay` applies.
+//!
+//! These pin the flag's three states through a real index build and the
+//! list-retraction semantics on the merged path.
+
+#![cfg(feature = "native")]
+
+mod support;
+use crate::support::{
+    query_jsonld_formatted, start_background_indexer_local, trigger_index_and_wait_outcome,
+};
+use fluree_db_api::{CommitOpts, FlureeBuilder, IndexConfig, TxnOpts};
+use serde_json::json;
+
+fn ctx() -> serde_json::Value {
+    json!({"ex": "http://example.org/ns/"})
+}
+
+/// Novelty never indexed: `reindex_min_bytes` is unreachable so the
+/// background worker only runs on explicit triggers.
+fn index_cfg() -> IndexConfig {
+    IndexConfig {
+        reindex_min_bytes: 1 << 40,
+        reindex_max_bytes: 1 << 41,
+    }
+}
+
+async fn count(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &fluree_db_api::LedgerState,
+    pred: &str,
+) -> usize {
+    let q = json!({
+        "@context": ctx(),
+        "select": ["?s", "?o"],
+        "where": {"@id": "?s", pred: "?o"}
+    });
+    query_jsonld_formatted(fluree, ledger, &q)
+        .await
+        .expect("count query")
+        .as_array()
+        .map(Vec::len)
+        .unwrap_or(0)
+}
+
+async fn list_values(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &fluree_db_api::LedgerState,
+    subject: &str,
+) -> Vec<String> {
+    let q = json!({
+        "@context": ctx(),
+        "select": {"?s": ["ex:items"]},
+        "where": {"@id": "?s"},
+        "values": ["?s", [{"@id": subject}]]
+    });
+    let rows = query_jsonld_formatted(fluree, ledger, &q)
+        .await
+        .expect("list query");
+    rows.as_array()
+        .and_then(|a| a.first())
+        .and_then(|node| node.get("ex:items"))
+        .map(|v| match v {
+            serde_json::Value::Array(items) => items
+                .iter()
+                .filter_map(|x| x.as_str().map(str::to_string))
+                .collect(),
+            serde_json::Value::String(s) => vec![s.clone()],
+            _ => vec![],
+        })
+        .unwrap_or_default()
+}
+
+/// No `@list` anywhere: the indexed root records `Some(false)`, novelty
+/// stays `false`, and a predicate-wide filtered delete spanning base rows
+/// and novelty-only rows still retracts everything (the skip path must not
+/// drop retractions).
+#[tokio::test]
+async fn no_list_ledger_records_flag_and_deletes_cleanly() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mut fluree = FlureeBuilder::file(tmp.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/list-meta-none:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+            assert_eq!(ledger.snapshot.has_list_meta, Some(false), "empty snapshot is exact");
+
+            let batch = |from: usize, to: usize| {
+                let graph: Vec<_> = (from..to)
+                    .map(|n| json!({"@id": format!("ex:r{n}"), "ex:created": format!("2024-01-{:02}", n % 28 + 1), "ex:name": format!("r{n}")}))
+                    .collect();
+                json!({"@context": ctx(), "@graph": graph})
+            };
+            let r = fluree
+                .upsert_with_opts(ledger, &batch(0, 300), TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            trigger_index_and_wait_outcome(&handle, ledger_id, r.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(ledger.snapshot.range_provider.is_some());
+            assert_eq!(ledger.snapshot.has_list_meta, Some(false), "full build observed no list rows");
+            assert!(!ledger.novelty.has_list_meta);
+
+            // Novelty-only subjects on top of the indexed base.
+            let _ = fluree
+                .upsert_with_opts(ledger, &batch(300, 600), TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(!ledger.novelty.has_list_meta);
+            assert_eq!(count(&fluree, &ledger, "ex:created").await, 600);
+
+            let del = json!({
+                "@context": ctx(),
+                "where": [{"@id": "?s", "ex:created": "?d"}],
+                "delete": [{"@id": "?s", "ex:created": "?d"}]
+            });
+            let r = fluree
+                .update_with_opts(ledger, &del, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 600);
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(count(&fluree, &ledger, "ex:created").await, 0);
+            assert_eq!(count(&fluree, &ledger, "ex:name").await, 600, "unrelated predicate untouched");
+        })
+        .await;
+}
+
+/// `@list` rows in the base AND in novelty: the root records `Some(true)`
+/// after indexing, novelty flips its bit on the first list commit, and a
+/// filtered delete of one value removes exactly one positional entry per
+/// WHERE binding — for a base-indexed list, a novelty-only list, and a
+/// base list whose entry was re-asserted in novelty.
+#[tokio::test]
+async fn list_ledger_hydrates_positions_across_base_and_novelty() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mut fluree = FlureeBuilder::file(tmp.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/list-meta-some:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            // Base: two lists, plus filler subjects so the delete's WHERE
+            // spans many (s,p) groups.
+            let mut graph = vec![
+                json!({"@id": "ex:base1", "ex:items": {"@list": ["a", "b", "c"]}}),
+                json!({"@id": "ex:base2", "ex:items": {"@list": ["b", "b", "d"]}}),
+            ];
+            graph.extend((0..200).map(|n| json!({"@id": format!("ex:f{n}"), "ex:items": {"@list": ["b"]}})));
+            let r = fluree
+                .insert_with_opts(ledger, &json!({"@context": ctx(), "@graph": graph}), TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(ledger.novelty.has_list_meta, "novelty saw a list position");
+            trigger_index_and_wait_outcome(&handle, ledger_id, r.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(ledger.snapshot.has_list_meta, Some(true), "full build observed list rows");
+
+            // Novelty: a new list subject, and a second commit that retracts
+            // `ex:base2`'s middle entry so the merged view must drop it.
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:nov1", "ex:items": {"@list": ["b", "e"]}}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(list_values(&fluree, &ledger, "ex:base1").await, vec!["a", "b", "c"]);
+            assert_eq!(list_values(&fluree, &ledger, "ex:nov1").await, vec!["b", "e"]);
+
+            // Delete every "b" everywhere. Each (subject, "b") binding must
+            // remove exactly one positional entry: base1 loses its b, base2
+            // keeps one of its two b's (one binding → one entry), nov1 loses
+            // its b, every filler empties.
+            let del = json!({
+                "@context": ctx(),
+                "where": [{"@id": "?s", "ex:items": "b"}],
+                "delete": [{"@id": "?s", "ex:items": "b"}]
+            });
+            let r = fluree
+                .update_with_opts(ledger, &del, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 203, "base1 + base2 + nov1 + 200 fillers");
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(list_values(&fluree, &ledger, "ex:base1").await, vec!["a", "c"]);
+            assert_eq!(list_values(&fluree, &ledger, "ex:base2").await, vec!["b", "d"]);
+            assert_eq!(list_values(&fluree, &ledger, "ex:nov1").await, vec!["e"]);
+            assert_eq!(list_values(&fluree, &ledger, "ex:f7").await, Vec::<String>::new());
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_filtered_delete_list_meta.rs
+++ b/fluree-db-api/tests/it_filtered_delete_list_meta.rs
@@ -61,25 +61,45 @@ async fn list_values(
     ledger: &fluree_db_api::LedgerState,
     subject: &str,
 ) -> Vec<String> {
+    list_items(fluree, ledger, subject, "ex:items").await
+}
+
+/// Items of `subject`'s `pred` list; language-tagged entries render as
+/// `value@lang` so two tags on the same lexical form stay distinguishable.
+async fn list_items(
+    fluree: &fluree_db_api::Fluree,
+    ledger: &fluree_db_api::LedgerState,
+    subject: &str,
+    pred: &str,
+) -> Vec<String> {
     let q = json!({
         "@context": ctx(),
-        "select": {"?s": ["ex:items"]},
+        "select": {"?s": [pred]},
         "where": {"@id": "?s"},
         "values": ["?s", [{"@id": subject}]]
     });
     let rows = query_jsonld_formatted(fluree, ledger, &q)
         .await
         .expect("list query");
+    let render = |v: &serde_json::Value| -> Option<String> {
+        match v {
+            serde_json::Value::String(s) => Some(s.clone()),
+            serde_json::Value::Object(o) => {
+                let val = o.get("@value")?.as_str()?;
+                Some(match o.get("@language").and_then(|l| l.as_str()) {
+                    Some(lang) => format!("{val}@{lang}"),
+                    None => val.to_string(),
+                })
+            }
+            _ => None,
+        }
+    };
     rows.as_array()
         .and_then(|a| a.first())
-        .and_then(|node| node.get("ex:items"))
+        .and_then(|node| node.get(pred))
         .map(|v| match v {
-            serde_json::Value::Array(items) => items
-                .iter()
-                .filter_map(|x| x.as_str().map(str::to_string))
-                .collect(),
-            serde_json::Value::String(s) => vec![s.clone()],
-            _ => vec![],
+            serde_json::Value::Array(items) => items.iter().filter_map(render).collect(),
+            other => render(other).into_iter().collect(),
         })
         .unwrap_or_default()
 }
@@ -153,7 +173,7 @@ async fn no_list_ledger_records_flag_and_deletes_cleanly() {
 /// after indexing, novelty flips its bit on the first list commit, and a
 /// filtered delete of one value removes exactly one positional entry per
 /// WHERE binding — for a base-indexed list, a novelty-only list, and a
-/// base list whose entry was re-asserted in novelty.
+/// base list with an entry retracted and re-asserted in novelty.
 #[tokio::test]
 async fn list_ledger_hydrates_positions_across_base_and_novelty() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -202,6 +222,36 @@ async fn list_ledger_hydrates_positions_across_base_and_novelty() {
                 .await
                 .unwrap();
             let ledger = fluree.ledger(ledger_id).await.unwrap();
+
+            // Lifecycle over the base: retract `ex:base2`'s trailing "d"
+            // (a novelty retract of a base-indexed list row), then re-assert
+            // the whole list so "d" comes back at position 2 as a novelty
+            // assert. The merged base+overlay view must resolve that fact
+            // key to its newest op (live) when hydrating below.
+            let retract_d = json!({
+                "@context": ctx(),
+                "where": [{"@id": "ex:base2", "ex:items": "d"}],
+                "delete": [{"@id": "ex:base2", "ex:items": "d"}]
+            });
+            let r = fluree
+                .update_with_opts(ledger, &retract_d, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 1);
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(list_values(&fluree, &ledger, "ex:base2").await, vec!["b", "b"]);
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:base2", "ex:items": {"@list": ["b", "b", "d"]}}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(list_values(&fluree, &ledger, "ex:base2").await, vec!["b", "b", "d"]);
             assert_eq!(list_values(&fluree, &ledger, "ex:base1").await, vec!["a", "b", "c"]);
             assert_eq!(list_values(&fluree, &ledger, "ex:nov1").await, vec!["b", "e"]);
 
@@ -224,6 +274,98 @@ async fn list_ledger_hydrates_positions_across_base_and_novelty() {
             assert_eq!(list_values(&fluree, &ledger, "ex:base2").await, vec!["b", "d"]);
             assert_eq!(list_values(&fluree, &ledger, "ex:nov1").await, vec!["e"]);
             assert_eq!(list_values(&fluree, &ledger, "ex:f7").await, Vec::<String>::new());
+        })
+        .await;
+}
+
+/// Language-tagged list entries carry `m = { lang, i }`. A retraction bound
+/// from a tagged value arrives with `{ lang, i: None }` and must still get
+/// its position hydrated — and from the candidate with the SAME tag, so
+/// identical lexical forms under different languages are not confused.
+#[tokio::test]
+async fn language_tagged_list_entries_hydrate_by_tag() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mut fluree = FlureeBuilder::file(tmp.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/list-meta-lang:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            let labels = |id: &str| {
+                json!({"@id": id, "ex:labels": {"@list": [
+                    {"@value": "b", "@language": "en"},
+                    {"@value": "b", "@language": "fr"},
+                    {"@value": "c", "@language": "en"}
+                ]}})
+            };
+            // `ex:base` is indexed; `ex:nov` lives only in novelty.
+            let r = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@graph": [labels("ex:base")]}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            trigger_index_and_wait_outcome(&handle, ledger_id, r.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(ledger.snapshot.has_list_meta, Some(true));
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@graph": [labels("ex:nov")]}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            for id in ["ex:base", "ex:nov"] {
+                assert_eq!(
+                    list_items(&fluree, &ledger, id, "ex:labels").await,
+                    vec!["b@en", "b@fr", "c@en"]
+                );
+            }
+
+            // Delete only the French "b". The English "b" shares its lexical
+            // form and datatype; matching on language must pick position 1,
+            // not position 0.
+            let del = json!({
+                "@context": ctx(),
+                "where": [{"@id": "?s", "ex:labels": {"@value": "b", "@language": "fr"}}],
+                "delete": [{"@id": "?s", "ex:labels": {"@value": "b", "@language": "fr"}}]
+            });
+            let r = fluree
+                .update_with_opts(
+                    ledger,
+                    &del,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 2, "one entry per subject");
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            for id in ["ex:base", "ex:nov"] {
+                assert_eq!(
+                    list_items(&fluree, &ledger, id, "ex:labels").await,
+                    vec!["b@en", "c@en"],
+                    "{id}"
+                );
+            }
         })
         .await;
 }

--- a/fluree-db-api/tests/it_filtered_delete_list_meta.rs
+++ b/fluree-db-api/tests/it_filtered_delete_list_meta.rs
@@ -369,3 +369,190 @@ async fn language_tagged_list_entries_hydrate_by_tag() {
         })
         .await;
 }
+
+/// The `!ledger.novelty.has_list_meta` half of the skip guard.
+///
+/// An indexed root that observed no list rows (`Some(false)`) can still have
+/// a `@list` arrive in novelty afterwards. Only the novelty bit distinguishes
+/// that from a genuinely list-free ledger, so dropping it from the guard
+/// skips hydration and the positional entry silently survives its retraction.
+/// The reload leg pins the other half: novelty replayed from the commit chain
+/// must carry the bit forward, or the guard is wrong again after a restart.
+#[tokio::test]
+async fn novelty_list_over_indexed_no_list_root_still_hydrates() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().to_string_lossy().to_string();
+    let mut fluree = FlureeBuilder::file(dir.clone()).build().unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/list-meta-novelty-only:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            // Base carries `ex:items` as PLAIN values only — no `@list`
+            // anywhere, so the full build records `Some(false)`.
+            let graph: Vec<_> = (0..50)
+                .map(|n| json!({"@id": format!("ex:b{n}"), "ex:items": "b", "ex:name": format!("b{n}")}))
+                .collect();
+            let r = fluree
+                .insert_with_opts(ledger, &json!({"@context": ctx(), "@graph": graph}), TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert!(!fluree.ledger(ledger_id).await.unwrap().novelty.has_list_meta);
+            trigger_index_and_wait_outcome(&handle, ledger_id, r.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(ledger.snapshot.range_provider.is_some());
+            assert_eq!(ledger.snapshot.has_list_meta, Some(false), "full build observed no list rows");
+
+            // Now a `@list` lands in novelty. Root still says `Some(false)`:
+            // the novelty bit is the only thing keeping hydration alive.
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:nov1", "ex:items": {"@list": ["a", "b", "c"]}}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(ledger.snapshot.has_list_meta, Some(false), "root unchanged");
+            assert!(ledger.novelty.has_list_meta, "novelty saw the list position");
+            assert_eq!(list_values(&fluree, &ledger, "ex:nov1").await, vec!["a", "b", "c"]);
+
+            let del = json!({
+                "@context": ctx(),
+                "where": [{"@id": "?s", "ex:items": "b"}],
+                "delete": [{"@id": "?s", "ex:items": "b"}]
+            });
+            let r = fluree
+                .update_with_opts(ledger, &del, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 51, "50 plain base rows + the list entry");
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_values(&fluree, &ledger, "ex:nov1").await,
+                vec!["a", "c"],
+                "novelty list entry retracted at its hydrated position"
+            );
+            assert_eq!(count(&fluree, &ledger, "ex:items").await, 2, "only ex:nov1's a and c remain");
+            assert_eq!(count(&fluree, &ledger, "ex:name").await, 50, "base subjects survive");
+
+            // Reload: novelty is replayed from the commit chain on top of the
+            // same `Some(false)` root, and must carry the bit — otherwise the
+            // guard skips hydration for every write after a restart.
+            drop(fluree);
+            let reloaded = FlureeBuilder::file(dir).build().unwrap();
+            let ledger = reloaded.ledger(ledger_id).await.unwrap();
+            assert_eq!(ledger.snapshot.has_list_meta, Some(false));
+            assert!(ledger.novelty.has_list_meta, "replayed novelty carries the bit");
+            assert_eq!(list_values(&reloaded, &ledger, "ex:nov1").await, vec!["a", "c"]);
+
+            // And it is load-bearing on the reloaded handle, not just present.
+            let del_c = json!({
+                "@context": ctx(),
+                "where": [{"@id": "?s", "ex:items": "c"}],
+                "delete": [{"@id": "?s", "ex:items": "c"}]
+            });
+            let r = reloaded
+                .update_with_opts(ledger, &del_c, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 1);
+            let ledger = reloaded.ledger(ledger_id).await.unwrap();
+            assert_eq!(list_values(&reloaded, &ledger, "ex:nov1").await, vec!["a"]);
+        })
+        .await;
+}
+
+/// A retracted base list row must not out-vote the live novelty one.
+///
+/// Hydration copies the FIRST list-carrying meta indexed per object value,
+/// and the base seek's rows land before the overlay's. Delete `"b"` from an
+/// indexed `["b"]`, re-assert as `["x", "b"]`, then delete `"b"` again: the
+/// stale base candidate is `b@0` and the live one is `b@1`, so without
+/// `resolve_current_flakes` dropping the retracted key the retraction is
+/// hydrated to position 0 and the real entry survives.
+#[tokio::test]
+async fn stale_base_list_candidate_resolves_before_hydration() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mut fluree = FlureeBuilder::file(tmp.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/list-meta-stale:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            // Base: "b" at position 0, indexed.
+            let r = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:stale", "ex:items": {"@list": ["b"]}}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            trigger_index_and_wait_outcome(&handle, ledger_id, r.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(ledger.snapshot.has_list_meta, Some(true));
+            assert_eq!(list_values(&fluree, &ledger, "ex:stale").await, vec!["b"]);
+
+            let del_b = json!({
+                "@context": ctx(),
+                "where": [{"@id": "ex:stale", "ex:items": "b"}],
+                "delete": [{"@id": "ex:stale", "ex:items": "b"}]
+            });
+            let _ = fluree
+                .update_with_opts(ledger, &del_b, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(list_values(&fluree, &ledger, "ex:stale").await, Vec::<String>::new());
+
+            // Re-assert with "b" moved to position 1. The base's `b@0` is now
+            // a retracted key that still sorts ahead of the live `b@1`.
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:stale", "ex:items": {"@list": ["x", "b"]}}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(list_values(&fluree, &ledger, "ex:stale").await, vec!["x", "b"]);
+
+            let r = fluree
+                .update_with_opts(ledger, &del_b, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 1);
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_values(&fluree, &ledger, "ex:stale").await,
+                vec!["x"],
+                "hydrated from the live b@1, not the retracted base b@0"
+            );
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_indexing_stats.rs
+++ b/fluree-db-api/tests/it_indexing_stats.rs
@@ -75,6 +75,7 @@ async fn apply_index<S: Storage + Clone + 'static>(
         has_annotations: root.has_annotations,
         annotation_index: root.annotation_index.clone(),
         had_annotation_arena: root.had_annotation_arena,
+        has_list_meta: root.has_list_meta,
     };
     let mut db = LedgerSnapshot::new_meta(meta).expect("seed graph registry from root");
     db.range_provider = Some(Arc::new(provider));

--- a/fluree-db-binary-index/src/format/expanded_cas.rs
+++ b/fluree-db-binary-index/src/format/expanded_cas.rs
@@ -291,6 +291,7 @@ mod tests {
             has_annotations: false,
             annotation_index: None,
             had_annotation_arena: false,
+            has_list_meta: None,
             o_type_table: IndexRoot::build_o_type_table(&[], &[]),
             ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode::default(),
         }

--- a/fluree-db-binary-index/src/format/index_root.rs
+++ b/fluree-db-binary-index/src/format/index_root.rs
@@ -258,6 +258,37 @@ pub struct IndexRoot {
     ///   `true` via the `|| annotation_index.is_some()` coercion
     ///   (matches "indexer already sealed an arena here").
     pub had_annotation_arena: bool,
+
+    /// Whether any indexed row carries an RDF-list position (`o_i !=
+    /// LIST_INDEX_NONE`, i.e. a `@list` value).
+    ///
+    /// - `Some(false)` — the indexer observed every row and none carried a
+    ///   list index. Write-path consumers (filtered-DELETE list-meta
+    ///   hydration in `fluree-db-transact::stage`) may skip their
+    ///   per-retraction lookups entirely when novelty agrees.
+    /// - `Some(true)` — at least one list-carrying row exists (sticky:
+    ///   never cleared by any root assembly path, retractions included).
+    /// - `None` — untracked: the root predates this flag (legacy FIR6
+    ///   roots decode here) or was produced by a path that did not observe
+    ///   the rows. Consumers must behave as if lists may exist. A full
+    ///   rebuild, or any incremental pass that observes a list row, moves
+    ///   the root out of this state.
+    ///
+    /// Carried in the FIR6 extended-flags byte as two bits
+    /// (`FLAG_EXT_LIST_META_TRACKED`, `FLAG_EXT_HAS_LIST_META`) so a
+    /// legacy zero byte reads as "untracked" rather than "none".
+    pub has_list_meta: Option<bool>,
+}
+
+/// Decode the two-bit `has_list_meta` state from the FIR6 extended-flags
+/// byte. Shared with `fluree-db-core`'s metadata-only decoder, which reads
+/// the same byte with the same bit assignments.
+pub fn decode_list_meta_flags(flags_ext: u8, tracked_bit: u8, has_bit: u8) -> Option<bool> {
+    if flags_ext & tracked_bit == 0 {
+        None
+    } else {
+        Some(flags_ext & has_bit != 0)
+    }
 }
 
 impl IndexRoot {
@@ -567,6 +598,12 @@ impl IndexRoot {
     /// See `IndexRoot.had_annotation_arena` for the full state
     /// machine.
     const FLAG_EXT_HAD_ANNOTATION_ARENA: u8 = 1 << 0;
+    /// Extended-flags bit: `has_list_meta` is tracked (`Some(_)`).
+    /// Zero on legacy roots, which therefore decode to `None`.
+    const FLAG_EXT_LIST_META_TRACKED: u8 = 1 << 1;
+    /// Extended-flags bit: at least one indexed row carries a list index.
+    /// Only meaningful when `FLAG_EXT_LIST_META_TRACKED` is set.
+    const FLAG_EXT_HAS_LIST_META: u8 = 1 << 2;
 
     /// Encode to the binary FIR6 wire format.
     ///
@@ -647,11 +684,18 @@ impl IndexRoot {
         // bootstrap scan-fallback.
         let had_annotation_arena_on_wire =
             self.had_annotation_arena || self.annotation_index.is_some();
-        let flags_ext = if had_annotation_arena_on_wire {
+        let mut flags_ext = if had_annotation_arena_on_wire {
             Self::FLAG_EXT_HAD_ANNOTATION_ARENA
         } else {
             0
         };
+        match self.has_list_meta {
+            Some(true) => {
+                flags_ext |= Self::FLAG_EXT_LIST_META_TRACKED | Self::FLAG_EXT_HAS_LIST_META;
+            }
+            Some(false) => flags_ext |= Self::FLAG_EXT_LIST_META_TRACKED,
+            None => {}
+        }
         buf.push(flags_ext);
         buf.push(0); // reserved high pad byte
         buf.extend_from_slice(&self.index_t.to_le_bytes());
@@ -847,6 +891,11 @@ impl IndexRoot {
         let lex_sorted_string_ids = (flags & Self::FLAG_LEX_SORTED_STRING_IDS) != 0;
         let has_annotations = (flags & Self::FLAG_HAS_ANNOTATIONS) != 0;
         let had_annotation_arena = (flags_ext & Self::FLAG_EXT_HAD_ANNOTATION_ARENA) != 0;
+        let has_list_meta = decode_list_meta_flags(
+            flags_ext,
+            Self::FLAG_EXT_LIST_META_TRACKED,
+            Self::FLAG_EXT_HAS_LIST_META,
+        );
 
         // Ledger ID
         let ledger_id = read_string(data, &mut pos)?;
@@ -1107,6 +1156,7 @@ impl IndexRoot {
             // losing the dropped arena's history.
             had_annotation_arena: had_annotation_arena || annotation_index.is_some(),
             annotation_index,
+            has_list_meta,
         })
     }
     /// Collect all CAS content-artifact CIDs referenced **directly** by this root.
@@ -1407,6 +1457,7 @@ mod tests {
             has_annotations: false,
             annotation_index: None,
             had_annotation_arena: false,
+            has_list_meta: None,
             ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode::default(),
         }
     }
@@ -1503,6 +1554,62 @@ mod tests {
         assert!(snap.has_annotations, "snapshot path also sees sticky bit");
         let snap_ann = snap.annotation_index.expect("metadata path roundtrip");
         assert_eq!(snap_ann, ann);
+    }
+
+    #[test]
+    fn fir6_round_trip_has_list_meta_three_state() {
+        // Two bits in the extended-flags byte: TRACKED distinguishes a
+        // root that observed its rows from a legacy root whose byte is
+        // simply zero, so "untracked" never decodes as "no lists".
+        let mut root = minimal_root_v6();
+        root.has_list_meta = None;
+        let bytes_none = root.encode();
+        assert_eq!(bytes_none[6] & IndexRoot::FLAG_EXT_LIST_META_TRACKED, 0);
+        assert_eq!(IndexRoot::decode(&bytes_none).unwrap().has_list_meta, None);
+
+        root.has_list_meta = Some(false);
+        let bytes_false = root.encode();
+        assert_ne!(bytes_false[6] & IndexRoot::FLAG_EXT_LIST_META_TRACKED, 0);
+        assert_eq!(bytes_false[6] & IndexRoot::FLAG_EXT_HAS_LIST_META, 0);
+        assert_eq!(
+            IndexRoot::decode(&bytes_false).unwrap().has_list_meta,
+            Some(false)
+        );
+        assert_eq!(
+            fluree_db_core::LedgerSnapshot::from_root_bytes(&bytes_false)
+                .unwrap()
+                .has_list_meta,
+            Some(false),
+            "metadata-only decode agrees"
+        );
+
+        root.has_list_meta = Some(true);
+        let bytes_true = root.encode();
+        assert_ne!(bytes_true[6] & IndexRoot::FLAG_EXT_HAS_LIST_META, 0);
+        assert_eq!(
+            IndexRoot::decode(&bytes_true).unwrap().has_list_meta,
+            Some(true)
+        );
+        assert_eq!(
+            fluree_db_core::LedgerSnapshot::from_root_bytes(&bytes_true)
+                .unwrap()
+                .has_list_meta,
+            Some(true)
+        );
+
+        // Legacy: a zeroed extended-flags byte decodes to untracked.
+        let mut bytes_legacy = bytes_true;
+        bytes_legacy[6] = 0;
+        assert_eq!(
+            IndexRoot::decode(&bytes_legacy).unwrap().has_list_meta,
+            None
+        );
+        assert_eq!(
+            fluree_db_core::LedgerSnapshot::from_root_bytes(&bytes_legacy)
+                .unwrap()
+                .has_list_meta,
+            None
+        );
     }
 
     #[test]

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -1070,6 +1070,55 @@ mod tests {
         assert_eq!((start, end), (0, 0));
     }
 
+    /// `emit_overlay_only` must stop at `overlay_end`, not at
+    /// `overlay_ops.len()`: the window is the cursor's share of an `Arc`
+    /// slice held in common with every other cursor over the same overlay.
+    /// Today's callers all narrow via `overlay_window_for_range`, whose
+    /// out-of-window ops are filtered anyway, so the tail was cost rather
+    /// than wrong rows — O(overlay) per novelty-only point lookup. Nothing
+    /// below the api tests pins the window itself.
+    #[test]
+    fn overlay_only_emits_exactly_the_window() {
+        use crate::format::branch::BranchManifest;
+        use crate::read::binary_index_store::tests::{empty_store, temp_cache_dir};
+        use crate::read::column_types::{BinaryFilter, ColumnProjection};
+        use fluree_db_core::{ContentStore, MemoryContentStore};
+
+        let cs: Arc<dyn ContentStore> = Arc::new(MemoryContentStore::new());
+        let store = Arc::new(empty_store(cs, temp_cache_dir()));
+        // No leaves: `next_batch` goes straight to the overlay-only path.
+        let branch = Arc::new(BranchManifest { leaves: Vec::new() });
+        let ops: Arc<[OverlayOp]> = vec![
+            make_op(1, 1),
+            make_op(2, 1),
+            make_op(3, 1),
+            make_op(4, 1),
+            make_op(5, 1),
+        ]
+        .into();
+
+        let mut cursor = BinaryCursor::scan_all(
+            store,
+            RunSortOrder::Spot,
+            branch,
+            BinaryFilter::default(),
+            ColumnProjection::all(),
+        );
+        cursor.set_overlay_ops_window(Arc::clone(&ops), 1, 3);
+
+        let batch = cursor.next_batch().unwrap().expect("overlay-only batch");
+        assert_eq!(batch.row_count, 2, "window is [1, 3), not the whole slice");
+        let ColumnData::Block(s_ids) = &batch.s_id else {
+            panic!("expected materialized s_id block");
+        };
+        assert_eq!(
+            &s_ids[..],
+            &[2, 3],
+            "the window's ops, not a prefix of the slice"
+        );
+        assert!(cursor.next_batch().unwrap().is_none(), "cursor exhausted");
+    }
+
     /// An OPST batch in sort order (o_type, o_key, ...): a filter binding
     /// both must narrow to exactly the matching run, not just the o_type
     /// range (the pre-cascade behavior that linear-scanned every ref row

--- a/fluree-db-binary-index/src/read/binary_cursor.rs
+++ b/fluree-db-binary-index/src/read/binary_cursor.rs
@@ -191,8 +191,11 @@ impl BinaryCursor {
     /// key range: ops outside the window cost an O(overlay) merge walk per
     /// cursor and defeat leaflet pre-skips.
     pub fn set_overlay_ops_window(&mut self, ops: Arc<[OverlayOp]>, start: usize, end: usize) {
+        debug_assert!(start <= end && end <= ops.len());
         debug_assert!(
-            ops.windows(2).all(|w| w[0].fact_key() != w[1].fact_key()),
+            ops[start..end]
+                .windows(2)
+                .all(|w| w[0].fact_key() != w[1].fact_key()),
             "overlay ops contain duplicate fact keys — caller must resolve \
              assert/retract lifecycles via resolve_overlay_ops() before set_overlay_ops()"
         );
@@ -216,7 +219,6 @@ impl BinaryCursor {
              in the cursor projection; got {:?}",
             self.projection
         );
-        debug_assert!(start <= end && end <= ops.len());
         self.overlay_ops = ops;
         self.overlay_pos = start;
         self.overlay_end = end;
@@ -708,7 +710,7 @@ impl BinaryCursor {
         let mut out_o_i: Vec<u32> = Vec::new();
         let mut out_t: Vec<u32> = Vec::new();
 
-        while self.overlay_pos < self.overlay_ops.len() {
+        while self.overlay_pos < self.overlay_end {
             let ov = &self.overlay_ops[self.overlay_pos];
             self.overlay_pos += 1;
 

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -2942,7 +2942,7 @@ impl super::leaf_access::RangeReadFetcher for ContentStoreRangeFetcher {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use async_trait::async_trait;
     use fluree_db_core::content_kind::ContentKind;
@@ -3018,7 +3018,7 @@ mod tests {
         }
     }
 
-    fn temp_cache_dir() -> PathBuf {
+    pub(crate) fn temp_cache_dir() -> PathBuf {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let suffix = COUNTER.fetch_add(1, AtomicOrdering::Relaxed);
         let path = std::env::temp_dir().join(format!(
@@ -3030,7 +3030,10 @@ mod tests {
         path
     }
 
-    fn empty_store(cs: Arc<dyn ContentStore>, cache_dir: PathBuf) -> BinaryIndexStore {
+    /// Field-complete store with no graphs, dicts, or leaves. Shared with
+    /// `binary_cursor`'s tests, which need an `Arc<BinaryIndexStore>` to build
+    /// a cursor but never read through it.
+    pub(crate) fn empty_store(cs: Arc<dyn ContentStore>, cache_dir: PathBuf) -> BinaryIndexStore {
         BinaryIndexStore {
             store_id: NEXT_STORE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             dicts: DictionarySet {

--- a/fluree-db-core/src/db.rs
+++ b/fluree-db-core/src/db.rs
@@ -110,6 +110,13 @@ pub struct LedgerSnapshotMetadata {
     /// `annotation_index` is present (handles pre-this-change
     /// roots that already sealed an arena).
     pub had_annotation_arena: bool,
+
+    /// Whether any indexed row carries an RDF-list position. `Some(false)`
+    /// lets the write path skip list-meta hydration; `None` means the root
+    /// predates tracking and lists must be assumed possible. See
+    /// `IndexRoot.has_list_meta` in `fluree-db-binary-index` for the
+    /// canonical contract.
+    pub has_list_meta: Option<bool>,
 }
 
 /// Database value at a specific point in time.
@@ -229,6 +236,13 @@ pub struct LedgerSnapshot {
     /// `IndexRoot.had_annotation_arena` via the FIR6 extended-flags
     /// byte.
     pub had_annotation_arena: bool,
+
+    /// Whether any indexed row carries an RDF-list position. `Some(false)`
+    /// lets the write path skip list-meta hydration; `None` means the root
+    /// predates tracking and lists must be assumed possible. See
+    /// `IndexRoot.has_list_meta` in `fluree-db-binary-index` for the
+    /// canonical contract.
+    pub has_list_meta: Option<bool>,
 }
 
 impl Clone for LedgerSnapshot {
@@ -251,6 +265,7 @@ impl Clone for LedgerSnapshot {
             has_annotations: self.has_annotations,
             annotation_index: self.annotation_index.clone(),
             had_annotation_arena: self.had_annotation_arena,
+            has_list_meta: self.has_list_meta,
             content_store: self.content_store.clone(),
         }
     }
@@ -305,6 +320,9 @@ impl LedgerSnapshot {
             has_annotations: false,
             annotation_index: None,
             had_annotation_arena: false,
+            // An empty snapshot has no indexed rows, so "no list rows" is
+            // exact — everything lives in novelty, which tracks its own bit.
+            has_list_meta: Some(false),
             content_store: None,
         }
     }
@@ -344,6 +362,7 @@ impl LedgerSnapshot {
             has_annotations: meta.has_annotations,
             annotation_index: meta.annotation_index,
             had_annotation_arena: meta.had_annotation_arena,
+            has_list_meta: meta.has_list_meta,
             content_store: None,
         })
     }
@@ -685,8 +704,15 @@ fn decode_fir6_metadata(bytes: &[u8]) -> std::io::Result<LedgerSnapshotMetadata>
     // roots whose `annotation_index` was sealed before this
     // change shipped.
     const FLAG_EXT_HAD_ANNOTATION_ARENA: u8 = 1 << 0;
+    const FLAG_EXT_LIST_META_TRACKED: u8 = 1 << 1;
+    const FLAG_EXT_HAS_LIST_META: u8 = 1 << 2;
     let flags_ext = bytes[6];
     let had_annotation_arena = flags_ext & FLAG_EXT_HAD_ANNOTATION_ARENA != 0;
+    let has_list_meta = if flags_ext & FLAG_EXT_LIST_META_TRACKED == 0 {
+        None
+    } else {
+        Some(flags_ext & FLAG_EXT_HAS_LIST_META != 0)
+    };
 
     #[inline]
     fn ensure(bytes: &[u8], pos: usize, need: usize, ctx: &str) -> std::io::Result<()> {
@@ -1041,6 +1067,7 @@ fn decode_fir6_metadata(bytes: &[u8]) -> std::io::Result<LedgerSnapshotMetadata>
         has_annotations,
         annotation_index,
         had_annotation_arena,
+        has_list_meta,
     })
 }
 
@@ -1140,6 +1167,7 @@ mod tests {
             has_annotations: false,
             annotation_index: None,
             had_annotation_arena: false,
+            has_list_meta: None,
         })
         .unwrap();
 

--- a/fluree-db-core/src/range.rs
+++ b/fluree-db-core/src/range.rs
@@ -412,6 +412,58 @@ fn remove_stale_flakes(flakes: Vec<Flake>) -> Vec<Flake> {
 mod tests {
     use super::*;
 
+    fn fact(s: &str, o: &str, t: i64, op: bool, i: Option<i32>) -> Flake {
+        let m = i.map(|i| FlakeMeta {
+            lang: None,
+            i: Some(i),
+        });
+        Flake {
+            s: Sid::new(1, s),
+            p: Sid::new(2, "p"),
+            o: FlakeValue::String(o.to_string()),
+            dt: Sid::new(3, "string"),
+            t,
+            op,
+            m,
+            g: None,
+        }
+    }
+
+    #[test]
+    fn resolve_current_flakes_newest_op_wins_and_retracts_drop() {
+        // Out of order on purpose: the resolver must sort first.
+        let flakes = vec![
+            fact("a", "x", 3, false, None), // retract at t=3 …
+            fact("a", "x", 1, true, None),  // … of an assert at t=1
+            fact("a", "y", 2, true, None),  // untouched assert
+            fact("b", "x", 2, false, None), // retract at t=2 …
+            fact("b", "x", 4, true, None),  // … re-asserted later → live
+        ];
+        let out = resolve_current_flakes(flakes, IndexType::Spot);
+        let keys: Vec<(String, String)> = out
+            .iter()
+            .map(|f| (f.s.name.to_string(), format!("{:?}", f.o)))
+            .collect();
+        assert_eq!(out.len(), 2);
+        assert!(out.iter().all(|f| f.op));
+        assert!(keys.contains(&("a".into(), format!("{:?}", FlakeValue::String("y".into())))));
+        assert!(keys.contains(&("b".into(), format!("{:?}", FlakeValue::String("x".into())))));
+    }
+
+    #[test]
+    fn resolve_current_flakes_list_positions_are_distinct_facts() {
+        // Same (s, p, o, dt) at two list positions; retracting position 1
+        // must leave position 0 live — `m` is part of the fact key.
+        let flakes = vec![
+            fact("a", "x", 1, true, Some(0)),
+            fact("a", "x", 1, true, Some(1)),
+            fact("a", "x", 2, false, Some(1)),
+        ];
+        let out = resolve_current_flakes(flakes, IndexType::Spot);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].m.as_ref().and_then(|m| m.i), Some(0));
+    }
+
     #[test]
     fn test_range_match_builders() {
         let s = Sid::new(1, "test");

--- a/fluree-db-core/src/range.rs
+++ b/fluree-db-core/src/range.rs
@@ -348,6 +348,17 @@ fn collect_overlay_only<O: OverlayProvider + ?Sized>(
     remove_stale_flakes(flakes)
 }
 
+/// Resolve a mixed bag of assert/retract flakes to the currently-asserted
+/// set: sort in `index` order (which places the newest `t` last within a
+/// fact key), keep the newest op per fact key, drop retractions. This is the
+/// same lifecycle rule the overlay-only range path applies; callers that
+/// merge base rows with a raw overlay walk themselves use it to get
+/// identical results to [`range_with_overlay`].
+pub fn resolve_current_flakes(mut flakes: Vec<Flake>, index: IndexType) -> Vec<Flake> {
+    flakes.sort_by(index.comparator());
+    remove_stale_flakes(flakes)
+}
+
 /// Remove stale flakes from an owned vector.
 ///
 /// Iterates in reverse (newest first for identical facts), keeps only the

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -1272,6 +1272,7 @@ pub async fn incremental_index(
 
     let new_pred_sids = build_predicate_sids(&novelty.shared, &new_ns_codes);
     root_builder.set_predicate_sids(new_pred_sids);
+    root_builder.note_list_meta(novelty.shared.saw_list_meta);
 
     let new_graph_iris: Vec<String> = (0..novelty.shared.graphs.len())
         .filter_map(|id| {

--- a/fluree-db-indexer/src/build/rebuild.rs
+++ b/fluree-db-indexer/src/build/rebuild.rs
@@ -1127,6 +1127,7 @@ where
                 total_commit_size,
                 total_asserts,
                 total_retracts,
+                saw_list_meta: shared.saw_list_meta,
                 db_stats: Some(db_stats),
                 db_schema,
                 sketch_ref,

--- a/fluree-db-indexer/src/build/root_assembly.rs
+++ b/fluree-db-indexer/src/build/root_assembly.rs
@@ -201,6 +201,9 @@ pub(crate) struct Fir6Inputs {
     pub total_commit_size: u64,
     pub total_asserts: u64,
     pub total_retracts: u64,
+    /// Whether the resolver observed any list-carrying (`@list`) row.
+    /// Full rebuilds observe every row, so the root records `Some(_)`.
+    pub saw_list_meta: bool,
     /// Full query-time stats (HLL-derived cardinalities, per-graph properties).
     /// `None` if stats collection was skipped or deferred.
     pub db_stats: Option<fluree_db_core::index_stats::IndexStats>,
@@ -335,6 +338,7 @@ pub(crate) async fn encode_and_write_root_v6(
         // signal carried forward — defensive-drop semantics live
         // exclusively on the incremental path.
         had_annotation_arena: false,
+        has_list_meta: Some(inputs.saw_list_meta),
     };
 
     // `IndexStats.size` is defined as total commit data size (bytes) for the ledger.
@@ -630,6 +634,7 @@ mod tests {
             sketch_ref: None,
             has_annotations: false,
             had_annotation_arena: false,
+            has_list_meta: None,
             annotation_index: None,
             o_type_table: IndexRoot::build_o_type_table(&[], &[]),
             ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode::default(),

--- a/fluree-db-indexer/src/drop.rs
+++ b/fluree-db-indexer/src/drop.rs
@@ -243,6 +243,7 @@ mod tests {
             sketch_ref: None,
             has_annotations: annotation_index.is_some(),
             had_annotation_arena: annotation_index.is_some(),
+            has_list_meta: None,
             annotation_index,
             o_type_table: IndexRoot::build_o_type_table(&[], &[]),
             ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode::default(),

--- a/fluree-db-indexer/src/gc/collector.rs
+++ b/fluree-db-indexer/src/gc/collector.rs
@@ -1159,6 +1159,7 @@ mod tests {
             total_commit_size: 0,
             total_asserts: 0,
             total_retracts: 0,
+            saw_list_meta: false,
             db_stats: None,
             db_schema: None,
             sketch_ref: None,

--- a/fluree-db-indexer/src/gc/test_support.rs
+++ b/fluree-db-indexer/src/gc/test_support.rs
@@ -57,6 +57,7 @@ pub(crate) fn minimal_fir6_for(
         has_annotations: false,
         annotation_index: None,
         had_annotation_arena: false,
+        has_list_meta: None,
         o_type_table: IndexRoot::build_o_type_table(&[], &[]),
         ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode::default(),
     };

--- a/fluree-db-indexer/src/run_index/build/incremental_root.rs
+++ b/fluree-db-indexer/src/run_index/build/incremental_root.rs
@@ -277,6 +277,17 @@ impl IncrementalRootBuilder {
         self.root.annotation_index = new_index;
     }
 
+    /// Fold this pass's list-row observation into the sticky
+    /// `has_list_meta` state. Seeing a list row is conclusive (`Some(true)`)
+    /// regardless of the inherited state; seeing none only preserves what
+    /// the base root already knew — an untracked legacy root stays
+    /// untracked until a full rebuild observes every row.
+    pub fn note_list_meta(&mut self, saw_list_meta: bool) {
+        if saw_list_meta {
+            self.root.has_list_meta = Some(true);
+        }
+    }
+
     /// Add to cumulative commit stats.
     pub fn add_commit_stats(&mut self, size: u64, asserts: u64, retracts: u64) {
         self.root.total_commit_size += size;
@@ -382,6 +393,7 @@ mod tests {
             has_annotations: false,
             annotation_index: None,
             had_annotation_arena: false,
+            has_list_meta: None,
             o_type_table: IndexRoot::build_o_type_table(&[], &[]),
             ns_split_mode: NsSplitMode::default(),
         }

--- a/fluree-db-indexer/src/run_index/resolve/resolver.rs
+++ b/fluree-db-indexer/src/run_index/resolve/resolver.rs
@@ -1126,6 +1126,9 @@ pub struct SharedResolverState {
     /// for every `rdfs:subClassOf` / `rdfs:subPropertyOf` user-data op so rebuild
     /// can populate `IndexSchema` in the FIR6 root.
     pub schema_hook: Option<crate::stats::SchemaExtractor>,
+    /// Sticky: any resolved user-data op carried a list index (`@list`
+    /// value). Feeds `IndexRoot.has_list_meta` at root assembly.
+    pub saw_list_meta: bool,
 }
 
 impl SharedResolverState {
@@ -1172,6 +1175,7 @@ impl SharedResolverState {
             fulltext_hook: None,
             fulltext_hook_config: crate::fulltext_hook::FulltextHookConfig::default(),
             schema_hook: None,
+            saw_list_meta: false,
         }
     }
 
@@ -1299,6 +1303,7 @@ impl SharedResolverState {
             fulltext_hook: None,
             fulltext_hook_config: crate::fulltext_hook::FulltextHookConfig::default(),
             schema_hook: None,
+            saw_list_meta: false,
         })
     }
 
@@ -1532,6 +1537,7 @@ impl SharedResolverState {
         let dt_id = dt_id as u16;
 
         // 5. List index — needed by vector fact-identity lookup before object encode.
+        self.saw_list_meta |= op.i.is_some();
         let i = match op.i {
             Some(idx) if idx >= 0 => idx as u32,
             Some(idx) => {

--- a/fluree-db-novelty/src/lib.rs
+++ b/fluree-db-novelty/src/lib.rs
@@ -496,6 +496,11 @@ pub struct Novelty {
     /// enforcement reuse the previously compiled shapes when nothing
     /// shape-affecting changed.
     pub shacl_epoch: u64,
+    /// Sticky: some flake in this overlay carried an RDF-list position
+    /// (`m.i`). Lets filtered-DELETE staging skip list-meta hydration when
+    /// both the index root and novelty report no list rows. Never cleared —
+    /// a trimmed overlay keeps the bit; the indexed root takes over.
+    pub has_list_meta: bool,
 
     /// Highest `commit_t` at which the ledger config graph (`CONFIG_GRAPH_ID`)
     /// received a write. Monotonic within a novelty window; resets to 0 when
@@ -522,6 +527,11 @@ pub struct Novelty {
 /// `0` uniquely means "empty since construction".
 static NEXT_CONTENT_VERSION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
+#[inline]
+fn flake_has_list_meta(flake: &Flake) -> bool {
+    flake.m.as_ref().is_some_and(|m| m.i.is_some())
+}
+
 impl Novelty {
     /// Create a new empty novelty overlay
     pub fn new(t: i64) -> Self {
@@ -534,6 +544,7 @@ impl Novelty {
             content_version: 0,
             schema_epoch: 0,
             shacl_epoch: 0,
+            has_list_meta: false,
             config_write_t: 0,
             attachments: AttachmentNovelty::new(),
             fact_state: NoveltyFactState::new(),
@@ -884,6 +895,7 @@ impl Novelty {
             // SHACL-vocabulary flake invalidates the compiled-shapes cache.
             schema_touched |= fluree_db_core::namespaces::is_rdfs_hierarchy_predicate(&flake.p);
             shacl_touched |= fluree_db_core::namespaces::is_shacl_affecting_flake(&flake);
+            self.has_list_meta |= flake_has_list_meta(&flake);
             per_graph.entry(g_id).or_default().push(flake);
         }
         if schema_touched {
@@ -984,6 +996,7 @@ impl Novelty {
                 if fluree_db_core::namespaces::is_shacl_affecting_flake(&flake) {
                     self.shacl_epoch += 1;
                 }
+                self.has_list_meta |= flake_has_list_meta(&flake);
                 per_graph.entry(g_id).or_default().push(flake);
             }
         }

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -1617,13 +1617,14 @@ async fn hydrate_list_index_meta_for_retractions(
 ) -> Result<()> {
     use std::collections::BTreeMap;
 
-    // Group candidates by (graph, subject, predicate): one range lookup per
-    // group, not one per retraction. Every `range_with_overlay` call pays a
-    // full overlay translation of the graph's novelty (walk + translate +
-    // sort), so per-flake lookups make filtered-DELETE staging
-    // O(matched_triples × novelty log novelty) — observed as a >900s livelock
-    // for ~21k matched triples on a novelty-heavy ledger. Grouped, the cost
-    // scales with distinct (subject, predicate) pairs instead.
+    // Nothing to copy when neither the indexed base nor novelty holds a
+    // single `@list` position. `Some(false)` is an exact observation by the
+    // indexer; `None` (legacy root, bulk import) must fall through.
+    if ledger.snapshot.has_list_meta == Some(false) && !ledger.novelty.has_list_meta {
+        return Ok(());
+    }
+
+    // Group candidates by (graph, subject, predicate).
     let mut groups: HashMap<(GraphId, Sid, Sid), Vec<usize>> = HashMap::new();
     for (idx, flake) in retractions.iter().enumerate() {
         // Only retractions with no metadata are candidates.
@@ -1636,32 +1637,70 @@ async fn hydrate_list_index_meta_for_retractions(
             .or_default()
             .push(idx);
     }
+    if groups.is_empty() {
+        return Ok(());
+    }
+
+    let to_t = ledger.t();
+
+    // Novelty side: ONE SPOT walk per touched graph, keeping every op on a
+    // requested (subject, predicate) pair. `range_with_overlay` per group
+    // would instead translate (or walk) the graph's entire overlay once per
+    // group — O(groups × novelty), observed as a multi-minute-to-never
+    // filtered DELETE once both are in the tens of thousands.
+    let mut wanted: HashMap<GraphId, HashSet<(&Sid, &Sid)>> = HashMap::new();
+    for (g_id, s, p) in groups.keys() {
+        wanted.entry(*g_id).or_default().insert((s, p));
+    }
+    let mut overlay_by_key: HashMap<(GraphId, Sid, Sid), Vec<Flake>> = HashMap::new();
+    for (g_id, pairs) in &wanted {
+        ledger.novelty.for_each_overlay_flake(
+            *g_id,
+            IndexType::Spot,
+            None,
+            None,
+            true,
+            to_t,
+            &mut |f| {
+                if f.t <= to_t && pairs.contains(&(&f.s, &f.p)) {
+                    overlay_by_key
+                        .entry((*g_id, f.s.clone(), f.p.clone()))
+                        .or_default()
+                        .push(f.clone());
+                }
+            },
+        );
+    }
 
     for ((g_id, s, p), members) in groups {
-        // Find currently asserted flakes for this (subject, predicate)
-        // (db + novelty overlay) and copy list index meta where present.
+        // Base side: subject + predicate bound against the persisted index
+        // only (`NoOverlay`) — a leaf seek, no overlay translation.
         let rm = fluree_db_core::RangeMatch::new()
-            .with_subject(s)
-            .with_predicate(p);
-
-        let found = fluree_db_core::range_with_overlay(
+            .with_subject(s.clone())
+            .with_predicate(p.clone());
+        let mut found = fluree_db_core::range_with_overlay(
             &ledger.snapshot,
             g_id,
-            ledger.novelty.as_ref(),
-            fluree_db_core::IndexType::Spot,
+            &fluree_db_core::NoOverlay,
+            IndexType::Spot,
             fluree_db_core::RangeTest::Eq,
             rm,
-            fluree_db_core::RangeOptions::new().with_to_t(ledger.t()),
+            fluree_db_core::RangeOptions::new().with_to_t(to_t),
         )
         .await?;
+        if let Some(ops) = overlay_by_key.remove(&(g_id, s, p)) {
+            found.extend(ops);
+        }
+        // Same lifecycle rule `range_with_overlay` applies to its merged
+        // result: newest op per fact key wins, retractions drop out.
+        let found = fluree_db_core::range::resolve_current_flakes(found, IndexType::Spot);
 
         // Index asserted list-carrying metas per object value, in index
         // order. Every matching retraction copies the FIRST dt-compatible
-        // meta — mirroring the per-flake lookup's `.find()` this replaces:
-        // identical duplicates then collapse in the accumulator, so a value
-        // asserted at N list positions loses exactly one entry per distinct
-        // WHERE binding (pinned by the `object-probe-list-retract` case in
-        // `it_join_batched_overlay.rs`).
+        // meta: identical duplicates then collapse in the accumulator, so a
+        // value asserted at N list positions loses exactly one entry per
+        // distinct WHERE binding (pinned by the `object-probe-list-retract`
+        // case in `it_join_batched_overlay.rs`).
         let mut metas: BTreeMap<FlakeValue, Vec<(Sid, fluree_db_core::FlakeMeta)>> =
             BTreeMap::new();
         for f in found {

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -1627,8 +1627,10 @@ async fn hydrate_list_index_meta_for_retractions(
     // Group candidates by (graph, subject, predicate).
     let mut groups: HashMap<(GraphId, Sid, Sid), Vec<usize>> = HashMap::new();
     for (idx, flake) in retractions.iter().enumerate() {
-        // Only retractions with no metadata are candidates.
-        if flake.op || flake.m.is_some() {
+        // Only retractions lacking a list position are candidates. A
+        // language-tagged binding already carries `m = { lang, i: None }`
+        // and still needs its position filled in.
+        if flake.op || flake.m.as_ref().is_some_and(|m| m.i.is_some()) {
             continue;
         }
         let g_id = resolve_flake_graph_id(flake, reverse_graph)?;
@@ -1716,13 +1718,17 @@ async fn hydrate_list_index_meta_for_retractions(
 
         for idx in members {
             let flake = &mut retractions[idx];
-            if let Some(candidates) = metas.get(&flake.o) {
-                if let Some((_, m)) = candidates
-                    .iter()
-                    .find(|(dt, _)| fluree_db_core::dt_compatible(&flake.dt, dt))
-                {
-                    flake.m = Some(m.clone());
-                }
+            let Some(candidates) = metas.get(&flake.o) else {
+                continue;
+            };
+            // Same lexical value under different language tags are distinct
+            // facts: the candidate must match the retraction's tag (absent
+            // on both for plain literals) as well as its datatype.
+            let lang = flake.m.as_ref().and_then(|m| m.lang.as_deref());
+            if let Some((_, m)) = candidates.iter().find(|(dt, m)| {
+                fluree_db_core::dt_compatible(&flake.dt, dt) && m.lang.as_deref() == lang
+            }) {
+                flake.m = Some(m.clone());
             }
         }
     }


### PR DESCRIPTION
## Problem

A `WHERE { ?s p ?o } DELETE { ?s p ?o }` update over a predicate carried by ~40k subjects never committed on a novelty-heavy ledger. Staging called `range_with_overlay` once per retracted (subject, predicate) to copy `@list` positions onto retractions, and every call paid for the graph's entire overlay: `retractions × novelty`. Commit itself took 0.2 s; all the time was in `hydrate_list_index_meta_for_retractions`. Stack-sampled three distinct per-call taxes:

- unindexed ledger → `collect_overlay_only` full walk + sort + `remove_stale_flakes`
- indexed ledger, novelty-only subject → `BinaryCursor::emit_overlay_only` looped to `overlay_ops.len()` instead of the computed `overlay_end`
- debug builds → `set_overlay_ops_window`'s duplicate-key `debug_assert!` scanned the whole ops slice

## Changes

1. **`IndexRoot.has_list_meta: Option<bool>`** — two bits in the FIR6 extended-flags byte (`LIST_META_TRACKED` + `HAS_LIST_META`), no format bump. A legacy zero byte decodes to `None` (untracked), never "no lists". Full rebuilds record it exactly from the resolver; incremental passes flip to `Some(true)` on the first list row; bulk import leaves it `None`. `Novelty.has_list_meta` is the sticky in-memory twin. When both say no lists, hydration is skipped entirely.
2. **Hydration rewrite** — otherwise ONE SPOT overlay walk per graph, bucketed by the wanted (s,p) pairs, plus a `NoOverlay` base seek per group, merged with the same lifecycle rule `range_with_overlay` applies (new `fluree_db_core::range::resolve_current_flakes`).
3. **`emit_overlay_only`** stops at `overlay_end` (engine-wide: every overlay-only point lookup on a novelty-only subject was scanning to the end of the overlay).
4. **Debug assert** checks only the window.
5. **Language-tagged list entries** (pre-existing gap surfaced while testing): a tagged binding yields `m = { lang, i: None }`, which was treated as "already has meta" and skipped — `DELETE { ?s p "b"@fr }` on a list entry silently retracted nothing. Candidates now require a matching tag as well as datatype.

## Numbers

40.5k-retraction delete, ~243k flakes (unoptimized test build, debug assertions off):

| Scenario | Before | After |
|---|---|---|
| All flakes in novelty, no lists | >20 min (killed) | 0.9 s |
| Same, with a `@list` value present (O(N) path) | >20 min | 3.1 s |
| Half in novelty, indexed | 8.9 s | 1.3 s |

## Tests

- `fluree-db-api/tests/it_filtered_delete_list_meta.rs`: flag states through a real index build; one-entry-per-binding list retraction across base-indexed, novelty-only, and retract-then-reassert lists; tagged-list deletion by language (fails on `main`).
- FIR6 round-trip of the three-state bits incl. legacy decode; `resolve_current_flakes` unit tests.
- grp_transact / grp_index / list-related query suites, lower-crate units; clippy `--all-features --all-targets -D warnings` clean.

Docs: `docs/design/index-format.md` documents the header flag bytes.

## Follow-ups (not in this PR)

- Wrap the WHERE-stream/hydrate loop in `spawn_blocking` so a caller's `tokio::time::timeout` can actually fire on a slow staging.
- SHACL `validate_staged_nodes` has the same per-subject-range shape (and the `StagedLedger` overlay has no `content_version`, so no translation LRU).
- Carry `m` through from the WHERE match so hydration disappears as a concept.
- Bulk-import roots stay untracked until their first full rebuild.
