### PR TITLE
fix(query): novelty-only-predicate retractions were invisible to the crawl read path

### DIFF
--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -400,6 +400,10 @@ name = "transact_commit"
 harness = false
 
 [[bench]]
+name = "transact_filtered_delete"
+harness = false
+
+[[bench]]
 name = "query_cold_reload"
 harness = false
 

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -404,6 +404,10 @@ name = "transact_filtered_delete"
 harness = false
 
 [[bench]]
+name = "query_overlay_only_range"
+harness = false
+
+[[bench]]
 name = "query_cold_reload"
 harness = false
 
@@ -455,6 +459,11 @@ harness = false
 [[bench]]
 name = "annotation_planner"
 harness = false
+
+[[test]]
+name = "it_batched_refs_overlay_lifecycle"
+path = "tests/it_batched_refs_overlay_lifecycle.rs"
+required-features = ["native"]
 
 [[test]]
 name = "it_filtered_delete_list_meta"

--- a/fluree-db-api/benches/query_overlay_only_range.rs
+++ b/fluree-db-api/benches/query_overlay_only_range.rs
@@ -1,0 +1,298 @@
+//! Read latency on the overlay-only range path.
+//!
+//! `binary_range_eq_v3` serves a pattern straight from the overlay whenever a
+//! bound component has no persisted id — a novelty-only subject, predicate, or
+//! object — or the requested order has no branch manifest. That path used to
+//! filter its walk to asserts, which silently resurrected any fact whose
+//! assert and retraction both lived in the novelty window (#1683). It now keeps
+//! both ops and lifecycle-resolves the matched set, which costs a clone per
+//! matched flake and a per-run resolution instead of an early exit.
+//!
+//! This bench measures that path. The subject crawl is the shape #1683 was
+//! reported on: `select {"?s": ["ex:tag"]}` binds subject and predicate, the
+//! predicate has no persisted id, and the range provider hands the pattern to
+//! the overlay-only path.
+//!
+//! ## Scenarios
+//!
+//! 1. `narrow_subject` — crawl a subject holding ONE value under the
+//!    novelty-only predicate, over a ledger carrying `novelty_subjects` rows
+//!    for that predicate. The matched set is one fact; what scales with
+//!    novelty is the walk, which this path always paid.
+//! 2. `wide_subject` — crawl a subject holding `wide_values` values under the
+//!    same predicate with half of them retracted. This is where the change
+//!    actually shows: the matched set is what gets cloned and resolved, and
+//!    the retracted half is work the old assert-only filter skipped (by
+//!    getting the answer wrong).
+//!
+//! The two together separate "cost that scales with the overlay" from "cost
+//! that scales with the matched fact set", which is the distinction that
+//! matters for whether the removed `limit` early exit needs restoring.
+//!
+//! What they said on the author's box (quick profile):
+//!
+//! ```text
+//!   narrow_subject  small (2k novelty)   13.6 µs
+//!   narrow_subject  medium (10k novelty) 13.8 µs
+//!   wide_subject    small (200 values)   31.8 µs
+//!   wide_subject    medium (1k values)   95.9 µs
+//! ```
+//!
+//! `narrow_subject` is flat across a 5× increase in overlay size, while
+//! `wide_subject` tracks the matched set at roughly 80 ns per matched row.
+//! So the clone-and-resolve cost this path took on is bounded by the matched
+//! fact set, not by novelty — which is why the `limit` early exit was not
+//! worth restoring at the price of depending on the walk order with no sort
+//! to fall back on. Revisit if a caller ever sets a limit on a pattern with
+//! no bound component; today none does.
+//!
+//! ## Matrix
+//!
+//!   inputs:    BenchScale → (novelty_subjects, wide_values)
+//!              (Tiny=500×50, Small=2k×200, Medium=10k×1k, Large=40k×4k)
+//!   metric:    ns/query (criterion default; no Throughput — the interesting
+//!              comparison is between the two scenarios at a fixed scale)
+//!
+//! ## Running
+//!
+//!   cargo bench -p fluree-db-api --bench query_overlay_only_range
+//!   cargo bench -p fluree-db-api --bench query_overlay_only_range -- --test
+//!   FLUREE_BENCH_SCALE=medium cargo bench -p fluree-db-api --bench query_overlay_only_range
+//!
+//! ## Cargo.toml + budget already wired (see fluree-db-api/Cargo.toml,
+//! regression-budget.json).
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use fluree_bench_support::{
+    bench_runtime, current_profile, current_scale, init_tracing_for_bench, next_ledger_alias,
+    BenchScale,
+};
+use fluree_db_api::{CommitOpts, Fluree, FlureeBuilder, IndexConfig, ReindexOptions, TxnOpts};
+use serde_json::json;
+
+/// Map BenchScale to (novelty subjects, values on the wide subject).
+fn scale_inputs(scale: BenchScale) -> (usize, usize) {
+    match scale {
+        BenchScale::Tiny => (500, 50),
+        BenchScale::Small => (2_000, 200),
+        BenchScale::Medium => (10_000, 1_000),
+        BenchScale::Large => (40_000, 4_000),
+    }
+}
+
+const CTX_PREFIX: &str = "http://example.org/ns/";
+
+/// Novelty must survive the fixture — a reindex would fold it into the base
+/// and route the crawl through the cursor instead of the path under test.
+fn index_config() -> IndexConfig {
+    IndexConfig {
+        reindex_min_bytes: 1 << 40,
+        reindex_max_bytes: 1 << 41,
+    }
+}
+
+fn ctx() -> serde_json::Value {
+    json!({"ex": CTX_PREFIX})
+}
+
+/// Crawl one subject's novelty-only predicate.
+fn crawl(subject: &str) -> serde_json::Value {
+    json!({
+        "@context": ctx(),
+        "select": {"?s": ["ex:tag"]},
+        "where": {"@id": "?s"},
+        "values": ["?s", [{"@id": subject}]]
+    })
+}
+
+/// Indexed base with no `ex:tag` anywhere, then a novelty burst that
+/// introduces it. `ex:wide` holds `wide_values` values with half retracted;
+/// `ex:narrow` holds one.
+async fn setup(novelty_subjects: usize, wide_values: usize) -> (tempfile::TempDir, Fluree, String) {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .with_ledger_cache_config(fluree_db_api::LedgerManagerConfig::default())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let alias = next_ledger_alias("overlay-only-range");
+    let mut ledger = fluree.create_ledger(&alias).await.expect("create_ledger");
+
+    // Base: `ex:name` only, so `ex:tag` never reaches the persisted
+    // predicate dictionary and every crawl below takes the overlay-only path.
+    let base: Vec<_> = (0..200)
+        .map(|n| json!({"@id": format!("ex:b{n}"), "ex:name": format!("b{n}")}))
+        .collect();
+    let r = fluree
+        .insert_with_opts(
+            ledger,
+            &json!({"@context": ctx(), "@graph": base}),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config(),
+        )
+        .await
+        .expect("base insert");
+    drop(r.ledger);
+    let _ = fluree
+        .reindex(&alias, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    ledger = fluree.ledger(&alias).await.expect("reload after reindex");
+    assert!(
+        ledger.snapshot.range_provider.is_some(),
+        "fixture needs an indexed base"
+    );
+
+    // Novelty burst: `ex:tag` on many subjects, so the overlay the path walks
+    // is large.
+    let batch = 500usize;
+    let mut from = 0usize;
+    while from < novelty_subjects {
+        let to = (from + batch).min(novelty_subjects);
+        let graph: Vec<_> = (from..to)
+            .map(|n| json!({"@id": format!("ex:n{n}"), "ex:tag": format!("t{n}")}))
+            .collect();
+        let r = fluree
+            .insert_with_opts(
+                ledger,
+                &json!({"@context": ctx(), "@graph": graph}),
+                TxnOpts::default(),
+                CommitOpts::default(),
+                &index_config(),
+            )
+            .await
+            .expect("novelty insert");
+        ledger = r.ledger;
+        from = to;
+    }
+
+    // `ex:narrow`: one value.
+    let r = fluree
+        .insert_with_opts(
+            ledger,
+            &json!({"@context": ctx(), "@id": "ex:narrow", "ex:tag": "only"}),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config(),
+        )
+        .await
+        .expect("narrow insert");
+    ledger = r.ledger;
+
+    // `ex:wide`: many values, then retract the first half so resolution has
+    // real lifecycle work on the matched set.
+    let values: Vec<String> = (0..wide_values).map(|n| format!("w{n:06}")).collect();
+    let r = fluree
+        .insert_with_opts(
+            ledger,
+            &json!({"@context": ctx(), "@id": "ex:wide", "ex:tag": values}),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config(),
+        )
+        .await
+        .expect("wide insert");
+    let ledger = r.ledger;
+
+    let doomed: Vec<serde_json::Value> = values[..wide_values / 2]
+        .iter()
+        .map(|v| json!({"@id": "ex:wide", "ex:tag": v}))
+        .collect();
+    let r: fluree_db_api::TransactResult = fluree
+        .update_with_opts(
+            ledger,
+            &json!({
+                "@context": ctx(),
+                "where": [{"@id": "ex:wide", "ex:tag": "?o"}],
+                "delete": {"@graph": doomed}
+            }),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config(),
+        )
+        .await
+        .expect("wide retract");
+    assert_eq!(
+        r.receipt.flake_count,
+        wide_values / 2,
+        "the retract must land, or the resolved half of the fixture is missing"
+    );
+
+    // Correctness stamp: the measured path must be returning the RESOLVED
+    // set. If this ever reads `wide_values`, the crawl stopped taking the
+    // overlay-only path (or stopped resolving) and the numbers below would be
+    // measuring something else.
+    let snapshot = fluree.graph(&alias).load().await.expect("graph load");
+    let q = crawl("ex:wide");
+    let rows = snapshot
+        .query()
+        .jsonld(&q)
+        .execute_formatted()
+        .await
+        .expect("stamp query");
+    let live = rows
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|node| node.get("ex:tag"))
+        .and_then(|v| v.as_array())
+        .map(Vec::len)
+        .unwrap_or(0);
+    assert_eq!(
+        live,
+        wide_values - wide_values / 2,
+        "overlay-only crawl must return only live values, got {rows}"
+    );
+
+    (db_dir, fluree, alias)
+}
+
+fn bench_query_overlay_only_range(c: &mut Criterion) {
+    init_tracing_for_bench();
+
+    let rt = bench_runtime();
+    let scale = current_scale();
+    let profile = current_profile();
+    let (novelty_subjects, wide_values) = scale_inputs(scale);
+
+    eprintln!(
+        "  [query_overlay_only_range] scale={} novelty_subjects={} wide_values={} (half retracted)",
+        scale.as_str(),
+        novelty_subjects,
+        wide_values
+    );
+
+    // Read-only scenarios, so the fixture is built once and shared.
+    let (_db_dir, fluree, alias) = rt.block_on(setup(novelty_subjects, wide_values));
+    let snapshot = rt.block_on(async { fluree.graph(&alias).load().await.expect("graph load") });
+
+    let mut group = c.benchmark_group("query_overlay_only_range");
+    group.sample_size(profile.sample_size());
+    group.sampling_mode(criterion::SamplingMode::Flat);
+
+    for (name, subject) in [("narrow_subject", "ex:narrow"), ("wide_subject", "ex:wide")] {
+        let q = crawl(subject);
+        group.bench_with_input(
+            BenchmarkId::new(name, scale.as_str()),
+            &novelty_subjects,
+            |b, _| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let rows = snapshot
+                            .query()
+                            .jsonld(&q)
+                            .execute()
+                            .await
+                            .expect("crawl execute");
+                        black_box(rows);
+                    });
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_query_overlay_only_range);
+criterion_main!(benches);

--- a/fluree-db-api/benches/query_overlay_only_range.rs
+++ b/fluree-db-api/benches/query_overlay_only_range.rs
@@ -54,15 +54,20 @@
 //! subject, no object — with `flake_limit(1)` against the txn-meta graph, and
 //! adds `object_bounds` when resolving `after: Some`. Its matched set is one
 //! flake per commit, so it scales with commits-in-novelty rather than with a
-//! bound subject's fact count, and it is doubly exposed: those object bounds
-//! now prune AFTER resolution instead of inside the walk.
+//! bound subject's fact count. It is the counter-example to "every
+//! limit-setting caller binds a subject", which is what an earlier version of
+//! this reasoning claimed.
 //!
-//! It stays off this bench deliberately — it only takes the overlay-only path
+//! Its `after: Some` leg used to be doubly exposed, because object bounds
+//! pruned after resolution rather than inside the walk. They now prune inside
+//! the walk — sound because a fact and its retraction share `o`, so the bound
+//! is true for both halves or false for both — which puts that leg back to
+//! collecting only the commits past the target instead of all of them.
+//!
+//! It stays off this bench deliberately: it only takes the overlay-only path
 //! when the txn-meta graph has no POST branch, it reads a system graph, and at
-//! ~80 ns per matched row the absolute cost is small. But it is the site to
-//! measure first if this path ever needs the bound back, and it is the
-//! counter-example to "every limit-setting caller binds a subject", which is
-//! what an earlier version of this reasoning claimed.
+//! ~80 ns per matched row the absolute cost is small. It remains the site to
+//! measure first if this path ever needs the `limit` bound back.
 //!
 //! ## Matrix
 //!

--- a/fluree-db-api/benches/query_overlay_only_range.rs
+++ b/fluree-db-api/benches/query_overlay_only_range.rs
@@ -43,8 +43,26 @@
 //! So the clone-and-resolve cost this path took on is bounded by the matched
 //! fact set, not by novelty — which is why the `limit` early exit was not
 //! worth restoring at the price of depending on the walk order with no sort
-//! to fall back on. Revisit if a caller ever sets a limit on a pattern with
-//! no bound component; today none does.
+//! to fall back on.
+//!
+//! ## The shape neither scenario models
+//!
+//! Both scenarios bind a subject, which is what keeps their matched set
+//! small. One caller does not: `probe_timestamp_axis`
+//! (`fluree-db-api/src/time_resolve.rs:154`, the `@iso:`/timestamp
+//! time-travel probe) issues `RangeMatch::predicate(..)` — predicate only, no
+//! subject, no object — with `flake_limit(1)` against the txn-meta graph, and
+//! adds `object_bounds` when resolving `after: Some`. Its matched set is one
+//! flake per commit, so it scales with commits-in-novelty rather than with a
+//! bound subject's fact count, and it is doubly exposed: those object bounds
+//! now prune AFTER resolution instead of inside the walk.
+//!
+//! It stays off this bench deliberately — it only takes the overlay-only path
+//! when the txn-meta graph has no POST branch, it reads a system graph, and at
+//! ~80 ns per matched row the absolute cost is small. But it is the site to
+//! measure first if this path ever needs the bound back, and it is the
+//! counter-example to "every limit-setting caller binds a subject", which is
+//! what an earlier version of this reasoning claimed.
 //!
 //! ## Matrix
 //!

--- a/fluree-db-api/benches/transact_filtered_delete.rs
+++ b/fluree-db-api/benches/transact_filtered_delete.rs
@@ -1,0 +1,281 @@
+//! Filtered-DELETE staging latency over a novelty-heavy ledger.
+//!
+//! `WHERE { ?s ex:tag ?o } DELETE { ?s ex:tag ?o }` on a bulk-imported
+//! ledger that has since accumulated novelty. Nothing else in the suite
+//! exercises WHERE/DELETE — `transact_commit.rs` measures insert-shaped
+//! commits only — which is how a `retractions × novelty` shape in
+//! `hydrate_list_index_meta_for_retractions` went unnoticed until a
+//! 40k-subject delete stopped finishing altogether.
+//!
+//! ## What the two scenarios separate
+//!
+//! Staging skips list-position hydration entirely when the index root AND
+//! novelty both report no `@list` rows (`fluree-db-transact/src/stage.rs`,
+//! the `has_list_meta == Some(false) && !novelty.has_list_meta` gate).
+//! The two sides of that gate have very different cost profiles — 0.9 s
+//! vs 3.1 s on the same 40.5k-retraction delete when the fix landed — so
+//! each gets its own scenario:
+//!
+//! 1. `no_lists` — the import carries no RDF collection, so the root
+//!    records `Some(false)` and novelty stays clean: hydration is skipped.
+//!    (Bulk-import roots record the flag exactly; before that they were
+//!    left untracked and this branch was unreachable without a full
+//!    rebuild in the fixture.)
+//! 2. `with_lists` — the import carries one collection, so the root
+//!    records `Some(true)` and every retraction group pays the one-SPOT
+//!    overlay walk plus a base-only seek. The deleted predicate is the
+//!    same plain `ex:tag` in both, so the delete itself is identical and
+//!    the delta is the hydration path.
+//!
+//! Both scenarios assert the gate state they mean to measure during
+//! setup: a fixture that quietly stops covering its branch fails the
+//! bench instead of reporting a number for the wrong path.
+//!
+//! The two curves separate from Medium up — 69 ms vs 127 ms at
+//! 20k groups on the author's box, where at Small both read ~39 ms
+//! because the WHERE and the commit dominate. Read a flat Tiny/Small
+//! pair as "the fixture is below the separation point", not as "the
+//! gate is free". Either scale still catches what this bench exists
+//! for: the shape it replaced was `retractions × novelty`, so a
+//! regression back to it turns tens of milliseconds into seconds.
+//!
+//! ## Matrix
+//!
+//!   inputs:    BenchScale → (imported_subjects, novelty_subjects)
+//!              (Tiny=500×500, Small=2k×2k, Medium=10k×10k, Large=40k×40k)
+//!              Every subject contributes one retraction group, so the
+//!              measured delete retracts base+novelty facts. Large mirrors
+//!              the 40.5k-retraction shape the original bug was found on.
+//!   metric:    ns/delete (criterion default; no Throughput — the guard is
+//!              on the superlinear curve, and a per-flake rate would hide
+//!              it behind a growing denominator)
+//!
+//! ## Running
+//!
+//!   cargo bench -p fluree-db-api --bench transact_filtered_delete
+//!   cargo bench -p fluree-db-api --bench transact_filtered_delete -- --test
+//!   FLUREE_BENCH_SCALE=medium cargo bench -p fluree-db-api --bench transact_filtered_delete
+//!
+//! ## Cargo.toml + budget already wired (see fluree-db-api/Cargo.toml,
+//! regression-budget.json).
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use fluree_bench_support::{
+    bench_runtime, current_profile, current_scale, init_tracing_for_bench, next_ledger_alias,
+    BenchScale,
+};
+use fluree_db_api::{CommitOpts, FlureeBuilder, IndexConfig, LedgerState, TxnOpts};
+use serde_json::json;
+use std::io::Write;
+
+/// Map BenchScale to (imported subjects, novelty subjects).
+fn scale_inputs(scale: BenchScale) -> (usize, usize) {
+    match scale {
+        // Keep tiny tiny so PR-gated runs finish quickly.
+        BenchScale::Tiny => (500, 500),
+        BenchScale::Small => (2_000, 2_000),
+        BenchScale::Medium => (10_000, 10_000),
+        // The shape the original >20-min delete was found on.
+        BenchScale::Large => (40_000, 40_000),
+    }
+}
+
+const CTX_PREFIX: &str = "http://example.org/ns/";
+
+/// Novelty must survive the whole fixture: any reindex would fold it into
+/// the base and erase the shape this bench exists to measure.
+fn index_config() -> IndexConfig {
+    IndexConfig {
+        reindex_min_bytes: 1 << 40,
+        reindex_max_bytes: 1 << 41,
+    }
+}
+
+/// Turtle for the imported base: `n` subjects each carrying the deleted
+/// predicate plus an untouched one. `with_list` appends a single subject
+/// with an RDF collection — enough to flip the root's `has_list_meta`
+/// without changing what the measured delete retracts.
+fn base_turtle(n: usize, with_list: bool) -> String {
+    let mut out = String::with_capacity(n * 64 + 128);
+    out.push_str("@prefix ex: <");
+    out.push_str(CTX_PREFIX);
+    out.push_str("> .\n");
+    for i in 0..n {
+        out.push_str(&format!("ex:b{i} ex:tag 'keep' ; ex:name 'base{i}' .\n"));
+    }
+    if with_list {
+        out.push_str("ex:listed ex:items ( 'a' 'b' 'c' ) .\n");
+    }
+    out
+}
+
+/// One novelty insert batch as JSON-LD: subjects `[from, to)` carrying the
+/// same deleted predicate, so the delete's WHERE spans base and novelty.
+fn novelty_batch(from: usize, to: usize) -> serde_json::Value {
+    let graph: Vec<_> = (from..to)
+        .map(|i| json!({"@id": format!("ex:n{i}"), "ex:tag": "keep", "ex:name": format!("nov{i}")}))
+        .collect();
+    json!({"@context": {"ex": CTX_PREFIX}, "@graph": graph})
+}
+
+/// The measured transaction: retract every `ex:tag` fact in the ledger.
+fn delete_txn() -> serde_json::Value {
+    json!({
+        "@context": {"ex": CTX_PREFIX},
+        "where": [{"@id": "?s", "ex:tag": "?o"}],
+        "delete": [{"@id": "?s", "ex:tag": "?o"}]
+    })
+}
+
+/// Everything one measured iteration consumes. The tempdirs ride along so
+/// the file-backed store outlives the timed block.
+struct Fixture {
+    _db_dir: tempfile::TempDir,
+    _data_dir: tempfile::TempDir,
+    fluree: fluree_db_api::Fluree,
+    ledger: LedgerState,
+}
+
+/// Bulk-import the base, then pile `novelty_subjects` on top without
+/// letting the indexer fold them in.
+///
+/// Asserts the `has_list_meta` gate state the caller expects: this is the
+/// only thing separating the two scenarios, and a fixture that stopped
+/// producing it would report a plausible number for the wrong code path.
+fn build_fixture(
+    rt: &tokio::runtime::Runtime,
+    base_turtle: &str,
+    novelty_subjects: usize,
+    expect_list_meta: bool,
+) -> Fixture {
+    rt.block_on(async {
+        let db_dir = tempfile::tempdir().expect("db tmpdir");
+        let data_dir = tempfile::tempdir().expect("data tmpdir");
+        let ttl_path = data_dir.path().join("base.ttl");
+        let mut f = std::fs::File::create(&ttl_path).expect("create ttl");
+        f.write_all(base_turtle.as_bytes()).expect("write ttl");
+        drop(f);
+
+        let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+            .with_ledger_cache_config(fluree_db_api::LedgerManagerConfig::default())
+            .build()
+            .expect("build file-backed Fluree");
+        let alias = next_ledger_alias("tfd");
+        let result = fluree
+            .create(&alias)
+            .import(&ttl_path)
+            .cleanup(false)
+            .execute()
+            .await
+            .expect("bulk import");
+        assert!(result.root_id.is_some(), "fixture needs an indexed base");
+
+        let mut ledger = fluree.ledger(&alias).await.expect("load imported ledger");
+        assert_eq!(
+            ledger.snapshot.has_list_meta,
+            Some(expect_list_meta),
+            "fixture must land on the intended side of the hydration-skip gate"
+        );
+
+        // Novelty in batches — one commit per batch, all retained.
+        let batch = 500usize;
+        let mut from = 0usize;
+        while from < novelty_subjects {
+            let to = (from + batch).min(novelty_subjects);
+            let r = fluree
+                .insert_with_opts(
+                    ledger,
+                    &novelty_batch(from, to),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_config(),
+                )
+                .await
+                .expect("novelty insert");
+            ledger = r.ledger;
+            from = to;
+        }
+        // Novelty is list-free in BOTH scenarios — the burst carries plain
+        // values only — so the root is the whole difference between them.
+        // With a dirty novelty bit the gate would fail closed either way and
+        // the two scenarios would measure the same path.
+        assert!(
+            !ledger.novelty.has_list_meta,
+            "novelty must stay list-free so the root alone decides the gate"
+        );
+
+        Fixture {
+            _db_dir: db_dir,
+            _data_dir: data_dir,
+            fluree,
+            ledger,
+        }
+    })
+}
+
+fn bench_transact_filtered_delete(c: &mut Criterion) {
+    init_tracing_for_bench();
+
+    let rt = bench_runtime();
+    let scale = current_scale();
+    let profile = current_profile();
+    let (base_subjects, novelty_subjects) = scale_inputs(scale);
+
+    let plain_ttl = base_turtle(base_subjects, false);
+    let listed_ttl = base_turtle(base_subjects, true);
+    let del = delete_txn();
+
+    eprintln!(
+        "  [transact_filtered_delete] scale={} base={} novelty={} groups~={}",
+        scale.as_str(),
+        base_subjects,
+        novelty_subjects,
+        base_subjects + novelty_subjects
+    );
+
+    let mut group = c.benchmark_group("transact_filtered_delete");
+    group.sample_size(profile.sample_size());
+    // The fixture (import + novelty burst) is rebuilt per iteration because
+    // the measured op is destructive; Flat keeps criterion from assuming a
+    // cheap, repeatable routine.
+    group.sampling_mode(criterion::SamplingMode::Flat);
+
+    for (name, ttl, has_lists) in [
+        ("no_lists", &plain_ttl, false),
+        ("with_lists", &listed_ttl, true),
+    ] {
+        group.bench_with_input(
+            BenchmarkId::new(name, scale.as_str()),
+            &(base_subjects, novelty_subjects),
+            |b, _| {
+                b.iter_batched(
+                    // Setup: import + novelty. NOT measured.
+                    || build_fixture(&rt, ttl, novelty_subjects, has_lists),
+                    // Measured: one filtered DELETE over every group.
+                    |fixture| {
+                        rt.block_on(async {
+                            let result = fixture
+                                .fluree
+                                .update_with_opts(
+                                    fixture.ledger,
+                                    &del,
+                                    TxnOpts::default(),
+                                    CommitOpts::default(),
+                                    &index_config(),
+                                )
+                                .await
+                                .expect("filtered delete");
+                            black_box(result.ledger);
+                        });
+                    },
+                    criterion::BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_transact_filtered_delete);
+criterion_main!(benches);

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -3747,6 +3747,10 @@ struct IndexBuildInput<'a> {
     named_g_ids: Vec<u16>,
     /// Actual split mode the import used; written into the root and predicate sids.
     ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode,
+    /// Whether any imported record carried an RDF-list position (OR'd across
+    /// every parse chunk via `SpoolConfig::saw_list_meta`). Written into
+    /// `IndexRoot.has_list_meta`.
+    saw_list_meta: bool,
 }
 
 /// Run phases 2-6: import chunks, build indexes, upload to CAS, write V4 root, publish.
@@ -3810,6 +3814,7 @@ where
             prefix_map: &import_result.prefix_map,
             named_g_ids: import_result.named_g_ids,
             ns_split_mode: import_result.ns_split_mode,
+            saw_list_meta: import_result.saw_list_meta,
         };
         let index_result = build_and_upload(
             storage,
@@ -3923,6 +3928,9 @@ struct ChunkImportResult {
     /// `HostPlusN`). Recorded into the root, predicate sids, and genesis commit so
     /// reads split IRIs the same way the dictionary was keyed.
     ns_split_mode: fluree_db_core::ns_encoding::NsSplitMode,
+    /// Whether any imported record carried an RDF-list position, OR'd across
+    /// every parse chunk. Recorded into `IndexRoot.has_list_meta`.
+    saw_list_meta: bool,
 }
 
 /// Import all TTL chunks: parallel parse + serial commit + streaming runs.
@@ -4322,6 +4330,10 @@ where
         numbig_pool: Arc::new(SharedNumBigPool::new()),
         vector_pool: Arc::new(SharedVectorArenaPool::new()),
         ns_alloc: Arc::clone(&shared_alloc),
+        // Parse workers OR their per-chunk observation in here at finish;
+        // read once at root assembly (after every worker has joined) to
+        // record `IndexRoot.has_list_meta` exactly.
+        saw_list_meta: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     });
 
     // Pre-insert rdf:type so we know the predicate ID before Phase A begins.
@@ -6025,6 +6037,11 @@ where
         named_g_ids: v3_named_g_ids,
         // Forwarder thread joined above, so this reflects any preflight coarsening.
         ns_split_mode: shared_alloc.split_mode(),
+        // Every parse worker has finished its `SpoolContext` by now, so this
+        // read sees every chunk's contribution.
+        saw_list_meta: spool_config
+            .saw_list_meta
+            .load(std::sync::atomic::Ordering::Relaxed),
     })
 }
 
@@ -6831,10 +6848,18 @@ where
             // later defensive drop carries the sticky bit forward
             // and stays out of the bootstrap path.
             had_annotation_arena: false,
-            // Bulk import does not observe list positions at root
-            // assembly; leave the flag untracked so the write path keeps
-            // hydrating until the first full rebuild records it exactly.
-            has_list_meta: None,
+            // Every record written through the spool pipeline reports
+            // whether it carried an RDF-list position, OR'd into one sticky
+            // bit on the shared `SpoolConfig` and read after the parse
+            // workers joined — so this is an exact observation, the same
+            // grade the full-rebuild resolver produces. `Some(false)` is
+            // what lets filtered-DELETE staging skip list-meta hydration on
+            // bulk-imported ledgers, which are the large ones.
+            //
+            // The txn-meta records assembled outside the spool (they hard-code
+            // `i: LIST_INDEX_NONE`) are the only other rows in the root, and
+            // they are never list rows.
+            has_list_meta: Some(input.saw_list_meta),
             ns_split_mode: input.ns_split_mode,
         };
 

--- a/fluree-db-api/tests/it_batched_refs_overlay_lifecycle.rs
+++ b/fluree-db-api/tests/it_batched_refs_overlay_lifecycle.rs
@@ -1,0 +1,173 @@
+//! Batched `rdf:type` lookup must resolve overlay lifecycles.
+//!
+//! `RangeProvider::lookup_subject_predicate_refs_batched` is the latency path
+//! policy enforcement uses for `f:onClass` (`fluree-db-policy/src/class_lookup.rs`)
+//! and the indexer uses for class/property stats. It has three internal paths,
+//! picked by what the persisted index can contribute; the one taken when the
+//! target graph has no PSOT branch served the overlay assert-only, with no
+//! lifecycle resolution.
+//!
+//! The overlay is a log, so a type asserted and then retracted inside the same
+//! novelty window has both flakes in it. Reporting the class anyway means a
+//! class-based policy grant outliving its own revocation until the first index
+//! build — which for a named graph written only in novelty is indefinitely.
+//!
+//! The fixture is exactly that shape: the default graph is indexed (so
+//! `rdf:type` has a persisted predicate id and the store exists), while the
+//! named graph lives only in novelty and therefore has no branch for its
+//! `g_id`.
+
+#![cfg(feature = "native")]
+
+mod support;
+use crate::support::{start_background_indexer_local, trigger_index_and_wait_outcome};
+use fluree_db_api::FlureeBuilder;
+use fluree_db_core::{IndexType, RangeOptions, Sid};
+
+const GRAPH_IRI: &str = "http://example.org/graphs/novelty-only";
+
+#[tokio::test]
+async fn retracted_type_in_a_branchless_graph_is_not_reported() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mut fluree = FlureeBuilder::file(tmp.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/batched-refs-overlay:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            // Default graph, indexed. Carries `rdf:type` so the predicate is
+            // in the persisted dictionary — without that the batched lookup
+            // short-circuits on an unknown predicate and never reaches the
+            // overlay path at all.
+            let seed = r#"
+                @prefix ex: <http://example.org/> .
+                @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                ex:seed rdf:type ex:Person .
+                ex:seed ex:name "seed" .
+            "#;
+            let r = fluree
+                .stage_owned(ledger)
+                .upsert_turtle(seed)
+                .execute()
+                .await
+                .expect("seed insert");
+            trigger_index_and_wait_outcome(&handle, ledger_id, r.receipt.t).await;
+
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(
+                ledger.snapshot.range_provider.is_some(),
+                "fixture needs an indexed base with a range provider"
+            );
+
+            // Named graph, novelty only: grant two classes, then revoke one.
+            let grant = format!(
+                r"
+                @prefix ex: <http://example.org/> .
+                @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                GRAPH <{GRAPH_IRI}> {{
+                    ex:alice rdf:type ex:Admin .
+                    ex:alice rdf:type ex:Person .
+                }}
+                ",
+            );
+            let r = fluree
+                .stage_owned(ledger)
+                .upsert_turtle(&grant)
+                .execute()
+                .await
+                .expect("grant insert");
+
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            let revoke = format!(
+                r"
+                PREFIX ex: <http://example.org/>
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                DELETE {{ GRAPH <{GRAPH_IRI}> {{ ex:alice rdf:type ex:Admin }} }}
+                WHERE  {{ GRAPH <{GRAPH_IRI}> {{ ex:alice rdf:type ex:Admin }} }}
+                ",
+            );
+            let parsed = fluree_db_sparql::parse_sparql(&revoke);
+            assert!(
+                !parsed.has_errors(),
+                "SPARQL parse: {:?}",
+                parsed.diagnostics
+            );
+            let mut ns = fluree_db_transact::NamespaceRegistry::from_db(&ledger.snapshot);
+            let txn = fluree_db_transact::lower_sparql_update_ast(
+                &parsed.ast.expect("SPARQL AST"),
+                &mut ns,
+                fluree_db_transact::TxnOpts::default(),
+            )
+            .expect("lower SPARQL UPDATE");
+            let r2 = fluree
+                .stage_owned(ledger)
+                .txn(txn)
+                .execute()
+                .await
+                .expect("revoke");
+            assert_eq!(
+                r2.receipt.flake_count, 1,
+                "the revoke must retract one flake"
+            );
+            assert!(r2.receipt.t > r.receipt.t);
+
+            // Ask the provider the same question policy asks.
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            let g_sid = ledger
+                .snapshot
+                .encode_iri(GRAPH_IRI)
+                .expect("named graph IRI is registered");
+            let g_id = *ledger
+                .snapshot
+                .build_reverse_graph()
+                .expect("reverse graph")
+                .get(&g_sid)
+                .expect("named graph has a g_id");
+            assert_ne!(g_id, 0, "the fixture must exercise the named graph");
+
+            let provider = ledger.snapshot.range_provider.as_ref().unwrap();
+            let rdf_type = Sid::new(
+                fluree_vocab::namespaces::RDF,
+                fluree_vocab::predicates::RDF_TYPE,
+            );
+            let alice = ledger
+                .snapshot
+                .encode_iri("http://example.org/alice")
+                .expect("alice is registered");
+
+            let classes = provider
+                .lookup_subject_predicate_refs_batched(
+                    g_id,
+                    IndexType::Psot,
+                    &rdf_type,
+                    std::slice::from_ref(&alice),
+                    &RangeOptions::new().with_to_t(ledger.t()),
+                    &*ledger.novelty,
+                )
+                .expect("batched class lookup");
+
+            let names: Vec<String> = classes
+                .get(&alice)
+                .map(|cs| cs.iter().map(|c| c.name_str().to_string()).collect())
+                .unwrap_or_default();
+            assert!(
+                !names.iter().any(|n| n == "Admin"),
+                "a revoked rdf:type must not be reported — a class-based policy \
+                 grant would outlive its revocation; got {names:?}"
+            );
+            assert!(
+                names.iter().any(|n| n == "Person"),
+                "the class that was never revoked must still be reported; got {names:?}"
+            );
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_filtered_delete_list_meta.rs
+++ b/fluree-db-api/tests/it_filtered_delete_list_meta.rs
@@ -815,6 +815,23 @@ async fn novelty_only_predicate_resolves_metadata_siblings() {
                 vec!["hello@fr"],
                 "the @en fact goes; the @fr fact sharing its lexical form stays"
             );
+
+            // The COMBINATION of the two legs above — one list position
+            // carrying two language tags — is pinned at the unit level
+            // instead (`binary_range::tests::
+            // one_list_position_under_two_language_tags_resolves_independently`),
+            // because it cannot currently be built through this path at all.
+            //
+            // `FlakeMeta`'s `Ord` ignores `lang` whenever both sides carry a
+            // list index, so `{en, i: 0}` and `{fr, i: 0}` compare equal
+            // without being equal (#1711). Asserting the second tag at the
+            // same position commits (receipt says one flake at its own `t`)
+            // but never appears in the live view: novelty keys the fact by
+            // that same ordering and folds it onto the first tag. So the
+            // write side collapses the shape before the read side can be
+            // asked about it. Worth knowing when #1711 is fixed — repairing
+            // the type will make this shape constructible, and this is the
+            // test that should then grow an end-to-end leg.
         })
         .await;
 }

--- a/fluree-db-api/tests/it_filtered_delete_list_meta.rs
+++ b/fluree-db-api/tests/it_filtered_delete_list_meta.rs
@@ -698,3 +698,242 @@ async fn novelty_only_predicate_retraction_takes_effect() {
         })
         .await;
 }
+
+/// Two facts that share `(s, p, o, dt)` and differ only in `m` — a `@list`
+/// repeating a value, and one lexical form under two language tags.
+///
+/// These are distinct facts, but every comparator orders `t` before `m`, so
+/// the sibling's assert lands between a fact's own assert and its retraction.
+/// Resolution that cuts groups on run adjacency over full identity therefore
+/// closes early and hands back the retracted entry as live — the same
+/// resurrection this file exists to pin, one layer down in the resolver.
+///
+/// Both legs delete the entry whose metadata sorts FIRST: that is the failing
+/// direction. Deleting the last position passes even with the grouping bug,
+/// so a pin that only covered it would be vacuous.
+#[tokio::test]
+async fn novelty_only_predicate_resolves_metadata_siblings() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mut fluree = FlureeBuilder::file(tmp.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/list-meta-novpred-siblings:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            // Indexed base that has never seen either predicate, so both
+            // patterns below are served straight from the overlay.
+            let graph: Vec<_> = (0..50)
+                .map(|n| json!({"@id": format!("ex:r{n}"), "ex:name": format!("r{n}")}))
+                .collect();
+            let r = fluree
+                .upsert_with_opts(ledger, &json!({"@context": ctx(), "@graph": graph}), TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            trigger_index_and_wait_outcome(&handle, ledger_id, r.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(ledger.snapshot.range_provider.is_some());
+
+            // `["a", "b", "a"]` — "a" at positions 0 and 2.
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:dup", "ex:items": {"@list": ["a", "b", "a"]}}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_values(&fluree, &ledger, "ex:dup").await,
+                vec!["a", "b", "a"]
+            );
+
+            // One WHERE binding retracts exactly one positional entry, and
+            // hydration copies the FIRST candidate meta — position 0.
+            let del_a = json!({
+                "@context": ctx(),
+                "where": [{"@id": "ex:dup", "ex:items": "a"}],
+                "delete": [{"@id": "ex:dup", "ex:items": "a"}]
+            });
+            let r = fluree
+                .update_with_opts(ledger, &del_a, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 1);
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_values(&fluree, &ledger, "ex:dup").await,
+                vec!["b", "a"],
+                "the position-0 entry goes; its twin at position 2 stays"
+            );
+
+            // Same lexical form under two language tags on a second
+            // novelty-only predicate.
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:tagged", "ex:labels": [
+                        {"@value": "hello", "@language": "en"},
+                        {"@value": "hello", "@language": "fr"}
+                    ]}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_items(&fluree, &ledger, "ex:tagged", "ex:labels").await,
+                vec!["hello@en", "hello@fr"]
+            );
+
+            let del_en = json!({
+                "@context": ctx(),
+                "where": [{"@id": "ex:tagged", "ex:labels": {"@value": "hello", "@language": "en"}}],
+                "delete": [{"@id": "ex:tagged", "ex:labels": {"@value": "hello", "@language": "en"}}]
+            });
+            let r = fluree
+                .update_with_opts(ledger, &del_en, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 1);
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_items(&fluree, &ledger, "ex:tagged", "ex:labels").await,
+                vec!["hello@fr"],
+                "the @en fact goes; the @fr fact sharing its lexical form stays"
+            );
+        })
+        .await;
+}
+
+/// `offset` / `limit` on the overlay-only path apply to the RESOLVED current
+/// state, not to the log.
+///
+/// The fix moved when they apply relative to resolution, and nothing else
+/// pins the order — a later refactor could reorder it silently and only fail
+/// on a ledger where a retraction happens to sit inside the first page.
+/// Here `ex:page` carries ten novelty-only values with the first two
+/// retracted: paging that ran before resolution would spend its window on
+/// retracted rows and hand back a short or wrong page.
+#[tokio::test]
+async fn novelty_only_predicate_paging_applies_after_resolution() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mut fluree = FlureeBuilder::file(tmp.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/list-meta-novpred-paging:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            let graph: Vec<_> = (0..50)
+                .map(|n| json!({"@id": format!("ex:r{n}"), "ex:name": format!("r{n}")}))
+                .collect();
+            let r = fluree
+                .upsert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@graph": graph}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            trigger_index_and_wait_outcome(&handle, ledger_id, r.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(ledger.snapshot.range_provider.is_some());
+
+            // v0..v9 under a novelty-only predicate.
+            let values: Vec<String> = (0..10).map(|n| format!("v{n}")).collect();
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:page", "ex:vals": values}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+
+            // Retract the two that sort first.
+            for v in ["v0", "v1"] {
+                let ledger = fluree.ledger(ledger_id).await.unwrap();
+                let del = json!({
+                    "@context": ctx(),
+                    "where": [{"@id": "ex:page", "ex:vals": v}],
+                    "delete": [{"@id": "ex:page", "ex:vals": v}]
+                });
+                let r = fluree
+                    .update_with_opts(
+                        ledger,
+                        &del,
+                        TxnOpts::default(),
+                        CommitOpts::default(),
+                        &index_cfg(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(r.receipt.flake_count, 1, "retracting {v}");
+            }
+
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            let mut live = list_items(&fluree, &ledger, "ex:page", "ex:vals").await;
+            live.sort();
+            assert_eq!(
+                live,
+                vec!["v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9"],
+                "the two retracted values are gone from the unpaged read"
+            );
+
+            // A LIMIT smaller than the retracted prefix: every returned row
+            // must be a live value. Resolution-before-paging is what makes
+            // that true — paging the log first would surface `v0`/`v1`.
+            let paged = json!({
+                "@context": ctx(),
+                "select": ["?o"],
+                "where": {"@id": "ex:page", "ex:vals": "?o"},
+                "limit": 3
+            });
+            let rows = query_jsonld_formatted(&fluree, &ledger, &paged)
+                .await
+                .unwrap();
+            let got: Vec<String> = rows
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|r| {
+                    r.as_array()
+                        .and_then(|c| c.first())
+                        .and_then(|v| v.as_str())
+                })
+                .map(String::from)
+                .collect();
+            assert_eq!(got.len(), 3, "a full page of live rows, got {got:?}");
+            assert!(
+                got.iter().all(|v| v != "v0" && v != "v1"),
+                "retracted values must never enter a page, got {got:?}"
+            );
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_filtered_delete_list_meta.rs
+++ b/fluree-db-api/tests/it_filtered_delete_list_meta.rs
@@ -15,6 +15,11 @@
 //!
 //! These pin the flag's three states through a real index build and the
 //! list-retraction semantics on the merged path.
+//!
+//! The last case sits one layer down, on the read side: when no bound
+//! component of the pattern resolves to a persisted id, the range provider
+//! serves the pattern from the overlay alone, and that overlay is a log —
+//! it must be lifecycle-resolved, not filtered to asserts.
 
 #![cfg(feature = "native")]
 
@@ -552,6 +557,143 @@ async fn stale_base_list_candidate_resolves_before_hydration() {
                 list_values(&fluree, &ledger, "ex:stale").await,
                 vec!["x"],
                 "hydrated from the live b@1, not the retracted base b@0"
+            );
+        })
+        .await;
+}
+
+/// The predicate itself exists ONLY in novelty: the indexed base has never
+/// seen `ex:items` in any form (the seed rows carry `ex:name` only), so no
+/// bound component of the crawl's `(subject, predicate)` seek resolves to a
+/// persisted id and the range provider serves the pattern straight from the
+/// overlay. That overlay is a LOG — the assert at `t=2` and its retraction
+/// at `t=3` both sit in novelty — so serving it assert-only resurrected the
+/// deleted entry: the receipt said one flake retracted and the value stayed
+/// readable.
+///
+/// Nothing about this is list-specific, so the plain-valued leg rides along
+/// on a second novelty-only predicate. The reload leg pins that the durable
+/// commit chain agrees with the live view (the bug was symmetric: a reload
+/// replays the same novelty and read it the same wrong way).
+#[tokio::test]
+async fn novelty_only_predicate_retraction_takes_effect() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().to_string_lossy().to_string();
+    let mut fluree = FlureeBuilder::file(dir.clone()).build().unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "it/list-meta-novpred:main";
+            let ledger = fluree.create_ledger(ledger_id).await.unwrap();
+
+            // Seed rows WITHOUT the predicate, so `ex:items` never reaches
+            // the persisted predicate dictionary.
+            let graph: Vec<_> = (0..50)
+                .map(|n| json!({"@id": format!("ex:r{n}"), "ex:name": format!("r{n}")}))
+                .collect();
+            let r = fluree
+                .upsert_with_opts(ledger, &json!({"@context": ctx(), "@graph": graph}), TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            trigger_index_and_wait_outcome(&handle, ledger_id, r.receipt.t).await;
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert!(ledger.snapshot.range_provider.is_some());
+
+            // The list AND its predicate live only in novelty.
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:nov1", "ex:items": {"@list": ["a", "b", "c"]}}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(list_values(&fluree, &ledger, "ex:nov1").await, vec!["a", "b", "c"]);
+
+            let del = json!({
+                "@context": ctx(),
+                "where": [{"@id": "?s", "ex:items": "b"}],
+                "delete": [{"@id": "?s", "ex:items": "b"}]
+            });
+            let r = fluree
+                .update_with_opts(ledger, &del, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 1);
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_values(&fluree, &ledger, "ex:nov1").await,
+                vec!["a", "c"],
+                "live handle must observe the retraction"
+            );
+            // The BGP path resolved the overlay correctly all along; pin it so
+            // the two read paths stay in agreement.
+            let q_sel = json!({
+                "@context": ctx(),
+                "select": ["?s", "?o"],
+                "where": {"@id": "?s", "ex:items": "?o"}
+            });
+            assert_eq!(
+                query_jsonld_formatted(&fluree, &ledger, &q_sel)
+                    .await
+                    .unwrap()
+                    .as_array()
+                    .map(Vec::len),
+                Some(2),
+                "BGP path agrees with the crawl"
+            );
+
+            // Same mechanism, plain values: a second novelty-only predicate
+            // with no `@list` anywhere.
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:nov2", "ex:tags": ["p", "q"]}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            let del_p = json!({
+                "@context": ctx(),
+                "where": [{"@id": "ex:nov2", "ex:tags": "p"}],
+                "delete": [{"@id": "ex:nov2", "ex:tags": "p"}]
+            });
+            let r = fluree
+                .update_with_opts(ledger, &del_p, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 1);
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_items(&fluree, &ledger, "ex:nov2", "ex:tags").await,
+                vec!["q"],
+                "plain-valued novelty-only predicate retracts too"
+            );
+
+            // Reload: a fresh process replays the commit chain and must agree.
+            drop(fluree);
+            let reloaded = FlureeBuilder::file(dir).build().unwrap();
+            let ledger = reloaded.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_values(&reloaded, &ledger, "ex:nov1").await,
+                vec!["a", "c"],
+                "replayed commit chain must observe the retraction"
+            );
+            assert_eq!(
+                list_items(&reloaded, &ledger, "ex:nov2", "ex:tags").await,
+                vec!["q"]
             );
         })
         .await;

--- a/fluree-db-api/tests/it_import.rs
+++ b/fluree-db-api/tests/it_import.rs
@@ -1061,6 +1061,141 @@ ex:bob   ex:worksFor ex:acme .
     );
 }
 
+/// A bulk import with no RDF collections anywhere must record
+/// `IndexRoot.has_list_meta = Some(false)` — an exact observation, not
+/// `None`. That is what lets filtered-DELETE staging skip list-meta
+/// hydration on bulk-imported ledgers, which are the large ones.
+#[tokio::test]
+async fn import_without_lists_records_has_list_meta_false() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    let ttl = r"
+@prefix ex: <http://example.org/> .
+ex:alice ex:worksFor ex:acme ; ex:name 'Alice' .
+ex:bob   ex:worksFor ex:acme ; ex:name 'Bob' .
+";
+    let ttl_path = write_ttl(data_dir.path(), "plain.ttl", ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .with_ledger_cache_config(fluree_db_api::LedgerManagerConfig::default())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let ledger_id = "test/import-no-lists:main";
+    let result = fluree
+        .create(ledger_id)
+        .import(&ttl_path)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("plain import should succeed");
+    assert!(result.root_id.is_some(), "index should have been built");
+
+    let ledger = fluree.ledger(ledger_id).await.expect("load imported ledger");
+    assert_eq!(
+        ledger.snapshot.has_list_meta,
+        Some(false),
+        "bulk import observed no list positions and must say so exactly"
+    );
+}
+
+/// The load-bearing half: one RDF collection anywhere in the import must
+/// record `Some(true)`. A wrongly-`false` root would let staging skip
+/// position hydration, and the list retraction below would silently do
+/// nothing — so the flag is asserted AND exercised.
+#[tokio::test]
+async fn import_with_list_records_has_list_meta_true_and_still_retracts() {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let data_dir = tempfile::tempdir().expect("data tmpdir");
+
+    // `ex:bob` carries no collection; `ex:alice`'s is the only one in the
+    // dataset, so the bit has to survive being OR'd across chunks.
+    let ttl = r"
+@prefix ex: <http://example.org/> .
+ex:bob   ex:name 'Bob' .
+ex:alice ex:items ( 'a' 'b' 'c' ) .
+";
+    let ttl_path = write_ttl(data_dir.path(), "listed.ttl", ttl);
+
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .with_ledger_cache_config(fluree_db_api::LedgerManagerConfig::default())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let ledger_id = "test/import-with-lists:main";
+    let result = fluree
+        .create(ledger_id)
+        .import(&ttl_path)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("list-bearing import should succeed");
+    assert!(result.root_id.is_some(), "index should have been built");
+
+    let ledger = fluree.ledger(ledger_id).await.expect("load imported ledger");
+    assert_eq!(
+        ledger.snapshot.has_list_meta,
+        Some(true),
+        "one collection in the import must flip the flag on"
+    );
+
+    // And it is not merely reported: a filtered DELETE of one entry has to
+    // land, which needs hydration to have run.
+    let ctx = json!({"ex": "http://example.org/"});
+    let items = |v: &serde_json::Value| -> Vec<String> {
+        v.as_array()
+            .and_then(|a| a.first())
+            .and_then(|node| node.get("ex:items"))
+            .map(|v| match v {
+                serde_json::Value::Array(a) => {
+                    a.iter().filter_map(|x| x.as_str().map(str::to_string)).collect()
+                }
+                other => other.as_str().map(str::to_string).into_iter().collect(),
+            })
+            .unwrap_or_default()
+    };
+    let read = json!({
+        "@context": ctx,
+        "select": {"?s": ["ex:items"]},
+        "where": {"@id": "?s"},
+        "values": ["?s", [{"@id": "ex:alice"}]]
+    });
+
+    let before = support::query_jsonld_formatted(&fluree, &ledger, &read)
+        .await
+        .expect("list query");
+    assert_eq!(items(&before), vec!["a", "b", "c"]);
+
+    let del = json!({
+        "@context": ctx,
+        "where": [{"@id": "?s", "ex:items": "b"}],
+        "delete": [{"@id": "?s", "ex:items": "b"}]
+    });
+    let r = fluree
+        .update_with_opts(
+            ledger,
+            &del,
+            fluree_db_api::TxnOpts::default(),
+            fluree_db_api::CommitOpts::default(),
+            // Unreachable thresholds: the delete must not trigger a rebuild
+            // that would re-derive the flag and mask a wrong root.
+            &fluree_db_api::IndexConfig {
+                reindex_min_bytes: 1 << 40,
+                reindex_max_bytes: 1 << 41,
+            },
+        )
+        .await
+        .expect("filtered delete");
+    assert_eq!(r.receipt.flake_count, 1);
+
+    let ledger = fluree.ledger(ledger_id).await.expect("reload");
+    let after = support::query_jsonld_formatted(&fluree, &ledger, &read)
+        .await
+        .expect("list query");
+    assert_eq!(items(&after), vec!["a", "c"], "the entry must actually go");
+}
+
 /// Firewall regression: a JSON-LD bulk import that hand-writes a
 /// fully-expanded `https://ns.flur.ee/db#reifies*` IRI must be rejected,
 /// exactly as the transact path rejects it. The expanded form carries none

--- a/fluree-db-api/tests/it_import.rs
+++ b/fluree-db-api/tests/it_import.rs
@@ -1092,7 +1092,10 @@ ex:bob   ex:worksFor ex:acme ; ex:name 'Bob' .
         .expect("plain import should succeed");
     assert!(result.root_id.is_some(), "index should have been built");
 
-    let ledger = fluree.ledger(ledger_id).await.expect("load imported ledger");
+    let ledger = fluree
+        .ledger(ledger_id)
+        .await
+        .expect("load imported ledger");
     assert_eq!(
         ledger.snapshot.has_list_meta,
         Some(false),
@@ -1133,7 +1136,10 @@ ex:alice ex:items ( 'a' 'b' 'c' ) .
         .expect("list-bearing import should succeed");
     assert!(result.root_id.is_some(), "index should have been built");
 
-    let ledger = fluree.ledger(ledger_id).await.expect("load imported ledger");
+    let ledger = fluree
+        .ledger(ledger_id)
+        .await
+        .expect("load imported ledger");
     assert_eq!(
         ledger.snapshot.has_list_meta,
         Some(true),
@@ -1148,9 +1154,10 @@ ex:alice ex:items ( 'a' 'b' 'c' ) .
             .and_then(|a| a.first())
             .and_then(|node| node.get("ex:items"))
             .map(|v| match v {
-                serde_json::Value::Array(a) => {
-                    a.iter().filter_map(|x| x.as_str().map(str::to_string)).collect()
-                }
+                serde_json::Value::Array(a) => a
+                    .iter()
+                    .filter_map(|x| x.as_str().map(str::to_string))
+                    .collect(),
                 other => other.as_str().map(str::to_string).into_iter().collect(),
             })
             .unwrap_or_default()

--- a/fluree-db-core/src/range.rs
+++ b/fluree-db-core/src/range.rs
@@ -349,20 +349,26 @@ fn collect_overlay_only<O: OverlayProvider + ?Sized>(
 }
 
 /// Resolve a mixed bag of assert/retract flakes to the currently-asserted
-/// set: sort in `index` order (which places the newest `t` last within a
-/// fact key), keep the newest op per fact key, drop retractions. This is the
-/// same lifecycle rule the overlay-only range path applies; callers that
-/// merge base rows with a raw overlay walk themselves use it to get
-/// identical results to [`range_with_overlay`].
+/// set: sort in `index` order, keep the newest op per fact key, drop
+/// retractions. This is the same lifecycle rule the overlay-only range path
+/// applies; callers that merge base rows with a raw overlay walk themselves
+/// use it to get identical results to [`range_with_overlay`].
+///
+/// At equal `t` a retraction beats an assert, so an assert and a retract of
+/// the same fact at one `t` resolve to absent. That matches
+/// `fluree_db_binary_index::read::types::resolve_overlay_ops`, which the
+/// cursor path uses, and the per-commit apply path. The transaction
+/// accumulator dedups within a commit so the tie is not reachable through a
+/// single transaction, but the segment-aware overlay assembly merges runs
+/// across segments — the rule is here so every path lands on the same answer
+/// rather than on whichever flake sorted last.
 pub fn resolve_current_flakes(mut flakes: Vec<Flake>, index: IndexType) -> Vec<Flake> {
     flakes.sort_by(index.comparator());
     remove_stale_flakes(flakes)
 }
 
-/// Remove stale flakes from an owned vector.
-///
-/// Iterates in reverse (newest first for identical facts), keeps only the
-/// first occurrence of each fact key, and drops retractions.
+/// Remove stale flakes from an owned vector: keep the winning op per fact
+/// key, drop retractions, preserve the input's order among survivors.
 ///
 /// The fact key includes the flake metadata `m` (language tag and list
 /// index), not just `(s, p, o, dt)`. Two flakes that share a subject,
@@ -370,8 +376,20 @@ pub fn resolve_current_flakes(mut flakes: Vec<Flake>, index: IndexType) -> Vec<F
 /// (e.g. `"animal"@en` vs `"animal"@fr`) or list position are **distinct
 /// RDF facts** and must both survive — omitting `m` here silently collapses
 /// language variants on insert (issue #1273).
+///
+/// Hashing the full identity is what makes that robust: it needs no
+/// adjacency between a fact's own flakes, so it does not care that the
+/// comparators order `t` before `m` and therefore interleave metadata
+/// siblings (see #1703), nor that `FlakeMeta`'s `Ord` disagrees with its
+/// `Eq` when both sides carry a list index (see #1711). `Hash`/`Eq` are
+/// derived together and agree.
+///
+/// The winner is chosen explicitly rather than by taking the first hit of a
+/// reverse scan, so the equal-`t` tie resolves to the retraction (see
+/// [`resolve_current_flakes`]) instead of to whichever op the comparator
+/// happened to sort last.
 fn remove_stale_flakes(flakes: Vec<Flake>) -> Vec<Flake> {
-    use std::collections::HashSet;
+    use std::collections::HashMap;
 
     #[derive(Clone, Copy, Hash, PartialEq, Eq)]
     struct FactKeyRef<'a> {
@@ -382,10 +400,9 @@ fn remove_stale_flakes(flakes: Vec<Flake>) -> Vec<Flake> {
         m: &'a Option<FlakeMeta>,
     }
 
-    let mut seen: HashSet<FactKeyRef<'_>> = HashSet::new();
-    let mut keep = vec![false; flakes.len()];
+    let mut winner: HashMap<FactKeyRef<'_>, usize> = HashMap::with_capacity(flakes.len());
 
-    for (idx, f) in flakes.iter().enumerate().rev() {
+    for (idx, f) in flakes.iter().enumerate() {
         let key = FactKeyRef {
             s: &f.s,
             p: &f.p,
@@ -393,10 +410,23 @@ fn remove_stale_flakes(flakes: Vec<Flake>) -> Vec<Flake> {
             dt: &f.dt,
             m: &f.m,
         };
-        if !seen.insert(key) {
-            continue;
+        match winner.get(&key) {
+            None => {
+                winner.insert(key, idx);
+            }
+            Some(&cur_idx) => {
+                let cur = &flakes[cur_idx];
+                // Newest op wins; at equal `t` the retraction does.
+                if f.t > cur.t || (f.t == cur.t && !f.op && cur.op) {
+                    winner.insert(key, idx);
+                }
+            }
         }
-        if f.op {
+    }
+
+    let mut keep = vec![false; flakes.len()];
+    for idx in winner.into_values() {
+        if flakes[idx].op {
             keep[idx] = true;
         }
     }
@@ -462,6 +492,239 @@ mod tests {
         let out = resolve_current_flakes(flakes, IndexType::Spot);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].m.as_ref().and_then(|m| m.i), Some(0));
+    }
+
+    /// An assert and a retract of the same fact at the SAME `t` resolve to
+    /// absent. The comparator orders `op` ascending, so a reverse scan that
+    /// took its first hit picked the assert and the fact survived — which
+    /// disagreed with `resolve_overlay_ops` on the cursor path, and so with
+    /// this function's own documented promise of "identical results to
+    /// `range_with_overlay`".
+    #[test]
+    fn resolve_current_flakes_retraction_wins_at_equal_t() {
+        let out = resolve_current_flakes(
+            vec![
+                fact("a", "x", 2, true, None),
+                fact("a", "x", 2, false, None),
+            ],
+            IndexType::Spot,
+        );
+        assert!(out.is_empty(), "same-t assert+retract resolves to absent");
+
+        // Order of the input must not change the answer.
+        let out = resolve_current_flakes(
+            vec![
+                fact("a", "x", 2, false, None),
+                fact("a", "x", 2, true, None),
+            ],
+            IndexType::Spot,
+        );
+        assert!(out.is_empty());
+    }
+
+    /// Metadata siblings: the comparators order `t` before `m`, so a
+    /// sibling's assert sits between a fact's own assert and its retraction.
+    /// Hashing the full identity is immune to that — no adjacency is
+    /// assumed (#1703).
+    #[test]
+    fn resolve_current_flakes_metadata_siblings_are_independent() {
+        // `["a", "b", "a"]` with position 0 retracted. Deleting position 0 is
+        // the failing direction for adjacency-based grouping; position 2
+        // passes either way.
+        let out = resolve_current_flakes(
+            vec![
+                fact("s", "a", 2, true, Some(0)),
+                fact("s", "b", 2, true, Some(1)),
+                fact("s", "a", 2, true, Some(2)),
+                fact("s", "a", 3, false, Some(0)),
+            ],
+            IndexType::Spot,
+        );
+        let mut positions: Vec<i32> = out.iter().filter_map(|f| f.m.as_ref()?.i).collect();
+        positions.sort_unstable();
+        assert_eq!(positions, vec![1, 2], "only position 0 goes");
+    }
+
+    /// One list position under two language tags: `FlakeMeta::cmp` consults
+    /// only `i` when both sides carry a list index, so those two compare
+    /// `Equal` without being equal (#1711). The fact key hashes `Hash`/`Eq`,
+    /// which agree, so they stay distinct facts here.
+    #[test]
+    fn resolve_current_flakes_one_position_two_language_tags() {
+        let tagged = |lang: &str, t: i64, op: bool| Flake {
+            s: Sid::new(1, "s"),
+            p: Sid::new(2, "p"),
+            o: FlakeValue::String("x".to_string()),
+            dt: Sid::new(3, "string"),
+            t,
+            op,
+            m: Some(FlakeMeta {
+                lang: Some(lang.to_string()),
+                i: Some(0),
+            }),
+            g: None,
+        };
+        let out = resolve_current_flakes(
+            vec![
+                tagged("en", 2, true),
+                tagged("fr", 3, true),
+                tagged("en", 4, false),
+            ],
+            IndexType::Spot,
+        );
+        assert_eq!(out.len(), 1, "the retracted @en must go");
+        assert_eq!(
+            out[0].m.as_ref().and_then(|m| m.lang.as_deref()),
+            Some("fr")
+        );
+    }
+
+    /// Mirror of the metadata-sibling case: retracting the LAST position
+    /// passed even under adjacency-based grouping, so it is kept so a future
+    /// regrouping cannot fix one direction by breaking the other.
+    #[test]
+    fn resolve_current_flakes_metadata_siblings_last_position() {
+        let out = resolve_current_flakes(
+            vec![
+                fact("s", "a", 2, true, Some(0)),
+                fact("s", "b", 2, true, Some(1)),
+                fact("s", "a", 2, true, Some(2)),
+                fact("s", "a", 3, false, Some(2)),
+            ],
+            IndexType::Spot,
+        );
+        let mut positions: Vec<i32> = out.iter().filter_map(|f| f.m.as_ref()?.i).collect();
+        positions.sort_unstable();
+        assert_eq!(positions, vec![0, 1]);
+    }
+
+    /// The winner is the newest op for a fact's OWN key, not the newest op in
+    /// its neighbourhood: a position retracted and then re-asserted comes
+    /// back even when a sibling carries a later `t`.
+    #[test]
+    fn resolve_current_flakes_reasserted_position_survives_later_sibling() {
+        let out = resolve_current_flakes(
+            vec![
+                fact("s", "a", 2, true, Some(0)),
+                fact("s", "a", 3, false, Some(0)),
+                fact("s", "a", 4, true, Some(0)),
+                fact("s", "a", 5, true, Some(1)),
+            ],
+            IndexType::Spot,
+        );
+        let mut positions: Vec<i32> = out.iter().filter_map(|f| f.m.as_ref()?.i).collect();
+        positions.sort_unstable();
+        assert_eq!(positions, vec![0, 1]);
+    }
+
+    /// Same lexical form under two language tags with no list index — the
+    /// #1273 shape — must retract independently.
+    #[test]
+    fn resolve_current_flakes_language_siblings_without_list_index() {
+        let tagged = |lang: &str, t: i64, op: bool| Flake {
+            s: Sid::new(1, "s"),
+            p: Sid::new(2, "p"),
+            o: FlakeValue::String("hello".to_string()),
+            dt: Sid::new(3, "string"),
+            t,
+            op,
+            m: Some(FlakeMeta {
+                lang: Some(lang.to_string()),
+                i: None,
+            }),
+            g: None,
+        };
+        let out = resolve_current_flakes(
+            vec![
+                tagged("en", 2, true),
+                tagged("fr", 2, true),
+                tagged("en", 3, false),
+            ],
+            IndexType::Spot,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].m.as_ref().and_then(|m| m.lang.as_deref()),
+            Some("fr")
+        );
+    }
+
+    /// Distinct datatypes on one lexical value are distinct facts, so `dt`
+    /// must stay in the key.
+    #[test]
+    fn resolve_current_flakes_datatype_siblings_are_independent() {
+        let typed = |dt: &str, t: i64, op: bool| Flake {
+            s: Sid::new(1, "s"),
+            p: Sid::new(2, "p"),
+            o: FlakeValue::String("1".to_string()),
+            dt: Sid::new(3, dt),
+            t,
+            op,
+            m: None,
+            g: None,
+        };
+        let out = resolve_current_flakes(
+            vec![
+                typed("string", 2, true),
+                typed("token", 2, true),
+                typed("string", 3, false),
+            ],
+            IndexType::Spot,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].dt.name_str(), "token");
+    }
+
+    /// Survivors come back in index order — callers take this as a range
+    /// result. Hashing the identity means the winner is chosen per key, so
+    /// the output must still follow the sorted input's order.
+    #[test]
+    fn resolve_current_flakes_output_is_comparator_ordered() {
+        let out = resolve_current_flakes(
+            vec![
+                // `m` ascending but `t` descending across the two survivors.
+                fact("s", "a", 9, true, Some(0)),
+                fact("s", "a", 3, true, Some(1)),
+            ],
+            IndexType::Spot,
+        );
+        let cmp = IndexType::Spot.comparator();
+        assert!(
+            out.windows(2)
+                .all(|w| cmp(&w[0], &w[1]) != std::cmp::Ordering::Greater),
+            "resolved range results must be index-ordered"
+        );
+    }
+
+    /// A list holding ONE value at many positions puts every entry under the
+    /// same `(s, p, o, dt)` with a distinct `m`. Hashing the identity keeps
+    /// that linear; an adjacency- or scan-based grouper would go quadratic
+    /// here, which is the shape this area of the code exists to have stopped
+    /// doing.
+    #[test]
+    fn resolve_current_flakes_many_positions_of_one_value_stay_linear() {
+        const K: i32 = 4_000;
+        let mut flakes: Vec<Flake> = (0..K).map(|i| fact("s", "x", 2, true, Some(i))).collect();
+        flakes.extend(
+            (0..K)
+                .filter(|i| i % 3 == 0)
+                .map(|i| fact("s", "x", 3, false, Some(i))),
+        );
+
+        let started = std::time::Instant::now();
+        let out = resolve_current_flakes(flakes, IndexType::Spot);
+        let elapsed = started.elapsed();
+
+        let expected = (0..K).filter(|i| i % 3 != 0).count();
+        assert_eq!(out.len(), expected);
+        let positions: Vec<i32> = out.iter().filter_map(|f| f.m.as_ref()?.i).collect();
+        assert!(positions.iter().all(|i| i % 3 != 0));
+        assert!(positions.windows(2).all(|w| w[0] < w[1]));
+        // Generous by ~2 orders of magnitude against the real runtime.
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "resolution took {elapsed:?} for {K} positions — went superlinear"
+        );
     }
 
     #[test]

--- a/fluree-db-query/src/binary_range.rs
+++ b/fluree-db-query/src/binary_range.rs
@@ -13,9 +13,9 @@ use fluree_db_binary_index::{
 use fluree_db_core::dict_novelty::DictNovelty;
 use fluree_db_core::subject_id::SubjectId;
 use fluree_db_core::{
-    flake_matches_range_eq, range_provider::RangeQuery, Flake, FlakeMeta, FlakeValue, GraphId,
-    IndexType, OType, OverlayProvider, RangeMatch, RangeOptions, RangeProvider, RangeTest,
-    RuntimeSmallDicts, Sid,
+    flake_matches_range_eq, range_provider::RangeQuery, Flake, FlakeValue, GraphId, IndexType,
+    OType, OverlayProvider, RangeMatch, RangeOptions, RangeProvider, RangeTest, RuntimeSmallDicts,
+    Sid,
 };
 
 use crate::binary_scan::{encode_bound_object_prefilter, index_type_to_sort_order};
@@ -793,7 +793,7 @@ fn binary_range_eq_v3(
     // Correctness fallback: merge untranslated overlay flakes (including retracts),
     // resolve per-fact lifecycles (latest-op-wins), then apply RangeOptions.
     flakes.extend(untranslated);
-    let mut resolved = resolve_latest_ops_keep_asserts(flakes, index);
+    let mut resolved = fluree_db_core::range::resolve_current_flakes(flakes, index);
     resolved.retain(|f| flake_matches_range_eq(f, match_val));
 
     if let Some(bounds) = &opts.object_bounds {
@@ -818,151 +818,6 @@ fn binary_range_eq_v3(
 #[inline]
 fn resolve_sid(s_id: u64, view: &BinaryGraphView) -> std::io::Result<Sid> {
     view.resolve_subject_sid(s_id)
-}
-
-/// Resolve fact lifecycles (latest op wins) and drop retracts.
-///
-/// Used as a correctness fallback when some overlay flakes cannot be translated
-/// into V3 `OverlayOp`s (e.g., missing dict novelty), and by the raw-overlay
-/// paths that serve a pattern the persisted index cannot contribute to. The
-/// input should include both cursor output flakes (asserts) and raw overlay
-/// flakes (asserts/retracts).
-///
-/// ## Why the grouping is two-level
-///
-/// A fact's identity is `(s, p, o, dt, m)`: two `@list` entries holding the
-/// same value at different positions, and one lexical form under two language
-/// tags, are DISTINCT facts (the #1273 class). But every comparator orders
-/// `… t, op, m` — `t` BEFORE `m` (`fluree-db-core/src/comparator.rs`). So
-/// flakes that share `(s, p, o, dt)` and differ only in `m` interleave by `t`,
-/// which puts a sibling's assert between a fact's own assert and its
-/// retraction. Cutting runs on full identity therefore closes a group early
-/// and emits the retracted assert as live — the exact resurrection this
-/// helper exists to prevent, on `["a", "b", "a"]` or `"x"@en` + `"x"@fr`.
-///
-/// So runs are cut on [`same_fact_key`] — the four fields all four comparators
-/// DO order before `t`, making those runs contiguous — and the winner is
-/// picked per distinct `m` inside the run.
-fn resolve_latest_ops_keep_asserts(mut flakes: Vec<Flake>, index: IndexType) -> Vec<Flake> {
-    let cmp = index.comparator();
-    flakes.sort_by(cmp);
-
-    if flakes.len() < 2 {
-        return flakes.into_iter().filter(|f| f.op).collect();
-    }
-
-    let mut out: Vec<Flake> = Vec::with_capacity(flakes.len());
-    // Scratch index buffer for the multi-flake run path, reused across runs.
-    let mut idxs: Vec<usize> = Vec::new();
-    let mut start = 0usize;
-    while start < flakes.len() {
-        let mut end = start + 1;
-        while end < flakes.len() && same_fact_key(&flakes[start], &flakes[end]) {
-            end += 1;
-        }
-
-        // Overwhelmingly the common run: one flake, so no grouping at all.
-        if end - start == 1 {
-            if flakes[start].op {
-                out.push(flakes[start].clone());
-            }
-            start = end;
-            continue;
-        }
-
-        // Group the run by `m`. Sorting rather than scanning a winners list
-        // keeps this O(k log k): a list that repeats one value across k
-        // positions puts all k in ONE run with k distinct `m`, and a linear
-        // "have I seen this `m`" probe would make that quadratic — the shape
-        // this whole area of the code exists to have stopped doing.
-        //
-        // The sort keys on `m` ALONE via `meta_group_cmp`, NOT `FlakeMeta`'s
-        // own `Ord` — that one ignores `lang` whenever both sides carry a
-        // list index, so it calls `{en, i: 0}` and `{fr, i: 0}` equal while
-        // `==` calls them distinct. Grouping on `==` after sorting by it
-        // would sort by one relation and cut by a stricter one: the same
-        // mismatch as #1703, one level down. `meta_group_cmp` agrees with
-        // `==` by construction (pinned by
-        // `group_order_agrees_with_metadata_equality`).
-        //
-        // The sort is stable, so the comparator's `t, op` order survives
-        // inside each group and the winner scan below sees candidates in
-        // ascending `t`.
-        idxs.clear();
-        idxs.extend(start..end);
-        idxs.sort_by(|&a, &b| meta_group_cmp(&flakes[a].m, &flakes[b].m));
-
-        let mut g = 0usize;
-        while g < idxs.len() {
-            let mut best = idxs[g];
-            let mut h = g + 1;
-            while h < idxs.len() && flakes[idxs[h]].m == flakes[best].m {
-                let cand = &flakes[idxs[h]];
-                let cur = &flakes[best];
-                // Newest op wins; at equal `t` a retraction beats an assert,
-                // matching `resolve_current_flakes`.
-                if cand.t > cur.t || (cand.t == cur.t && !cand.op && cur.op) {
-                    best = idxs[h];
-                }
-                h += 1;
-            }
-            if flakes[best].op {
-                out.push(flakes[best].clone());
-            }
-            g = h;
-        }
-
-        start = end;
-    }
-
-    // Survivors of a multi-flake run are emitted in `m` order, which is not
-    // the comparator's order for the run (it orders `t` first). Callers take
-    // this as a range result and expect index order, which the
-    // single-winner-per-group predecessor gave them for free. Cheap to
-    // restore: `out` is a subsequence of an already-sorted vec whose only
-    // inversions are inside those runs.
-    out.sort_by(cmp);
-    out
-}
-
-/// Strict total order on flake metadata, for grouping inside a fact run.
-///
-/// [`FlakeMeta`](fluree_db_core::FlakeMeta)'s own `Ord` compares ONLY `i`
-/// when both sides carry a list index — `lang` is never consulted — while its
-/// `PartialEq` is derived over both fields. So `{lang: en, i: 0}` and
-/// `{lang: fr, i: 0}` compare `Equal` without being equal: `Ord` is not
-/// consistent with `Eq` for that type. Sorting by it and then cutting groups
-/// on `==` sorts by one relation and groups by a stricter one, which lets a
-/// sibling's assert separate a fact from its own retraction — the #1703
-/// failure, one level down.
-///
-/// This order is consistent with `==` by construction: it compares `i` and
-/// then `lang`, so `Equal` here means equal in fact.
-///
-/// Deliberately local. Repairing `FlakeMeta::Ord` itself moves index ordering
-/// semantics repo-wide (every comparator's `cmp_meta` tiebreak reads it), so
-/// that belongs in #1711 rather than in a fix for the range path.
-#[inline]
-fn meta_group_cmp(a: &Option<FlakeMeta>, b: &Option<FlakeMeta>) -> std::cmp::Ordering {
-    match (a, b) {
-        (None, None) => std::cmp::Ordering::Equal,
-        (None, Some(_)) => std::cmp::Ordering::Less,
-        (Some(_), None) => std::cmp::Ordering::Greater,
-        (Some(x), Some(y)) => x.i.cmp(&y.i).then_with(|| x.lang.cmp(&y.lang)),
-    }
-}
-
-/// Run key for [`resolve_latest_ops_keep_asserts`]: the four fields every
-/// comparator orders BEFORE `t`, so flakes sharing it land contiguously after
-/// the sort. Deliberately NOT full fact identity — `m` is resolved per-fact
-/// inside the run, because the comparators interleave differing `m` by `t`.
-///
-/// `g` is absent because every caller walks one `g_id` at a time, so a
-/// mixed-graph vector never reaches here. A caller that ever scopes
-/// differently has to add it.
-#[inline]
-fn same_fact_key(a: &Flake, b: &Flake) -> bool {
-    a.s == b.s && a.p == b.p && a.o == b.o && a.dt == b.dt
 }
 
 /// Batched lookup for ref-valued predicate objects across many subjects (V3).
@@ -1188,8 +1043,15 @@ fn apply_raw_overlay_deltas_to_batched_refs(
             None => {
                 subj_entry.insert(class_sid, (flake.t, flake.op));
             }
-            Some(&(t0, _op0)) => {
-                if flake.t > t0 {
+            Some(&(t0, op0)) => {
+                // Newest op wins; at equal `t` the retraction does. Taking
+                // `>` alone let whichever flake the walk happened to yield
+                // first win the tie — and on this lane, which decides
+                // class-based policy grants, the direction it failed was
+                // open: a same-`t` assert+retract of a class left the class
+                // granted. Same rule as `resolve_current_flakes` and
+                // `resolve_overlay_ops`.
+                if flake.t > t0 || (flake.t == t0 && !flake.op && op0) {
                     subj_entry.insert(class_sid, (flake.t, flake.op));
                 }
             }
@@ -1205,6 +1067,14 @@ fn apply_raw_overlay_deltas_to_batched_refs(
             } else {
                 vec.retain(|c| c != class_sid);
             }
+        }
+        // A subject whose overlay flakes are all retractions would otherwise
+        // be left holding an empty vector, which reads as "present with no
+        // classes". `lookup_subject_classes` documents that subjects with no
+        // `rdf:type` assertions are absent from the map, and its per-subject
+        // fallback enforces that — so don't diverge from it here.
+        if vec.is_empty() {
+            out.remove(subj);
         }
     }
 }
@@ -1534,7 +1404,7 @@ fn binary_range_bounded_v3(
 
     // Correctness fallback: merge raw overlay flakes, resolve lifecycles, then apply options.
     flakes.extend(raw_overlay);
-    let mut resolved = resolve_latest_ops_keep_asserts(flakes, IndexType::Spot);
+    let mut resolved = fluree_db_core::range::resolve_current_flakes(flakes, IndexType::Spot);
 
     // Re-apply subject bounds: start_bound.s <= s < end_bound.s.
     resolved.retain(|f| f.s >= start_bound.s && f.s < end_bound.s);
@@ -1589,7 +1459,7 @@ fn overlay_only_flakes_bounded(
     );
 
     // Resolve lifecycles (latest op wins) and drop retracts.
-    let mut resolved = resolve_latest_ops_keep_asserts(flakes, index);
+    let mut resolved = fluree_db_core::range::resolve_current_flakes(flakes, index);
 
     // Apply options after lifecycle resolution.
     if let Some(ref bounds) = opts.object_bounds {
@@ -1610,22 +1480,37 @@ fn overlay_only_flakes_bounded(
 ///
 /// Reached whenever a bound component of `match_val` has no persisted id
 /// (a novelty-only subject, predicate, or object), or no branch manifest
-/// exists for the requested order (genesis / pre-first-index).
+/// exists for `(g_id, order)`.
+///
+/// That second trigger is broader than "genesis / pre-first-index":
+/// `branch_for_order` is keyed per graph AND order, and the bulk-import path
+/// emits SPOT unconditionally while skipping PSOT/POST/OPST when the order
+/// produced no run files (`index_build.rs`'s empty-run-dir early return),
+/// so a graph with zero rows at the indexed `t` lands here for three of the
+/// four orders. Falling back is still correct: the orders that go missing
+/// are exactly the zero-row ones, so there are no persisted rows to drop.
+/// The converse does NOT hold — SPOT can be `Some` with an empty branch —
+/// so nothing here may treat "this order resolved" as "this graph is
+/// indexed".
 ///
 /// The overlay is a **log**, not a current-state view: an assert at `t=2`
 /// and its retraction at `t=3` both sit in novelty. So retractions are kept
-/// through the walk and the whole matching set is lifecycle-resolved
-/// (newest op per fact identity wins, retracted keys drop out) before
-/// options are applied — the same rule the cursor path gets from
-/// `resolve_overlay_ops` and the bounded twin gets from
-/// `resolve_latest_ops_keep_asserts`. Filtering to `op == true` inside the
-/// walk instead silently resurrects every fact whose assert AND retract
-/// both live in novelty.
+/// through the walk and the whole matching set is lifecycle-resolved by
+/// `resolve_current_flakes` — the shared rule, hashing the full
+/// `(s, p, o, dt, m)` identity, which the bounded twin and the untranslated
+/// fallback also use and which the cursor path mirrors in
+/// `resolve_overlay_ops`. Filtering to `op == true` inside the walk instead
+/// silently resurrects every fact whose assert AND retract both live in
+/// novelty.
 ///
-/// This also rules out an early exit at `limit`: the retraction that
-/// cancels an already-collected assert can arrive after the limit is
-/// reached. `for_each_overlay_flake` walks the graph's whole overlay
-/// regardless, so the exit only ever saved clones of matching flakes.
+/// `object_bounds` stays IN the walk: a retraction that can cancel an assert
+/// carries the same `o` by construction (the fact identity requires it), so
+/// the bound is true for both halves or false for both, and pruning early is
+/// equivalent to pruning survivors while collecting and cloning less. The
+/// `offset`/`limit` pair cannot move in with it — they count survivors, and
+/// the retraction that cancels an already-counted assert can arrive after
+/// the count is reached. `for_each_overlay_flake` walks the graph's whole
+/// overlay regardless, so no early exit would shorten the traversal anyway.
 fn overlay_only_flakes(
     store: &Arc<BinaryIndexStore>,
     g_id: GraphId,
@@ -1677,17 +1562,23 @@ fn overlay_only_flakes(
                 }
             }
 
+            // Object bounds are a pure function of `o`, which a fact and its
+            // retraction share, so this prunes whole facts rather than
+            // splitting one — see the note above.
+            if let Some(ref bounds) = opts.object_bounds {
+                if !bounds.matches(&flake.o) {
+                    return;
+                }
+            }
+
             // Keep both asserts and retracts; resolve lifecycles below.
             flakes.push(flake.clone());
         },
     );
 
-    let mut resolved = resolve_latest_ops_keep_asserts(flakes, index);
+    let mut resolved = fluree_db_core::range::resolve_current_flakes(flakes, index);
 
-    // Options apply to the resolved current state, not to the log.
-    if let Some(ref bounds) = opts.object_bounds {
-        resolved.retain(|f| bounds.matches(&f.o));
-    }
+    // Counting options apply to the resolved current state, not to the log.
     if offset > 0 && !resolved.is_empty() {
         let n = offset.min(resolved.len());
         resolved.drain(0..n);
@@ -1702,294 +1593,9 @@ fn overlay_only_flakes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fluree_db_core::FlakeMeta;
 
     fn s(name: &str) -> Sid {
         Sid::new(100, name)
-    }
-
-    fn dt_string() -> Sid {
-        Sid::new(fluree_vocab::namespaces::XSD, "string")
-    }
-
-    /// One flake on `ex:sub ex:pred`, with `m` supplied directly.
-    fn f(o: &str, t: i64, op: bool, m: Option<FlakeMeta>) -> Flake {
-        Flake::new(
-            s("sub"),
-            s("pred"),
-            FlakeValue::String(o.to_string()),
-            dt_string(),
-            t,
-            op,
-            m,
-        )
-    }
-
-    fn at(i: i32) -> Option<FlakeMeta> {
-        FlakeMeta::from_parts(None, Some(i))
-    }
-
-    fn tagged(lang: &str) -> Option<FlakeMeta> {
-        FlakeMeta::from_parts(Some(lang), None)
-    }
-
-    fn rendered(flakes: &[Flake]) -> Vec<(String, Option<FlakeMeta>)> {
-        flakes
-            .iter()
-            .map(|f| {
-                let o = match &f.o {
-                    FlakeValue::String(v) => v.clone(),
-                    other => format!("{other:?}"),
-                };
-                (o, f.m.clone())
-            })
-            .collect()
-    }
-
-    /// The plain case the helper always handled: one fact, asserted then
-    /// retracted, resolves away.
-    #[test]
-    fn single_valued_retraction_resolves() {
-        let out = resolve_latest_ops_keep_asserts(
-            vec![f("a", 2, true, None), f("a", 3, false, None)],
-            IndexType::Spot,
-        );
-        assert!(out.is_empty());
-    }
-
-    /// A `@list` that repeats a value: `["a", "b", "a"]` with position 0
-    /// deleted. The comparators order `t` before `m`, so the sibling `a@2`
-    /// assert sits between `a@0`'s assert and its retraction — cutting runs
-    /// on full identity closed the group early and emitted the retracted
-    /// `a@0` as live. Position 0 is the load-bearing case: deleting position
-    /// 2 passed even with the bug, because it only fails when the retracted
-    /// entry's metadata sorts below a surviving sibling's.
-    #[test]
-    fn repeated_list_value_retracts_the_right_position() {
-        let out = resolve_latest_ops_keep_asserts(
-            vec![
-                f("a", 2, true, at(0)),
-                f("b", 2, true, at(1)),
-                f("a", 2, true, at(2)),
-                f("a", 3, false, at(0)),
-            ],
-            IndexType::Spot,
-        );
-        assert_eq!(
-            rendered(&out),
-            vec![("a".to_string(), at(2)), ("b".to_string(), at(1))],
-            "only the position-0 entry may go"
-        );
-    }
-
-    /// The mirror case that used to pass, kept so a future regrouping can't
-    /// fix one position by breaking the other.
-    #[test]
-    fn repeated_list_value_retracts_the_last_position() {
-        let out = resolve_latest_ops_keep_asserts(
-            vec![
-                f("a", 2, true, at(0)),
-                f("b", 2, true, at(1)),
-                f("a", 2, true, at(2)),
-                f("a", 3, false, at(2)),
-            ],
-            IndexType::Spot,
-        );
-        assert_eq!(
-            rendered(&out),
-            vec![("a".to_string(), at(0)), ("b".to_string(), at(1))]
-        );
-    }
-
-    /// One lexical form under two language tags: distinct facts (#1273), so
-    /// retracting the `@en` must leave the `@fr` and take nothing else.
-    #[test]
-    fn language_tagged_siblings_retract_independently() {
-        let out = resolve_latest_ops_keep_asserts(
-            vec![
-                f("hello", 2, true, tagged("en")),
-                f("hello", 2, true, tagged("fr")),
-                f("hello", 3, false, tagged("en")),
-            ],
-            IndexType::Spot,
-        );
-        assert_eq!(rendered(&out), vec![("hello".to_string(), tagged("fr"))]);
-    }
-
-    /// A position retracted and re-asserted must come back, and the winner is
-    /// the newest op for that `m` alone — not the newest in the whole run.
-    #[test]
-    fn reasserted_position_survives_a_sibling_with_a_later_t() {
-        let out = resolve_latest_ops_keep_asserts(
-            vec![
-                f("a", 2, true, at(0)),
-                f("a", 3, false, at(0)),
-                f("a", 4, true, at(0)),
-                f("a", 5, true, at(1)),
-            ],
-            IndexType::Spot,
-        );
-        assert_eq!(
-            rendered(&out),
-            vec![("a".to_string(), at(0)), ("a".to_string(), at(1))]
-        );
-    }
-
-    /// At equal `t` a retraction beats an assert, per `resolve_current_flakes`.
-    #[test]
-    fn retraction_wins_at_equal_t() {
-        let out = resolve_latest_ops_keep_asserts(
-            vec![f("a", 2, true, at(0)), f("a", 2, false, at(0))],
-            IndexType::Spot,
-        );
-        assert!(out.is_empty());
-    }
-
-    /// Output must stay in comparator order: callers take it as a range
-    /// result. Winners are collected in `t` order inside a run, so a run
-    /// whose survivors' `t` order disagrees with their `m` order would emit
-    /// unsorted without the final sort.
-    #[test]
-    fn output_is_comparator_ordered() {
-        let out = resolve_latest_ops_keep_asserts(
-            vec![
-                // `m` ascending but `t` descending across the two survivors.
-                f("a", 9, true, at(0)),
-                f("a", 3, true, at(1)),
-            ],
-            IndexType::Spot,
-        );
-        let cmp = IndexType::Spot.comparator();
-        assert!(
-            out.windows(2)
-                .all(|w| cmp(&w[0], &w[1]) != std::cmp::Ordering::Greater),
-            "resolved range results must be index-ordered, got {:?}",
-            rendered(&out)
-        );
-    }
-
-    /// One list POSITION carrying two language tags — the combination the
-    /// other cases only cover separately, and the one place `FlakeMeta`'s
-    /// `Ord`/`Eq` disagreement bites (#1711).
-    ///
-    /// `FlakeMeta::cmp` consults only `i` when both sides carry a list index,
-    /// so `{lang: en, i: 0}` and `{lang: fr, i: 0}` compare `Equal` while
-    /// being unequal. Grouping that sorts on `cmp` and cuts on `==` therefore
-    /// sorts by one relation and groups by a stricter one — the #1703 mistake
-    /// one level down — and the `@en` sibling's assert separates the `@fr`
-    /// fact from its own retraction.
-    ///
-    /// The retraction must land in a LATER transaction than the sibling's
-    /// assert; a same-transaction rewrite happens to resolve either way.
-    #[test]
-    fn one_list_position_under_two_language_tags_resolves_independently() {
-        let at_lang = |lang: &str, i: i32| FlakeMeta::from_parts(Some(lang), Some(i));
-        let out = resolve_latest_ops_keep_asserts(
-            vec![
-                f("x", 2, true, at_lang("en", 0)),
-                f("x", 3, true, at_lang("fr", 0)),
-                f("x", 4, false, at_lang("en", 0)),
-            ],
-            IndexType::Spot,
-        );
-        assert_eq!(
-            rendered(&out),
-            vec![("x".to_string(), at_lang("fr", 0))],
-            "the retracted @en fact must go; its @fr sibling at the same \
-             position must stay"
-        );
-    }
-
-    /// Mirror of the above with the tags swapped, so a grouping that happens
-    /// to work for one tag order can't pass.
-    #[test]
-    fn one_list_position_two_tags_mirror_order() {
-        let at_lang = |lang: &str, i: i32| FlakeMeta::from_parts(Some(lang), Some(i));
-        let out = resolve_latest_ops_keep_asserts(
-            vec![
-                f("x", 2, true, at_lang("fr", 0)),
-                f("x", 3, true, at_lang("en", 0)),
-                f("x", 4, false, at_lang("fr", 0)),
-            ],
-            IndexType::Spot,
-        );
-        assert_eq!(rendered(&out), vec![("x".to_string(), at_lang("en", 0))]);
-    }
-
-    /// The invariant the grouping rests on: the order it sorts by must agree
-    /// with the equality it cuts groups on. `FlakeMeta`'s own `Ord` does NOT
-    /// (that is #1711), which is why grouping uses a local strict order.
-    #[test]
-    fn group_order_agrees_with_metadata_equality() {
-        let m = |lang: Option<&str>, i: Option<i32>| FlakeMeta::from_parts(lang, i);
-        let metas = [
-            m(None, None),
-            m(Some("en"), None),
-            m(Some("fr"), None),
-            m(None, Some(0)),
-            m(Some("en"), Some(0)),
-            m(Some("fr"), Some(0)),
-            m(Some("en"), Some(1)),
-            m(None, Some(1)),
-        ];
-        for a in &metas {
-            for b in &metas {
-                assert_eq!(
-                    meta_group_cmp(a, b) == std::cmp::Ordering::Equal,
-                    a == b,
-                    "group order disagrees with equality for {a:?} vs {b:?}"
-                );
-            }
-        }
-        // And the pair that motivates it: equal under `FlakeMeta::cmp`,
-        // unequal in fact.
-        let en0 = m(Some("en"), Some(0)).unwrap();
-        let fr0 = m(Some("fr"), Some(0)).unwrap();
-        assert_eq!(en0.cmp(&fr0), std::cmp::Ordering::Equal, "see #1711");
-        assert_ne!(en0, fr0);
-    }
-
-    /// A list holding ONE value at many positions puts every entry in a
-    /// single `(s, p, o, dt)` run with a distinct `m` each — the worst case
-    /// for the per-`m` grouping, and the shape a "have I seen this `m`"
-    /// linear probe would turn quadratic. Sized so a quadratic grouper would
-    /// be conspicuous rather than merely slower.
-    #[test]
-    fn many_positions_of_one_value_resolve_without_a_quadratic() {
-        const K: i32 = 4_000;
-        let mut flakes: Vec<Flake> = (0..K).map(|i| f("x", 2, true, at(i))).collect();
-        // Retract every third position.
-        flakes.extend(
-            (0..K)
-                .filter(|i| i % 3 == 0)
-                .map(|i| f("x", 3, false, at(i))),
-        );
-
-        let started = std::time::Instant::now();
-        let out = resolve_latest_ops_keep_asserts(flakes, IndexType::Spot);
-        let elapsed = started.elapsed();
-
-        let expected = (0..K).filter(|i| i % 3 != 0).count();
-        assert_eq!(
-            out.len(),
-            expected,
-            "exactly the unretracted positions live"
-        );
-        let survivors: Vec<i32> = out.iter().filter_map(|f| f.m.as_ref()?.i).collect();
-        assert!(
-            survivors.iter().all(|i| i % 3 != 0),
-            "no retracted position may survive"
-        );
-        assert!(
-            survivors.windows(2).all(|w| w[0] < w[1]),
-            "survivors stay in index order"
-        );
-        // Generous by ~2 orders of magnitude against the real runtime, so it
-        // fails on a reintroduced quadratic without flaking on a slow box.
-        assert!(
-            elapsed < std::time::Duration::from_secs(2),
-            "resolution took {elapsed:?} for {K} positions — grouping went superlinear"
-        );
     }
 
     /// The latest-op-wins rule `batched_refs_overlay_only` delegates to.
@@ -2052,31 +1658,57 @@ mod tests {
         );
     }
 
-    /// Distinct datatypes on the same lexical value are distinct facts, so a
-    /// retraction of one must not take the other. Pins that `dt` stays in the
-    /// run key rather than being folded in with `m`.
+    /// The equal-`t` tie on the policy lane, and the map-shape contract.
+    ///
+    /// `t > t0` alone let whichever flake the walk yielded first win a tie,
+    /// and the direction it failed was open: a same-`t` assert+retract left
+    /// the class granted. And a subject whose overlay flakes are all
+    /// retractions must be ABSENT from the map, not present with an empty
+    /// vector — `lookup_subject_classes` documents that, and its per-subject
+    /// fallback enforces it.
     #[test]
-    fn datatype_siblings_retract_independently() {
-        let typed = |dt: &str, t: i64, op: bool| {
+    fn batched_ref_deltas_tie_and_map_shape() {
+        let rdf_type = s("type");
+        let type_flake = |subject: &str, class: &str, t: i64, op: bool| {
             Flake::new(
-                s("sub"),
-                s("pred"),
-                FlakeValue::String("1".to_string()),
-                Sid::new(fluree_vocab::namespaces::XSD, dt),
+                s(subject),
+                rdf_type.clone(),
+                FlakeValue::Ref(s(class)),
+                Sid::new(0, ""),
                 t,
                 op,
                 None,
             )
         };
-        let out = resolve_latest_ops_keep_asserts(
-            vec![
-                typed("string", 2, true),
-                typed("token", 2, true),
-                typed("string", 3, false),
-            ],
-            IndexType::Spot,
+
+        // Assert-first and retract-first orderings must agree.
+        for flip in [false, true] {
+            let mut raw = vec![
+                type_flake("carol", "Admin", 2, true),
+                type_flake("carol", "Admin", 2, false),
+            ];
+            if flip {
+                raw.reverse();
+            }
+            let mut out: HashMap<Sid, Vec<Sid>> = HashMap::new();
+            apply_raw_overlay_deltas_to_batched_refs(&mut out, &raw, &rdf_type, 10);
+            assert!(
+                !out.contains_key(&s("carol")),
+                "same-t assert+retract must revoke, and leave no empty entry (flip={flip})"
+            );
+        }
+
+        // Retraction-only overlay for a subject: absent, not empty.
+        let mut out: HashMap<Sid, Vec<Sid>> = HashMap::new();
+        apply_raw_overlay_deltas_to_batched_refs(
+            &mut out,
+            &[type_flake("dave", "Admin", 3, false)],
+            &rdf_type,
+            10,
         );
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].dt.name_str(), "token");
+        assert!(
+            !out.contains_key(&s("dave")),
+            "a subject with no surviving class must not appear in the map"
+        );
     }
 }

--- a/fluree-db-query/src/binary_range.rs
+++ b/fluree-db-query/src/binary_range.rs
@@ -13,9 +13,9 @@ use fluree_db_binary_index::{
 use fluree_db_core::dict_novelty::DictNovelty;
 use fluree_db_core::subject_id::SubjectId;
 use fluree_db_core::{
-    flake_matches_range_eq, range_provider::RangeQuery, Flake, FlakeValue, GraphId, IndexType,
-    OType, OverlayProvider, RangeMatch, RangeOptions, RangeProvider, RangeTest, RuntimeSmallDicts,
-    Sid,
+    flake_matches_range_eq, range_provider::RangeQuery, Flake, FlakeMeta, FlakeValue, GraphId,
+    IndexType, OType, OverlayProvider, RangeMatch, RangeOptions, RangeProvider, RangeTest,
+    RuntimeSmallDicts, Sid,
 };
 
 use crate::binary_scan::{encode_bound_object_prefilter, index_type_to_sort_order};
@@ -876,12 +876,21 @@ fn resolve_latest_ops_keep_asserts(mut flakes: Vec<Flake>, index: IndexType) -> 
         // "have I seen this `m`" probe would make that quadratic — the shape
         // this whole area of the code exists to have stopped doing.
         //
-        // The sort keys on `m` ALONE and is stable, so the comparator's
-        // `t, op` order survives inside each group and the winner scan below
-        // sees candidates in ascending `t`.
+        // The sort keys on `m` ALONE via `meta_group_cmp`, NOT `FlakeMeta`'s
+        // own `Ord` — that one ignores `lang` whenever both sides carry a
+        // list index, so it calls `{en, i: 0}` and `{fr, i: 0}` equal while
+        // `==` calls them distinct. Grouping on `==` after sorting by it
+        // would sort by one relation and cut by a stricter one: the same
+        // mismatch as #1703, one level down. `meta_group_cmp` agrees with
+        // `==` by construction (pinned by
+        // `group_order_agrees_with_metadata_equality`).
+        //
+        // The sort is stable, so the comparator's `t, op` order survives
+        // inside each group and the winner scan below sees candidates in
+        // ascending `t`.
         idxs.clear();
         idxs.extend(start..end);
-        idxs.sort_by(|&a, &b| flakes[a].m.cmp(&flakes[b].m));
+        idxs.sort_by(|&a, &b| meta_group_cmp(&flakes[a].m, &flakes[b].m));
 
         let mut g = 0usize;
         while g < idxs.len() {
@@ -914,6 +923,33 @@ fn resolve_latest_ops_keep_asserts(mut flakes: Vec<Flake>, index: IndexType) -> 
     // inversions are inside those runs.
     out.sort_by(cmp);
     out
+}
+
+/// Strict total order on flake metadata, for grouping inside a fact run.
+///
+/// [`FlakeMeta`](fluree_db_core::FlakeMeta)'s own `Ord` compares ONLY `i`
+/// when both sides carry a list index — `lang` is never consulted — while its
+/// `PartialEq` is derived over both fields. So `{lang: en, i: 0}` and
+/// `{lang: fr, i: 0}` compare `Equal` without being equal: `Ord` is not
+/// consistent with `Eq` for that type. Sorting by it and then cutting groups
+/// on `==` sorts by one relation and groups by a stricter one, which lets a
+/// sibling's assert separate a fact from its own retraction — the #1703
+/// failure, one level down.
+///
+/// This order is consistent with `==` by construction: it compares `i` and
+/// then `lang`, so `Equal` here means equal in fact.
+///
+/// Deliberately local. Repairing `FlakeMeta::Ord` itself moves index ordering
+/// semantics repo-wide (every comparator's `cmp_meta` tiebreak reads it), so
+/// that belongs in #1711 rather than in a fix for the range path.
+#[inline]
+fn meta_group_cmp(a: &Option<FlakeMeta>, b: &Option<FlakeMeta>) -> std::cmp::Ordering {
+    match (a, b) {
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Less,
+        (Some(_), None) => std::cmp::Ordering::Greater,
+        (Some(x), Some(y)) => x.i.cmp(&y.i).then_with(|| x.lang.cmp(&y.lang)),
+    }
 }
 
 /// Run key for [`resolve_latest_ops_keep_asserts`]: the four fields every
@@ -1830,6 +1866,87 @@ mod tests {
             "resolved range results must be index-ordered, got {:?}",
             rendered(&out)
         );
+    }
+
+    /// One list POSITION carrying two language tags — the combination the
+    /// other cases only cover separately, and the one place `FlakeMeta`'s
+    /// `Ord`/`Eq` disagreement bites (#1711).
+    ///
+    /// `FlakeMeta::cmp` consults only `i` when both sides carry a list index,
+    /// so `{lang: en, i: 0}` and `{lang: fr, i: 0}` compare `Equal` while
+    /// being unequal. Grouping that sorts on `cmp` and cuts on `==` therefore
+    /// sorts by one relation and groups by a stricter one — the #1703 mistake
+    /// one level down — and the `@en` sibling's assert separates the `@fr`
+    /// fact from its own retraction.
+    ///
+    /// The retraction must land in a LATER transaction than the sibling's
+    /// assert; a same-transaction rewrite happens to resolve either way.
+    #[test]
+    fn one_list_position_under_two_language_tags_resolves_independently() {
+        let at_lang = |lang: &str, i: i32| FlakeMeta::from_parts(Some(lang), Some(i));
+        let out = resolve_latest_ops_keep_asserts(
+            vec![
+                f("x", 2, true, at_lang("en", 0)),
+                f("x", 3, true, at_lang("fr", 0)),
+                f("x", 4, false, at_lang("en", 0)),
+            ],
+            IndexType::Spot,
+        );
+        assert_eq!(
+            rendered(&out),
+            vec![("x".to_string(), at_lang("fr", 0))],
+            "the retracted @en fact must go; its @fr sibling at the same \
+             position must stay"
+        );
+    }
+
+    /// Mirror of the above with the tags swapped, so a grouping that happens
+    /// to work for one tag order can't pass.
+    #[test]
+    fn one_list_position_two_tags_mirror_order() {
+        let at_lang = |lang: &str, i: i32| FlakeMeta::from_parts(Some(lang), Some(i));
+        let out = resolve_latest_ops_keep_asserts(
+            vec![
+                f("x", 2, true, at_lang("fr", 0)),
+                f("x", 3, true, at_lang("en", 0)),
+                f("x", 4, false, at_lang("fr", 0)),
+            ],
+            IndexType::Spot,
+        );
+        assert_eq!(rendered(&out), vec![("x".to_string(), at_lang("en", 0))]);
+    }
+
+    /// The invariant the grouping rests on: the order it sorts by must agree
+    /// with the equality it cuts groups on. `FlakeMeta`'s own `Ord` does NOT
+    /// (that is #1711), which is why grouping uses a local strict order.
+    #[test]
+    fn group_order_agrees_with_metadata_equality() {
+        let m = |lang: Option<&str>, i: Option<i32>| FlakeMeta::from_parts(lang, i);
+        let metas = [
+            m(None, None),
+            m(Some("en"), None),
+            m(Some("fr"), None),
+            m(None, Some(0)),
+            m(Some("en"), Some(0)),
+            m(Some("fr"), Some(0)),
+            m(Some("en"), Some(1)),
+            m(None, Some(1)),
+        ];
+        for a in &metas {
+            for b in &metas {
+                assert_eq!(
+                    meta_group_cmp(a, b) == std::cmp::Ordering::Equal,
+                    a == b,
+                    "group order disagrees with equality for {a:?} vs {b:?}"
+                );
+            }
+        }
+        // And the pair that motivates it: equal under `FlakeMeta::cmp`,
+        // unequal in fact.
+        let en0 = m(Some("en"), Some(0)).unwrap();
+        let fr0 = m(Some("fr"), Some(0)).unwrap();
+        assert_eq!(en0.cmp(&fr0), std::cmp::Ordering::Equal, "see #1711");
+        assert_ne!(en0, fr0);
     }
 
     /// A list holding ONE value at many positions puts every entry in a

--- a/fluree-db-query/src/binary_range.rs
+++ b/fluree-db-query/src/binary_range.rs
@@ -1501,11 +1501,26 @@ fn overlay_only_flakes_bounded(
     Ok(resolved)
 }
 
-/// Overlay-only results when no branch exists for the requested order.
+/// Overlay-only results when the persisted index cannot contribute a row.
 ///
-/// Collects flakes directly from the overlay provider, applies match filtering
-/// and options (offset/limit). Used at genesis or before first indexing when
-/// no persisted branch exists for the requested sort order.
+/// Reached whenever a bound component of `match_val` has no persisted id
+/// (a novelty-only subject, predicate, or object), or no branch manifest
+/// exists for the requested order (genesis / pre-first-index).
+///
+/// The overlay is a **log**, not a current-state view: an assert at `t=2`
+/// and its retraction at `t=3` both sit in novelty. So retractions are kept
+/// through the walk and the whole matching set is lifecycle-resolved
+/// (newest op per fact identity wins, retracted keys drop out) before
+/// options are applied — the same rule the cursor path gets from
+/// `resolve_overlay_ops` and the bounded twin gets from
+/// `resolve_latest_ops_keep_asserts`. Filtering to `op == true` inside the
+/// walk instead silently resurrects every fact whose assert AND retract
+/// both live in novelty.
+///
+/// This also rules out an early exit at `limit`: the retraction that
+/// cancels an already-collected assert can arrive after the limit is
+/// reached. `for_each_overlay_flake` walks the graph's whole overlay
+/// regardless, so the exit only ever saved clones of matching flakes.
 fn overlay_only_flakes(
     store: &Arc<BinaryIndexStore>,
     g_id: GraphId,
@@ -1518,9 +1533,6 @@ fn overlay_only_flakes(
     let limit = opts.flake_limit.or(opts.limit).unwrap_or(usize::MAX);
     let offset = opts.offset.unwrap_or(0);
 
-    // Use Cell for early-exit: once we've collected offset+limit, stop cloning.
-    let mut skipped = 0usize;
-    let mut collected = 0usize;
     let mut flakes = Vec::new();
 
     overlay.for_each_overlay_flake(
@@ -1531,17 +1543,9 @@ fn overlay_only_flakes(
         true,
         effective_to_t,
         &mut |flake| {
-            // Early exit: already have enough results.
-            if collected >= limit {
-                return;
-            }
-
-            // Only include asserts (op=true).
-            if !flake.op {
-                return;
-            }
-
-            // Filter by match components.
+            // Filter by match components. A retraction carries the same
+            // subject/predicate/object as the assert it cancels, so these
+            // gates keep both halves of a fact together.
             if let Some(ref s_sid) = match_val.s {
                 if flake.s != *s_sid {
                     return;
@@ -1568,23 +1572,24 @@ fn overlay_only_flakes(
                 }
             }
 
-            // Apply object bounds (same as persisted path).
-            if let Some(ref bounds) = opts.object_bounds {
-                if !bounds.matches(&flake.o) {
-                    return;
-                }
-            }
-
-            // Apply offset.
-            if skipped < offset {
-                skipped += 1;
-                return;
-            }
-
+            // Keep both asserts and retracts; resolve lifecycles below.
             flakes.push(flake.clone());
-            collected += 1;
         },
     );
 
-    Ok(flakes)
+    let mut resolved = resolve_latest_ops_keep_asserts(flakes, index);
+
+    // Options apply to the resolved current state, not to the log.
+    if let Some(ref bounds) = opts.object_bounds {
+        resolved.retain(|f| bounds.matches(&f.o));
+    }
+    if offset > 0 && !resolved.is_empty() {
+        let n = offset.min(resolved.len());
+        resolved.drain(0..n);
+    }
+    if resolved.len() > limit {
+        resolved.truncate(limit);
+    }
+
+    Ok(resolved)
 }

--- a/fluree-db-query/src/binary_range.rs
+++ b/fluree-db-query/src/binary_range.rs
@@ -823,8 +823,26 @@ fn resolve_sid(s_id: u64, view: &BinaryGraphView) -> std::io::Result<Sid> {
 /// Resolve fact lifecycles (latest op wins) and drop retracts.
 ///
 /// Used as a correctness fallback when some overlay flakes cannot be translated
-/// into V3 `OverlayOp`s (e.g., missing dict novelty). The input should include
-/// both cursor output flakes (asserts) and raw overlay flakes (asserts/retracts).
+/// into V3 `OverlayOp`s (e.g., missing dict novelty), and by the raw-overlay
+/// paths that serve a pattern the persisted index cannot contribute to. The
+/// input should include both cursor output flakes (asserts) and raw overlay
+/// flakes (asserts/retracts).
+///
+/// ## Why the grouping is two-level
+///
+/// A fact's identity is `(s, p, o, dt, m)`: two `@list` entries holding the
+/// same value at different positions, and one lexical form under two language
+/// tags, are DISTINCT facts (the #1273 class). But every comparator orders
+/// `… t, op, m` — `t` BEFORE `m` (`fluree-db-core/src/comparator.rs`). So
+/// flakes that share `(s, p, o, dt)` and differ only in `m` interleave by `t`,
+/// which puts a sibling's assert between a fact's own assert and its
+/// retraction. Cutting runs on full identity therefore closes a group early
+/// and emits the retracted assert as live — the exact resurrection this
+/// helper exists to prevent, on `["a", "b", "a"]` or `"x"@en` + `"x"@fr`.
+///
+/// So runs are cut on [`same_fact_key`] — the four fields all four comparators
+/// DO order before `t`, making those runs contiguous — and the winner is
+/// picked per distinct `m` inside the run.
 fn resolve_latest_ops_keep_asserts(mut flakes: Vec<Flake>, index: IndexType) -> Vec<Flake> {
     let cmp = index.comparator();
     flakes.sort_by(cmp);
@@ -834,31 +852,64 @@ fn resolve_latest_ops_keep_asserts(mut flakes: Vec<Flake>, index: IndexType) -> 
     }
 
     let mut out: Vec<Flake> = Vec::with_capacity(flakes.len());
-    let mut i = 0usize;
-    while i < flakes.len() {
-        let mut best = i;
-        i += 1;
+    // Winners for the run being scanned: one index per distinct `m`. A linear
+    // scan beats a map — the cardinality is how many distinct metadata values
+    // a single `(s, p, o, dt)` carries, which is 1 for every plain fact and
+    // stays small even for a list that repeats a value.
+    let mut winners: Vec<usize> = Vec::new();
+    let mut start = 0usize;
+    while start < flakes.len() {
+        let mut end = start + 1;
+        while end < flakes.len() && same_fact_key(&flakes[start], &flakes[end]) {
+            end += 1;
+        }
 
-        while i < flakes.len() && same_fact_identity(&flakes[best], &flakes[i]) {
-            let cand = &flakes[i];
-            let cur = &flakes[best];
-            if cand.t > cur.t || (cand.t == cur.t && !cand.op && cur.op) {
-                best = i;
+        winners.clear();
+        for j in start..end {
+            match winners.iter().position(|&w| flakes[w].m == flakes[j].m) {
+                Some(slot) => {
+                    let cur = &flakes[winners[slot]];
+                    let cand = &flakes[j];
+                    // Newest op wins; at equal `t` a retraction beats an
+                    // assert, matching `resolve_current_flakes`.
+                    if cand.t > cur.t || (cand.t == cur.t && !cand.op && cur.op) {
+                        winners[slot] = j;
+                    }
+                }
+                None => winners.push(j),
             }
-            i += 1;
         }
+        out.extend(
+            winners
+                .iter()
+                .filter(|&&w| flakes[w].op)
+                .map(|&w| flakes[w].clone()),
+        );
 
-        if flakes[best].op {
-            out.push(flakes[best].clone());
-        }
+        start = end;
     }
 
+    // Winners are collected in first-appearance (`t`) order within a run, so a
+    // run resolving to more than one surviving fact can emit them out of the
+    // comparator's order. Callers take this as a range result and expect index
+    // order, which the single-winner-per-group predecessor gave them for free.
+    // Nearly free to restore: `out` is a subsequence of an already-sorted vec
+    // with at most a few local inversions.
+    out.sort_by(cmp);
     out
 }
 
+/// Run key for [`resolve_latest_ops_keep_asserts`]: the four fields every
+/// comparator orders BEFORE `t`, so flakes sharing it land contiguously after
+/// the sort. Deliberately NOT full fact identity — `m` is resolved per-fact
+/// inside the run, because the comparators interleave differing `m` by `t`.
+///
+/// `g` is absent because every caller walks one `g_id` at a time, so a
+/// mixed-graph vector never reaches here. A caller that ever scopes
+/// differently has to add it.
 #[inline]
-fn same_fact_identity(a: &Flake, b: &Flake) -> bool {
-    a.s == b.s && a.p == b.p && a.o == b.o && a.dt == b.dt && a.m == b.m
+fn same_fact_key(a: &Flake, b: &Flake) -> bool {
+    a.s == b.s && a.p == b.p && a.o == b.o && a.dt == b.dt
 }
 
 /// Batched lookup for ref-valued predicate objects across many subjects (V3).
@@ -1106,6 +1157,16 @@ fn apply_raw_overlay_deltas_to_batched_refs(
 }
 
 /// Overlay-only fallback for batched ref lookup when no PSOT branch exists.
+///
+/// The overlay is a log: an `rdf:type` asserted and then retracted inside the
+/// same novelty window has both flakes here. Filtering the walk to asserts
+/// would report a class that was revoked — and since this function's caller
+/// serves policy `rdf:type` lookups, that means a class-based grant surviving
+/// its own revocation until the first index build. So retractions are kept and
+/// the merged set goes through
+/// [`apply_raw_overlay_deltas_to_batched_refs`] — the same latest-op-wins rule
+/// this function's two sibling paths already apply, rather than a third
+/// variant of it.
 #[allow(clippy::too_many_arguments)]
 fn batched_refs_overlay_only(
     store: &Arc<BinaryIndexStore>,
@@ -1119,8 +1180,9 @@ fn batched_refs_overlay_only(
     let effective_to_t = opts.to_t.unwrap_or_else(|| store.max_t());
     let subject_set: HashSet<&Sid> = subjects.iter().collect();
 
-    let mut out: HashMap<Sid, Vec<Sid>> = HashMap::new();
-
+    // Gate on the two components that narrow the walk; the delta helper
+    // applies the `to_t` and ref-object filters itself.
+    let mut raw_overlay: Vec<Flake> = Vec::new();
     overlay.for_each_overlay_flake(
         g_id,
         IndexType::Psot,
@@ -1129,24 +1191,14 @@ fn batched_refs_overlay_only(
         true,
         effective_to_t,
         &mut |flake| {
-            if !flake.op {
-                return;
-            }
-            if !subject_set.contains(&flake.s) {
-                return;
-            }
-            if flake.p != *predicate {
-                return;
-            }
-            // No translation needed: we can inspect the FlakeValue directly.
-            // Only include IRI-ref object values.
-            if let FlakeValue::Ref(ref class_sid) = flake.o {
-                out.entry(flake.s.clone())
-                    .or_default()
-                    .push(class_sid.clone());
+            if flake.p == *predicate && subject_set.contains(&flake.s) {
+                raw_overlay.push(flake.clone());
             }
         },
     );
+
+    let mut out: HashMap<Sid, Vec<Sid>> = HashMap::new();
+    apply_raw_overlay_deltas_to_batched_refs(&mut out, &raw_overlay, predicate, effective_to_t);
 
     for classes in out.values_mut() {
         classes.sort();
@@ -1592,4 +1644,262 @@ fn overlay_only_flakes(
     }
 
     Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluree_db_core::FlakeMeta;
+
+    fn s(name: &str) -> Sid {
+        Sid::new(100, name)
+    }
+
+    fn dt_string() -> Sid {
+        Sid::new(fluree_vocab::namespaces::XSD, "string")
+    }
+
+    /// One flake on `ex:sub ex:pred`, with `m` supplied directly.
+    fn f(o: &str, t: i64, op: bool, m: Option<FlakeMeta>) -> Flake {
+        Flake::new(
+            s("sub"),
+            s("pred"),
+            FlakeValue::String(o.to_string()),
+            dt_string(),
+            t,
+            op,
+            m,
+        )
+    }
+
+    fn at(i: i32) -> Option<FlakeMeta> {
+        FlakeMeta::from_parts(None, Some(i))
+    }
+
+    fn tagged(lang: &str) -> Option<FlakeMeta> {
+        FlakeMeta::from_parts(Some(lang), None)
+    }
+
+    fn rendered(flakes: &[Flake]) -> Vec<(String, Option<FlakeMeta>)> {
+        flakes
+            .iter()
+            .map(|f| {
+                let o = match &f.o {
+                    FlakeValue::String(v) => v.clone(),
+                    other => format!("{other:?}"),
+                };
+                (o, f.m.clone())
+            })
+            .collect()
+    }
+
+    /// The plain case the helper always handled: one fact, asserted then
+    /// retracted, resolves away.
+    #[test]
+    fn single_valued_retraction_resolves() {
+        let out = resolve_latest_ops_keep_asserts(
+            vec![f("a", 2, true, None), f("a", 3, false, None)],
+            IndexType::Spot,
+        );
+        assert!(out.is_empty());
+    }
+
+    /// A `@list` that repeats a value: `["a", "b", "a"]` with position 0
+    /// deleted. The comparators order `t` before `m`, so the sibling `a@2`
+    /// assert sits between `a@0`'s assert and its retraction — cutting runs
+    /// on full identity closed the group early and emitted the retracted
+    /// `a@0` as live. Position 0 is the load-bearing case: deleting position
+    /// 2 passed even with the bug, because it only fails when the retracted
+    /// entry's metadata sorts below a surviving sibling's.
+    #[test]
+    fn repeated_list_value_retracts_the_right_position() {
+        let out = resolve_latest_ops_keep_asserts(
+            vec![
+                f("a", 2, true, at(0)),
+                f("b", 2, true, at(1)),
+                f("a", 2, true, at(2)),
+                f("a", 3, false, at(0)),
+            ],
+            IndexType::Spot,
+        );
+        assert_eq!(
+            rendered(&out),
+            vec![("a".to_string(), at(2)), ("b".to_string(), at(1))],
+            "only the position-0 entry may go"
+        );
+    }
+
+    /// The mirror case that used to pass, kept so a future regrouping can't
+    /// fix one position by breaking the other.
+    #[test]
+    fn repeated_list_value_retracts_the_last_position() {
+        let out = resolve_latest_ops_keep_asserts(
+            vec![
+                f("a", 2, true, at(0)),
+                f("b", 2, true, at(1)),
+                f("a", 2, true, at(2)),
+                f("a", 3, false, at(2)),
+            ],
+            IndexType::Spot,
+        );
+        assert_eq!(
+            rendered(&out),
+            vec![("a".to_string(), at(0)), ("b".to_string(), at(1))]
+        );
+    }
+
+    /// One lexical form under two language tags: distinct facts (#1273), so
+    /// retracting the `@en` must leave the `@fr` and take nothing else.
+    #[test]
+    fn language_tagged_siblings_retract_independently() {
+        let out = resolve_latest_ops_keep_asserts(
+            vec![
+                f("hello", 2, true, tagged("en")),
+                f("hello", 2, true, tagged("fr")),
+                f("hello", 3, false, tagged("en")),
+            ],
+            IndexType::Spot,
+        );
+        assert_eq!(rendered(&out), vec![("hello".to_string(), tagged("fr"))]);
+    }
+
+    /// A position retracted and re-asserted must come back, and the winner is
+    /// the newest op for that `m` alone — not the newest in the whole run.
+    #[test]
+    fn reasserted_position_survives_a_sibling_with_a_later_t() {
+        let out = resolve_latest_ops_keep_asserts(
+            vec![
+                f("a", 2, true, at(0)),
+                f("a", 3, false, at(0)),
+                f("a", 4, true, at(0)),
+                f("a", 5, true, at(1)),
+            ],
+            IndexType::Spot,
+        );
+        assert_eq!(
+            rendered(&out),
+            vec![("a".to_string(), at(0)), ("a".to_string(), at(1))]
+        );
+    }
+
+    /// At equal `t` a retraction beats an assert, per `resolve_current_flakes`.
+    #[test]
+    fn retraction_wins_at_equal_t() {
+        let out = resolve_latest_ops_keep_asserts(
+            vec![f("a", 2, true, at(0)), f("a", 2, false, at(0))],
+            IndexType::Spot,
+        );
+        assert!(out.is_empty());
+    }
+
+    /// Output must stay in comparator order: callers take it as a range
+    /// result. Winners are collected in `t` order inside a run, so a run
+    /// whose survivors' `t` order disagrees with their `m` order would emit
+    /// unsorted without the final sort.
+    #[test]
+    fn output_is_comparator_ordered() {
+        let out = resolve_latest_ops_keep_asserts(
+            vec![
+                // `m` ascending but `t` descending across the two survivors.
+                f("a", 9, true, at(0)),
+                f("a", 3, true, at(1)),
+            ],
+            IndexType::Spot,
+        );
+        let cmp = IndexType::Spot.comparator();
+        assert!(
+            out.windows(2)
+                .all(|w| cmp(&w[0], &w[1]) != std::cmp::Ordering::Greater),
+            "resolved range results must be index-ordered, got {:?}",
+            rendered(&out)
+        );
+    }
+
+    /// The latest-op-wins rule `batched_refs_overlay_only` delegates to.
+    ///
+    /// Its overlay walk is a log, so an `rdf:type` asserted and retracted in
+    /// the same novelty window arrives as both flakes. Filtering to asserts
+    /// (what that function used to do) reports a revoked class — and its
+    /// caller serves policy `rdf:type` lookups, so a class-based grant would
+    /// outlive its own revocation until the first index build.
+    #[test]
+    fn batched_ref_deltas_drop_a_retracted_class() {
+        let rdf_type = s("type");
+        let type_flake = |subject: &str, class: &str, t: i64, op: bool| {
+            Flake::new(
+                s(subject),
+                rdf_type.clone(),
+                FlakeValue::Ref(s(class)),
+                Sid::new(0, ""),
+                t,
+                op,
+                None,
+            )
+        };
+
+        let mut out: HashMap<Sid, Vec<Sid>> = HashMap::new();
+        apply_raw_overlay_deltas_to_batched_refs(
+            &mut out,
+            &[
+                // Revoked in the same window.
+                type_flake("alice", "Admin", 2, true),
+                type_flake("alice", "Admin", 3, false),
+                // Still held.
+                type_flake("alice", "Person", 2, true),
+                // Revoked, then granted again.
+                type_flake("bob", "Admin", 2, true),
+                type_flake("bob", "Admin", 3, false),
+                type_flake("bob", "Admin", 4, true),
+            ],
+            &rdf_type,
+            10,
+        );
+
+        let classes = |subject: &str| -> Vec<String> {
+            let mut v: Vec<String> = out
+                .get(&s(subject))
+                .map(|cs| cs.iter().map(|c| c.name_str().to_string()).collect())
+                .unwrap_or_default();
+            v.sort();
+            v
+        };
+        assert_eq!(
+            classes("alice"),
+            vec!["Person".to_string()],
+            "a revoked class must not be reported"
+        );
+        assert_eq!(
+            classes("bob"),
+            vec!["Admin".to_string()],
+            "a re-granted class comes back"
+        );
+    }
+
+    /// Distinct datatypes on the same lexical value are distinct facts, so a
+    /// retraction of one must not take the other. Pins that `dt` stays in the
+    /// run key rather than being folded in with `m`.
+    #[test]
+    fn datatype_siblings_retract_independently() {
+        let typed = |dt: &str, t: i64, op: bool| {
+            Flake::new(
+                s("sub"),
+                s("pred"),
+                FlakeValue::String("1".to_string()),
+                Sid::new(fluree_vocab::namespaces::XSD, dt),
+                t,
+                op,
+                None,
+            )
+        };
+        let out = resolve_latest_ops_keep_asserts(
+            vec![
+                typed("string", 2, true),
+                typed("token", 2, true),
+                typed("string", 3, false),
+            ],
+            IndexType::Spot,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].dt.name_str(), "token");
+    }
 }

--- a/fluree-db-query/src/binary_range.rs
+++ b/fluree-db-query/src/binary_range.rs
@@ -852,11 +852,8 @@ fn resolve_latest_ops_keep_asserts(mut flakes: Vec<Flake>, index: IndexType) -> 
     }
 
     let mut out: Vec<Flake> = Vec::with_capacity(flakes.len());
-    // Winners for the run being scanned: one index per distinct `m`. A linear
-    // scan beats a map — the cardinality is how many distinct metadata values
-    // a single `(s, p, o, dt)` carries, which is 1 for every plain fact and
-    // stays small even for a list that repeats a value.
-    let mut winners: Vec<usize> = Vec::new();
+    // Scratch index buffer for the multi-flake run path, reused across runs.
+    let mut idxs: Vec<usize> = Vec::new();
     let mut start = 0usize;
     while start < flakes.len() {
         let mut end = start + 1;
@@ -864,37 +861,57 @@ fn resolve_latest_ops_keep_asserts(mut flakes: Vec<Flake>, index: IndexType) -> 
             end += 1;
         }
 
-        winners.clear();
-        for j in start..end {
-            match winners.iter().position(|&w| flakes[w].m == flakes[j].m) {
-                Some(slot) => {
-                    let cur = &flakes[winners[slot]];
-                    let cand = &flakes[j];
-                    // Newest op wins; at equal `t` a retraction beats an
-                    // assert, matching `resolve_current_flakes`.
-                    if cand.t > cur.t || (cand.t == cur.t && !cand.op && cur.op) {
-                        winners[slot] = j;
-                    }
-                }
-                None => winners.push(j),
+        // Overwhelmingly the common run: one flake, so no grouping at all.
+        if end - start == 1 {
+            if flakes[start].op {
+                out.push(flakes[start].clone());
             }
+            start = end;
+            continue;
         }
-        out.extend(
-            winners
-                .iter()
-                .filter(|&&w| flakes[w].op)
-                .map(|&w| flakes[w].clone()),
-        );
+
+        // Group the run by `m`. Sorting rather than scanning a winners list
+        // keeps this O(k log k): a list that repeats one value across k
+        // positions puts all k in ONE run with k distinct `m`, and a linear
+        // "have I seen this `m`" probe would make that quadratic — the shape
+        // this whole area of the code exists to have stopped doing.
+        //
+        // The sort keys on `m` ALONE and is stable, so the comparator's
+        // `t, op` order survives inside each group and the winner scan below
+        // sees candidates in ascending `t`.
+        idxs.clear();
+        idxs.extend(start..end);
+        idxs.sort_by(|&a, &b| flakes[a].m.cmp(&flakes[b].m));
+
+        let mut g = 0usize;
+        while g < idxs.len() {
+            let mut best = idxs[g];
+            let mut h = g + 1;
+            while h < idxs.len() && flakes[idxs[h]].m == flakes[best].m {
+                let cand = &flakes[idxs[h]];
+                let cur = &flakes[best];
+                // Newest op wins; at equal `t` a retraction beats an assert,
+                // matching `resolve_current_flakes`.
+                if cand.t > cur.t || (cand.t == cur.t && !cand.op && cur.op) {
+                    best = idxs[h];
+                }
+                h += 1;
+            }
+            if flakes[best].op {
+                out.push(flakes[best].clone());
+            }
+            g = h;
+        }
 
         start = end;
     }
 
-    // Winners are collected in first-appearance (`t`) order within a run, so a
-    // run resolving to more than one surviving fact can emit them out of the
-    // comparator's order. Callers take this as a range result and expect index
-    // order, which the single-winner-per-group predecessor gave them for free.
-    // Nearly free to restore: `out` is a subsequence of an already-sorted vec
-    // with at most a few local inversions.
+    // Survivors of a multi-flake run are emitted in `m` order, which is not
+    // the comparator's order for the run (it orders `t` first). Callers take
+    // this as a range result and expect index order, which the
+    // single-winner-per-group predecessor gave them for free. Cheap to
+    // restore: `out` is a subsequence of an already-sorted vec whose only
+    // inversions are inside those runs.
     out.sort_by(cmp);
     out
 }
@@ -1812,6 +1829,49 @@ mod tests {
                 .all(|w| cmp(&w[0], &w[1]) != std::cmp::Ordering::Greater),
             "resolved range results must be index-ordered, got {:?}",
             rendered(&out)
+        );
+    }
+
+    /// A list holding ONE value at many positions puts every entry in a
+    /// single `(s, p, o, dt)` run with a distinct `m` each — the worst case
+    /// for the per-`m` grouping, and the shape a "have I seen this `m`"
+    /// linear probe would turn quadratic. Sized so a quadratic grouper would
+    /// be conspicuous rather than merely slower.
+    #[test]
+    fn many_positions_of_one_value_resolve_without_a_quadratic() {
+        const K: i32 = 4_000;
+        let mut flakes: Vec<Flake> = (0..K).map(|i| f("x", 2, true, at(i))).collect();
+        // Retract every third position.
+        flakes.extend(
+            (0..K)
+                .filter(|i| i % 3 == 0)
+                .map(|i| f("x", 3, false, at(i))),
+        );
+
+        let started = std::time::Instant::now();
+        let out = resolve_latest_ops_keep_asserts(flakes, IndexType::Spot);
+        let elapsed = started.elapsed();
+
+        let expected = (0..K).filter(|i| i % 3 != 0).count();
+        assert_eq!(
+            out.len(),
+            expected,
+            "exactly the unretracted positions live"
+        );
+        let survivors: Vec<i32> = out.iter().filter_map(|f| f.m.as_ref()?.i).collect();
+        assert!(
+            survivors.iter().all(|i| i % 3 != 0),
+            "no retracted position may survive"
+        );
+        assert!(
+            survivors.windows(2).all(|w| w[0] < w[1]),
+            "survivors stay in index order"
+        );
+        // Generous by ~2 orders of magnitude against the real runtime, so it
+        // fails on a reintroduced quadratic without flaking on a slow box.
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "resolution took {elapsed:?} for {K} positions — grouping went superlinear"
         );
     }
 

--- a/fluree-db-transact/src/import_sink.rs
+++ b/fluree-db-transact/src/import_sink.rs
@@ -93,6 +93,16 @@ mod inner {
         pub vector_pool: Arc<SharedVectorArenaPool>,
         /// Shared namespace allocator (for prefix lookup).
         pub ns_alloc: Arc<SharedNamespaceAllocator>,
+        /// Sticky: some record written through this config carried an RDF-list
+        /// position. Set once per chunk at [`SpoolContext::finish`] /
+        /// [`SpoolContext::finish_buffered`] from a plain per-chunk bool, so
+        /// the per-record path stays free of atomic traffic. Read at root
+        /// assembly to fill `IndexRoot.has_list_meta` exactly instead of
+        /// leaving it untracked — that is what lets filtered-DELETE staging
+        /// skip list-meta hydration on bulk-imported ledgers.
+        ///
+        /// Only ever set to `true`; the caller starts it `false` per import.
+        pub saw_list_meta: Arc<std::sync::atomic::AtomicBool>,
     }
 
     /// Result of finishing a [`SpoolContext`] via [`SpoolContext::finish`] —
@@ -160,6 +170,12 @@ mod inner {
         next_lang_id: u16,
         /// Graph ID for all records in this chunk (0 = default).
         g_id: GraphId,
+        /// Per-chunk mirror of `SpoolConfig::saw_list_meta` — a plain bool so
+        /// `write_record` never touches the shared atomic. Folded in at
+        /// finish.
+        saw_list_meta: bool,
+        /// The shared sticky bit this chunk folds into at finish.
+        saw_list_meta_shared: Arc<std::sync::atomic::AtomicBool>,
     }
 
     impl SpoolContext {
@@ -189,6 +205,8 @@ mod inner {
                 languages: FxHashMap::default(),
                 next_lang_id: 1, // 0 = no language tag
                 g_id,
+                saw_list_meta: false,
+                saw_list_meta_shared: Arc::clone(&config.saw_list_meta),
             })
         }
 
@@ -203,6 +221,7 @@ mod inner {
         /// dictionaries for the merge phase. This is the backward-compatible path
         /// used by the existing import pipeline.
         pub fn finish(self) -> Result<SpoolResult, std::io::Error> {
+            self.publish_list_meta();
             let mut writer = SpoolWriter::new(&self.spool_path, self.chunk_idx)?;
             for record in &self.records {
                 writer.push(record)?;
@@ -221,12 +240,27 @@ mod inner {
         /// contains all records with chunk-local IDs ready for post-parse
         /// sorting and sorted commit file writing.
         pub fn finish_buffered(self) -> BufferedSpoolResult {
+            self.publish_list_meta();
             BufferedSpoolResult {
                 records: self.records,
                 subjects: self.subjects,
                 strings: self.strings,
                 languages: self.languages,
                 chunk_idx: self.chunk_idx,
+            }
+        }
+
+        /// Fold this chunk's list-position observation into the shared sticky
+        /// bit. Called from both finish paths — every `SpoolContext` ends at
+        /// one of them, so no chunk's observation is lost.
+        ///
+        /// Relaxed is enough: the store happens-before the join that collects
+        /// the chunk results, and the root-assembly read happens after every
+        /// worker has been joined.
+        fn publish_list_meta(&self) {
+            if self.saw_list_meta {
+                self.saw_list_meta_shared
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
             }
         }
 
@@ -467,6 +501,11 @@ mod inner {
                     u32::try_from(idx).unwrap_or(LIST_INDEX_NONE)
                 })
                 .unwrap_or(LIST_INDEX_NONE);
+            // Observe the position on the branch that actually records one:
+            // an out-of-range `list_index` coerces to the sentinel above and
+            // is not a list row in the index, so gate on `i`, not on
+            // `list_index.is_some()`.
+            self.saw_list_meta |= i != LIST_INDEX_NONE;
 
             let record = RunRecord {
                 g_id: self.g_id,
@@ -979,6 +1018,7 @@ mod inner {
                 numbig_pool: Arc::new(SharedNumBigPool::new()),
                 vector_pool: Arc::new(SharedVectorArenaPool::new()),
                 ns_alloc: Arc::new(SharedNamespaceAllocator::from_registry(ns)),
+                saw_list_meta: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             }
         }
 
@@ -1001,6 +1041,60 @@ mod inner {
             // A user-range code allocated outside the shared allocator.
             let rogue = Sid::new(fluree_vocab::namespaces::USER_START, "name");
             let _ = ctx.assign_predicate_id(&rogue);
+        }
+
+        /// The sticky list-position bit is per-import, not per-chunk: a chunk
+        /// with no list rows must leave it alone, and a single list row in any
+        /// later chunk must flip it. Root assembly reads it to write
+        /// `IndexRoot.has_list_meta` — a wrongly-`false` root would let
+        /// filtered-DELETE staging skip position hydration and silently drop
+        /// list retractions.
+        #[test]
+        fn spool_context_tracks_list_positions_across_chunks() {
+            use std::sync::atomic::Ordering;
+
+            let ns = NamespaceRegistry::new();
+            let config = make_spool_config(&ns);
+            let dir = std::env::temp_dir();
+
+            let s = Sid::new(fluree_vocab::namespaces::RDF, "subject");
+            let p = Sid::new(fluree_vocab::namespaces::RDF, "pred");
+            let dt = Sid::new(fluree_vocab::namespaces::XSD, "string");
+            let o = FlakeValue::String("v".to_string());
+            let rec = |list_index| FlakeRecord {
+                s: &s,
+                p: &p,
+                o: &o,
+                dt: &dt,
+                lang: None,
+                list_index,
+                t: 1,
+            };
+
+            let mut ctx = SpoolContext::new(dir.join("fluree-list-meta-a.spool"), 0, 0, &config)
+                .expect("spool ctx");
+            ctx.write_record(rec(None));
+            let _ = ctx.finish_buffered();
+            assert!(
+                !config.saw_list_meta.load(Ordering::Relaxed),
+                "a chunk without list rows must not set the bit"
+            );
+
+            let mut ctx = SpoolContext::new(dir.join("fluree-list-meta-b.spool"), 1, 0, &config)
+                .expect("spool ctx");
+            ctx.write_record(rec(Some(0)));
+            let _ = ctx.finish_buffered();
+            assert!(
+                config.saw_list_meta.load(Ordering::Relaxed),
+                "one list row in any chunk sets the bit"
+            );
+
+            // Sticky: a later list-free chunk must not clear it.
+            let mut ctx = SpoolContext::new(dir.join("fluree-list-meta-c.spool"), 2, 0, &config)
+                .expect("spool ctx");
+            ctx.write_record(rec(None));
+            let _ = ctx.finish_buffered();
+            assert!(config.saw_list_meta.load(Ordering::Relaxed));
         }
 
         #[test]

--- a/fluree-db-transact/src/import_sink.rs
+++ b/fluree-db-transact/src/import_sink.rs
@@ -251,8 +251,18 @@ mod inner {
         }
 
         /// Fold this chunk's list-position observation into the shared sticky
-        /// bit. Called from both finish paths — every `SpoolContext` ends at
-        /// one of them, so no chunk's observation is lost.
+        /// bit. Called from both finish paths.
+        ///
+        /// A context can also be dropped without finishing: every call site
+        /// has a `?` on the parse and on `into_parts()` between construction
+        /// and finish, and either one drops the sink with the context still
+        /// inside it. What makes a `Some(false)` root safe is therefore NOT
+        /// "every context finishes" but "a context that doesn't finish means
+        /// no root": both of those errors propagate a `TransactError` that
+        /// aborts the whole import, so there is no root assembled to record a
+        /// wrong flag into. A future change that tolerates per-chunk failures
+        /// would break that and has to publish the bit some other way — a
+        /// wrongly-`false` root silently skips list-meta hydration.
         ///
         /// Relaxed is enough: the store happens-before the join that collects
         /// the chunk results, and the root-assembly read happens after every

--- a/regression-budget.json
+++ b/regression-budget.json
@@ -24,6 +24,11 @@
         "small": 5.0,
         "medium": 5.0
       },
+      "transact_filtered_delete": {
+        "tiny": 10.0,
+        "small": 5.0,
+        "medium": 5.0
+      },
       "query_cold_reload": {
         "tiny": 10.0,
         "small": 5.0,

--- a/regression-budget.json
+++ b/regression-budget.json
@@ -29,6 +29,11 @@
         "small": 5.0,
         "medium": 5.0
       },
+      "query_overlay_only_range": {
+        "tiny": 10.0,
+        "small": 5.0,
+        "medium": 5.0
+      },
       "query_cold_reload": {
         "tiny": 10.0,
         "small": 5.0,


### PR DESCRIPTION
Fixes the P0 from #1683, folds in the two deferrals that were sequenced behind it, and closes two pre-existing defects of the same class that surfaced while fixing it.

## The bug is bigger and simpler than the issue title

#1683 reported this as a `@list` problem: a filtered DELETE of one list entry commits with `receipt.flake_count = 1` and the entry stays readable. The narrowing in the issue was right that staging is not at fault — `hydrate_list_index_meta_for_retractions` hands the commit a retraction with the correct `m = { i: 1 }`, and I confirmed that again here: novelty at `t=3` holds `s=ex:nov1 p=ex:items o="b" i=Some(1) op=false`, exactly as it should.

The write path was fine. **The read path was dropping the retraction on the floor.**

`fluree-db-query/src/binary_range.rs` — `binary_range_eq_v3` bails to `overlay_only_flakes` whenever a bound component of the pattern has no persisted id (a novelty-only subject, predicate, or object) or the requested order has no branch manifest. `overlay_only_flakes` served that by filtering the walk to `if !flake.op { return; }` — assert-only, no lifecycle resolution at all. But the overlay is a **log**, not a current-state view: the assert at `t=2` and its retraction at `t=3` both sit in novelty. Filtering to asserts resurrects every fact whose assert *and* retract live there.

Consequence: any workload that writes a fact under a brand-new predicate and then deletes it before the next index build is told the flake was retracted and can still read the value. Silent, and shaped like data loss in the opposite direction.

Two things about the shape are worth stating plainly, because both change how the issue reads.

**Nothing about it is list-specific.** I added a plain-valued leg to the repro on a second novelty-only predicate — `ex:tags: ["p", "q"]`, delete `"p"` — and got `["p", "q"]` back at the pin. `@list` is just how the bug was *found*: a brand-new predicate carrying a collection is a very natural way to land a fact wholly in novelty.

**Reload does not heal it.** That was the open remediation question from the sweep, and the answer is no. I ran the reload leg against the unfixed code specifically to answer it: a fresh handle replays the same commit chain into novelty and reads it the same wrong way, so an affected ledger stays wrong across a restart. It heals on the next *index build* (the fact leaves novelty and the cursor path resolves it correctly), not on reload. The regression pin has a reload leg so that stays honest.

That also explains the sweep's puzzle about the CLI probes not reproducing: the BGP path (`select ["?s","?o"]`) resolves the overlay correctly and always did — it takes the cursor path. Only the subject-crawl (`select {"?s": ["ex:items"]}`) goes through `fetch_subject_predicate_pair`, binds both `s` and `p`, fails to resolve the novelty-only `p`, and lands in `overlay_only_flakes`. The maintainer probe in the thread used the crawl; the CLI probes used a BGP. Same ledger, two answers.

## The fix

Keep both ops through the walk, run the matching set through `resolve_latest_ops_keep_asserts` (newest op per fact identity wins, retracted keys drop out), then apply object bounds / offset / limit to the *resolved* state. That is the same rule the cursor path already gets from `resolve_overlay_ops`, and the same thing the bounded twin `overlay_only_flakes_bounded` twenty lines up was already doing — this function was simply the odd one out.

The early exit at `limit` had to go with it: the retraction that cancels an already-collected assert can arrive after the limit is reached. Worth noting it was never buying much — `for_each_overlay_flake` walks the graph's whole overlay either way, so the exit only saved clones of matching flakes. (There's a measured argument about restoring it further down.)

Regression pin lives with its siblings in `fluree-db-api/tests/it_filtered_delete_list_meta.rs` (`novelty_only_predicate_retraction_takes_effect`): novelty-only predicate over an indexed base, live handle across the background-index swap, list leg + plain leg + reload leg, plus a BGP assertion so the two read paths stay in agreement. It fails at the merge base with the reported `["a","b","c"]` vs `["a","c"]`.

## Two more instances of the same defect — #1703 and #1704

Both were already broken before this branch, and the `overlay_only_flakes` fix does not, on its own, close either. Both live in code this branch already holds, and both are the same "the overlay is a log" defect #1683 is about, so they land here rather than as deferred follow-ups. Filed as #1703 and #1704 so the history is honest about them being pre-existing.

### #1703 — the helper I delegate to had the same bug for values that repeat under different metadata

`resolve_latest_ops_keep_asserts` cut resolution groups on full fact identity `(s, p, o, dt, m)` by run adjacency. But every comparator orders `… t, op, m`, with `t` *before* `m` (`fluree-db-core/src/comparator.rs:161-207`), so siblings sharing `(s, p, o, dt)` interleave by `t`: a sibling's assert lands between a fact's own assert and its retraction, the run closes early, and the retracted assert is emitted live. `["a", "b", "a"]` deleting position 0 returned both `"a"` entries; `"hello"@en` + `"hello"@fr` deleting the `@en` returned both. Deleting the *last* position passes, so it only fails when the retracted entry's metadata sorts below a surviving sibling's — about a coin flip on any list that repeats a value.

Runs are now cut on the four fields all four comparators *do* order before `t`, with the winner picked per distinct `m` inside the run. I verified non-vacuity by putting `m` back into the run key and re-running: exactly the two reported outputs come back, and the last-position case stays green — so both directions are pinned.

The per-`m` grouping inside the run needs its own comparator, and this is the part that is easiest to "simplify" wrongly. `FlakeMeta::cmp` (`fluree-db-core/src/flake.rs:110-129`) compares **only** `i` when both sides carry a list index — `lang` is never consulted — while `PartialEq` is derived over both fields. So `{lang: en, i: 0}` and `{lang: fr, i: 0}` compare `Equal` without being equal: `Ord` is not consistent with `Eq` for that type. Sorting by that relation and then cutting groups on `m == m` is sorting by one relation and grouping by a stricter one — structurally the same mistake as #1703 itself, one level down. One list position under two language tags lets the sibling's assert separate a fact from its own retraction, and the retracted value survives. Grouping therefore sorts with a local `meta_group_cmp` that compares `i` then `lang`, so `Equal` means equal in fact and the sort agrees with the `==` the groups are cut on.

**Two things here are load-bearing and shouldn't be simplified away.** Runs are not cut by moving `m` ahead of `t` in the comparators, which would change index ordering semantics repo-wide. And `FlakeMeta::Ord` itself is left alone deliberately — every comparator's `cmp_meta` tiebreak reads it, so repairing the type moves index ordering semantics repo-wide too. That's #1711's job, not something to smuggle in here.

Three tests cover the combination specifically, because the residual lives there and not in either half: tests covering list positions and language tags separately all pass. Both tag orders of the combined shape, plus one that asserts the invariant directly — `meta_group_cmp` returns `Equal` exactly when the metas are equal, across the eight interesting `(lang, i)` combinations, plus the `en@0`/`fr@0` pair that is `Ord`-equal and `Eq`-unequal. Verified non-vacuous by putting `FlakeMeta::cmp` back as the sort key: both new cases fail with the reported output while the other eleven stay green.

**One thing I found trying to write the end-to-end leg, which is worth carrying into #1711.** The combined shape can't currently be built through the write path at all. Asserting a second language tag at an occupied list position commits — the receipt reports one flake at its own `t` — but it never reaches the live view: novelty keys the fact by that same inconsistent ordering and folds it onto the first tag. So the write side collapses the shape before the read side can be asked about it. That means the `Ord`/`Eq` disagreement is silently dropping a legitimately distinct write, not just mis-resolving a read, which I think widens #1711's blast radius beyond how it's currently scoped. I left a note in `it_filtered_delete_list_meta.rs` naming that test as the one to grow an end-to-end leg once the type is fixed, rather than contriving a fixture that can't exist today.

### #1704 — a third assert-only overlay path

`batched_refs_overlay_only` was still filtering to asserts with no resolution, the odd one out among the three paths of `binary_lookup_subject_predicate_refs_batched_v3` — which serves policy `rdf:type` lookups. On a graph with no PSOT branch, a class asserted and revoked inside one novelty window kept granting class-based policy access until the first index build. It now hands the merged set to `apply_raw_overlay_deltas_to_batched_refs`, the same rule its two sibling paths already use, rather than a third variant of it. The guard test drives the real provider entry point on a named graph that lives only in novelty; I confirmed it reaches the intended path, and that restoring the assert-only filter makes it fail with `["Admin", "Person"]`.

Beyond those, the test additions here cover the duplicate-valued list and language-tag shapes end to end, and an offset/limit pin — the fix moved when paging applies relative to resolution, and nothing held that ordering down.

## #1685 — `has_list_meta` on bulk-import roots

`import.rs:6837` left the flag `None`, so the `stage.rs:1623` skip (`snapshot.has_list_meta == Some(false) && !novelty.has_list_meta`) could never fire for bulk-imported ledgers — which are the large ones, i.e. exactly where the O(novelty) walk costs something.

Implemented as the issue proposed, which does match the `numbig_pool` / `vector_pool` / `ns_alloc` precedent: a sticky `Arc<AtomicBool>` on `SpoolConfig`, a plain `bool` on `SpoolContext` OR'd in `write_record`, one relaxed store per chunk at `finish` / `finish_buffered`, read once at root assembly after the workers join. No per-record atomic traffic.

One deliberate detail: the OR gates on the *mapped* `i != LIST_INDEX_NONE`, not on `list_index.is_some()`. An out-of-range index coerces to the sentinel a few lines above and is not a list row in the index, so gating on the option would let a `Some(true)` root claim a list that the index doesn't actually carry. Cheap insurance in the safe direction, but the safe direction here is *not* the obvious one — a wrongly-`false` root is the dangerous case, which is why `import_with_list_records_has_list_meta_true_and_still_retracts` asserts the flag *and* then runs the filtered DELETE it protects.

The `import_sink.rs:253` comment is also corrected: it claimed every `SpoolContext` reaches a finish path, which isn't true (there's a `?` on the parse and on `into_parts()` between construction and finish). The flag is still safe, but the invariant is "a context that doesn't finish means no root", not "every context finishes" — the old wording would let a future change that tolerates per-chunk failures look correct. And `same_fact_key` now carries the note about `g` being absent because every caller scopes to one `g_id`.

## #1684 — `transact_filtered_delete` bench

Two scenarios over a bulk-imported, novelty-heavy ledger, covering both sides of the `stage.rs:1623` gate with the same deleted predicate so the delta is the hydration path and nothing else. The `no_lists` branch is only reachable this cheaply because of the #1685 work above — before it, that branch needed a full rebuild inside the fixture.

Each scenario asserts its gate state during setup rather than trusting the fixture; a fixture that drifts off its branch fails the bench instead of quietly reporting a plausible number for the wrong path.

On the honesty front: at Small both scenarios read ~39 ms, because the WHERE and the commit dominate — the curves only separate from Medium up (69 ms vs 127 ms at 20k groups on my box). I've said that in the module doc so nobody reads a flat Tiny/Small pair as "the gate is free". Either scale still catches what the bench exists for, since a regression back to `retractions × novelty` turns tens of milliseconds into seconds.

Wired into `fluree-db-api/Cargo.toml` and `regression-budget.json`; `workspace_reconcile` passes.

## The read-side bench, and why the `limit` early exit stays gone

`transact_filtered_delete` guards the write side; nothing covered the read side this PR actually changes. `query_overlay_only_range` does, with two scenarios that separate the candidate cost drivers. Quick profile on my box: `narrow_subject` (one matched fact) is 13.6 µs at 2k novelty subjects and 13.8 µs at 10k — flat across a 5× increase in overlay size — while `wide_subject` goes 31.8 µs at 200 matched values to 95.9 µs at 1k, about 80 ns per matched row. So the cost is bounded by the matched fact set, not by novelty.

Restoring the early exit by streaming the resolution is the obvious alternative — `for_each_overlay_flake` is contractually comparator-ordered, so it's available. I don't think it's the right trade here.

The caller trace says the exposure is small. Every caller that sets a limit and can reach this function: `policy_builder.rs:603` and `cypher_write.rs:900` are subject-bound with `flake_limit(1)`; `ledger_view.rs:331` is predicate+object-bound with `flake_limit(16)`; `time_resolve.rs:342` and `ledger_view.rs:235` go through `range_bounded_with_overlay`, i.e. the bounded twin, which already collected everything before this PR. The one that is *not* subject-bound is `probe_timestamp_axis` (`time_resolve.rs:154`), which issues `RangeMatch::predicate(..)` — predicate only, no subject, no object — with `flake_limit(1)`, and adds `object_bounds` when resolving `after: Some`. Its matched set is one flake per commit in the txn-meta graph, so it scales with commits-in-novelty rather than with a bound subject's fact count, and it's doubly exposed because those object bounds now prune after resolution instead of inside the walk. It only takes this path when txn-meta has no POST branch, it reads a system graph, and at ~80 ns per matched row the absolute cost is small — but it is the shape neither bench scenario models, so rather than a third scenario, `query_overlay_only_range`'s doc names the site, its exact bind pattern, the `object_bounds` interaction, and the fact that it's where to measure first if this path ever needs the bound back.

Against that small cost, streaming would trade the helper's internal `sort` — which today self-heals if any overlay provider ever violates the ordering contract — for a hard dependency on that contract, in the fallback path that exists precisely to be defensive. A few hundred nanoseconds of clone on bound patterns isn't worth that. The bench is in the tree, so the day someone does add a limit-setting caller on an unbound pattern, we'll see it. Happy to be talked back into the restructure if the balance reads differently to someone else.

## Gates

- `cargo test -p fluree-db-api` — 3250 passed, 0 failed
- `cargo test -p fluree-db-query` — 1494 passed (1434 lib, incl. 13 resolver unit tests)
- `cargo test -p fluree-db-transact` / `-p fluree-db-policy` / `-p fluree-db-sparql` / `-p fluree-db-cypher` — all green
- `cargo test -p fluree-bench-support --test workspace_reconcile` — green
- `cargo clippy -p fluree-db-query -p fluree-db-transact -p fluree-db-api --all-targets --no-deps` — clean
- `cargo fmt --all` — clean (run last)
- `cargo bench -p fluree-db-api --bench transact_filtered_delete --bench query_overlay_only_range -- --test` — all four scenarios green

Two things I did **not** do, flagging rather than hiding them. The W3C SPARQL suite didn't run — its `rdf-tests` submodule isn't populated in this worktree, and that suite runs on memory ledgers, which don't reach `binary_range_eq_v3` at all, so I don't think it exercises the changed line. And `--all-features` won't build in my environment (`cxx` build script fails), which is pre-existing and unrelated; everything above is default features.

I'd also note for the record that #1683's title and labels understate it now — it isn't an `@list` bug, it's "novelty-only-predicate retractions are invisible to the crawl read path". Happy to retitle the issue if that's useful, or leave it and let this PR body carry the correction.

Fixes #1683
Fixes #1685
Closes #1684
Fixes #1703
Fixes #1704

Follow-up: #1711
