### PR TITLE
fix(query): keep a VALUES written after an OPTIONAL below it

### DIFF
--- a/fluree-db-api/tests/it_query_values.rs
+++ b/fluree-db-api/tests/it_query_values.rs
@@ -621,6 +621,144 @@ async fn trailing_values_keeps_minus_correlated() {
     assert_eq!(rows, normalize_rows(&json!([])));
 }
 
+// --- a trailing VALUES over an OPTIONAL-bound variable (#1690) -------------
+//
+// `{ P . OPTIONAL { O } . VALUES ?v { … } }` is `Join(LeftJoin(P, O), V)`.
+// Hoisting the VALUES to seed position makes it `LeftJoin(Join(P, V), O)` —
+// the left join then matches an already-bound `?v` and, dropping nothing, lets
+// every driving row out carrying the seeded value. The answer is not merely
+// too big: rows report a binding the data never had for them.
+//
+// The correct answer is NOT the FILTER rewrite. Per SPARQL 1.1 §18.2.4 this is
+// a JOIN, and a solution whose OPTIONAL left `?v` UNBOUND is compatible with
+// every VALUES row: it SURVIVES and ADOPTS the value. W3C
+// `sparql11/bindings/values07` pins exactly this three-way outcome, and the
+// fixture below reproduces it:
+//
+//   * `ex:cam` / `ex:liam` — OPTIONAL bound `?f` to `ex:alice`     → KEPT
+//   * `ex:alice`           — OPTIONAL bound `?f` to `ex:brian`     → DROPPED
+//   * `ex:brian` / `ex:nikola` — no `ex:friend` at all, `?f` UNBOUND
+//                                                     → KEPT, ADOPTS `ex:alice`
+
+const OPTIONAL_THEN_VALUES: &str = "SELECT ?s ?f WHERE { ?s schema:name ?name . \
+     OPTIONAL { ?s ex:friend ?f } VALUES ?f { ex:alice } }";
+
+#[tokio::test]
+async fn trailing_values_over_an_optional_var_joins_instead_of_seeding() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    let rows = sparql_rows(&fluree, &ledger, OPTIONAL_THEN_VALUES).await;
+
+    // `ex:alice`'s only friend is `ex:brian`, so no solution may report her
+    // with `?f = ex:alice`. That row is the fabricated binding the hoist
+    // invented — it used to be here, and its absence is the whole fix.
+    let fabricated = normalize_rows(&json!([["ex:alice", "ex:alice"]]));
+    assert!(
+        !rows.iter().any(|r| fabricated.contains(r)),
+        "ex:alice has no ex:friend ex:alice; the VALUES must not fabricate one: {rows:?}"
+    );
+
+    assert_eq!(
+        rows,
+        normalize_rows(&json!([
+            // bound and compatible — kept with the binding the data gave them
+            ["ex:cam", "ex:alice"],
+            ["ex:liam", "ex:alice"],
+            // UNBOUND — compatible with every VALUES row, so kept AND bound
+            ["ex:brian", "ex:alice"],
+            ["ex:nikola", "ex:alice"]
+        ]))
+    );
+}
+
+#[tokio::test]
+async fn in_group_values_matches_the_post_query_spelling() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    // The two spellings of the same query. The post-query form (`} VALUES …`)
+    // has always planned correctly; it is the reference answer.
+    let in_group = sparql_rows(&fluree, &ledger, OPTIONAL_THEN_VALUES).await;
+    let post_query = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s ?f WHERE { ?s schema:name ?name . \
+         OPTIONAL { ?s ex:friend ?f } } VALUES ?f { ex:alice }",
+    )
+    .await;
+
+    assert_eq!(in_group, post_query);
+}
+
+#[tokio::test]
+async fn trailing_values_is_a_join_not_a_filter() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    // Pins the §18.2.4 distinction so the fix is never "simplified" into the
+    // FILTER semantics: FILTER evaluates `?f = ex:alice` to an error on an
+    // unbound `?f` and drops the row; VALUES joins, and an unbound `?f` is
+    // compatible with the VALUES row, so the solution survives and adopts it.
+    let with_values = sparql_rows(&fluree, &ledger, OPTIONAL_THEN_VALUES).await;
+    let with_filter = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s ?f WHERE { ?s schema:name ?name . \
+         OPTIONAL { ?s ex:friend ?f } FILTER(?f = ex:alice) }",
+    )
+    .await;
+
+    assert_eq!(
+        with_filter,
+        normalize_rows(&json!([["ex:cam", "ex:alice"], ["ex:liam", "ex:alice"]])),
+        "FILTER drops the rows the OPTIONAL left unbound"
+    );
+    assert_ne!(
+        with_values, with_filter,
+        "VALUES adopts the unbound rows FILTER drops — they are not interchangeable"
+    );
+}
+
+#[tokio::test]
+async fn jsonld_values_after_optional_joins_instead_of_seeding() {
+    // Parity twin: the JSON-LD `["values", …]` after `["optional", …]` lowers
+    // to the same IR, so it clobbered identically and must now agree.
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    let ctx = json!({
+        "schema": "http://schema.org/",
+        "ex": "http://example.com/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    });
+
+    let query = json!({
+        "@context": ctx,
+        "select": ["?s", "?f"],
+        "where": [
+            {"@id": "?s", "schema:name": "?name"},
+            ["optional", {"@id": "?s", "ex:friend": "?f"}],
+            ["values", ["?f", [{"@type": "@id", "@value": "ex:alice"}]]]
+        ]
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("query");
+    let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+
+    assert_eq!(
+        normalize_rows(&json_rows),
+        normalize_rows(&json!([
+            ["ex:cam", "ex:alice"],
+            ["ex:liam", "ex:alice"],
+            ["ex:brian", "ex:alice"],
+            ["ex:nikola", "ex:alice"]
+        ]))
+    );
+}
+
 #[tokio::test]
 async fn trailing_values_keeps_not_exists_correlated() {
     let fluree = FlureeBuilder::memory().build_memory();

--- a/fluree-db-api/tests/it_query_values.rs
+++ b/fluree-db-api/tests/it_query_values.rs
@@ -753,6 +753,58 @@ async fn a_union_binding_the_var_does_not_suppress_the_barrier() {
 }
 
 #[tokio::test]
+async fn an_undef_values_column_does_not_suppress_the_barrier() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    // The same suppressor class as the UNION above, reached through a leading
+    // VALUES instead. `Values::produced_vars` is its whole variable list, but
+    // both surfaces lower `UNDEF` to `Binding::Unbound`, so an all-UNDEF `?f`
+    // column binds `?f` in no row at all while reading as "required-bound" —
+    // the barrier didn't fire and the trailing `VALUES ?f` went back to seed
+    // position. `must_bind_vars` now counts only the columns with no `Unbound`
+    // cell.
+    //
+    // Not a synthetic corner: an UNDEF placeholder column is the parameterized
+    // -query idiom #1690 names as its motivating usage.
+    //
+    // Asserted on the PLAN, not the rows, for the same reason as
+    // `a_union_binding_the_var_does_not_suppress_the_barrier` — this query's
+    // answer is wrong for the second, independent reason filed as #1713.
+    // Without the arm the plan is
+    // `ProjectOperator > OptionalOperator > NestedLoopJoin > Values > Values`
+    // and the answer is the 5-row fabrication (`["ex:alice","ex:alice"]`, whose
+    // only `ex:friend` is `ex:brian`; the reference answer is 4). With it the
+    // trailing VALUES lands above the left join as it must — and the answer
+    // becomes 8 rows still carrying that fabricated one, because #1713 leaves
+    // `?f` Null on every row the OPTIONAL matched. Pinning rows here would pin
+    // that defect's output.
+    let ops = physical_plan_ops(
+        &ledger,
+        "SELECT ?s ?f WHERE { ?s schema:name ?name . \
+         VALUES (?s ?f) { (ex:alice UNDEF) (ex:cam UNDEF) (ex:liam UNDEF) \
+         (ex:brian UNDEF) (ex:nikola UNDEF) } \
+         OPTIONAL { ?s ex:friend ?f } VALUES ?f { ex:alice } }",
+    )
+    .await;
+
+    let optional_at = ops
+        .iter()
+        .position(|o| o.contains("Optional"))
+        .unwrap_or_else(|| panic!("the OPTIONAL must survive planning: {ops:?}"));
+    // Pre-order walk of the physical tree, so an earlier index is HIGHER in the
+    // plan: the trailing VALUES applying above the left join is the fix.
+    let values_at = ops
+        .iter()
+        .position(|o| o == "ValuesOperator")
+        .unwrap_or_else(|| panic!("the VALUES must be applied somewhere: {ops:?}"));
+    assert!(
+        values_at < optional_at,
+        "an all-UNDEF VALUES column must not suppress the barrier: {ops:?}"
+    );
+}
+
+#[tokio::test]
 async fn a_subquery_exposing_an_optional_bound_var_still_joins() {
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger = seed_values_dataset(&fluree, "values-test:main").await;

--- a/fluree-db-api/tests/it_query_values.rs
+++ b/fluree-db-api/tests/it_query_values.rs
@@ -643,6 +643,23 @@ async fn trailing_values_keeps_minus_correlated() {
 const OPTIONAL_THEN_VALUES: &str = "SELECT ?s ?f WHERE { ?s schema:name ?name . \
      OPTIONAL { ?s ex:friend ?f } VALUES ?f { ex:alice } }";
 
+/// The spec answer for [`OPTIONAL_THEN_VALUES`] — two kept-as-bound rows and
+/// two unbound-and-adopted rows. `ex:alice` is absent: her only `ex:friend` is
+/// `ex:brian`, so the VALUES join drops that solution.
+fn optional_then_values_rows() -> serde_json::Value {
+    json!([
+        ["ex:cam", "ex:alice"],
+        ["ex:liam", "ex:alice"],
+        ["ex:brian", "ex:alice"],
+        ["ex:nikola", "ex:alice"]
+    ])
+}
+
+/// The row the hoist invented: `ex:alice` reported as her own friend.
+fn fabricated_row() -> Vec<serde_json::Value> {
+    normalize_rows(&json!([["ex:alice", "ex:alice"]]))
+}
+
 #[tokio::test]
 async fn trailing_values_over_an_optional_var_joins_instead_of_seeding() {
     let fluree = FlureeBuilder::memory().build_memory();
@@ -653,21 +670,125 @@ async fn trailing_values_over_an_optional_var_joins_instead_of_seeding() {
     // `ex:alice`'s only friend is `ex:brian`, so no solution may report her
     // with `?f = ex:alice`. That row is the fabricated binding the hoist
     // invented — it used to be here, and its absence is the whole fix.
-    let fabricated = normalize_rows(&json!([["ex:alice", "ex:alice"]]));
+    let fabricated = fabricated_row();
     assert!(
         !rows.iter().any(|r| fabricated.contains(r)),
         "ex:alice has no ex:friend ex:alice; the VALUES must not fabricate one: {rows:?}"
     );
 
+    // `ex:cam`/`ex:liam` were bound and compatible — kept with the binding the
+    // data gave them. `ex:brian`/`ex:nikola` have no `ex:friend` at all, so the
+    // OPTIONAL left `?f` UNBOUND: compatible with every VALUES row, therefore
+    // kept AND bound (§18.2.4). A "drop the unbound rows" fix loses those two.
+    assert_eq!(rows, normalize_rows(&optional_then_values_rows()));
+}
+
+/// The ops of a query's planned physical plan, root first.
+async fn physical_plan_ops(ledger: &MemoryLedger, body: &str) -> Vec<String> {
+    let query = format!("{VALUES_PREFIXES}{body}");
+    let plan = fluree_db_api::explain::explain_sparql(&ledger.snapshot, &query)
+        .await
+        .expect("explain should succeed");
+    fn walk(node: &serde_json::Value, out: &mut Vec<String>) {
+        if let Some(op) = node.get("op").and_then(serde_json::Value::as_str) {
+            out.push(op.to_string());
+        }
+        if let Some(children) = node.get("children").and_then(serde_json::Value::as_array) {
+            for edge in children {
+                if let Some(child) = edge.get("node") {
+                    walk(child, out);
+                }
+            }
+        }
+    }
+    let mut ops = Vec::new();
+    walk(&plan["plan"]["physical"], &mut ops);
+    ops
+}
+
+#[tokio::test]
+async fn a_union_binding_the_var_does_not_suppress_the_barrier() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    // One UNION away from the OPTIONAL-only shape. `Union::produced_vars` unions
+    // its branches, so treating it as "already bound" recorded `?f` as
+    // required-bound and SUPPRESSED the barrier for the sibling OPTIONAL that
+    // genuinely introduces it — the VALUES went back to seed position. The
+    // planner now accumulates MUST-bind vars (branch intersection for a UNION),
+    // so `?f` is correctly not required-bound and the barrier fires.
+    //
+    // Asserted on the PLAN, not the rows, and deliberately so: this query's
+    // answer is also wrong for a SECOND, independent reason that this PR does
+    // not touch. `{ ?s schema:name ?name . { {?s ex:friend ?f} UNION
+    // {?s schema:age ?age} } OPTIONAL { ?s ex:friend ?f } }` — no VALUES
+    // anywhere — returns 10 rows where §18.2.4 says 13, identical to the same
+    // query with the OPTIONAL deleted: the left join is a no-op over the rows a
+    // UNION branch left `?f` unbound on, so it never binds `?f = ex:brian` for
+    // `ex:alice`. Pinning rows here would pin that unrelated defect's output.
+    // The row-level §18.2.4 contract is pinned by
+    // `trailing_values_over_an_optional_var_joins_instead_of_seeding` and
+    // `a_subquery_exposing_an_optional_bound_var_still_joins`, whose inputs are
+    // correct.
+    let ops = physical_plan_ops(
+        &ledger,
+        "SELECT ?s ?f WHERE { ?s schema:name ?name . \
+         { { ?s ex:friend ?f } UNION { ?s schema:age ?age } } \
+         OPTIONAL { ?s ex:friend ?f } VALUES ?f { ex:alice } }",
+    )
+    .await;
+
+    let values_at = ops
+        .iter()
+        .position(|o| o == "ValuesOperator")
+        .unwrap_or_else(|| panic!("the VALUES must be applied somewhere: {ops:?}"));
+    let optional_at = ops
+        .iter()
+        .position(|o| o.contains("Optional"))
+        .unwrap_or_else(|| panic!("the OPTIONAL must survive planning: {ops:?}"));
+    assert!(
+        values_at < optional_at,
+        "a UNION branch binding ?f must not suppress the barrier: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_subquery_exposing_an_optional_bound_var_still_joins() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_values_dataset(&fluree, "values-test:main").await;
+
+    // `Subquery::produced_vars` is the SELECT list, so `?f` read as
+    // unconditionally bound even though the body binds it only in an OPTIONAL —
+    // the same may-bind class as the UNION above, reached through the
+    // subquery's outward schema. Unlike the UNION shape this one has a correct
+    // input, so it pins the ANSWER: `ex:brian` has no `ex:friend` at all, so the
+    // subquery emits him with `?f` unbound and he survives and adopts.
+    //
+    // HONEST SCOPE: this shape is already correct without the barrier — the
+    // correlated-subquery deferral keeps the VALUES below the subquery, and this
+    // test stays green under a barrier-disabling mutation. It is a regression
+    // pin on the §18.2.4 answer for the may-bind class, not evidence about the
+    // barrier.
+    let rows = sparql_rows(
+        &fluree,
+        &ledger,
+        "SELECT ?s ?f WHERE { ?s schema:name ?name . \
+         { SELECT ?s ?f WHERE { ?s schema:email ?e . OPTIONAL { ?s ex:friend ?f } } } \
+         VALUES ?f { ex:alice } }",
+    )
+    .await;
+
+    let fabricated = fabricated_row();
+    assert!(
+        !rows.iter().any(|r| fabricated.contains(r)),
+        "ex:alice's only ex:friend is ex:brian; no row may report otherwise: {rows:?}"
+    );
     assert_eq!(
         rows,
         normalize_rows(&json!([
-            // bound and compatible — kept with the binding the data gave them
-            ["ex:cam", "ex:alice"],
-            ["ex:liam", "ex:alice"],
-            // UNBOUND — compatible with every VALUES row, so kept AND bound
-            ["ex:brian", "ex:alice"],
-            ["ex:nikola", "ex:alice"]
+            ["ex:brian", "ex:alice"], // unbound in the subquery, adopts
+            ["ex:cam", "ex:alice"],   // bound to ex:alice, kept
+            ["ex:liam", "ex:alice"]   // bound to ex:alice, kept
         ]))
     );
 }
@@ -709,6 +830,14 @@ async fn trailing_values_is_a_join_not_a_filter() {
     )
     .await;
 
+    // Both sides asserted exactly. An `assert_ne!` alone would be vacuous —
+    // the pre-fix VALUES answer is also unequal to the FILTER answer, so this
+    // test would pass with the barrier reverted and earn none of its name.
+    assert_eq!(
+        with_values,
+        normalize_rows(&optional_then_values_rows()),
+        "VALUES keeps the unbound rows and gives them the value"
+    );
     assert_eq!(
         with_filter,
         normalize_rows(&json!([["ex:cam", "ex:alice"], ["ex:liam", "ex:alice"]])),

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -3595,6 +3595,47 @@ mod tests {
         );
     }
 
+    /// #1690: a VALUES over a variable a preceding OPTIONAL introduces must
+    /// build ABOVE that OPTIONAL.
+    ///
+    /// Seeded below it, the VALUES binds `?b` before the left join runs; the
+    /// left join then matches an already-bound `?b` and — dropping nothing —
+    /// lets every driving row out carrying the seeded value, so rows whose
+    /// OPTIONAL bound `?b` to something else are reported with a value the data
+    /// never had. `plan_ops` is root-first, so "above" is the smaller index.
+    #[test]
+    fn values_after_optional_builds_above_the_optional() {
+        use crate::binding::Binding;
+
+        // ?ev <ex:entity1> ?a . OPTIONAL { ?ev <ex:entity2> ?b } . VALUES ?b { <ex:B> }
+        let (ev, a, b) = (VarId(0), VarId(1), VarId(2));
+        let patterns = vec![
+            Pattern::Triple(make_pattern(ev, "entity1", a)),
+            Pattern::Optional(vec![Pattern::Triple(make_pattern(ev, "entity2", b))]),
+            Pattern::Values {
+                vars: vec![b],
+                rows: vec![vec![Binding::iri("ex:B")]],
+            },
+        ];
+
+        let op = build_where_operators(&patterns, None).unwrap();
+        let plan = op.describe();
+        let ops = plan_ops(&plan);
+
+        let values_at = ops
+            .iter()
+            .position(|o| *o == "ValuesOperator")
+            .unwrap_or_else(|| panic!("the VALUES must be applied somewhere: {ops:?}"));
+        let optional_at = ops
+            .iter()
+            .position(|o| o.contains("Optional"))
+            .unwrap_or_else(|| panic!("the OPTIONAL must survive planning: {ops:?}"));
+        assert!(
+            values_at < optional_at,
+            "ValuesOperator must sit ABOVE the OPTIONAL, not be seeded below it: {ops:?}"
+        );
+    }
+
     // --- single-row VALUES object inlining --------------------------------
 
     fn object_terms(patterns: &[Pattern]) -> Vec<Term> {

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -1240,6 +1240,64 @@ struct DeferredPattern {
     orig_index: usize,
     required_vars: HashSet<VarId>,
     pattern: Pattern,
+    /// May this pattern be nested INTO a preceding compound (UNION / GRAPH /
+    /// SERVICE) once it becomes ready — see [`try_nest_deferred`]?
+    ///
+    /// True for the dependency-placed FILTER/BIND/subquery cases, where nesting
+    /// is the whole point (filter pushdown into each branch). False for a
+    /// pattern deferred purely to preserve WRITTEN ORDER: nesting it inside a
+    /// container that was itself placed early puts it back above the pattern
+    /// the barrier exists to keep it below (#1690).
+    nestable: bool,
+}
+
+/// Must a `VALUES` at this position stay behind the patterns written before it?
+///
+/// True when some PRECEDING `Pattern::Optional` *introduces* one of the VALUES
+/// variables — binds it where nothing ahead of that OPTIONAL already did.
+///
+/// `Join(LeftJoin(P, O), V)` and `LeftJoin(Join(P, V), O)` are the same query
+/// only when `V` binds nothing `O` introduces. When `O` does introduce one of
+/// `V`'s variables, hoisting `V` seeds that variable before the left join even
+/// runs; the left join then matches on the seeded value and — being a left join,
+/// so dropping nothing — lets every driving row out carrying it (#1690).
+///
+/// A variable already bound ahead of the OPTIONAL is deliberately NOT counted:
+/// there the OPTIONAL only *restricts* a required variable, and restricting a
+/// required variable commutes across the left join. So `VALUES ?ev` over an
+/// `?ev` a preceding triple binds keeps its seed, and with it the
+/// exact-cardinality seed race that `values_seed_beats_disconnected_class_anchor`
+/// pins (the 21k-row UNWIND cliff).
+///
+/// Scope note: only `Optional` siblings in this group are inspected, matching
+/// the MINUS/EXISTS arm's altitude. An OPTIONAL nested inside a preceding
+/// `Graph`/`Service` container is not covered here.
+fn values_needs_optional_barrier(
+    values_vars: &[VarId],
+    preceding: &[Pattern],
+    initial_bound_vars: &HashSet<VarId>,
+) -> bool {
+    if values_vars.is_empty() {
+        return false;
+    }
+    let wanted: HashSet<VarId> = values_vars.iter().copied().collect();
+    // Variables bound REQUIREDLY before the OPTIONAL under test. An OPTIONAL
+    // contributes nothing here — it binds nothing unconditionally.
+    let mut required_before: HashSet<VarId> = initial_bound_vars.clone();
+    for p in preceding {
+        if let Pattern::Optional(inner) = p {
+            if inner
+                .iter()
+                .flat_map(super::ir::Pattern::produced_vars)
+                .any(|v| wanted.contains(&v) && !required_before.contains(&v))
+            {
+                return true;
+            }
+        } else {
+            required_before.extend(p.produced_vars());
+        }
+    }
+    false
 }
 
 /// Reorder all pattern types for optimal join order.
@@ -1300,10 +1358,17 @@ pub fn reorder_patterns(
     // VALUES vars into the anchor set lets the existing class-anchor
     // demotion fire at seed time; genuinely class-only queries keep their
     // seed via the demotion's non-empty-pool fallback.
+    //
+    // A VALUES held behind an OPTIONAL barrier (see
+    // [`values_needs_optional_barrier`]) is deliberately excluded: it is not
+    // seeding anything, so letting it demote a class anchor would cost that
+    // anchor its seed with nothing taking its place.
     let mut seed_anchor_vars: HashSet<VarId> = subquery_output_vars.clone();
-    for p in patterns {
+    for (i, p) in patterns.iter().enumerate() {
         if let Pattern::Values { vars, .. } = p {
-            seed_anchor_vars.extend(vars.iter().copied());
+            if !values_needs_optional_barrier(vars, &patterns[..i], initial_bound_vars) {
+                seed_anchor_vars.extend(vars.iter().copied());
+            }
         }
     }
 
@@ -1336,8 +1401,52 @@ pub fn reorder_patterns(
                 orig_index: i,
                 required_vars: required,
                 pattern: pattern.clone(),
+                nestable: true,
             });
             continue;
+        }
+
+        // A VALUES is order-sensitive for exactly the same reason MINUS is
+        // whenever a PRECEDING OPTIONAL introduces one of its variables.
+        //
+        // `Pattern::Values` is otherwise an exact-cardinality *source* and wins
+        // the seed race outright (see `seed_anchor_vars` above), which rewrites
+        // `Join(LeftJoin(P, O), V)` into `LeftJoin(Join(P, V), O)`. Those are
+        // NOT the same query: with `V` seeded first the left join matches
+        // against an already-bound variable and, dropping nothing, lets every
+        // driving row out carrying the seeded value. A row whose OPTIONAL bound
+        // `?b` to `ns:X0` is then reported as `?b = ns:B` — a fabricated
+        // binding, not merely an extra row (#1690).
+        //
+        // Deferring on the preceding patterns' produced vars — which include
+        // the OPTIONAL's own, per `Pattern::produced_vars` — lands the VALUES
+        // immediately after the OPTIONAL, i.e. the plan the post-query
+        // `} VALUES …` spelling already gets and the one W3C `bindings/values07`
+        // pins.
+        //
+        // The barrier does NOT turn the VALUES into a filter. Per SPARQL 1.1
+        // §18.2.4 this stays `Join(…, ToMultiSet(data))`, and a solution whose
+        // OPTIONAL left the variable UNBOUND is *compatible* with every VALUES
+        // row: it SURVIVES and ADOPTS the VALUES binding. `FILTER(?b = …)` is
+        // not the equivalent rewrite — FILTER drops unbound rows, VALUES adopts
+        // them.
+        //
+        // `nestable: false` because the barrier is about WRITTEN ORDER: letting
+        // the VALUES be folded into a preceding UNION/GRAPH/SERVICE that the
+        // greedy loop placed early would put it back above the OPTIONAL.
+        if let Pattern::Values { vars, .. } = pattern {
+            if values_needs_optional_barrier(vars, &patterns[..i], initial_bound_vars) {
+                deferred.push(DeferredPattern {
+                    orig_index: i,
+                    required_vars: patterns[..i]
+                        .iter()
+                        .flat_map(super::ir::Pattern::produced_vars)
+                        .collect(),
+                    pattern: pattern.clone(),
+                    nestable: false,
+                });
+                continue;
+            }
         }
 
         // A CORRELATED subquery — one whose SELECT list shares variables with
@@ -1358,6 +1467,7 @@ pub fn reorder_patterns(
                     orig_index: i,
                     required_vars: corr,
                     pattern: pattern.clone(),
+                    nestable: true,
                 });
                 continue;
             }
@@ -1374,6 +1484,7 @@ pub fn reorder_patterns(
                     orig_index: i,
                     required_vars: needs,
                     pattern: pattern.clone(),
+                    nestable: true,
                 });
                 continue;
             }
@@ -1431,6 +1542,7 @@ pub fn reorder_patterns(
                     orig_index: i,
                     required_vars,
                     pattern: pattern.clone(),
+                    nestable: true,
                 });
             }
         }
@@ -1879,9 +1991,10 @@ fn drain_ready_deferred(
         ready.sort_by_key(|dp| dp.orig_index);
 
         for dp in ready {
-            let nested = result
-                .last_mut()
-                .is_some_and(|last| try_nest_deferred(last, &dp));
+            let nested = dp.nestable
+                && result
+                    .last_mut()
+                    .is_some_and(|last| try_nest_deferred(last, &dp));
 
             // A deferred pattern's produced variables must enter the bound set
             // so later patterns referencing them place after and correlate.
@@ -4173,6 +4286,85 @@ mod tests {
         assert!(
             matches!(ordered[0], Pattern::Values { .. }),
             "the exact-cardinality VALUES must seed, not the class anchor: {ordered:?}"
+        );
+    }
+
+    /// One-row VALUES over a variable an `OPTIONAL` introduces.
+    fn optional_shadowed_values_group() -> (Pattern, Pattern, Pattern) {
+        let (ev, a, b) = (VarId(0), VarId(1), VarId(2));
+        let anchor = Pattern::Triple(make_pattern(ev, "entity1", a));
+        let optional = Pattern::Optional(vec![Pattern::Triple(make_pattern(ev, "entity2", b))]);
+        let values = Pattern::Values {
+            vars: vec![b],
+            rows: vec![vec![crate::binding::Binding::lit(
+                FlakeValue::Long(1),
+                Sid::new(2, "long"),
+            )]],
+        };
+        (anchor, optional, values)
+    }
+
+    #[test]
+    fn values_after_optional_is_not_hoisted_above_it() {
+        // `?ev :entity1 ?a . OPTIONAL { ?ev :entity2 ?b } . VALUES ?b { … }`.
+        // Seeding the VALUES rewrites `Join(LeftJoin(P, O), V)` as
+        // `LeftJoin(Join(P, V), O)`: the left join then drops nothing and every
+        // driving row exits carrying the seeded value — a binding the data
+        // never had for it (#1690).
+        let (anchor, optional, values) = optional_shadowed_values_group();
+        let ordered = reorder_patterns(&[anchor, optional, values], None, &HashSet::new());
+
+        let optional_at = ordered
+            .iter()
+            .position(|p| matches!(p, Pattern::Optional(_)))
+            .expect("OPTIONAL survives the reorder");
+        let values_at = ordered
+            .iter()
+            .position(|p| matches!(p, Pattern::Values { .. }))
+            .expect("VALUES survives the reorder");
+        assert!(
+            values_at > optional_at,
+            "VALUES over an OPTIONAL-introduced var must stay below it: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn values_before_optional_still_seeds() {
+        // The barrier is positional: written FIRST, the same VALUES is the
+        // correct seed and keeps it.
+        let (anchor, optional, values) = optional_shadowed_values_group();
+        let ordered = reorder_patterns(&[values, anchor, optional], None, &HashSet::new());
+        assert!(
+            matches!(ordered[0], Pattern::Values { .. }),
+            "a VALUES written before the OPTIONAL still seeds: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn values_on_a_required_var_still_seeds_past_an_optional() {
+        // The OPTIONAL only RESTRICTS `?ev` — a preceding triple already binds
+        // it — so restricting it commutes across the left join and the seed is
+        // kept. Without this carve-out every OPTIONAL mentioning the seed
+        // variable would cost the exact-cardinality seed (the 21k-row UNWIND
+        // cliff `values_seed_beats_disconnected_class_anchor` pins).
+        let (ev, a, b) = (VarId(0), VarId(1), VarId(2));
+        let anchor = Pattern::Triple(make_pattern(ev, "entity1", a));
+        let optional = Pattern::Optional(vec![Pattern::Triple(make_pattern(ev, "entity2", b))]);
+        let values = Pattern::Values {
+            vars: vec![ev],
+            rows: (0..3)
+                .map(|i| {
+                    vec![crate::binding::Binding::lit(
+                        FlakeValue::Long(i),
+                        Sid::new(2, "long"),
+                    )]
+                })
+                .collect(),
+        };
+        let ordered = reorder_patterns(&[anchor, optional, values], None, &HashSet::new());
+        assert!(
+            matches!(ordered[0], Pattern::Values { .. }),
+            "VALUES over a var the OPTIONAL only restricts must keep its seed: {ordered:?}"
         );
     }
 

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -1244,17 +1244,176 @@ struct DeferredPattern {
     /// SERVICE) once it becomes ready — see [`try_nest_deferred`]?
     ///
     /// True for the dependency-placed FILTER/BIND/subquery cases, where nesting
-    /// is the whole point (filter pushdown into each branch). False for a
-    /// pattern deferred purely to preserve WRITTEN ORDER: nesting it inside a
-    /// container that was itself placed early puts it back above the pattern
-    /// the barrier exists to keep it below (#1690).
+    /// is the whole point (filter pushdown into each branch). The VALUES barrier
+    /// sets it false.
+    ///
+    /// **Defensive, not load-bearing today, and deliberately untested.** No
+    /// reachable plan needs it: a barriered VALUES' `required_vars` contains the
+    /// left-join-introduced variable, and by the barrier's own precondition
+    /// nothing ahead of that left join binds it — so the VALUES cannot become
+    /// ready until the OPTIONAL has been placed, at which point
+    /// `drain_ready_deferred` sees the OPTIONAL as `result.last()` and
+    /// `try_nest_deferred` rejects it anyway. Flipping this flag leaves every
+    /// suite green. It is kept as a cheap invariant guard in case
+    /// `required_vars` is ever narrowed, NOT because it closes an observed
+    /// route — please don't read a missing test here as missing coverage.
     nestable: bool,
+    /// Original indices of patterns this one must not be placed before.
+    ///
+    /// `required_vars` is a variable-readiness test, so it cannot express "stay
+    /// behind THIS pattern": any sibling binding the same variable satisfies it.
+    /// The VALUES barrier needs the positional form — a UNION branch binding
+    /// `?b` otherwise drains the VALUES before the OPTIONAL that introduces `?b`
+    /// is placed at all. Empty for every dependency-placed deferral.
+    after_indices: Vec<usize>,
 }
 
-/// Must a `VALUES` at this position stay behind the patterns written before it?
+/// Variables `pattern` binds in **every** solution it emits.
 ///
-/// True when some PRECEDING `Pattern::Optional` *introduces* one of the VALUES
-/// variables — binds it where nothing ahead of that OPTIONAL already did.
+/// [`Pattern::produced_vars`] is a MAY-bind set and must not be used for this
+/// question: it unions a `UNION`'s branches (`ir/pattern.rs`) and recurses
+/// straight through a nested `Optional`. Reading it as "already bound" is what
+/// let a variable bound in only ONE union branch suppress
+/// [`values_needs_optional_barrier`] for a later sibling OPTIONAL that genuinely
+/// introduces it — the barrier stopped firing and #1690 came back one UNION
+/// away from the shape it was written for.
+///
+/// Shared with [`subquery_correlation_vars`], which needs the identical rule to
+/// decide whether a shared SELECT-list variable is a join key or a correlation
+/// input — it used to state it as an inline `matches!` allow-list. One relation
+/// over one concept, so the two cannot drift.
+///
+/// Note `collect_guaranteed_vars` is NOT this function despite the name: it is
+/// plain `produced_vars`, with the branch intersection done at its
+/// `try_nest_deferred` call site.
+fn must_bind_vars(pattern: &Pattern) -> HashSet<VarId> {
+    match pattern {
+        // A left join binds nothing unconditionally.
+        Pattern::Optional(_) => HashSet::new(),
+        // Pure row filters introduce no bindings at all.
+        Pattern::Filter(_) | Pattern::Minus(_) | Pattern::Exists(_) | Pattern::NotExists(_) => {
+            HashSet::new()
+        }
+        // A UNION guarantees only what EVERY branch guarantees.
+        Pattern::Union(branches) => branches
+            .iter()
+            .map(|branch| {
+                branch
+                    .iter()
+                    .flat_map(must_bind_vars)
+                    .collect::<HashSet<_>>()
+            })
+            .reduce(|mut acc, branch_vars| {
+                acc.retain(|v| branch_vars.contains(v));
+                acc
+            })
+            .unwrap_or_default(),
+        // Containers: whatever their body guarantees. A `GRAPH ?g` that emits a
+        // row has always bound `?g`.
+        Pattern::Graph { name, patterns } => {
+            let mut vars: HashSet<VarId> = patterns.iter().flat_map(must_bind_vars).collect();
+            if let crate::ir::GraphName::Var(v) = name {
+                vars.insert(*v);
+            }
+            vars
+        }
+        Pattern::DefaultGraphSource { patterns } => {
+            patterns.iter().flat_map(must_bind_vars).collect()
+        }
+        Pattern::Service(sp) => sp.patterns.iter().flat_map(must_bind_vars).collect(),
+        // A subquery exposes only its SELECT list, and only the members of it
+        // its own body binds unconditionally.
+        Pattern::Subquery(sq) => {
+            let body: HashSet<VarId> = sq.patterns.iter().flat_map(must_bind_vars).collect();
+            sq.select
+                .iter()
+                .copied()
+                .filter(|v| body.contains(v))
+                .collect()
+        }
+        Pattern::EdgeAnnotation {
+            edge,
+            annotation,
+            body,
+        }
+        | Pattern::AnnotationTarget {
+            annotation,
+            edge,
+            body,
+        } => {
+            let mut vars: HashSet<VarId> = edge.produced_vars().into_iter().collect();
+            if let Ref::Var(v) = annotation {
+                vars.insert(*v);
+            }
+            vars.extend(body.iter().flat_map(must_bind_vars));
+            vars
+        }
+        // Triples, property paths, BIND/UNWIND/VALUES, search adapters: every
+        // solution they emit carries their produced vars.
+        other => other.produced_vars().into_iter().collect(),
+    }
+}
+
+/// Variables a **left join** inside `pattern` can introduce — bound in some of
+/// its solutions and left UNBOUND in others because an `OPTIONAL` produced them.
+/// Recurses through every container that shares the enclosing solution pipeline,
+/// so an OPTIONAL nested in a preceding `GRAPH`/`SERVICE`/`UNION` counts too.
+///
+/// A `UNION` that merely binds a variable on one branch is deliberately NOT
+/// included. `Join` is commutative, so a VALUES hoisted past a UNION still meets
+/// the other branch's rows with the variable unbound, and they still adopt the
+/// value — same answer. Only a left join reorders into a different query, which
+/// is why this is narrower than "may-bind minus must-bind".
+///
+/// A `Subquery` contributes the SELECT-list variables its body does not bind
+/// unconditionally: the same conditional-output shape reached through the
+/// subquery's outward schema.
+fn left_join_introduced_vars(pattern: &Pattern, out: &mut HashSet<VarId>) {
+    match pattern {
+        Pattern::Optional(inner) => {
+            // `produced_vars` recurses, so nested containers inside the OPTIONAL
+            // are covered — everything it binds is conditional on the left join.
+            out.extend(inner.iter().flat_map(super::ir::Pattern::produced_vars));
+        }
+        Pattern::Union(branches) => {
+            for p in branches.iter().flatten() {
+                left_join_introduced_vars(p, out);
+            }
+        }
+        Pattern::Graph { patterns, .. } | Pattern::DefaultGraphSource { patterns } => {
+            for p in patterns {
+                left_join_introduced_vars(p, out);
+            }
+        }
+        Pattern::Service(sp) => {
+            for p in &sp.patterns {
+                left_join_introduced_vars(p, out);
+            }
+        }
+        Pattern::Subquery(sq) => {
+            let body = must_bind_vars(pattern);
+            out.extend(sq.select.iter().copied().filter(|v| !body.contains(v)));
+        }
+        Pattern::EdgeAnnotation { body, .. } | Pattern::AnnotationTarget { body, .. } => {
+            for p in body {
+                left_join_introduced_vars(p, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Which preceding patterns must a `VALUES` at this position stay behind?
+///
+/// Returns the original indices of every preceding pattern that *introduces* one
+/// of the VALUES variables through a left join — binds it where nothing ahead of
+/// that left join already did. Empty means the VALUES is free to be reordered.
+///
+/// These are POSITIONAL blockers, deliberately, because `required_vars` alone is
+/// not enough: it is a variable-readiness test, so a sibling that happens to bind
+/// the same variable (a UNION branch, say) satisfies it and drains the VALUES
+/// before the OPTIONAL has been placed at all. The barrier has to name the
+/// pattern, not just the variable.
 ///
 /// `Join(LeftJoin(P, O), V)` and `LeftJoin(Join(P, V), O)` are the same query
 /// only when `V` binds nothing `O` introduces. When `O` does introduce one of
@@ -1267,37 +1426,39 @@ struct DeferredPattern {
 /// required variable commutes across the left join. So `VALUES ?ev` over an
 /// `?ev` a preceding triple binds keeps its seed, and with it the
 /// exact-cardinality seed race that `values_seed_beats_disconnected_class_anchor`
-/// pins (the 21k-row UNWIND cliff).
+/// pins (the 21k-row UNWIND cliff). "Already bound" here means
+/// [`must_bind_vars`], never `produced_vars` — see that function's note.
 ///
-/// Scope note: only `Optional` siblings in this group are inspected, matching
-/// the MINUS/EXISTS arm's altitude. An OPTIONAL nested inside a preceding
-/// `Graph`/`Service` container is not covered here.
-fn values_needs_optional_barrier(
+/// The whole table defers as a unit when ANY of its variables is introduced this
+/// way: a multi-var `VALUES (?ev ?f)` with `?ev` required-bound gives up the
+/// seed on `?ev` too, because the table has to join above the OPTIONAL as one
+/// pattern. Recovering that seed means splitting it into a semi-join on the
+/// required-bound projection plus the full join above the OPTIONAL — a real
+/// design addition, deliberately left out of the fix.
+fn values_optional_barrier_indices(
     values_vars: &[VarId],
     preceding: &[Pattern],
     initial_bound_vars: &HashSet<VarId>,
-) -> bool {
+) -> Vec<usize> {
+    let mut blockers = Vec::new();
     if values_vars.is_empty() {
-        return false;
+        return blockers;
     }
     let wanted: HashSet<VarId> = values_vars.iter().copied().collect();
-    // Variables bound REQUIREDLY before the OPTIONAL under test. An OPTIONAL
-    // contributes nothing here — it binds nothing unconditionally.
+    // Variables bound REQUIREDLY before the pattern under test.
     let mut required_before: HashSet<VarId> = initial_bound_vars.clone();
-    for p in preceding {
-        if let Pattern::Optional(inner) = p {
-            if inner
-                .iter()
-                .flat_map(super::ir::Pattern::produced_vars)
-                .any(|v| wanted.contains(&v) && !required_before.contains(&v))
-            {
-                return true;
-            }
-        } else {
-            required_before.extend(p.produced_vars());
+    for (i, p) in preceding.iter().enumerate() {
+        let mut introduced = HashSet::new();
+        left_join_introduced_vars(p, &mut introduced);
+        if introduced
+            .iter()
+            .any(|v| wanted.contains(v) && !required_before.contains(v))
+        {
+            blockers.push(i);
         }
+        required_before.extend(must_bind_vars(p));
     }
-    false
+    blockers
 }
 
 /// Reorder all pattern types for optimal join order.
@@ -1366,7 +1527,8 @@ pub fn reorder_patterns(
     let mut seed_anchor_vars: HashSet<VarId> = subquery_output_vars.clone();
     for (i, p) in patterns.iter().enumerate() {
         if let Pattern::Values { vars, .. } = p {
-            if !values_needs_optional_barrier(vars, &patterns[..i], initial_bound_vars) {
+            if values_optional_barrier_indices(vars, &patterns[..i], initial_bound_vars).is_empty()
+            {
                 seed_anchor_vars.extend(vars.iter().copied());
             }
         }
@@ -1402,12 +1564,15 @@ pub fn reorder_patterns(
                 required_vars: required,
                 pattern: pattern.clone(),
                 nestable: true,
+                after_indices: Vec::new(),
             });
             continue;
         }
 
         // A VALUES is order-sensitive for exactly the same reason MINUS is
-        // whenever a PRECEDING OPTIONAL introduces one of its variables.
+        // whenever a PRECEDING left join introduces one of its variables —
+        // an OPTIONAL sibling, or one nested in a preceding GRAPH/SERVICE/UNION
+        // container.
         //
         // `Pattern::Values` is otherwise an exact-cardinality *source* and wins
         // the seed race outright (see `seed_anchor_vars` above), which rewrites
@@ -1418,11 +1583,13 @@ pub fn reorder_patterns(
         // `?b` to `ns:X0` is then reported as `?b = ns:B` — a fabricated
         // binding, not merely an extra row (#1690).
         //
-        // Deferring on the preceding patterns' produced vars — which include
-        // the OPTIONAL's own, per `Pattern::produced_vars` — lands the VALUES
-        // immediately after the OPTIONAL, i.e. the plan the post-query
-        // `} VALUES …` spelling already gets and the one W3C `bindings/values07`
-        // pins.
+        // The barrier is POSITIONAL (`after_indices`), not just a var
+        // dependency: `required_vars` is a variable-readiness test, so a
+        // sibling UNION branch that happens to bind the same variable would
+        // satisfy it and drain the VALUES before the OPTIONAL is placed at all.
+        // Naming the blocking patterns lands the VALUES after every left join
+        // that feeds it — the plan the post-query `} VALUES …` spelling already
+        // gets, and the one W3C `bindings/values07` pins.
         //
         // The barrier does NOT turn the VALUES into a filter. Per SPARQL 1.1
         // §18.2.4 this stays `Join(…, ToMultiSet(data))`, and a solution whose
@@ -1430,12 +1597,10 @@ pub fn reorder_patterns(
         // row: it SURVIVES and ADOPTS the VALUES binding. `FILTER(?b = …)` is
         // not the equivalent rewrite — FILTER drops unbound rows, VALUES adopts
         // them.
-        //
-        // `nestable: false` because the barrier is about WRITTEN ORDER: letting
-        // the VALUES be folded into a preceding UNION/GRAPH/SERVICE that the
-        // greedy loop placed early would put it back above the OPTIONAL.
         if let Pattern::Values { vars, .. } = pattern {
-            if values_needs_optional_barrier(vars, &patterns[..i], initial_bound_vars) {
+            let blockers =
+                values_optional_barrier_indices(vars, &patterns[..i], initial_bound_vars);
+            if !blockers.is_empty() {
                 deferred.push(DeferredPattern {
                     orig_index: i,
                     required_vars: patterns[..i]
@@ -1444,6 +1609,7 @@ pub fn reorder_patterns(
                         .collect(),
                     pattern: pattern.clone(),
                     nestable: false,
+                    after_indices: blockers,
                 });
                 continue;
             }
@@ -1468,6 +1634,7 @@ pub fn reorder_patterns(
                     required_vars: corr,
                     pattern: pattern.clone(),
                     nestable: true,
+                    after_indices: Vec::new(),
                 });
                 continue;
             }
@@ -1485,6 +1652,7 @@ pub fn reorder_patterns(
                     required_vars: needs,
                     pattern: pattern.clone(),
                     nestable: true,
+                    after_indices: Vec::new(),
                 });
                 continue;
             }
@@ -1543,28 +1711,48 @@ pub fn reorder_patterns(
                     required_vars,
                     pattern: pattern.clone(),
                     nestable: true,
+                    after_indices: Vec::new(),
                 });
             }
         }
     }
 
     let mut result: Vec<Pattern> = Vec::with_capacity(patterns.len());
+    // Original indices already emitted into `result`, for the positional
+    // `after_indices` barrier (see [`DeferredPattern::after_indices`]).
+    let mut placed_indices: HashSet<usize> = HashSet::new();
 
     // Place any deferred patterns whose inputs are already satisfied by the
     // initial bound_vars (e.g. from a seed operator).
-    drain_ready_deferred(&mut deferred, &mut bound_vars, &mut result);
+    drain_ready_deferred(
+        &mut deferred,
+        &mut bound_vars,
+        &mut result,
+        &mut placed_indices,
+    );
 
     // Greedy loop: place patterns by priority
     while !sources.is_empty() || !reducers.is_empty() || !expanders.is_empty() {
-        let placed = try_place_reducer(&mut reducers, &mut bound_vars, stats, &mut result)
-            || try_place_source(
-                &mut sources,
-                &mut bound_vars,
-                stats,
-                &mut result,
-                &seed_anchor_vars,
-            )
-            || try_place_expander(&mut expanders, &mut bound_vars, stats, &mut result);
+        let placed = try_place_reducer(
+            &mut reducers,
+            &mut bound_vars,
+            stats,
+            &mut result,
+            &mut placed_indices,
+        ) || try_place_source(
+            &mut sources,
+            &mut bound_vars,
+            stats,
+            &mut result,
+            &seed_anchor_vars,
+            &mut placed_indices,
+        ) || try_place_expander(
+            &mut expanders,
+            &mut bound_vars,
+            stats,
+            &mut result,
+            &mut placed_indices,
+        );
 
         if !placed {
             // Nothing could be placed (shouldn't happen with sources always eligible).
@@ -1581,13 +1769,19 @@ pub fn reorder_patterns(
             for v in rp.pattern.produced_vars() {
                 bound_vars.insert(v);
             }
+            placed_indices.insert(rp.orig_index);
             result.push(rp.pattern);
         }
 
         // After each placement, drain any deferred patterns that have become
         // ready.  BIND outputs feed back into bound_vars, so a single source
         // placement can cascade through multiple BINDs.
-        drain_ready_deferred(&mut deferred, &mut bound_vars, &mut result);
+        drain_ready_deferred(
+            &mut deferred,
+            &mut bound_vars,
+            &mut result,
+            &mut placed_indices,
+        );
     }
 
     // Append any remaining deferred patterns (their inputs may never be bound,
@@ -1606,6 +1800,7 @@ fn try_place_reducer(
     bound_vars: &mut HashSet<VarId>,
     stats: Option<&StatsView>,
     result: &mut Vec<Pattern>,
+    placed: &mut HashSet<usize>,
 ) -> bool {
     // Find eligible reducers (at least one variable already bound)
     let eligible_idx = remaining
@@ -1627,6 +1822,7 @@ fn try_place_reducer(
         for v in rp.pattern.produced_vars() {
             bound_vars.insert(v);
         }
+        placed.insert(rp.orig_index);
         result.push(rp.pattern);
         true
     } else {
@@ -1891,6 +2087,7 @@ fn try_place_source(
     stats: Option<&StatsView>,
     result: &mut Vec<Pattern>,
     anchor_vars: &HashSet<VarId>,
+    placed: &mut HashSet<usize>,
 ) -> bool {
     if remaining.is_empty() {
         return false;
@@ -1909,6 +2106,7 @@ fn try_place_source(
         for v in rp.pattern.produced_vars() {
             bound_vars.insert(v);
         }
+        placed.insert(rp.orig_index);
         result.push(rp.pattern);
         true
     } else {
@@ -1922,6 +2120,7 @@ fn try_place_expander(
     bound_vars: &mut HashSet<VarId>,
     stats: Option<&StatsView>,
     result: &mut Vec<Pattern>,
+    placed: &mut HashSet<usize>,
 ) -> bool {
     let eligible_idx = remaining
         .iter()
@@ -1942,6 +2141,7 @@ fn try_place_expander(
         for v in rp.pattern.produced_vars() {
             bound_vars.insert(v);
         }
+        placed.insert(rp.orig_index);
         result.push(rp.pattern);
         true
     } else {
@@ -1968,13 +2168,17 @@ fn drain_ready_deferred(
     deferred: &mut Vec<DeferredPattern>,
     bound_vars: &mut HashSet<VarId>,
     result: &mut Vec<Pattern>,
+    placed: &mut HashSet<usize>,
 ) {
     loop {
         // Find all deferred patterns whose inputs are satisfied.
         let ready_indices: Vec<usize> = deferred
             .iter()
             .enumerate()
-            .filter(|(_, dp)| dp.required_vars.is_subset(bound_vars))
+            .filter(|(_, dp)| {
+                dp.required_vars.is_subset(bound_vars)
+                    && dp.after_indices.iter().all(|i| placed.contains(i))
+            })
             .map(|(idx, _)| idx)
             .collect();
 
@@ -2005,6 +2209,7 @@ fn drain_ready_deferred(
             for v in dp.pattern.produced_vars() {
                 bound_vars.insert(v);
             }
+            placed.insert(dp.orig_index);
 
             if !nested {
                 result.push(dp.pattern);
@@ -2034,11 +2239,12 @@ fn drain_ready_deferred(
 ///    which rows survive the slice (e.g. `ORDER BY DESC(?x) LIMIT 1` means "top
 ///    row per outer binding"), so such a subquery stays genuinely correlated.
 /// 2. **Unconditionally bound.** The variable must be bound in *every* subquery
-///    solution — produced by a top-level required pattern (a triple or property
-///    path), NOT inside a `UNION` branch or `OPTIONAL`. A conditionally-bound
-///    var can be Unbound in some output rows; evaluating once and joining would
-///    then differ from per-row seeding (an Unbound join key would scan rather
-///    than filter). We only count always-bound producers.
+///    solution — NOT only inside a `UNION` branch or `OPTIONAL`. A
+///    conditionally-bound var can be Unbound in some output rows; evaluating
+///    once and joining would then differ from per-row seeding (an Unbound join
+///    key would scan rather than filter). That is exactly [`must_bind_vars`],
+///    which this site shares with the VALUES/OPTIONAL barrier so the two
+///    cannot drift apart.
 fn subquery_correlation_vars(
     sq: &SubqueryPattern,
     siblings: &[Pattern],
@@ -2049,29 +2255,20 @@ fn subquery_correlation_vars(
         return HashSet::new();
     }
     // Variables the subquery binds in EVERY solution on its own — but only when
-    // no inner slice makes per-row seeding result-sensitive. Restricted to
-    // top-level UNCONDITIONAL producers so a var that is only conditionally
-    // bound (UNION branch, OPTIONAL) is NOT declassified. Besides triples /
-    // property paths this must include the WITH-pipeline binders — UNWIND, BIND,
-    // VALUES — otherwise a var the subquery produces via one of them is
-    // mistaken for an external correlation, the subquery is deferred on a var
-    // only it can bind (so it never becomes ready and is placed last), and a
-    // consuming OPTIONAL/Filter runs first uncorrelated, clobbering that var.
+    // no inner slice makes per-row seeding result-sensitive. This is the
+    // must-bind question, so it uses the shared [`must_bind_vars`]: a var bound
+    // only in a UNION branch or an OPTIONAL is NOT declassified, while the
+    // WITH-pipeline binders (UNWIND, BIND, VALUES) alongside triples and
+    // property paths ARE counted — otherwise a var the subquery produces via one
+    // of them is mistaken for an external correlation, the subquery is deferred
+    // on a var only it can bind (so it never becomes ready and is placed last),
+    // and a consuming OPTIONAL/Filter runs first uncorrelated, clobbering it.
+    //
+    // This replaced an inline `matches!` allow-list that stated the same rule
+    // but was flat (no Graph/Service recursion) and treated UNION as wholly
+    // absent rather than intersecting its branches.
     let self_produced: HashSet<VarId> = if sq.limit.is_none() && sq.offset.is_none() {
-        sq.patterns
-            .iter()
-            .filter(|p| {
-                matches!(
-                    p,
-                    Pattern::Triple(_)
-                        | Pattern::PropertyPath(_)
-                        | Pattern::Unwind { .. }
-                        | Pattern::Bind { .. }
-                        | Pattern::Values { .. }
-                )
-            })
-            .flat_map(Pattern::produced_vars)
-            .collect()
+        sq.patterns.iter().flat_map(must_bind_vars).collect()
     } else {
         HashSet::new()
     };
@@ -4337,6 +4534,146 @@ mod tests {
         assert!(
             matches!(ordered[0], Pattern::Values { .. }),
             "a VALUES written before the OPTIONAL still seeds: {ordered:?}"
+        );
+    }
+
+    /// Index of the first pattern matching `pred`.
+    fn position_of(ordered: &[Pattern], pred: impl Fn(&Pattern) -> bool) -> usize {
+        ordered
+            .iter()
+            .position(pred)
+            .unwrap_or_else(|| panic!("pattern survives the reorder: {ordered:?}"))
+    }
+
+    #[test]
+    fn union_may_bind_does_not_suppress_the_optional_barrier() {
+        // `?ev :entity1 ?a . { {?ev :entity2 ?b} UNION {?ev :other ?c} }
+        //  OPTIONAL { ?ev :entity2 ?b } . VALUES ?b { … }`
+        //
+        // `Union::produced_vars` unions its branches, so reading it as
+        // "already bound" recorded `?b` as required-bound and SUPPRESSED the
+        // barrier for the sibling OPTIONAL that genuinely introduces it — the
+        // fabricated binding was reachable one UNION away from the shape the
+        // barrier was written for. `must_bind_vars` takes the branch
+        // INTERSECTION, so `?b` is correctly not required-bound here.
+        let (ev, a, b, c) = (VarId(0), VarId(1), VarId(2), VarId(3));
+        let anchor = Pattern::Triple(make_pattern(ev, "entity1", a));
+        let union = Pattern::Union(vec![
+            vec![Pattern::Triple(make_pattern(ev, "entity2", b))],
+            vec![Pattern::Triple(make_pattern(ev, "other", c))],
+        ]);
+        let optional = Pattern::Optional(vec![Pattern::Triple(make_pattern(ev, "entity2", b))]);
+        let values = Pattern::Values {
+            vars: vec![b],
+            rows: vec![vec![crate::binding::Binding::lit(
+                FlakeValue::Long(1),
+                Sid::new(2, "long"),
+            )]],
+        };
+
+        let ordered = reorder_patterns(&[anchor, union, optional, values], None, &HashSet::new());
+        let optional_at = position_of(&ordered, |p| matches!(p, Pattern::Optional(_)));
+        let values_at = position_of(&ordered, |p| matches!(p, Pattern::Values { .. }));
+        assert!(
+            values_at > optional_at,
+            "a UNION branch binding the var must not suppress the barrier: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn pure_union_without_an_optional_keeps_the_values_seed() {
+        // The other direction: with no left join anywhere, hoisting the VALUES
+        // past a UNION is a plain commutative join reorder. Branch rows that
+        // leave `?b` unbound still adopt the value either way, so this shape
+        // must KEEP its exact-cardinality seed.
+        let (ev, b, c) = (VarId(0), VarId(1), VarId(2));
+        let union = Pattern::Union(vec![
+            vec![Pattern::Triple(make_pattern(ev, "entity2", b))],
+            vec![Pattern::Triple(make_pattern(ev, "other", c))],
+        ]);
+        let values = Pattern::Values {
+            vars: vec![b],
+            rows: vec![vec![crate::binding::Binding::lit(
+                FlakeValue::Long(1),
+                Sid::new(2, "long"),
+            )]],
+        };
+
+        let ordered = reorder_patterns(&[union, values], None, &HashSet::new());
+        assert!(
+            matches!(ordered[0], Pattern::Values { .. }),
+            "a UNION with no left join must not cost the VALUES its seed: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn optional_nested_in_a_preceding_graph_still_raises_the_barrier() {
+        // `?ev :entity1 ?a . GRAPH <g> { ?ev :snap ?s . OPTIONAL { ?ev :entity2 ?b } }
+        //  VALUES ?b { … }` — the left join is one container down, but it
+        // introduces `?b` into the same solution pipeline, so hoisting the
+        // VALUES fabricates exactly as it does for a top-level OPTIONAL.
+        use crate::ir::GraphName;
+        let (ev, a, s, b) = (VarId(0), VarId(1), VarId(2), VarId(3));
+        let anchor = Pattern::Triple(make_pattern(ev, "entity1", a));
+        let graph = Pattern::Graph {
+            name: GraphName::Iri(std::sync::Arc::from("http://example.org/g")),
+            patterns: vec![
+                Pattern::Triple(make_pattern(ev, "snap", s)),
+                Pattern::Optional(vec![Pattern::Triple(make_pattern(ev, "entity2", b))]),
+            ],
+        };
+        let values = Pattern::Values {
+            vars: vec![b],
+            rows: vec![vec![crate::binding::Binding::lit(
+                FlakeValue::Long(1),
+                Sid::new(2, "long"),
+            )]],
+        };
+
+        let ordered = reorder_patterns(&[anchor, graph, values], None, &HashSet::new());
+        let graph_at = position_of(&ordered, |p| matches!(p, Pattern::Graph { .. }));
+        let values_at = position_of(&ordered, |p| matches!(p, Pattern::Values { .. }));
+        assert!(
+            values_at > graph_at,
+            "an OPTIONAL nested in a preceding GRAPH must still raise the barrier: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn subquery_conditionally_bound_output_stays_below_the_subquery() {
+        // A subquery whose SELECT list exposes a var its body binds only inside
+        // an OPTIONAL is the same conditional-output shape, reached through the
+        // subquery's outward schema — `Subquery::produced_vars` is the SELECT
+        // list, so it reads as unconditionally bound without `must_bind_vars`.
+        //
+        // HONEST SCOPE: this does NOT go red if the barrier is removed. The
+        // correlated-subquery deferral above already keeps the VALUES down for
+        // this shape, so the route is unsound on paper but was never reachable
+        // in practice. Kept as a regression pin on the ORDER for the may-bind
+        // class — not as evidence the barrier is what holds it.
+        let (ev, a, b) = (VarId(0), VarId(1), VarId(2));
+        let anchor = Pattern::Triple(make_pattern(ev, "entity1", a));
+        let subquery = Pattern::Subquery(SubqueryPattern::new(
+            vec![ev, b],
+            vec![
+                Pattern::Triple(make_pattern(ev, "snap", a)),
+                Pattern::Optional(vec![Pattern::Triple(make_pattern(ev, "entity2", b))]),
+            ],
+        ));
+        let values = Pattern::Values {
+            vars: vec![b],
+            rows: vec![vec![crate::binding::Binding::lit(
+                FlakeValue::Long(1),
+                Sid::new(2, "long"),
+            )]],
+        };
+
+        let ordered = reorder_patterns(&[anchor, subquery, values], None, &HashSet::new());
+        let subquery_at = position_of(&ordered, |p| matches!(p, Pattern::Subquery(_)));
+        let values_at = position_of(&ordered, |p| matches!(p, Pattern::Values { .. }));
+        assert!(
+            values_at > subquery_at,
+            "a subquery exposing an OPTIONAL-bound var must raise the barrier: {ordered:?}"
         );
     }
 

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -1274,14 +1274,27 @@ struct DeferredPattern {
 /// question: it unions a `UNION`'s branches (`ir/pattern.rs`) and recurses
 /// straight through a nested `Optional`. Reading it as "already bound" is what
 /// let a variable bound in only ONE union branch suppress
-/// [`values_needs_optional_barrier`] for a later sibling OPTIONAL that genuinely
-/// introduces it — the barrier stopped firing and #1690 came back one UNION
-/// away from the shape it was written for.
+/// [`values_optional_barrier_indices`] for a later sibling OPTIONAL that
+/// genuinely introduces it — the barrier stopped firing and #1690 came back one
+/// UNION away from the shape it was written for.
 ///
-/// Shared with [`subquery_correlation_vars`], which needs the identical rule to
+/// **`Bind` is a known may-bind variant this function deliberately counts, so
+/// the contract above is not unconditional.** `Pattern::Bind` binds nothing on
+/// a row whose expression errors — `bind.rs` yields `Binding::Unbound` — and a
+/// BIND-then-OPTIONAL lead can therefore fabricate exactly as a UNION lead
+/// does. It is counted anyway because [`subquery_correlation_vars`] needs it
+/// counted: a variable the subquery produces through a WITH-pipeline binder
+/// must not be read as an external correlation, or the subquery is deferred on
+/// a variable only it can bind. That is the one concept where the two call
+/// sites genuinely want different answers, and it is resolved in the
+/// correlation site's favour — so tightening `Bind` here on the strength of the
+/// stated contract would quietly break subquery correlation. It needs a fix at
+/// both sites or at neither.
+///
+/// Shared with [`subquery_correlation_vars`], which needs the same rule to
 /// decide whether a shared SELECT-list variable is a join key or a correlation
 /// input — it used to state it as an inline `matches!` allow-list. One relation
-/// over one concept, so the two cannot drift.
+/// over one concept, with `Bind` above as the single knowing exception.
 ///
 /// Note `collect_guaranteed_vars` is NOT this function despite the name: it is
 /// plain `produced_vars`, with the branch intersection done at its
@@ -1348,8 +1361,34 @@ fn must_bind_vars(pattern: &Pattern) -> HashSet<VarId> {
             vars.extend(body.iter().flat_map(must_bind_vars));
             vars
         }
-        // Triples, property paths, BIND/UNWIND/VALUES, search adapters: every
-        // solution they emit carries their produced vars.
+        // A constant table guarantees only the columns with no UNDEF cell. Both
+        // surfaces lower `UNDEF` to `Binding::Unbound` — SPARQL in
+        // `lower_values_pattern`, JSON-LD in `lower_values_cell` — so such a
+        // column does not bind its variable in every row, and a leading
+        // `VALUES (?s ?f) { (ex:alice UNDEF) … }` otherwise recorded `?f` as
+        // required-bound and SUPPRESSED the barrier for a following OPTIONAL
+        // that genuinely introduces it. Same suppressor class as the UNION
+        // above, and UNDEF-in-VALUES is the parameterized-query idiom #1690
+        // names as its motivating usage, so it is not a corner.
+        //
+        // A zero-row table is vacuously must-bind on every column: it emits no
+        // solutions at all (the missing-predicate sentinel in `parse/lower.rs`
+        // and `empty_path_result` are both this). Cypher's WITH-pipeline
+        // binders never emit `Unbound`, so this narrowing cannot reach the
+        // `self_produced` set [`subquery_correlation_vars`] builds for them.
+        Pattern::Values { vars, rows } => vars
+            .iter()
+            .enumerate()
+            .filter(|(col, _)| {
+                rows.iter().all(|row| {
+                    row.get(*col)
+                        .is_some_and(|cell| !matches!(cell, crate::binding::Binding::Unbound))
+                })
+            })
+            .map(|(_, v)| *v)
+            .collect(),
+        // Triples, property paths, BIND/UNWIND, search adapters: every solution
+        // they emit carries their produced vars.
         other => other.produced_vars().into_iter().collect(),
     }
 }
@@ -1521,7 +1560,7 @@ pub fn reorder_patterns(
     // seed via the demotion's non-empty-pool fallback.
     //
     // A VALUES held behind an OPTIONAL barrier (see
-    // [`values_needs_optional_barrier`]) is deliberately excluded: it is not
+    // [`values_optional_barrier_indices`]) is deliberately excluded: it is not
     // seeding anything, so letting it demote a class anchor would cost that
     // anchor its seed with nothing taking its place.
     let mut seed_anchor_vars: HashSet<VarId> = subquery_output_vars.clone();
@@ -4577,6 +4616,111 @@ mod tests {
         assert!(
             values_at > optional_at,
             "a UNION branch binding the var must not suppress the barrier: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn an_undef_column_does_not_suppress_the_optional_barrier() {
+        // `?ev :entity1 ?a . VALUES (?ev ?b) { (1 UNDEF) (2 UNDEF) }
+        //  OPTIONAL { ?ev :entity2 ?b } . VALUES ?b { … }`
+        //
+        // `Values::produced_vars` is its whole variable list, so a leading table
+        // with an all-UNDEF `?b` column read as "?b is required-bound", the
+        // barrier didn't fire for the OPTIONAL that genuinely introduces `?b`,
+        // and the trailing VALUES went back to seed position — the #1690
+        // fabrication, one UNDEF away from the shape the barrier was written
+        // for. `must_bind_vars` counts only the columns with no `Unbound` cell,
+        // so `?ev` stays required-bound and `?b` correctly does not.
+        //
+        // UNDEF is not a corner here: parameterized VALUES is the usage #1690
+        // is filed over.
+        //
+        // Asserted on the PLAN, not the rows, for the same reason as
+        // `union_may_bind_does_not_suppress_the_optional_barrier`: this shape's
+        // ANSWER is also wrong for the independent, pre-existing reason filed as
+        // #1713 (an OPTIONAL over a variable already present as `Unbound`
+        // matches the triples and then doesn't write the binding), so pinning
+        // rows would pin that defect's output.
+        let (ev, a, b) = (VarId(0), VarId(1), VarId(2));
+        let anchor = Pattern::Triple(make_pattern(ev, "entity1", a));
+        let parameterized = Pattern::Values {
+            vars: vec![ev, b],
+            rows: (0..2)
+                .map(|i| {
+                    vec![
+                        crate::binding::Binding::lit(FlakeValue::Long(i), Sid::new(2, "long")),
+                        crate::binding::Binding::Unbound,
+                    ]
+                })
+                .collect(),
+        };
+        let optional = Pattern::Optional(vec![Pattern::Triple(make_pattern(ev, "entity2", b))]);
+        let values = Pattern::Values {
+            vars: vec![b],
+            rows: vec![vec![crate::binding::Binding::lit(
+                FlakeValue::Long(1),
+                Sid::new(2, "long"),
+            )]],
+        };
+
+        let ordered = reorder_patterns(
+            &[anchor, parameterized, optional, values],
+            None,
+            &HashSet::new(),
+        );
+        let optional_at = position_of(&ordered, |p| matches!(p, Pattern::Optional(_)));
+        let values_at = position_of(
+            &ordered,
+            |p| matches!(p, Pattern::Values { vars, .. } if vars == &vec![b]),
+        );
+        assert!(
+            values_at > optional_at,
+            "an UNDEF column must not suppress the barrier: {ordered:?}"
+        );
+    }
+
+    #[test]
+    fn a_bound_values_column_still_seeds_past_an_optional() {
+        // The over-fire direction for the arm above: the SAME leading table with
+        // `?b` actually bound in every row really does make `?b` required-bound,
+        // so the OPTIONAL only RESTRICTS it and the trailing VALUES keeps its
+        // exact-cardinality seed. Excluding a column on the mere presence of the
+        // variable — rather than on an `Unbound` cell — would cost that seed.
+        let (ev, a, b) = (VarId(0), VarId(1), VarId(2));
+        let anchor = Pattern::Triple(make_pattern(ev, "entity1", a));
+        let bound_table = Pattern::Values {
+            vars: vec![ev, b],
+            rows: (0..2)
+                .map(|i| {
+                    vec![
+                        crate::binding::Binding::lit(FlakeValue::Long(i), Sid::new(2, "long")),
+                        crate::binding::Binding::lit(FlakeValue::Long(1), Sid::new(2, "long")),
+                    ]
+                })
+                .collect(),
+        };
+        let optional = Pattern::Optional(vec![Pattern::Triple(make_pattern(ev, "entity2", b))]);
+        let values = Pattern::Values {
+            vars: vec![b],
+            rows: vec![vec![crate::binding::Binding::lit(
+                FlakeValue::Long(1),
+                Sid::new(2, "long"),
+            )]],
+        };
+
+        let ordered = reorder_patterns(
+            &[anchor, bound_table, optional, values],
+            None,
+            &HashSet::new(),
+        );
+        let optional_at = position_of(&ordered, |p| matches!(p, Pattern::Optional(_)));
+        let values_at = position_of(
+            &ordered,
+            |p| matches!(p, Pattern::Values { vars, .. } if vars == &vec![b]),
+        );
+        assert!(
+            values_at < optional_at,
+            "a fully-bound VALUES column must keep the trailing seed: {ordered:?}"
         );
     }
 


### PR DESCRIPTION
`{ ?ev :entity1 ?a . OPTIONAL { ?ev :entity2 ?b } VALUES ?b { :B } }` has been returning rows that report a binding the data never had for them. On a 6-row fixture where the OPTIONAL binds `?b` to `ns:X0..X5`/`ns:B`, the in-group VALUES form returned **all six rows saying `?b = ns:B`** — a *fabricated* value, not merely an extra row. Correct answer there is 1 row. Both surfaces were affected (the JSON-LD `["values", …]` after `["optional", …]` clobbered identically), which is the tell that the cause is in the shared planner rather than in SPARQL lowering.

The fixture choice turns out to be load-bearing rather than incidental, so it's worth stating up front. The defect only surfaces once the OPTIONAL binds a **different** value than the VALUES supplies. On a shape where one subject has the OPTIONAL predicate and every other driving row leaves the variable unbound, the buggy and the correct paths agree exactly — the fabricated rows and the legitimately-adopting rows are indistinguishable by count. #1690's own filed repro is that shape, which is why its 1500 rows look like a cross-product and its "correct answer is 1" is really the FILTER answer (see below — FILTER is not the equivalent rewrite). The tests here deliberately use a fixture where the OPTIONAL binds something else, because that is the only arrangement that separates the two.

## Mechanism

`reorder_patterns` in `fluree-db-query/src/planner.rs` classifies `Pattern::Values` as an exact-cardinality **source**, and — via `seed_anchor_vars` — it wins the seed race outright. EXPLAIN's logical plan lists `source values` first even for a VALUES written last.

The order-sensitivity guard immediately above it (the `Minus | Exists | NotExists` arm, and the correlated-subquery deferral just below) exists precisely so the reorder cannot outrun what feeds a pattern. A `Values` whose variable a **preceding `Optional` produces** was never covered by it. That is the whole gap.

In algebra terms the hoist rewrites

```
Join(LeftJoin(P, O), V)   →   LeftJoin(Join(P, V), O)
```

and those are the same query only when `V` binds nothing that `O` *introduces*. When it does, `?b` is already bound before the left join runs, the left join matches on the seeded value, and — being a left join — drops nothing, so every driving row exits carrying it. The physical plan shows it directly: `OptionalOperator > ValuesOperator` before, `ValuesOperator > OptionalOperator` after.

## The fix

A small order-sensitivity barrier alongside the existing MINUS/EXISTS one. `values_optional_barrier_indices` (`planner.rs`) answers "does a preceding `Optional` *introduce* one of this VALUES' variables"; when it does, the VALUES is deferred on the preceding patterns' produced vars — which include the OPTIONAL's own, per `Pattern::produced_vars` — so it lands immediately after the OPTIONAL.

Two deliberate narrowings, both to avoid paying for this where it isn't a hazard:

- **"Introduces", not "mentions."** A variable already bound *ahead* of the OPTIONAL is not introduced by it — there the OPTIONAL only *restricts* a required variable, and restricting a required variable commutes across the left join. So `VALUES ?ev` over an `?ev` a preceding triple binds keeps its seed. Without that carve-out every OPTIONAL mentioning the seed variable would cost the exact-cardinality seed, which is the 21k-row UNWIND cliff `values_seed_beats_disconnected_class_anchor` was written to pin; `values_on_a_required_var_still_seeds_past_an_optional` guards the carve-out from the other side.
- A barriered VALUES no longer joins `seed_anchor_vars`. It isn't seeding anything, so letting it demote a disconnected class anchor would cost that anchor its seed with nothing taking its place.

### The carve-out has to be computed over must-bind, not may-bind

This is the load-bearing subtlety, and it's wrong in a way that looks right. `Pattern::produced_vars()` is a **may-bind** set: `Union` unions its branches, `Graph` recurses straight through a nested `Optional`, `Subquery` is just the SELECT list, and `Values` is its whole variable list regardless of `UNDEF`. Accumulate "already bound ahead of the OPTIONAL" from that and the carve-out above stops being a narrowing and becomes a *suppressor* — a variable bound in only one branch/column is recorded as required-bound, the barrier stops firing for a later sibling OPTIONAL that genuinely introduces it, and the hoist comes straight back one UNION (or one `UNDEF`) away from the shape the barrier was written for.

So three things hold it together:

- **`must_bind_vars` is the single definition** of "bound in every solution this pattern emits" — empty for `Optional` and the pure row filters, branch **intersection** for `Union`, recursive through `Graph`/`Service`, `select ∩ body-must-bind` for a subquery, and for `Values` only the columns with no `Binding::Unbound` cell. I didn't write it fresh: `subquery_correlation_vars` needs exactly this rule and already stated it almost verbatim in its own comment, as an inline `matches!` allow-list that was flat (no container recursion) and blunt about UNION (simply absent). Both call sites now share the helper. Worth flagging that `collect_guaranteed_vars` is *not* this despite the name — it's plain `produced_vars` with the intersection done at its call site.
- **Detection recurses, and is a separate notion from accumulation.** `left_join_introduced_vars` walks preceding containers, so an OPTIONAL nested in a `GRAPH`/`SERVICE`/`UNION` raises the barrier too. It deliberately does *not* include a UNION that merely binds a variable on one branch, because `Join` is commutative: a VALUES hoisted past a UNION still meets the other branch's rows unbound and they still adopt the value. Branch intersection separates the two exactly — `{?f} UNION {?f}` keeps its seed (it really is must-bound), `{?f} UNION {?e}` raises the barrier.
- **The barrier had to become positional.** This one surprised me: with must-bind alone the plan is *still* wrong. `required_vars` is a variable-readiness test, so a sibling UNION branch binding the same variable satisfies it and drains the VALUES before the OPTIONAL has been placed at all. `after_indices` names the blocking patterns and `drain_ready_deferred` holds the VALUES until they're placed.

#### `UNDEF` is the second may-bind spelling, and it's the motivating one

`Pattern::Values` is itself may-bind, and it was the last variant the arm misclassified. Both surfaces lower `UNDEF` to `Binding::Unbound` — SPARQL in `lower_values_pattern`, JSON-LD in `lower_values_cell` — so an all-`UNDEF` column binds its variable in *no* row while `produced_vars` still reports it. That reproduces the fabrication with no UNION anywhere:

```sparql
?s schema:name ?name .
VALUES (?s ?f) { (ex:alice UNDEF) (ex:cam UNDEF) (ex:liam UNDEF) (ex:brian UNDEF) (ex:nikola UNDEF) }
OPTIONAL { ?s ex:friend ?f }
VALUES ?f { ex:alice }
```

The leading table recorded `?f` as required-bound, the barrier didn't fire, and the trailing VALUES seeded: **5 rows including `["ex:alice","ex:alice"]`**, whose only `ex:friend` is `ex:brian`. The reference answer is 4. This is not a synthetic corner — a placeholder `UNDEF` column is exactly the parameterized-query idiom #1690 names as its motivating usage, which makes it the shape most likely to be hit in the wild.

`must_bind_vars` now counts only the columns with no `Unbound` cell, so `?s` stays required-bound and `?f` correctly does not. A zero-row table stays vacuously must-bind on every column — it emits no solutions at all, and the missing-predicate sentinels in `parse/lower.rs` and `empty_path_result` are both that shape. Cypher's WITH-pipeline binders never emit `Unbound`, so the narrowing cannot reach the `self_produced` set `subquery_correlation_vars` builds for them.

**This one is a plan-shape fix only, and the test says so.** With the arm the trailing VALUES lands above the left join as it must — and the answer becomes 8 rows *still* carrying the fabricated one, because #1713 bites the same query (below). Same posture as the UNION shape: `an_undef_values_column_does_not_suppress_the_barrier` asserts the physical plan, not the rows.

#### `Bind` is a deliberate exception, and the contract says so

`Pattern::Bind` is may-bind for the same reason — `bind.rs` yields `Binding::Unbound` when the expression errors — and a BIND-then-OPTIONAL lead can fabricate the same way a UNION lead does. `must_bind_vars` counts it anyway, because `subquery_correlation_vars` needs it counted: a variable the subquery produces through a WITH-pipeline binder must not be read as an external correlation, or the subquery is deferred on a variable only it can bind. That is the one concept where the two call sites genuinely want different answers, and it's resolved in the correlation site's favour.

So the doc comment states it as an exception rather than as an unconditional contract, and names which site depends on it. The helper's whole value is that a future reader trusts it, and "one relation over one concept" would otherwise read as an invariant — someone tightening `Bind` here on the strength of it would quietly break subquery correlation. It needs a fix at both sites or at neither.

## Two things here are load-bearing and shouldn't be simplified away

**1. This isn't an open semantics question.** `testsuite-sparql/rdf-tests/sparql/sparql11/bindings/values07` is exactly this shape (`?s ?p1 ?o1 . OPTIONAL { ?s foaf:knows ?o2 } } VALUES (?o2) { (:b) }`), it isn't in the skip register, and its `.srx` pins the answer at 5 rows. It has been passing all along — because it uses the *post-query* spelling (`} VALUES …`), which we already plan correctly. So the correct behaviour existed in-engine on the sibling path the entire time; this PR just makes the in-group spelling agree with it, and there's now a test asserting the two spellings return the same rows on the same data.

**2. `FILTER` is *not* the equivalent rewrite, and a "drop the unbound rows" fix would be wrong.** Per SPARQL 1.1 §18.2.4 this stays `Join(…, ToMultiSet(data))`, and Join keeps a solution when the two mappings are **compatible** — which, for a variable the OPTIONAL left **UNBOUND**, is trivially true. Those rows **survive and adopt the VALUES binding**. `FILTER(?b = :B)` evaluates to a type error on an unbound `?b` and drops the row; VALUES adopts it. The distinction is invisible on a fixture where every row has the variable bound, which is exactly why an over-fix here would look green — so the tests pin all three outcomes on one fixture:

| driving row | OPTIONAL bound `?f` to | outcome |
|---|---|---|
| `ex:cam`, `ex:liam` | `ex:alice` | kept, with the binding the data gave them |
| `ex:alice` | `ex:brian` | dropped |
| `ex:brian`, `ex:nikola` | *nothing — no `ex:friend` at all* | **kept, and adopts `ex:alice`** |

`trailing_values_is_a_join_not_a_filter` asserts **both** answer sets exactly rather than just asserting they differ. An `assert_ne!` between the two is vacuous here — the pre-fix VALUES answer is *also* unequal to the FILTER answer, so it passes with the barrier fully reverted. Pinning both sets exactly goes red under that mutation.

## A second, pre-existing defect this deliberately doesn't fix

Two of the shapes above are planned correctly by this PR and *still* answer wrong, for a second and unrelated reason. The rows they return are the *faithful* §18.2.4 join of a wrong input.

The clearest statement of it needs no VALUES-after-OPTIONAL at all:

```sparql
SELECT ?s ?f WHERE { ?s schema:name ?name .
  VALUES (?s ?f) { (ex:alice UNDEF) (ex:cam UNDEF) (ex:liam UNDEF) (ex:brian UNDEF) (ex:nikola UNDEF) }
  OPTIONAL { ?s ex:friend ?f } }
```

returns **8 rows — the correct multiplicity — with `?f` `null` on every single one.** Delete the VALUES line and the same query returns those 8 rows with `?f` bound on 6 of them (`ex:alice`→`ex:brian`, `ex:cam`→`ex:alice`/`ex:brian`, `ex:liam`→`ex:alice`/`ex:brian`/`ex:cam`, and `ex:brian`/`ex:nikola` genuinely unbound). So the OPTIONAL *did* match the triples — the row count proves it — and then didn't write the binding, because `?f` was already present in the row as `Unbound`. That is stronger than "the left join is a no-op": the join happened and the result was discarded.

The UNION spelling is the same defect through a third door:

```sparql
SELECT ?s ?f WHERE { ?s schema:name ?name .
  { { ?s ex:friend ?f } UNION { ?s schema:age ?age } }
  OPTIONAL { ?s ex:friend ?f } }
```

returns **10 rows — byte-identical to the same query with the `OPTIONAL` deleted**, where §18.2.4 says 13. I verified both on **pristine `a824bbfd1`** with `planner.rs` and `where_plan.rs` reverted — no part of this PR present — and they reproduce identically. Neither can be this PR by construction: the second query contains no `Pattern::Values` and no subquery, so neither the barrier nor `must_bind_vars` is reached.

This looks like the `nested-opt-1`/`nested-opt-2`/`join-scope-1` correlated-OPTIONAL-independence cluster already registered as a known divergence. It's filed as #1713 and I'd rather not widen this PR into it. The consequence: `a_union_binding_the_var_does_not_suppress_the_barrier` and `an_undef_values_column_does_not_suppress_the_barrier` assert the **plan shape**, not the rows, and say why in the tests — pinning rows there would pin the other defect's output. The row-level §18.2.4 contract is carried by the tests whose inputs are correct.

## Tests

- `planner.rs` — `values_after_optional_is_not_hoisted_above_it`; `union_may_bind_does_not_suppress_the_optional_barrier` and `an_undef_column_does_not_suppress_the_optional_barrier` (the two may-bind hazards above); `pure_union_without_an_optional_keeps_the_values_seed` and `a_bound_values_column_still_seeds_past_an_optional` (the over-fire direction — `{?f} UNION {?f}` and a fully-bound VALUES column must both keep the seed); `optional_nested_in_a_preceding_graph_still_raises_the_barrier`; `values_before_optional_still_seeds`; `values_on_a_required_var_still_seeds_past_an_optional` (the carve-out that protects the UNWIND-cliff seed); `subquery_conditionally_bound_output_stays_below_the_subquery`.
- `where_plan.rs` — `values_after_optional_builds_above_the_optional`, the physical-plan pin via `Operator::describe`, so a future reorder change can't silently reintroduce this without a plan-shape failure.
- `it_query_values.rs` — `trailing_values_over_an_optional_var_joins_instead_of_seeding` (asserts the fabricated `["ex:alice","ex:alice"]` row is absent, then pins the exact 4-row answer), `in_group_values_matches_the_post_query_spelling`, `trailing_values_is_a_join_not_a_filter`, `a_union_binding_the_var_does_not_suppress_the_barrier`, `an_undef_values_column_does_not_suppress_the_barrier`, `a_subquery_exposing_an_optional_bound_var_still_joins`, and the JSON-LD twin `jsonld_values_after_optional_joins_instead_of_seeding` per the three-surface parity rule.

One supporting change: `DeferredPattern` gains a `nestable` flag, and `drain_ready_deferred` honours it. Every existing deferral sets `nestable: true`, so those paths are byte-identical; only the barrier sets it `false`. I couldn't actually construct a case that reaches the state it guards — the barriered VALUES can't become ready until the OPTIONAL is placed, at which point `try_nest_deferred` rejects it anyway. It's kept as a cheap invariant guard in case `required_vars` is ever narrowed, and **the doc comment says plainly that it's defensive and untested** so nobody reads the missing test as missing coverage.

**Mutation results**, since "the tests are green" isn't the claim worth making:

| mutation | reddens |
|---|---|
| barrier forced to return no blockers | 4 planner tests + 6 `it_query_values` tests |
| `must_bind_vars` → `produced_vars` (both may-bind bugs) | `union_may_bind_does_not_suppress_the_optional_barrier`, `an_undef_column_does_not_suppress_the_optional_barrier`, and their two `it_query_values` twins |
| the `Values` arm deleted (UNDEF alone) | `an_undef_column_does_not_suppress_the_optional_barrier` + `an_undef_values_column_does_not_suppress_the_barrier`, and nothing else |
| `Values` contributes no must-bind vars (over-fire) | `a_bound_values_column_still_seeds_past_an_optional`, and nothing else |

The last two are the point of the pair: each direction of the `Values` arm is pinned by exactly one test, and neither test goes red under the other's mutation. The carve-out and perf pins (`values_before_optional_still_seeds`, `values_on_a_required_var_still_seeds_past_an_optional`, `pure_union_without_an_optional_keeps_the_values_seed`, `values_seed_beats_disconnected_class_anchor`) stay green under all four, which is what they're for. Two tests are honestly vacuous w.r.t. the barrier and say so in their own comments: both subquery ones, because the correlated-subquery deferral already keeps the VALUES down for that shape — unsound on paper, not reachable in practice, and `must_bind_vars` closes it regardless.

## W3C suite

I did run it — `testsuite-sparql`, `cargo test --test w3c_sparql`, submodule initialised: **36/36 groups green, registers untouched**. Nothing flipped in either direction. `values07` lives in `sparql11_bindings` and was already passing on the post-query spelling, so the fix neither greens a registered failure nor costs a passing test.

Worth saying plainly rather than letting the number imply more than it does: **`values07` is the only file in the entire W3C `bindings/` directory that contains an `OPTIONAL`**, so the suite has never covered the in-group spelling at all. 36/36 means this broke nothing — not that the suite validates the fix. The integration tests are carrying that load on their own.

The suite matters for a second reason here: `subquery_correlation_vars` now shares `must_bind_vars`, which both widens its `self_produced` set (the old inline allow-list excluded `Graph`/`Service`/search adapters outright) and narrows it for an `UNDEF` column. `sparql11_subquery` and `sparql10_query_eval_tests` are the oracle for that, and both are green.

## Gates

- `cargo test -p fluree-db-query --lib` — 1431 passed, 0 failed, 1 ignored
- `cargo test -p fluree-db-api --test grp_query_sparql` — 356 passed, 0 failed
- `cargo test -p fluree-db-api --test grp_query` — 422 passed, 0 failed, 2 ignored
- `cargo test -p fluree-db-api --features native --test it_values_object_bounds` — 9 passed, 0 failed (the #1681 regression file this issue came out of)
- `cargo test -p fluree-db-api --test it_query_explain` — 13 passed, 0 failed
- `testsuite-sparql` `cargo test --test w3c_sparql` — 36 passed, 0 failed
- `cargo clippy -p fluree-db-query -p fluree-db-api --all-targets --no-deps` — clean, zero warnings
- `cargo fmt --all` (root) and `cargo fmt --all -- --check` in `testsuite-sparql` — both clean

Fixes #1690
