### PR TITLE
fix(storage): clamp FileStorage ranged reads to the object, and sweep orphaned .tmp staging files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "tempfile",
  "testcontainers",
  "thiserror 1.0.69",
  "tokio",

--- a/docs/operations/storage.md
+++ b/docs/operations/storage.md
@@ -385,6 +385,37 @@ in place: nameservice head refs and ledger config.
 Configuration details: [Connection config (JSON-LD)](../reference/connection-config-jsonld.md#durability)
 and [Configuration](configuration.md).
 
+### Staging files left by a crash
+
+Because writes stage alongside the destination, a process killed between
+staging the bytes and moving them into place leaves the staged copy behind,
+named `<file>.<pid>.<token>.<seq>.tmp`. These are never served — listings skip
+them, so they can't be read back as content — but they are a full copy of the
+object being written, and a crash loop produces one per attempt.
+
+Opening a file-backed storage reclaims them. The sweep is deliberately timid,
+because in a multi-instance deployment the directory it is walking may have
+another process writing into it right now:
+
+- A staging file carrying **this process's token** is never removed, at any
+  age. In flight and already-leaked look identical from a directory entry.
+- A staging file **modified within the last 24 hours** is never removed. A
+  staging write is a single write of one in-memory buffer, so a day is far past
+  any real one.
+- Anything the sweep can't classify — an unparseable name, an entry it can't
+  stat, an mtime in the future — is kept.
+
+What this does *not* do is coordinate with other processes. It is an age
+heuristic, not a lease: it compares another host's clock against this one's,
+and a foreign staging write that somehow stayed open for over a day would be
+unlinked. Even then nothing is corrupted — on POSIX the writer keeps its open
+descriptor, so only its final rename fails and the write reports an error.
+
+The walk is bounded (100,000 directory entries) and runs at most once per
+directory per process; whatever it doesn't reach is picked up on a later start.
+Set `FLUREE_STORAGE_TMP_SWEEP=0` to skip it entirely — worth doing if you want
+a crash's leftovers preserved for a post-mortem.
+
 ## AWS Storage Details
 
 ### S3 Structure

--- a/docs/operations/storage.md
+++ b/docs/operations/storage.md
@@ -428,6 +428,9 @@ so if the first 100,000 entries it encounters are content, every subsequent
 start re-walks those same entries and the orphans beyond them are never
 reached. That case logs at `warn`; if you see it, raise
 `FLUREE_STORAGE_TMP_SWEEP_BUDGET` past the number of files under the directory.
+That variable only ever *sizes* the walk — an unparseable value, or `0`, keeps
+the 100,000 default rather than meaning "don't walk". Turning the sweep off is
+the other variable's job.
 
 Set `FLUREE_STORAGE_TMP_SWEEP=0` to skip the sweep entirely — worth doing if
 you want a crash's leftovers preserved for a post-mortem.

--- a/docs/operations/storage.md
+++ b/docs/operations/storage.md
@@ -394,9 +394,14 @@ them, so they can't be read back as content — but they are a full copy of the
 object being written, and a crash loop produces one per attempt.
 
 Opening a file-backed storage reclaims them. The sweep is deliberately timid,
-because in a multi-instance deployment the directory it is walking may have
-another process writing into it right now:
+because the directory it walks is shared — by other instances in a
+multi-instance deployment, and by other subsystems even in a single process:
 
+- Only files named the way this backend's own staging writer names them are
+  considered at all. `.tmp` is a suffix, not a namespace — the indexer, the
+  disk cache, the nameservice and the Raft log all stage under it, and the
+  nameservice writes into this same tree. Anything whose name doesn't parse as
+  ours is ignored outright, whatever its age.
 - A staging file carrying **this process's token** is never removed, at any
   age. In flight and already-leaked look identical from a directory entry.
 - A staging file **modified within the last 24 hours** is never removed. A
@@ -411,10 +416,21 @@ and a foreign staging write that somehow stayed open for over a day would be
 unlinked. Even then nothing is corrupted — on POSIX the writer keeps its open
 descriptor, so only its final rename fails and the write reports an error.
 
-The walk is bounded (100,000 directory entries) and runs at most once per
-directory per process; whatever it doesn't reach is picked up on a later start.
-Set `FLUREE_STORAGE_TMP_SWEEP=0` to skip it entirely — worth doing if you want
-a crash's leftovers preserved for a post-mortem.
+The walk runs at most once per directory per process, and is handed to a
+background thread when one is available, so opening a storage never waits on
+it.
+
+It is also bounded, at 100,000 directory entries by default — a walk bounded in
+entries is not bounded in wall-clock on a network mount, where every directory
+read is a round trip. **Exhausting that budget is not a deferral.** The walk
+restarts from the top each time with no cursor and never removes content files,
+so if the first 100,000 entries it encounters are content, every subsequent
+start re-walks those same entries and the orphans beyond them are never
+reached. That case logs at `warn`; if you see it, raise
+`FLUREE_STORAGE_TMP_SWEEP_BUDGET` past the number of files under the directory.
+
+Set `FLUREE_STORAGE_TMP_SWEEP=0` to skip the sweep entirely — worth doing if
+you want a crash's leftovers preserved for a post-mortem.
 
 ## AWS Storage Details
 

--- a/docs/operations/storage.md
+++ b/docs/operations/storage.md
@@ -393,9 +393,13 @@ named `<file>.<pid>.<token>.<seq>.tmp`. These are never served — listings skip
 them, so they can't be read back as content — but they are a full copy of the
 object being written, and a crash loop produces one per attempt.
 
-Opening a file-backed storage reclaims them. The sweep is deliberately timid,
-because the directory it walks is shared — by other instances in a
-multi-instance deployment, and by other subsystems even in a single process:
+Starting a file-backed Fluree instance — opening a connection, or building an
+API client — reclaims them. The sweep is a deliberate startup action, taken
+explicitly by those startup paths: merely constructing a storage handle (as a
+test or an inspection tool might, on a directory it does not own) never
+deletes anything. The sweep is also deliberately timid, because the directory
+it walks is shared — by other instances in a multi-instance deployment, and by
+other subsystems even in a single process:
 
 - Only files named the way this backend's own staging writer names them are
   considered at all. `.tmp` is a suffix, not a namespace — the indexer, the
@@ -404,6 +408,11 @@ multi-instance deployment, and by other subsystems even in a single process:
   ours is ignored outright, whatever its age.
 - A staging file carrying **this process's token** is never removed, at any
   age. In flight and already-leaked look identical from a directory entry.
+  Staging files written by a pre-token build (v4.1.5/v4.1.6) carry a pid where
+  the token now sits, so this rule cannot recognize them as anyone's — for
+  those, the 24-hour rule below is the only protection. The deployment where
+  that matters is a rolling upgrade, with an old-format process still staging
+  into the shared tree.
 - A staging file **modified within the last 24 hours** is never removed. A
   staging write is a single write of one in-memory buffer, so a day is far past
   any real one.
@@ -417,8 +426,7 @@ unlinked. Even then nothing is corrupted — on POSIX the writer keeps its open
 descriptor, so only its final rename fails and the write reports an error.
 
 The walk runs at most once per directory per process, and is handed to a
-background thread when one is available, so opening a storage never waits on
-it.
+background thread when one is available, so startup never waits on it.
 
 It is also bounded, at 100,000 directory entries by default — a walk bounded in
 entries is not bounded in wall-clock on a network mount, where every directory

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -1159,6 +1159,10 @@ fn build_local_storage_from_config(
                 .as_ref()
                 .ok_or_else(|| ApiError::config("File storage requires filePath"))?;
             let storage = FileStorage::new(path.as_ref());
+            // Address-identifier storages are opened at client build — that
+            // is startup, so the startup sweep of crash-orphaned staging
+            // files is taken here explicitly.
+            storage.sweep_orphaned_staging();
             if let Some(key_str) = storage_config.aes256_key.as_ref() {
                 let key = decode_encryption_key_base64(key_str.as_ref())?;
                 let encryption_key = EncryptionKey::new(key, 0);
@@ -2047,6 +2051,11 @@ impl FlureeBuilder {
             .ok_or_else(|| ApiError::config("File storage requires a path"))?;
 
         let storage = FileStorage::new(&path);
+        // Building the instance is startup: reclaim staging files a crash
+        // left behind. Explicit here rather than a side effect of `new`, and
+        // once per base path per process — the nameservice below shares this
+        // tree and needs no sweep of its own.
+        storage.sweep_orphaned_staging();
         let nameservice = FileNameService::new(&path);
         let event_bus = self.resolve_event_bus();
         let notifying =
@@ -2185,6 +2194,10 @@ impl FlureeBuilder {
             .ok_or_else(|| ApiError::config("File storage requires a path"))?;
 
         let file_storage = FileStorage::new(&path);
+        // Startup sweep, before the encryption wrapper hides the concrete
+        // storage. Staging debris is on-disk state, not content, so the
+        // sweep is the same for an encrypted tree.
+        file_storage.sweep_orphaned_staging();
         let encryption_key = EncryptionKey::new(key, 0);
         let key_provider = StaticKeyProvider::new(encryption_key);
         let storage = EncryptedStorage::new(file_storage, key_provider);
@@ -2948,6 +2961,9 @@ impl FlureeBuilder {
                 .clone();
 
             let file_storage = FileStorage::new(path.as_ref());
+            // Client build is startup: take the explicit sweep of
+            // crash-orphaned staging files here, where startup is known.
+            file_storage.sweep_orphaned_staging();
             let base_storage: Arc<dyn Storage> = if let Some(key) = self.encryption_key {
                 let encryption_key = EncryptionKey::new(key, 0);
                 let key_provider = StaticKeyProvider::new(encryption_key);
@@ -4966,10 +4982,15 @@ mod tests {
         assert_eq!(fluree.config.cache.max_mb, 500);
     }
 
+    // A tempdir, not a hardcoded path: `build()` is a startup path, and
+    // startup sweeps crash-orphaned staging files — pointing it at a shared
+    // directory like /tmp/test would have this test unlinking an operator's
+    // stale `.tmp` files.
     #[tokio::test]
     #[cfg(feature = "native")]
     async fn test_fluree_builder_file() {
-        let result = FlureeBuilder::file("/tmp/test")
+        let dir = tempfile::tempdir().unwrap();
+        let result = FlureeBuilder::file(dir.path().to_str().unwrap())
             .without_indexing()
             .parallelism(8)
             .cache_max_mb(1000)
@@ -4978,6 +4999,38 @@ mod tests {
         assert!(result.is_ok());
         let fluree = result.unwrap();
         assert_eq!(fluree.config.parallelism, 8);
+    }
+
+    /// Moving the sweep out of `FileStorage::new` must not cost the builder
+    /// path its sweep: building a file-backed instance is startup, and
+    /// startup reclaims what a crash left behind. Built without a runtime
+    /// (no indexer, no ledger cache — nothing to spawn) so the walk runs
+    /// inline and the assertion cannot race it.
+    #[test]
+    #[cfg(feature = "native")]
+    fn building_a_file_instance_sweeps_orphaned_staging() {
+        let dir = tempfile::tempdir().unwrap();
+        // A stale orphan in the staging format, another process's token,
+        // aged well past the 24h threshold.
+        let orphan = dir.path().join("leaf.json.4242.fedcba9876543210.0.tmp");
+        std::fs::write(&orphan, b"half a leaf").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&orphan)
+            .unwrap()
+            .set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(48 * 3600))
+            .unwrap();
+
+        let _fluree = FlureeBuilder::file(dir.path().to_str().unwrap())
+            .without_indexing()
+            .without_ledger_caching()
+            .build()
+            .unwrap();
+
+        assert!(
+            !orphan.exists(),
+            "the builder startup path lost the staging sweep"
+        );
     }
 
     #[test]

--- a/fluree-db-connection/Cargo.toml
+++ b/fluree-db-connection/Cargo.toml
@@ -37,6 +37,7 @@ aws-config = { workspace = true, optional = true }
 [dev-dependencies]
 tokio = { workspace = true }
 fluree-db-query = { path = "../fluree-db-query" }
+tempfile = "3"
 testcontainers = "0.23"
 aws-sdk-s3 = { workspace = true }
 aws-sdk-dynamodb = { workspace = true }

--- a/fluree-db-connection/src/lib.rs
+++ b/fluree-db-connection/src/lib.rs
@@ -199,6 +199,11 @@ fn create_sync_connection(config: ConnectionConfig) -> Result<ConnectionHandle> 
                     })?;
                 let storage = FileStorage::new(path.as_ref())
                     .with_durability(Durability::resolve(config.index_storage.durability));
+                // Opening a connection is startup, and startup is the layer
+                // that knows it: reclaiming staging files a crash left behind
+                // is an explicit action here, not a side effect of holding a
+                // storage handle.
+                storage.sweep_orphaned_staging();
                 Ok(ConnectionHandle::File { config, storage })
             }
         }
@@ -235,6 +240,11 @@ async fn create_async_connection(config: ConnectionConfig) -> Result<ConnectionH
                     })?;
                 let storage = FileStorage::new(path.as_ref())
                     .with_durability(Durability::resolve(config.index_storage.durability));
+                // Opening a connection is startup, and startup is the layer
+                // that knows it: reclaiming staging files a crash left behind
+                // is an explicit action here, not a side effect of holding a
+                // storage handle.
+                storage.sweep_orphaned_staging();
                 Ok(ConnectionHandle::File { config, storage })
             }
         }
@@ -392,6 +402,12 @@ mod tests {
         );
     }
 
+    // The hardcoded shared path below is safe *only because* constructing a
+    // `FileStorage` touches nothing on disk — the staging sweep is an
+    // explicit startup call (`sweep_orphaned_staging`), taken by
+    // `create_sync_connection` / `create_async_connection`, not by `new`.
+    // When it hung off the constructor, running this test unlinked stale
+    // `.tmp` files an operator had under /tmp/test.
     #[test]
     #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
     fn test_connection_handle_file() {
@@ -400,5 +416,34 @@ mod tests {
             storage: FileStorage::new("/tmp/test"),
         };
         assert!(format!("{handle:?}").contains("FileStorage"));
+    }
+
+    /// The sweep moved out of `FileStorage::new` and into the startup layer,
+    /// so the startup layer has to be seen taking it: opening a file
+    /// connection reclaims what a crash left behind. Sync creation runs
+    /// outside a runtime, so the walk is inline and finished by the time the
+    /// handle exists — no polling.
+    #[test]
+    #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
+    fn file_connection_startup_sweeps_orphaned_staging() {
+        let dir = tempfile::tempdir().unwrap();
+        // A stale orphan in the current staging format, bearing another
+        // process's token, aged well past the 24h threshold.
+        let orphan = dir.path().join("leaf.json.4242.0123456789abcdef.0.tmp");
+        std::fs::write(&orphan, b"half a leaf").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&orphan)
+            .unwrap()
+            .set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(48 * 3600))
+            .unwrap();
+
+        let _handle =
+            create_sync_connection(ConnectionConfig::file(dir.path().to_str().unwrap())).unwrap();
+
+        assert!(
+            !orphan.exists(),
+            "opening a file connection did not sweep a stale staging orphan"
+        );
     }
 }

--- a/fluree-db-core/src/storage.rs
+++ b/fluree-db-core/src/storage.rs
@@ -222,9 +222,19 @@ pub trait StorageRead: Debug + Send + Sync {
     /// gives — absence of bytes is not an error here, and callers distinguish
     /// "no bytes" from "no object" by the `NotFound` error, not by this.
     ///
-    /// Known gap: `S3Storage` returns 416 rather than an empty vec for a start
-    /// past the end. That predates this doc and is tracked in #1712; the
-    /// clamping half of the contract holds on every backend.
+    /// Two known divergences, named so this paragraph stays authoritative
+    /// rather than optimistic — a contract doc that names one exception as if
+    /// it were the only one is how a backend drifts out from under it:
+    ///
+    /// - `S3Storage` returns 416 rather than an empty vec for a start past
+    ///   the end. That predates this doc and is tracked in #1712; the
+    ///   clamping half of the contract holds on every backend.
+    /// - A **zero-length object** reads as `NotFound` from `FileStorage` —
+    ///   the #1599 debris guard treats an empty blob as absent on every read
+    ///   surface, this one included — where `MemoryStorage` and this default
+    ///   implementation return `Ok(vec![])`. Deliberate, and callers relying
+    ///   on the guard want exactly that answer, but it is a divergence in
+    ///   this method's observable behavior all the same.
     ///
     /// The default implementation fetches the full object and slices.
     /// StorageBackends that support native range reads (S3, HTTP) should override

--- a/fluree-db-core/src/storage.rs
+++ b/fluree-db-core/src/storage.rs
@@ -223,7 +223,7 @@ pub trait StorageRead: Debug + Send + Sync {
     /// "no bytes" from "no object" by the `NotFound` error, not by this.
     ///
     /// Known gap: `S3Storage` returns 416 rather than an empty vec for a start
-    /// past the end. That predates this doc and is tracked separately; the
+    /// past the end. That predates this doc and is tracked in #1712; the
     /// clamping half of the contract holds on every backend.
     ///
     /// The default implementation fetches the full object and slices.

--- a/fluree-db-core/src/storage.rs
+++ b/fluree-db-core/src/storage.rs
@@ -213,6 +213,19 @@ pub trait StorageRead: Debug + Send + Sync {
     /// the range, which may be shorter than requested if the object is
     /// smaller than `range.end`.
     ///
+    /// **Clamping is the contract, not an implementation detail.** An
+    /// implementation must size its result from the object, never from the
+    /// width of the range: `mid..u64::MAX` is the established spelling of
+    /// "read to the end" against this trait, so a `range.end` past the object
+    /// is normal input rather than an error. A `range.start` at or past the
+    /// end of the object returns `Ok(vec![])`, the same answer an empty range
+    /// gives — absence of bytes is not an error here, and callers distinguish
+    /// "no bytes" from "no object" by the `NotFound` error, not by this.
+    ///
+    /// Known gap: `S3Storage` returns 416 rather than an empty vec for a start
+    /// past the end. That predates this doc and is tracked separately; the
+    /// clamping half of the contract holds on every backend.
+    ///
     /// The default implementation fetches the full object and slices.
     /// StorageBackends that support native range reads (S3, HTTP) should override
     /// for efficiency.

--- a/fluree-db-core/src/storage/file.rs
+++ b/fluree-db-core/src/storage/file.rs
@@ -112,6 +112,173 @@ fn is_tmp_artifact(name: &str) -> bool {
     name.ends_with(TMP_SUFFIX)
 }
 
+/// The process token embedded in a staging name, for names shaped the way
+/// [`tmp_sibling`] writes them (`<name>.<pid>.<token>.<seq>.tmp`).
+///
+/// Returns `None` for anything else ending in `.tmp` — a file an operator
+/// dropped there, or one written by an older version of this code. The sweep
+/// treats an unparseable name as *not* ours, which is the safe direction: it
+/// still has to clear the age threshold before anything happens to it.
+fn staging_token(name: &str) -> Option<&str> {
+    let rest = name.strip_suffix(TMP_SUFFIX)?;
+    let (head, _seq) = rest.rsplit_once('.')?;
+    let (_prefix, token) = head.rsplit_once('.')?;
+    Some(token)
+}
+
+/// How long a staging file must have gone untouched before a sweep may
+/// reclaim it.
+///
+/// A staging file's entire life is one [`stage_bytes`] call: create, write one
+/// in-memory buffer, optionally fsync, then rename or link immediately. There
+/// is no legitimate case where that takes a long time, which is what makes an
+/// age threshold a sound discriminator here — unlike an index build (#1635),
+/// whose duration grows with the ledger and so can never be bounded by a
+/// constant. A day is orders of magnitude past any real staging write and
+/// swamps NTP-scale clock skew between hosts sharing a mount.
+const STALE_STAGING_AGE: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
+
+/// Directory entries one sweep will look at before giving up.
+///
+/// The walk runs on the construction path, so it must not turn opening a large
+/// volume into a startup stall. Exhausting the budget leaves the rest of the
+/// tree for the next start rather than delaying this one — orphans are inert,
+/// so deferring them costs nothing but the disk they sit on.
+const SWEEP_ENTRY_BUDGET: usize = 100_000;
+
+/// What one sweep did.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct StagingSweep {
+    /// Staging files unlinked.
+    reclaimed: usize,
+    /// Staging files deliberately left alone — this process's own, too young,
+    /// or refusing to be removed.
+    kept: usize,
+    /// The entry budget ran out before the walk finished, so part of the tree
+    /// was never looked at.
+    truncated: bool,
+}
+
+/// Unlink staging files left behind by writes that never finished.
+///
+/// A crash between the `File::create` in [`stage_bytes`] and the rename that
+/// follows leaves a full copy of the object on disk under a `.tmp` name.
+/// `list_prefix` filters those out, so one can never be served as content —
+/// which is also precisely why nothing ever removed them. They accumulate, and
+/// the crash loop that produces them is often a disk-exhaustion crash loop, so
+/// the growth lands on the volume that can least afford it.
+///
+/// # What this will not delete
+///
+/// Storage is shared by more than one process in a multi-instance deployment,
+/// so a sweep that guessed wrong would pull a live writer's file out from under
+/// it. Two rules stop that:
+///
+/// 1. **Never this process's own.** The staging name carries a 64-bit token
+///    drawn once per process, so a name bearing our token is ours — in flight
+///    or already leaked, and a directory entry cannot tell those apart. Both
+///    are left alone. This rule is exact, not a heuristic.
+/// 2. **Never a file touched recently.** Anything modified within `older_than`
+///    is left for whoever is writing it. This rule *is* a heuristic: it reads
+///    the writer's clock through ours, and it assumes no legitimate staging
+///    write stays open that long. See [`STALE_STAGING_AGE`] for why that
+///    assumption holds for staging files specifically.
+///
+/// Anything the sweep cannot classify — a name it cannot parse, an entry it
+/// cannot stat, an mtime in the future — is kept. Every unknown resolves
+/// toward leaving the file alone.
+///
+/// If both rules were somehow beaten, the damage is bounded: on POSIX the
+/// writer keeps its open descriptor, so its `write_all` and `sync_all` still
+/// succeed against the now-unlinked inode and only the final rename fails. The
+/// write reports an error; nothing partial is ever published under a content
+/// address.
+fn sweep_orphaned_staging_files(
+    base: &Path,
+    older_than: std::time::Duration,
+    budget: usize,
+) -> StagingSweep {
+    let mut sweep = StagingSweep::default();
+    let own_token = format!("{:016x}", process_token());
+    let now = std::time::SystemTime::now();
+    let mut budget = budget;
+    let mut dirs = vec![base.to_path_buf()];
+
+    while let Some(dir) = dirs.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if budget == 0 {
+                sweep.truncated = true;
+                return sweep;
+            }
+            budget -= 1;
+
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                dirs.push(entry.path());
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !is_tmp_artifact(&name) {
+                continue;
+            }
+            // Rule 1: ours, whatever its age.
+            if staging_token(&name) == Some(own_token.as_str()) {
+                sweep.kept += 1;
+                continue;
+            }
+            // Rule 2: young enough that someone may still be writing it. An
+            // mtime we cannot read, or one in the future, counts as young —
+            // `duration_since` fails on a future timestamp, and a clock the
+            // sweep does not understand is not grounds for deleting data.
+            let stale = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|m| now.duration_since(m).ok())
+                .is_some_and(|age| age >= older_than);
+            if !stale {
+                sweep.kept += 1;
+                continue;
+            }
+
+            match std::fs::remove_file(entry.path()) {
+                Ok(()) => sweep.reclaimed += 1,
+                // Someone else got there first, or the platform refuses to
+                // unlink a file another process still holds open (Windows).
+                // Both are fine outcomes for a best-effort reclaim.
+                Err(_) => sweep.kept += 1,
+            }
+        }
+    }
+    sweep
+}
+
+/// Base paths this process has already swept.
+///
+/// `FileStorage::new` runs once per connection, once per nameservice and again
+/// for the API's own handle, frequently on the same directory. Only the first
+/// walk can find anything; the rest would re-walk the tree to look at exactly
+/// the files the first one declined to touch.
+fn claim_sweep(base: &Path) -> bool {
+    static SWEPT: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<PathBuf>>> =
+        std::sync::OnceLock::new();
+    SWEPT
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(base.to_path_buf())
+}
+
 /// Write `bytes` to a staging sibling of `path`, returning the staging path.
 ///
 /// Under [`Durability::Sync`] the contents are flushed before returning, so a
@@ -244,11 +411,66 @@ impl FileStorage {
     /// Durability defaults to [`Durability::Sync`], overridable for this
     /// process by [`Durability::ENV_VAR`] or per instance by
     /// [`Self::with_durability`].
+    ///
+    /// Constructing the storage also reclaims staging files orphaned by an
+    /// earlier crash — see [`sweep_orphaned_staging_files`] for what it will
+    /// and will not delete, and [`Self::SWEEP_ENV_VAR`] to turn it off. The
+    /// walk is bounded and runs at most once per base path per process.
     pub fn new(base_path: impl Into<std::path::PathBuf>) -> Self {
+        let base_path = base_path.into();
+        Self::sweep_on_construction(&base_path);
         Self {
-            base_path: base_path.into(),
+            base_path,
             durability: Durability::from_env(),
             fsyncs: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Set to a falsey value (`0`, `false`, `off`, `no`) to skip the
+    /// startup sweep of orphaned staging files.
+    ///
+    /// The escape hatch exists because the sweep walks the storage tree, and
+    /// an operator who knows their volume is enormous — or who wants a crash's
+    /// leftovers preserved for a post-mortem — should be able to say so
+    /// without patching the binary.
+    pub const SWEEP_ENV_VAR: &'static str = "FLUREE_STORAGE_TMP_SWEEP";
+
+    /// Whether [`Self::SWEEP_ENV_VAR`] asks for the sweep to be skipped.
+    fn sweep_disabled_by_env() -> bool {
+        std::env::var(Self::SWEEP_ENV_VAR)
+            .ok()
+            .is_some_and(|v| Self::env_says_off(&v))
+    }
+
+    /// Pure half of [`Self::sweep_disabled_by_env`], so the accepted spellings
+    /// are testable without touching process environment. Same spellings
+    /// [`Durability::ENV_VAR`] accepts — one convention for the whole storage
+    /// backend, not one per switch.
+    fn env_says_off(value: &str) -> bool {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        )
+    }
+
+    /// Reclaim orphaned staging files under `base_path`, at most once per path
+    /// per process.
+    fn sweep_on_construction(base_path: &Path) {
+        if Self::sweep_disabled_by_env() || !claim_sweep(base_path) {
+            return;
+        }
+        let sweep = sweep_orphaned_staging_files(base_path, STALE_STAGING_AGE, SWEEP_ENTRY_BUDGET);
+        // Silence is the normal case, and a startup log line per storage would
+        // be noise. Say something only when there was debris to report or a
+        // walk that did not finish.
+        if sweep.reclaimed > 0 || sweep.truncated {
+            tracing::info!(
+                base_path = %base_path.display(),
+                reclaimed = sweep.reclaimed,
+                kept = sweep.kept,
+                truncated = sweep.truncated,
+                "reclaimed staging files orphaned by an interrupted write"
+            );
         }
     }
 
@@ -855,6 +1077,8 @@ impl StorageCas for FileStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use std::time::{Duration, SystemTime};
 
     fn storage() -> (tempfile::TempDir, FileStorage) {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1264,6 +1488,218 @@ mod tests {
             .filter(|n| is_tmp_artifact(n))
             .collect();
         assert!(leftovers.is_empty(), "staging files left: {leftovers:?}");
+    }
+
+    // ---------------------------------------------------------------------
+    // Orphaned staging files
+    // ---------------------------------------------------------------------
+
+    /// Plant a staging file the way a crashed write would leave one, aged
+    /// `age` by setting its mtime rather than by waiting. `token` stands in
+    /// for the writing process, so a test can plant one that looks like
+    /// another instance's or like our own.
+    fn plant_staging_file(dir: &Path, name: &str, token: &str, age: Duration) -> PathBuf {
+        let path = dir.join(format!("{name}.4242.{token}.0{TMP_SUFFIX}"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(b"half a leaf").unwrap();
+        // Age the file by stamping its mtime, not by sleeping — the threshold
+        // is the thing under test, and a test that waits for a real clock is
+        // both slow and a flake waiting to happen.
+        file.set_modified(SystemTime::now() - age).unwrap();
+        assert!(path.exists());
+        path
+    }
+
+    fn own_token() -> String {
+        format!("{:016x}", process_token())
+    }
+
+    /// A crash between `File::create` and the rename leaves a full copy of the
+    /// object behind, and `list_prefix` hides it from every reader — which is
+    /// exactly why nothing ever removed it. Opening the storage has to.
+    #[test]
+    fn construction_reclaims_an_orphaned_staging_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let orphan = plant_staging_file(
+            &dir.path().join("a/b"),
+            "leaf.json",
+            "0123456789abcdef",
+            STALE_STAGING_AGE * 2,
+        );
+
+        let _storage = FileStorage::new(dir.path());
+
+        assert!(
+            !orphan.exists(),
+            "an orphan older than the threshold survived construction: {}",
+            orphan.display()
+        );
+    }
+
+    /// THE ONE THAT MATTERS. Storage is shared in a multi-instance deployment,
+    /// so a sweep that deletes a staging file another process is still writing
+    /// takes that process's rename out from under it. A file young enough to
+    /// belong to a live write is not the sweep's business at any age policy.
+    #[test]
+    fn construction_leaves_a_live_looking_staging_file_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        // Another instance's token, written a moment ago — the shape of a
+        // write that is in flight right now.
+        let live = plant_staging_file(
+            dir.path(),
+            "commit.json",
+            "fedcba9876543210",
+            Duration::from_secs(0),
+        );
+
+        let _storage = FileStorage::new(dir.path());
+
+        assert!(
+            live.exists(),
+            "the sweep deleted a staging file a concurrent writer may still hold: {}",
+            live.display()
+        );
+    }
+
+    /// A file bearing our own token is either in flight on another task or
+    /// already leaked, and a directory entry cannot tell those apart. Age is
+    /// not allowed to break the tie: even with the threshold at zero, the
+    /// exact rule wins.
+    #[test]
+    fn our_own_staging_file_is_never_reclaimed_however_old() {
+        let dir = tempfile::tempdir().unwrap();
+        let ours = plant_staging_file(
+            dir.path(),
+            "mine.json",
+            &own_token(),
+            STALE_STAGING_AGE * 100,
+        );
+
+        let sweep = sweep_orphaned_staging_files(dir.path(), Duration::ZERO, SWEEP_ENTRY_BUDGET);
+
+        assert!(
+            ours.exists(),
+            "the sweep deleted this process's own staging file: {}",
+            ours.display()
+        );
+        assert_eq!(sweep.reclaimed, 0);
+        assert_eq!(sweep.kept, 1);
+    }
+
+    /// The token in the name is what separates our files from every other
+    /// writer's, so the sweep must read it out of a real `tmp_sibling` name
+    /// rather than a shape a test invented.
+    #[test]
+    fn staging_token_reads_what_tmp_sibling_writes() {
+        let name = tmp_sibling(Path::new("/data/a.json.gz"))
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(staging_token(&name), Some(own_token().as_str()), "{name}");
+
+        // Anything not shaped like a staging name is not ours, which is the
+        // safe answer: it still has to clear the age threshold.
+        assert_eq!(staging_token("plain.tmp"), None);
+        assert_eq!(staging_token("leaf.json"), None);
+        assert_ne!(staging_token("leaf.json.999.0.tmp"), Some(own_token().as_str()));
+    }
+
+    /// The threshold is the only thing standing between a foreign in-flight
+    /// write and deletion, so it has to be the age that decides — not merely
+    /// "is this file ours".
+    #[test]
+    fn only_files_past_the_threshold_are_reclaimed() {
+        let dir = tempfile::tempdir().unwrap();
+        let threshold = Duration::from_secs(3600);
+        let young = plant_staging_file(dir.path(), "young.json", "aaaa", threshold / 2);
+        let old = plant_staging_file(dir.path(), "old.json", "bbbb", threshold * 2);
+
+        let sweep = sweep_orphaned_staging_files(dir.path(), threshold, SWEEP_ENTRY_BUDGET);
+
+        assert!(young.exists(), "a file inside the threshold was reclaimed");
+        assert!(!old.exists(), "a file past the threshold survived");
+        assert_eq!((sweep.reclaimed, sweep.kept), (1, 1));
+    }
+
+    /// An mtime in the future means the writer's clock and ours disagree, and
+    /// a clock the sweep does not understand is not grounds for deleting data.
+    #[test]
+    fn a_future_mtime_is_treated_as_live() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(format!("skewed.json.7.cccc.0{TMP_SUFFIX}"));
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(b"partial").unwrap();
+        file.set_modified(SystemTime::now() + Duration::from_secs(3600))
+            .unwrap();
+
+        let sweep = sweep_orphaned_staging_files(dir.path(), Duration::ZERO, SWEEP_ENTRY_BUDGET);
+
+        assert!(path.exists(), "a future-dated staging file was reclaimed");
+        assert_eq!((sweep.reclaimed, sweep.kept), (0, 1));
+    }
+
+    /// Content is not staging debris. The sweep must not touch a real object
+    /// however old it is — content-addressed blobs are written once and then
+    /// sit there for the life of the ledger.
+    #[tokio::test]
+    async fn the_sweep_never_touches_content() {
+        let (dir, storage) = storage();
+        storage.write_bytes("a/b/real.json", b"content").await.unwrap();
+        let real = storage.resolve_path("a/b/real.json").unwrap();
+        // `futimens` needs a writable descriptor, so this cannot be a plain
+        // `File::open`.
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&real)
+            .unwrap()
+            .set_modified(SystemTime::now() - STALE_STAGING_AGE * 10)
+            .unwrap();
+
+        let sweep = sweep_orphaned_staging_files(dir.path(), Duration::ZERO, SWEEP_ENTRY_BUDGET);
+
+        assert_eq!(sweep.reclaimed, 0, "the sweep reclaimed real content");
+        assert_eq!(storage.read_bytes("a/b/real.json").await.unwrap(), b"content");
+    }
+
+    /// The walk is on the construction path, so a huge volume must not turn
+    /// opening a ledger into a startup stall. Running out of budget stops the
+    /// walk and says so, rather than running to completion.
+    #[test]
+    fn the_walk_is_bounded_by_its_entry_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..8 {
+            plant_staging_file(dir.path(), &format!("o{i}.json"), "dddd", STALE_STAGING_AGE * 2);
+        }
+
+        let sweep = sweep_orphaned_staging_files(dir.path(), Duration::ZERO, 3);
+
+        assert!(sweep.truncated, "the budget did not stop the walk");
+        assert_eq!(sweep.reclaimed, 3, "the walk went past its budget");
+    }
+
+    /// One walk per base path per process. `FileStorage::new` runs once per
+    /// connection, once per nameservice and again for the API's own handle,
+    /// often on the same directory; re-walking the tree each time would only
+    /// re-examine the files the first walk declined to touch.
+    #[test]
+    fn a_base_path_is_swept_at_most_once_per_process() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(claim_sweep(dir.path()), "first claim must win");
+        assert!(!claim_sweep(dir.path()), "second claim must be refused");
+    }
+
+    /// Same spellings the durability switch accepts — one convention for the
+    /// storage backend, not one per environment variable.
+    #[test]
+    fn sweep_env_var_accepts_the_durability_spellings() {
+        for v in ["0", "false", "off", "no", "OFF", " false "] {
+            assert!(FileStorage::env_says_off(v), "{v:?}");
+        }
+        for v in ["1", "true", "on", "", "nonsense"] {
+            assert!(!FileStorage::env_says_off(v), "{v:?}");
+        }
     }
 
     /// Write a zero-length file directly, bypassing the storage API — which is

--- a/fluree-db-core/src/storage/file.rs
+++ b/fluree-db-core/src/storage/file.rs
@@ -112,9 +112,23 @@ fn is_tmp_artifact(name: &str) -> bool {
     name.ends_with(TMP_SUFFIX)
 }
 
-/// A run of ASCII digits — a pid or a sequence number.
-fn is_ascii_digits(s: &str) -> bool {
-    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
+/// A decimal number written the way this backend writes one: digits, and no
+/// leading zeros.
+///
+/// The zero-padding rule is free — `std::process::id()` and a `fetch_add`
+/// counter never produce a padded number, so nothing we emit is excluded — and
+/// it narrows what the legacy branch below will admit. `backup.2026.08.tmp` and
+/// `wal.000001.000002.tmp` are the shape of a foreign file that would otherwise
+/// read as `<name>.<pid>.<seq>.tmp`.
+fn is_plain_decimal(s: &str) -> bool {
+    match s.as_bytes() {
+        [] => false,
+        // A sequence number legitimately starts at zero; `00` does not.
+        [b'0'] => true,
+        [first, rest @ ..] => {
+            first.is_ascii_digit() && *first != b'0' && rest.iter().all(u8::is_ascii_digit)
+        }
+    }
 }
 
 /// The 16 lowercase hex digits [`tmp_sibling`] formats a process token as.
@@ -137,9 +151,21 @@ fn is_process_token(s: &str) -> bool {
 ///
 /// Both formats this backend has ever written parse: the current one, and the
 /// pre-`b0a9c416a` `<name>.<pid>.<seq>.tmp`, whose pid lands in the token
-/// position and is accepted as digits. Every segment is shape-checked, so a
-/// foreign name that merely happens to have enough dots in it (`a.b.c.tmp`)
-/// does not slip through on arity alone.
+/// position and is accepted as a decimal. **That branch is load-bearing, not
+/// legacy politeness** — staging writes arrived in `85183c9ca`, which is
+/// contained in v4.1.5 and v4.1.6, so every store written by a currently
+/// released build produces orphans in that format. Dropping it would strand
+/// them on disk forever.
+///
+/// Every segment is shape-checked, so a foreign name that merely happens to
+/// have enough dots in it (`a.b.c.tmp`) does not slip through on arity alone.
+///
+/// Residual: the legacy branch still admits a foreign name shaped
+/// `<non-empty>.<decimal>.<decimal>.tmp` — `dump.1.2.tmp` parses. No in-tree
+/// `.tmp` producer emits that shape, so this is an operator's own file rather
+/// than a collision with anything we ship, and narrowing it further means
+/// gating legacy reclaim behind an opt-in, which is an upgrade-behavior
+/// decision rather than a parser one.
 ///
 /// Returns `None` for anything else. That is the safe direction in the only
 /// sense that matters: failing to reclaim an orphan wastes disk, and reclaiming
@@ -150,10 +176,10 @@ fn staging_token(name: &str) -> Option<&str> {
     let (prefix, token) = head.rsplit_once('.')?;
     // There has to be a destination name in front of the pid, or this is some
     // other file that merely ends in `.tmp`.
-    if prefix.is_empty() || !is_ascii_digits(seq) {
+    if prefix.is_empty() || !is_plain_decimal(seq) {
         return None;
     }
-    if is_process_token(token) || is_ascii_digits(token) {
+    if is_process_token(token) || is_plain_decimal(token) {
         Some(token)
     } else {
         None
@@ -532,6 +558,12 @@ impl FileStorage {
     /// An unrecognized value keeps the default rather than guessing, matching
     /// how `Durability::parse` treats a typo — a mistyped budget should not
     /// quietly turn the sweep into a no-op.
+    ///
+    /// Note that includes `0`, which therefore means [`SWEEP_ENTRY_BUDGET`] and
+    /// *not* "don't walk", even though it reads like the latter. Turning the
+    /// sweep off is [`Self::SWEEP_ENV_VAR`]'s job: a budget of zero would be a
+    /// second, sideways spelling of off, and one switch per decision is the
+    /// whole reason these are two variables.
     fn parse_budget(value: Option<&str>) -> usize {
         value
             .and_then(|v| v.trim().parse::<usize>().ok())
@@ -1749,6 +1781,47 @@ mod tests {
         assert_eq!(staging_token(".4242.7.tmp"), None, "no destination name");
         assert_eq!(staging_token("plain.tmp"), None);
         assert_eq!(staging_token("leaf.json"), None);
+
+        // Zero-padded numbers are not something this backend emits, and
+        // rejecting them is what keeps date- and offset-stamped foreign files
+        // out of the legacy branch.
+        assert_eq!(staging_token("backup.2026.08.tmp"), None);
+        assert_eq!(staging_token("wal.000001.000002.tmp"), None);
+        // ...while a sequence number legitimately starting at zero still parses.
+        assert_eq!(staging_token("leaf.json.999.0.tmp"), Some("999"));
+        assert_eq!(staging_token("leaf.json.999.00.tmp"), None);
+    }
+
+    /// The staging name is built from a caller-supplied destination, so the
+    /// shape check must not reject the odd but legal names a real ledger
+    /// produces. Driven through `tmp_sibling` itself so it cannot drift.
+    #[test]
+    fn the_shape_check_accepts_every_destination_name_we_can_stage() {
+        for destination in [
+            "leaf",
+            "a.json.gz",
+            "many.dots.in.here.json",
+            ".hidden",
+            "UPPER.JSON",
+            "with space.json",
+            "ünïcødé.json",
+            "trailing.",
+            "4242",
+            "0123456789abcdef",
+            "-",
+            "_",
+        ] {
+            let name = tmp_sibling(Path::new("/data").join(destination).as_path())
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_string();
+            assert_eq!(
+                staging_token(&name),
+                Some(own_token().as_str()),
+                "{destination:?} staged as {name:?} and was not recognised as ours"
+            );
+        }
     }
 
     /// THE OTHER ONE THAT MATTERS. `.tmp` is a suffix, not a namespace: the
@@ -1850,13 +1923,26 @@ mod tests {
 
     /// Without a runtime there is nothing to hand the walk to, and a plain
     /// synchronous caller can afford to block — so it runs inline and is
-    /// finished by the time `new` returns.
+    /// *finished* by the time construction returns. Asserting the orphan is
+    /// already gone is the part that carries the coverage; `is_none()` alone
+    /// would also be satisfied by a sweep that never ran.
     #[test]
     fn the_walk_runs_inline_without_a_runtime() {
         let dir = tempfile::tempdir().unwrap();
+        let orphan = plant_staging_file(
+            dir.path(),
+            "leaf.json",
+            "fedcba9876543210",
+            STALE_STAGING_AGE * 2,
+        );
+
         assert!(
             FileStorage::sweep_on_construction(dir.path()).is_none(),
             "no runtime, so there is no task to return"
+        );
+        assert!(
+            !orphan.exists(),
+            "the inline sweep had not finished when construction returned"
         );
     }
 

--- a/fluree-db-core/src/storage/file.rs
+++ b/fluree-db-core/src/storage/file.rs
@@ -1603,7 +1603,10 @@ mod tests {
         // safe answer: it still has to clear the age threshold.
         assert_eq!(staging_token("plain.tmp"), None);
         assert_eq!(staging_token("leaf.json"), None);
-        assert_ne!(staging_token("leaf.json.999.0.tmp"), Some(own_token().as_str()));
+        assert_ne!(
+            staging_token("leaf.json.999.0.tmp"),
+            Some(own_token().as_str())
+        );
     }
 
     /// The threshold is the only thing standing between a foreign in-flight
@@ -1646,7 +1649,10 @@ mod tests {
     #[tokio::test]
     async fn the_sweep_never_touches_content() {
         let (dir, storage) = storage();
-        storage.write_bytes("a/b/real.json", b"content").await.unwrap();
+        storage
+            .write_bytes("a/b/real.json", b"content")
+            .await
+            .unwrap();
         let real = storage.resolve_path("a/b/real.json").unwrap();
         // `futimens` needs a writable descriptor, so this cannot be a plain
         // `File::open`.
@@ -1660,7 +1666,10 @@ mod tests {
         let sweep = sweep_orphaned_staging_files(dir.path(), Duration::ZERO, SWEEP_ENTRY_BUDGET);
 
         assert_eq!(sweep.reclaimed, 0, "the sweep reclaimed real content");
-        assert_eq!(storage.read_bytes("a/b/real.json").await.unwrap(), b"content");
+        assert_eq!(
+            storage.read_bytes("a/b/real.json").await.unwrap(),
+            b"content"
+        );
     }
 
     /// The walk is on the construction path, so a huge volume must not turn
@@ -1670,7 +1679,12 @@ mod tests {
     fn the_walk_is_bounded_by_its_entry_budget() {
         let dir = tempfile::tempdir().unwrap();
         for i in 0..8 {
-            plant_staging_file(dir.path(), &format!("o{i}.json"), "dddd", STALE_STAGING_AGE * 2);
+            plant_staging_file(
+                dir.path(),
+                &format!("o{i}.json"),
+                "dddd",
+                STALE_STAGING_AGE * 2,
+            );
         }
 
         let sweep = sweep_orphaned_staging_files(dir.path(), Duration::ZERO, 3);

--- a/fluree-db-core/src/storage/file.rs
+++ b/fluree-db-core/src/storage/file.rs
@@ -416,11 +416,10 @@ impl StorageRead for FileStorage {
         if range.end <= range.start {
             return Ok(Vec::new());
         }
-        let len = (range.end - range.start) as usize;
+        let requested = range.end - range.start;
         let offset = range.start;
         let address = address.to_owned();
         tokio::task::spawn_blocking(move || {
-            let mut buf = vec![0u8; len];
             let file = std::fs::File::open(&path).map_err(|e| {
                 if e.kind() == std::io::ErrorKind::NotFound {
                     crate::error::Error::not_found(format!("{}: {}", address, path.display()))
@@ -428,6 +427,17 @@ impl StorageRead for FileStorage {
                     crate::error::Error::io(format!("Failed to open {}: {}", path.display(), e))
                 }
             })?;
+            // One stat off the open handle, serving both the zero-length guard
+            // and the clamp below: no extra syscall, and no window between the
+            // check and the read. `fstat` on a descriptor this thread owns does
+            // not fail in practice; if it ever did there would be nothing to
+            // size the read against, and saying so beats guessing a length.
+            let file_len = file
+                .metadata()
+                .map_err(|e| {
+                    crate::error::Error::io(format!("Failed to stat {}: {}", path.display(), e))
+                })?
+                .len();
             // The fourth read path, held to the same rule as the other three:
             // an empty file at a content address is debris, not content. A
             // ranged read would otherwise stop at EOF and hand back an empty
@@ -435,9 +445,8 @@ impl StorageRead for FileStorage {
             // replace with "absent". This arm is not hypothetical: once
             // `resolve_local_path` refuses the debris, the leaflet reader
             // falls through to `ContentStore::get_range`, which lands here for
-            // the very same file. Read off the open handle, so there is no
-            // extra stat and no window between the check and the read.
-            if file.metadata().map(|m| m.len() == 0).unwrap_or(false) {
+            // the very same file.
+            if file_len == 0 {
                 tracing::warn!(
                     address,
                     path = %path.display(),
@@ -450,6 +459,19 @@ impl StorageRead for FileStorage {
                     path.display()
                 )));
             }
+            // SIZE THE BUFFER FROM THE OBJECT, NOT FROM THE RANGE. The trait
+            // documents a ranged read as returning bytes that "may be shorter
+            // than requested if the object is smaller than `range.end`", and
+            // `mid..u64::MAX` is the established spelling of "read to the end"
+            // against it. Trusting the range's width made that spelling a
+            // `usize::MAX` allocation — a capacity-overflow panic that
+            // `spawn_blocking` caught and relabelled `Io("spawn_blocking
+            // failed: ...")`, so the one backend that could not serve the call
+            // was also the one that could not say why. The loops below already
+            // stop at EOF, so a range that fits reads exactly as before; this
+            // only stops the allocation from believing the caller.
+            let len = requested.min(file_len.saturating_sub(offset)) as usize;
+            let mut buf = vec![0u8; len];
             #[cfg(unix)]
             {
                 use std::os::unix::fs::FileExt;
@@ -1341,6 +1363,79 @@ mod tests {
             storage.read_byte_range(address, 0..4).await.unwrap(),
             b"real"
         );
+    }
+
+    /// `StorageRead::read_byte_range` documents a ranged read as returning
+    /// "the bytes within the range, which may be shorter than requested if the
+    /// object is smaller than `range.end`", and `mid..u64::MAX` is the
+    /// established spelling of "read to the end" against that trait. The
+    /// default implementation, `MemoryStorage` and the proxy (which inherits
+    /// the default) all clamp; this backend sized its buffer from the range's
+    /// width instead, so the same call allocated `usize::MAX` and came back as
+    /// `Io("spawn_blocking failed: task panicked ... capacity overflow")`.
+    #[tokio::test]
+    async fn an_open_ended_range_is_clamped_to_the_object() {
+        let (_dir, storage) = storage();
+        storage
+            .write_bytes("z/clamp.dict", b"hello world")
+            .await
+            .unwrap();
+
+        let tail = storage
+            .read_byte_range("z/clamp.dict", 6..u64::MAX)
+            .await
+            .expect("open-ended range must clamp like every other backend");
+        assert_eq!(tail, b"world");
+
+        // From the top, too — the whole object, not a `usize::MAX` buffer.
+        let all = storage
+            .read_byte_range("z/clamp.dict", 0..u64::MAX)
+            .await
+            .expect("open-ended range from zero must clamp");
+        assert_eq!(all, b"hello world");
+
+        // A start past the end is empty, matching the default implementation
+        // rather than erroring.
+        assert!(storage
+            .read_byte_range("z/clamp.dict", 99..u64::MAX)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    /// The clamp must agree with the backend every caller compares against.
+    /// Same bytes, same ranges, same answers — that is the whole point of the
+    /// shared trait.
+    #[tokio::test]
+    async fn ranged_reads_match_the_memory_backend() {
+        let (_dir, file) = storage();
+        let memory = crate::storage::memory::MemoryStorage::new();
+        let bytes = b"the quick brown fox".as_slice();
+        file.write_bytes("z/same.dict", bytes).await.unwrap();
+        memory.write_bytes("z/same.dict", bytes).await.unwrap();
+
+        for range in [
+            0..u64::MAX,
+            4..u64::MAX,
+            0..4,
+            4..9,
+            0..1000,
+            18..1000,
+            19..u64::MAX,
+            50..60,
+            5..5,
+        ] {
+            assert_eq!(
+                file.read_byte_range("z/same.dict", range.clone())
+                    .await
+                    .unwrap_or_else(|e| panic!("file backend refused {range:?}: {e:?}")),
+                memory
+                    .read_byte_range("z/same.dict", range.clone())
+                    .await
+                    .unwrap(),
+                "backends disagree on {range:?}"
+            );
+        }
     }
 
     /// The guard must not fire on legitimate content. A one-byte blob is the

--- a/fluree-db-core/src/storage/file.rs
+++ b/fluree-db-core/src/storage/file.rs
@@ -112,18 +112,52 @@ fn is_tmp_artifact(name: &str) -> bool {
     name.ends_with(TMP_SUFFIX)
 }
 
-/// The process token embedded in a staging name, for names shaped the way
-/// [`tmp_sibling`] writes them (`<name>.<pid>.<token>.<seq>.tmp`).
+/// A run of ASCII digits — a pid or a sequence number.
+fn is_ascii_digits(s: &str) -> bool {
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// The 16 lowercase hex digits [`tmp_sibling`] formats a process token as.
+fn is_process_token(s: &str) -> bool {
+    s.len() == 16
+        && s.bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+/// The process token embedded in a staging name, for names shaped exactly the
+/// way [`tmp_sibling`] writes them (`<name>.<pid>.<token>.<seq>.tmp`).
 ///
-/// Returns `None` for anything else ending in `.tmp` — a file an operator
-/// dropped there, or one written by an older version of this code. The sweep
-/// treats an unparseable name as *not* ours, which is the safe direction: it
-/// still has to clear the age threshold before anything happens to it.
+/// **This is the sweep's admission test, not a convenience.** `.tmp` is a
+/// suffix, not a namespace: the indexer's vocab merge, the disk cache, the
+/// nameservice's tracking file and the Raft log all stage under it, and the
+/// nameservice shares the swept tree by construction (`FileNameService::new`
+/// builds a `FileStorage` on the path `FlureeBuilder::build` also hands to
+/// storage). Recognizing our own naming — rather than trusting the extension —
+/// is the only thing keeping this sweep off their files.
+///
+/// Both formats this backend has ever written parse: the current one, and the
+/// pre-`b0a9c416a` `<name>.<pid>.<seq>.tmp`, whose pid lands in the token
+/// position and is accepted as digits. Every segment is shape-checked, so a
+/// foreign name that merely happens to have enough dots in it (`a.b.c.tmp`)
+/// does not slip through on arity alone.
+///
+/// Returns `None` for anything else. That is the safe direction in the only
+/// sense that matters: failing to reclaim an orphan wastes disk, and reclaiming
+/// someone else's file loses data.
 fn staging_token(name: &str) -> Option<&str> {
     let rest = name.strip_suffix(TMP_SUFFIX)?;
-    let (head, _seq) = rest.rsplit_once('.')?;
-    let (_prefix, token) = head.rsplit_once('.')?;
-    Some(token)
+    let (head, seq) = rest.rsplit_once('.')?;
+    let (prefix, token) = head.rsplit_once('.')?;
+    // There has to be a destination name in front of the pid, or this is some
+    // other file that merely ends in `.tmp`.
+    if prefix.is_empty() || !is_ascii_digits(seq) {
+        return None;
+    }
+    if is_process_token(token) || is_ascii_digits(token) {
+        Some(token)
+    } else {
+        None
+    }
 }
 
 /// How long a staging file must have gone untouched before a sweep may
@@ -140,10 +174,17 @@ const STALE_STAGING_AGE: std::time::Duration = std::time::Duration::from_secs(24
 
 /// Directory entries one sweep will look at before giving up.
 ///
-/// The walk runs on the construction path, so it must not turn opening a large
-/// volume into a startup stall. Exhausting the budget leaves the rest of the
-/// tree for the next start rather than delaying this one — orphans are inert,
-/// so deferring them costs nothing but the disk they sit on.
+/// A walk bounded in *entries* is not bounded in wall-clock — on the shared
+/// mount this design is written for, each `readdir` is a network round trip —
+/// so the cap stays even though the walk no longer runs on the caller's thread.
+///
+/// **Exhausting it is not a deferral.** The walk restarts from the base path
+/// every time with no cursor, and it never removes content files, so a tree
+/// whose first `SWEEP_ENTRY_BUDGET` entries in traversal order are content will
+/// re-walk those same entries on every start and never reach an orphan beyond
+/// them. That is silent under-delivery, which is why truncation logs at `warn`
+/// and why [`FileStorage::SWEEP_ENV_VAR`] accepts a larger budget: an operator
+/// who sees the warning needs something to do about it.
 const SWEEP_ENTRY_BUDGET: usize = 100_000;
 
 /// What one sweep did.
@@ -171,9 +212,13 @@ struct StagingSweep {
 /// # What this will not delete
 ///
 /// Storage is shared by more than one process in a multi-instance deployment,
-/// so a sweep that guessed wrong would pull a live writer's file out from under
-/// it. Two rules stop that:
+/// and the tree is shared by other *subsystems* even in one process, so a sweep
+/// that guessed wrong would pull a live writer's file out from under it. Three
+/// rules stop that:
 ///
+/// 0. **Never a file this backend's staging writer did not name.** `.tmp` is a
+///    suffix, not a namespace — see [`staging_token`], which is the admission
+///    test. Everything below applies only to names that pass it.
 /// 1. **Never this process's own.** The staging name carries a 64-bit token
 ///    drawn once per process, so a name bearing our token is ours — in flight
 ///    or already leaked, and a directory entry cannot tell those apart. Both
@@ -231,8 +276,20 @@ fn sweep_orphaned_staging_files(
             if !is_tmp_artifact(&name) {
                 continue;
             }
+            // RULE 0, and the one that decides whether the other two are even
+            // asked. `.tmp` is a suffix several subsystems use, some of them
+            // writing into this very tree, so a file only becomes the sweep's
+            // business once its name parses as one *this* writer produced.
+            // Without this, rule 1 protects nothing outside our own naming and
+            // the age heuristic alone stands between every other subsystem's
+            // staging file and an unlink — including the indexer's vocab-merge
+            // temporaries, which are exactly the long-running shape
+            // `STALE_STAGING_AGE` argues an age threshold must not judge.
+            let Some(token) = staging_token(&name) else {
+                continue;
+            };
             // Rule 1: ours, whatever its age.
-            if staging_token(&name) == Some(own_token.as_str()) {
+            if token == own_token.as_str() {
                 sweep.kept += 1;
                 continue;
             }
@@ -269,14 +326,20 @@ fn sweep_orphaned_staging_files(
 /// for the API's own handle, frequently on the same directory. Only the first
 /// walk can find anything; the rest would re-walk the tree to look at exactly
 /// the files the first one declined to touch.
+///
+/// Canonicalized first, so the guarantee is about the *directory* and not about
+/// how a caller spelled it — `/x`, `/x/.` and `/x/` are one base path, not
+/// three. Falls back to the literal path when canonicalization fails (the
+/// directory may not exist yet), which is the pre-existing behaviour.
 fn claim_sweep(base: &Path) -> bool {
     static SWEPT: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<PathBuf>>> =
         std::sync::OnceLock::new();
+    let key = std::fs::canonicalize(base).unwrap_or_else(|_| base.to_path_buf());
     SWEPT
         .get_or_init(Default::default)
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(base.to_path_buf())
+        .insert(key)
 }
 
 /// Write `bytes` to a staging sibling of `path`, returning the staging path.
@@ -414,11 +477,13 @@ impl FileStorage {
     ///
     /// Constructing the storage also reclaims staging files orphaned by an
     /// earlier crash — see [`sweep_orphaned_staging_files`] for what it will
-    /// and will not delete, and [`Self::SWEEP_ENV_VAR`] to turn it off. The
-    /// walk is bounded and runs at most once per base path per process.
+    /// and will not delete, and [`Self::SWEEP_ENV_VAR`] to tune or disable it.
+    /// The walk is bounded, runs at most once per base path per process, and is
+    /// handed to the blocking pool when there is a runtime to hand it to, so
+    /// constructing a storage never waits on it.
     pub fn new(base_path: impl Into<std::path::PathBuf>) -> Self {
         let base_path = base_path.into();
-        Self::sweep_on_construction(&base_path);
+        let _ = Self::sweep_on_construction(&base_path);
         Self {
             base_path,
             durability: Durability::from_env(),
@@ -426,24 +491,55 @@ impl FileStorage {
         }
     }
 
-    /// Set to a falsey value (`0`, `false`, `off`, `no`) to skip the
-    /// startup sweep of orphaned staging files.
+    /// Set to a falsey value (`0`, `false`, `off`, `no`) to skip the startup
+    /// sweep of orphaned staging files.
     ///
-    /// The escape hatch exists because the sweep walks the storage tree, and
-    /// an operator who knows their volume is enormous — or who wants a crash's
-    /// leftovers preserved for a post-mortem — should be able to say so
-    /// without patching the binary.
+    /// The escape hatch exists because the sweep walks the storage tree, and an
+    /// operator who wants a crash's leftovers preserved for a post-mortem
+    /// should be able to say so without patching the binary.
     pub const SWEEP_ENV_VAR: &'static str = "FLUREE_STORAGE_TMP_SWEEP";
 
-    /// Whether [`Self::SWEEP_ENV_VAR`] asks for the sweep to be skipped.
-    fn sweep_disabled_by_env() -> bool {
-        std::env::var(Self::SWEEP_ENV_VAR)
+    /// Overrides [`SWEEP_ENTRY_BUDGET`], the number of directory entries one
+    /// sweep will look at.
+    ///
+    /// Deliberately a *separate* variable rather than an overload of
+    /// [`Self::SWEEP_ENV_VAR`]: `FLUREE_STORAGE_FSYNC=1` means "on", so an
+    /// operator would reasonably write `FLUREE_STORAGE_TMP_SWEEP=1` meaning the
+    /// same — and if that spelling were read as a budget it would silently mean
+    /// "look at one entry", which is off wearing a disguise. One variable, one
+    /// job.
+    ///
+    /// This exists so the truncation warning has a remedy attached. A warning
+    /// an operator cannot act on is just noise.
+    pub const SWEEP_BUDGET_ENV_VAR: &'static str = "FLUREE_STORAGE_TMP_SWEEP_BUDGET";
+
+    /// The entry budget for a sweep, or `None` to skip it entirely.
+    fn sweep_budget_from_env() -> Option<usize> {
+        if std::env::var(Self::SWEEP_ENV_VAR)
             .ok()
             .is_some_and(|v| Self::env_says_off(&v))
+        {
+            return None;
+        }
+        Some(Self::parse_budget(
+            std::env::var(Self::SWEEP_BUDGET_ENV_VAR).ok().as_deref(),
+        ))
     }
 
-    /// Pure half of [`Self::sweep_disabled_by_env`], so the accepted spellings
-    /// are testable without touching process environment. Same spellings
+    /// Pure half of the budget lookup, so the accepted spellings are testable
+    /// without touching process environment.
+    ///
+    /// An unrecognized value keeps the default rather than guessing, matching
+    /// how `Durability::parse` treats a typo — a mistyped budget should not
+    /// quietly turn the sweep into a no-op.
+    fn parse_budget(value: Option<&str>) -> usize {
+        value
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(SWEEP_ENTRY_BUDGET)
+    }
+
+    /// Whether a value spells one of the falsey settings. Same spellings
     /// [`Durability::ENV_VAR`] accepts — one convention for the whole storage
     /// backend, not one per switch.
     fn env_says_off(value: &str) -> bool {
@@ -455,21 +551,59 @@ impl FileStorage {
 
     /// Reclaim orphaned staging files under `base_path`, at most once per path
     /// per process.
-    fn sweep_on_construction(base_path: &Path) {
-        if Self::sweep_disabled_by_env() || !claim_sweep(base_path) {
-            return;
+    ///
+    /// Returns the spawned task when the walk was handed to the blocking pool,
+    /// so a test can await it. Production ignores it — the sweep is best-effort
+    /// and nothing waits on the result.
+    fn sweep_on_construction(base_path: &Path) -> Option<tokio::task::JoinHandle<()>> {
+        let budget = Self::sweep_budget_from_env()?;
+        if !claim_sweep(base_path) {
+            return None;
         }
-        let sweep = sweep_orphaned_staging_files(base_path, STALE_STAGING_AGE, SWEEP_ENTRY_BUDGET);
-        // Silence is the normal case, and a startup log line per storage would
-        // be noise. Say something only when there was debris to report or a
-        // walk that did not finish.
-        if sweep.reclaimed > 0 || sweep.truncated {
+        let base = base_path.to_path_buf();
+        // A RECURSIVE `read_dir` IS BLOCKING I/O, AND `new` IS REACHABLE FROM
+        // ASYNC CONNECTION SETUP (`create_async_connection`, and
+        // `build_from_config`'s async path), so running it here would park a
+        // runtime worker for the whole walk — measured at ~1s warm on local
+        // APFS for the default budget, and a readdir on the shared mount this
+        // design targets is a network round trip rather than a page-cache hit.
+        // #1620 asked for the walk to be bounded *or* backgrounded; it is worth
+        // being both.
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => Some(handle.spawn_blocking(move || Self::run_sweep(&base, budget))),
+            // No runtime: a plain synchronous caller (`create_sync_connection`),
+            // which can afford to block on its own thread.
+            Err(_) => {
+                Self::run_sweep(&base, budget);
+                None
+            }
+        }
+    }
+
+    /// The walk itself, plus what it reports.
+    fn run_sweep(base_path: &Path, budget: usize) {
+        let sweep = sweep_orphaned_staging_files(base_path, STALE_STAGING_AGE, budget);
+        // Silence is the normal case, and a startup line per storage would be
+        // noise. Reclaiming is routine good news at `info`.
+        if sweep.reclaimed > 0 {
             tracing::info!(
                 base_path = %base_path.display(),
                 reclaimed = sweep.reclaimed,
                 kept = sweep.kept,
-                truncated = sweep.truncated,
                 "reclaimed staging files orphaned by an interrupted write"
+            );
+        }
+        // Truncation is a different event and a worse one: the walk has no
+        // cursor, so this base path stays under-swept on every future start
+        // until the budget is raised. That is not a deferral, so it does not
+        // get to look like one.
+        if sweep.truncated {
+            tracing::warn!(
+                base_path = %base_path.display(),
+                budget,
+                env_var = Self::SWEEP_BUDGET_ENV_VAR,
+                "staging-file sweep hit its entry budget and stopped; entries past it are not \
+                 reached on this or any later start. Raise the budget to cover the tree."
             );
         }
     }
@@ -1599,14 +1733,158 @@ mod tests {
             .to_string();
         assert_eq!(staging_token(&name), Some(own_token().as_str()), "{name}");
 
-        // Anything not shaped like a staging name is not ours, which is the
-        // safe answer: it still has to clear the age threshold.
-        assert_eq!(staging_token("plain.tmp"), None);
-        assert_eq!(staging_token("leaf.json"), None);
+        // The pre-`b0a9c416a` format put the pid where the token now sits. It
+        // still parses, so an orphan written by that build is still reclaimable
+        // — and it is plainly not ours.
+        assert_eq!(staging_token("leaf.json.999.0.tmp"), Some("999"));
         assert_ne!(
             staging_token("leaf.json.999.0.tmp"),
             Some(own_token().as_str())
         );
+
+        // Enough dots is not the same as the right shape: a foreign name with
+        // the same arity must not slip through on arity alone.
+        assert_eq!(staging_token("subjects.offsets.0.tmp"), None);
+        assert_eq!(staging_token("a.b.c.tmp"), None);
+        assert_eq!(staging_token(".4242.7.tmp"), None, "no destination name");
+        assert_eq!(staging_token("plain.tmp"), None);
+        assert_eq!(staging_token("leaf.json"), None);
+    }
+
+    /// THE OTHER ONE THAT MATTERS. `.tmp` is a suffix, not a namespace: the
+    /// indexer's vocab merge, the disk cache, the nameservice tracking file and
+    /// the Raft log all stage under it, and the nameservice shares this very
+    /// tree — `FileNameService::new` builds a `FileStorage` on the path
+    /// `FlureeBuilder::build` also hands to storage. If the sweep predicated on
+    /// the extension, the age threshold would be the only thing between all of
+    /// them and an unlink. The vocab-merge entries are the sharp case: index
+    /// build temporaries are exactly the long-running shape `STALE_STAGING_AGE`
+    /// argues an age threshold must not judge.
+    #[test]
+    fn the_sweep_ignores_tmp_files_other_subsystems_wrote() {
+        let dir = tempfile::tempdir().unwrap();
+        let foreign = [
+            "notes.tmp",
+            "report.tmp",
+            "subjects.offsets.tmp", // vocab_merge.rs
+            "strings.lens.tmp",     // vocab_merge.rs
+            ".cas_4242_7.tmp",      // disk_cache.rs
+            "myledger.json.tmp",    // tracking_file.rs
+            "snap-0.tmp",           // fluree-raft-core storage/fs.rs
+            // Same arity as one of ours, but the segments are the wrong shape.
+            "subjects.offsets.0.tmp",
+        ];
+        for name in &foreign {
+            let path = dir.path().join(name);
+            let mut f = std::fs::File::create(&path).unwrap();
+            f.write_all(b"someone else's in-flight work").unwrap();
+            f.set_modified(SystemTime::now() - STALE_STAGING_AGE * 10)
+                .unwrap();
+        }
+
+        // Threshold at zero, so age offers no protection at all — the shape
+        // check is the only thing on trial.
+        let sweep = sweep_orphaned_staging_files(dir.path(), Duration::ZERO, SWEEP_ENTRY_BUDGET);
+
+        assert_eq!(
+            sweep.reclaimed, 0,
+            "the sweep unlinked another subsystem's staging file"
+        );
+        for name in &foreign {
+            assert!(dir.path().join(name).exists(), "{name} was reclaimed");
+        }
+    }
+
+    /// The shape check must not cost us the orphans the sweep exists for: a
+    /// foreign-token file in our own naming is still reclaimed, sitting in the
+    /// same directory as the files that must survive.
+    #[test]
+    fn the_shape_check_still_reclaims_our_own_orphans() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("subjects.offsets.tmp"), b"theirs").unwrap();
+        let ours = plant_staging_file(
+            dir.path(),
+            "leaf.json",
+            "fedcba9876543210",
+            STALE_STAGING_AGE * 2,
+        );
+        // And the legacy `<name>.<pid>.<seq>.tmp` shape, which predates the
+        // token and must still be reclaimable.
+        let legacy = dir.path().join(format!("old.json.999.0{TMP_SUFFIX}"));
+        let mut f = std::fs::File::create(&legacy).unwrap();
+        f.write_all(b"legacy orphan").unwrap();
+        f.set_modified(SystemTime::now() - STALE_STAGING_AGE * 2)
+            .unwrap();
+
+        let sweep = sweep_orphaned_staging_files(dir.path(), STALE_STAGING_AGE, SWEEP_ENTRY_BUDGET);
+
+        assert!(!ours.exists(), "a real orphan survived the shape check");
+        assert!(!legacy.exists(), "a legacy-format orphan survived");
+        assert_eq!(sweep.reclaimed, 2);
+        assert!(
+            dir.path().join("subjects.offsets.tmp").exists(),
+            "the foreign file next to them was taken"
+        );
+    }
+
+    /// `FileStorage::new` is called from inside `create_async_connection`, so a
+    /// synchronous recursive `read_dir` there parks a runtime worker for the
+    /// whole walk. Awaiting the handle rather than polling for the file keeps
+    /// this deterministic.
+    #[tokio::test]
+    async fn the_walk_is_handed_to_the_blocking_pool_when_a_runtime_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let orphan = plant_staging_file(
+            dir.path(),
+            "leaf.json",
+            "fedcba9876543210",
+            STALE_STAGING_AGE * 2,
+        );
+
+        let handle = FileStorage::sweep_on_construction(dir.path())
+            .expect("a sweep inside a runtime must be spawned, not run inline");
+        handle.await.expect("sweep task panicked");
+
+        assert!(!orphan.exists(), "the spawned sweep did not run");
+    }
+
+    /// Without a runtime there is nothing to hand the walk to, and a plain
+    /// synchronous caller can afford to block — so it runs inline and is
+    /// finished by the time `new` returns.
+    #[test]
+    fn the_walk_runs_inline_without_a_runtime() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            FileStorage::sweep_on_construction(dir.path()).is_none(),
+            "no runtime, so there is no task to return"
+        );
+    }
+
+    /// Same spellings the durability switch accepts — one convention for the
+    /// storage backend, not one per environment variable.
+    #[test]
+    fn sweep_env_var_accepts_the_durability_spellings() {
+        for v in ["0", "false", "off", "no", "OFF", " false "] {
+            assert!(FileStorage::env_says_off(v), "{v:?}");
+        }
+        for v in ["1", "true", "on", "", "nonsense"] {
+            assert!(!FileStorage::env_says_off(v), "{v:?}");
+        }
+    }
+
+    /// An operator who sees the truncation warning needs something to do about
+    /// it. Note `"1"` means a budget of one only because it arrives through the
+    /// budget variable — through the on/off switch it would mean "on", which is
+    /// exactly why these are two variables and not one.
+    #[test]
+    fn sweep_budget_env_var_parses_a_size() {
+        assert_eq!(FileStorage::parse_budget(Some("5000000")), 5_000_000);
+        assert_eq!(FileStorage::parse_budget(Some(" 250 ")), 250);
+        // Unset, mistyped, or a zero that would quietly make the sweep a no-op
+        // all keep the default rather than guessing.
+        for v in [None, Some(""), Some("nonsense"), Some("0"), Some("-5")] {
+            assert_eq!(FileStorage::parse_budget(v), SWEEP_ENTRY_BUDGET, "{v:?}");
+        }
     }
 
     /// The threshold is the only thing standing between a foreign in-flight
@@ -1616,8 +1894,8 @@ mod tests {
     fn only_files_past_the_threshold_are_reclaimed() {
         let dir = tempfile::tempdir().unwrap();
         let threshold = Duration::from_secs(3600);
-        let young = plant_staging_file(dir.path(), "young.json", "aaaa", threshold / 2);
-        let old = plant_staging_file(dir.path(), "old.json", "bbbb", threshold * 2);
+        let young = plant_staging_file(dir.path(), "young.json", "aaaaaaaaaaaaaaaa", threshold / 2);
+        let old = plant_staging_file(dir.path(), "old.json", "bbbbbbbbbbbbbbbb", threshold * 2);
 
         let sweep = sweep_orphaned_staging_files(dir.path(), threshold, SWEEP_ENTRY_BUDGET);
 
@@ -1631,7 +1909,9 @@ mod tests {
     #[test]
     fn a_future_mtime_is_treated_as_live() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join(format!("skewed.json.7.cccc.0{TMP_SUFFIX}"));
+        let path = dir
+            .path()
+            .join(format!("skewed.json.7.cccccccccccccccc.0{TMP_SUFFIX}"));
         let mut file = std::fs::File::create(&path).unwrap();
         file.write_all(b"partial").unwrap();
         file.set_modified(SystemTime::now() + Duration::from_secs(3600))
@@ -1682,7 +1962,7 @@ mod tests {
             plant_staging_file(
                 dir.path(),
                 &format!("o{i}.json"),
-                "dddd",
+                "dddddddddddddddd",
                 STALE_STAGING_AGE * 2,
             );
         }
@@ -1702,18 +1982,6 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         assert!(claim_sweep(dir.path()), "first claim must win");
         assert!(!claim_sweep(dir.path()), "second claim must be refused");
-    }
-
-    /// Same spellings the durability switch accepts — one convention for the
-    /// storage backend, not one per environment variable.
-    #[test]
-    fn sweep_env_var_accepts_the_durability_spellings() {
-        for v in ["0", "false", "off", "no", "OFF", " false "] {
-            assert!(FileStorage::env_says_off(v), "{v:?}");
-        }
-        for v in ["1", "true", "on", "", "nonsense"] {
-            assert!(!FileStorage::env_says_off(v), "{v:?}");
-        }
     }
 
     /// Write a zero-length file directly, bypassing the storage API — which is

--- a/fluree-db-core/src/storage/file.rs
+++ b/fluree-db-core/src/storage/file.rs
@@ -165,7 +165,11 @@ fn is_process_token(s: &str) -> bool {
 /// `.tmp` producer emits that shape, so this is an operator's own file rather
 /// than a collision with anything we ship, and narrowing it further means
 /// gating legacy reclaim behind an opt-in, which is an upgrade-behavior
-/// decision rather than a parser one.
+/// decision rather than a parser one. The residual is tolerable *because*
+/// the sweep is a deliberate startup action an operator can see and disable
+/// ([`FileStorage::sweep_orphaned_staging`], [`FileStorage::SWEEP_ENV_VAR`])
+/// — not a side effect of constructing a storage, which is what would let a
+/// stray unit test or inspection tool reach it.
 ///
 /// Returns `None` for anything else. That is the safe direction in the only
 /// sense that matters: failing to reclaim an orphan wastes disk, and reclaiming
@@ -248,7 +252,17 @@ struct StagingSweep {
 /// 1. **Never this process's own.** The staging name carries a 64-bit token
 ///    drawn once per process, so a name bearing our token is ours — in flight
 ///    or already leaked, and a directory entry cannot tell those apart. Both
-///    are left alone. This rule is exact, not a heuristic.
+///    are left alone. This rule is exact, not a heuristic — but exact for the
+///    *current* name format only. A legacy `<name>.<pid>.<seq>.tmp` name (see
+///    [`staging_token`]) carries a pid in the token slot, and a pid can never
+///    equal a 16-hex process token, so for legacy names this rule is inert
+///    and rule 2 stands alone. That case is not a corner but the upgrade
+///    path itself: in a rolling upgrade, a still-running v4.1.5/v4.1.6
+///    process stages into the shared tree in the legacy format, and the age
+///    heuristic is the only thing protecting its in-flight writes. Tolerable
+///    — a staging write is open for milliseconds against a one-day threshold
+///    — but the rules do not layer there, and this doc should not pretend
+///    they do.
 /// 2. **Never a file touched recently.** Anything modified within `older_than`
 ///    is left for whoever is writing it. This rule *is* a heuristic: it reads
 ///    the writer's clock through ours, and it assumes no legitimate staging
@@ -348,10 +362,11 @@ fn sweep_orphaned_staging_files(
 
 /// Base paths this process has already swept.
 ///
-/// `FileStorage::new` runs once per connection, once per nameservice and again
-/// for the API's own handle, frequently on the same directory. Only the first
-/// walk can find anything; the rest would re-walk the tree to look at exactly
-/// the files the first one declined to touch.
+/// Startup opens several handles on one directory — the connection's storage,
+/// the API's own handle — and more than one startup layer calls
+/// [`FileStorage::sweep_orphaned_staging`] on the way up. Only the first walk
+/// can find anything; the rest would re-walk the tree to look at exactly the
+/// files the first one declined to touch.
 ///
 /// Canonicalized first, so the guarantee is about the *directory* and not about
 /// how a caller spelled it — `/x`, `/x/.` and `/x/` are one base path, not
@@ -501,17 +516,15 @@ impl FileStorage {
     /// process by [`Durability::ENV_VAR`] or per instance by
     /// [`Self::with_durability`].
     ///
-    /// Constructing the storage also reclaims staging files orphaned by an
-    /// earlier crash — see [`sweep_orphaned_staging_files`] for what it will
-    /// and will not delete, and [`Self::SWEEP_ENV_VAR`] to tune or disable it.
-    /// The walk is bounded, runs at most once per base path per process, and is
-    /// handed to the blocking pool when there is a runtime to hand it to, so
-    /// constructing a storage never waits on it.
+    /// Constructing a storage touches nothing on disk. In particular it does
+    /// **not** reclaim orphaned staging files: unlinking is a startup
+    /// decision, and only the startup layer knows it is starting up. A test
+    /// or a tool that constructs a `FileStorage` on a directory it does not
+    /// own must not mutate that directory — the connection and builder
+    /// startup paths call [`Self::sweep_orphaned_staging`] explicitly.
     pub fn new(base_path: impl Into<std::path::PathBuf>) -> Self {
-        let base_path = base_path.into();
-        let _ = Self::sweep_on_construction(&base_path);
         Self {
-            base_path,
+            base_path: base_path.into(),
             durability: Durability::from_env(),
             fsyncs: Arc::new(AtomicU64::new(0)),
         }
@@ -581,26 +594,43 @@ impl FileStorage {
         )
     }
 
-    /// Reclaim orphaned staging files under `base_path`, at most once per path
-    /// per process.
+    /// Reclaim staging files orphaned by an earlier crash under this
+    /// storage's base path — see [`sweep_orphaned_staging_files`] for what
+    /// the walk will and will not delete, and [`Self::SWEEP_ENV_VAR`] /
+    /// [`Self::SWEEP_BUDGET_ENV_VAR`] to disable or widen it.
+    ///
+    /// **A deliberate startup action, not a constructor side effect.** The
+    /// sweep unlinks files, and every argument for its rules leans on it
+    /// being a startup decision — so it is mounted where startup is actually
+    /// known to be happening: the file arms of `create_sync_connection` /
+    /// `create_async_connection` in `fluree-db-connection`, and the
+    /// file-backed build paths in `fluree-db-api`. Constructing a
+    /// `FileStorage` deletes nothing, so a unit test or a tool holding a
+    /// handle on a directory it does not own cannot unlink an operator's
+    /// files by existing.
+    ///
+    /// The walk is bounded ([`SWEEP_ENTRY_BUDGET`]), runs at most once per
+    /// base path per process however many handles startup opens on it, and
+    /// is handed to the blocking pool when there is a runtime to hand it to,
+    /// so the caller never waits on it.
     ///
     /// Returns the spawned task when the walk was handed to the blocking pool,
     /// so a test can await it. Production ignores it — the sweep is best-effort
     /// and nothing waits on the result.
-    fn sweep_on_construction(base_path: &Path) -> Option<tokio::task::JoinHandle<()>> {
+    pub fn sweep_orphaned_staging(&self) -> Option<tokio::task::JoinHandle<()>> {
         let budget = Self::sweep_budget_from_env()?;
-        if !claim_sweep(base_path) {
+        if !claim_sweep(&self.base_path) {
             return None;
         }
-        let base = base_path.to_path_buf();
-        // A RECURSIVE `read_dir` IS BLOCKING I/O, AND `new` IS REACHABLE FROM
-        // ASYNC CONNECTION SETUP (`create_async_connection`, and
-        // `build_from_config`'s async path), so running it here would park a
-        // runtime worker for the whole walk — measured at ~1s warm on local
-        // APFS for the default budget, and a readdir on the shared mount this
-        // design targets is a network round trip rather than a page-cache hit.
-        // #1620 asked for the walk to be bounded *or* backgrounded; it is worth
-        // being both.
+        let base = self.base_path.clone();
+        // A RECURSIVE `read_dir` IS BLOCKING I/O, AND THIS IS CALLED FROM
+        // ASYNC STARTUP (`create_async_connection`, and the API's async
+        // client builds), so running it on the caller would park a runtime
+        // worker for the whole walk — measured at ~1s warm on local APFS for
+        // the default budget, and a readdir on the shared mount this design
+        // targets is a network round trip rather than a page-cache hit.
+        // #1620 asked for the walk to be bounded *or* backgrounded; it is
+        // worth being both.
         match tokio::runtime::Handle::try_current() {
             Ok(handle) => Some(handle.spawn_blocking(move || Self::run_sweep(&base, budget))),
             // No runtime: a plain synchronous caller (`create_sync_connection`),
@@ -1683,9 +1713,15 @@ mod tests {
 
     /// A crash between `File::create` and the rename leaves a full copy of the
     /// object behind, and `list_prefix` hides it from every reader — which is
-    /// exactly why nothing ever removed it. Opening the storage has to.
+    /// exactly why nothing ever removed it. The explicit startup sweep has to.
+    ///
+    /// The intermediate assertion is a pin of its own: **constructing a
+    /// storage deletes nothing.** A bare `FileStorage::new` is reachable from
+    /// unit tests and tooling pointed at directories the process does not own
+    /// (a Debug-formatting test on a hardcoded `/tmp/test` was the
+    /// demonstrated case), so the unlink must wait for the deliberate call.
     #[test]
-    fn construction_reclaims_an_orphaned_staging_file() {
+    fn construction_is_pure_and_the_explicit_sweep_reclaims_an_orphan() {
         let dir = tempfile::tempdir().unwrap();
         let orphan = plant_staging_file(
             &dir.path().join("a/b"),
@@ -1694,11 +1730,19 @@ mod tests {
             STALE_STAGING_AGE * 2,
         );
 
-        let _storage = FileStorage::new(dir.path());
+        let storage = FileStorage::new(dir.path());
+        assert!(
+            orphan.exists(),
+            "constructing a FileStorage must not delete anything: {}",
+            orphan.display()
+        );
 
+        // No runtime in a plain #[test], so the walk runs inline and is
+        // finished when the call returns.
+        storage.sweep_orphaned_staging();
         assert!(
             !orphan.exists(),
-            "an orphan older than the threshold survived construction: {}",
+            "an orphan older than the threshold survived the startup sweep: {}",
             orphan.display()
         );
     }
@@ -1708,7 +1752,7 @@ mod tests {
     /// takes that process's rename out from under it. A file young enough to
     /// belong to a live write is not the sweep's business at any age policy.
     #[test]
-    fn construction_leaves_a_live_looking_staging_file_alone() {
+    fn the_sweep_leaves_a_live_looking_staging_file_alone() {
         let dir = tempfile::tempdir().unwrap();
         // Another instance's token, written a moment ago — the shape of a
         // write that is in flight right now.
@@ -1719,7 +1763,7 @@ mod tests {
             Duration::from_secs(0),
         );
 
-        let _storage = FileStorage::new(dir.path());
+        FileStorage::new(dir.path()).sweep_orphaned_staging();
 
         assert!(
             live.exists(),
@@ -1900,10 +1944,10 @@ mod tests {
         );
     }
 
-    /// `FileStorage::new` is called from inside `create_async_connection`, so a
-    /// synchronous recursive `read_dir` there parks a runtime worker for the
-    /// whole walk. Awaiting the handle rather than polling for the file keeps
-    /// this deterministic.
+    /// The sweep is called from inside `create_async_connection` and the
+    /// API's async client builds, so a synchronous recursive `read_dir` there
+    /// parks a runtime worker for the whole walk. Awaiting the handle rather
+    /// than polling for the file keeps this deterministic.
     #[tokio::test]
     async fn the_walk_is_handed_to_the_blocking_pool_when_a_runtime_exists() {
         let dir = tempfile::tempdir().unwrap();
@@ -1914,7 +1958,8 @@ mod tests {
             STALE_STAGING_AGE * 2,
         );
 
-        let handle = FileStorage::sweep_on_construction(dir.path())
+        let handle = FileStorage::new(dir.path())
+            .sweep_orphaned_staging()
             .expect("a sweep inside a runtime must be spawned, not run inline");
         handle.await.expect("sweep task panicked");
 
@@ -1923,7 +1968,7 @@ mod tests {
 
     /// Without a runtime there is nothing to hand the walk to, and a plain
     /// synchronous caller can afford to block — so it runs inline and is
-    /// *finished* by the time construction returns. Asserting the orphan is
+    /// *finished* by the time the call returns. Asserting the orphan is
     /// already gone is the part that carries the coverage; `is_none()` alone
     /// would also be satisfied by a sweep that never ran.
     #[test]
@@ -1937,12 +1982,14 @@ mod tests {
         );
 
         assert!(
-            FileStorage::sweep_on_construction(dir.path()).is_none(),
+            FileStorage::new(dir.path())
+                .sweep_orphaned_staging()
+                .is_none(),
             "no runtime, so there is no task to return"
         );
         assert!(
             !orphan.exists(),
-            "the inline sweep had not finished when construction returned"
+            "the inline sweep had not finished when the call returned"
         );
     }
 
@@ -2038,7 +2085,7 @@ mod tests {
         );
     }
 
-    /// The walk is on the construction path, so a huge volume must not turn
+    /// The walk is on the startup path, so a huge volume must not turn
     /// opening a ledger into a startup stall. Running out of budget stops the
     /// walk and says so, rather than running to completion.
     #[test]
@@ -2059,10 +2106,10 @@ mod tests {
         assert_eq!(sweep.reclaimed, 3, "the walk went past its budget");
     }
 
-    /// One walk per base path per process. `FileStorage::new` runs once per
-    /// connection, once per nameservice and again for the API's own handle,
-    /// often on the same directory; re-walking the tree each time would only
-    /// re-examine the files the first walk declined to touch.
+    /// One walk per base path per process. Startup opens several handles on
+    /// one directory and more than one startup layer sweeps on the way up;
+    /// re-walking the tree each time would only re-examine the files the
+    /// first walk declined to touch.
     #[test]
     fn a_base_path_is_swept_at_most_once_per_process() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Two storage fixes that both live in `fluree-db-core/src/storage/file.rs`, so they're riding together rather than as two one-file PRs.

Fixes #1671
Fixes #1620

## #1671 — ranged reads now clamp, like the trait already said they would

The issue frames this as `FileStorage` and `ProxyStorage` disagreeing. Having gone looking, I think it's actually a bit stronger than that: the trait's own doc comment at `fluree-db-core/src/storage.rs:212-214` already promises the clamp —

> Returns the bytes within the range, which may be shorter than requested if the object is smaller than `range.end`.

— and the default impl (`storage.rs:219-229`), `MemoryStorage` (`storage/memory.rs:94-107`), and the proxy (which has no override, so it inherits the default) all honour it. `FileStorage` was the only `StorageRead` implementation that sized its buffer from `range.end - range.start` rather than from the object, so this is a lone contract violation rather than a sibling divergence. I think that also answers the open question at the end of the issue — there isn't really a doc decision to make, the doc was already right and the code just wasn't meeting it.

Mechanism, and it's worth being precise that this was never only about open-ended ranges: `let len = (range.end - range.start) as usize` ran before any I/O, so the allocation was sized from the *request* for **any** range. `0..40_000_000_000` on a 10-byte file allocated 40 GB of address space and handed the caller a `Vec` with len 10 and capacity 40,000,000,000 — I reproduced that shape directly and got exactly `len=10 capacity=40000000000` at ~1.7 MB max RSS, because `vec![0u8; len]` gets lazy zero pages that never fault in. So oversized ranges "worked" while quietly reserving whatever the caller asked for, and only a width past `Vec`'s capacity limit actually tripped: `mid..u64::MAX` — the established "read to the end" spelling, asserted against the proxy at `fluree-db-server/tests/proxy_integration.rs:1821` — became `vec![0u8; usize::MAX]`, whose capacity-overflow panic `spawn_blocking` caught and relabelled `Io("spawn_blocking failed: task panicked ...")`. A slightly unkind touch: the one backend that couldn't serve the call was also the one that couldn't say why.

The fix is the one suggested in the issue. #1599 already stats the open handle in this same function for its zero-length guard, so the size was sitting right there — I hoisted that single `metadata()` call above both guards and clamped with it:

```rust
let len = requested.min(file_len.saturating_sub(offset)) as usize;
```

The read loops already stopped at EOF, so an in-range request is byte-identical to before.

One deliberate behaviour change worth flagging, since it's the bit I'm least certain about: the zero-length guard used to be `file.metadata().map(|m| m.len() == 0).unwrap_or(false)`, i.e. it tolerated a stat failure and carried on. It now returns `Io` instead. My reasoning is that the buffer size is *derived* from that stat, so without it there's nothing to size the read against, and an error naming the failure beats either guessing a length or falling back to trusting the caller's `u64`. In practice this is `fstat` on a descriptor the thread owns and doesn't fail — but if the permissive form is preferred, I'm happy to put it back.

I checked the other implementations for the same class while I was in there and none of them have it: the default / memory / proxy-filtered paths slice after a full read, `Arc<dyn Storage>` and the two routers in `fluree-db-api/src/lib.rs` are pure delegation, and S3 and proxy-raw hand the range straight to a remote as an HTTP `Range` header, where the server does the clamping per RFC 7233.

One boundary over, though, the backends still don't fully agree, and the trait doc now names **both** known divergences rather than letting one stand as if it were exhaustive — a contract paragraph with an unnamed exception is exactly the shape #1671 grew from. First: at `start >= object length`, `FileStorage` and `MemoryStorage` both return `Ok(vec![])` — this PR's own test asserts it at `99..u64::MAX` — while S3 returns 416. That predates this change, isn't in this diff, and is tracked as #1712; fixing it wants someone who can exercise real S3 rather than my reading of RFC 7233. Second: a zero-length object reads as `NotFound` from `FileStorage` — the #1599 debris guard treats an empty blob as absent on every read surface, this one included — where `MemoryStorage` and the default implementation return `Ok(vec![])`. That one is deliberate and stays deliberate; it's still a divergence in this method's observable behaviour, so the doc says so.

## #1620 — sweeping staging files a crash left behind

Confirmed neither candidate coverer actually covers this. #1612 cleans up on its own error paths in `stage_bytes` / `write_atomic` / `create_new_atomic`, and none of those run for a `SIGKILL`, an OOM kill or a power loss. #1614's sweep plans over `list_prefix`, which `continue`s on `is_tmp_artifact` (`file.rs:561` at the merge base) — so it structurally can never enumerate one of these files, let alone reclaim it. That filter is exactly what makes an orphan harmless and immortal at the same time.

The sweep is `FileStorage::sweep_orphaned_staging()`, an **explicit startup action** — deliberately *not* mounted on the constructor. That placement is load-bearing, not taste. The parser below tolerates one residual (a foreign `<name>.<decimal>.<decimal>.tmp` still parses as a legacy orphan), and the argument for tolerating it leans entirely on the sweep being a deliberate, visible, disable-able startup step. Hung off `new`, that argument collapses, because `FileStorage::new` is reachable from any unit test or tool pointed at a directory the process doesn't own — `fluree-db-connection` has a Debug-formatting test that constructs `FileStorage::new("/tmp/test")`, and with the sweep on the constructor, running that one test unlinks a 90-day-old `mybackup.json.1.2.tmp` an operator left under `/tmp/test`. Each decision is defensible alone; composed, they silently delete operator data. So constructing a storage now touches nothing on disk — which also takes the env reads, the `canonicalize` and the global claim-mutex back out of the constructor — and the layers that actually *know* it's startup make the call:

- `create_sync_connection` / `create_async_connection`'s file arms in `fluree-db-connection`
- `FlureeBuilder::build`, `build_encrypted_internal`, `build_client_file`, and the address-identifier storages in `build_local_storage_from_config` in `fluree-db-api`

That covers every production entry to a file-backed instance — the server and CLI arrive through those builders, and `FileNameService::new` shares the very tree the builder already sweeps, with the once-per-canonicalized-path claim making the layered calls idempotent. `fluree-search-httpd` constructs read-only `FileStorage` handles and deliberately does not sweep: a reader has no business unlinking anything in a writer's tree, and no released build ever swept there.

**The part I'd most like a second opinion on is the concurrency stance**, so it's worth being explicit about what it does and doesn't promise. The tree is shared — between processes in a multi-instance deployment, and between *subsystems* even in one process — and a sweep that guesses wrong pulls a live writer's file out from under it. Three rules:

0. **Never a file this backend's staging writer didn't name.** `.tmp` is a suffix, not a namespace: the indexer's vocab merge, the disk cache, the nameservice tracking file and the Raft log all stage under it, and the nameservice shares this exact tree — `FileNameService::new` builds a `FileStorage` on the path `FlureeBuilder::build` also hands to storage. So a file is only the sweep's business once its name parses as one *this* writer produced, with every segment shape-checked rather than just the dot count. Rules 1 and 2 apply only to names that pass. Predicating on `ends_with(".tmp")` instead — the obvious cheap version — would leave the age heuristic as the only thing standing between `vocab_merge`'s index-build temporaries and an unlink, and a long-running index build is precisely the shape rule 2 is not competent to judge.
1. **Never a staging file bearing this process's token.** `tmp_sibling` embeds a 64-bit token drawn once per process, so a name carrying ours is ours. In-flight and already-leaked are indistinguishable from a directory entry, so both are left alone. This rule is exact — *for the current name format*. A legacy `<name>.<pid>.<seq>.tmp` name carries a pid where the token now sits, and a pid can never equal a 16-hex token, so for legacy names rule 1 is inert and rule 2 stands alone. That case isn't a corner, it's the upgrade path itself: a rolling upgrade has a still-running v4.1.5/v4.1.6 process staging into the shared tree in the old format, protected by the age heuristic and nothing else. Fine in practice — a staging write is open for milliseconds against a one-day threshold — but the rules don't layer there, and the docs now say so plainly instead of presenting 1 and 2 as stacked defenses.
2. **Never a file modified inside 24 hours.** This one is a heuristic and I want to name it as one: it reads another host's clock through ours, and it assumes no legitimate staging write stays open that long.

Anything the sweep can't classify — an unparseable name, an entry it can't stat, an mtime in the future — is kept. Every unknown resolves toward leaving the file alone.

Two notes on that parser, since it's the load-bearing bit. Zero-padded numbers are rejected — nothing here emits one, and it keeps date- and offset-stamped foreign names (`backup.2026.08.tmp`, `wal.000001.000002.tmp`) out of the legacy branch. **One residual remains, deliberately:** a foreign name shaped `<non-empty>.<decimal>.<decimal>.tmp` — `dump.1.2.tmp` — still parses as legacy. I checked all four in-tree `.tmp` producers against the parser and none emits that shape, so it's an operator's own file rather than a collision with anything we ship. Closing it properly means gating legacy reclaim behind an opt-in, which is an upgrade-behavior decision rather than a parser one — and with the sweep now reachable *only* from an explicit startup call an operator can see coming and switch off, rather than from any construction, I think recording it on `staging_token` is the right resting place.

And the legacy branch is load-bearing rather than politeness: staging writes arrived in `85183c9ca`, which **v4.1.5 and v4.1.6 both contain**, so every store written by a currently released build produces orphans in that format. Dropping it would strand them on disk permanently.

On why an age threshold is defensible here when #1635 argues (correctly, I think) that it isn't for the index-build sweep: the objection there is that a reindex replays the whole commit chain, so its duration grows with the ledger and no constant can bound it. A staging file doesn't have that shape — its entire life is one `write_all` of one already-in-memory buffer, followed immediately by a rename. There's no long-running case to get wrong. I believe that's a genuinely different situation rather than the same heuristic reused, but if it reads as the same heuristic wearing a different hat, I'd rather hear that before this ships than after.

**What it explicitly does not guarantee:** it is not a lease, and it does not coordinate with other processes. A foreign staging write that somehow stayed open for over a day would be unlinked. Even then I think the blast radius is small — on POSIX the writer keeps its open descriptor, so its `write_all` and `sync_all` still succeed against the now-unlinked inode and only the final rename fails, surfacing as a write error rather than anything torn or wrong landing under a content address. But it *is* a spurious write error, and I'd rather say that than imply the sweep is airtight. If/when #1635 lands a real lease, this is a natural thing to hang off it.

Practicalities: the walk is handed to the blocking pool when there's a runtime to hand it to (the sweep is called from `create_async_connection` and the API's async client builds, so a recursive `read_dir` on the caller would park a runtime worker — ~1s warm on local APFS for the default budget), and runs inline only for the genuinely synchronous caller (`create_sync_connection`). It runs at most once per base path per process however many startup layers call it, keyed on the canonicalized path so that's a property of the directory rather than of how someone spelled it.

It's also bounded, at 100k directory entries. **Exhausting that budget is not a deferral**, and it would be easy to describe it as one: the walk restarts from the top with no cursor and never removes content, so if the first 100k entries it meets are content, every later start re-walks those same entries and never reaches the orphans past them. That case logs at `warn` (reclaiming logs at `info` — different events), and `FLUREE_STORAGE_TMP_SWEEP_BUDGET` raises the cap, because a warning an operator can't act on is just noise. `FLUREE_STORAGE_TMP_SWEEP=0` turns the sweep off entirely, using the same falsey spellings `FLUREE_STORAGE_FSYNC` already accepts. The budget is a separate variable rather than an overload of that one on purpose — `FLUREE_STORAGE_FSYNC=1` means "on", so reading `FLUREE_STORAGE_TMP_SWEEP=1` as a one-entry budget would be "off" wearing a disguise.

## Tests

For #1671 the guard test fails at the parent commit with the exact error from the issue and passes after. There's also a differential test that runs nine ranges — three of them open-ended — through both `FileStorage` and `MemoryStorage` and asserts they agree, since backend agreement is the property that was actually broken.

For #1620, both directions the issue asked for, plus both directions of the mounting decision — the constructor must not sweep, and no startup path may lose its sweep:

- `construction_is_pure_and_the_explicit_sweep_reclaims_an_orphan` — two pins in one: an aged orphan **survives** `FileStorage::new`, then the explicit sweep reclaims it
- `file_connection_startup_sweeps_orphaned_staging` (`fluree-db-connection`) and `building_a_file_instance_sweeps_orphaned_staging` (`fluree-db-api`) — the flip-side regression guards: opening a file connection and building a file-backed client each still reclaim a planted stale orphan. Both run without a runtime, so the walk is inline and the assertion can't race it.
- `the_sweep_leaves_a_live_looking_staging_file_alone` — a fresh foreign-token file survives
- `our_own_staging_file_is_never_reclaimed_however_old` — rule 1 beats rule 2 even at a zero threshold
- `the_sweep_ignores_tmp_files_other_subsystems_wrote` — the seven real foreign `.tmp` shapes, plus an arity case, all aged past the threshold and swept at a *zero* threshold so age offers no cover and rule 0 is the only thing on trial
- `the_shape_check_still_reclaims_our_own_orphans` — the tightening didn't cost us the orphans the sweep exists for, current format and legacy alike, sitting next to a foreign file that must survive
- `the_walk_is_handed_to_the_blocking_pool_when_a_runtime_exists` / `the_walk_runs_inline_without_a_runtime` — the hand-off both ways; the async one awaits the returned `JoinHandle` rather than polling for the file
- `a_future_mtime_is_treated_as_live`, `only_files_past_the_threshold_are_reclaimed`, `the_sweep_never_touches_content`, `the_walk_is_bounded_by_its_entry_budget`, `a_base_path_is_swept_at_most_once_per_process`

And the concrete shape that motivated the mounting: with a 90-day-old `mybackup.json.1.2.tmp` planted in `/tmp/test`, both hardcoded-path unit tests (`test_connection_handle_file` in `fluree-db-connection/src/lib.rs`, `test_create_file_storage` in `fluree-db-connection/src/storage.rs`) run green and the file survives. The one test that pointed a *real* startup path at `/tmp/test` — `test_fluree_builder_file` — now builds in a tempdir, since a startup path sweeping is exactly its documented behaviour.

I mutation-checked the mounting as well as the rules this time — ten mutants, ten killed, each by the test that owns it: disabling the shape check reddens `the_sweep_ignores_tmp_files_other_subsystems_wrote`; disabling the token rule reddens `our_own_staging_file_is_never_reclaimed_however_old` and only that; disabling the age rule reddens three; admitting zero-padded decimals reddens the parser test with `Some("2026")` for `backup.2026.08.tmp`; a spawned walk that never runs reddens the blocking-pool test; a gutted inline walk reddens two; letting every claim win reddens the once-per-path test; hanging the sweep back on `new` reddens the purity pin; and deleting the wiring call from either `create_sync_connection` or `FlureeBuilder::build` reddens the corresponding startup pin. The assertions check the `reclaimed`/`kept` counts and not just file existence, so a file that was never *examined* can't pass as one that was deliberately kept.

## Gates

- `cargo test -p fluree-db-core --all-features` — 815 lib tests green (46 of them in `storage::file`), plus integration and doc-tests
- `cargo test -p fluree-db-connection --lib` (39), `cargo test -p fluree-db-api --lib` (776), `cargo test -p fluree-db-nameservice --lib` (163) — the crates whose startup paths now own the sweep call
- `cargo check -p fluree-db-connection --features aws` — the async (S3-capable) connection path compiles with its file-arm sweep
- `cargo check -p fluree-db-core --no-default-features --features native --lib` — clean, since `Handle::try_current` needs tokio's `rt` and I didn't want that quietly supplied by a dev-dependency
- `cargo clippy -p fluree-db-core --all-features` / `-p fluree-db-connection` / `-p fluree-db-api` — `--all-targets --no-deps`, clean
- `cargo fmt --all --check` — clean

Docs: the "Staging files left by a crash" section in `docs/operations/storage.md` now says the sweep is an explicit startup step (constructing a storage handle never deletes anything) and carries the legacy-format carve-out in operator terms, next to the durability table.
