### PR TITLE
fix: let a no-op republish complete its raft queue entry

### DIFF
--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -4323,7 +4323,14 @@ impl Fluree {
     /// }
     /// ```
     pub async fn ledger_exists(&self, ledger_id: &str) -> Result<bool> {
-        Ok(self.nameservice().lookup(ledger_id).await?.is_some())
+        // Retracted counts as absent: tombstoning backends (the raft
+        // nameservice) keep serving the record so admin tooling can read
+        // the flag, but "exists" is a query-path question.
+        Ok(self
+            .nameservice()
+            .lookup(ledger_id)
+            .await?
+            .is_some_and(|r| !r.retracted))
     }
 
     /// Get a cached ledger handle (loads if not cached).

--- a/fluree-db-consensus/src/raft/commit_worker.rs
+++ b/fluree-db-consensus/src/raft/commit_worker.rs
@@ -747,11 +747,12 @@ impl Worker {
     /// blob to CAS, finalize local state, and return the new head
     /// identity. NoOp short-circuits (the conflict strategy dropped
     /// every reverted flake) republish the existing head so the
-    /// queue entry completes cleanly without advancing — `ApplyHead`
-    /// against the same head is a stale-write that the state machine
-    /// surfaces via `QueueDesync::WrongFront` only if another
-    /// transactor jumped ahead, which is exactly the race the queue
-    /// already serializes against.
+    /// queue entry completes cleanly without advancing. `ApplyHead`
+    /// recognizes that republish — equal `t` AND equal commit id —
+    /// as the designed no-op completion: it consumes the queue entry
+    /// and leaves the ref untouched. Equal `t` with a DIFFERENT
+    /// commit id is still a stale writer and is still refused with
+    /// `HeadNotMonotonic`.
     async fn process_revert(&self, revert: QueuedRevert) -> Result<StagedOutcome, WorkerError> {
         use fluree_db_api::GuardedStagedCommit;
 

--- a/fluree-db-consensus/src/raft/integration.rs
+++ b/fluree-db-consensus/src/raft/integration.rs
@@ -123,6 +123,25 @@ pub struct RaftIntegration {
     /// [`attach_ledger_manager`](Self::attach_ledger_manager) once
     /// `Fluree` exists.
     ledger_manager: Arc<OnceLock<Arc<fluree_db_api::LedgerManager>>>,
+    /// File-registry adoption inputs, when the embedder configured
+    /// them (see [`RaftBootstrapConfig::adopt_file_registry`]):
+    /// where the predecessor registry lives, and the marker file
+    /// under the raft storage root that records a completed replay.
+    adoption: Option<AdoptionPaths>,
+}
+
+/// Where a configured file-registry adoption reads from and how it
+/// remembers completion. Derived in [`RaftIntegration::bootstrap`].
+#[derive(Clone, Debug)]
+struct AdoptionPaths {
+    /// The store root holding the predecessor `ns@v2` registry.
+    registry_root: PathBuf,
+    /// `<raft storage root>/file-registry-adopted` — written after a
+    /// successful replay. Node-local on purpose: only the node that
+    /// initialized the cluster ever adopts, and a crash between the
+    /// (idempotent, conflict-tolerant) replay and this write is
+    /// healed by simply replaying again on the next boot.
+    marker: PathBuf,
 }
 
 /// Shared HTTP transport: a `reqwest::Client` paired with the
@@ -190,6 +209,7 @@ impl RaftIntegration {
             nameservice,
             release_rx: Arc::new(Mutex::new(Some(release_rx))),
             ledger_manager,
+            adoption: None,
         }
     }
 
@@ -224,6 +244,13 @@ impl RaftIntegration {
     /// - `POST /cluster/add-learner` (the existing leader, naming
     ///   this node) — joins an existing cluster.
     pub async fn bootstrap(config: RaftBootstrapConfig) -> Result<Self, RaftBootstrapError> {
+        let adoption = config
+            .adopt_file_registry
+            .as_ref()
+            .map(|root| AdoptionPaths {
+                registry_root: root.clone(),
+                marker: config.storage_path.join("file-registry-adopted"),
+            });
         let storage = Arc::new(FsRaftStorage::open(config.storage_path).await?);
 
         let event_bus = Arc::new(LedgerEventBus::new(config.event_bus_capacity));
@@ -265,7 +292,7 @@ impl RaftIntegration {
 
         let raft = Raft::new(config.node_id, raft_cfg, factory, log, sm).await?;
 
-        Ok(Self::new(
+        let mut integration = Self::new(
             Arc::new(raft),
             config.node_id,
             shared_state,
@@ -280,7 +307,9 @@ impl RaftIntegration {
                 config: network_config,
             },
             release_rx,
-        ))
+        );
+        integration.adoption = adoption;
+        Ok(integration)
     }
 
     /// Inter-node Raft RPC router. Mount under `/raft` on the private
@@ -313,6 +342,173 @@ impl RaftIntegration {
     /// staged receipts.
     pub fn nameservice(&self) -> Arc<RaftNameService> {
         Arc::clone(&self.nameservice)
+    }
+
+    /// Replay a predecessor file-nameservice registry into the
+    /// replicated one — the transition boot for a deployment moving
+    /// from the single-node file posture into raft.
+    ///
+    /// Call on the node that performed `Raft::initialize`, once a
+    /// leader is known (a fresh single voter elects itself within the
+    /// election timeout). Joining nodes must NOT call this — they
+    /// receive the registry by replication like any other log state.
+    ///
+    /// Semantics:
+    /// - No-op unless the bootstrap config carried
+    ///   [`adopt_file_registry`](RaftBootstrapConfig::adopt_file_registry),
+    ///   and at most once per raft storage root: a marker file written
+    ///   after a successful replay makes every later call `Ok(0)`.
+    ///   The registry is deliberately replayed ONLY into the machine
+    ///   this node just initialized — after that, the file registry
+    ///   beside the store goes stale on every raft write and must
+    ///   never be consulted again (embedders should guard their
+    ///   non-raft boot path accordingly).
+    /// - Each non-retracted record replays as ordinary proposals:
+    ///   ledger init, commit head, index head, and the config / status
+    ///   values VERBATIM. Retracted records are skipped — a tombstone
+    ///   carries no live state.
+    /// - Crash-safe by idempotence, not atomicity: a crash between the
+    ///   replay and the marker write re-runs the replay next boot, and
+    ///   every step tolerates its own prior success (`AlreadyExists`
+    ///   on init; a head CAS conflict where the machine already holds
+    ///   a value at least as new; a config/status conflict).
+    ///
+    /// Returns how many ledger records were carried.
+    pub async fn adopt_file_registry(&self) -> Result<usize, FileRegistryAdoptionError> {
+        use fluree_db_nameservice::{
+            CasResult, ConfigLookup, ConfigPublisher, LedgerLifecycle, NameServiceError,
+            NameServiceLookup, RefKind, RefLookup, RefPublisher, RefValue, StatusLookup,
+            StatusPublisher,
+        };
+
+        let Some(adoption) = &self.adoption else {
+            return Ok(0);
+        };
+        if adoption.marker.is_file() {
+            return Ok(0);
+        }
+        let registry = adoption.registry_root.join("ns@v2");
+        let finish = |adopted: usize| -> Result<usize, FileRegistryAdoptionError> {
+            std::fs::write(
+                &adoption.marker,
+                format!("adopted {adopted} ledger records\n"),
+            )
+            .map_err(FileRegistryAdoptionError::Marker)?;
+            Ok(adopted)
+        };
+        if !registry.is_dir() {
+            return finish(0);
+        }
+        let file_ns = fluree_db_nameservice::file::FileNameService::new(&adoption.registry_root);
+        let records = file_ns
+            .all_records()
+            .await
+            .map_err(FileRegistryAdoptionError::Registry)?;
+
+        let publisher = self.nameservice();
+        let mut adopted = 0usize;
+        for record in records {
+            if record.retracted {
+                continue;
+            }
+            let ledger_id = &record.ledger_id;
+            match publisher.init(ledger_id).await {
+                Ok(()) | Err(NameServiceError::LedgerAlreadyExists(_)) => {}
+                Err(e) => return Err(FileRegistryAdoptionError::replay(ledger_id, "init", e)),
+            }
+            if record.commit_head_id.is_some() {
+                let head = RefValue {
+                    id: record.commit_head_id.clone(),
+                    t: record.commit_t,
+                };
+                match publisher.fast_forward_commit(ledger_id, &head, 3).await {
+                    Ok(CasResult::Updated) => {}
+                    // A retried replay finds its own prior write; a
+                    // machine already AHEAD of the file registry means
+                    // raft writes happened, which the marker should
+                    // have prevented — still nothing to carry.
+                    Ok(CasResult::Conflict { actual })
+                        if actual.as_ref().is_some_and(|a| a.t >= record.commit_t) => {}
+                    Ok(CasResult::Conflict { actual }) => {
+                        return Err(FileRegistryAdoptionError::Diverged {
+                            ledger_id: ledger_id.clone(),
+                            kind: "commit head",
+                            detail: format!(
+                                "machine holds {actual:?}, registry carries t={}",
+                                record.commit_t
+                            ),
+                        });
+                    }
+                    Err(e) => {
+                        return Err(FileRegistryAdoptionError::replay(
+                            ledger_id,
+                            "commit head",
+                            e,
+                        ))
+                    }
+                }
+            }
+            if record.index_head_id.is_some() {
+                let idx = RefValue {
+                    id: record.index_head_id.clone(),
+                    t: record.index_t,
+                };
+                // Read-then-CAS: a freshly initialized ledger may hold
+                // an implicit empty index ref, and a retried replay
+                // holds the previous attempt's value — start from
+                // whatever is actually there.
+                let current = publisher
+                    .get_ref(ledger_id, RefKind::IndexHead)
+                    .await
+                    .map_err(|e| FileRegistryAdoptionError::replay(ledger_id, "index head", e))?;
+                if !current.as_ref().is_some_and(|c| c.t >= record.index_t) {
+                    match publisher
+                        .compare_and_set_ref(ledger_id, RefKind::IndexHead, current.as_ref(), &idx)
+                        .await
+                    {
+                        Ok(CasResult::Updated) => {}
+                        Ok(CasResult::Conflict { actual }) => {
+                            return Err(FileRegistryAdoptionError::Diverged {
+                                ledger_id: ledger_id.clone(),
+                                kind: "index head",
+                                detail: format!(
+                                    "machine holds {actual:?}, registry carries t={}",
+                                    record.index_t
+                                ),
+                            });
+                        }
+                        Err(e) => {
+                            return Err(FileRegistryAdoptionError::replay(
+                                ledger_id,
+                                "index head",
+                                e,
+                            ))
+                        }
+                    }
+                }
+            }
+            if let Ok(Some(config)) = file_ns.get_config(ledger_id).await {
+                match publisher.push_config(ledger_id, None, &config).await {
+                    // A conflict is a retried replay's own prior write.
+                    Ok(_) => {}
+                    Err(e) => {
+                        return Err(FileRegistryAdoptionError::replay(ledger_id, "config", e))
+                    }
+                }
+            }
+            if let Ok(Some(status)) = file_ns.get_status(ledger_id).await {
+                match publisher.push_status(ledger_id, None, &status).await {
+                    Ok(_) => {}
+                    Err(e) => {
+                        return Err(FileRegistryAdoptionError::replay(ledger_id, "status", e))
+                    }
+                }
+            }
+            tracing::info!(ledger = %ledger_id, t = record.commit_t, index_t = record.index_t,
+                "file registry record adopted into the replicated nameservice");
+            adopted += 1;
+        }
+        finish(adopted)
     }
 
     /// Cluster admin router — bootstrap and membership-change
@@ -365,6 +561,15 @@ pub struct RaftBootstrapConfig {
     /// this far behind receive `RecvError::Lagged` and fall back to
     /// a catch-up sweep.
     pub event_bus_capacity: usize,
+    /// Store root that MAY hold a predecessor file-nameservice
+    /// registry (`<root>/ns@v2`), for a deployment moving from the
+    /// single-node file posture into raft. When set, the node that
+    /// initializes the cluster calls
+    /// [`RaftIntegration::adopt_file_registry`] once after election
+    /// and every record replays into the replicated registry —
+    /// existence, both heads, config and status verbatim. `None`
+    /// (the default) means no adoption is ever attempted.
+    pub adopt_file_registry: Option<PathBuf>,
 }
 
 impl RaftBootstrapConfig {
@@ -380,7 +585,16 @@ impl RaftBootstrapConfig {
             raft_config: runtime::default_raft_config(&network_config.transport),
             network_config,
             event_bus_capacity: 1024,
+            adopt_file_registry: None,
         }
+    }
+
+    /// Configure file-registry adoption (see the field docs): `root`
+    /// is the store directory whose `ns@v2` subtree holds the
+    /// predecessor registry.
+    pub fn with_file_registry_adoption(mut self, root: impl Into<PathBuf>) -> Self {
+        self.adopt_file_registry = Some(root.into());
+        self
     }
 }
 
@@ -411,6 +625,48 @@ pub enum RaftBootstrapError {
     /// surfaced during initial state load.
     #[error("raft startup: {0}")]
     RaftStart(#[from] RaftFatal<NodeId>),
+}
+
+/// Failures out of [`RaftIntegration::adopt_file_registry`].
+#[derive(Debug, Error)]
+pub enum FileRegistryAdoptionError {
+    /// Reading the predecessor file registry failed.
+    #[error("reading the file registry: {0}")]
+    Registry(fluree_db_nameservice::NameServiceError),
+    /// One record's replay failed at the named step.
+    #[error("adopting '{ledger_id}' ({step}): {source}")]
+    Replay {
+        ledger_id: String,
+        step: &'static str,
+        source: fluree_db_nameservice::NameServiceError,
+    },
+    /// The replicated registry already holds DIFFERENT state for a
+    /// ledger — the machine was written outside this adoption, which
+    /// the completion marker should have prevented. Refuse rather
+    /// than guess which side is authoritative.
+    #[error("adopting '{ledger_id}' ({kind}): registry diverged — {detail}")]
+    Diverged {
+        ledger_id: String,
+        kind: &'static str,
+        detail: String,
+    },
+    /// Writing the completion marker failed.
+    #[error("writing the adoption marker: {0}")]
+    Marker(std::io::Error),
+}
+
+impl FileRegistryAdoptionError {
+    fn replay(
+        ledger_id: &str,
+        step: &'static str,
+        source: fluree_db_nameservice::NameServiceError,
+    ) -> Self {
+        Self::Replay {
+            ledger_id: ledger_id.to_string(),
+            step,
+            source,
+        }
+    }
 }
 
 // ============================================================================

--- a/fluree-db-consensus/src/raft/integration.rs
+++ b/fluree-db-consensus/src/raft/integration.rs
@@ -362,7 +362,9 @@ impl RaftIntegration {
     ///   this node just initialized — after that, the file registry
     ///   beside the store goes stale on every raft write and must
     ///   never be consulted again (embedders should guard their
-    ///   non-raft boot path accordingly).
+    ///   non-raft boot path accordingly). A configured root with no
+    ///   `ns@v2` subtree answers `Ok(0)` WITHOUT the marker, so a
+    ///   mistyped path stays correctable.
     /// - Each non-retracted record replays as ordinary proposals:
     ///   ledger init, commit head, index head, and the config / status
     ///   values VERBATIM. Retracted records are skipped — a tombstone
@@ -371,14 +373,19 @@ impl RaftIntegration {
     ///   replay and the marker write re-runs the replay next boot, and
     ///   every step tolerates its own prior success (`AlreadyExists`
     ///   on init; a head CAS conflict where the machine already holds
-    ///   a value at least as new; a config/status conflict).
+    ///   a value at least as new; a config/status watermark already at
+    ///   or above the registry's).
+    /// - Any step that cannot be READ or replayed aborts the whole
+    ///   adoption before the marker is written, so the operator can
+    ///   repair the record and re-run. Nothing is carried in partially
+    ///   and silently.
     ///
     /// Returns how many ledger records were carried.
     pub async fn adopt_file_registry(&self) -> Result<usize, FileRegistryAdoptionError> {
         use fluree_db_nameservice::{
-            CasResult, ConfigLookup, ConfigPublisher, LedgerLifecycle, NameServiceError,
-            NameServiceLookup, RefKind, RefLookup, RefPublisher, RefValue, StatusLookup,
-            StatusPublisher,
+            CasResult, ConfigCasResult, ConfigLookup, ConfigPublisher, LedgerLifecycle,
+            NameServiceError, NameServiceLookup, RefKind, RefLookup, RefPublisher, RefValue,
+            StatusCasResult, StatusLookup, StatusPublisher,
         };
 
         let Some(adoption) = &self.adoption else {
@@ -396,8 +403,13 @@ impl RaftIntegration {
             .map_err(FileRegistryAdoptionError::Marker)?;
             Ok(adopted)
         };
+        // Nothing to carry — and deliberately NO marker. A mistyped
+        // registry root would otherwise burn the one-shot adoption
+        // before the corrected config ever got a turn, exactly like
+        // the unconfigured case above, which also answers zero
+        // without writing one.
         if !registry.is_dir() {
-            return finish(0);
+            return Ok(0);
         }
         let file_ns = fluree_db_nameservice::file::FileNameService::new(&adoption.registry_root);
         let records = file_ns
@@ -487,20 +499,78 @@ impl RaftIntegration {
                     }
                 }
             }
-            if let Ok(Some(config)) = file_ns.get_config(ledger_id).await {
-                match publisher.push_config(ledger_id, None, &config).await {
-                    // A conflict is a retried replay's own prior write.
-                    Ok(_) => {}
-                    Err(e) => {
-                        return Err(FileRegistryAdoptionError::replay(ledger_id, "config", e))
+            // Config and status replay read-then-CAS, exactly like the
+            // index head above, for two reasons. An unreadable record
+            // must refuse loudly rather than carry the ledger in with
+            // its config silently absent — adoption is once-only, so a
+            // swallowed read error loses that config permanently and
+            // tells nobody. And the machine reads an unset value as
+            // the `unborn` / `initial` watermark rather than as
+            // missing, so `apply_versioned_push` demands `expected`
+            // match that watermark exactly: pushing `None` conflicts
+            // every time and would carry nothing at all.
+            let config = file_ns
+                .get_config(ledger_id)
+                .await
+                .map_err(|e| FileRegistryAdoptionError::replay(ledger_id, "config", e))?;
+            if let Some(config) = config {
+                let current = publisher
+                    .get_config(ledger_id)
+                    .await
+                    .map_err(|e| FileRegistryAdoptionError::replay(ledger_id, "config", e))?;
+                // A retried replay finds its own prior write at the
+                // same or a higher watermark; so does a registry whose
+                // config never moved off `unborn`. Nothing to carry.
+                if !current.as_ref().is_some_and(|c| c.v >= config.v) {
+                    match publisher
+                        .push_config(ledger_id, current.as_ref(), &config)
+                        .await
+                    {
+                        Ok(ConfigCasResult::Updated) => {}
+                        Ok(ConfigCasResult::Conflict { actual }) => {
+                            return Err(FileRegistryAdoptionError::Diverged {
+                                ledger_id: ledger_id.clone(),
+                                kind: "config",
+                                detail: format!(
+                                    "machine holds {actual:?}, registry carries v={}",
+                                    config.v
+                                ),
+                            });
+                        }
+                        Err(e) => {
+                            return Err(FileRegistryAdoptionError::replay(ledger_id, "config", e))
+                        }
                     }
                 }
             }
-            if let Ok(Some(status)) = file_ns.get_status(ledger_id).await {
-                match publisher.push_status(ledger_id, None, &status).await {
-                    Ok(_) => {}
-                    Err(e) => {
-                        return Err(FileRegistryAdoptionError::replay(ledger_id, "status", e))
+            let status = file_ns
+                .get_status(ledger_id)
+                .await
+                .map_err(|e| FileRegistryAdoptionError::replay(ledger_id, "status", e))?;
+            if let Some(status) = status {
+                let current = publisher
+                    .get_status(ledger_id)
+                    .await
+                    .map_err(|e| FileRegistryAdoptionError::replay(ledger_id, "status", e))?;
+                if !current.as_ref().is_some_and(|c| c.v >= status.v) {
+                    match publisher
+                        .push_status(ledger_id, current.as_ref(), &status)
+                        .await
+                    {
+                        Ok(StatusCasResult::Updated) => {}
+                        Ok(StatusCasResult::Conflict { actual }) => {
+                            return Err(FileRegistryAdoptionError::Diverged {
+                                ledger_id: ledger_id.clone(),
+                                kind: "status",
+                                detail: format!(
+                                    "machine holds {actual:?}, registry carries v={}",
+                                    status.v
+                                ),
+                            });
+                        }
+                        Err(e) => {
+                            return Err(FileRegistryAdoptionError::replay(ledger_id, "status", e))
+                        }
                     }
                 }
             }

--- a/fluree-db-consensus/src/raft/state_machine.rs
+++ b/fluree-db-consensus/src/raft/state_machine.rs
@@ -2453,10 +2453,8 @@ fn apply_head(state: &mut NameServiceState, log_index: u64, args: StagedHead) ->
     // The read copies `.t` and the head comparison out, so the
     // borrow ends before the `state.queues` push-back below.
     let mut noop_completion = false;
-    if let Some((current_t, head_matches)) = state
-        .refs
-        .get(&ref_key)
-        .map(|r| (r.t, r.head == commit_id))
+    if let Some((current_t, head_matches)) =
+        state.refs.get(&ref_key).map(|r| (r.t, r.head == commit_id))
     {
         if commit_t == current_t && head_matches {
             noop_completion = true;

--- a/fluree-db-consensus/src/raft/state_machine.rs
+++ b/fluree-db-consensus/src/raft/state_machine.rs
@@ -2439,10 +2439,28 @@ fn apply_head(state: &mut NameServiceState, log_index: u64, args: StagedHead) ->
     // `t` and replace the head's content lineage with a non-
     // descendant. Push the popped entry back at the front so the
     // worker retries once its local view catches up.
-    // The read borrows only `.t` (a `Copy`), so it ends before the
-    // `state.queues` push-back below.
-    if let Some(current_t) = state.refs.get(&ref_key).map(|r| r.t) {
-        if commit_t <= current_t {
+    //
+    // One deliberate exception: the no-op completion. A worker that
+    // staged a zero-change transaction completes its queue entry by
+    // republishing the branch's CURRENT head unchanged (the
+    // commit worker's no-change arm), which arrives here as
+    // `commit_t == current_t` with `commit_id` equal to the stored
+    // head. That is not a stale writer — it is the designed way an
+    // entry that advances nothing leaves the queue. Rejecting it
+    // (as this guard once did) pushed the entry back and stranded
+    // the submission in a re-stage → reject loop, since re-staging
+    // a no-op can only ever reproduce the same unchanged head.
+    // The read copies `.t` and the head comparison out, so the
+    // borrow ends before the `state.queues` push-back below.
+    let mut noop_completion = false;
+    if let Some((current_t, head_matches)) = state
+        .refs
+        .get(&ref_key)
+        .map(|r| (r.t, r.head == commit_id))
+    {
+        if commit_t == current_t && head_matches {
+            noop_completion = true;
+        } else if commit_t <= current_t {
             state
                 .queues
                 .get_mut(&ref_key)
@@ -2471,27 +2489,30 @@ fn apply_head(state: &mut NameServiceState, log_index: u64, args: StagedHead) ->
     // Advance the branch's `RefEntry`. Mutate the existing entry in
     // place so its index pointer + lineage (source/child count) stay
     // put without cloning them out and rebuilding; only a fresh
-    // branch (no entry yet) takes the insert path.
-    match state.refs.get_mut(&ref_key) {
-        Some(existing) => {
-            existing.head = commit_id.clone();
-            existing.t = commit_t;
-            existing.last_advanced_at_millis = applied_at_millis;
-            existing.last_advanced_index = log_index;
-        }
-        None => {
-            state.refs.insert(
-                ref_key.clone(),
-                RefEntry {
-                    head: commit_id.clone(),
-                    t: commit_t,
-                    last_advanced_at_millis: applied_at_millis,
-                    last_advanced_index: log_index,
-                    index: None,
-                    source_branch: None,
-                    branches: 0,
-                },
-            );
+    // branch (no entry yet) takes the insert path. A no-op
+    // completion advances nothing — the ref already IS this head.
+    if !noop_completion {
+        match state.refs.get_mut(&ref_key) {
+            Some(existing) => {
+                existing.head = commit_id.clone();
+                existing.t = commit_t;
+                existing.last_advanced_at_millis = applied_at_millis;
+                existing.last_advanced_index = log_index;
+            }
+            None => {
+                state.refs.insert(
+                    ref_key.clone(),
+                    RefEntry {
+                        head: commit_id.clone(),
+                        t: commit_t,
+                        last_advanced_at_millis: applied_at_millis,
+                        last_advanced_index: log_index,
+                        index: None,
+                        source_branch: None,
+                        branches: 0,
+                    },
+                );
+            }
         }
     }
 
@@ -4244,6 +4265,81 @@ mod tests {
                 },
                 ..
             }
+        ));
+    }
+
+    #[test]
+    fn apply_head_completes_a_no_op_republish_of_the_current_head() {
+        // The commit worker's no-change arm completes a zero-change
+        // transaction by republishing the branch's CURRENT head
+        // unchanged. Equal `t` + equal commit id is that completion,
+        // not a stale writer: the entry must be consumed and the ref
+        // left untouched. Refusing it (as the monotonic guard once
+        // did) pushed the entry back and stranded the submission in a
+        // re-stage → reject loop — a no-op can only ever reproduce
+        // the same unchanged head.
+        let mut state = NameServiceState::new();
+        apply(&mut state, create_ledger("test/db"), 1);
+        let qid1 = match apply(&mut state, enqueue("test/db", "main", 7, None), 2) {
+            Response::Enqueued { queue_id, .. } => queue_id,
+            other => panic!("not Enqueued: {other:?}"),
+        };
+        apply(
+            &mut state,
+            apply_head_cmd("test/db", "main", qid1, cid(20), 20),
+            3,
+        );
+
+        let key = body_kid("noop");
+        let qid2 = match apply(
+            &mut state,
+            enqueue("test/db", "main", 8, Some(key.clone())),
+            4,
+        ) {
+            Response::Enqueued { queue_id, .. } => queue_id,
+            other => panic!("not Enqueued: {other:?}"),
+        };
+        // Same commit id AND same t as the current head: the no-op
+        // completion.
+        let resp = apply(
+            &mut state,
+            apply_head_cmd("test/db", "main", qid2, cid(20), 20),
+            5,
+        );
+        match resp {
+            Response::HeadApplied {
+                commit_id,
+                commit_t,
+                ..
+            } => {
+                assert_eq!(commit_id, cid(20));
+                assert_eq!(commit_t, 20);
+            }
+            other => panic!("expected HeadApplied, got {other:?}"),
+        }
+
+        // Entry consumed — the queue drained (and was dropped empty).
+        let ref_key = RefKey::new("test/db", "main");
+        assert!(state
+            .queues
+            .get(&ref_key)
+            .map(VecDeque::is_empty)
+            .unwrap_or(true));
+
+        // Ref untouched: same head, same t, and the advance stamp
+        // still points at the REAL advance (log index 3), not the
+        // no-op's apply.
+        let entry = state.refs.get(&ref_key).expect("ref present");
+        assert_eq!(entry.head, cid(20));
+        assert_eq!(entry.t, 20);
+        assert_eq!(entry.last_advanced_index, 3);
+
+        // The keyed no-op is idempotency-cached like any completion,
+        // so a retry of the same submission dedups instead of
+        // re-queueing.
+        assert!(matches!(
+            state.idempotency.get(&key),
+            Some(ApplyOutcome::Applied(_))
         ));
     }
 

--- a/fluree-db-consensus/tests/it_file_registry_adoption.rs
+++ b/fluree-db-consensus/tests/it_file_registry_adoption.rs
@@ -1,0 +1,198 @@
+//! The transition boot: a store that lived in the single-node FILE
+//! posture moves into raft, and `adopt_file_registry` carries every
+//! registry record — existence, both heads, config, status — into the
+//! replicated nameservice. Also pins the once-only marker semantics
+//! and the crash-retry idempotence (a re-run over a partially adopted
+//! machine converges instead of conflicting).
+
+#![cfg(feature = "raft")]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use fluree_db_consensus::raft::integration::{RaftBootstrapConfig, RaftIntegration};
+use fluree_db_core::{ContentId, ContentKind};
+use fluree_db_nameservice::file::FileNameService;
+use fluree_db_nameservice::{
+    CasResult, LedgerLifecycle, NameServiceLookup, RefKind, RefLookup, RefPublisher, RefValue,
+};
+
+async fn eventually(what: &str, mut check: impl AsyncFnMut() -> bool) {
+    for _ in 0..100 {
+        if check().await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("timed out waiting for {what}");
+}
+
+fn cid(kind: ContentKind, seed: u8) -> ContentId {
+    ContentId::new(kind, &[seed])
+}
+
+/// Seed a file registry the way a life in the file posture would have:
+/// through the FileNameService's own publisher surface.
+async fn seed_file_registry(root: &std::path::Path) {
+    let ns = FileNameService::new(root);
+    for (ledger, commit_seed, commit_t, index_seed, index_t) in [
+        ("adopted/one", 1u8, 5i64, 2u8, 3i64),
+        ("adopted/two", 3u8, 12i64, 4u8, 12i64),
+    ] {
+        ns.init(ledger).await.expect("init");
+        let head = RefValue {
+            id: Some(cid(ContentKind::Commit, commit_seed)),
+            t: commit_t,
+        };
+        assert!(matches!(
+            ns.fast_forward_commit(ledger, &head, 3)
+                .await
+                .expect("commit head"),
+            CasResult::Updated
+        ));
+        let idx = RefValue {
+            id: Some(cid(ContentKind::IndexRoot, index_seed)),
+            t: index_t,
+        };
+        let current = ns.get_ref(ledger, RefKind::IndexHead).await.expect("read");
+        assert!(matches!(
+            ns.compare_and_set_ref(ledger, RefKind::IndexHead, current.as_ref(), &idx)
+                .await
+                .expect("index head"),
+            CasResult::Updated
+        ));
+    }
+    // A tombstone must NOT carry.
+    ns.init("adopted/gone").await.expect("init tombstone");
+    ns.retract("adopted/gone").await.expect("retract");
+}
+
+async fn boot_initialized(
+    node_id: u64,
+    raft_dir: &std::path::Path,
+    store_dir: &std::path::Path,
+) -> Arc<RaftIntegration> {
+    let integration = Arc::new(
+        RaftIntegration::bootstrap(
+            RaftBootstrapConfig::new(node_id, raft_dir).with_file_registry_adoption(store_dir),
+        )
+        .await
+        .expect("bootstrap"),
+    );
+    let mut members = BTreeMap::new();
+    members.insert(
+        node_id,
+        fluree_db_consensus::raft::ClusterNode::new(
+            "http://127.0.0.1:1/raft/nameservice".to_string(),
+            "http://127.0.0.1:1".to_string(),
+        ),
+    );
+    integration
+        .raft
+        .initialize(members)
+        .await
+        .expect("initialize");
+    let raft = Arc::clone(&integration.raft);
+    let id = node_id;
+    eventually("self-election", async || {
+        raft.current_leader().await == Some(id)
+    })
+    .await;
+    integration
+}
+
+#[tokio::test]
+async fn a_file_registry_adopts_once_and_survives_a_partial_retry() {
+    let raft_dir = tempfile::tempdir().expect("raft dir");
+    let store_dir = tempfile::tempdir().expect("store dir");
+    seed_file_registry(store_dir.path()).await;
+
+    let integration = boot_initialized(7, raft_dir.path(), store_dir.path()).await;
+
+    // The replay carries the two live records and skips the tombstone.
+    let adopted = integration.adopt_file_registry().await.expect("adoption");
+    assert_eq!(adopted, 2);
+    let ns = integration.nameservice();
+    let one = ns
+        .lookup("adopted/one:main")
+        .await
+        .expect("lookup")
+        .expect("adopted/one present");
+    assert_eq!(one.commit_t, 5);
+    assert_eq!(one.index_t, 3);
+    assert_eq!(one.commit_head_id, Some(cid(ContentKind::Commit, 1)));
+    assert_eq!(one.index_head_id, Some(cid(ContentKind::IndexRoot, 2)));
+    let two = ns
+        .lookup("adopted/two:main")
+        .await
+        .expect("lookup")
+        .expect("adopted/two present");
+    assert_eq!(two.commit_t, 12);
+    assert!(ns
+        .lookup("adopted/gone:main")
+        .await
+        .expect("lookup")
+        .is_none_or(|r| r.retracted));
+
+    // The marker makes a second call a no-op.
+    assert_eq!(integration.adopt_file_registry().await.expect("re-run"), 0);
+
+    // Crash between replay and marker: delete the marker and re-run —
+    // the conflict-tolerant replay converges over its own prior writes.
+    std::fs::remove_file(raft_dir.path().join("file-registry-adopted")).expect("drop marker");
+    assert_eq!(
+        integration
+            .adopt_file_registry()
+            .await
+            .expect("retry over a partially adopted machine"),
+        2
+    );
+    assert_eq!(
+        ns.lookup("adopted/one:main")
+            .await
+            .expect("lookup")
+            .expect("still present")
+            .commit_t,
+        5
+    );
+
+    integration.raft.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn no_registry_and_no_config_both_answer_zero() {
+    // Configured path with no ns@v2 underneath: marker written, zero carried.
+    let raft_dir = tempfile::tempdir().expect("raft dir");
+    let store_dir = tempfile::tempdir().expect("store dir");
+    let integration = boot_initialized(9, raft_dir.path(), store_dir.path()).await;
+    assert_eq!(integration.adopt_file_registry().await.expect("empty"), 0);
+    assert!(raft_dir.path().join("file-registry-adopted").is_file());
+
+    // No adoption configured at all: permanent no-op, no marker.
+    let raft_dir2 = tempfile::tempdir().expect("raft dir");
+    let bare = Arc::new(
+        RaftIntegration::bootstrap(RaftBootstrapConfig::new(11, raft_dir2.path()))
+            .await
+            .expect("bootstrap"),
+    );
+    let mut members = BTreeMap::new();
+    members.insert(
+        11,
+        fluree_db_consensus::raft::ClusterNode::new(
+            "http://127.0.0.1:1/raft/nameservice".to_string(),
+            "http://127.0.0.1:1".to_string(),
+        ),
+    );
+    bare.raft.initialize(members).await.expect("initialize");
+    let raft = Arc::clone(&bare.raft);
+    eventually("self-election", async || {
+        raft.current_leader().await == Some(11)
+    })
+    .await;
+    assert_eq!(bare.adopt_file_registry().await.expect("unconfigured"), 0);
+    assert!(!raft_dir2.path().join("file-registry-adopted").is_file());
+
+    integration.raft.shutdown().await.expect("shutdown");
+    bare.raft.shutdown().await.expect("shutdown");
+}

--- a/fluree-db-consensus/tests/it_file_registry_adoption.rs
+++ b/fluree-db-consensus/tests/it_file_registry_adoption.rs
@@ -1,9 +1,11 @@
 //! The transition boot: a store that lived in the single-node FILE
 //! posture moves into raft, and `adopt_file_registry` carries every
 //! registry record — existence, both heads, config, status — into the
-//! replicated nameservice. Also pins the once-only marker semantics
-//! and the crash-retry idempotence (a re-run over a partially adopted
-//! machine converges instead of conflicting).
+//! replicated nameservice. Also pins the once-only marker semantics,
+//! the crash-retry idempotence (a re-run over a partially adopted
+//! machine converges instead of conflicting), and the two cases that
+//! must NOT write the marker: a registry root with no `ns@v2` subtree,
+//! and a record the replay cannot read.
 
 #![cfg(feature = "raft")]
 
@@ -15,7 +17,9 @@ use fluree_db_consensus::raft::integration::{RaftBootstrapConfig, RaftIntegratio
 use fluree_db_core::{ContentId, ContentKind};
 use fluree_db_nameservice::file::FileNameService;
 use fluree_db_nameservice::{
-    CasResult, LedgerLifecycle, NameServiceLookup, RefKind, RefLookup, RefPublisher, RefValue,
+    CasResult, ConfigCasResult, ConfigLookup, ConfigPayload, ConfigPublisher, ConfigValue,
+    LedgerLifecycle, NameServiceLookup, RefKind, RefLookup, RefPublisher, RefValue,
+    StatusCasResult, StatusLookup, StatusPayload, StatusPublisher, StatusValue,
 };
 
 async fn eventually(what: &str, mut check: impl AsyncFnMut() -> bool) {
@@ -61,6 +65,31 @@ async fn seed_file_registry(root: &std::path::Path) {
                 .await
                 .expect("index head"),
             CasResult::Updated
+        ));
+
+        // Config and status are part of a record's live state and
+        // must carry too. The file backend reads an unset config as
+        // `unborn` and an unset status as `initial`, so the seeding
+        // CAS expects exactly that.
+        let config = ConfigValue::new(
+            4,
+            Some(ConfigPayload::with_default_context(cid(
+                ContentKind::Commit,
+                commit_seed.wrapping_add(40),
+            ))),
+        );
+        assert!(matches!(
+            ns.push_config(ledger, Some(&ConfigValue::unborn()), &config)
+                .await
+                .expect("seed config"),
+            ConfigCasResult::Updated
+        ));
+        let status = StatusValue::new(6, StatusPayload::new(format!("seeded-{commit_seed}")));
+        assert!(matches!(
+            ns.push_status(ledger, Some(&StatusValue::initial()), &status)
+                .await
+                .expect("seed status"),
+            StatusCasResult::Updated
         ));
     }
     // A tombstone must NOT carry.
@@ -135,6 +164,32 @@ async fn a_file_registry_adopts_once_and_survives_a_partial_retry() {
         .expect("lookup")
         .is_none_or(|r| r.retracted));
 
+    // Config and status carry VERBATIM — watermark and payload both.
+    // The machine reads an unset value as `unborn` / `initial`, so
+    // these assertions fail against a replay that pushed with a `None`
+    // expectation (which can never match) as well as against one that
+    // dropped the values outright.
+    for (ledger, commit_seed) in [("adopted/one:main", 1u8), ("adopted/two:main", 3u8)] {
+        let config = ns
+            .get_config(ledger)
+            .await
+            .expect("config read")
+            .expect("config present");
+        assert_eq!(config.v, 4, "{ledger} config watermark");
+        assert_eq!(
+            config.payload.expect("config payload").default_context,
+            Some(cid(ContentKind::Commit, commit_seed.wrapping_add(40))),
+            "{ledger} config payload"
+        );
+        let status = ns
+            .get_status(ledger)
+            .await
+            .expect("status read")
+            .expect("status present");
+        assert_eq!(status.v, 6, "{ledger} status watermark");
+        assert_eq!(status.payload.state, format!("seeded-{commit_seed}"));
+    }
+
     // The marker makes a second call a no-op.
     assert_eq!(integration.adopt_file_registry().await.expect("re-run"), 0);
 
@@ -156,18 +211,38 @@ async fn a_file_registry_adopts_once_and_survives_a_partial_retry() {
             .commit_t,
         5
     );
+    // The re-run tolerated its own prior config/status write rather
+    // than diverging on the unchanged watermark.
+    assert_eq!(
+        ns.get_config("adopted/one:main")
+            .await
+            .expect("config read")
+            .expect("config present")
+            .v,
+        4
+    );
+    assert_eq!(
+        ns.get_status("adopted/one:main")
+            .await
+            .expect("status read")
+            .expect("status present")
+            .v,
+        6
+    );
 
     integration.raft.shutdown().await.expect("shutdown");
 }
 
 #[tokio::test]
 async fn no_registry_and_no_config_both_answer_zero() {
-    // Configured path with no ns@v2 underneath: marker written, zero carried.
+    // Configured path with no ns@v2 underneath: zero carried and NO
+    // marker, so a mistyped registry root doesn't burn the one-shot
+    // adoption before the corrected config gets a turn.
     let raft_dir = tempfile::tempdir().expect("raft dir");
     let store_dir = tempfile::tempdir().expect("store dir");
     let integration = boot_initialized(9, raft_dir.path(), store_dir.path()).await;
     assert_eq!(integration.adopt_file_registry().await.expect("empty"), 0);
-    assert!(raft_dir.path().join("file-registry-adopted").is_file());
+    assert!(!raft_dir.path().join("file-registry-adopted").is_file());
 
     // No adoption configured at all: permanent no-op, no marker.
     let raft_dir2 = tempfile::tempdir().expect("raft dir");
@@ -195,4 +270,71 @@ async fn no_registry_and_no_config_both_answer_zero() {
 
     integration.raft.shutdown().await.expect("shutdown");
     bare.raft.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn an_unreadable_record_aborts_before_the_marker_is_written() {
+    // Adoption is once-only, so nothing it cannot READ may be skipped
+    // past: the run aborts and withholds the marker, leaving the
+    // operator a signal AND a second chance. Without that, a ledger
+    // arrives in raft with state silently absent and the marker
+    // makes every later call `Ok(0)`.
+    let raft_dir = tempfile::tempdir().expect("raft dir");
+    let store_dir = tempfile::tempdir().expect("store dir");
+    seed_file_registry(store_dir.path()).await;
+
+    // Truncate one record the way an unclean shutdown would, leaving
+    // the file present (so `all_records` still yields it) but its JSON
+    // unparseable.
+    let mut truncated = None;
+    for entry in walk(&store_dir.path().join("ns@v2")) {
+        if entry.to_string_lossy().contains("one") {
+            std::fs::write(&entry, b"{\"ledger\": ").expect("truncate");
+            truncated = Some(entry);
+            break;
+        }
+    }
+    let truncated = truncated.expect("a record file for adopted/one");
+
+    let integration = boot_initialized(13, raft_dir.path(), store_dir.path()).await;
+    let err = integration
+        .adopt_file_registry()
+        .await
+        .expect_err("a truncated record must not adopt silently");
+    // Surfaced by the registry read here; a corruption that survives
+    // `all_records` and fails a per-record read lands on the same
+    // abort-before-`finish` path through `Replay`.
+    assert!(
+        matches!(
+            err,
+            fluree_db_consensus::raft::integration::FileRegistryAdoptionError::Registry(_)
+                | fluree_db_consensus::raft::integration::FileRegistryAdoptionError::Replay { .. }
+        ),
+        "unreadable record surfaces as a read failure, not a marker write: {err}"
+    );
+    assert!(
+        !raft_dir.path().join("file-registry-adopted").is_file(),
+        "marker withheld so the operator can repair {} and re-run",
+        truncated.display()
+    );
+
+    integration.raft.shutdown().await.expect("shutdown");
+}
+
+/// Every file under `root`, recursively.
+fn walk(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(walk(&path));
+        } else {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
 }

--- a/fluree-db-ledger/src/lib.rs
+++ b/fluree-db-ledger/src/lib.rs
@@ -199,6 +199,14 @@ impl LedgerState {
         let record = ns
             .lookup(ledger_id)
             .await?
+            // Backends that tombstone (the raft nameservice keeps serving
+            // retracted records so admin tooling can read the flag) must
+            // not let a dropped ledger LOAD: on the query path, retracted
+            // reads identically to not-found — matching the backends that
+            // hide the record outright. Without this, a raft-mode server
+            // re-loads and serves a dropped ledger the moment its cache
+            // eviction lands.
+            .filter(|r| !r.retracted)
             .ok_or_else(|| LedgerError::not_found(ledger_id))?;
 
         // For branched ledgers, build a recursive content store that falls

--- a/fluree-db-server/src/lib.rs
+++ b/fluree-db-server/src/lib.rs
@@ -767,13 +767,24 @@ impl FlureeServerBuilder {
                     let nameservice: std::sync::Arc<
                         dyn fluree_db_nameservice::IndexingNameService,
                     > = raft_ns.clone();
-                    let (worker, _handle) = fluree_db_indexer::BackgroundIndexerWorker::new(
+                    let (worker, handle) = fluree_db_indexer::BackgroundIndexerWorker::new(
                         backend.clone(),
                         nameservice,
                         indexer_config.clone(),
                     );
                     let worker = worker.with_event_bus(Arc::clone(&event_bus));
-                    let mut tasks = vec![tokio::spawn(worker.run())];
+                    // The handle owns the worker's ShutdownTrigger:
+                    // dropping it fires the shutdown oneshot and `run()`
+                    // exits on its FIRST select — silently, before its
+                    // first log line — leaving a raft cluster with no
+                    // indexer at all and every read walking the commit
+                    // chain unindexed. Move it into the worker's task so
+                    // they live and die together; the leader watcher's
+                    // abort on leadership loss releases both.
+                    let mut tasks = vec![tokio::spawn(async move {
+                        let _keepalive = handle;
+                        worker.run().await;
+                    })];
                     // BM25 auto-sync is leader-only for the same reason
                     // the indexer is: it publishes through the
                     // nameservice, which under Raft proposes to the

--- a/fluree-raft-core/Cargo.toml
+++ b/fluree-raft-core/Cargo.toml
@@ -24,7 +24,7 @@ default = []
 # rendezvous ownership — and monolithic Fluree builds, which reach this
 # crate through `fluree-db-consensus` for `http::is_hop_by_hop` — do not
 # compile or link openraft.
-raft = ["dep:openraft", "dep:axum", "dep:reqwest", "dep:http-body-util", "dep:tokio-util"]
+raft = ["dep:openraft", "dep:axum", "dep:reqwest", "dep:http-body-util", "dep:tokio-util", "dep:serde_json"]
 # Conformance fixture for `AppStateMachine` implementations. Separate
 # from `raft` so it can be enabled as a dev-dependency by consumers
 # without shipping the fixture in their release builds.
@@ -66,6 +66,10 @@ openraft = { version = "0.9", optional = true, features = [
 axum = { workspace = true, optional = true }
 # HTTP client for the same layer, and for follower->leader forwarding.
 reqwest = { workspace = true, optional = true }
+# The propose relay's wire (`/propose` + `forward::propose_via_leader`):
+# JSON both ways, because application RESPONSES never ride the log and
+# may carry `serde_json::Value` state postcard cannot decode.
+serde_json = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
 # `CancellationToken` for the leader-task lifecycle.
 tokio-util = { version = "0.7", optional = true }

--- a/fluree-raft-core/src/forward.rs
+++ b/fluree-raft-core/src/forward.rs
@@ -920,3 +920,119 @@ mod tests {
         assert_eq!(incoming_hop_count(&h), 0);
     }
 }
+
+// ─── Follower-side propose ───────────────────────────────────────────────
+
+/// Why [`propose_via_leader`] could not land a command.
+#[derive(Debug, thiserror::Error)]
+pub enum ProposeError {
+    /// No leader is known — mid-election, or the group has no quorum.
+    #[error("no leader known for this group; retry once one is elected")]
+    NoLeader,
+    /// The membership-recorded leader address failed [`is_valid_leader_url`].
+    #[error("leader address rejected: {0}")]
+    BadLeaderAddress(String),
+    /// The relay could not reach the leader, or the leader refused.
+    #[error("propose relay failed: {0}")]
+    Relay(String),
+    /// The local or relayed apply failed with an application error.
+    #[error("{0}")]
+    Apply(String),
+}
+
+/// Propose `cmd` to this group from ANY node: a plain `client_write` when
+/// this node leads, an HTTP relay of the JSON-encoded command to the
+/// leader's network router (`{raft_addr}/propose`) when it does not. One
+/// retry after a relayed "leadership moved" answer, with a fresh leader
+/// lookup in between.
+///
+/// The wire is JSON in both directions — commands are constrained to
+/// postcard-safe shapes by the log, but RESPONSES never ride the log and
+/// may carry `serde_json::Value` state postcard cannot decode.
+///
+/// The relay dials a membership-supplied URL, so it uses a no-redirect
+/// client and [`is_valid_leader_url`] — the same SSRF posture as the
+/// request-forwarding middleware above.
+pub async fn propose_via_leader<C>(raft: &Raft<C>, cmd: C::D) -> Result<C::R, ProposeError>
+where
+    C: crate::config::FlureeRaftConfig,
+    C::D: Clone + serde::Serialize,
+{
+    let mut last_relay_error: Option<ProposeError> = None;
+    for _attempt in 0..2 {
+        match raft.client_write(cmd.clone()).await {
+            Ok(resp) => return Ok(resp.data),
+            Err(openraft::error::RaftError::APIError(
+                openraft::error::ClientWriteError::ForwardToLeader(fwd),
+            )) => {
+                let Some(node) = fwd.leader_node else {
+                    return Err(ProposeError::NoLeader);
+                };
+                match relay_propose::<C>(&node.raft_addr, &cmd).await {
+                    Ok(data) => return Ok(data),
+                    Err(e @ ProposeError::Relay(_)) => {
+                        // Leadership may have moved mid-relay; loop for
+                        // one fresh lookup.
+                        last_relay_error = Some(e);
+                        continue;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+            Err(openraft::error::RaftError::APIError(
+                openraft::error::ClientWriteError::ChangeMembershipError(e),
+            )) => return Err(ProposeError::Apply(format!("membership error: {e}"))),
+            Err(openraft::error::RaftError::Fatal(f)) => {
+                return Err(ProposeError::Apply(format!("raft fatal: {f}")))
+            }
+        }
+    }
+    Err(last_relay_error.unwrap_or(ProposeError::NoLeader))
+}
+
+async fn relay_propose<C>(leader_raft_addr: &str, cmd: &C::D) -> Result<C::R, ProposeError>
+where
+    C: crate::config::FlureeRaftConfig,
+    C::D: serde::Serialize,
+{
+    if !is_valid_leader_url(leader_raft_addr, true) {
+        return Err(ProposeError::BadLeaderAddress(leader_raft_addr.to_string()));
+    }
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    let client = CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            // Membership-supplied URL: never follow a redirect off it.
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("propose relay client builds")
+    });
+    let url = format!("{}/propose", leader_raft_addr.trim_end_matches('/'));
+    let body = serde_json::to_vec(cmd)
+        .map_err(|e| ProposeError::Apply(format!("command encode error: {e}")))?;
+    let resp = client
+        .post(&url)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| ProposeError::Relay(format!("POST {url}: {e}")))?;
+    let status = resp.status();
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| ProposeError::Relay(format!("read {url}: {e}")))?;
+    if status == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+        return Err(ProposeError::Relay(format!(
+            "leader at {url} stepped down mid-relay"
+        )));
+    }
+    if !status.is_success() {
+        return Err(ProposeError::Apply(format!(
+            "{url} answered {status}: {}",
+            String::from_utf8_lossy(&bytes)
+        )));
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|e| ProposeError::Apply(format!("response decode error: {e}")))
+}

--- a/fluree-raft-core/src/network.rs
+++ b/fluree-raft-core/src/network.rs
@@ -41,7 +41,8 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use axum::Router;
 use openraft::error::{
-    Fatal, InstallSnapshotError, NetworkError, RPCError, RaftError, RemoteError, Unreachable,
+    ClientWriteError, Fatal, InstallSnapshotError, NetworkError, RPCError, RaftError, RemoteError,
+    Unreachable,
 };
 use openraft::network::{RPCOption, RaftNetwork, RaftNetworkFactory};
 use openraft::raft::{
@@ -55,6 +56,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 const PATH_APPEND_ENTRIES: &str = "/append-entries";
+/// Client-write relay: a follower posts a command here on the LEADER's
+/// router when its own `client_write` answered `ForwardToLeader`. JSON
+/// both ways — unlike the Raft RPCs, application responses may carry
+/// `serde_json::Value` state, which postcard cannot decode.
+const PATH_PROPOSE: &str = "/propose";
 const PATH_VOTE: &str = "/vote";
 const PATH_INSTALL_SNAPSHOT: &str = "/install-snapshot";
 
@@ -496,7 +502,58 @@ pub fn router<C: FlureeRaftConfig>(raft: Arc<Raft<C>>, config: &RaftTransportCon
                 config.install_snapshot_max_body_bytes,
             )),
         )
+        .route(
+            PATH_PROPOSE,
+            post(handle_propose::<C>)
+                .layer(DefaultBodyLimit::max(config.append_entries_max_body_bytes)),
+        )
         .with_state(raft)
+}
+
+/// The receiving half of [`crate::forward::propose_via_leader`]: decode
+/// the JSON command, `client_write` it locally, answer the JSON response.
+/// Leadership can move between the caller's lookup and this apply — that
+/// answers 503 so the caller re-resolves and retries, exactly the
+/// contract the peer-trusted listener's other endpoints keep.
+async fn handle_propose<C: FlureeRaftConfig>(
+    State(raft): State<Arc<Raft<C>>>,
+    body: axum::body::Bytes,
+) -> Response {
+    let cmd: C::D = match serde_json::from_slice(&body) {
+        Ok(cmd) => cmd,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("propose decode error: {e}"),
+            )
+                .into_response()
+        }
+    };
+    match raft.client_write(cmd).await {
+        Ok(resp) => match serde_json::to_vec(&resp.data) {
+            Ok(bytes) => (
+                StatusCode::OK,
+                [(reqwest::header::CONTENT_TYPE, "application/json")],
+                bytes,
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("propose response encode error: {e}"),
+            )
+                .into_response(),
+        },
+        Err(RaftError::APIError(ClientWriteError::ForwardToLeader(_))) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "not the leader; re-resolve and retry".to_string(),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("propose failed: {e}"),
+        )
+            .into_response(),
+    }
 }
 
 /// Decode a postcard-encoded request body. Failure → 400.

--- a/fluree-raft-core/tests/multi_node_group.rs
+++ b/fluree-raft-core/tests/multi_node_group.rs
@@ -251,3 +251,50 @@ async fn a_task_that_ignores_cancellation_is_aborted_after_the_grace_period() {
         "an aborted straggler must actually be stopped once shutdown returns",
     );
 }
+
+/// Any node can accept a proposal: a FOLLOWER's `propose_via_leader`
+/// relays the command to the leader's `/propose` endpoint, the apply
+/// replicates, and the follower gets the application response back —
+/// the contract that lets a load balancer spread writes across a
+/// group's nodes instead of pinning them to whoever leads.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_follower_propose_relays_to_the_leader_and_applies() {
+    let group_id = GroupId::new("counter").expect("valid group id");
+    let nodes: Vec<CounterNode> = vec![
+        start_node(1, &group_id, |_| {}).await,
+        start_node(2, &group_id, |_| {}).await,
+        start_node(3, &group_id, |_| {}).await,
+    ];
+    form_cluster(&nodes).await;
+
+    let leader_id = leader(&nodes).await.id;
+    let follower = nodes
+        .iter()
+        .find(|n| n.id != leader_id)
+        .expect("two followers exist");
+
+    // Direct client_write on the follower refuses — the baseline the
+    // relay exists to fix.
+    let direct = follower
+        .group
+        .raft
+        .client_write(CounterCommand::Add(1))
+        .await;
+    assert!(
+        direct.is_err(),
+        "a follower's direct client_write must refuse"
+    );
+
+    // The relayed propose lands.
+    fluree_raft_core::forward::propose_via_leader(&follower.group.raft, CounterCommand::Add(41))
+        .await
+        .expect("relayed propose applies");
+
+    for node in &nodes {
+        let id = node.id;
+        eventually(&format!("node {id} to converge on 41"), || async {
+            node.group.state.read().await.value == 41
+        })
+        .await;
+    }
+}


### PR DESCRIPTION
## Problem

Every zero-change write routed through the raft committer hung until the waiter timed out with `submission stranded by leader transition`.

The commit worker's no-change arm completes a zero-change transaction by republishing the branch's **current** head unchanged — same `t`, same commit id. `apply_head`'s monotonicity guard (which exists to refuse stale writers) rejected exactly that shape (`commit_t <= current_t`) and pushed the queue entry back for retry. Re-staging a no-op can only reproduce the same unchanged head, so the submission looped re-stage → reject forever.

## Fix

Equal `t` **and** equal commit id is now recognized as the designed no-op completion:

- the queue entry is consumed and the idempotency record cached
- the ref is deliberately left untouched, so `last_advanced_*` stamps keep pointing at the last real advance

A same-`t` publish with a **different** commit id is still a stale writer and is still refused, so the guard's safety property is unchanged.

## Testing

- New regression test `apply_head_completes_a_no_op_republish_of_the_current_head` pins the completion behavior (entry consumed, ref untouched, stale same-`t`/different-id still rejected)
- `cargo test -p fluree-db-consensus`