### PR TITLE
fix(datalog): IRI comparison in rule FILTERs (fails open today) + a diagnostic when a rule can't derive

### DIFF
--- a/docs/query/datalog-rules.md
+++ b/docs/query/datalog-rules.md
@@ -89,6 +89,45 @@ ledger — see the reasoning budget under [Fixpoint evaluation](#fixpoint-evalua
 ]
 ```
 
+Filters can also compare against an **IRI**, which is how you constrain a
+variable-position predicate or an entity-valued object:
+
+```json
+"where": [
+  {"@id": "?s", "ex:sameAs": {"@id": "?other"}},
+  {"@id": "?other", "?prop": "?val"},
+  ["filter", "(!= ?prop ex:ssn)"]
+]
+```
+
+How a filter operand is classified:
+
+| Operand | Read as |
+|---------|---------|
+| `?name` | Variable |
+| `62`, `1.5`, `true` | Number / boolean literal |
+| `ex:ssn`, `http://example.org/ssn` | **IRI** — expanded via the rule's `@context` and resolved against the ledger |
+| `"senior"`, `"John Smith"` | String literal (quote it — quoted operands may contain spaces) |
+| `senior` | String literal (bare, unquoted) |
+
+Three rules worth knowing:
+
+- **IRI comparison is namespace-aware.** `(= ?p ex:knows)` matches `ex:knows`
+  and not `foaf:knows`. Only `=` and `!=` are defined for IRIs; ordering
+  operators against an IRI are rejected.
+- **A bare name is a string, not an IRI.** `(= ?p knows)` compares against the
+  *string* `"knows"` and will never match the IRI `ex:knows`. Write the
+  prefixed or absolute form instead. (Before Fluree resolved IRIs in filters,
+  the bare form was the only one that appeared to work — but it matched
+  namespace-blindly, so `ex:knows`, `foaf:knows` and any other `knows` were
+  treated as equal. A rule still using the bare form now derives nothing and
+  logs a warning naming the operand.)
+- **An unresolvable IRI operand is an error, not a fallback.** If a filter
+  names a prefix the rule's `@context` does not define, or a namespace the
+  ledger has never seen, the rule is rejected and skipped with a logged error
+  rather than quietly comparing the operand as a string. Quote the operand if
+  you did mean a literal.
+
 ### Insert clause
 
 The `insert` clause defines what facts to produce for each set of matching
@@ -105,6 +144,19 @@ variable bindings.
 - Use `{"@id": "?var"}` for IRI/entity values; use `"?var"` directly for
   literal values.
 - Multiple triples can be generated from a single insert pattern.
+- **Every variable used in `insert` must also appear in `where`.** A variable
+  the `where` clause never binds cannot produce a fact, so the rule is rejected
+  at parse time with an error naming the variable rather than running and
+  deriving nothing. A `where`/`insert` typo is the usual cause:
+
+  ```json
+  "where":  {"@id": "?s", "ex:relType": {"@id": "?relation"}},
+  "insert": {"@id": "?s", "?rel": {"@id": "?s"}}
+  ```
+
+  `?rel` is never bound — the `where` clause binds `?relation`.
+- Every node in an `insert` pattern needs an `@id`. An anonymous node has no
+  subject to derive facts about, and is reported the same way.
 
 ## Providing rules
 
@@ -381,21 +433,40 @@ Filters use S-expression syntax within the `where` array:
 
 ### Available operators
 
+A JSON-LD rule filter is a single comparison between two operands:
+
 | Category | Operators |
 |----------|-----------|
-| Comparison | `=`, `!=`, `<`, `>`, `<=`, `>=` |
-| Logical | `and`, `or`, `not` |
-| Arithmetic | `+`, `-`, `*`, `/` |
-| String | `str`, `strlen`, `contains`, `strstarts`, `strends` |
-| Type checking | `isIRI`, `isBlank`, `isLiteral`, `bound` |
+| Comparison | `=`, `!=` (also `not=`), `<`, `>`, `<=`, `>=` |
+
+Logical combinators (`and` / `or` / `not`), arithmetic, and string or
+type-checking functions are **not** available in JSON-LD rule filters — an
+unrecognized operator is a parse error and the rule is skipped. Use several
+`["filter", ...]` entries in the `where` array to require more than one
+condition; they are combined with AND. For richer expressions, write the rule
+in SPARQL (see [SPARQL rules](#sparql-rules)), where `FILTER(… && …)` and
+`FILTER(!(…))` are supported.
+
+Ordering operators (`<`, `<=`, `>`, `>=`) are defined for numbers and strings
+only; using one against an IRI operand is rejected.
 
 ### Examples
 
 ```json
 ["filter", "(> ?age 21)"]
-["filter", "(and (>= ?age 18) (< ?age 65))"]
-["filter", "(contains ?name \"Smith\")"]
 ["filter", "(!= ?person ?other)"]
+["filter", "(!= ?prop ex:ssn)"]
+["filter", "(= ?name \"John Smith\")"]
+```
+
+Two conditions, ANDed:
+
+```json
+"where": [
+  {"@id": "?person", "ex:age": "?age"},
+  ["filter", "(>= ?age 18)"],
+  ["filter", "(< ?age 65)"]
+]
 ```
 
 ## Performance considerations

--- a/docs/query/datalog-rules.md
+++ b/docs/query/datalog-rules.md
@@ -108,20 +108,24 @@ How a filter operand is classified:
 | `62`, `1.5`, `true` | Number / boolean literal |
 | `ex:ssn`, `http://example.org/ssn` | **IRI** — expanded via the rule's `@context` and resolved against the ledger |
 | `"senior"`, `"John Smith"` | String literal (quote it — quoted operands may contain spaces) |
-| `senior` | String literal (bare, unquoted) |
+| `senior` | **Rejected** — a bare unquoted token is ambiguous; quote it for a string, prefix it for an IRI |
 
 Three rules worth knowing:
 
 - **IRI comparison is namespace-aware.** `(= ?p ex:knows)` matches `ex:knows`
   and not `foaf:knows`. Only `=` and `!=` are defined for IRIs; ordering
   operators against an IRI are rejected.
-- **A bare name is a string, not an IRI.** `(= ?p knows)` compares against the
-  *string* `"knows"` and will never match the IRI `ex:knows`. Write the
-  prefixed or absolute form instead. (Before Fluree resolved IRIs in filters,
-  the bare form was the only one that appeared to work — but it matched
-  namespace-blindly, so `ex:knows`, `foaf:knows` and any other `knows` were
-  treated as equal. A rule still using the bare form now derives nothing and
-  logs a warning naming the operand.)
+- **A bare name is rejected, not guessed.** `(= ?p knows)` is a parse error
+  naming the operand: write `"knows"` (quoted) to compare against the string,
+  or `ex:knows` to compare against the IRI. A bare token cannot be safely read
+  as a string, because against an IRI-bound variable a string comparison fails
+  invisibly in both directions — `=` derives nothing, and `!=` keeps every row,
+  so an exclusion filter derives exactly the facts it was written to exclude.
+  (Before Fluree resolved IRIs in filters, the bare form was the only one that
+  appeared to work — but it matched namespace-blindly, so `ex:knows`,
+  `foaf:knows` and any other `knows` were treated as equal. A rule still using
+  the bare form is now rejected and skipped with a logged error naming the
+  operand and both rewrites.)
 - **An unresolvable IRI operand is an error, not a fallback.** If a filter
   names a prefix the rule's `@context` does not define, or a namespace the
   ledger has never seen, the rule is rejected and skipped with a logged error
@@ -145,9 +149,14 @@ variable bindings.
   literal values.
 - Multiple triples can be generated from a single insert pattern.
 - **Every variable used in `insert` must also appear in `where`.** A variable
-  the `where` clause never binds cannot produce a fact, so the rule is rejected
-  at parse time with an error naming the variable rather than running and
-  deriving nothing. A `where`/`insert` typo is the usual cause:
+  the `where` clause never binds cannot produce a fact. Each insert pattern is
+  checked independently: a pattern that references an unbound variable is
+  **skipped with a logged warning naming the variable**, while the rule's other
+  insert patterns keep deriving — so one typo'd head in a multi-head rule does
+  not silence the rest. Only a rule in which **no** insert pattern can ever
+  produce a fact is rejected outright at parse time (with the same
+  variable-naming error), rather than running and deriving nothing. A
+  `where`/`insert` typo is the usual cause:
 
   ```json
   "where":  {"@id": "?s", "ex:relType": {"@id": "?relation"}},

--- a/fluree-db-api/tests/it_datalog_rules.rs
+++ b/fluree-db-api/tests/it_datalog_rules.rs
@@ -2194,14 +2194,15 @@ async fn datalog_malformed_filter_does_not_silently_vanish() {
 
 /// The bare-local-name filter form — `(= ?p knows)` — was the only operand
 /// shape that ever matched a bound IRI before #1556 was fixed, so a rule
-/// written as a workaround uses exactly it. It now correctly derives nothing,
-/// because a bare name is a string literal and a string is never an IRI.
-///
-/// The risk is that it does so in silence: RDFterm-equal makes IRI-vs-literal
-/// a clean `False` rather than an `Error`, so the "could not compare its
-/// operands" path cannot see it. A stale rule must still say something.
+/// written as a workaround uses exactly it. Read as a string literal the form
+/// is a trap in BOTH directions: `=` derives nothing (a string never equals an
+/// IRI) and `!=` derives everything, including the fact the filter was written
+/// to exclude. Neither failure is visible at run time — RDFterm-equal makes
+/// IRI-vs-literal a clean `True`/`False`, never an `Error` — so the bare form
+/// is rejected at parse time with a message naming the operand and both
+/// rewrites (quote it for a string, prefix it for an IRI).
 #[tokio::test(flavor = "current_thread")]
-async fn datalog_bare_local_name_filter_warns_instead_of_going_quiet() {
+async fn datalog_bare_token_filter_operand_is_rejected_with_named_operand() {
     let (store, _guard) = support::span_capture::init_test_tracing();
 
     let fluree = FlureeBuilder::memory().build_memory();
@@ -2252,22 +2253,31 @@ async fn datalog_bare_local_name_filter_warns_instead_of_going_quiet() {
 
     assert!(
         results.is_empty(),
-        "a bare local name is a string literal and must not match an IRI \
-         namespace-blindly, got {results:?}"
+        "a bare local name must never match an IRI namespace-blindly — the rule \
+         is rejected at parse time and derives nothing, got {results:?}"
     );
 
     let diagnostics: Vec<String> = store
         .all_events()
         .into_iter()
         .filter(|e| e.level == tracing::Level::WARN)
-        .map(|e| e.message().to_string())
+        .flat_map(|e| {
+            let mut parts: Vec<String> = e.fields.values().cloned().collect();
+            parts.push(e.message().to_string());
+            parts
+        })
         .collect();
+    assert!(
+        diagnostics.iter().any(|d| d.contains("`knows`")),
+        "a bare-token filter operand must be rejected with a diagnostic naming \
+         the operand, got {diagnostics:?}"
+    );
     assert!(
         diagnostics
             .iter()
-            .any(|d| d.contains("compared an IRI against a literal")),
-        "a stale bare-local-name filter must not fail silently — it needs a \
-         diagnostic pointing at the operand form, got {diagnostics:?}"
+            .any(|d| d.contains("\"knows\"") && d.contains("ex:knows")),
+        "the rejection must offer both rewrites — quoted string and prefixed \
+         IRI, got {diagnostics:?}"
     );
 }
 
@@ -2338,5 +2348,363 @@ async fn datalog_iri_versus_literal_filter_that_keeps_rows_is_not_flagged() {
         noisy.is_empty(),
         "an IRI-vs-literal filter that keeps rows is correct usage and must not \
          be flagged, got {noisy:?}"
+    );
+}
+
+/// The headline failure mode of #1556, reached through the `!=` direction of
+/// the workaround operand form. `(!= ?prop ssn)` read as a string comparison
+/// keeps every row — an IRI-bound `?prop` never equals the string `"ssn"` —
+/// so the copy-properties rule derives exactly the fact its filter was written
+/// to withhold, and no run-time gate can see it (every row surviving looks
+/// like success). The bare operand must therefore be rejected at parse time:
+/// the rule derives nothing, and the diagnostic names the operand.
+#[tokio::test(flavor = "current_thread")]
+async fn datalog_bare_token_exclusion_filter_must_not_leak_the_excluded_fact() {
+    let (store, _guard) = support::span_capture::init_test_tracing();
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/bare-token-exclusion");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                // Sound rule: must keep deriving even though its sibling is rejected.
+                "@id": "ex:grandparentRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": {"@id": "?person", "ex:parent": {"ex:parent": "?grandparent"}},
+                        "insert": {"@id": "?person", "ex:grandparent": {"@id": "?grandparent"}}
+                    }
+                }
+            },
+            {
+                // The pre-#1556 workaround form, in the direction that leaks:
+                // as a string comparison `(!= ?prop ssn)` is true for every
+                // IRI-bound ?prop, so the rule would copy ex:ssn.
+                "@id": "ex:copyPropsRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "ex:sameAs": {"@id": "?other"}},
+                            {"@id": "?other", "?prop": "?val"},
+                            ["filter", "(!= ?prop ssn)"]
+                        ],
+                        "insert": {"@id": "?s", "?prop": "?val"}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:sameAs": {"@id": "ex:bob"}, "ex:parent": {"@id": "ex:dan"}},
+            {"@id": "ex:dan", "ex:parent": {"@id": "ex:erin"}},
+            {"@id": "ex:bob", "ex:name": "Bob", "ex:ssn": "123-45-6789"}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": ["?prop", "?val"],
+        "where": {"@id": "ex:alice", "?prop": "?val"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    let rendered = serde_json::to_string(&results).unwrap();
+    assert!(
+        !rendered.contains("123-45-6789"),
+        "a bare-token exclusion filter must fail CLOSED — the rule must not run \
+         and copy the value its filter was meant to exclude, got {results:?}"
+    );
+    assert!(
+        results.contains(&json!(["ex:grandparent", "ex:erin"])),
+        "the sound sibling rule must keep deriving, got {results:?}"
+    );
+
+    let diagnostics: Vec<String> = store
+        .all_events()
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .flat_map(|e| {
+            let mut parts: Vec<String> = e.fields.values().cloned().collect();
+            parts.push(e.message().to_string());
+            parts
+        })
+        .collect();
+    assert!(
+        diagnostics.iter().any(|d| d.contains("`ssn`")),
+        "the rejected rule must produce a diagnostic naming the operand, \
+         got {diagnostics:?}"
+    );
+}
+
+/// Bare numeric and boolean operands are legitimately unquoted — they classify
+/// as number/boolean literals before the bare-token rejection can see them —
+/// and must keep working exactly as documented.
+#[tokio::test(flavor = "current_thread")]
+async fn datalog_bare_numeric_and_boolean_filter_operands_still_parse() {
+    let (store, _guard) = support::span_capture::init_test_tracing();
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/bare-numeric-boolean");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:adultRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?person", "ex:age": "?age"},
+                            ["filter", "(> ?age 20)"]
+                        ],
+                        "insert": {"@id": "?person", "ex:status": "adult"}
+                    }
+                }
+            },
+            {
+                "@id": "ex:activeRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?person", "ex:enabled": "?flag"},
+                            ["filter", "(= ?flag true)"]
+                        ],
+                        "insert": {"@id": "?person", "ex:status": "active"}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:age": 34, "ex:enabled": true},
+            {"@id": "ex:bob", "ex:age": 12, "ex:enabled": false}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": ["?person", "?status"],
+        "where": {"@id": "?person", "ex:status": "?status"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.contains(&json!(["ex:alice", "adult"]))
+            && results.contains(&json!(["ex:alice", "active"])),
+        "bare numeric and boolean operands must keep filtering, got {results:?}"
+    );
+    assert!(
+        !results.iter().any(|r| r[0] == json!("ex:bob")),
+        "the filters must still exclude non-matching rows, got {results:?}"
+    );
+
+    let noisy: Vec<String> = store
+        .all_events()
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .map(|e| e.message().to_string())
+        .collect();
+    assert!(
+        noisy.is_empty(),
+        "legitimate numeric/boolean operands must not produce diagnostics, \
+         got {noisy:?}"
+    );
+}
+
+/// The run-time complement of the parse-time bare-token rejection: a QUOTED
+/// operand that spells a CURIE — `(= ?p "ex:knows")` — is an explicit string
+/// comparison, so it parses, and against IRI-bound rows it eliminates
+/// everything (RDFterm-equal: an IRI never equals a literal). When that
+/// filter empties the rule's rows entirely, the run-time gate must say so.
+#[tokio::test(flavor = "current_thread")]
+async fn datalog_quoted_curie_lookalike_that_empties_rows_gets_the_runtime_hint() {
+    let (store, _guard) = support::span_capture::init_test_tracing();
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/quoted-curie-lookalike");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:staleQuotedRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "?p": {"@id": "?o"}},
+                            ["filter", "(= ?p \"ex:knows\")"]
+                        ],
+                        "insert": {"@id": "?s", "ex:derivedKnows": {"@id": "?o"}}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [{"@id": "ex:alice", "ex:knows": {"@id": "ex:bob"}}]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?who",
+        "where": {"@id": "ex:alice", "ex:derivedKnows": "?who"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.is_empty(),
+        "a quoted operand is a string and must not match an IRI, got {results:?}"
+    );
+
+    let diagnostics: Vec<String> = store
+        .all_events()
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .map(|e| e.message().to_string())
+        .collect();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.contains("compared an IRI against a literal")),
+        "a quoted CURIE-lookalike that empties every row must get the run-time \
+         hint, got {diagnostics:?}"
+    );
+}
+
+// =============================================================================
+// Per-pattern insert instantiation (multi-head rules)
+// =============================================================================
+
+/// A multi-head rule with one bad head must keep deriving from its good heads.
+/// `execute_rule_with_bindings` instantiates each insert pattern independently
+/// — that per-pattern semantic predates the #1560 diagnostic and must survive
+/// it: only a rule where NO insert pattern can ever instantiate is rejected
+/// outright. The bad head is skipped with a warning naming the variable.
+#[tokio::test(flavor = "current_thread")]
+async fn datalog_multi_head_rule_keeps_deriving_when_one_head_is_unbound() {
+    let (store, _guard) = support::span_capture::init_test_tracing();
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/multi-head-partial");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                // Two heads: the first is sound, the second says ?rel where the
+                // where clause binds ?relation.
+                "@id": "ex:twoHeadRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": {"@id": "?s", "ex:relType": {"@id": "?relation"}},
+                        "insert": [
+                            {"@id": "?s", "ex:hasRelation": {"@id": "?relation"}},
+                            {"@id": "?s", "?rel": {"@id": "?s"}}
+                        ]
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:relType": {"@id": "ex:friendOf"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?rel",
+        "where": {"@id": "ex:alice", "ex:hasRelation": "?rel"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.contains(&json!("ex:friendOf")),
+        "the sound head of a multi-head rule must keep deriving when a sibling \
+         head cannot instantiate, got {results:?}"
+    );
+
+    let diagnostics: Vec<String> = store
+        .all_events()
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .flat_map(|e| {
+            let mut parts: Vec<String> = e.fields.values().cloned().collect();
+            parts.push(e.message().to_string());
+            parts
+        })
+        .collect();
+    assert!(
+        diagnostics.iter().any(|d| d.contains("?rel")),
+        "the skipped head must produce a diagnostic naming ?rel, got {diagnostics:?}"
     );
 }

--- a/fluree-db-api/tests/it_datalog_rules.rs
+++ b/fluree-db-api/tests/it_datalog_rules.rs
@@ -1805,3 +1805,160 @@ async fn datalog_filter_unresolvable_iri_operand_fails_closed() {
         "the rejected rule must produce a diagnostic naming the operand, got {diagnostics:?}"
     );
 }
+
+// =============================================================================
+// Unbound insert-pattern variables (issue #1560)
+// =============================================================================
+
+/// #1560: a rule whose `insert` references a variable the `where` clause never
+/// binds derives nothing for every binding row — `instantiate_pattern` returns
+/// `None` and the row is dropped. That is correct semantics but it used to be
+/// completely silent. It must now produce a diagnostic naming the variable,
+/// without disturbing any other rule's derivations.
+#[tokio::test(flavor = "current_thread")]
+async fn datalog_unbound_insert_variable_reports_named_diagnostic() {
+    let (store, _guard) = support::span_capture::init_test_tracing();
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/unbound-insert-var");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:grandparentRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": {"@id": "?person", "ex:parent": {"ex:parent": "?grandparent"}},
+                        "insert": {"@id": "?person", "ex:grandparent": {"@id": "?grandparent"}}
+                    }
+                }
+            },
+            {
+                // The where clause binds ?relation; the insert says ?rel.
+                "@id": "ex:typoRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": {"@id": "?s", "ex:relType": {"@id": "?relation"}},
+                        "insert": {"@id": "?s", "?rel": {"@id": "?s"}}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:relType": {"@id": "ex:friendOf"}, "ex:parent": {"@id": "ex:bob"}},
+            {"@id": "ex:bob", "ex:parent": {"@id": "ex:charlie"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?grandparent",
+        "where": {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.contains(&json!("ex:charlie")),
+        "the sound rule must keep deriving alongside the broken one, got {results:?}"
+    );
+
+    let diagnostics: Vec<String> = store
+        .all_events()
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .flat_map(|e| {
+            let mut parts: Vec<String> = e.fields.values().cloned().collect();
+            parts.push(e.message().to_string());
+            parts
+        })
+        .collect();
+    assert!(
+        diagnostics.iter().any(|d| d.contains("?rel")),
+        "a rule whose insert references an unbindable variable must produce a \
+         diagnostic naming ?rel, got {diagnostics:?}"
+    );
+}
+
+/// The other half of #1560's acceptance criteria: no diagnostic noise for a
+/// rule that legitimately derives nothing because its where clause matched
+/// nothing. Silence is correct there; only "matched but could not instantiate"
+/// is an authoring bug.
+#[tokio::test(flavor = "current_thread")]
+async fn datalog_rule_matching_nothing_is_not_flagged() {
+    let (store, _guard) = support::span_capture::init_test_tracing();
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/no-match-no-warning");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:grandparentRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": {"@id": "?person", "ex:parent": {"ex:parent": "?grandparent"}},
+                        "insert": {"@id": "?person", "ex:grandparent": {"@id": "?grandparent"}}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    // Only a one-hop chain: the two-hop where clause matches nothing.
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [{"@id": "ex:alice", "ex:parent": {"@id": "ex:bob"}}]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?grandparent",
+        "where": {"@id": "ex:alice", "ex:grandparent": "?grandparent"},
+        "reasoning": "datalog"
+    });
+    let _ = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+
+    let noisy: Vec<String> = store
+        .all_events()
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .map(|e| e.message().to_string())
+        .filter(|m| m.contains("derived no facts"))
+        .collect();
+    assert!(
+        noisy.is_empty(),
+        "a rule whose where clause matched nothing must not be flagged, got {noisy:?}"
+    );
+}

--- a/fluree-db-api/tests/it_datalog_rules.rs
+++ b/fluree-db-api/tests/it_datalog_rules.rs
@@ -1962,3 +1962,381 @@ async fn datalog_rule_matching_nothing_is_not_flagged() {
         "a rule whose where clause matched nothing must not be flagged, got {noisy:?}"
     );
 }
+
+// =============================================================================
+// Review follow-ups on the #1556 fix
+// =============================================================================
+
+/// Making every Sid-bound variable resolve as an IRI must not start dropping
+/// IRI-valued rows from a filter that tests a *literal*.
+///
+/// SPARQL 1.1 §17.4.1.7 makes RDFterm-equal a type error only when both
+/// operands are literals; an IRI against a literal is simply not the same RDF
+/// term, so `!=` is true and the row is kept. Treating that pairing as a type
+/// error would be fail-closed but wrong — silent under-derivation.
+#[tokio::test]
+async fn datalog_filter_literal_does_not_drop_iri_valued_rows() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/filter-literal-vs-iri");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:copyExceptBobRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "ex:sameAs": {"@id": "?other"}},
+                            {"@id": "?other", "?prop": "?val"},
+                            ["filter", "(!= ?val \"Bob\")"]
+                        ],
+                        "insert": {"@id": "?s", "?prop": "?val"}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:sameAs": {"@id": "ex:bob"}},
+            {"@id": "ex:bob", "ex:name": "Bob", "ex:friend": {"@id": "ex:carol"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": ["?prop", "?val"],
+        "where": {"@id": "ex:alice", "?prop": "?val"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.contains(&json!(["ex:friend", "ex:carol"])),
+        "an IRI-valued property must survive a filter that excludes a literal — \
+         an IRI is not the literal \"Bob\", so (!= ?val \"Bob\") holds, got {results:?}"
+    );
+    assert!(
+        !results.contains(&json!(["ex:name", "Bob"])),
+        "the literal the filter names must still be excluded, got {results:?}"
+    );
+}
+
+/// A filter that quotes an operand containing whitespace must survive
+/// tokenization — the parse error for an unresolvable IRI operand recommends
+/// quoting, so the hatch has to actually work.
+#[tokio::test]
+async fn datalog_filter_quoted_operand_with_whitespace_works() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/filter-quoted-whitespace");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:notJohnRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "ex:name": "?name"},
+                            ["filter", "(!= ?name \"John Smith\")"]
+                        ],
+                        "insert": {"@id": "?s", "ex:screened": true}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:a", "ex:name": "John Smith"},
+            {"@id": "ex:b", "ex:name": "Jane Doe"}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?s",
+        "where": {"@id": "?s", "ex:screened": true},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.contains(&json!("ex:b")),
+        "the non-excluded row must derive, got {results:?}"
+    );
+    assert!(
+        !results.contains(&json!("ex:a")),
+        "a quoted operand containing a space must still exclude its match, \
+         got {results:?}"
+    );
+}
+
+/// A malformed filter must not vanish. If it does, `rule.filters` is empty,
+/// filtering is skipped entirely, and the rule derives everything it was
+/// written to restrict — the #1556 failure mode reached by another route.
+///
+/// All three shapes were silently dropped before: a wrong-length array, a
+/// non-string expression, and a filter keyword whose case does not match.
+#[tokio::test(flavor = "current_thread")]
+async fn datalog_malformed_filter_does_not_silently_vanish() {
+    for (label, filter_element) in [
+        (
+            "wrong arity",
+            json!(["filter", "(!= ?prop ex:ssn)", "oops"]),
+        ),
+        ("wrong case", json!(["FILTER", "(!= ?prop ex:ssn)"])),
+        (
+            "non-string expression",
+            json!(["filter", {"expr": "(!= ?prop ex:ssn)"}]),
+        ),
+    ] {
+        let (store, _guard) = support::span_capture::init_test_tracing();
+
+        let fluree = FlureeBuilder::memory().build_memory();
+        let ledger0 = genesis_ledger(&fluree, "datalog/malformed-filter");
+
+        let rule_data = json!({
+            "@context": {
+                "ex": "http://example.org/",
+                "f": "https://ns.flur.ee/db#"
+            },
+            "@graph": [
+                {
+                    "@id": "ex:copyPropsRule",
+                    "f:rule": {
+                        "@type": "@json",
+                        "@value": {
+                            "@context": {"ex": "http://example.org/"},
+                            "where": [
+                                {"@id": "?s", "ex:sameAs": {"@id": "?other"}},
+                                {"@id": "?other", "?prop": "?val"},
+                                filter_element
+                            ],
+                            "insert": {"@id": "?s", "?prop": "?val"}
+                        }
+                    }
+                }
+            ]
+        });
+        let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+        let data = json!({
+            "@context": {"ex": "http://example.org/"},
+            "@graph": [
+                {"@id": "ex:alice", "ex:sameAs": {"@id": "ex:bob"}},
+                {"@id": "ex:bob", "ex:name": "Bob", "ex:ssn": "123-45-6789"}
+            ]
+        });
+        let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+        let q = json!({
+            "@context": {"ex": "http://example.org/"},
+            "select": ["?prop", "?val"],
+            "where": {"@id": "ex:alice", "?prop": "?val"},
+            "reasoning": "datalog"
+        });
+        let rows = support::query_jsonld(&fluree, &ledger, &q)
+            .await
+            .unwrap()
+            .to_jsonld(&ledger.snapshot)
+            .unwrap();
+        let results = normalize_rows(&rows);
+
+        let rendered = serde_json::to_string(&results).unwrap();
+        assert!(
+            !rendered.contains("123-45-6789"),
+            "[{label}] a malformed filter must not be dropped on the floor — the \
+             rule ran unfiltered and copied the value the filter was meant to \
+             exclude, got {results:?}"
+        );
+
+        let warned = store
+            .all_events()
+            .into_iter()
+            .any(|e| e.level == tracing::Level::WARN);
+        assert!(
+            warned,
+            "[{label}] rejecting a malformed filter must produce a diagnostic"
+        );
+    }
+}
+
+/// The bare-local-name filter form — `(= ?p knows)` — was the only operand
+/// shape that ever matched a bound IRI before #1556 was fixed, so a rule
+/// written as a workaround uses exactly it. It now correctly derives nothing,
+/// because a bare name is a string literal and a string is never an IRI.
+///
+/// The risk is that it does so in silence: RDFterm-equal makes IRI-vs-literal
+/// a clean `False` rather than an `Error`, so the "could not compare its
+/// operands" path cannot see it. A stale rule must still say something.
+#[tokio::test(flavor = "current_thread")]
+async fn datalog_bare_local_name_filter_warns_instead_of_going_quiet() {
+    let (store, _guard) = support::span_capture::init_test_tracing();
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/bare-local-name-filter");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:staleWorkaroundRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "?p": {"@id": "?o"}},
+                            ["filter", "(= ?p knows)"]
+                        ],
+                        "insert": {"@id": "?s", "ex:derivedKnows": {"@id": "?o"}}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [{"@id": "ex:alice", "ex:knows": {"@id": "ex:bob"}}]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?who",
+        "where": {"@id": "ex:alice", "ex:derivedKnows": "?who"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.is_empty(),
+        "a bare local name is a string literal and must not match an IRI \
+         namespace-blindly, got {results:?}"
+    );
+
+    let diagnostics: Vec<String> = store
+        .all_events()
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .map(|e| e.message().to_string())
+        .collect();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.contains("compared an IRI against a literal")),
+        "a stale bare-local-name filter must not fail silently — it needs a \
+         diagnostic pointing at the operand form, got {diagnostics:?}"
+    );
+}
+
+/// The converse guard: a filter that legitimately compares an IRI against a
+/// literal and keeps rows must NOT trip the bare-local-name warning. The
+/// signal is only meaningful if it stays quiet on correct usage.
+#[tokio::test(flavor = "current_thread")]
+async fn datalog_iri_versus_literal_filter_that_keeps_rows_is_not_flagged() {
+    let (store, _guard) = support::span_capture::init_test_tracing();
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/iri-vs-literal-no-warn");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:copyExceptBobRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "ex:sameAs": {"@id": "?other"}},
+                            {"@id": "?other", "?prop": "?val"},
+                            ["filter", "(!= ?val \"Bob\")"]
+                        ],
+                        "insert": {"@id": "?s", "?prop": "?val"}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:sameAs": {"@id": "ex:bob"}},
+            {"@id": "ex:bob", "ex:name": "Bob", "ex:friend": {"@id": "ex:carol"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": ["?prop", "?val"],
+        "where": {"@id": "ex:alice", "?prop": "?val"},
+        "reasoning": "datalog"
+    });
+    let _ = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+
+    let noisy: Vec<String> = store
+        .all_events()
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .map(|e| e.message().to_string())
+        .filter(|m| m.contains("compared an IRI against a literal"))
+        .collect();
+    assert!(
+        noisy.is_empty(),
+        "an IRI-vs-literal filter that keeps rows is correct usage and must not \
+         be flagged, got {noisy:?}"
+    );
+}

--- a/fluree-db-api/tests/it_datalog_rules.rs
+++ b/fluree-db-api/tests/it_datalog_rules.rs
@@ -1432,3 +1432,376 @@ async fn datalog_rule_all_unbound_leading_pattern_still_derives_correctly() {
         "reordered rule with all-unbound leading pattern must still derive, got {results:?}"
     );
 }
+
+// =============================================================================
+// IRI comparison in rule FILTERs (issue #1556)
+//
+// A filter operand that names an IRI must compare against a bound IRI as an
+// IRI. Before the fix all three sites disagreed — the operand parsed as the
+// *string* `"ex:ssn"`, a bound Sid resolved to its bare local name `"ssn"`,
+// and `compare_values` string-compared the two — so `=` was always false and
+// `!=` was always true. The `!=` direction is the dangerous one: an exclusion
+// filter silently excluded nothing and the rule derived the very fact it was
+// written to withhold.
+// =============================================================================
+
+/// The headline of #1556: a copy-properties rule that excludes a sensitive
+/// predicate with `(!= ?prop ex:ssn)` must actually exclude it.
+///
+/// Before the fix this FAILED OPEN — `ex:ssn` was copied onto `ex:alice`
+/// anyway, with no error and no warning.
+#[tokio::test]
+async fn datalog_filter_iri_exclusion_actually_excludes() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/filter-iri-exclusion");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:copyPropsRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "ex:sameAs": {"@id": "?other"}},
+                            {"@id": "?other", "?prop": "?val"},
+                            ["filter", "(!= ?prop ex:ssn)"]
+                        ],
+                        "insert": {"@id": "?s", "?prop": "?val"}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:sameAs": {"@id": "ex:bob"}},
+            {"@id": "ex:bob", "ex:name": "Bob", "ex:ssn": "123-45-6789"}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": ["?prop", "?val"],
+        "where": {"@id": "ex:alice", "?prop": "?val"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.contains(&json!(["ex:name", "Bob"])),
+        "the non-excluded property must still be copied, got {results:?}"
+    );
+    let rendered = serde_json::to_string(&results).unwrap();
+    assert!(
+        !rendered.contains("ssn") && !rendered.contains("123-45-6789"),
+        "(!= ?prop ex:ssn) must EXCLUDE ex:ssn — an exclusion filter that fails \
+         open copies the sensitive value, got {results:?}"
+    );
+}
+
+/// The other direction of #1556: `(= ?p ex:knows)` was always false, so the
+/// rule derived nothing at all.
+#[tokio::test]
+async fn datalog_filter_iri_equality_matches() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/filter-iri-equality");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:connectedRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "?p": {"@id": "?o"}},
+                            ["filter", "(= ?p ex:knows)"]
+                        ],
+                        "insert": {"@id": "?s", "ex:connected": {"@id": "?o"}}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:knows": {"@id": "ex:bob"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?who",
+        "where": {"@id": "ex:alice", "ex:connected": "?who"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.contains(&json!("ex:bob")),
+        "(= ?p ex:knows) must match a ?p bound to ex:knows, got {results:?}"
+    );
+}
+
+/// IRI comparison must be namespace-aware: `(= ?p ex:knows)` must not match
+/// `foaf:knows`. The only operand that matched before the fix was the bare
+/// local name `knows`, which matched every `knows` in every namespace.
+#[tokio::test]
+async fn datalog_filter_iri_equality_is_namespace_aware() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/filter-iri-namespace");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:connectedRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "?p": {"@id": "?o"}},
+                            ["filter", "(= ?p ex:knows)"]
+                        ],
+                        "insert": {"@id": "?s", "ex:connected": {"@id": "?o"}}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "foaf": "http://xmlns.com/foaf/0.1/"
+        },
+        "@graph": [
+            {"@id": "ex:alice",
+             "ex:knows": {"@id": "ex:bob"},
+             "foaf:knows": {"@id": "ex:carol"}}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?who",
+        "where": {"@id": "ex:alice", "ex:connected": "?who"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.contains(&json!("ex:bob")),
+        "ex:knows must match, got {results:?}"
+    );
+    assert!(
+        !results.contains(&json!("ex:carol")),
+        "foaf:knows must NOT match the ex:knows filter operand — IRI comparison \
+         must be namespace-aware, not local-name-blind, got {results:?}"
+    );
+}
+
+/// #1556 is not specific to predicate position: `flake_value_to_binding` maps
+/// a `Ref` object to a `Sid` binding too, so an object-position IRI filter was
+/// broken identically — and in the `!=` direction, identically fail-open.
+#[tokio::test]
+async fn datalog_filter_iri_object_position_exclusion() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/filter-iri-object");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                "@id": "ex:knowsOtherRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "ex:knows": {"@id": "?o"}},
+                            ["filter", "(!= ?o ex:bob)"]
+                        ],
+                        "insert": {"@id": "?s", "ex:knowsOther": {"@id": "?o"}}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:knows": [{"@id": "ex:bob"}, {"@id": "ex:carol"}]}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": "?who",
+        "where": {"@id": "ex:alice", "ex:knowsOther": "?who"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    assert!(
+        results.contains(&json!("ex:carol")),
+        "the non-excluded object must still derive, got {results:?}"
+    );
+    assert!(
+        !results.contains(&json!("ex:bob")),
+        "(!= ?o ex:bob) must exclude ex:bob in object position, got {results:?}"
+    );
+}
+
+/// Fail CLOSED, not open. A filter operand that is shaped like a compact IRI
+/// but whose prefix the rule's `@context` never defines cannot be compared as
+/// an IRI. Demoting it to a string — what the engine used to do — is exactly
+/// the fail-open exclusion of #1556, so the rule is rejected at parse time
+/// instead: it derives nothing rather than deriving the excluded fact, and the
+/// author gets a named error.
+#[tokio::test(flavor = "current_thread")]
+async fn datalog_filter_unresolvable_iri_operand_fails_closed() {
+    let (store, _guard) = support::span_capture::init_test_tracing();
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "datalog/filter-iri-unresolvable");
+
+    let rule_data = json!({
+        "@context": {
+            "ex": "http://example.org/",
+            "f": "https://ns.flur.ee/db#"
+        },
+        "@graph": [
+            {
+                // Sound rule: must keep deriving even though its sibling is rejected.
+                "@id": "ex:grandparentRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": {"@id": "?person", "ex:parent": {"ex:parent": "?grandparent"}},
+                        "insert": {"@id": "?person", "ex:grandparent": {"@id": "?grandparent"}}
+                    }
+                }
+            },
+            {
+                // `foo:` is never defined in this rule's @context, so the
+                // operand cannot be resolved to an IRI.
+                "@id": "ex:copyPropsRule",
+                "f:rule": {
+                    "@type": "@json",
+                    "@value": {
+                        "@context": {"ex": "http://example.org/"},
+                        "where": [
+                            {"@id": "?s", "ex:sameAs": {"@id": "?other"}},
+                            {"@id": "?other", "?prop": "?val"},
+                            ["filter", "(!= ?prop foo:ssn)"]
+                        ],
+                        "insert": {"@id": "?s", "?prop": "?val"}
+                    }
+                }
+            }
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &rule_data).await.unwrap().ledger;
+
+    let data = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:alice", "ex:sameAs": {"@id": "ex:bob"}, "ex:parent": {"@id": "ex:dan"}},
+            {"@id": "ex:dan", "ex:parent": {"@id": "ex:erin"}},
+            {"@id": "ex:bob", "ex:name": "Bob", "ex:ssn": "123-45-6789"}
+        ]
+    });
+    let ledger = fluree.insert(ledger, &data).await.unwrap().ledger;
+
+    let q = json!({
+        "@context": {"ex": "http://example.org/"},
+        "select": ["?prop", "?val"],
+        "where": {"@id": "ex:alice", "?prop": "?val"},
+        "reasoning": "datalog"
+    });
+    let rows = support::query_jsonld(&fluree, &ledger, &q)
+        .await
+        .unwrap()
+        .to_jsonld(&ledger.snapshot)
+        .unwrap();
+    let results = normalize_rows(&rows);
+
+    let rendered = serde_json::to_string(&results).unwrap();
+    assert!(
+        !rendered.contains("123-45-6789"),
+        "an unresolvable IRI filter operand must fail CLOSED — the rule must not \
+         run and copy the value its filter was meant to exclude, got {results:?}"
+    );
+    assert!(
+        results.contains(&json!(["ex:grandparent", "ex:erin"])),
+        "the sound sibling rule must keep deriving, got {results:?}"
+    );
+
+    let diagnostics: Vec<String> = store
+        .all_events()
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .flat_map(|e| {
+            let mut parts: Vec<String> = e.fields.values().cloned().collect();
+            parts.push(e.message().to_string());
+            parts
+        })
+        .collect();
+    assert!(
+        diagnostics.iter().any(|d| d.contains("foo:ssn")),
+        "the rejected rule must produce a diagnostic naming the operand, got {diagnostics:?}"
+    );
+}

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -283,14 +283,32 @@ fn parse_where_clause(
                     }
                     JsonValue::Array(filter_arr) if is_filter_expression(filter_arr) => {
                         // Filter expression like ["filter", "(>= ?age 62)"]
-                        if let Some(filter) =
-                            parse_filter_expression(filter_arr, context, snapshot)?
-                        {
-                            filters.push(filter);
-                        }
+                        filters.push(parse_filter_expression(filter_arr, context, snapshot)?);
                     }
+                    // A near-miss on the filter keyword — `["FILTER", ...]` —
+                    // is rejected outright. It is unambiguously a filter the
+                    // author meant to apply, and dropping it silently is the
+                    // #1556 failure mode by another route: the filter
+                    // disappears, `rule.filters` is empty, and the rule derives
+                    // everything it was written to restrict.
+                    _ if looks_like_misspelled_filter(item) => {
+                        return Err(QueryError::InvalidQuery(format!(
+                            "Unrecognized element in rule where clause: {item}. \
+                             The filter keyword is lowercase `filter` — this element \
+                             would otherwise be dropped, leaving the rule to derive \
+                             the facts the filter was written to exclude."
+                        )));
+                    }
+                    // Anything else stays tolerated, as it has been. Whether an
+                    // unknown where-clause element should be an outright error
+                    // is a language decision beyond this fix, but it should not
+                    // vanish without a trace.
                     _ => {
-                        // Skip unknown array elements
+                        tracing::warn!(
+                            element = %item,
+                            "unrecognized element in datalog rule where clause — ignored; \
+                             expected a node pattern object or [\"filter\", \"(op ?var value)\"]"
+                        );
                     }
                 }
             }
@@ -311,6 +329,14 @@ fn parse_where_clause(
 /// the head must appear in the body. A rule that breaks it can never derive
 /// anything — `instantiate_pattern` returns `None` for each row — which is the
 /// silent dead end reported in #1560.
+///
+/// Parser-generated names on the where side are deliberately NOT treated as
+/// binding. They are numbered off each clause's own `patterns.len()`, so a
+/// where-side `?__implicit_0` and an unrelated insert-side `?__implicit_0`
+/// would otherwise collide and suppress the diagnostic for exactly the
+/// anonymous-node case it exists to report. An author cannot write one of
+/// these names, so an insert pattern can never legitimately be referring to
+/// the where clause's copy.
 fn unbound_insert_variables(
     where_patterns: &[RuleTriplePattern],
     insert_patterns: &[RuleTriplePattern],
@@ -319,6 +345,7 @@ fn unbound_insert_variables(
     for pattern in where_patterns {
         bind_pattern_vars(pattern, &mut bound);
     }
+    bound.retain(|v| !v.starts_with(IMPLICIT_VAR_PREFIX));
 
     let mut unbound: Vec<Arc<str>> = Vec::new();
     for pattern in insert_patterns {
@@ -383,24 +410,52 @@ fn is_filter_expression(arr: &[JsonValue]) -> bool {
     matches!(arr.first(), Some(JsonValue::String(s)) if s == "filter")
 }
 
+/// Whether a where-clause element is an array whose head is some case variant
+/// of `filter` — i.e. the author meant a filter and the keyword did not match.
+/// Used only to sharpen the rejection message.
+fn looks_like_misspelled_filter(item: &JsonValue) -> bool {
+    matches!(
+        item.as_array().and_then(|a| a.first()).and_then(|v| v.as_str()),
+        Some(s) if s.eq_ignore_ascii_case("filter")
+    )
+}
+
 /// Parse a filter expression like ["filter", "(>= ?age 62)"]
 ///
 /// `context` and `snapshot` are threaded in so an IRI operand can be expanded
 /// and resolved the same way a node-pattern term is (#1556) — without them a
 /// colon-bearing operand was silently demoted to a string and could never
 /// equal the IRI it named.
+///
+/// Every rejection path is an error rather than a quiet `None`. A filter that
+/// fails to parse and disappears leaves `rule.filters` empty, and
+/// [`execute_rule_matching`] then skips filtering entirely — so a malformed
+/// exclusion filter derives exactly the facts it was written to withhold,
+/// which is the #1556 failure mode reached by a different route.
 fn parse_filter_expression(
     arr: &[JsonValue],
     context: &JsonValue,
     snapshot: &LedgerSnapshot,
-) -> Result<Option<RuleFilter>> {
+) -> Result<RuleFilter> {
     if arr.len() != 2 {
-        return Ok(None);
+        return Err(QueryError::InvalidQuery(format!(
+            "A rule filter must have exactly two elements, \
+             [\"filter\", \"(op ?var value)\"], but got {} — refusing to drop the \
+             filter, since a rule that silently loses its filter derives the facts \
+             the filter was written to exclude.",
+            arr.len()
+        )));
     }
 
     let expr = match &arr[1] {
         JsonValue::String(s) => s.as_str(),
-        _ => return Ok(None),
+        other => {
+            return Err(QueryError::InvalidQuery(format!(
+                "A rule filter expression must be a string, but got {other} — \
+                 refusing to drop the filter, since a rule that silently loses its \
+                 filter derives the facts the filter was written to exclude."
+            )));
+        }
     };
 
     // Parse S-expression style filter: "(op arg1 arg2)"
@@ -412,7 +467,7 @@ fn parse_filter_expression(
     }
 
     let inner = &expr[1..expr.len() - 1];
-    let parts: Vec<&str> = inner.split_whitespace().collect();
+    let parts = split_filter_tokens(inner)?;
 
     if parts.len() < 2 {
         return Err(QueryError::InvalidQuery(format!(
@@ -449,6 +504,14 @@ fn parse_filter_expression(
     // never be answered. Reject it here rather than letting it evaluate to
     // "no" per row — a silently-unsatisfiable ordering filter is the same
     // class of invisible failure as the fail-open equality of #1556.
+    //
+    // This parse-time guard is JSON-LD-only: SPARQL rules never reach this
+    // function, and `sparql_lang.rs` lowers a constant IRI to
+    // `RuleTerm::Value(RuleValue::Ref(_))` rather than `RuleTerm::Sid(_)`.
+    // Both paths still fail closed — `compare_values` returns `Error` for IRI
+    // ordering at run time — so the difference is only in the diagnostic: a
+    // JSON-LD author gets a parse error naming the operator, a SPARQL author
+    // gets a per-rule warn from `execute_rule_matching`.
     if !matches!(op, CompareOp::Equal | CompareOp::NotEqual)
         && (matches!(left, RuleTerm::Sid(_)) || matches!(right, RuleTerm::Sid(_)))
     {
@@ -458,7 +521,55 @@ fn parse_filter_expression(
         )));
     }
 
-    Ok(Some(RuleFilter::Compare { op, left, right }))
+    Ok(RuleFilter::Compare { op, left, right })
+}
+
+/// Split a filter's inner S-expression into tokens, keeping a quoted operand
+/// whole.
+///
+/// Plain `split_whitespace` tore `"John Smith"` into `"John` and `Smith"`, so
+/// the quoting escape hatch that [`parse_filter_term`]'s own error message
+/// recommends did not survive a value containing a space — the operand became
+/// the literal string `"John`, leading quote included. Quotes are kept in the
+/// token so `quoted_literal` can still recognise and strip them.
+///
+/// An unterminated quote is an error rather than a silently truncated operand.
+fn split_filter_tokens(inner: &str) -> Result<Vec<&str>> {
+    let bytes = inner.as_bytes();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            break;
+        }
+
+        let start = i;
+        if bytes[i] == b'"' || bytes[i] == b'\'' {
+            let quote = bytes[i];
+            i += 1;
+            while i < bytes.len() && bytes[i] != quote {
+                i += 1;
+            }
+            if i >= bytes.len() {
+                return Err(QueryError::InvalidQuery(format!(
+                    "Unterminated quote in filter expression: {inner}. \
+                     A quoted operand must close its quote."
+                )));
+            }
+            i += 1; // consume the closing quote
+        } else {
+            while i < bytes.len() && !bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+        }
+        tokens.push(&inner[start..i]);
+    }
+
+    Ok(tokens)
 }
 
 /// The prefix of a token shaped like a compact IRI (`prefix:local`).
@@ -895,41 +1006,72 @@ pub async fn execute_rule_matching(
     // Apply filters to eliminate non-matching bindings.
     //
     // A row survives only on an outright `True`. `Error` — an unresolvable
-    // operand or a pair of values with no defined comparison — drops the row,
-    // never keeps it, so no filter can fail open (#1556).
+    // operand or a pair of literals with no defined comparison — drops the row,
+    // never keeps it, so filter *evaluation* cannot fail open (#1556).
     if !rule.filters.is_empty() {
-        let mut errored_rows = 0usize;
+        let rows_before = binding_rows.len();
+        let mut diagnostics = FilterDiagnostics::default();
         binding_rows.retain(|bindings| {
             let mut row_errored = false;
-            let keep = rule
-                .filters
-                .iter()
-                .all(|filter| match evaluate_filter(filter, bindings) {
+            let keep = rule.filters.iter().all(|filter| {
+                match evaluate_filter(filter, bindings, &mut diagnostics) {
                     FilterOutcome::True => true,
                     FilterOutcome::False => false,
                     FilterOutcome::Error => {
                         row_errored = true;
                         false
                     }
-                });
-            errored_rows += row_errored as usize;
+                }
+            });
+            diagnostics.errored_rows += row_errored as usize;
             keep
         });
-        if errored_rows > 0 {
+
+        if diagnostics.errored_rows > 0 {
             // Excluding the row is the safe answer, but silently excluding it
             // is how a mis-typed filter looks exactly like a rule that
             // legitimately matched nothing.
             tracing::warn!(
                 rule = rule.name.as_deref().unwrap_or("<unnamed>"),
                 rule_id = %rule.id,
-                errored_rows,
+                errored_rows = diagnostics.errored_rows,
                 "datalog rule filter could not compare its operands on some binding \
                  rows; those rows were excluded — check the filter's operand types"
+            );
+        } else if rows_before > 0 && binding_rows.is_empty() && diagnostics.iri_vs_literal > 0 {
+            // Every row was eliminated, and at least one comparison put an IRI
+            // against a literal. That is the signature of a filter written
+            // against a bare local name — `(= ?p knows)` — which was the only
+            // operand form that matched a bound IRI before #1556 was fixed, so
+            // it is exactly what a rule authored as a workaround looks like.
+            // Such a rule now correctly derives nothing, and without this it
+            // would do so in complete silence: RDFterm-equal makes IRI-vs-literal
+            // a clean `False`, not an `Error`, so the branch above cannot see it.
+            tracing::warn!(
+                rule = rule.name.as_deref().unwrap_or("<unnamed>"),
+                rule_id = %rule.id,
+                rows_before,
+                "datalog rule filter compared an IRI against a literal and excluded \
+                 every binding row; if the operand was meant to name an IRI, write it \
+                 as a prefixed or absolute IRI (`ex:knows`) rather than a bare local \
+                 name (`knows`) — a bare name is a string literal and never equals an IRI"
             );
         }
     }
 
     Ok(binding_rows)
+}
+
+/// Per-rule tallies gathered while filtering, used only for diagnostics.
+#[derive(Default)]
+struct FilterDiagnostics {
+    /// Rows dropped because some filter could not be evaluated at all.
+    errored_rows: usize,
+    /// Comparisons that put an IRI against a literal. Well-defined (and false)
+    /// per RDFterm-equal, so it never drops a row on its own — but when it
+    /// coincides with "every row eliminated" it is the fingerprint of a stale
+    /// bare-local-name filter.
+    iri_vs_literal: usize,
 }
 
 /// Outcome of evaluating a rule filter against one binding row.
@@ -947,14 +1089,26 @@ enum FilterOutcome {
 }
 
 /// Evaluate a filter expression against a set of bindings
-fn evaluate_filter(filter: &RuleFilter, bindings: &Bindings) -> FilterOutcome {
+///
+/// `diagnostics` accumulates the tallies that make a silently-empty filter
+/// explainable afterwards; evaluation itself does not consult them.
+fn evaluate_filter(
+    filter: &RuleFilter,
+    bindings: &Bindings,
+    diagnostics: &mut FilterDiagnostics,
+) -> FilterOutcome {
     match filter {
         RuleFilter::Compare { op, left, right } => {
             let left_val = resolve_filter_term(left, bindings);
             let right_val = resolve_filter_term(right, bindings);
 
             match (left_val, right_val) {
-                (Some(l), Some(r)) => compare_values(&l, &r, *op),
+                (Some(l), Some(r)) => {
+                    if matches!(l, FlakeValue::Ref(_)) != matches!(r, FlakeValue::Ref(_)) {
+                        diagnostics.iri_vs_literal += 1;
+                    }
+                    compare_values(&l, &r, *op)
+                }
                 // An unbound operand cannot be judged either way.
                 _ => FilterOutcome::Error,
             }
@@ -963,7 +1117,7 @@ fn evaluate_filter(filter: &RuleFilter, bindings: &Bindings) -> FilterOutcome {
         RuleFilter::And(filters) => {
             let mut saw_error = false;
             for f in filters {
-                match evaluate_filter(f, bindings) {
+                match evaluate_filter(f, bindings, diagnostics) {
                     FilterOutcome::False => return FilterOutcome::False,
                     FilterOutcome::Error => saw_error = true,
                     FilterOutcome::True => {}
@@ -979,7 +1133,7 @@ fn evaluate_filter(filter: &RuleFilter, bindings: &Bindings) -> FilterOutcome {
         RuleFilter::Or(filters) => {
             let mut saw_error = false;
             for f in filters {
-                match evaluate_filter(f, bindings) {
+                match evaluate_filter(f, bindings, diagnostics) {
                     FilterOutcome::True => return FilterOutcome::True,
                     FilterOutcome::Error => saw_error = true,
                     FilterOutcome::False => {}
@@ -991,7 +1145,7 @@ fn evaluate_filter(filter: &RuleFilter, bindings: &Bindings) -> FilterOutcome {
                 FilterOutcome::False
             }
         }
-        RuleFilter::Not(inner) => match evaluate_filter(inner, bindings) {
+        RuleFilter::Not(inner) => match evaluate_filter(inner, bindings, diagnostics) {
             FilterOutcome::True => FilterOutcome::False,
             FilterOutcome::False => FilterOutcome::True,
             // Never `True`: negating something uncomparable must not admit the row.
@@ -1078,6 +1232,23 @@ fn compare_values(left: &FlakeValue, right: &FlakeValue, op: CompareOp) -> Filte
                 _ => FilterOutcome::Error,
             };
         }
+        // RDFterm-equal (SPARQL 1.1 §17.4.1.7) is a type error only "if the
+        // arguments are both literal but are not the same RDF term". An IRI
+        // against a literal is not both-literal, so the comparison is
+        // well-defined and simply false — they can never be the same RDF term.
+        // Routing this pair to `Error` instead would drop the row, which is
+        // safe but is silent under-derivation: a copy-properties rule filtering
+        // on a value, `(!= ?val "Bob")`, would discard every IRI-valued
+        // property. Must stay below the `(Ref, Ref)` arm so Sid identity wins
+        // when both sides really are IRIs.
+        (FlakeValue::Ref(_), _) | (_, FlakeValue::Ref(_)) => {
+            return match op {
+                CompareOp::Equal => outcome(false),
+                CompareOp::NotEqual => outcome(true),
+                // Ordering across an IRI and a literal remains undefined.
+                _ => FilterOutcome::Error,
+            };
+        }
         (FlakeValue::Boolean(l), FlakeValue::Boolean(r)) => {
             // Boolean comparison
             return match op {
@@ -1086,7 +1257,9 @@ fn compare_values(left: &FlakeValue, right: &FlakeValue, op: CompareOp) -> Filte
                 _ => FilterOutcome::Error, // Other comparisons don't make sense for booleans
             };
         }
-        _ => return FilterOutcome::Error, // Incompatible types
+        // Both literals, not the same RDF term: a genuine type error per
+        // §17.4.1.7 (e.g. a string against a number).
+        _ => return FilterOutcome::Error,
     };
 
     let cmp = left_str.cmp(right_str);
@@ -1936,12 +2109,61 @@ mod tests {
     }
 
     #[test]
-    fn incomparable_operands_never_fail_open() {
-        // The whole point of #1556: an inequality the engine cannot actually
-        // evaluate must not answer "true" and let the row through. An IRI
-        // against a string is exactly the pairing the old code stringified.
+    fn iri_versus_literal_follows_rdfterm_equal() {
+        // SPARQL 1.1 §17.4.1.7: RDFterm-equal is a type error only when BOTH
+        // operands are literals. An IRI and a literal are simply never the same
+        // RDF term, so `=` is false and `!=` is true — routing this pair to
+        // Error would drop rows the spec says to keep.
         let iri = FlakeValue::Ref(sid(100, "ssn"));
         let text = FlakeValue::String("ex:ssn".to_string());
+
+        assert_eq!(
+            compare_values(&iri, &text, CompareOp::Equal),
+            FilterOutcome::False
+        );
+        assert_eq!(
+            compare_values(&iri, &text, CompareOp::NotEqual),
+            FilterOutcome::True,
+            "an IRI is genuinely not a literal; `!=` must keep the row"
+        );
+        // Direction must not matter.
+        assert_eq!(
+            compare_values(&text, &iri, CompareOp::NotEqual),
+            FilterOutcome::True
+        );
+        // An IRI against a number is the same story.
+        assert_eq!(
+            compare_values(&iri, &FlakeValue::Long(5), CompareOp::NotEqual),
+            FilterOutcome::True
+        );
+        // Ordering across an IRI and a literal stays undefined.
+        for op in [CompareOp::LessThan, CompareOp::GreaterThan] {
+            assert_eq!(compare_values(&iri, &text, op), FilterOutcome::Error);
+        }
+    }
+
+    #[test]
+    fn two_literals_of_different_types_are_a_type_error() {
+        // The other half of §17.4.1.7: both operands literal and not the same
+        // RDF term IS the type-error case.
+        let text = FlakeValue::String("5".to_string());
+        let number = FlakeValue::Long(5);
+        assert_eq!(
+            compare_values(&text, &number, CompareOp::Equal),
+            FilterOutcome::Error
+        );
+        assert_eq!(
+            compare_values(&text, &number, CompareOp::NotEqual),
+            FilterOutcome::Error
+        );
+    }
+
+    #[test]
+    fn incomparable_operands_never_fail_open() {
+        // #1556's invariant, stated over the pairing that is genuinely
+        // undecidable: a type error must never answer "true" and admit the row.
+        let text = FlakeValue::String("5".to_string());
+        let number = FlakeValue::Long(5);
 
         for op in [
             CompareOp::Equal,
@@ -1950,9 +2172,9 @@ mod tests {
             CompareOp::GreaterThan,
         ] {
             assert_ne!(
-                compare_values(&iri, &text, op),
+                compare_values(&text, &number, op),
                 FilterOutcome::True,
-                "IRI vs string must never evaluate true for {op:?}"
+                "a type error must never evaluate true for {op:?}"
             );
         }
     }
@@ -1970,11 +2192,15 @@ mod tests {
         };
 
         assert_eq!(
-            evaluate_filter(&uncomparable, &bindings),
+            evaluate_filter(&uncomparable, &bindings, &mut FilterDiagnostics::default()),
             FilterOutcome::Error
         );
         assert_eq!(
-            evaluate_filter(&RuleFilter::Not(Box::new(uncomparable)), &bindings),
+            evaluate_filter(
+                &RuleFilter::Not(Box::new(uncomparable)),
+                &bindings,
+                &mut FilterDiagnostics::default()
+            ),
             FilterOutcome::Error,
             "negating an error must stay an error, never become True"
         );
@@ -2001,20 +2227,36 @@ mod tests {
 
         // false && error => false; true && error => error
         assert_eq!(
-            evaluate_filter(&RuleFilter::And(vec![falsehood(), error()]), &bindings),
+            evaluate_filter(
+                &RuleFilter::And(vec![falsehood(), error()]),
+                &bindings,
+                &mut FilterDiagnostics::default()
+            ),
             FilterOutcome::False
         );
         assert_eq!(
-            evaluate_filter(&RuleFilter::And(vec![truth(), error()]), &bindings),
+            evaluate_filter(
+                &RuleFilter::And(vec![truth(), error()]),
+                &bindings,
+                &mut FilterDiagnostics::default()
+            ),
             FilterOutcome::Error
         );
         // true || error => true; false || error => error
         assert_eq!(
-            evaluate_filter(&RuleFilter::Or(vec![truth(), error()]), &bindings),
+            evaluate_filter(
+                &RuleFilter::Or(vec![truth(), error()]),
+                &bindings,
+                &mut FilterDiagnostics::default()
+            ),
             FilterOutcome::True
         );
         assert_eq!(
-            evaluate_filter(&RuleFilter::Or(vec![falsehood(), error()]), &bindings),
+            evaluate_filter(
+                &RuleFilter::Or(vec![falsehood(), error()]),
+                &bindings,
+                &mut FilterDiagnostics::default()
+            ),
             FilterOutcome::Error
         );
     }
@@ -2030,6 +2272,52 @@ mod tests {
             Some(FlakeValue::Ref(sid(100, "knows"))),
             "a Sid binding must stay a Ref, not collapse to its local name"
         );
+    }
+
+    #[test]
+    fn quoted_operand_survives_whitespace() {
+        // The escape hatch the parse error recommends has to work for a value
+        // with a space in it; `split_whitespace` used to tear it in half and
+        // leave the operand as the literal `"John`.
+        let tokens = split_filter_tokens(r#"= ?name "John Smith""#).expect("tokenize");
+        assert_eq!(tokens, vec!["=", "?name", "\"John Smith\""]);
+        assert_eq!(quoted_literal(tokens[2]), Some("John Smith"));
+    }
+
+    #[test]
+    fn unterminated_quote_is_rejected() {
+        let err = split_filter_tokens(r#"= ?name "John"#).expect_err("must reject");
+        assert!(
+            format!("{err:?}").contains("Unterminated quote"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn plain_tokens_still_split_on_whitespace() {
+        assert_eq!(
+            split_filter_tokens(">=  ?age   62").expect("tokenize"),
+            vec![">=", "?age", "62"]
+        );
+        assert!(split_filter_tokens("   ").expect("tokenize").is_empty());
+    }
+
+    #[test]
+    fn misspelled_filter_keyword_is_recognized_for_the_message() {
+        assert!(looks_like_misspelled_filter(&serde_json::json!([
+            "FILTER",
+            "(!= ?p ex:ssn)"
+        ])));
+        assert!(looks_like_misspelled_filter(&serde_json::json!([
+            "Filter",
+            "(!= ?p ex:ssn)"
+        ])));
+        assert!(!looks_like_misspelled_filter(&serde_json::json!([
+            "bind", "(?x 1)"
+        ])));
+        assert!(!looks_like_misspelled_filter(&serde_json::json!({
+            "@id": "?s"
+        })));
     }
 
     // ------------------------------------------------------------------
@@ -2060,6 +2348,29 @@ mod tests {
             message.contains("?rel"),
             "the diagnostic must name the offending variable, got: {message}"
         );
+    }
+
+    #[test]
+    fn where_side_generated_name_does_not_mask_an_insert_side_one() {
+        // Both clauses number their generated variables from their own
+        // `patterns.len()`, so the names collide at index 0. A where-side
+        // `?__implicit_0` must not be treated as binding the insert-side one,
+        // or the anonymous-node diagnostic is suppressed exactly where it is
+        // needed.
+        let where_patterns = vec![triple(
+            RuleTerm::var("?__implicit_0"),
+            RuleTerm::sid(sid(100, "parent")),
+            RuleTerm::var("?p"),
+        )];
+        let insert_patterns = vec![triple(
+            RuleTerm::var("?__implicit_0"),
+            RuleTerm::sid(sid(100, "ancestor")),
+            RuleTerm::var("?p"),
+        )];
+
+        let message = unsafe_insert_variables_message(&where_patterns, &insert_patterns)
+            .expect("collision must not suppress the diagnostic");
+        assert!(message.contains("@id"), "got: {message}");
     }
 
     #[test]

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -47,6 +47,12 @@ impl From<RuleError> for QueryError {
 /// Local name for the f:rule predicate
 const RULE_LOCAL_NAME: &str = "rule";
 
+/// Prefix the parser puts on variables it invents for anonymous and nested
+/// nodes (`?__implicit_0`, `?__nested_1`, `?__anon_2`). A rule author never
+/// writes one, so diagnostics must not quote them back
+/// (see [`unsafe_insert_variables_message`]).
+const IMPLICIT_VAR_PREFIX: &str = "?__";
+
 /// Extract datalog rules from a database
 ///
 /// Queries for all `f:rule` triples and parses the rule definitions.
@@ -230,6 +236,13 @@ fn parse_rule_definition(
         .ok_or_else(|| QueryError::InvalidQuery("Rule missing 'insert' clause".to_string()))?;
     let insert_patterns = parse_insert_patterns(insert_json, &context, snapshot)?;
 
+    // Reject an insert pattern that references a variable nothing can bind
+    // (#1560). Left alone it is invisible: every binding row is dropped inside
+    // `instantiate_pattern`, so the rule "runs" and derives nothing.
+    if let Some(message) = unsafe_insert_variables_message(&where_patterns, &insert_patterns) {
+        return Err(QueryError::InvalidQuery(message));
+    }
+
     let mut rule = DatalogRule::new(rule_id.clone(), where_patterns, insert_patterns);
 
     // Add filters if any were parsed
@@ -290,6 +303,79 @@ fn parse_where_clause(
     }
 
     Ok((patterns, filters))
+}
+
+/// Variables an `insert` pattern references that no `where` pattern can bind.
+///
+/// This is datalog's range-restriction (safety) condition: every variable in
+/// the head must appear in the body. A rule that breaks it can never derive
+/// anything — `instantiate_pattern` returns `None` for each row — which is the
+/// silent dead end reported in #1560.
+fn unbound_insert_variables(
+    where_patterns: &[RuleTriplePattern],
+    insert_patterns: &[RuleTriplePattern],
+) -> Vec<Arc<str>> {
+    let mut bound: HashSet<Arc<str>> = HashSet::new();
+    for pattern in where_patterns {
+        bind_pattern_vars(pattern, &mut bound);
+    }
+
+    let mut unbound: Vec<Arc<str>> = Vec::new();
+    for pattern in insert_patterns {
+        for term in [&pattern.subject, &pattern.predicate, &pattern.object] {
+            if let RuleTerm::Var(v) = term {
+                if !bound.contains(v) && !unbound.contains(v) {
+                    unbound.push(v.clone());
+                }
+            }
+        }
+    }
+    unbound
+}
+
+/// Actionable message for a rule that violates range restriction, or `None`
+/// when the rule is safe.
+///
+/// Names the offending variables, because "this rule derives nothing" without
+/// them sends an author reading engine source (#1560). Auto-generated
+/// variables get their own wording: the author never wrote `?__implicit_0`, so
+/// naming it would be useless — what they need to know is that a node in the
+/// insert clause has no `@id`.
+fn unsafe_insert_variables_message(
+    where_patterns: &[RuleTriplePattern],
+    insert_patterns: &[RuleTriplePattern],
+) -> Option<String> {
+    let unbound = unbound_insert_variables(where_patterns, insert_patterns);
+    if unbound.is_empty() {
+        return None;
+    }
+
+    let (generated, authored): (Vec<&Arc<str>>, Vec<&Arc<str>>) = unbound
+        .iter()
+        .partition(|v| v.starts_with(IMPLICIT_VAR_PREFIX));
+
+    let mut parts: Vec<String> = Vec::new();
+    if !authored.is_empty() {
+        let names: Vec<&str> = authored.iter().map(|v| &***v).collect();
+        parts.push(format!(
+            "insert pattern references {} that the where clause never binds \
+             (check for a typo against the where clause's variable names)",
+            names.join(", ")
+        ));
+    }
+    if !generated.is_empty() {
+        parts.push(
+            "insert pattern contains a node with no `@id` (or a nested anonymous \
+             node), which has no subject to derive facts about"
+                .to_string(),
+        );
+    }
+
+    Some(format!(
+        "Rule cannot derive anything: {}. Every variable used in `insert` must \
+         also appear in `where`.",
+        parts.join("; ")
+    ))
 }
 
 /// Check if an array is a filter expression (starts with "filter")
@@ -488,7 +574,7 @@ fn parse_node_pattern(
     } else {
         // Generate unique implicit variable for anonymous node
         // Use patterns.len() to ensure uniqueness across multiple node patterns
-        let var_name = format!("?__implicit_{}", patterns.len());
+        let var_name = format!("{IMPLICIT_VAR_PREFIX}implicit_{}", patterns.len());
         RuleTerm::var(&var_name)
     };
 
@@ -529,7 +615,7 @@ fn parse_node_pattern(
                     parse_term(nested_id, context, snapshot)?
                 } else {
                     // Generate intermediate variable
-                    let var_name = format!("?__nested_{}", patterns.len());
+                    let var_name = format!("{IMPLICIT_VAR_PREFIX}nested_{}", patterns.len());
                     RuleTerm::var(&var_name)
                 };
 
@@ -594,7 +680,7 @@ fn parse_object_value(
         }
         JsonValue::Object(nested) => {
             // Nested anonymous node - generate variable and recurse
-            let var_name = format!("?__anon_{}", patterns.len());
+            let var_name = format!("{IMPLICIT_VAR_PREFIX}anon_{}", patterns.len());
             let nested_subject = RuleTerm::var(&var_name);
 
             // Create a map with @id for recursive parsing
@@ -1500,6 +1586,10 @@ pub async fn execute_datalog_rules_with_query_rules(
 
     let start = Instant::now();
     let mut capped: Option<&str> = None;
+    // Rules already flagged for "matched, but instantiated nothing" (#1560).
+    // The fixpoint re-runs every rule each round, so without this the same
+    // rule would warn once per iteration.
+    let mut warned_barren: HashSet<Sid> = HashSet::new();
 
     loop {
         // Budget check BEFORE another round — a round can scan the whole ledger
@@ -1536,12 +1626,32 @@ pub async fn execute_datalog_rules_with_query_rules(
             let binding_rows = execute_rule_matching(rule, iter_db).await?;
 
             if binding_rows.is_empty() {
+                // The where clause matched nothing. That is ordinary and says
+                // nothing about the rule's soundness — stay quiet (#1560).
                 continue;
             }
+            let matched_rows = binding_rows.len();
 
             // Generate flakes from bindings
             let flakes =
                 fluree_db_reasoner::execute_rule_with_bindings(rule, binding_rows, derived_t);
+
+            // "The where clause matched but the insert could not instantiate"
+            // is almost always an authoring bug, and it is invisible otherwise:
+            // the rule appears to run and the fixpoint completes normally
+            // (#1560). Catches what the parse-time safety check cannot see —
+            // SPARQL-lowered rules, and a subject/predicate variable that binds
+            // to a literal only at run time.
+            if flakes.is_empty() && warned_barren.insert(rule.id.clone()) {
+                tracing::warn!(
+                    rule = rule.name.as_deref().unwrap_or("<unnamed>"),
+                    rule_id = %rule.id,
+                    matched_rows,
+                    "datalog rule matched binding rows but derived no facts: every row \
+                     failed to instantiate its insert pattern — an insert variable is \
+                     unbound, or is bound to a literal in subject/predicate position"
+                );
+            }
 
             // Add new flakes (deduplicating by s, p, o, dt, m)
             for flake in flakes {
@@ -1919,6 +2029,80 @@ mod tests {
             resolved,
             Some(FlakeValue::Ref(sid(100, "knows"))),
             "a Sid binding must stay a Ref, not collapse to its local name"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Unbound insert variables (#1560)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn unbound_insert_variable_is_named() {
+        // The issue's own repro: where binds ?relation, insert says ?rel.
+        let where_patterns = vec![triple(
+            RuleTerm::var("?s"),
+            RuleTerm::sid(sid(100, "relType")),
+            RuleTerm::var("?relation"),
+        )];
+        let insert_patterns = vec![triple(
+            RuleTerm::var("?s"),
+            RuleTerm::var("?rel"),
+            RuleTerm::var("?s"),
+        )];
+
+        let unbound = unbound_insert_variables(&where_patterns, &insert_patterns);
+        assert_eq!(unbound.len(), 1);
+        assert_eq!(unbound[0].as_ref(), "?rel");
+
+        let message = unsafe_insert_variables_message(&where_patterns, &insert_patterns)
+            .expect("unsafe rule must produce a message");
+        assert!(
+            message.contains("?rel"),
+            "the diagnostic must name the offending variable, got: {message}"
+        );
+    }
+
+    #[test]
+    fn safe_rule_produces_no_message() {
+        let where_patterns = vec![triple(
+            RuleTerm::var("?s"),
+            RuleTerm::sid(sid(100, "parent")),
+            RuleTerm::var("?p"),
+        )];
+        let insert_patterns = vec![triple(
+            RuleTerm::var("?s"),
+            RuleTerm::sid(sid(100, "ancestor")),
+            RuleTerm::var("?p"),
+        )];
+
+        assert!(unbound_insert_variables(&where_patterns, &insert_patterns).is_empty());
+        assert!(unsafe_insert_variables_message(&where_patterns, &insert_patterns).is_none());
+    }
+
+    #[test]
+    fn generated_variables_get_their_own_wording() {
+        // An author never wrote `?__implicit_0`, so quoting it back is useless
+        // — the message has to say what they actually did wrong.
+        let where_patterns = vec![triple(
+            RuleTerm::var("?s"),
+            RuleTerm::sid(sid(100, "parent")),
+            RuleTerm::var("?p"),
+        )];
+        let insert_patterns = vec![triple(
+            RuleTerm::var("?__implicit_0"),
+            RuleTerm::sid(sid(100, "ancestor")),
+            RuleTerm::var("?p"),
+        )];
+
+        let message = unsafe_insert_variables_message(&where_patterns, &insert_patterns)
+            .expect("anonymous insert node must produce a message");
+        assert!(
+            message.contains("@id"),
+            "the diagnostic must point at the missing @id, got: {message}"
+        );
+        assert!(
+            !message.contains("?__implicit_0"),
+            "the diagnostic must not quote an engine-generated name, got: {message}"
         );
     }
 }

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -236,11 +236,37 @@ fn parse_rule_definition(
         .ok_or_else(|| QueryError::InvalidQuery("Rule missing 'insert' clause".to_string()))?;
     let insert_patterns = parse_insert_patterns(insert_json, &context, snapshot)?;
 
-    // Reject an insert pattern that references a variable nothing can bind
-    // (#1560). Left alone it is invisible: every binding row is dropped inside
-    // `instantiate_pattern`, so the rule "runs" and derives nothing.
-    if let Some(message) = unsafe_insert_variables_message(&where_patterns, &insert_patterns) {
-        return Err(QueryError::InvalidQuery(message));
+    // Range restriction (#1560), enforced PER insert pattern to preserve the
+    // runtime semantic: `execute_rule_with_bindings` instantiates each insert
+    // pattern independently, so one head that can never instantiate must not
+    // silence the others. A head referencing a variable nothing can bind is
+    // skipped with a diagnostic naming the variable, and the remaining heads
+    // keep deriving; only a rule with NO instantiable head — which can never
+    // derive anything at all — is rejected outright. Left alone either case is
+    // invisible: every binding row is dropped inside `instantiate_pattern`, so
+    // the rule "runs" and derives nothing (or less than it was written to).
+    let bound = authored_bound_vars(&where_patterns);
+    let (insert_patterns, skipped): (Vec<RuleTriplePattern>, Vec<RuleTriplePattern>) =
+        insert_patterns
+            .into_iter()
+            .partition(|p| insert_pattern_is_instantiable(p, &bound));
+    if !skipped.is_empty() {
+        if insert_patterns.is_empty() {
+            let message = unsafe_insert_variables_message(&where_patterns, &skipped)
+                .expect("skipped insert patterns reference unbound variables");
+            return Err(QueryError::InvalidQuery(message));
+        }
+        let description = unbound_insert_description(&where_patterns, &skipped)
+            .expect("skipped insert patterns reference unbound variables");
+        tracing::warn!(
+            rule_id = %rule_id,
+            skipped = skipped.len(),
+            kept = insert_patterns.len(),
+            "datalog rule insert pattern skipped — {}. Every variable used in \
+             `insert` must also appear in `where`; the rule's remaining insert \
+             patterns still derive",
+            description
+        );
     }
 
     let mut rule = DatalogRule::new(rule_id.clone(), where_patterns, insert_patterns);
@@ -341,11 +367,7 @@ fn unbound_insert_variables(
     where_patterns: &[RuleTriplePattern],
     insert_patterns: &[RuleTriplePattern],
 ) -> Vec<Arc<str>> {
-    let mut bound: HashSet<Arc<str>> = HashSet::new();
-    for pattern in where_patterns {
-        bind_pattern_vars(pattern, &mut bound);
-    }
-    bound.retain(|v| !v.starts_with(IMPLICIT_VAR_PREFIX));
+    let bound = authored_bound_vars(where_patterns);
 
     let mut unbound: Vec<Arc<str>> = Vec::new();
     for pattern in insert_patterns {
@@ -360,15 +382,38 @@ fn unbound_insert_variables(
     unbound
 }
 
-/// Actionable message for a rule that violates range restriction, or `None`
-/// when the rule is safe.
+/// The author-written variables a where clause binds. Parser-generated names
+/// are excluded — see [`unbound_insert_variables`] for why they must never be
+/// treated as binding.
+fn authored_bound_vars(where_patterns: &[RuleTriplePattern]) -> HashSet<Arc<str>> {
+    let mut bound: HashSet<Arc<str>> = HashSet::new();
+    for pattern in where_patterns {
+        bind_pattern_vars(pattern, &mut bound);
+    }
+    bound.retain(|v| !v.starts_with(IMPLICIT_VAR_PREFIX));
+    bound
+}
+
+/// Whether every variable `pattern` references is in `bound` — i.e. whether
+/// `instantiate_pattern` can ever produce a flake from it.
+fn insert_pattern_is_instantiable(pattern: &RuleTriplePattern, bound: &HashSet<Arc<str>>) -> bool {
+    [&pattern.subject, &pattern.predicate, &pattern.object]
+        .into_iter()
+        .all(|term| match term {
+            RuleTerm::Var(v) => bound.contains(v),
+            _ => true,
+        })
+}
+
+/// Human-readable description of why `insert_patterns` violate range
+/// restriction, or `None` when they are all safe.
 ///
 /// Names the offending variables, because "this rule derives nothing" without
 /// them sends an author reading engine source (#1560). Auto-generated
 /// variables get their own wording: the author never wrote `?__implicit_0`, so
 /// naming it would be useless — what they need to know is that a node in the
 /// insert clause has no `@id`.
-fn unsafe_insert_variables_message(
+fn unbound_insert_description(
     where_patterns: &[RuleTriplePattern],
     insert_patterns: &[RuleTriplePattern],
 ) -> Option<String> {
@@ -398,11 +443,22 @@ fn unsafe_insert_variables_message(
         );
     }
 
-    Some(format!(
-        "Rule cannot derive anything: {}. Every variable used in `insert` must \
-         also appear in `where`.",
-        parts.join("; ")
-    ))
+    Some(parts.join("; "))
+}
+
+/// Actionable message for a rule that violates range restriction in EVERY
+/// insert pattern — such a rule can never derive anything — or `None` when at
+/// least the given patterns are safe.
+fn unsafe_insert_variables_message(
+    where_patterns: &[RuleTriplePattern],
+    insert_patterns: &[RuleTriplePattern],
+) -> Option<String> {
+    unbound_insert_description(where_patterns, insert_patterns).map(|description| {
+        format!(
+            "Rule cannot derive anything: {description}. Every variable used in \
+             `insert` must also appear in `where`."
+        )
+    })
 }
 
 /// Check if an array is a filter expression (starts with "filter")
@@ -578,6 +634,9 @@ fn split_filter_tokens(inner: &str) -> Result<Vec<&str>> {
 /// or `_`), which keeps colon-bearing *literals* — `12:30:00`,
 /// `2026-08-25T09:30:00Z` — out of IRI classification, since no NCName starts
 /// with a digit. Returns `None` for anything that is not CURIE-shaped.
+/// (A non-CURIE unquoted token is then rejected by [`parse_filter_term`], with
+/// quoting as the escape hatch — so a colon-bearing literal is never misread
+/// as an IRI, and never silently read as a string either.)
 fn curie_prefix(s: &str) -> Option<&str> {
     let colon = s.find(':')?;
     let prefix = &s[..colon];
@@ -612,18 +671,32 @@ fn quoted_literal(s: &str) -> Option<&str> {
 ///    literal that happens to look like a compact IRI.
 /// 2. `?x` is a variable.
 /// 3. Numbers and booleans are literals.
-/// 4. An absolute `http(s)` IRI, or a [`curie_prefix`]-shaped token, is an
-///    IRI: it is expanded through the rule's `@context` and resolved to a Sid,
-///    exactly as [`parse_term`] resolves a node-pattern term.
-/// 5. Anything else is a plain string literal.
+/// 4. A [`curie_prefix`]-shaped token is an IRI (an absolute `http(s)` IRI is
+///    itself CURIE-shaped — `http`/`https` parse as the prefix — so one
+///    classification covers both forms, and [`expand_iri`] passes an absolute
+///    IRI through unchanged): it is expanded through the rule's `@context` and
+///    resolved to a Sid, exactly as [`parse_term`] resolves a node-pattern
+///    term.
+/// 5. Anything else — a bare unquoted token — is **rejected**.
 ///
-/// Step 4 **fails closed**. When an IRI-shaped operand cannot be resolved to a
-/// namespace registered on this ledger, the rule is rejected instead of
-/// falling back to a string comparison. That fallback is precisely the #1556
-/// defect: `(!= ?prop ex:ssn)` compared the string `"ex:ssn"` against the bare
-/// local name `"ssn"`, was therefore always true, and copied the property the
-/// author wrote the rule to withhold. A rule that refuses to run is recoverable;
-/// a rule that silently derives an excluded fact is not.
+/// Steps 4 and 5 both **fail closed**. When an IRI-shaped operand cannot be
+/// resolved to a namespace registered on this ledger, the rule is rejected
+/// instead of falling back to a string comparison. That fallback is precisely
+/// the #1556 defect: `(!= ?prop ex:ssn)` compared the string `"ex:ssn"`
+/// against the bare local name `"ssn"`, was therefore always true, and copied
+/// the property the author wrote the rule to withhold.
+///
+/// A bare token is rejected for the same reason: before #1556 was fixed, the
+/// bare form — `(!= ?prop ssn)` — was the only operand shape that ever matched
+/// a bound IRI, so it is exactly what a workaround rule looks like. Silently
+/// reading it as a string now would fail invisibly in BOTH directions: `=`
+/// derives nothing (a string never equals an IRI) and `!=` keeps every row and
+/// derives the very fact the filter was written to exclude — and no run-time
+/// gate can see the `!=` case, because every row surviving looks like success.
+/// Rejection covers both directions symmetrically, at zero per-row cost. A
+/// string comparison is still one keystroke away (quote the operand), and a
+/// rule that refuses to run is recoverable; a rule that silently derives an
+/// excluded fact is not.
 fn parse_filter_term(s: &str, context: &JsonValue, snapshot: &LedgerSnapshot) -> Result<RuleTerm> {
     if let Some(inner) = quoted_literal(s) {
         return Ok(RuleTerm::Value(RuleValue::String(inner.to_string())));
@@ -644,8 +717,7 @@ fn parse_filter_term(s: &str, context: &JsonValue, snapshot: &LedgerSnapshot) ->
         return Ok(RuleTerm::Value(RuleValue::Boolean(false)));
     }
 
-    let absolute = s.starts_with("http://") || s.starts_with("https://");
-    if absolute || curie_prefix(s).is_some() {
+    if curie_prefix(s).is_some() {
         let expanded = expand_iri(s, context)?;
         // `encode_iri_strict` (unlike `encode_iri`) refuses to mint a Sid in
         // the EMPTY namespace for an unrecognized IRI, which is what makes the
@@ -669,7 +741,14 @@ fn parse_filter_term(s: &str, context: &JsonValue, snapshot: &LedgerSnapshot) ->
         };
     }
 
-    Ok(RuleTerm::Value(RuleValue::String(s.to_string())))
+    Err(QueryError::InvalidQuery(format!(
+        "Filter operand `{s}` is a bare unquoted token. Quote it (\"{s}\") to \
+         compare it as a string, or write a prefixed or absolute IRI (ex:{s}) \
+         to compare it as an IRI. Refusing to guess: read as a string the bare \
+         form fails invisibly against an IRI-bound variable — `=` derives \
+         nothing, and `!=` keeps every row, so an exclusion rule derives the \
+         fact it was written to exclude."
+    )))
 }
 
 /// Parse a node-map pattern into triple patterns
@@ -1040,21 +1119,26 @@ pub async fn execute_rule_matching(
             );
         } else if rows_before > 0 && binding_rows.is_empty() && diagnostics.iri_vs_literal > 0 {
             // Every row was eliminated, and at least one comparison put an IRI
-            // against a literal. That is the signature of a filter written
-            // against a bare local name — `(= ?p knows)` — which was the only
-            // operand form that matched a bound IRI before #1556 was fixed, so
-            // it is exactly what a rule authored as a workaround looks like.
-            // Such a rule now correctly derives nothing, and without this it
-            // would do so in complete silence: RDFterm-equal makes IRI-vs-literal
-            // a clean `False`, not an `Error`, so the branch above cannot see it.
+            // against a literal. The bare-local-name workaround form —
+            // `(= ?p knows)` — is rejected at parse time now, so what reaches
+            // here is a QUOTED operand spelling out an IRI — `(= ?p "ex:knows")`
+            // — or a variable that binds a string where its partner binds an
+            // IRI. Either way the rule correctly derives nothing, and without
+            // this it would do so in complete silence: RDFterm-equal makes
+            // IRI-vs-literal a clean `False`, not an `Error`, so the branch
+            // above cannot see it. (The `!=` twin of this mistake keeps every
+            // row instead of dropping them all, which no run-time gate can
+            // distinguish from success — that direction is exactly why the
+            // bare form is rejected at parse.)
             tracing::warn!(
                 rule = rule.name.as_deref().unwrap_or("<unnamed>"),
                 rule_id = %rule.id,
                 rows_before,
                 "datalog rule filter compared an IRI against a literal and excluded \
-                 every binding row; if the operand was meant to name an IRI, write it \
-                 as a prefixed or absolute IRI (`ex:knows`) rather than a bare local \
-                 name (`knows`) — a bare name is a string literal and never equals an IRI"
+                 every binding row; a quoted operand is a string literal and never \
+                 equals an IRI — if the operand was meant to name an IRI, write it \
+                 unquoted as a prefixed or absolute IRI (`ex:knows`, not \
+                 `\"ex:knows\"`)"
             );
         }
     }
@@ -1069,8 +1153,9 @@ struct FilterDiagnostics {
     errored_rows: usize,
     /// Comparisons that put an IRI against a literal. Well-defined (and false)
     /// per RDFterm-equal, so it never drops a row on its own — but when it
-    /// coincides with "every row eliminated" it is the fingerprint of a stale
-    /// bare-local-name filter.
+    /// coincides with "every row eliminated" it is the fingerprint of a filter
+    /// whose operand spells an IRI as a string (a quoted `"ex:knows"`, or a
+    /// string-bound variable compared against an IRI-bound one).
     iri_vs_literal: usize,
 }
 
@@ -2371,6 +2456,39 @@ mod tests {
         let message = unsafe_insert_variables_message(&where_patterns, &insert_patterns)
             .expect("collision must not suppress the diagnostic");
         assert!(message.contains("@id"), "got: {message}");
+    }
+
+    #[test]
+    fn instantiability_is_judged_per_insert_pattern() {
+        // A two-head rule with one typo'd head: the good head must be
+        // recognized as instantiable on its own, so parsing can keep it while
+        // skipping the bad one — matching `execute_rule_with_bindings`, which
+        // instantiates each insert pattern independently.
+        let where_patterns = vec![triple(
+            RuleTerm::var("?s"),
+            RuleTerm::sid(sid(100, "relType")),
+            RuleTerm::var("?relation"),
+        )];
+        let good = triple(
+            RuleTerm::var("?s"),
+            RuleTerm::sid(sid(100, "hasRelation")),
+            RuleTerm::var("?relation"),
+        );
+        let bad = triple(
+            RuleTerm::var("?s"),
+            RuleTerm::var("?rel"),
+            RuleTerm::var("?s"),
+        );
+
+        let bound = authored_bound_vars(&where_patterns);
+        assert!(insert_pattern_is_instantiable(&good, &bound));
+        assert!(!insert_pattern_is_instantiable(&bad, &bound));
+
+        // The description for the skipped head names only its own variable.
+        let description = unbound_insert_description(&where_patterns, std::slice::from_ref(&bad))
+            .expect("the bad head must produce a description");
+        assert!(description.contains("?rel"), "got: {description}");
+        assert!(!description.contains("?relation"), "got: {description}");
     }
 
     #[test]

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -270,7 +270,9 @@ fn parse_where_clause(
                     }
                     JsonValue::Array(filter_arr) if is_filter_expression(filter_arr) => {
                         // Filter expression like ["filter", "(>= ?age 62)"]
-                        if let Some(filter) = parse_filter_expression(filter_arr)? {
+                        if let Some(filter) =
+                            parse_filter_expression(filter_arr, context, snapshot)?
+                        {
                             filters.push(filter);
                         }
                     }
@@ -296,7 +298,16 @@ fn is_filter_expression(arr: &[JsonValue]) -> bool {
 }
 
 /// Parse a filter expression like ["filter", "(>= ?age 62)"]
-fn parse_filter_expression(arr: &[JsonValue]) -> Result<Option<RuleFilter>> {
+///
+/// `context` and `snapshot` are threaded in so an IRI operand can be expanded
+/// and resolved the same way a node-pattern term is (#1556) — without them a
+/// colon-bearing operand was silently demoted to a string and could never
+/// equal the IRI it named.
+fn parse_filter_expression(
+    arr: &[JsonValue],
+    context: &JsonValue,
+    snapshot: &LedgerSnapshot,
+) -> Result<Option<RuleFilter>> {
     if arr.len() != 2 {
         return Ok(None);
     }
@@ -339,38 +350,129 @@ fn parse_filter_expression(arr: &[JsonValue]) -> Result<Option<RuleFilter>> {
     };
 
     // Parse left and right terms
-    let left = parse_filter_term(parts[1])?;
+    let left = parse_filter_term(parts[1], context, snapshot)?;
     let right = if parts.len() > 2 {
-        parse_filter_term(parts[2])?
+        parse_filter_term(parts[2], context, snapshot)?
     } else {
         return Err(QueryError::InvalidQuery(format!(
             "Comparison filter needs two arguments: {expr}"
         )));
     };
 
+    // An IRI has no ordering, so `<`/`<=`/`>`/`>=` against an IRI operand can
+    // never be answered. Reject it here rather than letting it evaluate to
+    // "no" per row — a silently-unsatisfiable ordering filter is the same
+    // class of invisible failure as the fail-open equality of #1556.
+    if !matches!(op, CompareOp::Equal | CompareOp::NotEqual)
+        && (matches!(left, RuleTerm::Sid(_)) || matches!(right, RuleTerm::Sid(_)))
+    {
+        return Err(QueryError::InvalidQuery(format!(
+            "Filter operator `{op_str}` cannot order IRIs: {expr}. \
+             Only `=` and `!=` are defined for IRI operands."
+        )));
+    }
+
     Ok(Some(RuleFilter::Compare { op, left, right }))
 }
 
-/// Parse a single term in a filter expression (variable or literal)
-fn parse_filter_term(s: &str) -> Result<RuleTerm> {
-    if s.starts_with('?') {
-        // Variable
-        Ok(RuleTerm::var(s))
-    } else if let Ok(n) = s.parse::<i64>() {
-        // Integer literal
-        Ok(RuleTerm::Value(RuleValue::Long(n)))
-    } else if let Ok(f) = s.parse::<f64>() {
-        // Float literal
-        Ok(RuleTerm::Value(RuleValue::Double(f)))
-    } else if s == "true" {
-        Ok(RuleTerm::Value(RuleValue::Boolean(true)))
-    } else if s == "false" {
-        Ok(RuleTerm::Value(RuleValue::Boolean(false)))
-    } else {
-        // String literal (strip quotes if present)
-        let s = s.trim_matches('"').trim_matches('\'');
-        Ok(RuleTerm::Value(RuleValue::String(s.to_string())))
+/// The prefix of a token shaped like a compact IRI (`prefix:local`).
+///
+/// Deliberately narrow: the prefix must be a plausible NCName (leading letter
+/// or `_`), which keeps colon-bearing *literals* — `12:30:00`,
+/// `2026-08-25T09:30:00Z` — out of IRI classification, since no NCName starts
+/// with a digit. Returns `None` for anything that is not CURIE-shaped.
+fn curie_prefix(s: &str) -> Option<&str> {
+    let colon = s.find(':')?;
+    let prefix = &s[..colon];
+    let mut chars = prefix.chars();
+    let first = chars.next()?;
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return None;
     }
+    if chars.any(|c| !(c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')) {
+        return None;
+    }
+    Some(prefix)
+}
+
+/// Whether a filter token is wrapped in matching quotes — the explicit
+/// "compare this as a string" escape hatch for a literal that would otherwise
+/// read as a compact IRI.
+fn quoted_literal(s: &str) -> Option<&str> {
+    for q in ['"', '\''] {
+        if s.len() >= 2 && s.starts_with(q) && s.ends_with(q) {
+            return Some(&s[1..s.len() - 1]);
+        }
+    }
+    None
+}
+
+/// Parse a single term in a filter expression (variable, literal, or IRI)
+///
+/// Classification order is load-bearing (#1556):
+///
+/// 1. A quoted token is always a string literal — the escape hatch for a
+///    literal that happens to look like a compact IRI.
+/// 2. `?x` is a variable.
+/// 3. Numbers and booleans are literals.
+/// 4. An absolute `http(s)` IRI, or a [`curie_prefix`]-shaped token, is an
+///    IRI: it is expanded through the rule's `@context` and resolved to a Sid,
+///    exactly as [`parse_term`] resolves a node-pattern term.
+/// 5. Anything else is a plain string literal.
+///
+/// Step 4 **fails closed**. When an IRI-shaped operand cannot be resolved to a
+/// namespace registered on this ledger, the rule is rejected instead of
+/// falling back to a string comparison. That fallback is precisely the #1556
+/// defect: `(!= ?prop ex:ssn)` compared the string `"ex:ssn"` against the bare
+/// local name `"ssn"`, was therefore always true, and copied the property the
+/// author wrote the rule to withhold. A rule that refuses to run is recoverable;
+/// a rule that silently derives an excluded fact is not.
+fn parse_filter_term(s: &str, context: &JsonValue, snapshot: &LedgerSnapshot) -> Result<RuleTerm> {
+    if let Some(inner) = quoted_literal(s) {
+        return Ok(RuleTerm::Value(RuleValue::String(inner.to_string())));
+    }
+    if s.starts_with('?') {
+        return Ok(RuleTerm::var(s));
+    }
+    if let Ok(n) = s.parse::<i64>() {
+        return Ok(RuleTerm::Value(RuleValue::Long(n)));
+    }
+    if let Ok(f) = s.parse::<f64>() {
+        return Ok(RuleTerm::Value(RuleValue::Double(f)));
+    }
+    if s == "true" {
+        return Ok(RuleTerm::Value(RuleValue::Boolean(true)));
+    }
+    if s == "false" {
+        return Ok(RuleTerm::Value(RuleValue::Boolean(false)));
+    }
+
+    let absolute = s.starts_with("http://") || s.starts_with("https://");
+    if absolute || curie_prefix(s).is_some() {
+        let expanded = expand_iri(s, context)?;
+        // `encode_iri_strict` (unlike `encode_iri`) refuses to mint a Sid in
+        // the EMPTY namespace for an unrecognized IRI, which is what makes the
+        // failure loud instead of producing a Sid that can never match. Same
+        // rule the SPARQL rule lowerer applies to an unresolved IRI.
+        return match snapshot.encode_iri_strict(&expanded) {
+            Some(sid) => Ok(RuleTerm::Sid(sid)),
+            None => Err(QueryError::InvalidQuery(format!(
+                "Filter operand `{s}` names an IRI that is not registered on this \
+                 ledger{}. Define the prefix in the rule's @context, use an absolute \
+                 IRI, or quote the operand (\"{s}\") to compare it as a string. \
+                 Refusing to compare it as a string: a filter whose IRI operand can \
+                 never match makes `!=` always true, so an exclusion rule derives the \
+                 fact it was written to exclude.",
+                if expanded == s {
+                    String::new()
+                } else {
+                    format!(" (expanded to `{expanded}`)")
+                }
+            ))),
+        };
+    }
+
+    Ok(RuleTerm::Value(RuleValue::String(s.to_string())))
 }
 
 /// Parse a node-map pattern into triple patterns
@@ -704,20 +806,62 @@ pub async fn execute_rule_matching(
         binding_rows = new_bindings;
     }
 
-    // Apply filters to eliminate non-matching bindings
+    // Apply filters to eliminate non-matching bindings.
+    //
+    // A row survives only on an outright `True`. `Error` — an unresolvable
+    // operand or a pair of values with no defined comparison — drops the row,
+    // never keeps it, so no filter can fail open (#1556).
     if !rule.filters.is_empty() {
+        let mut errored_rows = 0usize;
         binding_rows.retain(|bindings| {
-            rule.filters
+            let mut row_errored = false;
+            let keep = rule
+                .filters
                 .iter()
-                .all(|filter| evaluate_filter(filter, bindings))
+                .all(|filter| match evaluate_filter(filter, bindings) {
+                    FilterOutcome::True => true,
+                    FilterOutcome::False => false,
+                    FilterOutcome::Error => {
+                        row_errored = true;
+                        false
+                    }
+                });
+            errored_rows += row_errored as usize;
+            keep
         });
+        if errored_rows > 0 {
+            // Excluding the row is the safe answer, but silently excluding it
+            // is how a mis-typed filter looks exactly like a rule that
+            // legitimately matched nothing.
+            tracing::warn!(
+                rule = rule.name.as_deref().unwrap_or("<unnamed>"),
+                rule_id = %rule.id,
+                errored_rows,
+                "datalog rule filter could not compare its operands on some binding \
+                 rows; those rows were excluded — check the filter's operand types"
+            );
+        }
     }
 
     Ok(binding_rows)
 }
 
+/// Outcome of evaluating a rule filter against one binding row.
+///
+/// Three-valued on purpose, following SPARQL's treatment of a type error.
+/// Collapsing `Error` into `False` would be wrong under `Not`: `!(error)`
+/// would become `true` and re-admit a row the filter could not actually judge.
+/// Only [`FilterOutcome::True`] keeps a row, so an incomparable filter can
+/// exclude but never include.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FilterOutcome {
+    True,
+    False,
+    Error,
+}
+
 /// Evaluate a filter expression against a set of bindings
-fn evaluate_filter(filter: &RuleFilter, bindings: &Bindings) -> bool {
+fn evaluate_filter(filter: &RuleFilter, bindings: &Bindings) -> FilterOutcome {
     match filter {
         RuleFilter::Compare { op, left, right } => {
             let left_val = resolve_filter_term(left, bindings);
@@ -725,16 +869,57 @@ fn evaluate_filter(filter: &RuleFilter, bindings: &Bindings) -> bool {
 
             match (left_val, right_val) {
                 (Some(l), Some(r)) => compare_values(&l, &r, *op),
-                _ => false, // If either side can't be resolved, filter fails
+                // An unbound operand cannot be judged either way.
+                _ => FilterOutcome::Error,
             }
         }
-        RuleFilter::And(filters) => filters.iter().all(|f| evaluate_filter(f, bindings)),
-        RuleFilter::Or(filters) => filters.iter().any(|f| evaluate_filter(f, bindings)),
-        RuleFilter::Not(inner) => !evaluate_filter(inner, bindings),
+        // `false && error` is `false`; `true && error` is `error`.
+        RuleFilter::And(filters) => {
+            let mut saw_error = false;
+            for f in filters {
+                match evaluate_filter(f, bindings) {
+                    FilterOutcome::False => return FilterOutcome::False,
+                    FilterOutcome::Error => saw_error = true,
+                    FilterOutcome::True => {}
+                }
+            }
+            if saw_error {
+                FilterOutcome::Error
+            } else {
+                FilterOutcome::True
+            }
+        }
+        // `true || error` is `true`; `false || error` is `error`.
+        RuleFilter::Or(filters) => {
+            let mut saw_error = false;
+            for f in filters {
+                match evaluate_filter(f, bindings) {
+                    FilterOutcome::True => return FilterOutcome::True,
+                    FilterOutcome::Error => saw_error = true,
+                    FilterOutcome::False => {}
+                }
+            }
+            if saw_error {
+                FilterOutcome::Error
+            } else {
+                FilterOutcome::False
+            }
+        }
+        RuleFilter::Not(inner) => match evaluate_filter(inner, bindings) {
+            FilterOutcome::True => FilterOutcome::False,
+            FilterOutcome::False => FilterOutcome::True,
+            // Never `True`: negating something uncomparable must not admit the row.
+            FilterOutcome::Error => FilterOutcome::Error,
+        },
     }
 }
 
 /// Resolve a filter term to a comparable value
+///
+/// An IRI stays an IRI. Rendering a bound Sid as its bare local name — what
+/// this did before #1556 — threw away the namespace, so `ex:knows` and
+/// `foaf:knows` both resolved to `"knows"` and neither could ever equal the
+/// operand `"ex:knows"` that the author actually wrote.
 fn resolve_filter_term(term: &RuleTerm, bindings: &Bindings) -> Option<FlakeValue> {
     match term {
         RuleTerm::Var(name) => bindings.get(name.as_ref()).map(|bv| match bv {
@@ -744,23 +929,35 @@ fn resolve_filter_term(term: &RuleTerm, bindings: &Bindings) -> Option<FlakeValu
             BindingValue::BigInt(n) => FlakeValue::BigInt(n.clone()),
             BindingValue::String(s) => FlakeValue::String(s.clone()),
             BindingValue::Boolean(b) => FlakeValue::Boolean(*b),
-            BindingValue::Sid(sid) => FlakeValue::String(sid.name.to_string()),
+            BindingValue::Sid(sid) => FlakeValue::Ref(sid.clone()),
         }),
         RuleTerm::Value(val) => Some(match val {
             RuleValue::Long(n) => FlakeValue::Long(*n),
             RuleValue::Double(d) => FlakeValue::Double(*d),
             RuleValue::String(s) => FlakeValue::String(s.clone()),
             RuleValue::Boolean(b) => FlakeValue::Boolean(*b),
-            RuleValue::Ref(sid) => FlakeValue::String(sid.name.to_string()),
+            RuleValue::Ref(sid) => FlakeValue::Ref(sid.clone()),
         }),
-        RuleTerm::Sid(sid) => Some(FlakeValue::String(sid.name.to_string())),
+        RuleTerm::Sid(sid) => Some(FlakeValue::Ref(sid.clone())),
     }
 }
 
-/// Compare two filter values using the given operator. Only the
-/// Long/Double/String/Boolean variants of FlakeValue are inspected; other
-/// variants fall through to "incompatible".
-fn compare_values(left: &FlakeValue, right: &FlakeValue, op: CompareOp) -> bool {
+/// Compare two filter values using the given operator.
+///
+/// Numeric, IRI (`Ref`), string and boolean pairs are comparable; every other
+/// pairing is [`FilterOutcome::Error`], which excludes the row. Note what is
+/// deliberately absent: a `Ref`-versus-`String` pairing does NOT stringify the
+/// IRI to make the comparison "work". That coercion is what made `!=` against
+/// an IRI always true (#1556).
+fn compare_values(left: &FlakeValue, right: &FlakeValue, op: CompareOp) -> FilterOutcome {
+    let outcome = |b: bool| {
+        if b {
+            FilterOutcome::True
+        } else {
+            FilterOutcome::False
+        }
+    };
+
     // Try numeric comparison first: exact across all numeric representations
     // (Long/Double/BigInt/Decimal), with BigDecimal promotion where an f64
     // cast would lose precision.
@@ -771,39 +968,50 @@ fn compare_values(left: &FlakeValue, right: &FlakeValue, op: CompareOp) -> bool 
     };
 
     if let Some(cmp) = numeric_result {
-        return match op {
+        return outcome(match op {
             CompareOp::Equal => cmp == std::cmp::Ordering::Equal,
             CompareOp::NotEqual => cmp != std::cmp::Ordering::Equal,
             CompareOp::LessThan => cmp == std::cmp::Ordering::Less,
             CompareOp::LessThanOrEqual => cmp != std::cmp::Ordering::Greater,
             CompareOp::GreaterThan => cmp == std::cmp::Ordering::Greater,
             CompareOp::GreaterThanOrEqual => cmp != std::cmp::Ordering::Less,
-        };
+        });
     }
 
     // Fall back to string comparison
     let (left_str, right_str) = match (left, right) {
         (FlakeValue::String(l), FlakeValue::String(r)) => (l.as_str(), r.as_str()),
+        // IRI identity: Sid equality, namespace included. Ordering is
+        // undefined for IRIs — the parser rejects an ordering operator against
+        // a constant IRI, and a variable that turns out to be IRI-bound at run
+        // time lands here.
+        (FlakeValue::Ref(l), FlakeValue::Ref(r)) => {
+            return match op {
+                CompareOp::Equal => outcome(l == r),
+                CompareOp::NotEqual => outcome(l != r),
+                _ => FilterOutcome::Error,
+            };
+        }
         (FlakeValue::Boolean(l), FlakeValue::Boolean(r)) => {
             // Boolean comparison
             return match op {
-                CompareOp::Equal => l == r,
-                CompareOp::NotEqual => l != r,
-                _ => false, // Other comparisons don't make sense for booleans
+                CompareOp::Equal => outcome(l == r),
+                CompareOp::NotEqual => outcome(l != r),
+                _ => FilterOutcome::Error, // Other comparisons don't make sense for booleans
             };
         }
-        _ => return false, // Incompatible types
+        _ => return FilterOutcome::Error, // Incompatible types
     };
 
     let cmp = left_str.cmp(right_str);
-    match op {
+    outcome(match op {
         CompareOp::Equal => cmp == std::cmp::Ordering::Equal,
         CompareOp::NotEqual => cmp != std::cmp::Ordering::Equal,
         CompareOp::LessThan => cmp == std::cmp::Ordering::Less,
         CompareOp::LessThanOrEqual => cmp != std::cmp::Ordering::Greater,
         CompareOp::GreaterThan => cmp == std::cmp::Ordering::Greater,
         CompareOp::GreaterThanOrEqual => cmp != std::cmp::Ordering::Less,
-    }
+    })
 }
 
 /// Match a single triple pattern against the database
@@ -1545,5 +1753,172 @@ mod tests {
             &flake_value_to_binding(&dec("19.99")),
             &BindingValue::Double(19.99)
         ));
+    }
+
+    // ------------------------------------------------------------------
+    // IRI comparison in filters (#1556)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn curie_prefix_rejects_colon_bearing_literals() {
+        // Real CURIEs.
+        assert_eq!(curie_prefix("ex:ssn"), Some("ex"));
+        assert_eq!(curie_prefix("foaf:knows"), Some("foaf"));
+        assert_eq!(curie_prefix("_x:y"), Some("_x"));
+        assert_eq!(curie_prefix("dc-terms:title"), Some("dc-terms"));
+
+        // Literals that merely contain a colon must NOT be read as IRIs — no
+        // NCName may start with a digit, which is what keeps times and
+        // timestamps out of IRI classification.
+        assert_eq!(curie_prefix("12:30:00"), None);
+        assert_eq!(curie_prefix("2026-08-25T09:30:00Z"), None);
+        assert_eq!(curie_prefix("no-colon-here"), None);
+        assert_eq!(curie_prefix("has space:x"), None);
+    }
+
+    #[test]
+    fn quoted_operand_is_the_string_escape_hatch() {
+        assert_eq!(quoted_literal("\"ex:ssn\""), Some("ex:ssn"));
+        assert_eq!(quoted_literal("'ex:ssn'"), Some("ex:ssn"));
+        assert_eq!(quoted_literal("ex:ssn"), None);
+        assert_eq!(quoted_literal("\"\""), Some(""));
+    }
+
+    fn sid(ns: u16, name: &str) -> Sid {
+        Sid::new(ns, name)
+    }
+
+    #[test]
+    fn iri_equality_compares_sids_not_local_names() {
+        // The #1556 defect in miniature: `ex:knows` and `foaf:knows` share a
+        // local name. Comparing local names conflated them; comparing Sids
+        // does not.
+        let ex_knows = FlakeValue::Ref(sid(100, "knows"));
+        let foaf_knows = FlakeValue::Ref(sid(200, "knows"));
+
+        assert_eq!(
+            compare_values(&ex_knows, &ex_knows.clone(), CompareOp::Equal),
+            FilterOutcome::True
+        );
+        assert_eq!(
+            compare_values(&ex_knows, &foaf_knows, CompareOp::Equal),
+            FilterOutcome::False,
+            "same local name in different namespaces must not compare equal"
+        );
+        assert_eq!(
+            compare_values(&ex_knows, &foaf_knows, CompareOp::NotEqual),
+            FilterOutcome::True
+        );
+    }
+
+    #[test]
+    fn iri_ordering_is_an_error_not_a_silent_false() {
+        let a = FlakeValue::Ref(sid(100, "a"));
+        let b = FlakeValue::Ref(sid(100, "b"));
+        for op in [
+            CompareOp::LessThan,
+            CompareOp::LessThanOrEqual,
+            CompareOp::GreaterThan,
+            CompareOp::GreaterThanOrEqual,
+        ] {
+            assert_eq!(compare_values(&a, &b, op), FilterOutcome::Error);
+        }
+    }
+
+    #[test]
+    fn incomparable_operands_never_fail_open() {
+        // The whole point of #1556: an inequality the engine cannot actually
+        // evaluate must not answer "true" and let the row through. An IRI
+        // against a string is exactly the pairing the old code stringified.
+        let iri = FlakeValue::Ref(sid(100, "ssn"));
+        let text = FlakeValue::String("ex:ssn".to_string());
+
+        for op in [
+            CompareOp::Equal,
+            CompareOp::NotEqual,
+            CompareOp::LessThan,
+            CompareOp::GreaterThan,
+        ] {
+            assert_ne!(
+                compare_values(&iri, &text, op),
+                FilterOutcome::True,
+                "IRI vs string must never evaluate true for {op:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn negating_an_uncomparable_filter_does_not_admit_the_row() {
+        // `Not` is reachable from SPARQL rules (`FILTER(!(...))`). If Error
+        // collapsed to False, `!Error` would become True and re-admit a row
+        // the engine could not judge — a fail-open path straight back in.
+        let bindings = Bindings::new();
+        let uncomparable = RuleFilter::Compare {
+            op: CompareOp::Equal,
+            left: RuleTerm::var("?never_bound"),
+            right: RuleTerm::Value(RuleValue::Long(1)),
+        };
+
+        assert_eq!(
+            evaluate_filter(&uncomparable, &bindings),
+            FilterOutcome::Error
+        );
+        assert_eq!(
+            evaluate_filter(&RuleFilter::Not(Box::new(uncomparable)), &bindings),
+            FilterOutcome::Error,
+            "negating an error must stay an error, never become True"
+        );
+    }
+
+    #[test]
+    fn and_or_follow_sparql_error_propagation() {
+        let bindings = Bindings::new();
+        let error = || RuleFilter::Compare {
+            op: CompareOp::Equal,
+            left: RuleTerm::var("?never_bound"),
+            right: RuleTerm::Value(RuleValue::Long(1)),
+        };
+        let truth = || RuleFilter::Compare {
+            op: CompareOp::Equal,
+            left: RuleTerm::Value(RuleValue::Long(1)),
+            right: RuleTerm::Value(RuleValue::Long(1)),
+        };
+        let falsehood = || RuleFilter::Compare {
+            op: CompareOp::Equal,
+            left: RuleTerm::Value(RuleValue::Long(1)),
+            right: RuleTerm::Value(RuleValue::Long(2)),
+        };
+
+        // false && error => false; true && error => error
+        assert_eq!(
+            evaluate_filter(&RuleFilter::And(vec![falsehood(), error()]), &bindings),
+            FilterOutcome::False
+        );
+        assert_eq!(
+            evaluate_filter(&RuleFilter::And(vec![truth(), error()]), &bindings),
+            FilterOutcome::Error
+        );
+        // true || error => true; false || error => error
+        assert_eq!(
+            evaluate_filter(&RuleFilter::Or(vec![truth(), error()]), &bindings),
+            FilterOutcome::True
+        );
+        assert_eq!(
+            evaluate_filter(&RuleFilter::Or(vec![falsehood(), error()]), &bindings),
+            FilterOutcome::Error
+        );
+    }
+
+    #[test]
+    fn sid_bound_variable_resolves_as_an_iri() {
+        let mut bindings = Bindings::new();
+        bindings.insert(Arc::from("?p"), BindingValue::Sid(sid(100, "knows")));
+
+        let resolved = resolve_filter_term(&RuleTerm::var("?p"), &bindings);
+        assert_eq!(
+            resolved,
+            Some(FlakeValue::Ref(sid(100, "knows"))),
+            "a Sid binding must stay a Ref, not collapse to its local name"
+        );
     }
 }


### PR DESCRIPTION
Two of zonotope's datalog audit findings — they sit on the same plumbing in `fluree-db-query/src/datalog_rules.rs`, so they're here together.

## The one that matters: a datalog exclusion filter fails open, silently

A rule FILTER can't compare a variable against an IRI today. `(= ?p ex:knows)` is always false and `(!= ?prop ex:ssn)` is always **true** — and it's that second direction that makes this a P1 rather than a papercut. An author who writes the obvious copy-properties rule with the obvious mitigation:

```json
"where": [
  {"@id": "?s", "ex:sameAs": {"@id": "?other"}},
  {"@id": "?other", "?prop": "?val"},
  ["filter", "(!= ?prop ex:ssn)"]
],
"insert": {"@id": "?s", "?prop": "?val"}
```

…gets `ex:ssn` copied anyway. No error, no warning, nothing in the diagnostics. The rule that was written specifically to withhold a value is the rule that hands it over. I added that exact repro as a test first and confirmed it fails on `main` — `ex:ssn` and `123-45-6789` both land on `ex:alice`. (Reverting `datalog_rules.rs` to the merge base with the tests kept turns the integration suite red.)

The mechanism is that three functions disagreed about what an IRI even is. `parse_filter_term` (`datalog_rules.rs:355`) had no IRI branch at all, so `ex:ssn` fell past the var/i64/f64/bool arms into the final `else` and became the *string* `"ex:ssn"`. `resolve_filter_term` (`:747`) rendered a bound Sid as `sid.name` — the bare local name `"ssn"`, namespace discarded. Then `compare_values` (`:785`) string-compared `"ssn"` against `"ex:ssn"`. The two sides can never agree, so `=` never fires and `!=` always does. This is pre-existing on `main` and independent of #1541, though that PR makes it much more reachable, since a filter is the natural way to constrain a variable predicate.

Worth noting it isn't predicate-specific either: `flake_value_to_binding` (`:1062`) maps a `Ref` object to a `Sid` binding too, so `["filter", "(!= ?o ex:bob)"]` on an ordinary object variable was broken the same way, in the same fail-open direction. Test included.

### What changed

**Parse** — thread the rule's `@context` and the snapshot into filter parsing (they were never passed in) and resolve an IRI operand exactly the way `parse_term` resolves a node-pattern term. A quoted operand is now unambiguously a string, which gives an explicit escape hatch, and CURIE detection requires an NCName-shaped prefix so colon-bearing *literals* stay literals — no NCName starts with a digit, so `12:30:00` and `2026-08-25T09:30:00Z` don't get swept into IRI classification. (An absolute `http(s)` IRI is itself CURIE-shaped — `http` parses as the prefix — so one classification covers both forms.) A token that survives *none* of these classifications — not a variable, number, boolean, quoted string, or IRI — is a **parse error**, not a string; that's the first behavior change below, and it's what closes the fail-open `!=` direction for good.

**Resolve** — a Sid binding stays a `FlakeValue::Ref` rather than collapsing to its local name, so comparison is namespace-aware. `ex:knows` no longer equals `foaf:knows`, which the old local-name comparison happily conflated.

**Compare** — IRI identity for `=`/`!=` by Sid equality, following RDFterm-equal (SPARQL 1.1 §17.4.1.7): a type error only when *both* operands are literals, so an IRI against a literal is well-defined and simply false. Ordering an IRI is rejected.

**Filter evaluation can't fail open.** Evaluation is three-valued in the SPARQL sense — an unresolvable operand or a literal-vs-literal type mismatch yields `Error`, and a row survives only on an outright `True`. `Error` deliberately does *not* collapse into `False`, because `!(error)` would then be `true` and re-admit a row the engine couldn't actually judge; `RuleFilter::Not` is reachable from SPARQL-lowered rules via `sparql_lang.rs:297`, so that path is live, not theoretical. `And`/`Or` propagate errors the SPARQL way (`false && error` is `false`, `true && error` is `error`).

**Filter *acceptance* couldn't fail open either, and that turned out to matter.** A malformed filter used to return `Ok(None)`, `parse_where_clause` dropped the `None` on the floor, `rule.filters` ended up empty, and `execute_rule_matching` skipped filtering altogether — so the rule derived everything it was written to restrict. Same failure mode, different route, and it slipped past the evaluation-side guarantee entirely. A wrong-length array and a non-string expression are now errors (with no `None` left, the signature simplifies to `Result<RuleFilter>`), and a near-miss on the keyword like `["FILTER", …]` is rejected. Any *other* unrecognized where-clause element keeps its current tolerance but warns instead of vanishing — turning that into a hard error is a language decision I didn't want to make inside this fix.

An IRI operand that resolves to no registered namespace is rejected at parse time rather than demoted to a string, since that demotion *is* the fail-open path — same thing the SPARQL rule lowerer already does at `sparql_lang.rs:203`, so I followed that rather than inventing a second convention.

## ⚠️ Behavior changes for existing rules

Two, and the first is the one most likely to be sitting in a deployed ledger right now.

**1. A bare unquoted filter operand is rejected at parse time.** `(= ?p knows)` — the bare form — was **the only operand form that ever matched a bound IRI** on `main`, so anyone who hit this bug and worked around it wrote exactly this shape. The tempting halfway house is to read it as a string literal and let a diagnostic catch the stale rules, but that fails invisibly in *both* directions: `=` eliminates every row (a string never equals an IRI), which a zero-derivation gate can see — and `!=` keeps **every** row, so `(!= ?prop ssn)` on the copy-properties rule copies `ex:ssn` right back out, and no run-time gate can see it, because every surviving row looks exactly like success. The parser is the one place that still knows the discriminator (quoted vs unquoted), so it refuses to guess: the error names the operand and both rewrites — quote it (`"knows"`) to compare a string, prefix it (`ex:knows`) to compare an IRI. Rejection warn-and-skips the one rule like any other rule parse failure; sibling rules keep deriving. The bare string form was never documented, nothing in the repo's own corpus ever used it legitimately, and the one population known to use it is the pre-fix workaround rules this exists to catch. Bare *numeric* and *boolean* operands (`(> ?age 20)`, `(= ?flag true)`) classify before the rejection can see them and are untouched; both are pinned by tests, as are the `=` and `!=` directions of the rejection itself.

To keep the *quoted* spelling of the same mistake from being a silent loss, a rule whose filters eliminate every binding row while comparing an IRI against a literal — `(= ?p "ex:knows")`, or a string-bound variable against an IRI-bound one — warns with the fix named. That signal needed building deliberately: once IRI-vs-literal became a clean `False` per §17.4.1.7, it stopped being an `Error`, so the existing "could not compare its operands" warn could no longer see it. It stays quiet when such a filter legitimately keeps rows — `(!= ?val "Bob")` over IRI-valued properties is correct usage and stays silent — and there's a test for each direction.

**2. An unresolvable IRI operand now refuses to parse** where it previously ran with a no-op filter. Narrower than it reads: both call sites warn-and-skip only the offending rule rather than failing the rule set (`:91` stored, `:1545` query-time), sibling rules keep deriving, and `encode_iri_strict` fails only on an unregistered *namespace prefix* — not an unused IRI — so `ex:ssn` resolves whenever any `ex:` IRI exists on the ledger. The error names the operand and all three remedies. Still a loss where a rule previously derived useful facts alongside a harmless broken filter, hence the callout.

`docs/query/datalog-rules.md` documents both, plus the operand classification table and the insert-variable requirement below. It also corrects the operator table, which advertised logical, arithmetic and string functions that a JSON-LD rule filter has never actually parsed.

## #1560 — a rule that can't derive anything now says so

Separate and much smaller, but it's the observability lever that makes the above debuggable, so it rides along. A rule whose `insert` references a variable `where` never binds derived nothing and said nothing — `instantiate_pattern` returns `None` per row, the rows get dropped, and the only signal was a per-iteration debug counter that attributes nothing to any particular rule. A where/insert typo looked exactly like a where clause that matched nothing.

Two nets, both using the diagnostic paths this module already has rather than a new one:

- **Parse time** — enforce datalog's range restriction (every `insert` variable must appear in `where`), judged **per insert pattern** to match the runtime semantic: `execute_rule_with_bindings` instantiates each head independently, so a two-head rule with one typo'd head keeps deriving from the good head exactly as it always has — the bad head is skipped with a warning naming the variable and how many heads were kept. Only a rule in which *no* head can ever instantiate — which can't derive anything by construction — is rejected outright, with a message naming the offending variables, flowing through the existing `tracing::warn!(?rule_id, %e, ...)` skip path so one bad rule still can't stop the others. Parser-invented variables get their own wording, since quoting `?__implicit_0` back at an author who never typed it explains nothing; that message points at the missing `@id` instead.
- **Run time** — warn when a rule matched binding rows but instantiated zero flakes. That's precisely "the where clause matched but the insert couldn't instantiate," and it catches what the parse check structurally can't see: SPARQL-lowered rules, and a subject/predicate variable that only turns out to be literal-bound once it binds. Recorded per rule so the fixpoint's repeated rounds don't repeat the warning.

Per the issue's second acceptance criterion, a rule whose where clause simply matched nothing stays silent — that's ordinary and says nothing about soundness. There's a test pinning the no-noise half specifically.

## On #1558 — looked at it, deliberately not included

It does share the "fail loud at parse time instead of minting a bogus `Sid(EMPTY, …)`" seam, and its Gap 3 (JSON-LD keywords becoming fabricated predicates) would genuinely be a few lines on top of what's here. But I don't think it's a small addition, for a reason that only showed up while looking:

Gap 3 done naively would reject the standard typed-literal form `{"@value": 65, "@type": "xsd:integer"}` in a rule pattern. `parse_object_value:679` routes a non-`@id` object map to `parse_node_pattern` as a nested anonymous node, and `parse_node_pattern:584` skips only `@id`/`@context`/`@type` — so `@value` arrives as a *key*, even though `parse_term:717` handles that form directly. Closing Gap 3 correctly therefore also means fixing how node-pattern object values are routed. **That routing bug is a real latent defect that #1558's own text doesn't currently describe**, so it's worth adding to the issue before someone picks it up and scopes only what's written there. Gaps 1 and 2 (bare context-mapped keys, bare `@type` values) are context term-definition expansion, different again.

Three sub-gaps across a different mechanism with its own regression matrix. I'd rather it got its own PR than be smuggled into this one — happy to pick it up next if that's the right call. No `Fixes #1558` here.

## Tests & gates

Sixteen new integration tests in `it_datalog_rules.rs` and nineteen new unit tests in `datalog_rules.rs` (twenty-seven in the module all told). The behavioral ones were confirmed red before their fix — including the `(!= ?prop ssn)` leak repro and the two-head-rule derivation, both red at the previous head of this branch — and the two narrowest arms have their own mutants: reverting just the RDFterm-equal arm turns the IRI-valued-row test red, and restoring the silent `Ok(None)` drop turns the malformed-filter test red.

- `cargo test -p fluree-db-query` — 1,440 lib + all targets green
- `cargo test -p fluree-db-reasoner` — 86 green
- `cargo test -p fluree-db-api` — `grp_reasoning` 98, `grp_query_reason` 100, `grp_policy` 96, `grp_query` 422, all green
- `cargo clippy -p fluree-db-query -p fluree-db-api --all-targets --no-deps` — clean
- `cargo fmt --all --check` — clean

Fixes #1556
Fixes #1560
