### PR TITLE
fix(cli): novelty-aware encoded-binding resolution in the table renderer, and never Debug-print a binding

### DIFF
--- a/fluree-db-cli/src/commands/branch.rs
+++ b/fluree-db-cli/src/commands/branch.rs
@@ -1245,11 +1245,15 @@ fn print_preview_local(p: &fluree_db_api::MergePreview) {
         }
     );
     for k in &p.conflicts.keys {
+        // `g` is `Option<Sid>`; Debug-printing the Option leaked `Some("…")`
+        // into the listing while `s`/`p` beside it rendered plain IRIs. A
+        // conflict with no graph is in the default graph — say so.
         println!(
-            "  - s={} p={} g={:?}",
+            "  - s={} p={} g={}",
             k.s,
             k.p,
-            k.g.as_ref().map(ToString::to_string)
+            k.g.as_ref()
+                .map_or_else(|| "<default>".to_string(), ToString::to_string)
         );
     }
     if !p.conflicts.details.is_empty() {

--- a/fluree-db-cli/src/commands/create.rs
+++ b/fluree-db-cli/src/commands/create.rs
@@ -261,8 +261,15 @@ async fn poll_remote_import(
             }
             Some("running" | "awaiting-upload") => {}
             other => {
+                // `other` is `Option<&str>`; Debug-printing it rendered the
+                // Rust container — `unexpected remote import status:
+                // Some("weird")`. Show the status the way the server sent it,
+                // and fall back to the raw JSON when the field is absent or
+                // isn't a string (`null`, a number, an object) so the message
+                // still names what arrived.
+                let shown = other.map_or_else(|| status["status"].to_string(), ToString::to_string);
                 return Err(CliError::Remote(format!(
-                    "unexpected remote import status: {other:?}"
+                    "unexpected remote import status: {shown}"
                 )));
             }
         }

--- a/fluree-db-cli/src/output.rs
+++ b/fluree-db-cli/src/output.rs
@@ -158,10 +158,41 @@ enum SparqlTableFastPath {
     NeedsDisaggregation,
 }
 
-/// Placeholder rendered when an encoded binding cannot be resolved to a
-/// user-facing value (missing graph view, or an ID the dictionaries don't
-/// know). Internal `Debug` representations must never reach user output.
-const UNRESOLVED_CELL: &str = "<unresolved>";
+/// Prefix of the placeholder rendered when an encoded binding cannot be
+/// resolved to a user-facing value. Internal `Debug` representations must never
+/// reach user output.
+const UNRESOLVED_CELL_PREFIX: &str = "(unresolved ";
+
+/// Render — and log — the fallback cell for an encoded binding that did not
+/// resolve, either because there is no graph view to resolve against or because
+/// the dictionaries don't know the ID.
+///
+/// `detail` carries the ID the resolver was handed. Without it every
+/// unresolvable binding collapses to the same text, so two distinct broken rows
+/// look alike and the cell is undiagnosable — which matters more, not less, for
+/// an arm this cold: the day it fires is the day the ID is wanted. This mirrors
+/// what the rest of the tree does with the same failure: the API formatters
+/// hard-error with the ID in the message (`fluree-db-api/src/format/materialize.rs:63`)
+/// and the materializer fabricates `_:unknown_p_{p_id}` alongside a
+/// `tracing::warn!` (`fluree-db-query/src/materializer.rs:669-673`).
+///
+/// The parenthesised shape is deliberate. A bare `<unresolved>` in RDF-facing
+/// output reads like a relative IRI — a user can reasonably parse that cell as a
+/// subject actually named `unresolved`.
+fn unresolved_cell(reason: &str, detail: &str) -> String {
+    tracing::warn!(
+        reason,
+        binding = detail,
+        "table cell: encoded binding did not resolve; rendering placeholder"
+    );
+    format!("{UNRESOLVED_CELL_PREFIX}{detail})")
+}
+
+/// `gv` is `None`: the query result carried no binary graph, so there is
+/// nothing to resolve encoded IDs against.
+const NO_GRAPH_VIEW: &str = "no binary graph view on the query result";
+/// The graph view was present and the resolver still came up empty.
+const RESOLVER_MISS: &str = "graph view could not resolve the ID";
 
 fn strip_question_mark(var_name: &str) -> String {
     var_name.strip_prefix('?').unwrap_or(var_name).to_string()
@@ -188,23 +219,43 @@ fn sparql_table_cell(
 
         Binding::EncodedSid { s_id, .. } => {
             let Some(gv) = gv else {
-                return Ok(UNRESOLVED_CELL.to_string());
+                return Ok(unresolved_cell(NO_GRAPH_VIEW, &format!("s_id={s_id}")));
             };
             // Novelty-aware resolve (parity with the API formatters'
             // materialization): subjects first seen after the index snapshot
             // live in DictNovelty, which the store-level resolver can't see.
             match gv.resolve_subject_iri(*s_id) {
                 Ok(iri) => compact_bnode_strip(compactor.compact_iri_for_display(&iri).ok()),
-                Err(_) => UNRESOLVED_CELL.to_string(),
+                Err(_) => unresolved_cell(RESOLVER_MISS, &format!("s_id={s_id}")),
             }
         }
+        // The store-level predicate resolver is correct here, and deliberate.
+        //
+        // There *is* an ephemeral predicate layer (`EphemeralPredicateMap`,
+        // `fluree-db-query/src/binary_scan.rs:2577`, routed by
+        // `DictOverlay::resolve_predicate_iri` at `dict_overlay.rs:291`), so
+        // "predicates have no novelty layer" would be the wrong reason. The
+        // right one is reachability: the engine has exactly one construction
+        // site for `Binding::EncodedPid` (`binary_scan.rs:1486`), and it is
+        // gated on `late_materialize`, which requires
+        // `overlay.epoch() == 0` (`binary_scan.rs:1366`) — no novelty overlay
+        // at all. Ephemeral p_ids are minted only during overlay translation,
+        // i.e. only when an overlay exists; under an overlay that same scan
+        // takes the eager branch (`binary_scan.rs:1488`) and emits a resolved
+        // `Binding::Sid`. So an ephemeral p_id cannot coexist with the path
+        // that puts an `EncodedPid` in front of this formatter, and the index
+        // root's inline predicate dict is complete for every p_id that can.
+        //
+        // Every other formatter resolves predicates the same way:
+        // `fluree-db-api/src/format/sparql_xml.rs:302`,
+        // `fluree-db-api/src/lib.rs:4580`, `fluree-db-query/src/sort.rs:93`.
         Binding::EncodedPid { p_id } => {
             let Some(gv) = gv else {
-                return Ok(UNRESOLVED_CELL.to_string());
+                return Ok(unresolved_cell(NO_GRAPH_VIEW, &format!("p_id={p_id}")));
             };
             match gv.store().resolve_predicate_iri(*p_id) {
                 Some(iri) => compact_bnode_strip(compactor.compact_iri_for_display(iri).ok()),
-                None => UNRESOLVED_CELL.to_string(),
+                None => unresolved_cell(RESOLVER_MISS, &format!("p_id={p_id}")),
             }
         }
         Binding::EncodedLit {
@@ -216,11 +267,17 @@ fn sparql_table_cell(
             ..
         } => {
             let Some(gv) = gv else {
-                return Ok(UNRESOLVED_CELL.to_string());
+                return Ok(unresolved_cell(
+                    NO_GRAPH_VIEW,
+                    &format!("o_kind={o_kind} o_key={o_key} p_id={p_id}"),
+                ));
             };
             match gv.decode_value_from_kind(*o_kind, *o_key, *p_id, *dt_id, *lang_id) {
                 Ok(v) => flake_value_to_table_cell(&v, compactor),
-                Err(_) => UNRESOLVED_CELL.to_string(),
+                Err(_) => unresolved_cell(
+                    RESOLVER_MISS,
+                    &format!("o_kind={o_kind} o_key={o_key} p_id={p_id}"),
+                ),
             }
         }
 
@@ -521,7 +578,7 @@ mod tests {
     //! placeholder — never a Rust `Debug` representation of an internal struct.
 
     use super::*;
-    use fluree_db_api::LedgerState;
+    use fluree_db_api::{Fluree, LedgerState};
     use fluree_db_api::{FlureeBuilder, ParsedContext, ReindexOptions};
     use fluree_db_binary_index::BinaryGraphView;
     use serde_json::json;
@@ -533,7 +590,14 @@ mod tests {
     /// Mirrors the reported repro's shape: `ex:m9` is committed after the
     /// index snapshot, so its subject ID lives in `DictNovelty` and the
     /// persisted forward packs know nothing about it.
-    async fn indexed_ledger_with_novelty_subject() -> (LedgerState, fluree_db_api::GraphDb) {
+    ///
+    /// `ex:knows` gives both `ex:s1` and `ex:m9` a reference to an indexed
+    /// node. That edge is what lets a query keep the *subject* variable
+    /// late-materialized (see
+    /// `novelty_only_encoded_sid_from_a_real_query_renders_its_iri`); a
+    /// literal-only fixture never produces an `EncodedSid` at all.
+    async fn indexed_ledger_with_novelty_subject() -> (Fluree, LedgerState, fluree_db_api::GraphDb)
+    {
         let fluree = FlureeBuilder::memory().build_memory();
         let ledger = fluree.create_ledger(LEDGER).await.expect("create ledger");
 
@@ -543,8 +607,9 @@ mod tests {
                 &json!({
                     "@context": {"ex": "http://example.org/"},
                     "@graph": [
-                        {"@id": "ex:x1", "ex:indexedProp": "val1"},
-                        {"@id": "ex:s1", "@type": "ex:Probe", "ex:ref": "val1"}
+                        {"@id": "ex:x1", "@type": "ex:Target", "ex:indexedProp": "val1"},
+                        {"@id": "ex:s1", "@type": "ex:Probe", "ex:ref": "val1",
+                         "ex:knows": {"@id": "ex:x1"}}
                     ]
                 }),
             )
@@ -566,7 +631,8 @@ mod tests {
                     "@context": {"ex": "http://example.org/"},
                     "@graph": [
                         {"@id": "ex:x2", "ex:indexedProp": "val2"},
-                        {"@id": "ex:m9", "@type": "ex:Probe", "ex:ref": "val2"}
+                        {"@id": "ex:m9", "@type": "ex:Probe", "ex:ref": "val2",
+                         "ex:knows": {"@id": "ex:x1"}}
                     ]
                 }),
             )
@@ -575,8 +641,20 @@ mod tests {
             .ledger;
 
         let db = fluree.db(LEDGER).await.expect("indexed view");
-        (ledger, db)
+        (fluree, ledger, db)
     }
+
+    /// The SPARQL shape that actually puts a novelty-only `EncodedSid` in front
+    /// of the table formatter.
+    ///
+    /// Joining a reference edge against a typed object keeps `?s`
+    /// late-materialized, so subject IDs arrive at the formatter encoded rather
+    /// than already resolved to `Binding::Sid`. A literal-only join does not —
+    /// its subjects come back materialized, which is why the plain repro shape
+    /// never reaches the arm this PR fixes.
+    const ENCODED_SID_QUERY: &str = "SELECT ?s ?o WHERE { \
+         ?s <http://example.org/knows> ?o . \
+         ?o a <http://example.org/Target> . }";
 
     /// The novelty-minted subject ID for `iri`, as the scan layer would emit it.
     fn novelty_s_id(ledger: &LedgerState, gv: &BinaryGraphView, iri: &str) -> u64 {
@@ -600,7 +678,7 @@ mod tests {
     /// is the only condition under which the old code path was wrong.
     #[tokio::test(flavor = "current_thread")]
     async fn encoded_sid_from_novelty_renders_iri_not_debug_repr() {
-        let (ledger, db) = indexed_ledger_with_novelty_subject().await;
+        let (_fluree, ledger, db) = indexed_ledger_with_novelty_subject().await;
         let gv = db.binary_graph().expect("indexed view has a binary graph");
         let compactor = compactor_for(&db);
 
@@ -626,18 +704,98 @@ mod tests {
             !cell.contains("EncodedSid"),
             "internal Debug repr leaked into table output: {cell:?}"
         );
-        assert_ne!(cell, UNRESOLVED_CELL, "resolvable subject fell back");
+        assert!(
+            !cell.starts_with(UNRESOLVED_CELL_PREFIX),
+            "resolvable subject fell back: {cell:?}"
+        );
+    }
+
+    /// The same property, but with the binding produced by the real query
+    /// engine rather than constructed by hand — and rendered through the whole
+    /// table fast path, not just one cell.
+    ///
+    /// This is the test that proves the `EncodedSid` arm is on a live path.
+    /// It asserts, before rendering anything, that the engine actually put an
+    /// `EncodedSid` in the batch *and* that the base store cannot resolve its
+    /// ID — the two conditions that together make the old store-only resolver
+    /// wrong. A shape that stopped emitting encoded subjects, or a fixture that
+    /// stopped being novelty-only, reddens here instead of passing quietly.
+    #[tokio::test(flavor = "current_thread")]
+    async fn novelty_only_encoded_sid_from_a_real_query_renders_its_iri() {
+        let (fluree, _ledger, db) = indexed_ledger_with_novelty_subject().await;
+        let result = fluree
+            .query(&db, ENCODED_SID_QUERY)
+            .await
+            .expect("join query runs");
+        let gv = result
+            .binary_graph
+            .as_ref()
+            .expect("query result carries a binary graph");
+
+        // Non-vacuity, in two parts.
+        let mut encoded = 0usize;
+        let mut novelty_only_encoded = 0usize;
+        for batch in &result.batches {
+            let schema: Vec<_> = batch.schema().to_vec();
+            for row in 0..batch.len() {
+                for var_id in &schema {
+                    if let Some(Binding::EncodedSid { s_id, .. }) = batch.get(row, *var_id) {
+                        encoded += 1;
+                        if gv.store().resolve_subject_iri(*s_id).is_err() {
+                            novelty_only_encoded += 1;
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            encoded > 0,
+            "this query no longer emits EncodedSid to the formatter — the arm \
+             under test is unreachable through it, so the assertions below \
+             would pass vacuously"
+        );
+        assert!(
+            novelty_only_encoded > 0,
+            "EncodedSid reaches the formatter, but every ID is resolvable from \
+             the persisted store — the novelty case (the one the old code got \
+             wrong) is not being exercised"
+        );
+
+        let output = format_sparql_table_from_result(&result, &db.snapshot, None)
+            .expect("table renders")
+            .expect("no grouped bindings, so the fast path applies");
+
+        assert!(
+            output.text.contains("m9"),
+            "novelty-only subject missing from the rendered table:\n{}",
+            output.text
+        );
+        assert!(
+            !output.text.contains("Encoded"),
+            "internal Debug repr leaked into table output:\n{}",
+            output.text
+        );
+        assert!(
+            !output.text.contains(UNRESOLVED_CELL_PREFIX),
+            "a resolvable binding fell back to the placeholder:\n{}",
+            output.text
+        );
     }
 
     /// A binding nothing can resolve renders the placeholder — never a
     /// `Debug` repr. Covers every encoded arm, with and without a graph view.
+    ///
+    /// The placeholder has to carry the ID: an arm this cold is only ever read
+    /// when something has already gone wrong, and a bare marker would make two
+    /// distinct broken rows indistinguishable.
     #[tokio::test(flavor = "current_thread")]
     async fn unresolvable_encoded_bindings_render_placeholder() {
-        let (_ledger, db) = indexed_ledger_with_novelty_subject().await;
+        let (_fluree, _ledger, db) = indexed_ledger_with_novelty_subject().await;
         let gv = db.binary_graph().expect("indexed view has a binary graph");
         let compactor = compactor_for(&db);
 
         // IDs above every watermark that were never minted in novelty either.
+        // Each is paired with the substring the placeholder must carry.
         let bogus_sid = Binding::encoded_sid(u64::MAX - 1);
         let bogus_pid = Binding::EncodedPid { p_id: u32::MAX };
         let bogus_lit = Binding::EncodedLit {
@@ -649,15 +807,40 @@ mod tests {
             i_val: 0,
             t: 1,
         };
+        let cases = [
+            (&bogus_sid, format!("s_id={}", u64::MAX - 1)),
+            (&bogus_pid, format!("p_id={}", u32::MAX)),
+            (&bogus_lit, format!("o_key={}", u64::from(u32::MAX - 1))),
+        ];
 
-        for b in [&bogus_sid, &bogus_pid, &bogus_lit] {
-            // With a graph view: resolution fails.
-            let cell = sparql_table_cell(b, &compactor, Some(&gv)).expect("cell renders");
-            assert_eq!(cell, UNRESOLVED_CELL, "with gv, binding {b:?}");
+        for (b, id_text) in &cases {
+            for gv in [Some(&gv), None] {
+                let cell = sparql_table_cell(b, &compactor, gv).expect("cell renders");
 
-            // Without a graph view: nothing to resolve against.
-            let cell = sparql_table_cell(b, &compactor, None).expect("cell renders");
-            assert_eq!(cell, UNRESOLVED_CELL, "without gv, binding {b:?}");
+                assert!(
+                    cell.starts_with(UNRESOLVED_CELL_PREFIX) && cell.ends_with(')'),
+                    "gv={}, binding {b:?}: {cell:?}",
+                    gv.is_some()
+                );
+                // The datum that makes the cell diagnosable.
+                assert!(
+                    cell.contains(id_text.as_str()),
+                    "placeholder dropped the ID (gv={}): {cell:?}",
+                    gv.is_some()
+                );
+                // Never the internal struct.
+                assert!(
+                    !cell.contains("Encoded"),
+                    "Debug repr leaked (gv={}): {cell:?}",
+                    gv.is_some()
+                );
+                // Never something a reader could take for a relative IRI.
+                assert!(
+                    !cell.starts_with('<'),
+                    "placeholder reads as an IRI (gv={}): {cell:?}",
+                    gv.is_some()
+                );
+            }
         }
     }
 
@@ -665,7 +848,7 @@ mod tests {
     /// the placeholder has to hold there too.
     #[tokio::test(flavor = "current_thread")]
     async fn unresolvable_binding_inside_list_renders_placeholder() {
-        let (_ledger, db) = indexed_ledger_with_novelty_subject().await;
+        let (_fluree, _ledger, db) = indexed_ledger_with_novelty_subject().await;
         let gv = db.binary_graph().expect("indexed view has a binary graph");
         let compactor = compactor_for(&db);
 
@@ -676,7 +859,11 @@ mod tests {
         )
         .expect("cell renders");
 
-        assert_eq!(cell, UNRESOLVED_CELL);
+        assert!(cell.starts_with(UNRESOLVED_CELL_PREFIX), "{cell:?}");
+        assert!(
+            cell.contains(&format!("s_id={}", u64::MAX - 1)),
+            "placeholder dropped the ID inside a list cell: {cell:?}"
+        );
         assert!(!cell.contains("EncodedSid"), "Debug repr leaked: {cell:?}");
     }
 }

--- a/fluree-db-cli/src/output.rs
+++ b/fluree-db-cli/src/output.rs
@@ -158,6 +158,11 @@ enum SparqlTableFastPath {
     NeedsDisaggregation,
 }
 
+/// Placeholder rendered when an encoded binding cannot be resolved to a
+/// user-facing value (missing graph view, or an ID the dictionaries don't
+/// know). Internal `Debug` representations must never reach user output.
+const UNRESOLVED_CELL: &str = "<unresolved>";
+
 fn strip_question_mark(var_name: &str) -> String {
     var_name.strip_prefix('?').unwrap_or(var_name).to_string()
 }
@@ -183,20 +188,23 @@ fn sparql_table_cell(
 
         Binding::EncodedSid { s_id, .. } => {
             let Some(gv) = gv else {
-                return Ok(format!("{b:?}"));
+                return Ok(UNRESOLVED_CELL.to_string());
             };
-            match gv.store().resolve_subject_iri(*s_id) {
+            // Novelty-aware resolve (parity with the API formatters'
+            // materialization): subjects first seen after the index snapshot
+            // live in DictNovelty, which the store-level resolver can't see.
+            match gv.resolve_subject_iri(*s_id) {
                 Ok(iri) => compact_bnode_strip(compactor.compact_iri_for_display(&iri).ok()),
-                Err(_) => format!("{b:?}"),
+                Err(_) => UNRESOLVED_CELL.to_string(),
             }
         }
         Binding::EncodedPid { p_id } => {
             let Some(gv) = gv else {
-                return Ok(format!("{b:?}"));
+                return Ok(UNRESOLVED_CELL.to_string());
             };
             match gv.store().resolve_predicate_iri(*p_id) {
                 Some(iri) => compact_bnode_strip(compactor.compact_iri_for_display(iri).ok()),
-                None => format!("{b:?}"),
+                None => UNRESOLVED_CELL.to_string(),
             }
         }
         Binding::EncodedLit {
@@ -208,11 +216,11 @@ fn sparql_table_cell(
             ..
         } => {
             let Some(gv) = gv else {
-                return Ok(format!("{b:?}"));
+                return Ok(UNRESOLVED_CELL.to_string());
             };
             match gv.decode_value_from_kind(*o_kind, *o_key, *p_id, *dt_id, *lang_id) {
                 Ok(v) => flake_value_to_table_cell(&v, compactor),
-                Err(_) => format!("{b:?}"),
+                Err(_) => UNRESOLVED_CELL.to_string(),
             }
         }
 
@@ -501,4 +509,174 @@ fn format_jsonld_table(json: &serde_json::Value, limit: Option<usize>) -> CliRes
         text: table.to_string(),
         total_rows,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    //! Guards for the encoded-binding arms of the table fast path (#1466).
+    //!
+    //! Two properties are pinned here: encoded subject IDs minted *after* the
+    //! index snapshot (novelty-only subjects) must render as their IRI, and an
+    //! encoded binding that cannot be resolved at all must render an explicit
+    //! placeholder — never a Rust `Debug` representation of an internal struct.
+
+    use super::*;
+    use fluree_db_api::LedgerState;
+    use fluree_db_api::{FlureeBuilder, ParsedContext, ReindexOptions};
+    use fluree_db_binary_index::BinaryGraphView;
+    use serde_json::json;
+
+    const LEDGER: &str = "cli/table-novelty:main";
+
+    /// Base data (indexed) plus a subject that lands only in novelty.
+    ///
+    /// Mirrors the reported repro's shape: `ex:m9` is committed after the
+    /// index snapshot, so its subject ID lives in `DictNovelty` and the
+    /// persisted forward packs know nothing about it.
+    async fn indexed_ledger_with_novelty_subject() -> (LedgerState, fluree_db_api::GraphDb) {
+        let fluree = FlureeBuilder::memory().build_memory();
+        let ledger = fluree.create_ledger(LEDGER).await.expect("create ledger");
+
+        fluree
+            .insert(
+                ledger,
+                &json!({
+                    "@context": {"ex": "http://example.org/"},
+                    "@graph": [
+                        {"@id": "ex:x1", "ex:indexedProp": "val1"},
+                        {"@id": "ex:s1", "@type": "ex:Probe", "ex:ref": "val1"}
+                    ]
+                }),
+            )
+            .await
+            .expect("base insert");
+
+        // Persist an index: everything above moves into the forward packs.
+        fluree
+            .reindex(LEDGER, ReindexOptions::default())
+            .await
+            .expect("reindex");
+
+        // Commit again *without* reindexing — ex:m9 is novelty-only.
+        let ledger = fluree.ledger(LEDGER).await.expect("post-index ledger");
+        let ledger = fluree
+            .insert(
+                ledger,
+                &json!({
+                    "@context": {"ex": "http://example.org/"},
+                    "@graph": [
+                        {"@id": "ex:x2", "ex:indexedProp": "val2"},
+                        {"@id": "ex:m9", "@type": "ex:Probe", "ex:ref": "val2"}
+                    ]
+                }),
+            )
+            .await
+            .expect("novelty insert")
+            .ledger;
+
+        let db = fluree.db(LEDGER).await.expect("indexed view");
+        (ledger, db)
+    }
+
+    /// The novelty-minted subject ID for `iri`, as the scan layer would emit it.
+    fn novelty_s_id(ledger: &LedgerState, gv: &BinaryGraphView, iri: &str) -> u64 {
+        let sid = gv.store().encode_iri(iri);
+        ledger
+            .dict_novelty
+            .subjects
+            .find_subject(sid.namespace_code, &sid.name)
+            .unwrap_or_else(|| panic!("{iri} was expected in DictNovelty but is not there"))
+    }
+
+    fn compactor_for(db: &fluree_db_api::GraphDb) -> IriCompactor {
+        IriCompactor::new(db.snapshot.shared_namespaces(), &ParsedContext::default())
+    }
+
+    /// #1466: a subject first seen after the index snapshot must resolve
+    /// through the novelty-aware `BinaryGraphView` resolver.
+    ///
+    /// The store-only assertion in the middle keeps this test honest: it fails
+    /// loudly if the fixture stops producing a genuinely novelty-only ID, which
+    /// is the only condition under which the old code path was wrong.
+    #[tokio::test(flavor = "current_thread")]
+    async fn encoded_sid_from_novelty_renders_iri_not_debug_repr() {
+        let (ledger, db) = indexed_ledger_with_novelty_subject().await;
+        let gv = db.binary_graph().expect("indexed view has a binary graph");
+        let compactor = compactor_for(&db);
+
+        let s_id = novelty_s_id(&ledger, &gv, "http://example.org/m9");
+
+        // Non-vacuity: the base-store resolver (what this code used to call)
+        // genuinely cannot see this ID. Without this, a fixture that quietly
+        // stopped being novelty-only would let the test pass against the bug.
+        assert!(
+            gv.store().resolve_subject_iri(s_id).is_err(),
+            "fixture is not exercising the novelty path: the persisted store \
+             already resolves s_id={s_id}"
+        );
+
+        let cell = sparql_table_cell(&Binding::encoded_sid(s_id), &compactor, Some(&gv))
+            .expect("cell renders");
+
+        assert!(
+            cell.ends_with("m9"),
+            "novelty-only subject should render as its IRI, got {cell:?}"
+        );
+        assert!(
+            !cell.contains("EncodedSid"),
+            "internal Debug repr leaked into table output: {cell:?}"
+        );
+        assert_ne!(cell, UNRESOLVED_CELL, "resolvable subject fell back");
+    }
+
+    /// A binding nothing can resolve renders the placeholder — never a
+    /// `Debug` repr. Covers every encoded arm, with and without a graph view.
+    #[tokio::test(flavor = "current_thread")]
+    async fn unresolvable_encoded_bindings_render_placeholder() {
+        let (_ledger, db) = indexed_ledger_with_novelty_subject().await;
+        let gv = db.binary_graph().expect("indexed view has a binary graph");
+        let compactor = compactor_for(&db);
+
+        // IDs above every watermark that were never minted in novelty either.
+        let bogus_sid = Binding::encoded_sid(u64::MAX - 1);
+        let bogus_pid = Binding::EncodedPid { p_id: u32::MAX };
+        let bogus_lit = Binding::EncodedLit {
+            o_kind: fluree_db_core::ObjKind::LEX_ID.as_u8(),
+            o_key: u64::from(u32::MAX - 1),
+            p_id: u32::MAX,
+            dt_id: 0,
+            lang_id: 0,
+            i_val: 0,
+            t: 1,
+        };
+
+        for b in [&bogus_sid, &bogus_pid, &bogus_lit] {
+            // With a graph view: resolution fails.
+            let cell = sparql_table_cell(b, &compactor, Some(&gv)).expect("cell renders");
+            assert_eq!(cell, UNRESOLVED_CELL, "with gv, binding {b:?}");
+
+            // Without a graph view: nothing to resolve against.
+            let cell = sparql_table_cell(b, &compactor, None).expect("cell renders");
+            assert_eq!(cell, UNRESOLVED_CELL, "without gv, binding {b:?}");
+        }
+    }
+
+    /// Nested containers (Cypher list cells) recurse through the same arm, so
+    /// the placeholder has to hold there too.
+    #[tokio::test(flavor = "current_thread")]
+    async fn unresolvable_binding_inside_list_renders_placeholder() {
+        let (_ledger, db) = indexed_ledger_with_novelty_subject().await;
+        let gv = db.binary_graph().expect("indexed view has a binary graph");
+        let compactor = compactor_for(&db);
+
+        let cell = sparql_table_cell(
+            &Binding::List(vec![Binding::encoded_sid(u64::MAX - 1)]),
+            &compactor,
+            Some(&gv),
+        )
+        .expect("cell renders");
+
+        assert_eq!(cell, UNRESOLVED_CELL);
+        assert!(!cell.contains("EncodedSid"), "Debug repr leaked: {cell:?}");
+    }
 }

--- a/fluree-db-cli/tests/integration.rs
+++ b/fluree-db-cli/tests/integration.rs
@@ -3536,14 +3536,23 @@ fn skolem_namespace_flag_controls_cross_ledger_blank_node_identity() {
 // #1466 — table output must never Debug-print an internal binding
 // ============================================================================
 
-/// End-to-end version of the reported repro: an indexed ledger with a subject
-/// whose triples arrived after the index snapshot, joined in through an indexed
-/// literal, rendered as a table.
+/// The fix, end to end through the real binary: an indexed ledger, a subject
+/// whose triples arrived after the index snapshot, and a `--format table`
+/// render that has to resolve that subject from novelty.
 ///
-/// The bug printed `EncodedSid { s_id: .., t: None, op: None }` in the `kind`
-/// column. The renderer-level guards live in `output.rs`; this pins the whole
-/// pipeline (insert, index, insert, `query --format table`) so a regression
-/// anywhere along it — not just in the resolver — is caught.
+/// The bug printed `EncodedSid { s_id: .., t: None, op: None }` into a cell.
+///
+/// The query shape matters. Joining the novelty subject in through a *literal*
+/// — the reported repro's shape — never reaches the arm this fixes: subjects
+/// arrive at the formatter already materialized as `Binding::Sid`, so that
+/// version of this test passed with the whole `EncodedSid` arm deleted. Joining
+/// through a *reference* edge against a typed object keeps `?s`
+/// late-materialized, which is what puts a novelty-only `EncodedSid` in front
+/// of the renderer. `output.rs`'s
+/// `novelty_only_encoded_sid_from_a_real_query_renders_its_iri` asserts that
+/// property directly on the batch; this pins the same shape through the whole
+/// pipeline (insert, index, insert, query), so a regression anywhere along it —
+/// not just in the resolver — is caught.
 #[test]
 fn table_output_renders_novelty_only_subject_after_index() {
     let tmp = TempDir::new().unwrap();
@@ -3558,9 +3567,9 @@ fn table_output_renders_novelty_only_subject_after_index() {
         .args([
             "insert",
             "-e",
-            "<urn:x1> <urn:indexed-prop> \"val1\" . \
+            "<urn:x1> a <urn:Target> ; <urn:indexed-prop> \"val1\" . \
              <urn:s1> <urn:ref> \"val1\" ; <urn:content> \"c1\" ; \
-             a <urn:Probe> .",
+             <urn:knows> <urn:x1> ; a <urn:Probe> .",
         ])
         .assert()
         .success();
@@ -3573,7 +3582,7 @@ fn table_output_renders_novelty_only_subject_after_index() {
             "-e",
             "<urn:x2> <urn:indexed-prop> \"val2\" . \
              <urn:m9> <urn:ref> \"val2\" ; <urn:content> \"probe content\" ; \
-             a <urn:Probe> .",
+             <urn:knows> <urn:x1> ; a <urn:Probe> .",
         ])
         .assert()
         .success();
@@ -3584,18 +3593,18 @@ fn table_output_renders_novelty_only_subject_after_index() {
             "--format",
             "table",
             "--sparql",
-            "SELECT ?m ?kind ?content WHERE { \
-               ?x <urn:indexed-prop> ?v . \
-               ?m <urn:ref> ?v ; <urn:content> ?content ; a ?kind . }",
+            "SELECT ?s ?o WHERE { \
+               ?s <urn:knows> ?o . \
+               ?o a <urn:Target> . }",
         ])
         .assert()
         .success()
         .stdout(predicate::str::contains("urn:m9"))
-        .stdout(predicate::str::contains("probe content"))
+        .stdout(predicate::str::contains("urn:s1"))
         // The reported symptom, and the placeholder that replaced it: neither
         // belongs in a correct render.
         .stdout(predicate::str::contains("EncodedSid").not())
         .stdout(predicate::str::contains("EncodedPid").not())
         .stdout(predicate::str::contains("EncodedLit").not())
-        .stdout(predicate::str::contains("<unresolved>").not());
+        .stdout(predicate::str::contains("(unresolved ").not());
 }

--- a/fluree-db-cli/tests/integration.rs
+++ b/fluree-db-cli/tests/integration.rs
@@ -3531,3 +3531,71 @@ fn skolem_namespace_flag_controls_cross_ledger_blank_node_identity() {
         "--skolem-namespace must reach the import builder on both sides"
     );
 }
+
+// ============================================================================
+// #1466 — table output must never Debug-print an internal binding
+// ============================================================================
+
+/// End-to-end version of the reported repro: an indexed ledger with a subject
+/// whose triples arrived after the index snapshot, joined in through an indexed
+/// literal, rendered as a table.
+///
+/// The bug printed `EncodedSid { s_id: .., t: None, op: None }` in the `kind`
+/// column. The renderer-level guards live in `output.rs`; this pins the whole
+/// pipeline (insert, index, insert, `query --format table`) so a regression
+/// anywhere along it — not just in the resolver — is caught.
+#[test]
+fn table_output_renders_novelty_only_subject_after_index() {
+    let tmp = TempDir::new().unwrap();
+    fluree_cmd(&tmp).arg("init").assert().success();
+    fluree_cmd(&tmp)
+        .args(["create", "noveltytable"])
+        .assert()
+        .success();
+
+    // Base data, then persist an index over it.
+    fluree_cmd(&tmp)
+        .args([
+            "insert",
+            "-e",
+            "<urn:x1> <urn:indexed-prop> \"val1\" . \
+             <urn:s1> <urn:ref> \"val1\" ; <urn:content> \"c1\" ; \
+             a <urn:Probe> .",
+        ])
+        .assert()
+        .success();
+    fluree_cmd(&tmp).args(["index"]).assert().success();
+
+    // Commit again *without* indexing: urn:m9 exists only in novelty.
+    fluree_cmd(&tmp)
+        .args([
+            "insert",
+            "-e",
+            "<urn:x2> <urn:indexed-prop> \"val2\" . \
+             <urn:m9> <urn:ref> \"val2\" ; <urn:content> \"probe content\" ; \
+             a <urn:Probe> .",
+        ])
+        .assert()
+        .success();
+
+    fluree_cmd(&tmp)
+        .args([
+            "query",
+            "--format",
+            "table",
+            "--sparql",
+            "SELECT ?m ?kind ?content WHERE { \
+               ?x <urn:indexed-prop> ?v . \
+               ?m <urn:ref> ?v ; <urn:content> ?content ; a ?kind . }",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("urn:m9"))
+        .stdout(predicate::str::contains("probe content"))
+        // The reported symptom, and the placeholder that replaced it: neither
+        // belongs in a correct render.
+        .stdout(predicate::str::contains("EncodedSid").not())
+        .stdout(predicate::str::contains("EncodedPid").not())
+        .stdout(predicate::str::contains("EncodedLit").not())
+        .stdout(predicate::str::contains("<unresolved>").not());
+}


### PR DESCRIPTION
Fixes #1466

## Where the reported symptom actually stands

#1466 reported `EncodedSid { s_id: .., t: None, op: None }` turning up in a `--format table` cell. The *query shape* in that report no longer reproduces — I ran it at `47e96b7b6` and the novelty-only subject renders as its IRI every time. For a while I thought that meant the bug had been fixed incidentally somewhere in the engine emit-path work since v4.1.2. It hasn't. The symptom is live on `main`; it just needs a different join shape, and I did reproduce it verbatim.

Indexed ledger, one commit on top that isn't indexed, then a query that joins through a **reference** edge rather than a literal:

```
$ fluree query --format table --sparql \
    'SELECT ?s ?o WHERE { ?s <urn:knows> ?o . ?o a <urn:Target> . }'
+--------+----------------------------------------------------------+
| o      | s                                                        |
+===================================================================+
| urn:x1 | urn:s1                                                   |
|--------+----------------------------------------------------------|
| urn:x1 | EncodedSid { s_id: 3659174697238532, t: None, op: None }  |
+--------+----------------------------------------------------------+
```

The difference is which bindings survive to the formatter. I instrumented `sparql_table_cell` to record the binding variant per output variable across ~20 shapes on an indexed-plus-novelty fixture. Under the reporter's literal join, `?m` and `?kind` arrive as `Binding::Sid` and `?content` as `EncodedLit` — **zero** `EncodedSid`, so that shape would render correctly even with the entire `EncodedSid` arm deleted. Under a reference-edge join against a typed object, `?s` stays late-materialized and reaches the formatter as `EncodedSid`; for a novelty-only subject that's an `s_id` the persisted store cannot resolve. Same for `OPTIONAL { ?s <knows> ?o }`, a two-hop `?a <knows> ?b . ?b <knows> ?c`, and a three-predicate star.

On the `Fixes` line: the issue was rescoped in a comment to *"cli: table renderer should use novelty-aware encoded-binding resolution and never Debug-print bindings"*, which is exactly what this PR does. It also fixes the original symptom under the shape that still produces it, so the closure holds against the issue as it reads now and as it was first reported.

## The gap

`fluree-db-cli/src/output.rs:188` resolved `Binding::EncodedSid` through `gv.store().resolve_subject_iri` — the **base-store** resolver, which consults only the persisted `subject_forward_packs` (`fluree-db-binary-index/src/read/binary_index_store.rs:1302`). A subject first seen after the index snapshot lives in `DictNovelty`, so that lookup **fails**. All six encoded-binding arms then fell back to `format!("{b:?}")` — the internal struct's `Debug` repr — straight into a table cell.

The novelty-aware resolver already exists one level up. `BinaryGraphView::resolve_subject_iri` (`binary_index_store.rs:2436`) tries `dict_novelty` first, then the store, then the novelty subject dict as a fallback. It's what every API formatter reaches through `fluree-db-api/src/format/materialize.rs:52-57`, whose `EncodedSid` arm is explicitly commented *"Novelty-aware: subjects first seen after the index snapshot resolve from DictNovelty"*. The CLI table fast path reads raw batches and bypasses that materialization pass, so it was the one remaining formatter in the tree using the store-only resolver behind a `Debug` fallback.

That's the same class as the newtype-`Display` footgun we've hit before: an internal repr with a plausible-looking string form leaking into something a user reads.

## What changed

**The resolver swap** (`output.rs:227`). `Binding::EncodedSid` now goes through `gv.resolve_subject_iri`, matching the API formatters. Two lines, and it's the whole correctness fix.

**All six `{b:?}` fallbacks become a placeholder that carries the ID** (`output.rs:182`). A failed resolve now renders `(unresolved s_id=3659174697238532)` / `(unresolved p_id=…)` / `(unresolved o_kind=… o_key=… p_id=…)` and emits a `tracing::warn!` naming the ID and whether the failure was a missing graph view or a resolver miss. Even with the resolver fixed, the fallback is the actual guarantee — it's what makes the class impossible rather than merely unlikely.

Two things drove that shape. A bare marker throws away the one datum worth having: every unresolvable binding would collapse to identical text, so two distinct broken rows look alike, and for an arm this cold the day it fires is the day you want the ID. And something like `<unresolved>` in RDF-facing output reads like a relative IRI — a user can reasonably parse that cell as a subject actually named `unresolved`. The parenthesised form can't be mistaken for one. This follows what the rest of the tree already does with the same failure: the API formatters hard-error with the ID in the message (`fluree-db-api/src/format/materialize.rs:63`), and the materializer fabricates `_:unknown_p_{p_id}` alongside a `tracing::warn!` (`fluree-db-query/src/materializer.rs:669-673`). The `EncodedPid` arm had no logging beneath it at all before this — it's an `Option`, and a `None` just vanished. (CLI logs are off by default; `--verbose` surfaces them.)

**The predicate arm deliberately keeps `gv.store().resolve_predicate_iri`**, and `output.rs:232-251` now records why. The reason is *not* that predicates have no novelty layer — they do have one: `EphemeralPredicateMap` (`fluree-db-query/src/binary_scan.rs:2577`), routed by `DictOverlay::resolve_predicate_iri` (`dict_overlay.rs:291`). The reason is reachability. The engine has exactly one construction site for `Binding::EncodedPid` (`binary_scan.rs:1486`), and it's gated on `late_materialize`, which requires `overlay.epoch() == 0` (`binary_scan.rs:1366`) — no novelty overlay at all. Ephemeral p_ids are minted only during overlay translation, i.e. only when an overlay exists, and under an overlay that same scan takes the eager branch (`binary_scan.rs:1488`) and emits an already-resolved `Binding::Sid`. So an ephemeral p_id can't coexist with the path that puts an `EncodedPid` in front of this formatter, and the index root's inline predicate dict is complete for every p_id that can. Every other formatter in the tree resolves predicates the same way (`fluree-db-api/src/format/sparql_xml.rs:302`, `fluree-db-api/src/lib.rs:4580`, `fluree-db-query/src/sort.rs:93`). Only the fallback changed there.

**`commands/branch.rs:1248`** — one more from the audit sweep. `merge preview`'s conflict listing Debug-printed an `Option<Sid>`, so a line read `s=ex:a p=ex:b g=Some("http://ex/g")` while `s` and `p` right beside it rendered plain IRIs. A key with no graph is in the default graph, so it says `<default>` now.

**`commands/create.rs:265`** — same class again. `status["status"].as_str()` is an `Option<&str>`, and the catch-all Debug-printed it, so an unrecognised status rendered as `unexpected remote import status: Some("weird")`. It now prints the value the server actually sent, falling back to the raw JSON when the field is absent or isn't a string (`null`, a number, an object), so the message still names what arrived.

## The audit — what I looked at and what I left alone

I swept the CLI crate for `{:?}` reaching user output. Beyond the eight sites fixed above, everything else is deliberate or harmless, and I'd rather name each than silently leave them:

| Site | Verdict |
|---|---|
| `commands/create.rs:685` | Not stdout — `{phase:?}` goes into a JSON crash-breadcrumb file. Leave. |
| `commands/create.rs:1122,1164` (`EdgePolicy`), `commands/server.rs:1156` (`server_role`), `commands/track.rs:118` (`RemoteEndpoint`), `commands/multi_query.rs:271` (`OutputFormat`), `commands/materialize.rs:149` (`MaterializeVerify`) | Fieldless enums with no `Display` impl. `{:?}` prints a bare variant name — no struct guts, nothing that can leak an ID. Cosmetic casing at worst (`Quick` vs `quick`). Scoped out. |
| `commands/load.rs:266` | `{s:?}` is deliberately quoting user input in an error message so an invisible character is visible. Correct as-is. |
| `commands/materialize.rs:356` | `{:?}` on `CheckOutcome` in the verify parity report — this one *does* print struct guts, but it's a developer-facing diagnostic where the payload *is* the content. I don't think it belongs in this PR, but I'm flagging it in case you disagree. |
| Test-only sites (`remote_client.rs`, `context.rs`, `mcp/ide.rs`, …) | Assertion messages. Fine. |

I also checked the rest of the tree for the same store-vs-view mistake. After this change, `grep` for `store().resolve_subject_iri` outside tests turns up only `fluree-db-query/src/dict_overlay.rs:220,241` — and that one does its **own** watermark routing (`dict_overlay.rs:212-250`), so it's already novelty-aware by construction. `output.rs` was genuinely the only novelty-blind site, and there are none left.

## Tests

Four renderer-level guards in `output.rs`, plus one end-to-end in `tests/integration.rs`:

1. **`novelty_only_encoded_sid_from_a_real_query_renders_its_iri`** — the one that proves the arm is on a live path. It runs the reference-edge join through the real query engine, then, *before* rendering anything, asserts that the engine actually put an `EncodedSid` in the batch **and** that `gv.store().resolve_subject_iri` can't resolve its ID. Those two conditions together are exactly what makes the store-only resolver wrong; asserting them means the guard can't quietly go vacuous if plan selection changes or the fixture stops being novelty-only. It then renders through `format_sparql_table_from_result` and asserts the IRI appears and no `Encoded*` or placeholder does.
2. **`encoded_sid_from_novelty_renders_iri_not_debug_repr`** — the same property at the single-cell level, on a hand-built binding, with the same store-can't-see-this non-vacuity assert.
3. **`unresolvable_encoded_bindings_render_placeholder`** — an unresolvable `EncodedSid` / `EncodedPid` / `EncodedLit`, with and without a graph view, all six paths. Asserts the placeholder shape, that it **carries the ID**, that it contains no `Encoded*`, and that it doesn't start with `<` (i.e. can't be read as an IRI).
4. **`unresolvable_binding_inside_list_renders_placeholder`** — the Cypher list/map arms recurse through the same cell function, so the placeholder and its ID have to hold there too.
5. **`table_output_renders_novelty_only_subject_after_index`** — the repro end to end through the real binary: `insert` → `index` → `insert` → `query --format table`. This used to use the reporter's literal-join shape, which as noted above never reaches the `EncodedSid` arm; it now uses the reference-edge shape that does.

Checked these aren't vacuous by reverting the two-line resolver change and re-running. Both `EncodedSid` tests and the end-to-end test fail, and the rendered table shows the placeholder in place of the subject:

```
+--------+------------------------------------+
| o      | s                                  |
+=============================================+
| urn:x1 | urn:s1                             |
|--------+------------------------------------|
| urn:x1 | (unresolved s_id=3659174697238532) |
+--------+------------------------------------+
```

Reverting the fallback as well as the resolver puts the original `EncodedSid { .. }` back in that cell, which is the repro quoted at the top.

## Gates

- `cargo test -p fluree-db-cli` — 346 passed, 0 failed
- `cargo clippy -p fluree-db-cli --all-targets --no-deps` — clean
- `cargo fmt --all` — clean (run last)
