### PR TITLE
fix(query): COUNT(*) counts joined rows, not distinct subjects, on an anchored star

### DIFF
--- a/docs/contributing/benches.md
+++ b/docs/contributing/benches.md
@@ -109,8 +109,20 @@ Numbers are percent regression allowed vs. the committed baseline. Omit a
 scale to fall back to `default_budget_pct` (5%). The CI gate fails if an
 observed run exceeds the budget for any listed scale.
 
-If you don't yet have a baseline, leave the entries empty — `default_budget_pct`
-applies. After your first nightly run lands a baseline, tighten the budget.
+Give every bench at least one scale. The reconciler treats an empty map the
+same as a missing one (`workspace_reconcile.rs` tests `!m.is_empty()`), so
+`"<category>_<name>": {}` fails the gate rather than falling back to
+`default_budget_pct`. If you don't yet have a baseline, copy the numbers from
+a sibling bench in the same category — they are placeholders until the first
+nightly run lands a baseline, and you tighten them in a follow-up once it
+exists.
+
+Verify before you push — this is the gate that catches a missing entry, and it
+is much cheaper than a CI round-trip:
+
+```bash
+cargo test -p fluree-bench-support --test workspace_reconcile
+```
 
 ### 6. Document if you added a new category
 
@@ -208,7 +220,7 @@ future micro-bench wants to exercise `fluree-db-indexer`,
 | `import` | bulk Turtle / N-Quads / JSON-LD ingest | `fluree-db-api/benches/import_bulk.rs` |
 | `transact` | stage + commit | `fluree-db-api/benches/transact_commit.rs` |
 | `reindex` | full reindex; incremental | `fluree-db-api/benches/reindex_full.rs`, `fluree-db-api/benches/reindex_incremental.rs` |
-| `query_hot` | warm-cache query latency | `fluree-db-api/benches/query_hot_bsbm.rs` (BSBM Explore Q3/Q5/Q9), `fluree-db-api/benches/query_hot_bsbm_bi.rs` (BI-F2 bowtie / seed tie-break), `fluree-db-api/benches/query_hot_whole_graph_agg.rs` (Cypher metadata-lane aggregate folds vs. pipeline baseline) |
+| `query_hot` | warm-cache query latency | `fluree-db-api/benches/query_hot_bsbm.rs` (BSBM Explore Q3/Q5/Q9), `fluree-db-api/benches/query_hot_bsbm_bi.rs` (BI-F2 bowtie / seed tie-break), `fluree-db-api/benches/query_hot_property_path.rs` (property-path traversal), `fluree-db-api/benches/query_hot_whole_graph_agg.rs` (Cypher metadata-lane aggregate folds vs. pipeline baseline), `fluree-db-api/benches/query_hot_fanout_star.rs` (same-subject star with an unprojected fan-out object — the property-join semijoin demotion) |
 | `query_cold` | reload + first-query latency | `fluree-db-api/benches/query_cold_reload.rs` |
 | `novelty` | replay, catch-up, bulk-apply | `fluree-db-api/benches/novelty_replay.rs` |
 | `vector_math` | SIMD vs scalar math micro-benches | `fluree-db-query/benches/vector_math.rs` |

--- a/docs/query/construct.md
+++ b/docs/query/construct.md
@@ -168,6 +168,50 @@ WHERE {
 }
 ```
 
+## Solution Multiplicity: Blank Nodes and LIMIT
+
+A CONSTRUCT template is instantiated once per **solution**, and a WHERE clause
+is a bag — a subject with three `ex:tag` values contributes three solutions,
+not one (SPARQL 1.1 §16.2). Because the result is an RDF graph, identical
+triples built from different solutions collapse into one, so this is usually
+invisible. It becomes visible in exactly two places:
+
+**Blank nodes in the template mint one blank node per solution.** A template
+blank node (`[ ... ]` or `_:b`) is fresh for every solution, so each solution
+produces distinct triples:
+
+```sparql
+PREFIX ex: <http://example.org/ns/>
+
+CONSTRUCT { ?s ex:note [ ex:v "seen" ] }
+WHERE { ?s a ex:Gadget . ?s ex:tag ?o }
+```
+
+A gadget with three tags yields three matched solutions and therefore three
+distinct `ex:note` blank nodes — one per solution, not one per gadget. If you
+want one node per subject, make the WHERE clause produce one solution per
+subject (for example, drop the `?s ex:tag ?o` pattern, or move it into a
+subquery with `SELECT DISTINCT ?s`).
+
+**`LIMIT` counts solutions, not output triples.** The slice is applied to the
+solution sequence *before* the template is instantiated, and duplicate triples
+from the surviving solutions still collapse afterward. So
+`CONSTRUCT { ?s ex:flag "y" } WHERE { ?s a ex:Gadget . ?s ex:tag ?o } LIMIT 10`
+can return far fewer than 10 triples: the first 10 solutions may cover only a
+few distinct subjects (a single gadget with 10+ tags covers them all), and
+without an `ORDER BY` which solutions those are is not defined. If you are
+using `LIMIT` to preview *n* subjects, limit the subjects rather than the
+solutions:
+
+```sparql
+PREFIX ex: <http://example.org/ns/>
+
+CONSTRUCT { ?s ex:flag "y" }
+WHERE {
+  { SELECT DISTINCT ?s WHERE { ?s a ex:Gadget . ?s ex:tag ?o } LIMIT 10 }
+}
+```
+
 ## Best Practices
 
 1. **Specific Patterns**: Construct specific patterns rather than wildcards

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -239,6 +239,11 @@ path = "tests/it_exists_semijoin_correlation.rs"
 name = "it_repeated_var_fast_path_guards"
 path = "tests/it_repeated_var_fast_path_guards.rs"
 
+# Own binary: toggles the process-global fast-path kill switch.
+[[test]]
+name = "it_count_star_row_multiplicity"
+path = "tests/it_count_star_row_multiplicity.rs"
+
 # Own binary: toggles the process-global fast-path kill switch AND asserts
 # fast-path routing, so it must not share a process with either.
 [[test]]

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -424,6 +424,14 @@ harness = false
 name = "query_hot_bsbm"
 harness = false
 
+# Same-subject star with a fan-out predicate whose object var is unprojected —
+# the shape `PropertyJoinOperator`'s semijoin demotion serves. Its own fixture:
+# BSBM has no multi-valued same-subject predicate and adding one would move
+# `query_hot_bsbm`'s committed baseline for unrelated cases.
+[[bench]]
+name = "query_hot_fanout_star"
+harness = false
+
 [[bench]]
 name = "query_overlay_matrix"
 harness = false

--- a/fluree-db-api/benches/query_hot_fanout_star.rs
+++ b/fluree-db-api/benches/query_hot_fanout_star.rs
@@ -1,0 +1,188 @@
+//! Hot-cache latency for a **same-subject star with a fan-out predicate** whose
+//! object variable nothing downstream projects.
+//!
+//! This is the shape `PropertyJoinOperator`'s existence-only (semijoin)
+//! demotion exists to make cheap, and the shape whose plan #1700 changed. It
+//! had no bench coverage in either direction, which is how a 6.7x CONSTRUCT
+//! regression could land and be measured only by hand:
+//!
+//! * **`construct_blank_free`** — the demotion is *licensed*: a CONSTRUCT result
+//!   is an RDF graph whose serializers canonicalize, so the fan-out rows are
+//!   discarded and pruning them is free. This is the regression guard. If the
+//!   license at `execute::operator_tree::construct_result_is_multiplicity_blind`
+//!   is lost, this case materializes the full cartesian product to produce a
+//!   byte-identical graph and the number moves by roughly the fan-out factor.
+//! * **`select_unprojected_object`** — the demotion is *not* licensed: SPARQL
+//!   projects a bag, so every fan-out row is an answer row. This case is
+//!   deliberately the expensive one; it is here so the cost of correctness is
+//!   tracked rather than rediscovered, and so a future optimization that
+//!   carries multiplicity without materializing the object bindings has a
+//!   number to beat.
+//! * **`select_distinct`** — the control. `SELECT DISTINCT` licenses the
+//!   demotion, so this must stay flat whatever happens to the other two. If all
+//!   three move together the run is measuring the box, not the planner.
+//!
+//! Separate fixture from `query_hot_bsbm` on purpose: BSBM has no multi-valued
+//! same-subject predicate, and adding one would shift that bench's committed
+//! baseline for unrelated cases.
+//!
+//! ## Matrix
+//!
+//!   inputs:   BenchScale → n_subjects × TAGS_PER_SUBJECT fan-out
+//!             (Tiny=200, Small=1k, Medium=5k, Large=20k subjects; 40 tags each)
+//!   metric:   ns/query (criterion default)
+//!
+//! ## Running
+//!
+//!   cargo bench -p fluree-db-api --bench query_hot_fanout_star
+//!   cargo bench -p fluree-db-api --bench query_hot_fanout_star -- --test
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use fluree_bench_support::{
+    bench_runtime, current_profile, current_scale, init_tracing_for_bench, next_ledger_alias,
+    BenchScale,
+};
+use fluree_db_api::admin::ReindexOptions;
+use fluree_db_api::{CommitOpts, Fluree, FlureeBuilder, IndexConfig, TxnOpts};
+
+/// Objects per subject on the fan-out predicate. The whole point of the shape
+/// is that this is > 1, so the pruned and unpruned plans differ by a factor of
+/// it rather than by a constant.
+const TAGS_PER_SUBJECT: usize = 40;
+
+fn scale_n_subjects(scale: BenchScale) -> usize {
+    match scale {
+        BenchScale::Tiny => 200,
+        BenchScale::Small => 1_000,
+        BenchScale::Medium => 5_000,
+        BenchScale::Large => 20_000,
+    }
+}
+
+/// `?s a ex:Gadget . ?s ex:tag ?o` — `?o` never leaves the WHERE clause.
+/// The template is blank-free and the query unsliced, so the result graph is
+/// exactly one node per subject however many tags each carries.
+const CONSTRUCT_BLANK_FREE: &str = r#"
+PREFIX ex: <http://example.org/>
+CONSTRUCT { ?s ex:flag "y" }
+WHERE { ?s a ex:Gadget . ?s ex:tag ?o }
+"#;
+
+/// The same star projected as a bag: every fan-out row is an answer row.
+const SELECT_UNPROJECTED_OBJECT: &str = r"
+PREFIX ex: <http://example.org/>
+SELECT ?s WHERE { ?s a ex:Gadget . ?s ex:tag ?o }
+";
+
+/// Control: DISTINCT licenses the demotion, so this keeps the pruned plan.
+const SELECT_DISTINCT: &str = r"
+PREFIX ex: <http://example.org/>
+SELECT DISTINCT ?s WHERE { ?s a ex:Gadget . ?s ex:tag ?o }
+";
+
+fn fanout_turtle(n_subjects: usize) -> String {
+    // ~24 bytes per tag line plus the subject header.
+    let mut out = String::with_capacity(n_subjects * TAGS_PER_SUBJECT * 24 + 64);
+    out.push_str("@prefix ex: <http://example.org/> .\n");
+    for s in 0..n_subjects {
+        out.push_str(&format!("ex:g{s} a ex:Gadget ; ex:tag "));
+        for t in 0..TAGS_PER_SUBJECT {
+            if t > 0 {
+                out.push_str(" , ");
+            }
+            out.push_str(&format!("\"t{t}\""));
+        }
+        out.push_str(" .\n");
+    }
+    out
+}
+
+/// Build a populated, indexed file-backed Fluree. Mirrors `query_hot_bsbm`'s
+/// setup discipline: populate behind a raised reindex threshold, then reindex
+/// explicitly so the measured queries traverse the binary columnar index rather
+/// than novelty replay.
+async fn setup_indexed(n_subjects: usize) -> (tempfile::TempDir, Fluree, String) {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let alias = next_ledger_alias("query-hot-fanout-star");
+    let ledger = fluree.create_ledger(&alias).await.expect("create_ledger");
+
+    let index_config = IndexConfig {
+        reindex_min_bytes: 5_000_000_000,
+        reindex_max_bytes: 5_000_000_000,
+    };
+    let _ = fluree
+        .insert_turtle_with_opts(
+            ledger,
+            &fanout_turtle(n_subjects),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config,
+            None,
+        )
+        .await
+        .expect("populate insert");
+
+    let _ = fluree
+        .reindex(&alias, ReindexOptions::default())
+        .await
+        .expect("reindex");
+
+    (db_dir, fluree, alias)
+}
+
+fn bench_query_hot_fanout_star(c: &mut Criterion) {
+    init_tracing_for_bench();
+    let rt = bench_runtime();
+    let scale = current_scale();
+    let profile = current_profile();
+    let n_subjects = scale_n_subjects(scale);
+
+    eprintln!(
+        "  [query_hot_fanout_star] scale={} n_subjects={} pairs={}",
+        scale.as_str(),
+        n_subjects,
+        n_subjects * TAGS_PER_SUBJECT
+    );
+
+    let (_db_dir, fluree, alias) = rt.block_on(setup_indexed(n_subjects));
+    let snapshot = rt.block_on(async { fluree.graph(&alias).load().await.expect("graph load") });
+
+    let mut group = c.benchmark_group("query_hot_fanout_star");
+    group.sample_size(profile.sample_size());
+    group.sampling_mode(criterion::SamplingMode::Flat);
+
+    for (name, sparql) in [
+        ("construct_blank_free", CONSTRUCT_BLANK_FREE),
+        ("select_unprojected_object", SELECT_UNPROJECTED_OBJECT),
+        ("select_distinct", SELECT_DISTINCT),
+    ] {
+        group.bench_with_input(
+            BenchmarkId::new(name, scale.as_str()),
+            &n_subjects,
+            |b, _| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let result = snapshot
+                            .query()
+                            .sparql(sparql)
+                            .execute()
+                            .await
+                            .unwrap_or_else(|e| panic!("{name} execute: {e}"));
+                        black_box(result);
+                    });
+                });
+            },
+        );
+    }
+
+    group.finish();
+    drop(snapshot);
+    drop(fluree);
+}
+
+criterion_group!(benches, bench_query_hot_fanout_star);
+criterion_main!(benches);

--- a/fluree-db-api/benches/query_hot_fanout_star.rs
+++ b/fluree-db-api/benches/query_hot_fanout_star.rs
@@ -3,15 +3,20 @@
 //!
 //! This is the shape `PropertyJoinOperator`'s existence-only (semijoin)
 //! demotion exists to make cheap, and the shape whose plan #1700 changed. It
-//! had no bench coverage in either direction, which is how a 6.7x CONSTRUCT
-//! regression could land and be measured only by hand:
+//! had no bench coverage in either direction, which is how the fix's own cost
+//! profile — flat for CONSTRUCT only because of a license that recovers a
+//! ~6.2x slowdown the fix would otherwise introduce (0.1464s → 0.9026s →
+//! 0.1380s at 120k pairs; the middle number is the fix without the license,
+//! not anything that ever shipped) — had to be measured by hand:
 //!
 //! * **`construct_blank_free`** — the demotion is *licensed*: a CONSTRUCT result
 //!   is an RDF graph whose serializers canonicalize, so the fan-out rows are
 //!   discarded and pruning them is free. This is the regression guard. If the
-//!   license at `execute::operator_tree::construct_result_is_multiplicity_blind`
+//!   license at `execute::operator_tree::result_is_multiplicity_blind`
 //!   is lost, this case materializes the full cartesian product to produce a
-//!   byte-identical graph and the number moves by roughly the fan-out factor.
+//!   byte-identical graph and the number moves by roughly the fan-out factor —
+//!   that is a regression against the *pre-#1700 planner*, not merely against
+//!   an intermediate state of the fix.
 //! * **`select_unprojected_object`** — the demotion is *not* licensed: SPARQL
 //!   projects a bag, so every fan-out row is an answer row. This case is
 //!   deliberately the expensive one; it is here so the cost of correctness is

--- a/fluree-db-api/src/view/stream_query.rs
+++ b/fluree-db-api/src/view/stream_query.rs
@@ -568,3 +568,31 @@ impl BatchSink for NdjsonRowSink<'_> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_streamable;
+    use fluree_db_query::ir::{ConstructTemplate, QueryOutput};
+
+    /// The WHERE-dedup license for CONSTRUCT and ASK (#1700 follow-up;
+    /// `result_is_multiplicity_blind` in fluree-db-query's
+    /// `execute::operator_tree`) counts on this endpoint refusing both output
+    /// forms: a streaming serializer emits solutions as they arrive and cannot
+    /// canonicalize after the fact, so if either rejection is ever lifted the
+    /// new path must dedup its triples itself — or the license must be
+    /// revoked. See `every_output_format_collapses_or_rejects_construct` in
+    /// `it_query_construct.rs` for the non-streaming half of the same gate.
+    #[test]
+    fn streaming_endpoint_keeps_rejecting_construct_and_ask() {
+        assert!(
+            ensure_streamable(&QueryOutput::Construct(ConstructTemplate::new(Vec::new()))).is_err(),
+            "streaming CONSTRUCT would bypass Graph::canonicalize and observe \
+             WHERE-level dedup"
+        );
+        assert!(
+            ensure_streamable(&QueryOutput::Ask).is_err(),
+            "streaming ASK has no row stream to emit; its boolean is computed \
+             from solution-sequence emptiness on the buffered path"
+        );
+    }
+}

--- a/fluree-db-api/tests/it_count_star_row_multiplicity.rs
+++ b/fluree-db-api/tests/it_count_star_row_multiplicity.rs
@@ -295,6 +295,74 @@ struct ConstructExpect {
     distinct_blanks: usize,
 }
 
+/// ASK over the same fixture, on both lanes and both surfaces.
+///
+/// ASK carries the dedup license too — its result is a boolean read off
+/// solution-sequence emptiness, so the fan-out rows are unobservable and the
+/// planner gives it the existence-only join (the plan shape is pinned by
+/// `ask_over_a_fanout_star_plans_the_existence_only_join` in
+/// `operator_tree.rs`; a result assertion alone cannot see the license, since
+/// the boolean is identical either way). What these cases guard is that the
+/// license did not *break* ASK: emptiness must survive the dedup in both
+/// directions, on the indexed lane where the demotion actually fires.
+fn ask_cases() -> Vec<(&'static str, &'static str, bool)> {
+    vec![
+        (
+            "ASK fan-out star (matching)",
+            "ASK { ?s a ex:Gadget . ?s ex:tag ?o }",
+            true,
+        ),
+        (
+            "ASK two-object cartesian (matching)",
+            "ASK { ?s a ex:Gadget . ?s ex:tag ?o . ?s ex:code ?c }",
+            true,
+        ),
+        (
+            "ASK star with an unmatched predicate",
+            "ASK { ?s a ex:Gadget . ?s ex:missing ?m }",
+            false,
+        ),
+        // Disjoint subjects: a cartesian of two blocks whose vars are all
+        // single-use, so the licensed plan may prune every column. Emptiness
+        // must still survive the zero-column join.
+        (
+            "ASK two disjoint bound-object triples (matching)",
+            "ASK { ?s a ex:Gadget . ?w a ex:Widget }",
+            true,
+        ),
+    ]
+}
+
+/// JSON-LD twins of the ASK shapes, per the three-surface parity rule.
+fn jsonld_ask_cases() -> Vec<(&'static str, Value, bool)> {
+    let ctx = json!({"ex": "http://example.org/"});
+    vec![
+        (
+            "jsonld ask fan-out star (matching)",
+            json!({
+                "@context": ctx,
+                "ask": {"@id": "?s", "@type": "ex:Gadget", "ex:tag": "?o"}
+            }),
+            true,
+        ),
+        (
+            "jsonld ask star with an unmatched predicate",
+            json!({
+                "@context": ctx,
+                "ask": {"@id": "?s", "@type": "ex:Gadget", "ex:missing": "?m"}
+            }),
+            false,
+        ),
+    ]
+}
+
+/// Read the boolean out of a SPARQL-JSON ASK envelope.
+fn summarize_ask(results: &Value) -> Result<bool, String> {
+    results["boolean"]
+        .as_bool()
+        .ok_or_else(|| format!("no boolean in {results}"))
+}
+
 /// Count graph nodes and distinct blank-node ids in a `to_construct` result.
 fn summarize_construct(graph: &Value) -> (usize, usize) {
     let nodes = graph["@graph"]
@@ -449,6 +517,39 @@ async fn count_star_counts_joined_rows_not_distinct_subjects() {
                     "[{lane}] {name}: got {got}, expected {expected} \
                      (SPARQL twin of the same shape)"
                 ));
+            }
+        }
+
+        for (name, sparql, expected) in &ask_cases() {
+            let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+            let q = format!("{PREFIX}{sparql}");
+            match fluree.query(&db, q.as_str()).await {
+                Ok(r) => match r.to_sparql_json(&ledger.snapshot) {
+                    Ok(json) => match summarize_ask(&json) {
+                        Ok(got) if got == *expected => {}
+                        Ok(got) => failures
+                            .push(format!("[{lane}] {name}: got {got}, expected {expected}")),
+                        Err(e) => failures.push(format!("[{lane}] {name}: {e}")),
+                    },
+                    Err(e) => failures.push(format!("[{lane}] {name}: ERR:{e}")),
+                },
+                Err(e) => failures.push(format!("[{lane}] {name}: ERR:{e}")),
+            }
+        }
+
+        for (name, query, expected) in &jsonld_ask_cases() {
+            let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+            match fluree.query(&db, query).await {
+                Ok(r) => match r.to_sparql_json(&ledger.snapshot) {
+                    Ok(json) => match summarize_ask(&json) {
+                        Ok(got) if got == *expected => {}
+                        Ok(got) => failures
+                            .push(format!("[{lane}] {name}: got {got}, expected {expected}")),
+                        Err(e) => failures.push(format!("[{lane}] {name}: {e}")),
+                    },
+                    Err(e) => failures.push(format!("[{lane}] {name}: ERR:{e}")),
+                },
+                Err(e) => failures.push(format!("[{lane}] {name}: ERR:{e}")),
             }
         }
     }

--- a/fluree-db-api/tests/it_count_star_row_multiplicity.rs
+++ b/fluree-db-api/tests/it_count_star_row_multiplicity.rs
@@ -245,6 +245,72 @@ fn jsonld_cases() -> Vec<(&'static str, Value, &'static str)> {
     ]
 }
 
+/// CONSTRUCT shapes over the same multiplicity-bearing fixture.
+///
+/// A CONSTRUCT result is an RDF graph, so the interesting question is the
+/// opposite of the SELECT one: the extra solutions must *not* reach the output.
+/// `?o` appears only in the WHERE clause and never in the template, so a
+/// blank-free template instantiates to the same triple from all 5 solutions and
+/// canonicalizes to 2 nodes — the distinct-subject count, not the row count.
+///
+/// The blank-node case is the exception that makes the rule load-bearing, and
+/// it is a behavior change this fix introduces: SPARQL 1.1 §16.2 instantiates
+/// the template once per *solution*, minting a fresh blank per row, so 5
+/// solutions yield 5 distinct blanks where the pre-fix collapsed sequence
+/// yielded 2. That is the SPARQL-correct number, and nothing pinned it before.
+fn construct_cases() -> Vec<(&'static str, &'static str, ConstructExpect)> {
+    vec![
+        (
+            "blank-free CONSTRUCT collapses to the subject count",
+            "CONSTRUCT { ?s ex:flag \"y\" } WHERE { ?s a ex:Gadget . ?s ex:tag ?o }",
+            ConstructExpect {
+                nodes: 2,
+                distinct_blanks: 0,
+            },
+        ),
+        (
+            "blank-free CONSTRUCT, two-object cartesian, still the subject count",
+            "CONSTRUCT { ?s ex:flag \"y\" } WHERE \
+             { ?s a ex:Gadget . ?s ex:tag ?o . ?s ex:code ?c }",
+            ConstructExpect {
+                nodes: 2,
+                distinct_blanks: 0,
+            },
+        ),
+        (
+            "blank-node template mints one blank per solution",
+            "CONSTRUCT { ?s ex:note [ ex:v \"z\" ] } WHERE { ?s a ex:Gadget . ?s ex:tag ?o }",
+            ConstructExpect {
+                nodes: 7,
+                distinct_blanks: 5,
+            },
+        ),
+    ]
+}
+
+struct ConstructExpect {
+    /// Total nodes in the canonicalized `@graph`.
+    nodes: usize,
+    /// Distinct blank-node identifiers appearing as `@id`.
+    distinct_blanks: usize,
+}
+
+/// Count graph nodes and distinct blank-node ids in a `to_construct` result.
+fn summarize_construct(graph: &Value) -> (usize, usize) {
+    let nodes = graph["@graph"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no @graph in {graph}"));
+    let mut blanks: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for n in nodes {
+        if let Some(id) = n.get("@id").and_then(Value::as_str) {
+            if id.starts_with("_:") {
+                blanks.insert(id.to_string());
+            }
+        }
+    }
+    (nodes.len(), blanks.len())
+}
+
 /// Canonical one-line rendering. A single-row aggregate renders `n=<value>`; a
 /// multi-row result whose every row carries `?n` renders its sorted counts too,
 /// so a grouped `COUNT(*)` is pinned by its per-group values and not merely by
@@ -345,6 +411,27 @@ async fn count_star_counts_joined_rows_not_distinct_subjects() {
                     "[{lane}] {}: got {got}, expected {} (hand-computed from the fixture)",
                     c.name, c.expected
                 ));
+            }
+        }
+
+        for (name, sparql, expect) in &construct_cases() {
+            let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+            let q = format!("{PREFIX}{sparql}");
+            match fluree.query(&db, q.as_str()).await {
+                Ok(r) => match r.to_construct(&ledger.snapshot) {
+                    Ok(graph) => {
+                        let (nodes, blanks) = summarize_construct(&graph);
+                        if nodes != expect.nodes || blanks != expect.distinct_blanks {
+                            failures.push(format!(
+                                "[{lane}] {name}: got {nodes} nodes / {blanks} blanks, \
+                                 expected {} / {}",
+                                expect.nodes, expect.distinct_blanks
+                            ));
+                        }
+                    }
+                    Err(e) => failures.push(format!("[{lane}] {name}: to_construct ERR:{e}")),
+                },
+                Err(e) => failures.push(format!("[{lane}] {name}: ERR:{e}")),
             }
         }
 

--- a/fluree-db-api/tests/it_count_star_row_multiplicity.rs
+++ b/fluree-db-api/tests/it_count_star_row_multiplicity.rs
@@ -1,0 +1,376 @@
+//! Regression pin (#1700): a star join whose object variable nothing
+//! downstream reads must still produce one row per solution, not one row per
+//! subject.
+//!
+//! `PropertyJoinOperator` demotes a predicate to an existence-only (semijoin)
+//! constraint when its object var is absent from the block's needed-vars set —
+//! it records that the subject has *some* object and drops the per-subject
+//! object list. That is a set operation. It was applied unconditionally, so on
+//! `{ ?s a ex:Gadget . ?s ex:tag ?o }` a subject with three tags contributed
+//! one row instead of three, and `COUNT(*)` returned the number of qualifying
+//! **subjects**.
+//!
+//! Three structural notes, each of which shapes this test:
+//!
+//! * **A single-object-per-subject fixture cannot tell the two answers
+//!   apart.** Every fixture below is deliberately multiplicity-bearing, and
+//!   each shape is pinned alongside its distinct-subject count so the two
+//!   numbers differ. Flatten the fixture and the `subjects` assertions fail
+//!   rather than the test quietly going vacuous.
+//! * **It is an indexed-lane defect.** The block only reaches
+//!   `PropertyJoinOperator` with a bound-object anchor on a real index, so the
+//!   ledger here is bulk-imported.
+//! * **Both lanes are pinned against the hand-computed SPARQL answer, never
+//!   against each other.** `FLUREE_DISABLE_QUERY_FAST_PATHS` is the repo's
+//!   differential oracle, and for this shape the oracle was the broken side:
+//!   the `COUNT(*)` fast path answered 5 from index metadata while the generic
+//!   pipeline it is checked against answered 2. A fast-vs-generic comparison
+//!   would have called the correct lane the regression. So the expectations
+//!   below are arithmetic on the fixture, and the lanes are checked against
+//!   that — not against one another.
+//!
+//! Own test binary: the kill switch is process-global.
+
+#![cfg(feature = "native")]
+
+use fluree_db_api::{set_fast_paths_disabled, FlureeBuilder};
+use serde_json::{json, Value};
+use std::io::Write;
+use tempfile::TempDir;
+
+/// Multiplicity-bearing by construction — every class below has more
+/// `(subject, object)` pairs than it has subjects.
+///
+/// * `ex:Gadget` / `ex:tag`  — 5 pairs over 2 tagged subjects (3 + 2).
+/// * `ex:Gadget` / `ex:code` — 3 pairs over 2 subjects (2 + 1); crossed with
+///   `ex:tag` it gives 3x2 + 2x1 = 8, which no single-predicate count produces.
+/// * `ex:g3` carries the type but no tag and no code, so an OPTIONAL tail has
+///   a non-matching subject to preserve.
+/// * `ex:Widget` / `ex:name` — 4 pairs over 3 subjects, the issue's second
+///   fixture: a shape where rows and subjects differ by one.
+const DATA: &str = r#"
+@prefix ex: <http://example.org/> .
+
+ex:g1 a ex:Gadget ; ex:tag "a" , "b" , "c" ; ex:code "x" , "y" .
+ex:g2 a ex:Gadget ; ex:tag "d" , "e" ; ex:code "z" .
+ex:g3 a ex:Gadget .
+
+ex:w1 a ex:Widget ; ex:name "one" , "two" .
+ex:w2 a ex:Widget ; ex:name "three" .
+ex:w3 a ex:Widget ; ex:name "four" .
+"#;
+
+const PREFIX: &str = "PREFIX ex: <http://example.org/> ";
+
+struct Case {
+    name: &'static str,
+    sparql: &'static str,
+    /// Hand-computed from `DATA`, as `summarize` renders it.
+    expected: &'static str,
+}
+
+fn cases() -> Vec<Case> {
+    vec![
+        // ---- the reported shape ---------------------------------------------
+        // g1 has 3 tags, g2 has 2 => 5 solutions over 2 subjects. Before the
+        // fix the generic pipeline answered 2 here and the fast path 5.
+        Case {
+            name: "COUNT(*) {?s a Gadget . ?s tag ?o}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?s a ex:Gadget . ?s ex:tag ?o }",
+            expected: "n=5",
+        },
+        // The discriminator: 2 != 5, so a fixture with one tag per subject
+        // could not tell a passing run from a failing one.
+        Case {
+            name: "COUNT(DISTINCT ?s) {?s a Gadget . ?s tag ?o}",
+            sparql: "SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE { ?s a ex:Gadget . ?s ex:tag ?o }",
+            expected: "n=2",
+        },
+        // COUNT(?o) was already right, for an unrelated reason: naming ?o in
+        // the aggregate puts it in the needed set, so the demotion never fired.
+        // Pinned so a fix cannot regress it.
+        Case {
+            name: "COUNT(?o) {?s a Gadget . ?s tag ?o}",
+            sparql: "SELECT (COUNT(?o) AS ?n) WHERE { ?s a ex:Gadget . ?s ex:tag ?o }",
+            expected: "n=5",
+        },
+        // ---- the same collapse, read as rows rather than as a count ---------
+        // Not an aggregate defect: the rows were already gone by the time the
+        // aggregate ran. SPARQL projects a bag, so this is 5 rows, not 2.
+        Case {
+            name: "rows ?s {?s a Gadget . ?s tag ?o}",
+            sparql: "SELECT ?s WHERE { ?s a ex:Gadget . ?s ex:tag ?o }",
+            expected: "rows=5",
+        },
+        Case {
+            name: "rows ?s ?o {?s a Gadget . ?s tag ?o}",
+            sparql: "SELECT ?s ?o WHERE { ?s a ex:Gadget . ?s ex:tag ?o }",
+            expected: "rows=5",
+        },
+        // ---- grouped COUNT(*): wrong on BOTH lanes before the fix -----------
+        // g1 -> 3, g2 -> 2. This one the kill-switch oracle could never have
+        // caught: the fast and generic lanes agreed on 1 and 1.
+        Case {
+            name: "GROUP BY ?s COUNT(*) {?s a Gadget . ?s tag ?o}",
+            sparql: "SELECT ?s (COUNT(*) AS ?n) WHERE { ?s a ex:Gadget . ?s ex:tag ?o } \
+                     GROUP BY ?s ORDER BY ?s",
+            expected: "rows=2 n=[2,3]",
+        },
+        // ---- two variable objects: a real cartesian, not just a fanout ------
+        // g1: 3 tags x 2 codes = 6; g2: 2 x 1 = 2; total 8 over 2 subjects.
+        // 8 is not the row count of either predicate alone, so this cannot be
+        // satisfied by accidentally counting one column.
+        Case {
+            name: "COUNT(*) {?s a Gadget . ?s tag ?o . ?s code ?c}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE \
+                     { ?s a ex:Gadget . ?s ex:tag ?o . ?s ex:code ?c }",
+            expected: "n=8",
+        },
+        Case {
+            name: "COUNT(DISTINCT ?s) {?s a Gadget . ?s tag ?o . ?s code ?c}",
+            sparql: "SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE \
+                     { ?s a ex:Gadget . ?s ex:tag ?o . ?s ex:code ?c }",
+            expected: "n=2",
+        },
+        Case {
+            name: "rows {?s a Gadget . ?s tag ?o . ?s code ?c}",
+            sparql: "SELECT ?s WHERE { ?s a ex:Gadget . ?s ex:tag ?o . ?s ex:code ?c }",
+            expected: "rows=8",
+        },
+        // ---- OPTIONAL tail folded into the same block -----------------------
+        // g1 -> 3, g2 -> 2, g3 -> 1 unmatched row = 6.
+        Case {
+            name: "COUNT(*) {?s a Gadget} OPTIONAL {?s tag ?o}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE \
+                     { ?s a ex:Gadget OPTIONAL { ?s ex:tag ?o } }",
+            expected: "n=6",
+        },
+        // ---- the issue's second fixture: rows and subjects differ by one ----
+        Case {
+            name: "COUNT(*) {?s a Widget . ?s name ?n2}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?s a ex:Widget . ?s ex:name ?n2 }",
+            expected: "n=4",
+        },
+        Case {
+            name: "COUNT(DISTINCT ?s) {?s a Widget . ?s name ?n2}",
+            sparql: "SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE { ?s a ex:Widget . ?s ex:name ?n2 }",
+            expected: "n=3",
+        },
+        // ---- the pruning must SURVIVE where it is licensed ------------------
+        // These consumers cannot observe row multiplicity, so the existence-only
+        // demotion is still sound and must still happen. If the fix were a
+        // blanket disable these would keep passing, but the unit tests in
+        // `where_plan.rs` pin the plan shape; here they guard the answers.
+        Case {
+            name: "DISTINCT ?s {?s a Gadget . ?s tag ?o}",
+            sparql: "SELECT DISTINCT ?s WHERE { ?s a ex:Gadget . ?s ex:tag ?o }",
+            expected: "rows=2",
+        },
+        Case {
+            name: "DISTINCT ?s {?s a Gadget . ?s tag ?o . ?s code ?c}",
+            sparql: "SELECT DISTINCT ?s WHERE { ?s a ex:Gadget . ?s ex:tag ?o . ?s ex:code ?c }",
+            expected: "rows=2",
+        },
+        // ---- a bound object carries multiplicity 1 and must stay collapsed --
+        // `?s ex:tag "a"` matches at most one flake per subject, so this is 1
+        // regardless of how many other tags g1 has.
+        Case {
+            name: "COUNT(*) {?s a Gadget . ?s tag \"a\"}",
+            sparql: "SELECT (COUNT(*) AS ?n) WHERE { ?s a ex:Gadget . ?s ex:tag \"a\" }",
+            expected: "n=1",
+        },
+    ]
+}
+
+/// The JSON-LD twin of each SPARQL shape above, per the three-surface parity
+/// rule: both surfaces lower to the same IR, so a WHERE-planner defect reaches
+/// both and a fix owes a regression test on both.
+fn jsonld_cases() -> Vec<(&'static str, Value, &'static str)> {
+    let ctx = json!({"ex": "http://example.org/"});
+    vec![
+        (
+            "jsonld COUNT(*) gadget/tag",
+            json!({
+                "@context": ctx,
+                "select": ["(as (count *) ?n)"],
+                "where": {"@id": "?s", "@type": "ex:Gadget", "ex:tag": "?o"}
+            }),
+            "n=5",
+        ),
+        (
+            "jsonld COUNT(DISTINCT ?s) gadget/tag",
+            json!({
+                "@context": ctx,
+                "select": ["(as (count-distinct ?s) ?n)"],
+                "where": {"@id": "?s", "@type": "ex:Gadget", "ex:tag": "?o"}
+            }),
+            "n=2",
+        ),
+        (
+            "jsonld rows ?s gadget/tag",
+            json!({
+                "@context": ctx,
+                "select": ["?s"],
+                "where": {"@id": "?s", "@type": "ex:Gadget", "ex:tag": "?o"}
+            }),
+            "rows=5",
+        ),
+        (
+            "jsonld COUNT(*) gadget/tag x code",
+            json!({
+                "@context": ctx,
+                "select": ["(as (count *) ?n)"],
+                "where": {"@id": "?s", "@type": "ex:Gadget", "ex:tag": "?o", "ex:code": "?c"}
+            }),
+            "n=8",
+        ),
+        (
+            "jsonld COUNT(*) widget/name",
+            json!({
+                "@context": ctx,
+                "select": ["(as (count *) ?n)"],
+                "where": {"@id": "?s", "@type": "ex:Widget", "ex:name": "?n2"}
+            }),
+            "n=4",
+        ),
+        (
+            "jsonld selectDistinct ?s gadget/tag",
+            json!({
+                "@context": ctx,
+                "selectDistinct": ["?s"],
+                "where": {"@id": "?s", "@type": "ex:Gadget", "ex:tag": "?o"}
+            }),
+            "rows=2",
+        ),
+    ]
+}
+
+/// Canonical one-line rendering. A single-row aggregate renders `n=<value>`; a
+/// multi-row result whose every row carries `?n` renders its sorted counts too,
+/// so a grouped `COUNT(*)` is pinned by its per-group values and not merely by
+/// its row count.
+fn summarize(results: &Value) -> String {
+    let bindings = results["results"]["bindings"]
+        .as_array()
+        .unwrap_or_else(|| panic!("no results.bindings in {results}"));
+    if bindings.len() == 1 {
+        if let Some(v) = bindings[0].get("n").and_then(|c| c["value"].as_str()) {
+            return format!("n={v}");
+        }
+    }
+    let mut ns: Vec<String> = bindings
+        .iter()
+        .filter_map(|b| {
+            b.get("n")
+                .and_then(|c| c["value"].as_str())
+                .map(str::to_string)
+        })
+        .collect();
+    if !ns.is_empty() && ns.len() == bindings.len() {
+        ns.sort();
+        return format!("rows={} n=[{}]", bindings.len(), ns.join(","));
+    }
+    format!("rows={}", bindings.len())
+}
+
+/// RAII restore of the process-global kill switch, including on panic.
+struct FastPathGuard;
+impl Drop for FastPathGuard {
+    fn drop(&mut self) {
+        set_fast_paths_disabled(false);
+    }
+}
+
+async fn indexed_ledger(dir: &TempDir, name: &str, ttl: &str) -> (fluree_db_api::Fluree, String) {
+    let data_dir = TempDir::new().expect("data tmpdir");
+    let path = data_dir.path().join("00-fixture.ttl");
+    let mut f = std::fs::File::create(&path).expect("create ttl");
+    f.write_all(ttl.as_bytes()).expect("write ttl");
+
+    // Bulk import builds a fully persisted binary index with no trailing
+    // novelty. Required: on a never-indexed ledger the block never reaches the
+    // property-join plan and every shape below is already correct, so a
+    // memory-backed fixture would pin nothing.
+    let fluree = FlureeBuilder::file(dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+    let ledger_id = format!("test/{name}:main");
+    fluree
+        .create(&ledger_id)
+        .import(data_dir.path())
+        .threads(1)
+        .memory_budget_mb(256)
+        .cleanup(false)
+        .execute()
+        .await
+        .expect("import");
+    (fluree, ledger_id)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn count_star_counts_joined_rows_not_distinct_subjects() {
+    // The kill switch OR's with this env var, so with it set the fast-path
+    // phase would run generically and half of every assertion below would be
+    // pinning the same lane twice.
+    assert!(
+        std::env::var_os("FLUREE_DISABLE_QUERY_FAST_PATHS").is_none(),
+        "FLUREE_DISABLE_QUERY_FAST_PATHS is set — the fast-path phase of this \
+         test would run generically and pin nothing. Unset it."
+    );
+    let _guard = FastPathGuard;
+
+    let db_dir = TempDir::new().expect("db tmpdir");
+    let (fluree, ledger_id) = indexed_ledger(&db_dir, "count-star-multiplicity", DATA).await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load");
+    let cases = cases();
+    let jsonld = jsonld_cases();
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for (lane, disabled) in [("fast", false), ("generic", true)] {
+        set_fast_paths_disabled(disabled);
+
+        for c in &cases {
+            let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+            let sparql = format!("{PREFIX}{}", c.sparql);
+            let got = match fluree.query(&db, sparql.as_str()).await {
+                Ok(r) => match r.to_sparql_json(&ledger.snapshot) {
+                    Ok(json) => summarize(&json),
+                    Err(e) => format!("ERR:{e}"),
+                },
+                Err(e) => format!("ERR:{e}"),
+            };
+            if got != c.expected {
+                failures.push(format!(
+                    "[{lane}] {}: got {got}, expected {} (hand-computed from the fixture)",
+                    c.name, c.expected
+                ));
+            }
+        }
+
+        for (name, query, expected) in &jsonld {
+            let db = fluree_db_api::GraphDb::from_ledger_state(&ledger);
+            let got = match fluree.query(&db, query).await {
+                Ok(r) => match r.to_sparql_json(&ledger.snapshot) {
+                    Ok(json) => summarize(&json),
+                    Err(e) => format!("ERR:{e}"),
+                },
+                Err(e) => format!("ERR:{e}"),
+            };
+            if got != *expected {
+                failures.push(format!(
+                    "[{lane}] {name}: got {got}, expected {expected} \
+                     (SPARQL twin of the same shape)"
+                ));
+            }
+        }
+    }
+
+    set_fast_paths_disabled(false);
+
+    assert!(
+        failures.is_empty(),
+        "COUNT(*) row-multiplicity failures:\n  {}",
+        failures.join("\n  ")
+    );
+}

--- a/fluree-db-api/tests/it_query_construct.rs
+++ b/fluree-db-api/tests/it_query_construct.rs
@@ -993,3 +993,165 @@ async fn sparql_construct_shared_object_rdfxml_keeps_both_predicates() {
         "RDF/XML must carry both predicates: {rdfxml}"
     );
 }
+
+/// A fully-constant template prunes the WHERE schema to zero columns
+/// (`compute_variable_deps` seeds an empty needed set from a template that
+/// references no variable), and a column-less `Batch` carries its row count
+/// out-of-band — so every operator that rebuilds a batch column-by-column is a
+/// place the count can silently vanish. `DistinctOperator` was the first
+/// (fixed here); `LimitOperator`'s truncation branch and `OffsetOperator`'s
+/// partial-skip branch were the second and third, both rebuilding via
+/// `Batch::new(schema, vec![])` and losing the length. Reachable from main:
+/// this exact query returned an **empty graph** whenever the WHERE matched
+/// more rows than the limit, because the truncated zero-column batch read as
+/// zero rows and ASK/CONSTRUCT formatting reads emptiness.
+#[tokio::test]
+async fn constant_template_construct_with_limit_keeps_its_triple() {
+    let (fluree, ledger) = seed_people().await;
+
+    // WHERE matches many rows; LIMIT slices the solution sequence. The
+    // template is constant, so any surviving solution instantiates the same
+    // single triple — the graph must never be empty.
+    for q in [
+        "CONSTRUCT { <http://ex/s> <http://ex/p> \"dup\" } WHERE { ?s ?p ?o } LIMIT 1",
+        "CONSTRUCT { <http://ex/s> <http://ex/p> \"dup\" } WHERE { ?s ?p ?o } LIMIT 5",
+        "CONSTRUCT { <http://ex/s> <http://ex/p> \"dup\" } WHERE { ?s ?p ?o } OFFSET 2",
+        "CONSTRUCT { <http://ex/s> <http://ex/p> \"dup\" } WHERE { ?s ?p ?o } LIMIT 3 OFFSET 2",
+    ] {
+        let result = support::query_sparql(&fluree, &ledger, q)
+            .await
+            .expect("construct query");
+        let graph = result
+            .to_construct(&ledger.snapshot)
+            .expect("construct format");
+        let n = graph["@graph"].as_array().map_or(0, Vec::len);
+        assert_eq!(
+            n, 1,
+            "{q}: a constant template over a non-empty sliced WHERE must \
+             yield exactly one triple, got {n} nodes: {graph}"
+        );
+    }
+}
+
+// ============================================================================
+// The WHERE-dedup license's output-path gate (#1700 follow-up, #1706)
+// ============================================================================
+
+/// Every output format must either canonicalize a CONSTRUCT graph or refuse
+/// CONSTRUCT outright — asserted behaviorally, per format, against a result
+/// that provably still carries duplicate solutions.
+///
+/// This is the gate that keeps `result_is_multiplicity_blind` (in
+/// `fluree-db-query`'s `execute::operator_tree`) honest. That license lets the
+/// WHERE planner collapse duplicate solutions for a blank-free, unsliced
+/// CONSTRUCT on the argument that *no* output path can observe them: every
+/// serializer either calls `Graph::canonicalize()` or rejects CONSTRUCT. The
+/// plan is built before the output format is chosen, so the license is sound
+/// only while that holds for EVERY format — one non-canonicalizing serializer
+/// anywhere and the license silently changes query results for it.
+///
+/// The enumeration is structural, not a comment: `classify` matches every
+/// `OutputFormat` variant with no wildcard arm, so adding a variant stops this
+/// file compiling until the new path is classified — and the classification is
+/// then executed, not taken on faith. If a future format legitimately needs to
+/// render CONSTRUCT without canonicalizing, the license itself has to change;
+/// this test failing is the reminder.
+mod construct_license_output_gate {
+    use crate::support;
+    use fluree_db_api::format::{format_results_string, FormatterConfig, OutputFormat};
+
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    enum ConstructPath {
+        /// Serializes the graph; duplicate solutions must collapse.
+        Canonicalizes,
+        /// Refuses CONSTRUCT results outright.
+        Rejects,
+    }
+
+    /// One list, used twice: the `match` (no wildcard) is the compile-time
+    /// exhaustiveness gate, and the same identifiers feed the runtime
+    /// iteration, so a variant cannot be classified without also being tested.
+    macro_rules! classified_formats {
+        ($($variant:ident => $path:ident),* $(,)?) => {
+            fn classify(format: OutputFormat) -> ConstructPath {
+                match format {
+                    $(OutputFormat::$variant => ConstructPath::$path,)*
+                }
+            }
+            fn all_formats() -> Vec<OutputFormat> {
+                vec![$(OutputFormat::$variant),*]
+            }
+        };
+    }
+
+    classified_formats! {
+        JsonLd     => Canonicalizes, // format_results → construct::format → Graph::canonicalize
+        SparqlJson => Canonicalizes, // coerced to the same construct::format path (#1274)
+        SparqlXml  => Rejects,       // sparql_xml::format: SELECT/ASK only
+        RdfXml     => Canonicalizes, // rdf_xml::format → Graph::canonicalize
+        TypedJson  => Canonicalizes, // coerced to construct::format
+        Tsv        => Rejects,       // delimited::reject_non_tabular
+        Csv        => Rejects,       // delimited::reject_non_tabular
+        AgentJson  => Canonicalizes, // coerced to construct::format
+        CypherJson => Canonicalizes, // coerced to construct::format
+    }
+
+    #[tokio::test]
+    async fn every_output_format_collapses_or_rejects_construct() {
+        let (fluree, ledger) = super::seed_people().await;
+
+        // `favNums` is multi-valued (jdoe 4, bbob 1, jbob 7 = 12 solutions over
+        // 3 subjects), and the LIMIT keeps the query outside the license, so
+        // the WHERE stage may not collapse anything: the duplicates must still
+        // be present when each serializer runs. The constant-object template
+        // then instantiates to one identical triple per solution.
+        let sparql = "CONSTRUCT { ?s <http://example.org/flagged> \"dup-collapse-marker\" } \
+                      WHERE { ?s <http://example.org/Person#favNums> ?n } LIMIT 100";
+        let result = support::query_sparql(&fluree, &ledger, sparql)
+            .await
+            .expect("construct query");
+
+        // Ran-marker: the gate is vacuous unless duplicate solutions actually
+        // reach the formatters. 12 rows over 3 distinct subjects, by fixture
+        // arithmetic — if WHERE-level dedup ever starts firing here (e.g. the
+        // license grows to cover sliced CONSTRUCT), this stops the test before
+        // the per-format loop can pass on an already-collapsed stream.
+        let rows: usize = result.batches.iter().map(fluree_db_api::Batch::len).sum();
+        assert_eq!(
+            rows, 12,
+            "precondition: the formatter input must still carry all 12 \
+             duplicate-bearing solutions (3 subjects x their favNums counts)"
+        );
+
+        for format in all_formats() {
+            let config = FormatterConfig {
+                format,
+                ..FormatterConfig::default()
+            };
+            let out = format_results_string(&result, &result.context, &ledger.snapshot, &config);
+            match classify(format) {
+                ConstructPath::Canonicalizes => {
+                    let s = out.unwrap_or_else(|e| {
+                        panic!("{format:?} is classified Canonicalizes but errored: {e}")
+                    });
+                    let occurrences = s.matches("dup-collapse-marker").count();
+                    assert_eq!(
+                        occurrences, 3,
+                        "{format:?} must collapse the 12 duplicate solutions to \
+                         one triple per subject (3); its output carried the \
+                         constructed object {occurrences} times:\n{s}"
+                    );
+                }
+                ConstructPath::Rejects => {
+                    assert!(
+                        out.is_err(),
+                        "{format:?} is classified Rejects but serialized a \
+                         CONSTRUCT result — if it now supports CONSTRUCT it \
+                         must canonicalize, and this gate must reclassify it: \
+                         {out:?}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/fluree-db-query/src/distinct.rs
+++ b/fluree-db-query/src/distinct.rs
@@ -147,6 +147,32 @@ impl Operator for DistinctOperator {
             // equality check, and only allocate the full signature for rows that
             // are genuinely new.
             let num_cols = self.schema.len();
+
+            // Zero-column input: every WHERE variable was projected away, so every
+            // row is the empty tuple and they are all duplicates of one another —
+            // DISTINCT over N of them is exactly one row, or none if the child was
+            // empty. This needs its own arm because a column-less `Batch` carries no
+            // row count (`Batch::new` reads it off `columns.first()`), so the
+            // general path below would build a zero-row batch and its
+            // `columns.first() … unwrap_or(true)` guard would read "all duplicates"
+            // forever, swallowing the whole stream. `Batch::empty_schema_with_len`
+            // is the constructor that preserves a row count without columns.
+            //
+            // Reachable from a CONSTRUCT whose template is entirely constant
+            // (`CONSTRUCT { <s> <p> "x" } WHERE { ?s ?p ?o }`): the graph result
+            // licenses WHERE-level dedup while the template needs no variable, so
+            // the block prunes to an empty schema.
+            if num_cols == 0 {
+                if batch.is_empty() {
+                    continue;
+                }
+                if self.seen.is_empty() {
+                    self.seen.insert(RowSignature::new(), ());
+                    return Ok(Some(Batch::empty_schema_with_len(1)));
+                }
+                continue;
+            }
+
             let mut columns: Vec<Vec<Binding>> = (0..num_cols).map(|_| Vec::new()).collect();
 
             for row_idx in 0..batch.len() {
@@ -335,6 +361,62 @@ mod tests {
         // Should be exhausted
         let result2 = distinct_op.next_batch(&ctx).await.unwrap();
         assert!(result2.is_none());
+    }
+
+    /// Zero-column input: every row is the empty tuple, so DISTINCT over any
+    /// number of them is exactly one row — and one row *total*, across every
+    /// batch in the stream.
+    ///
+    /// A column-less `Batch` carries no row count through `Batch::new` (it reads
+    /// the count off `columns.first()`), so the general dedup path built a
+    /// zero-row batch and then its `columns.first() … unwrap_or(true)` guard
+    /// read "all rows were duplicates" on every batch and swallowed the whole
+    /// stream. `CONSTRUCT { <s> <p> "x" } WHERE { ?s ?p ?o }` reaches this: the
+    /// graph result licenses WHERE-level dedup while the constant template needs
+    /// no variable, so the block prunes to an empty schema and the query
+    /// returned an empty graph instead of its one triple.
+    #[tokio::test]
+    async fn test_distinct_zero_column_batches_yield_exactly_one_row() {
+        let snapshot = LedgerSnapshot::genesis("test/main");
+        let vars = VarRegistry::new();
+        let ctx = ExecutionContext::new(&snapshot, &vars);
+
+        // Three batches of empty tuples: 4 rows, then 0, then 2.
+        let mock = MockOperator::new(vec![
+            Batch::empty_schema_with_len(4),
+            Batch::empty_schema_with_len(0),
+            Batch::empty_schema_with_len(2),
+        ]);
+
+        let mut distinct_op = DistinctOperator::new(Box::new(mock));
+        distinct_op.open(&ctx).await.unwrap();
+
+        let first = distinct_op.next_batch(&ctx).await.unwrap();
+        assert!(
+            first.is_some(),
+            "zero-column DISTINCT must emit the single empty-tuple row"
+        );
+        assert_eq!(first.unwrap().len(), 1);
+
+        assert!(
+            distinct_op.next_batch(&ctx).await.unwrap().is_none(),
+            "the remaining empty tuples are duplicates of the first"
+        );
+    }
+
+    /// The other half: a child that produced no rows at all must stay empty —
+    /// the fix must not manufacture a row out of an empty solution sequence.
+    #[tokio::test]
+    async fn test_distinct_zero_column_empty_child_stays_empty() {
+        let snapshot = LedgerSnapshot::genesis("test/main");
+        let vars = VarRegistry::new();
+        let ctx = ExecutionContext::new(&snapshot, &vars);
+
+        let mock = MockOperator::new(vec![Batch::empty_schema_with_len(0)]);
+        let mut distinct_op = DistinctOperator::new(Box::new(mock));
+        distinct_op.open(&ctx).await.unwrap();
+
+        assert!(distinct_op.next_batch(&ctx).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2317,6 +2317,44 @@ fn build_operator_tree_folds(
     build_operator_tree_inner(query, stats, true, planning)
 }
 
+/// Whether a CONSTRUCT/DESCRIBE result cannot observe WHERE-output row
+/// multiplicity, and so licenses the same WHERE-level dedup a
+/// `SELECT DISTINCT` does.
+///
+/// A CONSTRUCT result is an RDF **graph**, not a solution bag: several
+/// solutions instantiating the template to the same `(s, p, o)` contribute one
+/// triple (SPARQL 1.1 §16.2). Every output path enforces that or refuses the
+/// query outright — the JSON-LD serializer and RDF/XML both call
+/// `Graph::canonicalize()` (`format/construct.rs`, `format/rdf_xml.rs`),
+/// streaming JSON excludes CONSTRUCT from its eligibility check, and TSV/CSV,
+/// SPARQL-Results XML and the streaming endpoint all reject it. So duplicate
+/// solutions are erased before anyone can see them, and materializing them is
+/// pure cost.
+///
+/// `QueryOutput::restriction()` returns `None` for every non-`Select` output,
+/// so without this the license reads false for all of them and a fan-out join
+/// under a CONSTRUCT builds its full cartesian product only to canonicalize it
+/// back down.
+///
+/// Two shapes are excluded, and both exclusions are load-bearing:
+///
+/// * **A template blank node.** `bnode_vars` variables are minted fresh per
+///   *solution* and shared only within a row (see [`ConstructTemplate`]), so
+///   distinct solutions produce distinct triples and collapsing them changes
+///   the graph. Empty for every JSON-LD/FQL construct and every DESCRIBE, so
+///   this keeps the license for the whole non-SPARQL graph surface.
+/// * **A slice.** `LIMIT`/`OFFSET` cut the solution sequence *before* the
+///   template is instantiated, so collapsing rows first changes which
+///   solutions survive and therefore which triples get built.
+fn construct_result_is_multiplicity_blind(query: &Query) -> bool {
+    match &query.output {
+        QueryOutput::Construct(template) => {
+            template.bnode_vars.is_empty() && query.limit.is_none() && query.offset.is_none()
+        }
+        _ => false,
+    }
+}
+
 fn build_operator_tree_inner(
     query: &Query,
     stats: Option<Arc<StatsView>>,
@@ -3087,7 +3125,9 @@ fn build_operator_tree_inner(
     // aggregate check alone is vacuously true. An outer SELECT DISTINCT does
     // NOT license dedup — it dedups result rows *after* aggregation, so a
     // plain COUNT under it still observes pre-aggregation multiplicity.
-    // Without grouping, SELECT DISTINCT is exactly the license.
+    // Without grouping, SELECT DISTINCT is the license for a SELECT — and a
+    // CONSTRUCT/DESCRIBE carries its own, because its result is an RDF graph
+    // rather than a solution bag. See `construct_result_is_multiplicity_blind`.
     let where_dedup_safe = match query.grouping.as_ref() {
         Some(g) => {
             let aggregates_ok = g
@@ -3106,7 +3146,7 @@ fn build_operator_tree_inner(
             });
             aggregates_ok && no_raw_passthrough
         }
-        None => query.output.is_distinct(),
+        None => query.output.is_distinct() || construct_result_is_multiplicity_blind(query),
     };
 
     let mut operator = build_where_operators_with_needed(
@@ -3872,6 +3912,82 @@ mod tests {
             include_system_facts: false,
             cypher_vocab: None,
         }
+    }
+
+    // --- CONSTRUCT's WHERE-dedup license (#1700 follow-up) -------------------
+
+    /// `CONSTRUCT { ?s <flag> "y" } WHERE { … }` with the given template
+    /// blank-node vars and slice.
+    fn construct_query(
+        bnode_vars: HashSet<VarId>,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> Query {
+        use crate::ir::ConstructTemplate;
+        let template_tp = TriplePattern::new(
+            Ref::Var(VarId(0)),
+            Ref::Sid(Sid::new(100, "flag")),
+            Term::Var(VarId(1)),
+        );
+        let mut q = make_simple_query(Vec::new(), Vec::new());
+        q.output = QueryOutput::Construct(ConstructTemplate::with_bnode_vars(
+            vec![template_tp],
+            bnode_vars,
+        ));
+        q.limit = limit;
+        q.offset = offset;
+        q
+    }
+
+    /// A blank-free, unsliced CONSTRUCT result is an RDF graph whose serializers
+    /// canonicalize, so duplicate solutions are unobservable and the WHERE stage
+    /// may collapse them. Without this the license reads false for every
+    /// CONSTRUCT (`restriction()` is `None` for non-`Select` outputs) and a
+    /// fan-out join builds its full cartesian product only to have it
+    /// canonicalized back down — measured at 6.7x for byte-identical output.
+    #[test]
+    fn construct_licenses_where_dedup_when_blank_free_and_unsliced() {
+        assert!(construct_result_is_multiplicity_blind(&construct_query(
+            HashSet::new(),
+            None,
+            None
+        )));
+    }
+
+    /// A template blank node is minted fresh per *solution*, so distinct
+    /// solutions yield distinct triples and collapsing them changes the graph.
+    #[test]
+    fn construct_declines_where_dedup_with_a_template_blank_node() {
+        let bnodes: HashSet<VarId> = [VarId(1)].into_iter().collect();
+        assert!(!construct_result_is_multiplicity_blind(&construct_query(
+            bnodes, None, None
+        )));
+    }
+
+    /// `LIMIT`/`OFFSET` slice the solution sequence *before* the template is
+    /// instantiated, so collapsing rows first changes which solutions survive
+    /// and therefore which triples get built.
+    #[test]
+    fn construct_declines_where_dedup_when_sliced() {
+        assert!(!construct_result_is_multiplicity_blind(&construct_query(
+            HashSet::new(),
+            Some(10),
+            None
+        )));
+        assert!(!construct_result_is_multiplicity_blind(&construct_query(
+            HashSet::new(),
+            None,
+            Some(10)
+        )));
+    }
+
+    /// The license is CONSTRUCT-specific: a plain SELECT keeps `is_distinct()`
+    /// as its only license, so this cannot leak into the bag-semantics surface
+    /// that #1700 was about.
+    #[test]
+    fn select_never_gets_the_construct_license() {
+        let q = make_simple_query(vec![VarId(0)], Vec::new());
+        assert!(!construct_result_is_multiplicity_blind(&q));
     }
 
     #[test]

--- a/fluree-db-query/src/execute/operator_tree.rs
+++ b/fluree-db-query/src/execute/operator_tree.rs
@@ -2317,26 +2317,30 @@ fn build_operator_tree_folds(
     build_operator_tree_inner(query, stats, true, planning)
 }
 
-/// Whether a CONSTRUCT/DESCRIBE result cannot observe WHERE-output row
+/// Whether the query's output form cannot observe WHERE-output row
 /// multiplicity, and so licenses the same WHERE-level dedup a
 /// `SELECT DISTINCT` does.
 ///
-/// A CONSTRUCT result is an RDF **graph**, not a solution bag: several
-/// solutions instantiating the template to the same `(s, p, o)` contribute one
-/// triple (SPARQL 1.1 §16.2). Every output path enforces that or refuses the
-/// query outright — the JSON-LD serializer and RDF/XML both call
-/// `Graph::canonicalize()` (`format/construct.rs`, `format/rdf_xml.rs`),
+/// `QueryOutput::restriction()` returns `None` for every non-`Select` output,
+/// so without this the license reads false for all of them and a fan-out join
+/// under a CONSTRUCT or an ASK builds its full cartesian product for a
+/// consumer that provably cannot tell the difference. Two output forms
+/// qualify, each on its own argument:
+///
+/// **CONSTRUCT/DESCRIBE** — the result is an RDF **graph**, not a solution
+/// bag: several solutions instantiating the template to the same `(s, p, o)`
+/// contribute one triple (SPARQL 1.1 §16.2). Every output path enforces that
+/// or refuses the query outright — the JSON-LD serializer and RDF/XML both
+/// call `Graph::canonicalize()` (`format/construct.rs`, `format/rdf_xml.rs`),
 /// streaming JSON excludes CONSTRUCT from its eligibility check, and TSV/CSV,
 /// SPARQL-Results XML and the streaming endpoint all reject it. So duplicate
 /// solutions are erased before anyone can see them, and materializing them is
-/// pure cost.
+/// pure cost. (`every_output_format_collapses_or_rejects_construct` in
+/// `it_query_construct.rs` is the gate that keeps this enumeration honest: a
+/// new `OutputFormat` variant fails compilation there until it is classified,
+/// and the classification is asserted behaviorally, not taken on faith.)
 ///
-/// `QueryOutput::restriction()` returns `None` for every non-`Select` output,
-/// so without this the license reads false for all of them and a fan-out join
-/// under a CONSTRUCT builds its full cartesian product only to canonicalize it
-/// back down.
-///
-/// Two shapes are excluded, and both exclusions are load-bearing:
+/// Two CONSTRUCT shapes are excluded, and both exclusions are load-bearing:
 ///
 /// * **A template blank node.** `bnode_vars` variables are minted fresh per
 ///   *solution* and shared only within a row (see [`ConstructTemplate`]), so
@@ -2346,12 +2350,27 @@ fn build_operator_tree_folds(
 /// * **A slice.** `LIMIT`/`OFFSET` cut the solution sequence *before* the
 ///   template is instantiated, so collapsing rows first changes which
 ///   solutions survive and therefore which triples get built.
-fn construct_result_is_multiplicity_blind(query: &Query) -> bool {
+///
+/// **ASK** — the result is a boolean: every formatter either reads
+/// solution-sequence *emptiness* and nothing else (`format_ask`,
+/// `sparql_xml::format`) or rejects ASK outright (TSV/CSV, the streaming
+/// endpoint), so N duplicate rows and 1 row are indistinguishable. `LIMIT`
+/// does not weaken this — a limit of any value preserves emptiness (`LIMIT 0`
+/// is empty on both sides of the dedup) — and the license must tolerate it,
+/// because both surfaces already plan ASK with `LIMIT 1` (`lower_ask` in
+/// `fluree-db-sparql`, the `"ask"` branch of the JSON-LD parser). `OFFSET`
+/// does weaken it — it counts rows off the front, so `OFFSET 5` over six
+/// duplicates is non-empty while its deduped form is empty — and is excluded.
+/// Neither surface can currently attach an offset to an ASK (SPARQL lowering
+/// discards the modifier, the JSON-LD `"ask"` branch never parses options),
+/// so the guard exists for programmatically built IR.
+fn result_is_multiplicity_blind(query: &Query) -> bool {
     match &query.output {
         QueryOutput::Construct(template) => {
             template.bnode_vars.is_empty() && query.limit.is_none() && query.offset.is_none()
         }
-        _ => false,
+        QueryOutput::Ask => query.offset.is_none(),
+        QueryOutput::Select { .. } => false,
     }
 }
 
@@ -3097,6 +3116,27 @@ fn build_operator_tree_inner(
     let mut needed_where_vars: HashSet<VarId> = HashSet::new();
     if let Some(req) = required_where_vars {
         needed_where_vars.extend(req.iter().copied());
+    } else if matches!(query.output, QueryOutput::Ask)
+        && query.grouping.is_none()
+        && query.ordering.is_empty()
+        && query.order_binds.is_empty()
+        && query.post_values.is_none()
+        && result_is_multiplicity_blind(query)
+    {
+        // A licensed, modifier-free ASK reads nothing but solution-sequence
+        // emptiness, so no variable is "needed after WHERE" — the same
+        // empty-set a constant-template CONSTRUCT gets via
+        // `compute_variable_deps`. `referenced_vars()` still reports `None`
+        // for ASK (its conservative all-vars answer stays right for every
+        // other consumer of variable deps); this narrows only the WHERE
+        // planner's needed set, which `compute_where_var_stats` treats as the
+        // protected set. With it empty, `property_join_needed_vars` can demote
+        // an unread fan-out object var to an existence-only constraint — join
+        // and FILTER variables stay protected through `var_counts` (their
+        // reference count exceeds one). Any solution modifier that could read
+        // a variable (grouping, ordering, post-VALUES) or observe multiplicity
+        // (OFFSET, via the license check) falls through to the conservative
+        // all-vars default.
     } else {
         let mut counts: HashMap<VarId, usize> = HashMap::new();
         let mut vars: HashSet<VarId> = HashSet::new();
@@ -3125,9 +3165,10 @@ fn build_operator_tree_inner(
     // aggregate check alone is vacuously true. An outer SELECT DISTINCT does
     // NOT license dedup — it dedups result rows *after* aggregation, so a
     // plain COUNT under it still observes pre-aggregation multiplicity.
-    // Without grouping, SELECT DISTINCT is the license for a SELECT — and a
-    // CONSTRUCT/DESCRIBE carries its own, because its result is an RDF graph
-    // rather than a solution bag. See `construct_result_is_multiplicity_blind`.
+    // Without grouping, SELECT DISTINCT is the license for a SELECT — and
+    // CONSTRUCT/DESCRIBE and ASK each carry their own, because their results
+    // (an RDF graph; a boolean) are not solution bags. See
+    // `result_is_multiplicity_blind`.
     let where_dedup_safe = match query.grouping.as_ref() {
         Some(g) => {
             let aggregates_ok = g
@@ -3146,7 +3187,7 @@ fn build_operator_tree_inner(
             });
             aggregates_ok && no_raw_passthrough
         }
-        None => query.output.is_distinct() || construct_result_is_multiplicity_blind(query),
+        None => query.output.is_distinct() || result_is_multiplicity_blind(query),
     };
 
     let mut operator = build_where_operators_with_needed(
@@ -3914,7 +3955,7 @@ mod tests {
         }
     }
 
-    // --- CONSTRUCT's WHERE-dedup license (#1700 follow-up) -------------------
+    // --- CONSTRUCT's and ASK's WHERE-dedup license (#1700 follow-up) ---------
 
     /// `CONSTRUCT { ?s <flag> "y" } WHERE { … }` with the given template
     /// blank-node vars and slice.
@@ -3944,10 +3985,15 @@ mod tests {
     /// may collapse them. Without this the license reads false for every
     /// CONSTRUCT (`restriction()` is `None` for non-`Select` outputs) and a
     /// fan-out join builds its full cartesian product only to have it
-    /// canonicalized back down — measured at 6.7x for byte-identical output.
+    /// canonicalized back down. To be precise about what that buys: losing this
+    /// license makes the #1700 correctness fix ~6.2x more expensive for
+    /// blank-free CONSTRUCT (0.1464s on the pre-fix planner → 0.9026s at 120k
+    /// pairs, byte-identical output); with it, CONSTRUCT stays flat vs the
+    /// pre-fix planner (0.1380s). It recovers cost the fix would otherwise
+    /// introduce — it is not a speedup over what shipped before.
     #[test]
     fn construct_licenses_where_dedup_when_blank_free_and_unsliced() {
-        assert!(construct_result_is_multiplicity_blind(&construct_query(
+        assert!(result_is_multiplicity_blind(&construct_query(
             HashSet::new(),
             None,
             None
@@ -3959,7 +4005,7 @@ mod tests {
     #[test]
     fn construct_declines_where_dedup_with_a_template_blank_node() {
         let bnodes: HashSet<VarId> = [VarId(1)].into_iter().collect();
-        assert!(!construct_result_is_multiplicity_blind(&construct_query(
+        assert!(!result_is_multiplicity_blind(&construct_query(
             bnodes, None, None
         )));
     }
@@ -3969,25 +4015,118 @@ mod tests {
     /// and therefore which triples get built.
     #[test]
     fn construct_declines_where_dedup_when_sliced() {
-        assert!(!construct_result_is_multiplicity_blind(&construct_query(
+        assert!(!result_is_multiplicity_blind(&construct_query(
             HashSet::new(),
             Some(10),
             None
         )));
-        assert!(!construct_result_is_multiplicity_blind(&construct_query(
+        assert!(!result_is_multiplicity_blind(&construct_query(
             HashSet::new(),
             None,
             Some(10)
         )));
     }
 
-    /// The license is CONSTRUCT-specific: a plain SELECT keeps `is_distinct()`
+    /// The license never reaches a SELECT: a plain SELECT keeps `is_distinct()`
     /// as its only license, so this cannot leak into the bag-semantics surface
     /// that #1700 was about.
     #[test]
-    fn select_never_gets_the_construct_license() {
+    fn select_never_gets_the_output_form_license() {
         let q = make_simple_query(vec![VarId(0)], Vec::new());
-        assert!(!construct_result_is_multiplicity_blind(&q));
+        assert!(!result_is_multiplicity_blind(&q));
+    }
+
+    /// An `ASK` query with the given slice. Both real surfaces lower ASK with
+    /// `LIMIT 1` and no offset (`lower_ask` in `fluree-db-sparql`; the JSON-LD
+    /// parser's `"ask"` branch), so `Some(1)/None` below is the shape the
+    /// planner actually sees.
+    fn ask_query(limit: Option<usize>, offset: Option<usize>) -> Query {
+        let mut q = make_simple_query(Vec::new(), Vec::new());
+        q.output = QueryOutput::Ask;
+        q.limit = limit;
+        q.offset = offset;
+        q
+    }
+
+    /// ASK is a boolean read off solution-sequence emptiness, so no formatter
+    /// can observe row multiplicity and the license holds — including under the
+    /// `LIMIT 1` both surfaces always attach, since a limit of any value
+    /// preserves emptiness.
+    #[test]
+    fn ask_licenses_where_dedup_including_under_its_own_limit() {
+        assert!(result_is_multiplicity_blind(&ask_query(None, None)));
+        assert!(result_is_multiplicity_blind(&ask_query(Some(1), None)));
+        assert!(result_is_multiplicity_blind(&ask_query(Some(0), None)));
+    }
+
+    /// `OFFSET` counts rows off the front of the sequence, so it is the one
+    /// modifier through which an ASK *can* observe multiplicity: `OFFSET 5`
+    /// over six duplicate rows is non-empty, its deduped form is empty. No
+    /// surface currently lowers an ASK with an offset; the guard is for
+    /// programmatically built IR.
+    #[test]
+    fn ask_declines_where_dedup_with_an_offset() {
+        assert!(!result_is_multiplicity_blind(&ask_query(None, Some(5))));
+        assert!(!result_is_multiplicity_blind(&ask_query(Some(1), Some(5))));
+    }
+
+    /// End-to-end through `build_operator_tree`: an ASK over the #1700 fan-out
+    /// star must get the pruned, existence-only plan — the object var stays out
+    /// of the WHERE schema. This pins the wiring (`where_dedup_safe` →
+    /// `property_join_needed_vars`), not just the predicate above; revert the
+    /// `Ask` arm of `result_is_multiplicity_blind` and this fails with the
+    /// object var back in the schema.
+    #[test]
+    fn ask_over_a_fanout_star_plans_the_existence_only_join() {
+        let mut q = ask_query(Some(1), None);
+        q.patterns = vec![
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Iri(Arc::from(fluree_vocab::rdf::TYPE)),
+                Term::Iri(Arc::from("http://ex/C")),
+            )),
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Iri(Arc::from("http://ex/tag")),
+                Term::Var(VarId(1)),
+            )),
+        ];
+        let planning = crate::temporal_mode::PlanningContext::current();
+        let op = build_operator_tree(&q, None, &planning).expect("plan ASK fan-out star");
+        assert_eq!(
+            op.schema(),
+            &[VarId(0)],
+            "ASK licenses WHERE-level dedup, so the fan-out object var must be \
+             demoted to an existence-only constraint; schema was {:?}",
+            op.schema()
+        );
+    }
+
+    /// The offset guard, through the same wiring: an offset makes the ASK
+    /// multiplicity-observable, so the object var must survive.
+    #[test]
+    fn ask_with_offset_keeps_the_fanout_object_var() {
+        let mut q = ask_query(Some(1), Some(5));
+        q.patterns = vec![
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Iri(Arc::from(fluree_vocab::rdf::TYPE)),
+                Term::Iri(Arc::from("http://ex/C")),
+            )),
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Iri(Arc::from("http://ex/tag")),
+                Term::Var(VarId(1)),
+            )),
+        ];
+        let planning = crate::temporal_mode::PlanningContext::current();
+        let op = build_operator_tree(&q, None, &planning).expect("plan ASK with offset");
+        assert!(
+            op.schema().contains(&VarId(1)),
+            "an ASK with an OFFSET can observe row multiplicity, so the object \
+             var must stay; schema was {:?}",
+            op.schema()
+        );
     }
 
     #[test]

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1240,6 +1240,54 @@ fn build_single_pattern(
     }
 }
 
+/// Variables whose bindings must survive a `PropertyJoinOperator` block.
+///
+/// `PropertyJoinOperator` demotes any predicate whose object variable is absent
+/// from this set to an **existence-only** (semijoin) constraint: it records that
+/// the subject has *some* object under that predicate and drops the per-subject
+/// object list entirely. That is a set operation, so it collapses a subject's N
+/// objects down to a single row.
+///
+/// `where_dedup_safe` carries exactly the same license as the sequential chain's
+/// early dedup (see [`build_where_operators_with_needed`]): it asserts that
+/// nothing downstream can observe WHERE-output row multiplicity. When it is
+/// false the demotion is **not** sound — the dropped rows are answer rows, and
+/// every multiplicity-sensitive consumer (a plain `COUNT`, a grouped
+/// `COUNT(*)`, or a non-DISTINCT projection read as a bag) silently gets the
+/// subject count where it asked for the row count. So when the license is
+/// absent, every variable object in the block is pinned as needed and the block
+/// produces its full cartesian product.
+///
+/// Bound objects are unaffected: `?s a ex:Gadget` matches at most one flake per
+/// subject, so existence-only carries its multiplicity exactly.
+fn property_join_needed_vars(
+    triples: &[TriplePattern],
+    optional_triples: &[TriplePattern],
+    required_where_vars: Option<&[VarId]>,
+    var_counts: &HashMap<VarId, usize>,
+    protected_vars: &HashSet<VarId>,
+    where_dedup_safe: bool,
+) -> HashSet<VarId> {
+    let mut needed: HashSet<VarId> = HashSet::new();
+    if let Some(rwv) = required_where_vars {
+        needed.extend(rwv.iter().copied());
+    }
+    for (v, c) in var_counts {
+        if *c > 1 || protected_vars.contains(v) {
+            needed.insert(*v);
+        }
+    }
+    if !where_dedup_safe {
+        needed.extend(
+            triples
+                .iter()
+                .chain(optional_triples)
+                .filter_map(|tp| tp.o.as_var()),
+        );
+    }
+    needed
+}
+
 /// Build an operator tree for a property-join-eligible block of triples.
 ///
 /// Constructs a `PropertyJoinOperator` for the triples, then layers deferred
@@ -1255,17 +1303,17 @@ fn build_property_join_block(
     required_where_vars: Option<&[VarId]>,
     var_counts: &HashMap<VarId, usize>,
     protected_vars: &HashSet<VarId>,
+    where_dedup_safe: bool,
     planning: &PlanningContext,
 ) -> Result<Option<BoxedOperator>> {
-    let mut needed: HashSet<VarId> = HashSet::new();
-    if let Some(rwv) = required_where_vars {
-        needed.extend(rwv.iter().copied());
-    }
-    for (v, c) in var_counts {
-        if *c > 1 || protected_vars.contains(v) {
-            needed.insert(*v);
-        }
-    }
+    let mut needed = property_join_needed_vars(
+        triples,
+        optional_triples,
+        required_where_vars,
+        var_counts,
+        protected_vars,
+        where_dedup_safe,
+    );
 
     let mut available_vars: HashSet<VarId> = triples
         .iter()
@@ -2332,6 +2380,7 @@ pub fn build_where_operators_seeded_with_needed(
                         augmented_ref,
                         &var_counts,
                         &protected_vars,
+                        where_dedup_safe,
                         planning,
                     )?;
                 } else {
@@ -3134,16 +3183,16 @@ pub fn build_triple_operators(
         //
         // If an object var is not needed downstream (not in required_where_vars and not
         // otherwise protected), treat that predicate as existence-only (semijoin) to avoid
-        // cartesian-product blowups.
-        let mut needed: HashSet<VarId> = HashSet::new();
-        if let Some(rwv) = ctx.required_where_vars {
-            needed.extend(rwv.iter().copied());
-        }
-        for (v, c) in ctx.var_counts {
-            if *c > 1 || ctx.protected_vars.contains(v) {
-                needed.insert(*v);
-            }
-        }
+        // cartesian-product blowups — but only while `where_dedup_safe` licenses it. See
+        // `property_join_needed_vars`.
+        let needed = property_join_needed_vars(
+            &triples_for_exec,
+            &[],
+            ctx.required_where_vars,
+            ctx.var_counts,
+            ctx.protected_vars,
+            ctx.where_dedup_safe,
+        );
 
         let pj = PropertyJoinOperator::new_with_needed_vars(
             &triples_for_exec,
@@ -4241,6 +4290,72 @@ mod tests {
             op.schema(),
             &[VarId(0), VarId(1), VarId(2)],
             "PropertyJoinOperator should be used (schema = [subject, obj1, obj2])"
+        );
+    }
+
+    /// `?0 rdf:type <C> . ?0 <tag> ?1` — a bound-object-anchored star whose
+    /// object var nothing downstream reads. This is the shape from #1700.
+    fn anchored_star() -> Vec<Pattern> {
+        vec![
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Iri(Arc::from(fluree_vocab::rdf::TYPE)),
+                Term::Iri(Arc::from("http://ex/C")),
+            )),
+            Pattern::Triple(TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Iri(Arc::from("http://ex/tag")),
+                Term::Var(VarId(1)),
+            )),
+        ]
+    }
+
+    fn plan_anchored_star(where_dedup_safe: bool) -> BoxedOperator {
+        // Only the subject survives the WHERE stage — exactly what
+        // `COUNT(*)` / `SELECT ?s` / `SELECT DISTINCT ?s` all request.
+        let needed: HashSet<VarId> = [VarId(0)].into_iter().collect();
+        super::build_where_operators_with_needed(
+            &anchored_star(),
+            None,
+            &needed,
+            &[],
+            where_dedup_safe,
+            Some(&[VarId(0)]),
+            &crate::temporal_mode::PlanningContext::current(),
+        )
+        .expect("plan anchored star")
+    }
+
+    /// Regression (#1700): demoting a variable-object predicate to an
+    /// existence-only semijoin drops a subject's extra objects, so the WHERE
+    /// stage emits one row per subject instead of one row per solution. That is
+    /// a set operation and it is licensed only by `where_dedup_safe`. Without
+    /// the license the object var must stay in the schema so the block produces
+    /// its full cartesian product.
+    #[test]
+    fn test_property_join_keeps_object_var_when_multiplicity_is_observable() {
+        let op = plan_anchored_star(false);
+        assert!(
+            op.schema().contains(&VarId(1)),
+            "object var must survive when downstream can observe row \
+             multiplicity — pruning it collapses N objects to one row and \
+             turns COUNT(*) into a distinct-subject count; schema was {:?}",
+            op.schema()
+        );
+    }
+
+    /// The other direction: the fix must narrow the pruning, not disable it. A
+    /// dedup-safe consumer (`SELECT DISTINCT ?s`, `COUNT(DISTINCT ?s)`) cannot
+    /// observe the multiplicity, so the existence-only demotion must still fire
+    /// and keep the object column out of the schema.
+    #[test]
+    fn test_property_join_still_prunes_object_var_when_dedup_safe() {
+        let op = plan_anchored_star(true);
+        assert_eq!(
+            op.schema(),
+            &[VarId(0)],
+            "a dedup-safe consumer must still get the pruned, existence-only \
+             plan — otherwise the fix is a blanket disable"
         );
     }
 

--- a/fluree-db-query/src/limit.rs
+++ b/fluree-db-query/src/limit.rs
@@ -130,6 +130,19 @@ impl Operator for LimitOperator {
             self.emitted = self.limit;
             self.state = OperatorState::Exhausted;
 
+            // Zero-column input (every WHERE var projected away — e.g. a
+            // constant-template CONSTRUCT, or an ASK under its dedup license):
+            // a column-less `Batch` carries no row count through `Batch::new`
+            // (it reads the count off `columns.first()`), so the general
+            // rebuild below would produce a zero-row batch and the surviving
+            // `remaining` rows would silently vanish — an ASK reads false, a
+            // CONSTRUCT builds an empty graph. Same trap `DistinctOperator`
+            // had; `Batch::empty_schema_with_len` is the constructor that
+            // preserves the count.
+            if self.schema.is_empty() {
+                return Ok(Some(Batch::empty_schema_with_len(remaining)));
+            }
+
             // Build truncated batch
             let num_cols = self.schema.len();
             let mut columns: Vec<Vec<Binding>> = Vec::with_capacity(num_cols);
@@ -241,6 +254,52 @@ mod tests {
             })
             .collect();
         Batch::new(schema, columns).unwrap()
+    }
+
+    /// Truncating a zero-column batch must preserve the surviving row count.
+    ///
+    /// A column-less `Batch` carries no row count through `Batch::new` (it
+    /// reads the count off `columns.first()`), so the column-by-column rebuild
+    /// in the truncation branch produced a zero-row batch and the surviving
+    /// rows vanished. Reachable from a constant-template
+    /// `CONSTRUCT { <s> <p> "x" } WHERE { ?s ?p ?o } LIMIT 1` (empty graph
+    /// instead of one triple) and from a licensed `ASK` whose WHERE schema
+    /// prunes empty (`false` instead of `true` — W3C `ask-7` caught it). Same
+    /// trap family as `DistinctOperator`'s zero-column fix.
+    #[tokio::test]
+    async fn test_limit_truncation_keeps_zero_column_row_count() {
+        let snapshot = LedgerSnapshot::genesis("test/main");
+        let vars = VarRegistry::new();
+        let ctx = ExecutionContext::new(&snapshot, &vars);
+
+        // 5 empty-tuple rows, LIMIT 2: the truncation branch must report 2.
+        let mock = MockOperator::new(vec![Batch::empty_schema_with_len(5)]);
+        let mut limit_op = LimitOperator::new(Box::new(mock), 2);
+        limit_op.open(&ctx).await.unwrap();
+
+        let batch = limit_op
+            .next_batch(&ctx)
+            .await
+            .unwrap()
+            .expect("truncated batch must survive");
+        assert_eq!(batch.len(), 2, "zero-column truncation lost the row count");
+        assert!(limit_op.next_batch(&ctx).await.unwrap().is_none());
+    }
+
+    /// The pass-through side of the same seam: a zero-column batch entirely
+    /// under the limit must flow through with its count intact.
+    #[tokio::test]
+    async fn test_limit_passthrough_keeps_zero_column_row_count() {
+        let snapshot = LedgerSnapshot::genesis("test/main");
+        let vars = VarRegistry::new();
+        let ctx = ExecutionContext::new(&snapshot, &vars);
+
+        let mock = MockOperator::new(vec![Batch::empty_schema_with_len(3)]);
+        let mut limit_op = LimitOperator::new(Box::new(mock), 10);
+        limit_op.open(&ctx).await.unwrap();
+
+        let batch = limit_op.next_batch(&ctx).await.unwrap().expect("batch");
+        assert_eq!(batch.len(), 3);
     }
 
     #[tokio::test]

--- a/fluree-db-query/src/offset.rs
+++ b/fluree-db-query/src/offset.rs
@@ -114,6 +114,15 @@ impl Operator for OffsetOperator {
             self.skipped = self.offset;
             let start_idx = remaining_to_skip;
 
+            // Zero-column input: a column-less `Batch` carries no row count
+            // through `Batch::new` (it reads the count off `columns.first()`),
+            // so the general rebuild below would drop the surviving rows.
+            // Same trap as `DistinctOperator` and `LimitOperator`;
+            // `Batch::empty_schema_with_len` preserves the count.
+            if self.schema.is_empty() {
+                return Ok(Some(Batch::empty_schema_with_len(batch.len() - start_idx)));
+            }
+
             let num_cols = self.schema.len();
             let mut columns: Vec<Vec<Binding>> = Vec::with_capacity(num_cols);
 
@@ -234,6 +243,35 @@ mod tests {
             })
             .collect();
         Batch::new(schema, columns).unwrap()
+    }
+
+    /// A partial skip over a zero-column batch must preserve the surviving row
+    /// count. Same `Batch::new`-loses-the-length trap as `DistinctOperator`
+    /// and `LimitOperator`: the column-by-column rebuild produced a zero-row
+    /// batch, so `OFFSET n` over a pruned-empty schema dropped every surviving
+    /// row (a constant-template `CONSTRUCT … OFFSET 2` built an empty graph).
+    #[tokio::test]
+    async fn test_offset_partial_skip_keeps_zero_column_row_count() {
+        let snapshot = LedgerSnapshot::genesis("test/main");
+        let vars = VarRegistry::new();
+        let ctx = ExecutionContext::new(&snapshot, &vars);
+
+        // 5 empty-tuple rows, OFFSET 2: 3 rows must survive.
+        let mock = MockOperator::new(vec![Batch::empty_schema_with_len(5)]);
+        let mut offset_op = OffsetOperator::new(Box::new(mock), 2);
+        offset_op.open(&ctx).await.unwrap();
+
+        let batch = offset_op
+            .next_batch(&ctx)
+            .await
+            .unwrap()
+            .expect("partial-skip batch must survive");
+        assert_eq!(
+            batch.len(),
+            3,
+            "zero-column partial skip lost the row count"
+        );
+        assert!(offset_op.next_batch(&ctx).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/regression-budget.json
+++ b/regression-budget.json
@@ -74,6 +74,11 @@
         "small": 5.0,
         "medium": 3.0
       },
+      "query_hot_fanout_star": {
+        "tiny": 10.0,
+        "small": 5.0,
+        "medium": 3.0
+      },
       "query_overlay_matrix": {
         "tiny": 10.0,
         "small": 5.0,


### PR DESCRIPTION
Fixes #1700

## The trap first, because it's the opposite of what we usually assume

On the reported shape the **fast path was the correct one and the generic pipeline was wrong** — `COUNT(*)` over `{ ?s a ex:Gadget . ?s ex:tag ?o }` gave 5 normally and 2 under `FLUREE_DISABLE_QUERY_FAST_PATHS`. That inverts our usual polarity, and since the kill switch is the oracle every fast-path suite establishes ground truth against, the instinct to "fix toward the kill-switch answer" would have taken the correct lane and broken it. Flagging it up front because it's the easiest thing to get backwards while reading this diff.

It turned out not to be an aggregate defect at all. The rows were already gone before the aggregate ran — `SELECT ?s WHERE { ?s a ex:Gadget . ?s ex:tag ?o }` returns 2 rows at HEAD where SPARQL bag semantics want 5, and it does that on **both** lanes.

## Mechanism

`PropertyJoinOperator` demotes a predicate to an **existence-only** (semijoin) constraint when its object variable is absent from the block's needed-vars set — `property_join.rs:424`, `emit_object`. It records that the subject has *some* object under that predicate (`entry.1 |= 1u64 << pred_idx`, `property_join.rs:1060`) and drops the per-subject object list. That's a set operation, so a subject's N objects collapse to one row.

It was applied unconditionally, at both call sites (`where_plan.rs:1260` and `where_plan.rs:3138`). `COUNT(*)` names no variables, so `?o` is in nothing's needed set, the demotion fires, and the count comes back as the number of qualifying subjects.

The sequential chain already has exactly the right gate for this and the property-join path just never consulted it: `where_dedup_safe` (`operator_tree.rs:3172`) asserts that nothing downstream can observe WHERE-output row multiplicity, and it's what licenses the chain's early `DistinctOperator` at `where_plan.rs:3080`. `AggregateFn::CountAll.duplicate_insensitive()` is already `false`, so the license was sitting right there, correctly computed, unread. The fix threads it into `property_join_needed_vars` and, when the license is absent, pins every variable object in the block as needed.

Reusing `where_dedup_safe` rather than minting a second license is the load-bearing design decision here, because it makes the fix sound by reduction: on a block whose schema has already had the object var pruned, the demotion collapses exactly the rows an explicit `DistinctOperator` over that schema would collapse, so "demotion is sound" follows from "early dedup is sound" with no new argument needed. The doc comment at `where_plan.rs:1243` is the fullest statement of that invariant.

Bound objects are untouched — `?s a ex:Gadget` matches at most one flake per subject, so existence-only already carries its multiplicity exactly. And `SELECT DISTINCT ?s` / `COUNT(DISTINCT ?s)` still get the pruned plan; this narrows the pruning rather than disabling it, and there's a unit test pinning each direction so it can't quietly degrade into a blanket disable.

## It's meaningfully worse than the issue reported, and mostly in the oracle's blind spot

Reverting the one-line license check and re-running the new test gives the damage report. The shapes where the **two lanes disagreed** — the only ones a differential oracle could ever have seen — are just the two where a `COUNT(*)` fast path existed and got it right:

| shape | fast | generic | truth |
|---|---|---|---|
| `COUNT(*) { ?s a Gadget . ?s tag ?o }` | 5 | **2** | 5 |
| `COUNT(*) { ?s a Widget . ?s name ?n }` | 4 | **3** | 4 |

Everything else was wrong **identically on both lanes**, so fast-vs-generic was green on all of it:

| shape | both lanes | truth |
|---|---|---|
| `SELECT ?s { ?s a Gadget . ?s tag ?o }` | 2 rows | 5 |
| `SELECT ?s (COUNT(*)) … GROUP BY ?s` | 1, 1 | 3, 2 |
| `COUNT(*) { ?s a Gadget . ?s tag ?o . ?s code ?c }` | 2 | **8** |

That last one is the one I'd point at hardest — a 4x undercount on a two-variable-object star, invisible to the oracle, and 8 isn't the row count of either predicate alone so nothing else would have caught it by coincidence either. `COUNT(?o)` was right all along, but only by accident: naming `?o` in the aggregate puts it in the needed set, so the demotion never fired.

## The oracle-test grep

Went looking for existing assertions that pinned `COUNT(*)` through the kill switch, on the theory that any of them would have been measuring against a broken reference. **Nothing was** — the full `fluree-db-api` suite (43 test binaries) and the W3C SPARQL conformance suite are green with **zero expectation edits**. Worth saying why, since "no test changed" is also what a vacuous check looks like:

- `it_differential_fastpath.rs` is the fast-vs-generic harness, and its only `COUNT(*)` case is the single-triple `{ ?s ?p ?o }` — no star, no unread object var. Its one star with an unread object var (`?s bsbm:productType ?o . ?s bsbm:label ?l`, `:428`) has no bound object and no object bounds, so `has_property_join_anchor` is false and it never reaches the property join at all.
- `it_repeated_var_fast_path_guards.rs` does assert `COUNT(*)` on both lanes, but against hand-computed values rather than against the other lane, and its star cases repeat a variable — which makes `analyze_property_join` set `object_vars_distinct = false` and decline. So it was correct, and correct for a reason that survives this change.
- The W3C suite is memory-backed throughout, so it never indexes and never reaches this path — the same blind spot we hit in #1666's neighbourhood.

So the honest read is that the wrong answers here were entirely **unpinned** rather than mispinned, which is the more likely explanation for how it survived. I'd rather report that plainly than claim a cleanup I didn't have to do.

## What the fix costs on ordinary query shapes

The fan-out fixture numbers further down are deliberately adversarial; this table is the boring case. 2,000 subjects (`name`/`email` single-valued, `tag` ×8), bulk-imported and indexed, min of 7, debug build both sides, the two sides differing **only** in `where_plan.rs` (base vs this branch) so it isolates exactly the planner change. Times are end-to-end — query plus SPARQL-JSON serialization — so C's multiple includes serializing the 8x answer rows, which is real user-visible cost, not planner overhead:

| shape | main | branch | rows |
|---|---|---|---|
| A `SELECT ?s ?name { ?s a Person . ?s name ?name }` | 33.8 ms | 33.4 ms | 2000 → 2000 |
| B A + `?s email ?e` — unused, single-valued | 33.7 ms | 34.8 ms | 2000 → 2000 |
| C A + `?s tag ?t` — unused, multi-valued x8 | 36.3 ms | **215.9 ms** | 2000 → **16000** |
| D `SELECT DISTINCT` over C | 38.5 ms | 38.8 ms | 2000 → 2000 |
| `CONSTRUCT { ?s flag "y" }` over C's star | 30.1 ms | 30.5 ms | graph: 2000 nodes both |
| `ASK` over C's star | 10.6 ms | 10.4 ms | `true` both |

A and D flat is the narrowing working — this didn't become a blanket disable, and D still takes the pruned plan. B is the only true regression shape: the unused single-valued `?e` is now carried as a real column through the join instead of being reduced to an existence bit — same 2,000 rows, one extra column, ~3% here and possibly noise, but it's the shape to watch since it pays without its answer changing. C is not like-for-like: main returned 2,000 rows where SPARQL requires 16,000, so the branch does 8x the work for 5.9x the time and per-row cost *falls*, 18.2 → 13.5 µs/row end-to-end. The blast radius on shapes whose answers were already correct is roughly nil, and where the answer changed, the added time buys the rows that were owed.

## On the cost, and why CONSTRUCT and ASK get the license back

For `SELECT ?s` the extra rows *are* answer rows, and that half of the trade is well made — measured, the per-answer-row cost actually falls from 48 µs to 9.5 µs. But `where_dedup_safe` is sound without being *tight*, and the slack lands on the outputs that aren't solution bags at all.

`QueryOutput::restriction()` returns `None` for every non-`Select` output (`ir/query.rs:159`), so the license reads false for **all** CONSTRUCT and ASK queries. A CONSTRUCT result is an RDF graph and an ASK is a boolean, so for both, the extra rows are provably discarded.

**CONSTRUCT.** Measured on 3,000 subjects × 40 tags (120k pairs, indexed), min of 3, `CONSTRUCT { ?s ex:flag "y" } WHERE { ?s a ex:Gadget . ?s ex:tag ?o }`:

| | before the #1700 fix | fix without the CONSTRUCT license | fix as it stands |
|---|---|---|---|
| time | 0.1464s | **0.9026s** | 0.1380s |
| graph | 3,000 nodes | 3,000 nodes | 3,000 nodes, same sha |

Read the denominators carefully, because the 6.2x in that table is easy to misquote: **against main, licensed CONSTRUCT is flat** (0.1464s → 0.1380s). The 0.9026s middle column is what this correctness fix would have cost CONSTRUCT *without* the license — a state that never shipped. The license is damage control for the fix's own cost on graph outputs, not a speedup over the previous release, and the code comment at the license's unit test says exactly that so the number can't drift into a release note with the wrong denominator. `SELECT DISTINCT ?s` and `COUNT(DISTINCT ?s)` were flat across all three columns, which is what says this is the planner and not the box.

The obvious form of the narrowing — license every `QueryOutput::Construct` at the call site — has a hole in each direction, which is why it lives in a named helper instead: `result_is_multiplicity_blind` (`operator_tree.rs:2367`, consumed at `:3190`), with two exclusions that are load-bearing.

- A **template blank node** is minted fresh per solution and shared only within a row, so distinct solutions build distinct triples and collapsing them changes the graph.
- A **`LIMIT`/`OFFSET`** cuts the solution sequence before the template is instantiated, so collapsing rows first changes *which* solutions survive.

Both are unit-pinned in both directions. And `bnode_vars` is empty for every JSON-LD/FQL construct and every DESCRIBE per the field's own doc comment, so this recovers the whole non-SPARQL graph-producing surface rather than carving out one SPARQL shape.

**ASK.** The same reasoning covers ASK, and more simply: every formatter either reads solution-sequence *emptiness* and nothing else (`format_ask` in `format/mod.rs`, the boolean arm of `sparql_xml::format`) or rejects ASK outright (TSV/CSV, the streaming endpoint), so there's no blank-node caveat at all. Both surfaces already lower ASK with `LIMIT 1` — `lower_ask` in `fluree-db-sparql` and the `"ask"` branch of the JSON-LD parser (`parse/mod.rs:257`) both set it — so the true case was already cheap-ish at execution time, but the *plan* still carried the full cartesian join, and `PropertyJoinOperator` does its per-predicate scans and per-subject object collection in `open()` where no LIMIT can reach. Granting ASK the license took two pieces:

- an `Ask` arm in `result_is_multiplicity_blind`, which must tolerate `LIMIT` (a limit of any value preserves emptiness — `LIMIT 0` is empty on both sides of the dedup — and both surfaces always plan ASK with one) and must exclude `OFFSET` (it counts rows off the front, so `OFFSET 5` over six duplicates is non-empty while its deduped form is empty; no surface can currently produce that IR, the guard is for programmatic construction);
- an empty needed-vars set for a licensed, modifier-free ASK in `build_operator_tree_inner`. ASK's `referenced_vars()` conservatively reports `None`, which the WHERE planner was reading as *all vars needed* — and needed vars are protected vars, which blocks the demotion regardless of the license. A licensed ASK needs no variable downstream (the output is emptiness), so it now gets the same empty set a constant-template CONSTRUCT already gets via `compute_variable_deps`; join and FILTER vars stay protected through their reference counts, and any modifier that could read a variable (grouping, ordering, post-VALUES) falls back to the conservative default.

The plan shape is pinned end-to-end (`ask_over_a_fanout_star_plans_the_existence_only_join` builds the full operator tree and asserts the object var is out of the schema; its offset twin asserts it stays in), and the fan-out fixture's integration test now runs ASK on both lanes and both surfaces in both truth directions. A result test alone cannot see this license — the boolean is identical either way — which is exactly why the plan-shape pin exists; the integration cases guard the other direction, that the license didn't *break* ASK's emptiness semantics where the demotion actually fires.

Measured honestly, the ASK win is real but bounded at these scales, because `LIMIT 1` was already capping the materialization for the true case: `ASK { ?s a Person . ?s tag ?t }` end-to-end, min of 7, debug — 12.2 → 10.4 ms at 2,000 subjects ×8 (~15%), 54.1 → 41.5 ms at 3,000 ×40 (~23%, growing with fan-out; what the license removes is `open()`-side per-subject object-list collection and the first batch of product materialization, neither of which a LIMIT can reach). The control behaved: `ASK { … FILTER(?t = "nope") }` is flat across all states, because the FILTER reads `?t`, `?t`'s reference count protects it, and the demotion correctly never fires — licensed or not.

## The license's enumeration is a gate now, not a comment

The CONSTRUCT half of the license is the one part of this PR that *removes* rows, and it rests on an enumeration of output paths ("every serializer canonicalizes or rejects") that would fail silently if a new output path ever joined the set unclassified — the zero-column `DistinctOperator` bug below is proof the seam is live rather than theoretical. I considered splitting the optimization out so the correctness fix merges on its own risk profile, and decided the honest move is the opposite: keep it here and make the enumeration structural, so the risk is addressed by a gate rather than by distance.

`every_output_format_collapses_or_rejects_construct` (`it_query_construct.rs`) holds the classification in a macro whose `match` over `OutputFormat` has **no wildcard arm** — adding a variant stops the file compiling until the new path is classified — and the same identifier list drives the runtime loop, so a variant cannot be classified without also being tested. The test is behavioral, not documentary: it runs a CONSTRUCT whose WHERE provably still carries 12 duplicate solutions (asserted as a precondition, so the gate can't pass vacuously on an already-collapsed stream — a `LIMIT` keeps the query outside the license), then feeds the result to every format through `format_results_string` and asserts each one either collapses the duplicates to one triple per subject or errors. The streaming endpoint is the one path that doesn't route through there, so its rejection of CONSTRUCT and ASK is pinned separately (`streaming_endpoint_keeps_rejecting_construct_and_ask`, `view/stream_query.rs`) with a comment naming the license as the thing that breaks if it's ever lifted.

If a future format legitimately needs to stream CONSTRUCT without canonicalizing, the license itself has to change — and the gate failing is the reminder, instead of a wrong query result somewhere downstream.

## Two output changes worth naming

Both are consequences of the correctness fix, both are what SPARQL requires, and neither was stated or pinned anywhere before. They're pinned now, and documented for users in `docs/query/construct.md` (new **Solution Multiplicity: Blank Nodes and LIMIT** section, including the subselect rewrite for preview-with-LIMIT — verified against the fan-out fixture).

1. **A blank-node CONSTRUCT template mints one blank per *solution*, not per subject.** §16.2 instantiates the template once per solution and the sequence is a bag, so on this PR's own fixture the graph goes from 4 nodes / 2 blanks to 7 / 5. Measured both ways.
2. **`CONSTRUCT … LIMIT n` can return fewer triples.** With the solution sequence correctly 40-deep per subject, `LIMIT 10` now takes ten solutions off one subject where it used to take ten collapsed rows off ten subjects — 10 triples → 1 on the perf fixture. The old number came from slicing a solution sequence that was wrong; without an `ORDER BY` neither is more "correct" than the other under SPARQL, but it is a visible change, it's why the `LIMIT` guard above exists rather than being folded into the blank-node one, and it's the case the docs now spell out (preview-with-LIMIT is a common UI call, and it takes both barrels: excluded from the license *and* fewer triples than before).

## A latent family of zero-column row-count bugs, surfaced by the above

A column-less `Batch` carries no row count through `Batch::new` (it reads the count off `columns.first()`), and the batch layer has a test pinning exactly that trap (`test_batch_new_loses_len_for_empty_schema`) — so every operator that rebuilds a batch column-by-column is a place a row count can silently vanish once a plan's WHERE schema prunes to zero columns. This PR found **three** of them, each caught by a different net, which is the strongest evidence in the whole diff that this seam is live rather than theoretical:

1. **`DistinctOperator`** — caught by the existing api suite when the CONSTRUCT license made it reachable (`sparql_construct_repeated_triple_collapses_in_both_serializations` went to an empty graph). A fully-constant template — `CONSTRUCT { <s> <p> "dup" } WHERE { ?s ?p ?o }` — both licenses dedup and needs no WHERE variable, so the block prunes to an empty schema; the operator built a zero-row batch and its `columns.first() … unwrap_or(true)` guard read "all rows were duplicates" forever, swallowing the stream. Every row of a zero-column input is the empty tuple, so DISTINCT over N of them is exactly one row, or none when the child produced nothing. Fixed with `Batch::empty_schema_with_len`, in its own commit ahead of the one that makes it reachable, both directions pinned.
2. **`LimitOperator`** — caught by the W3C suite the moment the ASK license went in: `ask-7` (`ASK { :x :p ?x }`, three matches) came back `false`. The truncation branch rebuilds the batch column-by-column, so truncating a zero-column batch of 3 to `LIMIT 1` produced a zero-row batch and `format_ask` read emptiness. **This one is reachable from main today, no license required**: `CONSTRUCT { <s> <p> "dup" } WHERE { ?s ?p ?o } LIMIT 1` prunes the schema empty via `compute_variable_deps` (a constant template needs no variable — untouched, pre-existing behavior) and returns an **empty graph** whenever the WHERE matches more rows than the limit. Verified failing at this PR's own head before the fix; the plan for that query is identical on main.
3. **`OffsetOperator`** — same rebuild in its partial-skip branch, same fix, found by reading the sibling operator after Limit fell. `CONSTRUCT … OFFSET 2` over the pruned-empty schema dropped every surviving row.

All three now route zero-column batches through `Batch::empty_schema_with_len`, each with unit tests pinning both directions, plus an integration pin (`constant_template_construct_with_limit_keeps_its_triple`) covering the main-reachable LIMIT/OFFSET shapes end-to-end. None of the three was introduced here — a zero-column WHERE stage needs a consumer that needs no variable at all, and a wildcard SELECT reports `None` for its projection, which pins every variable — but the count going from one latent instance to three found is why the output-path enumeration above is a compiled gate and not a comment.

## Tests

New `it_count_star_row_multiplicity.rs` (own binary — the kill switch is process-global). Both lanes, both surfaces, every expectation arithmetic on the fixture and never fast-vs-generic, precisely because the oracle was the broken side here. It now also carries the ASK cases (both truth directions, SPARQL + JSON-LD twins).

The fixture is multiplicity-bearing by construction and each shape is pinned alongside its distinct-subject count so the two numbers always differ — **a single-object-per-subject fixture cannot tell a passing run from a failing one**, which is presumably how this survived, so flatten this one and the `subjects` assertions fail rather than the file going quietly vacuous. I checked non-vacuity the direct way: revert `where_plan.rs` alone with the tests kept and **18 assertions fail across both lanes**; restore it and all pass. The ASK license got the same treatment: with the `Ask` arm of `result_is_multiplicity_blind` stubbed to `false`, `ask_over_a_fanout_star_plans_the_existence_only_join` fails with the object var back in the schema and `ask_licenses_where_dedup_including_under_its_own_limit` fails on every licensed case; restored, all green. (The ASK *result* cases pass either way — the boolean can't see the plan — which is why the plan-shape tests exist.)

JSON-LD twins throughout, per the three-surface parity rule — both surfaces lower to the same IR, so a WHERE-planner defect reaches both, and the twins did in fact fail alongside the SPARQL cases before the fix.

## Bench

This is a hot-path change that had no bench coverage in either direction, and the advisory per-PR job runs only `query_overlay_matrix` and `query_hot_bsbm` — neither a CONSTRUCT nor a star with an unprojected object — so neither the regression nor the recovery would have surfaced in CI.

New `query_hot_fanout_star` covers the shape: `construct_blank_free` (licensed — the regression guard), `select_unprojected_object` (not licensed — so the cost of correctness is tracked rather than rediscovered), and `select_distinct` as the control. Verified discriminating at tiny scale — 240 µs / 789 µs / 240 µs in case order — and the attribution matters: the two 240s are `construct_blank_free` and `select_distinct`, both on the pruned plan, and the **789 µs is `select_unprojected_object`** — the SELECT cost of correctness at 8k pairs, the number this whole trade turns on. It grows with fan-out, which is why the case exists: a future optimization that carries multiplicity without materializing object bindings has a number to beat. Its own fixture because BSBM has no multi-valued same-subject predicate and adding one would move `query_hot_bsbm`'s committed baseline for unrelated cases.

**Registered, deliberately not gated — these are two separate things and the distinction is easy to misread, so stating it plainly.** The bench is fully registered per the six-step workflow in `docs/contributing/benches.md`: a `[[bench]]` entry, a `regression-budget.json` entry under `crates.fluree-db-api.query_hot_fanout_star` (tiny 10 / small 5 / medium 3, copied from its `query_hot_*` siblings), and a row in the `Current categories` table. `workspace_reconcile` reconciles clean in both directions — 17 declared benches, zero unbudgeted, zero stale.

What it is *not* in is the **gated per-PR run**, which is two hardcoded `cargo bench` lines in `ci.yml` (`query_overlay_matrix`, `query_hot_bsbm`). Adding a third spends every PR's CI budget, which is a call that affects everyone rather than one I should make unilaterally — so its absence there is a decision, not an oversight. Say the word and I'll add the line in this PR. It isn't dead meanwhile: the nightly workflow compiles and smoke-runs every declared bench target, and `bench-baseline compare` reports a case with no baseline as a new scenario rather than a breach.

I got this wrong on the first push — I added the `[[bench]]` entry without the budget entry and reddened the `test` job. Two small things came out of fixing it, both folded in here. The `Current categories` table was missing `query_hot_property_path` (declared and budgeted since it shipped, just unlisted), which I added while editing that cell. And step 5 of the guide tells you to "leave the entries empty" when you have no baseline yet — but the reconciler tests `!m.is_empty()`, so an empty map fails the gate exactly as a missing one does. Corrected, with a pointer to `cargo test -p fluree-bench-support --test workspace_reconcile`, which is the cheap local gate that would have caught my mistake before CI did.

## Gates

- `cargo test -p fluree-db-query` — 1,436 lib + 60 across the integration binaries, green
- `cargo test -p fluree-db-api --features native` — 43 binaries, zero failures
- `testsuite-sparql --test w3c_sparql` — 36 registers green (and load-bearing this time: the two ASK registers went red against an intermediate state of the ASK license and caught the `LimitOperator` zero-column trap before it could ship)
- `cargo clippy -p fluree-db-query -p fluree-db-api --all-targets --no-deps --features native` — clean (includes the new bench target)
- `cargo bench --bench query_hot_fanout_star -- --test` — green
- `cargo test -p fluree-bench-support` — green (`workspace_reconcile` still clean; no bench scenarios changed)
- `cargo fmt --all --check` — clean, run last
