### PR TITLE
docs: make PR↔issue reference direction explicit (Fixes / Follow-up / Partially addresses)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 <!-- Issue links — keep the reference direction explicit (see CONTRIBUTING.md):
-       Fixes #N               — this PR resolves the issue (keyword must be in this body to auto-close)
+       Fixes #N               — this PR resolves the issue; in THIS body, so the issue links back to the PR
        Follow-up: #N          — work deferred out of this PR (including issues filed during review)
        Partially addresses #N — issue stays open; say below what remains
+                                (write it this way — "partially fixes #N" would close it)
+     Closing keywords only fire when this PR's base is the default branch.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,5 @@
        Partially addresses #N — issue stays open; say below what remains
                                 (write it this way — "partially fixes #N" would close it)
      Closing keywords only fire when this PR's base is the default branch.
+     Creating with `gh pr create --body`/`--body-file`? This template is bypassed — add the line yourself.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+<!-- Issue links — keep the reference direction explicit (see CONTRIBUTING.md):
+       Fixes #N               — this PR resolves the issue (keyword must be in this body to auto-close)
+       Follow-up: #N          — work deferred out of this PR (including issues filed during review)
+       Partially addresses #N — issue stays open; say below what remains
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,11 @@
 # OS
 .DS_Store
 
-# Claude Code — track commands/ (team skills) but not local settings
+# Claude Code — track commands/ (team skills) and CLAUDE.md (shared conventions),
+# but not local settings or personal notes
 .claude/settings.local.json
 .claude/dev-docs/
+CLAUDE.local.md
 
 # Fluree data (storage, indexes, etc.)
 .fluree/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,11 @@ PR labels drive release-note categories via `.github/release.yml` — an unlabel
   indistinguishable from pending. Confirm the expected workflows actually created runs.
 - **Prove a new regression test is non-vacuous.** Revert the fix, watch the test fail, restore it.
   Several tests here have passed against the bug they were meant to pin.
-- **`FLUREE_DISABLE_QUERY_FAST_PATHS` is the usual differential oracle, but it is not infallible** —
-  see issue #1700, where the generic pipeline is the *wrong* lane for `COUNT(*)` over a
-  multi-object join. Confirm which lane is correct before "fixing" toward the oracle.
+- **Two lanes agreeing is not evidence of correctness.** `FLUREE_DISABLE_QUERY_FAST_PATHS` is the
+  usual differential oracle, but a defect in the *plan both lanes share* is invisible to it — see
+  #1700, where an unprojected object variable silently collapsed row multiplicity and both lanes
+  returned the same wrong answer on most shapes. Where the two do disagree, confirm which lane is
+  right before "fixing" toward the oracle.
 - **Fast-path suites use routing stamps** (`MustFire` / `MustNotFire`) so a test cannot pass by
   silently taking the generic lane. If you add a fast path, stamp it.
 - SPARQL and JSON-LD share an IR: a fix on one surface generally needs a twin test on the other.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# Working in this repo
+
+Repo-wide guidance for Claude Code sessions. Personal notes belong in `CLAUDE.local.md`
+(gitignored), not here — this file is shared, so keep it to things that are true for everyone.
+
+## Linking issues from PRs
+
+Reference direction must be explicit. Most issue↔PR references here are deferrals, not fixes, and
+today the two are indistinguishable — an audit of the open backlog found eight issues that were
+already fixed but still open for exactly this reason.
+
+- **`Fixes #N` / `Closes #N` — in the PR body** when the PR resolves the issue. The body
+  specifically: that is what creates the linked-PR relationship. (A commit-message keyword also
+  closes on merge to the default branch, but leaves the issue closed with no visible cause.)
+- **`Follow-up: #N`** when the PR *defers* work to an issue, including issues filed out of its own
+  review. Not a closing keyword, deliberately.
+- **`Partially addresses #N`** when the issue stays open; say what remains. Write it exactly that
+  way — GitHub matches closing keywords anywhere in the body, so "partially fixes #N" closes it.
+
+Closing keywords only fire when the PR's base is the default branch. Folding a child PR into its
+parent silently discards any `Fixes #N` in the child's body — move it to the parent.
+
+Full detail: `docs/contributing/issue-linking.md`.
+
+## Gates before pushing
+
+CI is the source of truth (`.github/workflows/ci.yml`). Two things catch people out:
+
+- CI runs **two** fmt/clippy pairs — one over the workspace, and a second with
+  `working-directory: testsuite-sparql`, which is *excluded* from the workspace. A root
+  `cargo fmt --all` never reaches it. If you touched `testsuite-sparql/`, format and lint there
+  separately.
+- Run `cargo fmt --all` **after** your last edit. A post-clippy touch-up is the usual way a PR
+  arrives with a red fmt gate.
+
+Prefer narrow targets (`cargo test -p <crate>`, `cargo clippy -p <crate> --all-targets --no-deps`)
+over workspace-wide runs.
+
+## Issue triage labels
+
+Open issues carry `P0`–`P3` (priority), one `area:*` (subsystem: `query`, `transact`, `storage`,
+`iceberg`, `sparql`, `datalog`, `server`, `cli`), and `triage:*` where applicable
+(`needs-decision`, `needs-info`, `blocked`). Keep them current when a PR changes an issue's scope.
+PR labels drive release-note categories via `.github/release.yml` — an unlabeled PR lands under
+"Other Changes".
+
+## Verification habits that this codebase specifically rewards
+
+- **A check that never ran is not a pass.** When a test, suite, or gate is skipped, say so
+  explicitly rather than letting its absence read as success. This applies to CI too: a PR can
+  end up with *no* workflow run at all, which `gh pr checks` reports as "no checks reported" —
+  indistinguishable from pending. Confirm the expected workflows actually created runs.
+- **Prove a new regression test is non-vacuous.** Revert the fix, watch the test fail, restore it.
+  Several tests here have passed against the bug they were meant to pin.
+- **`FLUREE_DISABLE_QUERY_FAST_PATHS` is the usual differential oracle, but it is not infallible** —
+  see issue #1700, where the generic pipeline is the *wrong* lane for `COUNT(*)` over a
+  multi-object join. Confirm which lane is correct before "fixing" toward the oracle.
+- **Fast-path suites use routing stamps** (`MustFire` / `MustNotFire`) so a test cannot pass by
+  silently taking the generic lane. If you add a fast path, stamp it.
+- SPARQL and JSON-LD share an IR: a fix on one surface generally needs a twin test on the other.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,30 @@
 # Contributing
 
+The full contributor guide — dev setup, code style, testing, PR format — lives in
+[`docs/contributing/README.md`](docs/contributing/README.md). This file covers one thing that
+GitHub surfaces at exactly the right moment: how to link a PR to an issue.
+
 ## Linking issues from PRs
 
 The issue tracker only stays truthful if PR↔issue references carry direction. Three forms, used deliberately:
 
-- **`Fixes #N` / `Closes #N` — in the PR body** — required when the PR resolves the issue. The body specifically, not a comment or a commit message: GitHub only auto-closes the issue on merge when the keyword is in the body (and only when the PR's base is the default branch).
-- **`Follow-up: #N`** — required when the PR *defers* work to an issue, including issues filed during the PR's own review. This marks the reference as a deferral, so it can't be mistaken for a fix.
-- **`Partially addresses #N`** — leaves the issue open by design. Say in the PR body what remains, and rescope the issue after merge so the open remainder is what the issue actually describes.
+- **`Fixes #N` / `Closes #N` — in the PR body** — when the PR resolves the issue. Put it in the body rather than only a comment: a keyword in the body creates the *linked pull request* relationship, so the issue shows what fixed it and the PR shows what it closes. (A closing keyword in a **commit message** also closes the issue when the commit reaches the default branch, but it does not create that linked-PR relationship — so prefer the body, and keep the commit trailer if you like both.) Either way, closing keywords only fire when the PR's base is the default branch.
+- **`Follow-up: #N`** — when the PR *defers* work to an issue, including issues filed during the PR's own review. This marks the reference as a deferral so it can't be mistaken for a fix. Deliberately not a closing keyword.
+- **`Partially addresses #N`** — leaves the issue open by design. Say in the PR body what remains, and rescope the issue after merge so the open remainder is what the issue actually describes. Write it exactly this way — *"partially fixes #N"* still contains a closing keyword and will close the issue on merge.
 
-Background: a 2026-08 audit of the full open backlog found the dominant failure mode was exactly this ambiguity — merged PRs referencing issues without closing keywords left fixed issues open, and deferral references were indistinguishable from fix references without reading every mention's context.
+### Stacked PRs
+
+Closing keywords fire only against the default branch, so a PR based on another PR won't close anything while it sits on that base. Two ways this repo lands stacks, with different consequences:
+
+- **Retarget to `main` before merging** (what we usually do) — the keyword fires normally. Nothing to do.
+- **Fold a child into its parent** — the child's PR body disappears with it, and any `Fixes #N` it carried is silently lost. Move those keywords into the surviving parent's body, or close the issues by hand with a citation.
+
+Background: a 2026-08 audit of the full open backlog found eight issues that were already fixed but still open, and the cause was the same each time — the fixing PR referenced the issue without a closing keyword, or the reference direction (fix vs deferral) was impossible to tell without reading each mention by hand.
 
 ## Gates
 
-CI is the source of truth: `cargo fmt --all --check`, clippy, and the test suites under `.github/workflows/`. One local habit worth keeping: run `cargo fmt --all` *after* your final edit — a post-clippy touch-up can re-redden fmt.
+CI is the source of truth; see `.github/workflows/ci.yml`. One thing worth knowing locally: `ci.yml` runs **two** fmt/clippy pairs — one over the workspace, and a second with `working-directory: testsuite-sparql`, which is excluded from the workspace. A root `cargo fmt --all` does not reach it, so if you touched `testsuite-sparql/`, format it separately or CI will redden on a file you never opened.
 
 ## Triage labels
 
-Open issues carry `P0`–`P3` (priority), `area:*` (subsystem), and `triage:*` (state: `needs-decision`, `needs-info`, `blocked`). Keep them current when a PR changes an issue's scope or priority.
+Open issues carry `P0`–`P3` (priority), `area:*` (subsystem), and `triage:*` (state: `needs-decision`, `needs-info`, `blocked`). Keep them current when a PR changes an issue's scope or priority. PR labels matter too — `.github/release.yml` derives release-note categories from them, so an unlabeled PR lands under "Other Changes".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Linking issues from PRs
+
+The issue tracker only stays truthful if PR↔issue references carry direction. Three forms, used deliberately:
+
+- **`Fixes #N` / `Closes #N` — in the PR body** — required when the PR resolves the issue. The body specifically, not a comment or a commit message: GitHub only auto-closes the issue on merge when the keyword is in the body (and only when the PR's base is the default branch).
+- **`Follow-up: #N`** — required when the PR *defers* work to an issue, including issues filed during the PR's own review. This marks the reference as a deferral, so it can't be mistaken for a fix.
+- **`Partially addresses #N`** — leaves the issue open by design. Say in the PR body what remains, and rescope the issue after merge so the open remainder is what the issue actually describes.
+
+Background: a 2026-08 audit of the full open backlog found the dominant failure mode was exactly this ambiguity — merged PRs referencing issues without closing keywords left fixed issues open, and deferral references were indistinguishable from fix references without reading every mention's context.
+
+## Gates
+
+CI is the source of truth: `cargo fmt --all --check`, clippy, and the test suites under `.github/workflows/`. One local habit worth keeping: run `cargo fmt --all` *after* your final edit — a post-clippy touch-up can re-redden fmt.
+
+## Triage labels
+
+Open issues carry `P0`–`P3` (priority), `area:*` (subsystem), and `triage:*` (state: `needs-decision`, `needs-info`, `blocked`). Keep them current when a PR changes an issue's scope or priority.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,39 @@
 # Contributing
 
-The full contributor guide — dev setup, code style, testing, PR format — lives in
-[`docs/contributing/README.md`](docs/contributing/README.md). This file covers one thing that
-GitHub surfaces at exactly the right moment: how to link a PR to an issue.
+The full contributor guide — dev setup, code style, testing, benchmarks, the W3C SPARQL
+compliance suite — lives in [`docs/contributing/`](docs/contributing/README.md).
+
+This file covers the one convention GitHub surfaces at exactly the right moment: **how to link a
+PR to an issue.** The full version, including stacked PRs and the reasoning, is at
+[`docs/contributing/issue-linking.md`](docs/contributing/issue-linking.md).
 
 ## Linking issues from PRs
 
-The issue tracker only stays truthful if PR↔issue references carry direction. Three forms, used deliberately:
+Reference direction has to be explicit, because most issue↔PR references in this repo are
+deferrals rather than fixes:
 
-- **`Fixes #N` / `Closes #N` — in the PR body** — when the PR resolves the issue. Put it in the body rather than only a comment: a keyword in the body creates the *linked pull request* relationship, so the issue shows what fixed it and the PR shows what it closes. (A closing keyword in a **commit message** also closes the issue when the commit reaches the default branch, but it does not create that linked-PR relationship — so prefer the body, and keep the commit trailer if you like both.) Either way, closing keywords only fire when the PR's base is the default branch.
-- **`Follow-up: #N`** — when the PR *defers* work to an issue, including issues filed during the PR's own review. This marks the reference as a deferral so it can't be mistaken for a fix. Deliberately not a closing keyword.
-- **`Partially addresses #N`** — leaves the issue open by design. Say in the PR body what remains, and rescope the issue after merge so the open remainder is what the issue actually describes. Write it exactly this way — *"partially fixes #N"* still contains a closing keyword and will close the issue on merge.
+- **`Fixes #N` / `Closes #N`, in the PR body** — this PR resolves the issue. The body, so the
+  issue links back to the PR. (A commit-message keyword also closes on merge to the default
+  branch, but creates no linked-PR relationship.) Closing keywords only fire when the PR's base
+  is the default branch.
+- **`Follow-up: #N`** — work this PR *defers* to an issue, including issues filed during its own
+  review. Not a closing keyword, by design.
+- **`Partially addresses #N`** — the issue stays open; say what remains. Write it this way:
+  GitHub matches closing keywords anywhere in the body, so *"partially fixes #N"* would close it.
 
-### Stacked PRs
-
-Closing keywords fire only against the default branch, so a PR based on another PR won't close anything while it sits on that base. Two ways this repo lands stacks, with different consequences:
-
-- **Retarget to `main` before merging** (what we usually do) — the keyword fires normally. Nothing to do.
-- **Fold a child into its parent** — the child's PR body disappears with it, and any `Fixes #N` it carried is silently lost. Move those keywords into the surviving parent's body, or close the issues by hand with a citation.
-
-Background: a 2026-08 audit of the full open backlog found eight issues that were already fixed but still open, and the cause was the same each time — the fixing PR referenced the issue without a closing keyword, or the reference direction (fix vs deferral) was impossible to tell without reading each mention by hand.
+Landing a stack? A child folded into its parent takes its `Fixes #N` with it, silently — see
+[the full page](docs/contributing/issue-linking.md#stacked-prs).
 
 ## Gates
 
-CI is the source of truth; see `.github/workflows/ci.yml`. One thing worth knowing locally: `ci.yml` runs **two** fmt/clippy pairs — one over the workspace, and a second with `working-directory: testsuite-sparql`, which is excluded from the workspace. A root `cargo fmt --all` does not reach it, so if you touched `testsuite-sparql/`, format it separately or CI will redden on a file you never opened.
+CI is the source of truth; see `.github/workflows/ci.yml`. Worth knowing locally: CI runs **two**
+fmt/clippy pairs — one over the workspace, and a second with `working-directory: testsuite-sparql`,
+which is excluded from the workspace. A root `cargo fmt --all` does not reach it, so if you
+touched `testsuite-sparql/`, format it there separately or CI reddens on a file you never opened.
 
 ## Triage labels
 
-Open issues carry `P0`–`P3` (priority), `area:*` (subsystem), and `triage:*` (state: `needs-decision`, `needs-info`, `blocked`). Keep them current when a PR changes an issue's scope or priority. PR labels matter too — `.github/release.yml` derives release-note categories from them, so an unlabeled PR lands under "Other Changes".
+Open issues carry `P0`–`P3` (priority), `area:*` (subsystem), and `triage:*` (state:
+`needs-decision`, `needs-info`, `blocked`). Keep them current when a PR changes an issue's scope
+or priority. PR labels matter too — `.github/release.yml` derives release-note categories from
+them, so an unlabeled PR lands under "Other Changes".

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -246,6 +246,7 @@
   - [Crate map](reference/crate-map.md)
 
 - [Contributing](contributing/README.md)
+  - [Linking issues from PRs](contributing/issue-linking.md)
   - [Dev setup](contributing/dev-setup.md)
   - [Tests](contributing/tests.md)
   - [Adding a benchmark](contributing/benches.md)

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -131,13 +131,19 @@ More detailed explanation if needed. Wrap at 72 characters.
 Fixes #123
 ```
 
+A `Fixes #123` trailer closes the issue once the commit reaches the default branch, but it does
+not create the *linked pull request* relationship — so put the closing keyword in the **PR body**
+as well (or instead). See [Linking issues from PRs](../../CONTRIBUTING.md#linking-issues-from-prs)
+for the three reference forms and how they behave on stacked PRs.
+
 ### 7. Push and Create PR
 
 ```bash
 git push origin feature/my-feature
 ```
 
-Create pull request on GitHub.
+Create pull request on GitHub. Put `Fixes #N` / `Follow-up: #N` / `Partially addresses #N` in the
+PR body so the reference direction is explicit.
 
 ### 8. Address Review Comments
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -133,8 +133,8 @@ Fixes #123
 
 A `Fixes #123` trailer closes the issue once the commit reaches the default branch, but it does
 not create the *linked pull request* relationship — so put the closing keyword in the **PR body**
-as well (or instead). See [Linking issues from PRs](../../CONTRIBUTING.md#linking-issues-from-prs)
-for the three reference forms and how they behave on stacked PRs.
+as well (or instead). See [Linking issues from PRs](issue-linking.md) for the three reference
+forms and how they behave on stacked PRs.
 
 ### 7. Push and Create PR
 
@@ -143,7 +143,7 @@ git push origin feature/my-feature
 ```
 
 Create pull request on GitHub. Put `Fixes #N` / `Follow-up: #N` / `Partially addresses #N` in the
-PR body so the reference direction is explicit.
+PR body so the reference direction is explicit — see [Linking issues from PRs](issue-linking.md).
 
 ### 8. Address Review Comments
 

--- a/docs/contributing/issue-linking.md
+++ b/docs/contributing/issue-linking.md
@@ -1,0 +1,50 @@
+# Linking issues from PRs
+
+The issue tracker only stays truthful if PR↔issue references carry direction. Most references in
+this repo are *deferrals* — an issue filed out of a PR's own review — and today those are
+indistinguishable from references that mean "this PR fixed it." Three forms, used deliberately:
+
+## `Fixes #N` / `Closes #N` — the PR resolves the issue
+
+Put it in the **PR body**. A closing keyword in the body creates the *linked pull request*
+relationship, so the issue shows what fixed it and the PR shows what it closes.
+
+A closing keyword in a **commit message** also closes the issue once that commit reaches the
+default branch — but it does not create the linked-PR relationship, so the issue ends up closed
+with no visible cause. Prefer the body; keep a commit trailer as well if you like both.
+
+Either way, closing keywords only fire when the PR's base is the default branch.
+
+## `Follow-up: #N` — the PR defers work to an issue
+
+Use this whenever a PR spins work out into an issue, including issues filed during the PR's own
+review. It marks the reference as a deferral so it cannot be mistaken for a fix. Deliberately not
+a closing keyword.
+
+## `Partially addresses #N` — the issue stays open by design
+
+Say in the PR body what remains, and rescope the issue after merge so the open remainder is what
+the issue actually describes.
+
+Write it exactly this way. GitHub matches closing keywords **anywhere in the body**, not just at
+the start of a line, so *"partially fixes #N"* still contains `fixes #N` and will close the issue
+on merge.
+
+## Stacked PRs
+
+Closing keywords fire only against the default branch, so a PR based on another PR closes nothing
+while it sits on that base. Two ways this repo lands stacks, with different consequences:
+
+- **Retarget to `main` before merging** — what we usually do, and the keyword then fires normally.
+  Nothing to remember.
+- **Fold a child into its parent** — the child's PR body disappears with it, and any `Fixes #N` it
+  carried is silently lost. Move those keywords into the surviving parent's body, or close the
+  issues by hand with a citation to the commit that did the work.
+
+## Why
+
+A 2026-08 audit of the full open backlog found eight issues that were already fixed but still
+open. The cause was the same every time: the fixing PR referenced the issue without a closing
+keyword, or the reference direction — fix versus deferral — was impossible to tell without
+reading each mention by hand. Of fifteen PRs merged in one sample window, one used a closing
+keyword.


### PR DESCRIPTION
Small process fix coming out of this week's full-backlog triage: of 94 open issues, 8 turned out to be already-fixed-but-open, and the root cause in every case was the same — the fixing PR referenced the issue without a closing keyword in its body. Meanwhile the *majority* of issue↔PR cross-references in this repo are deferrals (issues filed out of a PR's review, sometimes minutes before merge), which are indistinguishable from fix references without reading each mention's context by hand.

This adds the minimal convention that makes reference direction explicit — `Fixes #N` in the body when a PR resolves an issue, `Follow-up: #N` when it defers one, `Partially addresses #N` with a stated remainder — as a short `CONTRIBUTING.md` plus a comment-only PR template that nudges without imposing structure. It also documents the new triage labels (`P0`–`P3`, `area:*`, `triage:*`) so they don't drift.

Deliberately lean: no process invented beyond what we already do, and CI stays the source of truth for gates. If we'd rather grow a fuller CONTRIBUTING later, this gives it a home.
