### PR TITLE
fix(query): let OPTIONAL extend a row that left the shared variable unbound

### DIFF
--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -437,6 +437,10 @@ name = "query_hot_property_path"
 harness = false
 
 [[bench]]
+name = "query_hot_optional"
+harness = false
+
+[[bench]]
 name = "query_hot_whole_graph_agg"
 harness = false
 

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -312,6 +312,11 @@ path = "tests/it_cypher_import.rs"
 name = "it_query_explain"
 path = "tests/it_query_explain.rs"
 
+# Own binary: needs the background indexer to reach the indexed OPTIONAL lane.
+[[test]]
+name = "it_optional_after_union"
+path = "tests/it_optional_after_union.rs"
+
 [[test]]
 name = "it_query_sparql_indexed"
 path = "tests/it_query_sparql_indexed.rs"

--- a/fluree-db-api/benches/query_hot_optional.rs
+++ b/fluree-db-api/benches/query_hot_optional.rs
@@ -1,0 +1,242 @@
+//! Hot-cache latency of the four `OPTIONAL` execution lanes.
+//!
+//! `OptionalOperator` (`fluree-db-query/src/optional.rs`) is a hot operator
+//! with four builders, each with its own admission gates, its own batched
+//! probe, and its own fall-back to a per-row subplan rebuild — and until this
+//! bench, nothing in `regression-budget.json` covered any of it. The lanes are
+//! separated deliberately: a change that widens one builder's decline
+//! condition moves only that scenario, and the per-row rebuild it falls back
+//! to is an order of magnitude slower than the batched probe it replaces, so
+//! the signal is unmissable when it happens.
+//!
+//! 1. **`single_triple_probe`** — `OPTIONAL { ?s ex:email ?e }` with a
+//!    left-bound subject. `PatternOptionalBuilder::build_batch`'s batched
+//!    subject probe, plus the result cache on the fan-out.
+//! 2. **`object_correlated`** — `?s ex:tag ?t . OPTIONAL { ?s ex:altTag ?t }`.
+//!    The object variable is shared with the required side, so the batched
+//!    probe (which reads the object off the plan-time template) is declined
+//!    and the per-row substituted scan runs instead. This is also the shape
+//!    whose result-cache key must key the pushed-down literal, so it is where
+//!    a cache-hit-rate change shows up.
+//! 3. **`multi_pattern_hash_join`** — a two-pattern correlated `OPTIONAL`
+//!    routing to `PlanTreeOptionalBuilder`'s batched hash left-join: one inner
+//!    scan for the whole coalesced driving side, partitioned by correlation
+//!    key.
+//! 4. **`unbound_filter_operand`** — the same hash-join lane, but a `UNION`
+//!    leaves the `FILTER`'s operand unbound on half the driving rows. The
+//!    operand is a correlation variable the inner can only READ, so those rows
+//!    must stay on the batched lane; if the lane's unbound-correlation bail
+//!    ever widens back to every correlation column, the whole driving side
+//!    falls to the per-row rebuild and this scenario blows out by an order of
+//!    magnitude (measured 46.7s → 555.2s on a 7,500-row driving side, debug).
+//!
+//! ## Setup discipline
+//!
+//! Mirrors `query_hot_property_path.rs`: build once per scale, populate a
+//! file-backed ledger, full reindex behind the binary columnar index, then
+//! reuse the `GraphSnapshot` for all `b.iter` calls (warm-cache). The indexed
+//! view matters here — three of the four lanes only exist behind a binary
+//! store.
+//!
+//! ## Matrix
+//!
+//!   inputs:    BenchScale → n_persons, each with `FRIENDS` friend edges,
+//!              a name, a tag, an alternate tag, and (half of them) an email
+//!              (Tiny=200, Small=1_000, Medium=5_000, Large=20_000)
+//!   metric:    ns/query (criterion default)
+//!
+//! ## Running
+//!
+//!   cargo bench -p fluree-db-api --bench query_hot_optional
+//!   cargo bench -p fluree-db-api --bench query_hot_optional -- --test
+//!   FLUREE_BENCH_SCALE=medium cargo bench -p fluree-db-api --bench query_hot_optional
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use fluree_bench_support::{
+    bench_runtime, current_profile, current_scale, init_tracing_for_bench, next_ledger_alias,
+    BenchScale,
+};
+use fluree_db_api::admin::ReindexOptions;
+use fluree_db_api::{CommitOpts, Fluree, FlureeBuilder, IndexConfig, TxnOpts};
+use std::fmt::Write as _;
+
+/// Friend edges per person. Small and fixed so the left join's fan-out stays
+/// linear in `n_persons`.
+const FRIENDS: usize = 4;
+
+/// Distinct tag values, so the object-correlated scenario has real fan-out on
+/// the required side rather than one row per subject.
+const TAGS: usize = 8;
+
+fn scale_n_persons(scale: BenchScale) -> usize {
+    match scale {
+        BenchScale::Tiny => 200,
+        BenchScale::Small => 1_000,
+        BenchScale::Medium => 5_000,
+        BenchScale::Large => 20_000,
+    }
+}
+
+/// Lane 1: single-triple `OPTIONAL` on a left-bound subject — the batched
+/// subject probe. Half the subjects have no email, so the no-match (padded
+/// row) path is exercised too.
+const Q_SINGLE: &str = r"
+PREFIX ex: <http://example.org/opt/>
+SELECT ?s ?e WHERE { ?s ex:name ?n . OPTIONAL { ?s ex:email ?e } }
+";
+
+/// Lane 2: the object variable is shared with the required side, so the
+/// batched probe is declined and the per-row substituted scan runs with the
+/// row's own literal pushed into the object slot.
+const Q_OBJECT_CORR: &str = r"
+PREFIX ex: <http://example.org/opt/>
+SELECT ?s ?t WHERE { ?s ex:tag ?t . OPTIONAL { ?s ex:altTag ?t } }
+";
+
+/// Lane 3: two-pattern correlated `OPTIONAL` — `PlanTreeOptionalBuilder`'s
+/// batched hash left-join over the coalesced driving side.
+const Q_MULTI: &str = r"
+PREFIX ex: <http://example.org/opt/>
+SELECT ?s ?f ?fn WHERE {
+  ?s ex:name ?n .
+  OPTIONAL { ?s ex:friend ?f . ?f ex:name ?fn }
+}
+";
+
+/// Lane 3 with an unbound FILTER operand on half the driving rows. `?age` is a
+/// correlation variable the inner can only READ, so the rows that leave it
+/// unbound are answered by the padded row and must not take the batch off the
+/// hash-join lane.
+const Q_UNBOUND_FILTER: &str = r"
+PREFIX ex: <http://example.org/opt/>
+SELECT ?s ?f WHERE {
+  { { ?s ex:name ?n . ?s ex:age ?age } UNION { ?s ex:name ?n } }
+  OPTIONAL { ?s ex:friend ?f . FILTER(?age > 20) }
+}
+";
+
+/// Generate the person graph as Turtle.
+///
+/// Per person `i`:
+/// - `ex:name` (the driving-side triple every scenario starts from)
+/// - `ex:age` (bound on one UNION branch, unbound on the other)
+/// - `ex:tag` / `ex:altTag` — the same literal, so the object-correlated
+///   `OPTIONAL` matches rather than padding
+/// - `FRIENDS` `ex:friend` edges into the ring
+/// - `ex:email` on even `i` only, so the single-triple lane exercises both the
+///   match and the no-match path
+fn person_graph_turtle(n_persons: usize) -> String {
+    let mut ttl = String::with_capacity(n_persons * 160);
+    ttl.push_str("@prefix ex: <http://example.org/opt/> .\n");
+    ttl.push_str("@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n");
+    for i in 0..n_persons {
+        let tag = i % TAGS;
+        let _ = writeln!(ttl, "ex:p{i} ex:name \"person-{i}\" .");
+        let _ = writeln!(ttl, "ex:p{i} ex:age \"{}\"^^xsd:integer .", 18 + (i % 50));
+        let _ = writeln!(ttl, "ex:p{i} ex:tag \"tag-{tag}\" .");
+        let _ = writeln!(ttl, "ex:p{i} ex:altTag \"tag-{tag}\" .");
+        if i % 2 == 0 {
+            let _ = writeln!(ttl, "ex:p{i} ex:email \"p{i}@example.org\" .");
+        }
+        for k in 1..=FRIENDS {
+            let f = (i + k) % n_persons;
+            let _ = writeln!(ttl, "ex:p{i} ex:friend ex:p{f} .");
+        }
+    }
+    ttl
+}
+
+/// Build a populated, indexed file-backed Fluree ready for hot-cache OPTIONAL
+/// benchmarking (same discipline as `query_hot_property_path.rs`).
+async fn setup_indexed(n_persons: usize) -> (tempfile::TempDir, Fluree, String) {
+    let db_dir = tempfile::tempdir().expect("db tmpdir");
+    let fluree = FlureeBuilder::file(db_dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file-backed Fluree");
+
+    let alias = next_ledger_alias("query-hot-optional");
+    let ledger = fluree.create_ledger(&alias).await.expect("create_ledger");
+
+    let turtle = person_graph_turtle(n_persons);
+
+    // High thresholds during populate so the foreground commit doesn't race
+    // with background indexing — we run an explicit reindex below.
+    let index_config = IndexConfig {
+        reindex_min_bytes: 5_000_000_000,
+        reindex_max_bytes: 5_000_000_000,
+    };
+    let _ = fluree
+        .insert_turtle_with_opts(
+            ledger,
+            &turtle,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &index_config,
+            None,
+        )
+        .await
+        .expect("populate insert");
+
+    let _ = fluree
+        .reindex(&alias, ReindexOptions::default())
+        .await
+        .expect("reindex");
+
+    (db_dir, fluree, alias)
+}
+
+fn bench_query_hot_optional(c: &mut Criterion) {
+    init_tracing_for_bench();
+    let rt = bench_runtime();
+    let scale = current_scale();
+    let profile = current_profile();
+    let n_persons = scale_n_persons(scale);
+
+    eprintln!(
+        "  [query_hot_optional] scale={} n_persons={} (x{} friend edges)",
+        scale.as_str(),
+        n_persons,
+        FRIENDS
+    );
+
+    // Setup once per scale; `snapshot` borrows from `fluree`, both held in
+    // scope for the group's duration.
+    let (_db_dir, fluree, alias) = rt.block_on(setup_indexed(n_persons));
+    let snapshot = rt.block_on(async { fluree.graph(&alias).load().await.expect("graph load") });
+
+    let mut group = c.benchmark_group("query_hot_optional");
+    group.sample_size(profile.sample_size());
+    group.sampling_mode(criterion::SamplingMode::Flat);
+
+    for (name, query) in [
+        ("single_triple_probe", Q_SINGLE),
+        ("object_correlated", Q_OBJECT_CORR),
+        ("multi_pattern_hash_join", Q_MULTI),
+        ("unbound_filter_operand", Q_UNBOUND_FILTER),
+    ] {
+        group.bench_with_input(
+            BenchmarkId::new(name, scale.as_str()),
+            &n_persons,
+            |b, _| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let result = snapshot
+                            .query()
+                            .sparql(query)
+                            .execute()
+                            .await
+                            .unwrap_or_else(|e| panic!("{name} execute: {e}"));
+                        black_box(result);
+                    });
+                });
+            },
+        );
+    }
+
+    group.finish();
+    drop(snapshot);
+    drop(fluree);
+}
+
+criterion_group!(benches, bench_query_hot_optional);
+criterion_main!(benches);

--- a/fluree-db-api/tests/it_optional_after_union.rs
+++ b/fluree-db-api/tests/it_optional_after_union.rs
@@ -339,6 +339,15 @@ async fn indexed_optional_extends_union_unbound_rows() {
             trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
             wait_for_index_application(&fluree, ledger_id, ledger.t()).await;
             let view = fluree.db(ledger_id).await.expect("indexed view");
+            // Lane guard. Post-fix this shape declines the batched probe, so
+            // without this a lost indexer race would silently downgrade the
+            // whole test to a second novelty-lane assertion — which passes on
+            // the unfixed engine too.
+            assert!(
+                view.binary_store().is_some(),
+                "the indexed lane needs a binary store on the view; without one this test is a \
+                 duplicate of the novelty-lane one"
+            );
 
             let with_optional = fluree
                 .query(

--- a/fluree-db-api/tests/it_optional_after_union.rs
+++ b/fluree-db-api/tests/it_optional_after_union.rs
@@ -1,4 +1,4 @@
-//! `OPTIONAL` over a variable a preceding `UNION` left unbound (SPARQL 1.1
+//! `OPTIONAL` over a shared variable the required row left UNBOUND (SPARQL 1.1
 //! §18.2.4 `LeftJoin`).
 //!
 //! ```sparql
@@ -14,14 +14,27 @@
 //! with one that binds it, so the left join must EXTEND those four rows rather
 //! than pass them through — thirteen rows, not ten.
 //!
+//! The merge that fixes this asks only whether the required row's column is
+//! `Binding::Unbound`, never how it got that way, so the same tests cover the
+//! other way a variable arrives unbound: a `VALUES` row with an `UNDEF` cell,
+//! which lowers to exactly that binding and has no `UNION` anywhere.
+//!
 //! The property that cannot be satisfied by accident is the second assertion in
 //! each test: deleting the `OPTIONAL` clause outright must change the answer.
 //! Before the fix the two queries returned byte-identical rows, which is the
 //! sharpest possible statement of a left join contributing nothing.
 //!
-//! Both lanes are covered on purpose. The novelty lane and the indexed lane
-//! reach the OPTIONAL through different code (per-row substituted scan +
-//! result cache vs. the batched subject probe), and they failed differently.
+//! Every lane is covered on purpose, because they reach the OPTIONAL through
+//! different code and failed differently: the novelty lane's per-row
+//! substituted scan plus result cache, the indexed lane's batched subject
+//! probe, `PlanTreeOptionalBuilder`'s correlation-key partition for a
+//! multi-pattern inner, and `GroupedPatternOptionalBuilder`'s per-subject star
+//! probe for a chain of single-triple OPTIONALs. SPARQL and JSON-LD share the
+//! IR, so the surfaces are pinned in pairs.
+//!
+//! The `Binding::Poisoned` door — a second `OPTIONAL` on a variable an earlier
+//! `OPTIONAL` failed to bind — is deliberately NOT covered here; poison blocks
+//! matching by design and unpicking that is #1734.
 
 #![cfg(feature = "native")]
 
@@ -371,4 +384,271 @@ async fn indexed_optional_extends_union_unbound_rows() {
             );
         })
         .await;
+}
+
+// ---------------------------------------------------------------------------
+// `VALUES … UNDEF`: the same unbound column, reached without a UNION.
+// ---------------------------------------------------------------------------
+
+/// The five named subjects, with `?f` supplied as `UNDEF` on every row.
+const VALUES_UNDEF: &str = "VALUES (?s ?f) { \
+     (ex:alice UNDEF) (ex:cam UNDEF) (ex:liam UNDEF) \
+     (ex:brian UNDEF) (ex:nikola UNDEF) } ";
+
+/// The same left join with no `VALUES` at all — the answer the `UNDEF` column
+/// must not change.
+const OPTIONAL_ONLY: &str = "SELECT ?s ?f WHERE { \
+     ?s schema:name ?name . \
+     OPTIONAL { ?s ex:friend ?f } }";
+
+/// `ex:alice` has one friend, `ex:cam` two, `ex:liam` three; `ex:brian` and
+/// `ex:nikola` have none and pass through unbound. 1 + 2 + 3 + 1 + 1 = 8.
+fn expected_friends_left_join() -> Vec<Value> {
+    normalize_rows(&json!([
+        ["ex:alice", "ex:brian"],
+        ["ex:cam", "ex:alice"],
+        ["ex:cam", "ex:brian"],
+        ["ex:liam", "ex:alice"],
+        ["ex:liam", "ex:brian"],
+        ["ex:liam", "ex:cam"],
+        ["ex:brian", null],
+        ["ex:nikola", null]
+    ]))
+}
+
+fn jsonld_optional_only() -> Value {
+    json!({
+        "@context": query_context(),
+        "select": ["?s", "?f"],
+        "where": [
+            {"@id": "?s", "schema:name": "?name"},
+            ["optional", {"@id": "?s", "ex:friend": "?f"}]
+        ]
+    })
+}
+
+fn jsonld_values_undef_then_optional() -> Value {
+    json!({
+        "@context": query_context(),
+        "select": ["?s", "?f"],
+        "where": [
+            {"@id": "?s", "schema:name": "?name"},
+            ["values", [["?s", "?f"], [
+                [{"@type": "@id", "@value": "ex:alice"}, null],
+                [{"@type": "@id", "@value": "ex:cam"}, null],
+                [{"@type": "@id", "@value": "ex:liam"}, null],
+                [{"@type": "@id", "@value": "ex:brian"}, null],
+                [{"@type": "@id", "@value": "ex:nikola"}, null]
+            ]]],
+            ["optional", {"@id": "?s", "ex:friend": "?f"}]
+        ]
+    })
+}
+
+/// Assert the exact row multiset, plus the property that the `UNDEF` column
+/// changed nothing: an `UNDEF` cell is a variable the row leaves unbound, so
+/// the left join must produce the same solutions as if the `VALUES` were not
+/// there at all. Before the fix this returned eight rows with `?f` null on
+/// every one — the friends were found and then thrown away.
+fn assert_undef_column_is_transparent(lane: &str, with_values: &[Value], without_values: &[Value]) {
+    assert_eq!(
+        without_values,
+        expected_friends_left_join(),
+        "{lane}: the plain left join must be the eight solutions the UNDEF form is measured \
+         against"
+    );
+    assert_eq!(
+        with_values, without_values,
+        "{lane}: an UNDEF cell leaves ?f unbound, so OPTIONAL must extend it exactly as it does \
+         when no VALUES clause is present"
+    );
+    assert_eq!(
+        with_values,
+        expected_friends_left_join(),
+        "{lane}: OPTIONAL must extend the rows VALUES left ?f unbound on"
+    );
+}
+
+#[tokio::test]
+async fn sparql_optional_extends_values_undef_rows() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_novelty(&fluree, "optional-after-union:values-undef").await;
+    let db = graphdb_from_ledger(&ledger);
+
+    let with_undef = format!(
+        "SELECT ?s ?f WHERE {{ ?s schema:name ?name . {VALUES_UNDEF} \
+         OPTIONAL {{ ?s ex:friend ?f }} }}"
+    );
+
+    let with_values = fluree
+        .query(&db, QueryInput::Sparql(&format!("{PREFIXES}{with_undef}")))
+        .await
+        .expect("query with VALUES … UNDEF");
+    let without_values = fluree
+        .query(
+            &db,
+            QueryInput::Sparql(&format!("{PREFIXES}{OPTIONAL_ONLY}")),
+        )
+        .await
+        .expect("query without VALUES");
+
+    assert_undef_column_is_transparent(
+        "sparql/values-undef",
+        &rows(&with_values, &ledger.snapshot),
+        &rows(&without_values, &ledger.snapshot),
+    );
+}
+
+#[tokio::test]
+async fn jsonld_optional_extends_values_undef_rows() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_novelty(&fluree, "optional-after-union:values-undef-jsonld").await;
+
+    let with_values = support::query_jsonld(&fluree, &ledger, &jsonld_values_undef_then_optional())
+        .await
+        .expect("query with VALUES … UNDEF");
+    let without_values = support::query_jsonld(&fluree, &ledger, &jsonld_optional_only())
+        .await
+        .expect("query without VALUES");
+
+    assert_undef_column_is_transparent(
+        "json-ld/values-undef",
+        &rows(&with_values, &ledger.snapshot),
+        &rows(&without_values, &ledger.snapshot),
+    );
+}
+
+/// The `UNDEF` form on `PlanTreeOptionalBuilder`'s lane. Every friend has a
+/// `schema:name`, so the second inner pattern removes nothing and the answer is
+/// the same eight rows — but at the merge-base this returned five, all null:
+/// the correlation-key partition lost the multiplicity as well as the binding.
+#[tokio::test]
+async fn multi_pattern_optional_extends_values_undef_rows() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_novelty(&fluree, "optional-after-union:values-undef-multi").await;
+    let db = graphdb_from_ledger(&ledger);
+
+    let multi_pattern = format!(
+        "SELECT ?s ?f WHERE {{ ?s schema:name ?name . {VALUES_UNDEF} \
+         OPTIONAL {{ ?s ex:friend ?f . ?f schema:name ?fname }} }}"
+    );
+
+    let with_values = fluree
+        .query(
+            &db,
+            QueryInput::Sparql(&format!("{PREFIXES}{multi_pattern}")),
+        )
+        .await
+        .expect("query with multi-pattern OPTIONAL");
+    let without_values = fluree
+        .query(
+            &db,
+            QueryInput::Sparql(&format!("{PREFIXES}{OPTIONAL_ONLY}")),
+        )
+        .await
+        .expect("query without VALUES");
+
+    assert_undef_column_is_transparent(
+        "sparql/values-undef/multi-pattern",
+        &rows(&with_values, &ledger.snapshot),
+        &rows(&without_values, &ledger.snapshot),
+    );
+}
+
+/// A correlation variable the OPTIONAL can only READ, left unbound by the
+/// UNION's second branch.
+///
+/// `?age` reaches `PlanTreeOptionalBuilder`'s correlation set through the
+/// FILTER, but no inner pattern can bind it, so an unbound `?age` makes the
+/// filter an error under correlated and independent evaluation alike and the
+/// row's answer is the padded one either way. This pins that answer, so the
+/// scoping that keeps these rows on the batched hash-join lane cannot quietly
+/// change it: four `?age`-bound rows join or don't on the filter, and the five
+/// `?age`-unbound rows pass through — ten in all.
+#[tokio::test]
+async fn optional_reading_an_unbound_filter_operand_pads_the_row() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_novelty(&fluree, "optional-after-union:filter-operand").await;
+    let db = graphdb_from_ledger(&ledger);
+
+    let query = "SELECT ?s ?age ?f WHERE { \
+         { { ?s schema:name ?n . ?s schema:age ?age } UNION { ?s schema:name ?n } } \
+         OPTIONAL { ?s ex:friend ?f . FILTER(?age > 20) } }";
+
+    let result = fluree
+        .query(&db, QueryInput::Sparql(&format!("{PREFIXES}{query}")))
+        .await
+        .expect("query");
+
+    assert_eq!(
+        rows(&result, &ledger.snapshot),
+        normalize_rows(&json!([
+            // ?age bound: alice and cam clear the filter, brian has no friends,
+            // liam is 13.
+            ["ex:alice", 50, "ex:brian"],
+            ["ex:brian", 50, null],
+            ["ex:cam", 34, "ex:alice"],
+            ["ex:cam", 34, "ex:brian"],
+            ["ex:liam", 13, null],
+            // ?age unbound: `?age > 20` is an error, so no friend joins.
+            ["ex:alice", null, null],
+            ["ex:brian", null, null],
+            ["ex:cam", null, null],
+            ["ex:liam", null, null],
+            ["ex:nikola", null, null]
+        ]))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The grouped lane: a chain of single-triple OPTIONALs on one subject.
+// ---------------------------------------------------------------------------
+
+/// Two chained single-triple `OPTIONAL`s on the same subject route to
+/// `GroupedPatternOptionalBuilder`
+/// (`where_plan.rs::collect_grouped_single_triple_optionals`), a fourth lane
+/// with its own merge. Its object variables are structurally optional-only, but
+/// its SUBJECT only has to be PRESENT in the required schema — the UNION's
+/// second branch leaves it unbound on one row.
+///
+/// The failure mode this pins is the nastier one: not a solution missing a
+/// binding, but a solution reporting an email and an age for a subject it
+/// declines to name.
+#[tokio::test]
+async fn grouped_optional_chain_binds_the_subject_the_union_left_unbound() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_novelty(&fluree, "optional-after-union:grouped").await;
+    let db = graphdb_from_ledger(&ledger);
+
+    let query = "SELECT ?s ?e ?a WHERE { \
+         { { ?s schema:name ?n } UNION { ex:nikola schema:name ?nn } } \
+         OPTIONAL { ?s schema:email ?e } \
+         OPTIONAL { ?s schema:age ?a } }";
+
+    let result = fluree
+        .query(&db, QueryInput::Sparql(&format!("{PREFIXES}{query}")))
+        .await
+        .expect("query");
+    let actual = rows(&result, &ledger.snapshot);
+
+    assert!(
+        actual
+            .iter()
+            .all(|row| !row.as_array().expect("row array")[0].is_null()),
+        "no solution may report an email/age for a subject it leaves unbound; got {actual:#?}"
+    );
+    assert_eq!(
+        actual,
+        normalize_rows(&json!([
+            ["ex:alice", "alice@example.org", 50],
+            ["ex:brian", "brian@example.org", 50],
+            ["ex:cam", "cam@example.org", 34],
+            ["ex:liam", "liam@example.org", 13],
+            ["ex:nikola", null, null],
+            ["ex:alice", "alice@example.org", 50],
+            ["ex:brian", "brian@example.org", 50],
+            ["ex:cam", "cam@example.org", 34],
+            ["ex:liam", "liam@example.org", 13]
+        ]))
+    );
 }

--- a/fluree-db-api/tests/it_optional_after_union.rs
+++ b/fluree-db-api/tests/it_optional_after_union.rs
@@ -1,0 +1,365 @@
+//! `OPTIONAL` over a variable a preceding `UNION` left unbound (SPARQL 1.1
+//! §18.2.4 `LeftJoin`).
+//!
+//! ```sparql
+//! SELECT ?s ?f WHERE {
+//!   ?s schema:name ?name .
+//!   { { ?s ex:friend ?f } UNION { ?s schema:age ?age } }
+//!   OPTIONAL { ?s ex:friend ?f }
+//! }
+//! ```
+//!
+//! The UNION emits ten solutions: six that bind `?f` (branch one) and four that
+//! leave it unbound (branch two). A solution with `?f` unbound IS compatible
+//! with one that binds it, so the left join must EXTEND those four rows rather
+//! than pass them through — thirteen rows, not ten.
+//!
+//! The property that cannot be satisfied by accident is the second assertion in
+//! each test: deleting the `OPTIONAL` clause outright must change the answer.
+//! Before the fix the two queries returned byte-identical rows, which is the
+//! sharpest possible statement of a left join contributing nothing.
+//!
+//! Both lanes are covered on purpose. The novelty lane and the indexed lane
+//! reach the OPTIONAL through different code (per-row substituted scan +
+//! result cache vs. the batched subject probe), and they failed differently.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::{
+    FlureeBuilder, IndexConfig, LedgerManagerConfig, LedgerState, QueryInput, QueryResult,
+};
+use fluree_db_transact::{CommitOpts, TxnOpts};
+use serde_json::{json, Value};
+use support::{
+    genesis_ledger_for_fluree, graphdb_from_ledger, normalize_rows, start_background_indexer_local,
+    trigger_index_and_wait_outcome, wait_for_index_application,
+};
+
+/// `seed_values_dataset` from `it_query_values.rs`, verbatim — the fixture the
+/// issue's row counts were measured on.
+fn seed_data() -> Value {
+    json!({
+        "@context": {
+            "schema": "http://schema.org/",
+            "ex": "http://example.com/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@graph": [
+            {"@id":"ex:brian","schema:name":"Brian","schema:email":"brian@example.org","schema:age":50,"ex:favNums":7},
+            {"@id":"ex:alice","schema:name":"Alice","schema:email":"alice@example.org","schema:age":50,"ex:favNums":[42,76,9],"ex:friend":[{"@id":"ex:brian"}]},
+            {"@id":"ex:cam","schema:name":"Cam","schema:email":"cam@example.org","schema:age":34,"ex:favNums":[5,10],"ex:friend":[{"@id":"ex:alice"},{"@id":"ex:brian"}]},
+            {"@id":"ex:liam","schema:name":"Liam","schema:email":"liam@example.org","schema:age":13,"ex:favNums":[42,11],"ex:friend":[{"@id":"ex:alice"},{"@id":"ex:brian"},{"@id":"ex:cam"}]},
+            {"@id":"ex:nikola",
+             "schema:name":"Nikola",
+             "ex:greeting":[{"@value":"Здраво","@language":"sb"},{"@value":"Hello","@language":"en"}],
+             "ex:birthday":{"@value":"2000-01-01","@type":"xsd:datetime"},
+             "ex:cool":true}
+        ]
+    })
+}
+
+const PREFIXES: &str = "PREFIX ex: <http://example.com/>\n\
+     PREFIX schema: <http://schema.org/>\n";
+
+const UNION_THEN_OPTIONAL: &str = "SELECT ?s ?f WHERE { \
+     ?s schema:name ?name . \
+     { { ?s ex:friend ?f } UNION { ?s schema:age ?age } } \
+     OPTIONAL { ?s ex:friend ?f } }";
+
+/// The same query with the `OPTIONAL` clause deleted.
+const UNION_ONLY: &str = "SELECT ?s ?f WHERE { \
+     ?s schema:name ?name . \
+     { { ?s ex:friend ?f } UNION { ?s schema:age ?age } } }";
+
+fn query_context() -> Value {
+    json!({
+        "schema": "http://schema.org/",
+        "ex": "http://example.com/"
+    })
+}
+
+fn jsonld_union_then_optional() -> Value {
+    json!({
+        "@context": query_context(),
+        "select": ["?s", "?f"],
+        "where": [
+            {"@id": "?s", "schema:name": "?name"},
+            ["union",
+                {"@id": "?s", "ex:friend": "?f"},
+                {"@id": "?s", "schema:age": "?age"}
+            ],
+            ["optional", {"@id": "?s", "ex:friend": "?f"}]
+        ]
+    })
+}
+
+fn jsonld_union_only() -> Value {
+    json!({
+        "@context": query_context(),
+        "select": ["?s", "?f"],
+        "where": [
+            {"@id": "?s", "schema:name": "?name"},
+            ["union",
+                {"@id": "?s", "ex:friend": "?f"},
+                {"@id": "?s", "schema:age": "?age"}
+            ]
+        ]
+    })
+}
+
+/// The ten UNION solutions: six bind `?f`, four leave it unbound. `ex:nikola`
+/// has a name but neither `ex:friend` nor `schema:age`, so neither branch
+/// admits it.
+fn expected_union_only() -> Vec<Value> {
+    normalize_rows(&json!([
+        ["ex:alice", "ex:brian"],
+        ["ex:cam", "ex:alice"],
+        ["ex:cam", "ex:brian"],
+        ["ex:liam", "ex:alice"],
+        ["ex:liam", "ex:brian"],
+        ["ex:liam", "ex:cam"],
+        ["ex:brian", null],
+        ["ex:alice", null],
+        ["ex:cam", null],
+        ["ex:liam", null]
+    ]))
+}
+
+/// §18.2.4 over those ten. The six `?f`-bound rows join to their own friend
+/// triple and come back unchanged. Of the four unbound rows, `ex:brian` has no
+/// friends and passes through unbound, while `ex:alice`/`ex:cam`/`ex:liam` are
+/// extended by their 1/2/3 friends — 6 + 1 + 1 + 2 + 3 = 13.
+fn expected_union_then_optional() -> Vec<Value> {
+    normalize_rows(&json!([
+        ["ex:alice", "ex:brian"],
+        ["ex:cam", "ex:alice"],
+        ["ex:cam", "ex:brian"],
+        ["ex:liam", "ex:alice"],
+        ["ex:liam", "ex:brian"],
+        ["ex:liam", "ex:cam"],
+        ["ex:brian", null],
+        ["ex:alice", "ex:brian"],
+        ["ex:cam", "ex:alice"],
+        ["ex:cam", "ex:brian"],
+        ["ex:liam", "ex:alice"],
+        ["ex:liam", "ex:brian"],
+        ["ex:liam", "ex:cam"]
+    ]))
+}
+
+fn rows(result: &QueryResult, snapshot: &fluree_db_core::LedgerSnapshot) -> Vec<Value> {
+    normalize_rows(&result.to_jsonld(snapshot).expect("to_jsonld"))
+}
+
+/// Assert both the exact row multiset and the delete-the-clause property.
+fn assert_left_join_contributes(lane: &str, with_optional: &[Value], without_optional: &[Value]) {
+    assert_eq!(
+        without_optional,
+        expected_union_only(),
+        "{lane}: the UNION alone must still be the ten solutions the left join starts from"
+    );
+    assert_ne!(
+        with_optional, without_optional,
+        "{lane}: deleting the OPTIONAL must change the answer — identical rows mean the left \
+         join contributed nothing"
+    );
+    assert_eq!(
+        with_optional,
+        expected_union_then_optional(),
+        "{lane}: OPTIONAL must extend the four rows the UNION left ?f unbound on"
+    );
+}
+
+async fn seed_novelty(fluree: &fluree_db_api::Fluree, ledger_id: &str) -> LedgerState {
+    let ledger = genesis_ledger_for_fluree(fluree, ledger_id);
+    fluree
+        .insert(ledger, &seed_data())
+        .await
+        .expect("seed insert")
+        .ledger
+}
+
+#[tokio::test]
+async fn sparql_optional_extends_union_unbound_rows() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_novelty(&fluree, "optional-after-union:sparql").await;
+    let db = graphdb_from_ledger(&ledger);
+
+    let with_optional = fluree
+        .query(
+            &db,
+            QueryInput::Sparql(&format!("{PREFIXES}{UNION_THEN_OPTIONAL}")),
+        )
+        .await
+        .expect("query with OPTIONAL");
+    let without_optional = fluree
+        .query(&db, QueryInput::Sparql(&format!("{PREFIXES}{UNION_ONLY}")))
+        .await
+        .expect("query without OPTIONAL");
+
+    assert_left_join_contributes(
+        "sparql/novelty",
+        &rows(&with_optional, &ledger.snapshot),
+        &rows(&without_optional, &ledger.snapshot),
+    );
+}
+
+#[tokio::test]
+async fn jsonld_optional_extends_union_unbound_rows() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_novelty(&fluree, "optional-after-union:jsonld").await;
+
+    let with_optional = support::query_jsonld(&fluree, &ledger, &jsonld_union_then_optional())
+        .await
+        .expect("query with OPTIONAL");
+    let without_optional = support::query_jsonld(&fluree, &ledger, &jsonld_union_only())
+        .await
+        .expect("query without OPTIONAL");
+
+    assert_left_join_contributes(
+        "json-ld/novelty",
+        &rows(&with_optional, &ledger.snapshot),
+        &rows(&without_optional, &ledger.snapshot),
+    );
+}
+
+/// The merge is not specific to the object position. Here the UNION's second
+/// branch binds neither `?s` nor `?f`, so the single solution it contributes is
+/// compatible with every `ex:friend` triple and the left join extends it into
+/// all six — the six `?f`-bound rows plus six more, twelve in all.
+#[tokio::test]
+async fn optional_extends_a_row_with_no_correlation_bound_at_all() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_novelty(&fluree, "optional-after-union:free").await;
+    let db = graphdb_from_ledger(&ledger);
+
+    let query = "SELECT ?s ?f WHERE { \
+         { { ?s ex:friend ?f } UNION { ex:nikola schema:name ?nn } } \
+         OPTIONAL { ?s ex:friend ?f } }";
+
+    let result = fluree
+        .query(&db, QueryInput::Sparql(&format!("{PREFIXES}{query}")))
+        .await
+        .expect("query");
+
+    assert_eq!(
+        rows(&result, &ledger.snapshot),
+        normalize_rows(&json!([
+            ["ex:alice", "ex:brian"],
+            ["ex:cam", "ex:alice"],
+            ["ex:cam", "ex:brian"],
+            ["ex:liam", "ex:alice"],
+            ["ex:liam", "ex:brian"],
+            ["ex:liam", "ex:cam"],
+            ["ex:alice", "ex:brian"],
+            ["ex:cam", "ex:alice"],
+            ["ex:cam", "ex:brian"],
+            ["ex:liam", "ex:alice"],
+            ["ex:liam", "ex:brian"],
+            ["ex:liam", "ex:cam"]
+        ]))
+    );
+}
+
+/// A two-pattern OPTIONAL routes to `PlanTreeOptionalBuilder` instead of the
+/// single-triple builder, and its batched lane partitions inner results by a
+/// correlation key an unbound variable has no value for. Every friend here has
+/// a `schema:name`, so the second pattern removes no solutions and the answer
+/// is the same thirteen rows.
+#[tokio::test]
+async fn multi_pattern_optional_extends_union_unbound_rows() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_novelty(&fluree, "optional-after-union:multi").await;
+    let db = graphdb_from_ledger(&ledger);
+
+    let multi_pattern = "SELECT ?s ?f WHERE { \
+         ?s schema:name ?name . \
+         { { ?s ex:friend ?f } UNION { ?s schema:age ?age } } \
+         OPTIONAL { ?s ex:friend ?f . ?f schema:name ?fname } }";
+
+    let with_optional = fluree
+        .query(
+            &db,
+            QueryInput::Sparql(&format!("{PREFIXES}{multi_pattern}")),
+        )
+        .await
+        .expect("query with multi-pattern OPTIONAL");
+    let without_optional = fluree
+        .query(&db, QueryInput::Sparql(&format!("{PREFIXES}{UNION_ONLY}")))
+        .await
+        .expect("query without OPTIONAL");
+
+    assert_left_join_contributes(
+        "sparql/multi-pattern",
+        &rows(&with_optional, &ledger.snapshot),
+        &rows(&without_optional, &ledger.snapshot),
+    );
+}
+
+/// The indexed lane reaches the OPTIONAL through `build_batch`'s subject probe
+/// rather than the per-row substituted scan, so it needs its own coverage —
+/// a novelty-only pin would have gone green on a half fix.
+#[tokio::test]
+async fn indexed_optional_extends_union_unbound_rows() {
+    let fluree = FlureeBuilder::memory()
+        .with_ledger_cache_config(LedgerManagerConfig::default())
+        .build_memory();
+    let ledger_id = "optional-after-union:indexed";
+
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .publisher_arc()
+            .expect("test setup requires ReadWrite nameservice mode"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+
+    local
+        .run_until(async move {
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger = genesis_ledger_for_fluree(&fluree, ledger_id);
+            let ledger = fluree
+                .insert_with_opts(
+                    ledger,
+                    &seed_data(),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("seed insert")
+                .ledger;
+
+            trigger_index_and_wait_outcome(&handle, ledger_id, ledger.t()).await;
+            wait_for_index_application(&fluree, ledger_id, ledger.t()).await;
+            let view = fluree.db(ledger_id).await.expect("indexed view");
+
+            let with_optional = fluree
+                .query(
+                    &view,
+                    QueryInput::Sparql(&format!("{PREFIXES}{UNION_THEN_OPTIONAL}")),
+                )
+                .await
+                .expect("query with OPTIONAL");
+            let without_optional = fluree
+                .query(
+                    &view,
+                    QueryInput::Sparql(&format!("{PREFIXES}{UNION_ONLY}")),
+                )
+                .await
+                .expect("query without OPTIONAL");
+
+            assert_left_join_contributes(
+                "sparql/indexed",
+                &rows(&with_optional, &view.snapshot),
+                &rows(&without_optional, &view.snapshot),
+            );
+        })
+        .await;
+}

--- a/fluree-db-query/src/optional.rs
+++ b/fluree-db-query/src/optional.rs
@@ -2294,8 +2294,9 @@ pub struct OptionalOperator {
     /// one of them UNBOUND is still compatible with an optional solution that
     /// binds it, and SPARQL merge (§18.2.4) says the merged solution carries
     /// the optional side's value — so `combine_rows` patches these columns.
-    /// Empty for the overwhelmingly common OPTIONAL that shares only
-    /// already-bound correlation vars, which keeps the merge off the hot path.
+    /// For the canonical `OPTIONAL { ?s :email ?e }` this holds one entry
+    /// (`?s`): the per-row cost is one `is_unbound` test per merge column, and
+    /// the fill scan itself only runs on a column that is actually `Unbound`.
     shared_merge_cols: Vec<(usize, VarId)>,
     /// Memoized optional-side results keyed by correlation bindings.
     ///

--- a/fluree-db-query/src/optional.rs
+++ b/fluree-db-query/src/optional.rs
@@ -307,6 +307,17 @@ impl PatternOptionalBuilder {
     /// through instead of extended. The per-row `build` path substitutes the
     /// row's own object (and leaves an unbound one free), so it is exactly
     /// right here; this shape declines the probe and takes it.
+    ///
+    /// The alternative — widen the probe to materialise the object and let
+    /// `unify_check` filter — was declined because `Binding`'s `PartialEq`
+    /// answers `false`, not an error, across representations (`EncodedSid` vs
+    /// `Sid`, `Sid` vs `Iri`, `EncodedLit` vs `Lit`), so a cross-representation
+    /// object correlation would silently DROP rows; #1729 is a live instance on
+    /// the literal/datatype arm. Note this narrows the exposure rather than
+    /// removing it: `substitute_pattern` leaves a late-materialised
+    /// `EncodedSid`/`EncodedPid`/`EncodedLit` object free, and `unify_check`'s
+    /// `left_val == right_val` is then what enforces the correlation on the
+    /// per-row path too.
     fn object_var_shared_with_required(&self) -> bool {
         matches!(&self.pattern.o, Term::Var(v) if !self.optional_only_vars.contains(v))
     }
@@ -455,21 +466,37 @@ impl PatternOptionalBuilder {
 /// Append one correlation binding to a cache key, or return `false` when it
 /// has no stable encoding (the caller then declines to cache).
 ///
+/// The key is the SUBSTITUTED PATTERN, not the row: this mirrors
+/// [`PatternOptionalBuilder::substitute_pattern`] position by position, so a
+/// slot that substitution pushes a value into is keyed by that value, and a
+/// slot it leaves free gets the same `u` token whatever the row held. Two rows whose
+/// substituted patterns are identical then share one scan — which is what the
+/// cache is for, since `unify_check` re-applies the row's own correlation when
+/// the pending match is drained.
+///
 /// Every variable-length component is length-prefixed so two different
 /// correlation tuples can never concatenate to the same bytes.
-fn push_cache_key_component(key: &mut Vec<u8>, binding: &Binding) -> bool {
+fn push_cache_key_component(
+    key: &mut Vec<u8>,
+    position: PatternPosition,
+    binding: &Binding,
+) -> bool {
     fn push_bytes(key: &mut Vec<u8>, tag: u8, bytes: &[u8]) {
         key.push(tag);
         key.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
         key.extend_from_slice(bytes);
     }
 
+    // `substitute_pattern` leaves the slot a variable, so "free here" is a
+    // correlation state in its own right and gets its own token rather than
+    // colliding with any bound value.
+    fn push_free(key: &mut Vec<u8>) -> bool {
+        key.push(b'u');
+        true
+    }
+
     match binding {
-        Binding::EncodedSid { s_id, .. } => {
-            key.push(b'S');
-            key.extend_from_slice(&s_id.to_le_bytes());
-            true
-        }
+        Binding::Poisoned => false,
         Binding::Sid { sid, .. } => {
             // Fallback stable key: namespace code + suffix bytes.
             key.push(b's');
@@ -481,20 +508,22 @@ fn push_cache_key_component(key: &mut Vec<u8>, binding: &Binding) -> bool {
             push_bytes(key, b'i', iri.as_bytes());
             true
         }
-        // Not a defect: `substitute_pattern` leaves the slot a variable, so
-        // "unbound here" is a correlation state in its own right and must
-        // get its own key rather than collide with any bound value.
-        Binding::Unbound => {
-            key.push(b'u');
+        // Only the SUBJECT slot resolves an encoded id to an IRI and pushes it
+        // down; elsewhere substitution leaves the slot free.
+        Binding::EncodedSid { s_id, .. } if position == PatternPosition::Subject => {
+            key.push(b'S');
+            key.extend_from_slice(&s_id.to_le_bytes());
             true
         }
-        Binding::Poisoned => false,
-        Binding::EncodedPid { .. } | Binding::EncodedLit { .. } | Binding::Lit { .. } => false,
-        Binding::Grouped(_)
-        | Binding::Path { .. }
-        | Binding::Rel(_)
-        | Binding::List(_)
-        | Binding::Map(_) => false,
+        // A literal OBJECT is pushed down by value (plus a string term
+        // constraint), so rows carrying different literals must not share an
+        // entry. Keying it would need a stable byte encoding of every
+        // `FlakeValue`/datatype pair — more than this fix is buying — so the
+        // row goes uncached instead. In every other slot a literal is left
+        // free, like any other unsubstitutable binding.
+        Binding::Lit { .. } if position == PatternPosition::Object => false,
+        // Everything else: substitution's own `_ => leave as variable` arms.
+        _ => push_free(key),
     }
 }
 
@@ -676,11 +705,11 @@ impl OptionalBuilder for PatternOptionalBuilder {
         row: usize,
         ctx: &ExecutionContext<'_>,
     ) -> Result<Option<Box<[u8]>>> {
-        // Key on the FULL substituted correlation tuple — every position
-        // `substitute_pattern` reads, not just the subject. `OPTIONAL { ?s <p> ?o }`
+        // Key on the FULL substituted pattern — every position
+        // `substitute_pattern` touches, not just the subject. `OPTIONAL { ?s <p> ?o }`
         // where `?o` also arrives from the left substitutes the object too, so a
         // subject-only key served one row's answer to a row whose `?o` differed.
-        // For the common shape (a left-bound `?s`, a free `?o`) the tuple is still
+        // For the common shape (a left-bound `?s`, a free `?o`) the key is still
         // just the subject and left-side fan-out reuses right-side results as before.
         let _ = ctx;
         if self.has_poisoned_binding(required_batch, row) {
@@ -700,7 +729,7 @@ impl OptionalBuilder for PatternOptionalBuilder {
                 PatternPosition::Object => b'2',
             });
             let binding = required_batch.get_by_col(row, instr.left_col);
-            if !push_cache_key_component(&mut key, binding) {
+            if !push_cache_key_component(&mut key, instr.position, binding) {
                 return Ok(None);
             }
         }
@@ -731,6 +760,15 @@ pub struct GroupedPatternOptionalBuilder {
     triples: Vec<TriplePattern>,
     optional_only_vars: Vec<VarId>,
     subject_left_col: usize,
+    /// The shared subject variable, so `OptionalOperator` can merge it back.
+    ///
+    /// The subject only has to be PRESENT in the required schema, not bound on
+    /// every row: an upstream UNION / VALUES / OPTIONAL can leave it unbound,
+    /// and §18.2.4 then says the merged solution takes the optional side's
+    /// subject. Without this instruction the operator's `shared_merge_cols` is
+    /// empty for this builder and those rows keep a null subject while carrying
+    /// the objects it was found by — a fabricated solution, not a missing one.
+    unify_instructions: Vec<UnifyInstruction>,
     /// Planning context captured at planner-time for the per-row chain.
     planning: PlanningContext,
 }
@@ -768,11 +806,23 @@ impl GroupedPatternOptionalBuilder {
             optional_only_vars.push(obj_var);
         }
 
+        // The per-row chain (`build_fallback_chain`) seeds the whole required
+        // row and appends the optional vars, so the subject sits at
+        // `subject_left_col` in its output too. The BATCHED lane's schema is
+        // optional-only (`grouped_schema`) and carries no subject column —
+        // sound only because `build_batch` refuses a batch containing an
+        // unbound subject, which is the only case the merge has work to do.
+        let unify_instructions = vec![UnifyInstruction {
+            left_col: subject_left_col,
+            right_col: subject_left_col,
+        }];
+
         Ok(Self {
             required_schema,
             triples,
             optional_only_vars,
             subject_left_col,
+            unify_instructions,
             planning,
         })
     }
@@ -976,6 +1026,28 @@ impl OptionalBuilder for GroupedPatternOptionalBuilder {
                 row_subject_slots.push(None);
                 continue;
             }
+            // An UNBOUND subject is compatible with every triple this group can
+            // find (§18.2.4), and the merged solution takes the subject the
+            // optional side bound. A per-subject probe has no subject to probe
+            // with, and this lane's batches carry only optional-only vars, so
+            // there would be nothing for `combine_rows` to read the subject
+            // back off. Hand the whole batch to the per-row chain, whose output
+            // does carry it. `resolve_subject_id` already declines here; saying
+            // so explicitly keeps the invariant `unify_instructions` relies on
+            // visible at the place that establishes it.
+            if matches!(
+                required_batch.get_by_col(row, self.subject_left_col),
+                Binding::Unbound
+            ) {
+                tracing::debug!(
+                    predicate_count = self.triples.len(),
+                    start_row,
+                    row,
+                    reason = "unbound-subject",
+                    "grouped optional builder fallback"
+                );
+                return Ok(None);
+            }
             let Some(s_id) = self.resolve_subject_id(required_batch, row, ctx)? else {
                 tracing::debug!(
                     predicate_count = self.triples.len(),
@@ -1123,7 +1195,7 @@ impl OptionalBuilder for GroupedPatternOptionalBuilder {
     }
 
     fn unify_instructions(&self) -> &[UnifyInstruction] {
-        &[]
+        &self.unify_instructions
     }
 }
 
@@ -1158,6 +1230,17 @@ pub struct PlanTreeOptionalBuilder {
     unify_instructions: Vec<UnifyInstruction>,
     /// Indices of shared variables in the required schema (for poisoned check)
     shared_var_indices: Vec<usize>,
+    /// Variables the inner patterns can BIND, as opposed to merely read.
+    ///
+    /// Only an unbound correlation variable in here needs `build_batch`'s
+    /// per-row fallback: it is the only kind an inner solution can fill in, and
+    /// a partition by correlation key has no bucket for "matches everything".
+    /// A variable the inner only READS — a FILTER operand — can never be
+    /// extended, so the no-match row the batched lane already emits is right.
+    inner_bindable_vars: HashSet<VarId>,
+    /// True when some inner FILTER could still evaluate `true` with an UNBOUND
+    /// operand, which makes [`Self::inner_bindable_vars`] too narrow a gate.
+    filters_tolerate_unbound: bool,
     /// Stats for nested query optimization
     stats: Option<Arc<StatsView>>,
     /// Planning context captured at planner-time for the per-row inner subplan.
@@ -1226,12 +1309,20 @@ impl PlanTreeOptionalBuilder {
 
         let optional_schema: Arc<[VarId]> = Arc::from(optional_vars.into_boxed_slice());
 
+        let inner_bindable_vars: HashSet<VarId> = inner_patterns
+            .iter()
+            .flat_map(Pattern::produced_vars)
+            .collect();
+        let filters_tolerate_unbound = inner_patterns.iter().any(pattern_filters_tolerate_unbound);
+
         Self {
             inner_patterns,
             optional_schema,
             optional_only_vars,
             unify_instructions,
             shared_var_indices,
+            inner_bindable_vars,
+            filters_tolerate_unbound,
             stats,
             planning,
         }
@@ -1411,28 +1502,46 @@ impl OptionalBuilder for PlanTreeOptionalBuilder {
         let mut seed_rows: Vec<Vec<Binding>> = Vec::new();
         let mut seen_seed: HashSet<Vec<GroupKeyOwned>> = HashSet::new();
         for row in start_row..n {
-            // An UNBOUND correlation variable is compatible with every inner
-            // solution (§18.2.4), which a partition by correlation key cannot
-            // express — the key would have to match every bucket at once, and
-            // the optional-side batches carry only optional-only vars, so
-            // there is nothing for the merge to read the value back off. Hand
-            // the whole batch to the per-row path, which seeds the inner from
-            // the row and leaves the unbound variable free. Poison, by
-            // contrast, can never match anything.
-            let mut unbound_corr = false;
-            let mut poisoned_corr = false;
+            // An UNBOUND correlation variable the inner can BIND is compatible
+            // with every inner solution (§18.2.4), which a partition by
+            // correlation key cannot express — the key would have to match
+            // every bucket at once, and the optional-side batches carry only
+            // optional-only vars, so there is nothing for the merge to read the
+            // value back off. Hand the whole batch to the per-row path, which
+            // seeds the inner from the row and leaves the variable free.
+            //
+            // Scoped to what the inner can bind, not to every correlation
+            // column: `corr_cols` is every required column REFERENCED by the
+            // inner (`Pattern::referenced_vars`), and `Pattern::Filter` is
+            // hash-join safe, so `OPTIONAL { ?s ex:friend ?f . FILTER(?age>20) }`
+            // would otherwise take the whole coalesced driving side off this
+            // lane for one unbound `?age` — while answering identically, since
+            // a filter the inner cannot bind rejects that row either way. Only
+            // a filter that survives an unbound operand (`BOUND`, `||`, …)
+            // reopens the gate.
+            let mut unbound_bindable = false;
+            let mut unmatchable = false;
             for &c in &corr_cols {
                 let b = required_batch.get_by_col(row, c);
                 if matches!(b, Binding::Unbound) {
-                    unbound_corr = true;
-                    break;
+                    if self.filters_tolerate_unbound
+                        || self.inner_bindable_vars.contains(&req_schema[c])
+                    {
+                        unbound_bindable = true;
+                        break;
+                    }
+                    // Read-only and unbound: no inner solution can supply it and
+                    // the filter that reads it errors either way — the no-match
+                    // row is the answer, exactly as before this fix.
+                    unmatchable = true;
+                    continue;
                 }
-                poisoned_corr |= b.is_poisoned();
+                unmatchable |= b.is_poisoned();
             }
-            if unbound_corr {
+            if unbound_bindable {
                 return Ok(None);
             }
-            if poisoned_corr {
+            if unmatchable {
                 row_keys.push(None);
                 continue;
             }
@@ -1588,6 +1697,54 @@ impl OptionalBuilder for PlanTreeOptionalBuilder {
 
     fn unify_instructions(&self) -> &[UnifyInstruction] {
         &self.unify_instructions
+    }
+}
+
+/// Whether a FILTER expression could still evaluate to `true` with one of its
+/// operands UNBOUND.
+///
+/// This decides whether a correlation variable the inner patterns can only
+/// READ still needs the per-row OPTIONAL lane. SPARQL turns an unbound operand
+/// into a type error and every strict operator propagates it, `&&` included
+/// (`error && false` is `false`, `error && true` is an error — never `true`).
+/// So a filter built only from strict operators rejects the row whether it is
+/// evaluated correlated or per-row, and the no-match row the batched lane emits
+/// is already the answer §18.2.4 wants.
+///
+/// Four constructs escape that and are named here: `BOUND` and `COALESCE`
+/// inspect boundness instead of reading through it, `IF` evaluates only the
+/// branch it picks, `||` turns `error || true` into `true`, and `XOR` coerces
+/// rather than propagates. `EXISTS` escapes too — it evaluates a pattern with
+/// the variable free rather than reading it as an operand.
+///
+/// Deliberately conservative: anything this cannot prove strict (the Cypher
+/// comprehension/reduce/member family, a runtime-`Resolved` value) counts as
+/// tolerant, which only means those shapes keep the per-row lane they had.
+fn filter_tolerates_unbound(expr: &crate::ir::Expression) -> bool {
+    use crate::ir::expression::Function;
+    use crate::ir::Expression;
+
+    match expr {
+        Expression::Var(_) | Expression::Const(_) => false,
+        Expression::Call { func, args } => {
+            matches!(
+                func,
+                Function::Bound | Function::Coalesce | Function::If | Function::Or | Function::Xor
+            ) || args.iter().any(filter_tolerates_unbound)
+        }
+        _ => true,
+    }
+}
+
+/// [`filter_tolerates_unbound`] lifted to a pattern, recursing through the
+/// wrappers `inner_pattern_is_hash_join_safe` admits.
+fn pattern_filters_tolerate_unbound(p: &Pattern) -> bool {
+    match p {
+        Pattern::Filter(expr) => filter_tolerates_unbound(expr),
+        Pattern::DefaultGraphSource { patterns } => {
+            patterns.iter().any(pattern_filters_tolerate_unbound)
+        }
+        _ => false,
     }
 }
 
@@ -3778,5 +3935,185 @@ mod tests {
         );
         // Left-join preserves every driving row (all OPTIONAL misses).
         assert_eq!(out_rows, 6, "every driving row survives the left join");
+    }
+
+    /// A grouped chain of single-triple OPTIONALs shares its SUBJECT with the
+    /// required side, so `OptionalOperator` needs a merge instruction for it —
+    /// otherwise a row whose subject an upstream UNION/VALUES left unbound
+    /// keeps a null subject while carrying the objects it was found by.
+    #[test]
+    fn grouped_builder_reports_its_subject_as_a_merge_column() {
+        // required [?s, ?name]; OPTIONAL { ?s :email ?email } OPTIONAL { ?s :age ?age }
+        let required_schema: Arc<[VarId]> = Arc::from(vec![VarId(0), VarId(1)].into_boxed_slice());
+        let triples = vec![
+            make_optional_pattern(),
+            TriplePattern::new(
+                Ref::Var(VarId(0)),
+                Ref::Sid(Sid::new(101, "age")),
+                Term::Var(VarId(3)),
+            ),
+        ];
+        let builder = GroupedPatternOptionalBuilder::new(
+            required_schema,
+            triples,
+            crate::temporal_mode::PlanningContext::current(),
+        )
+        .expect("grouped builder");
+
+        assert_eq!(builder.unify_instructions().len(), 1);
+        assert_eq!(
+            builder.unify_instructions()[0].left_col,
+            0,
+            "?s is required column 0, and the merge reads it back off the per-row chain"
+        );
+    }
+
+    fn friend_triple() -> Pattern {
+        // ?s :friend ?f
+        Pattern::Triple(TriplePattern::new(
+            Ref::Var(VarId(0)),
+            Ref::Sid(Sid::new(101, "friend")),
+            Term::Var(VarId(2)),
+        ))
+    }
+
+    fn plan_tree_builder(inner: Vec<Pattern>) -> PlanTreeOptionalBuilder {
+        // required [?s, ?age]
+        let required_schema: Arc<[VarId]> = Arc::from(vec![VarId(0), VarId(1)].into_boxed_slice());
+        PlanTreeOptionalBuilder::new(
+            required_schema,
+            inner,
+            None,
+            crate::temporal_mode::PlanningContext::current(),
+        )
+    }
+
+    /// `?age` is a correlation var (`referenced_vars` sees it) that the inner
+    /// can only READ. An unbound one must not take the whole driving side off
+    /// the batched hash-join lane: no inner solution could have bound it, so
+    /// the no-match row the batched lane emits is already correct.
+    #[test]
+    fn a_filter_only_correlation_var_is_not_bindable_by_the_inner() {
+        let expr = crate::ir::Expression::gt(
+            crate::ir::Expression::Var(VarId(1)),
+            crate::ir::Expression::Const(fluree_db_core::FlakeValue::Long(20)),
+        );
+        let builder = plan_tree_builder(vec![friend_triple(), Pattern::Filter(expr)]);
+
+        assert!(builder.inner_bindable_vars.contains(&VarId(0)), "?s");
+        assert!(builder.inner_bindable_vars.contains(&VarId(2)), "?f");
+        assert!(
+            !builder.inner_bindable_vars.contains(&VarId(1)),
+            "?age is a FILTER operand, not something the inner can bind"
+        );
+        assert!(
+            !builder.filters_tolerate_unbound,
+            "`?age > 20` is strict: an unbound operand is an error, never true"
+        );
+    }
+
+    /// …unless the filter survives an unbound operand, in which case the row
+    /// can still join and the per-row lane is the only correct one.
+    #[test]
+    fn a_filter_that_survives_an_unbound_operand_keeps_the_per_row_lane() {
+        let bound_check = crate::ir::Expression::not(crate::ir::Expression::Call {
+            func: crate::ir::expression::Function::Bound,
+            args: vec![crate::ir::Expression::Var(VarId(1))],
+        });
+        let builder = plan_tree_builder(vec![friend_triple(), Pattern::Filter(bound_check)]);
+        assert!(
+            builder.filters_tolerate_unbound,
+            "`!BOUND(?age)` is TRUE precisely when ?age is unbound"
+        );
+    }
+
+    #[test]
+    fn filter_strictness_classification() {
+        use crate::ir::expression::Function;
+        use crate::ir::Expression;
+
+        let age = || Expression::Var(VarId(1));
+        let twenty = || Expression::Const(fluree_db_core::FlakeValue::Long(20));
+
+        // Strict: the error an unbound operand raises propagates out.
+        assert!(!filter_tolerates_unbound(&Expression::gt(age(), twenty())));
+        assert!(!filter_tolerates_unbound(&Expression::not(Expression::gt(
+            age(),
+            twenty()
+        ))));
+        // `error && true` is an error and `error && false` is false — never true.
+        assert!(!filter_tolerates_unbound(&Expression::and(vec![
+            Expression::gt(age(), twenty()),
+            Expression::gt(age(), twenty()),
+        ])));
+
+        // Non-strict: each of these can answer `true` with ?age unbound.
+        assert!(filter_tolerates_unbound(&Expression::or(vec![
+            Expression::gt(age(), twenty()),
+            Expression::Const(fluree_db_core::FlakeValue::Boolean(true)),
+        ])));
+        assert!(filter_tolerates_unbound(&Expression::Call {
+            func: Function::Bound,
+            args: vec![age()],
+        }));
+        assert!(filter_tolerates_unbound(&Expression::Call {
+            func: Function::Coalesce,
+            args: vec![age(), twenty()],
+        }));
+        // Nested under a strict operator still counts.
+        assert!(filter_tolerates_unbound(&Expression::not(
+            Expression::Call {
+                func: Function::Bound,
+                args: vec![age()],
+            }
+        )));
+    }
+
+    /// The cache key is the SUBSTITUTED PATTERN, so a slot substitution leaves
+    /// free keys as free whatever the row held, and two rows that would drive
+    /// the identical scan share one entry.
+    #[test]
+    fn cache_key_keys_a_free_slot_as_free() {
+        fn key(position: PatternPosition, binding: &Binding) -> Option<Vec<u8>> {
+            let mut k = Vec::new();
+            push_cache_key_component(&mut k, position, binding).then_some(k)
+        }
+
+        let encoded = Binding::EncodedSid {
+            s_id: 42,
+            t: None,
+            op: None,
+        };
+        // Object: substitution leaves a late-materialised IRI free, so this must
+        // key identically to an unbound object — N objects, ONE scan.
+        assert_eq!(
+            key(PatternPosition::Object, &encoded),
+            key(PatternPosition::Object, &Binding::Unbound),
+        );
+        // Subject: substitution resolves it and pushes it down, so it keys by value.
+        assert_ne!(
+            key(PatternPosition::Subject, &encoded),
+            key(PatternPosition::Subject, &Binding::Unbound),
+        );
+        assert_ne!(
+            key(PatternPosition::Subject, &encoded),
+            key(
+                PatternPosition::Subject,
+                &Binding::EncodedSid {
+                    s_id: 43,
+                    t: None,
+                    op: None
+                }
+            ),
+        );
+        // A literal OBJECT is pushed down by value; declining to cache is how
+        // rows carrying different literals are kept apart.
+        assert_eq!(
+            key(
+                PatternPosition::Object,
+                &Binding::lit(fluree_db_core::FlakeValue::Long(7), Sid::new(0, "integer"))
+            ),
+            None
+        );
     }
 }

--- a/fluree-db-query/src/optional.rs
+++ b/fluree-db-query/src/optional.rs
@@ -295,6 +295,22 @@ impl PatternOptionalBuilder {
         }
     }
 
+    /// True when the pattern's object variable is also a REQUIRED variable, so
+    /// the per-row object substitution is load-bearing.
+    ///
+    /// The batched probe keys on `(subject, predicate)` and reads the object
+    /// slot off the plan-time template, never off the row — sound while the
+    /// object variable is optional-only, wrong the moment the required side
+    /// carries values for it. Left in, it answered one bare existence row per
+    /// matching triple: a required row binding the variable was duplicated
+    /// instead of filtered, and a required row leaving it unbound was passed
+    /// through instead of extended. The per-row `build` path substitutes the
+    /// row's own object (and leaves an unbound one free), so it is exactly
+    /// right here; this shape declines the probe and takes it.
+    fn object_var_shared_with_required(&self) -> bool {
+        matches!(&self.pattern.o, Term::Var(v) if !self.optional_only_vars.contains(v))
+    }
+
     fn resolve_subject_id(
         &self,
         required_batch: &Batch,
@@ -436,6 +452,52 @@ impl PatternOptionalBuilder {
     }
 }
 
+/// Append one correlation binding to a cache key, or return `false` when it
+/// has no stable encoding (the caller then declines to cache).
+///
+/// Every variable-length component is length-prefixed so two different
+/// correlation tuples can never concatenate to the same bytes.
+fn push_cache_key_component(key: &mut Vec<u8>, binding: &Binding) -> bool {
+    fn push_bytes(key: &mut Vec<u8>, tag: u8, bytes: &[u8]) {
+        key.push(tag);
+        key.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+        key.extend_from_slice(bytes);
+    }
+
+    match binding {
+        Binding::EncodedSid { s_id, .. } => {
+            key.push(b'S');
+            key.extend_from_slice(&s_id.to_le_bytes());
+            true
+        }
+        Binding::Sid { sid, .. } => {
+            // Fallback stable key: namespace code + suffix bytes.
+            key.push(b's');
+            key.extend_from_slice(&sid.namespace_code.to_le_bytes());
+            push_bytes(key, b'n', sid.name_str().as_bytes());
+            true
+        }
+        Binding::IriMatch { iri, .. } | Binding::Iri(iri) => {
+            push_bytes(key, b'i', iri.as_bytes());
+            true
+        }
+        // Not a defect: `substitute_pattern` leaves the slot a variable, so
+        // "unbound here" is a correlation state in its own right and must
+        // get its own key rather than collide with any bound value.
+        Binding::Unbound => {
+            key.push(b'u');
+            true
+        }
+        Binding::Poisoned => false,
+        Binding::EncodedPid { .. } | Binding::EncodedLit { .. } | Binding::Lit { .. } => false,
+        Binding::Grouped(_)
+        | Binding::Path { .. }
+        | Binding::Rel(_)
+        | Binding::List(_)
+        | Binding::Map(_) => false,
+    }
+}
+
 #[async_trait]
 impl OptionalBuilder for PatternOptionalBuilder {
     /// The batched lane probes each required row independently (a pure
@@ -449,7 +511,10 @@ impl OptionalBuilder for PatternOptionalBuilder {
     /// True only when `build_batch`'s own admission gates hold, so the
     /// operator never buffers the driving side just to fall back per-row.
     fn supports_seed_coalescing(&self, ctx: &ExecutionContext<'_>) -> bool {
-        if ctx.is_multi_ledger() || self.pattern.dtc.is_some() || self.subject_left_col().is_none()
+        if ctx.is_multi_ledger()
+            || self.pattern.dtc.is_some()
+            || self.subject_left_col().is_none()
+            || self.object_var_shared_with_required()
         {
             return false;
         }
@@ -497,7 +562,10 @@ impl OptionalBuilder for PatternOptionalBuilder {
         start_row: usize,
         ctx: &ExecutionContext<'_>,
     ) -> Result<Option<Vec<OptionalBatchRow>>> {
-        if start_row >= required_batch.len() || ctx.is_multi_ledger() {
+        if start_row >= required_batch.len()
+            || ctx.is_multi_ledger()
+            || self.object_var_shared_with_required()
+        {
             return Ok(None);
         }
         let Some(store) = ctx.binary_store.as_ref() else {
@@ -608,57 +676,36 @@ impl OptionalBuilder for PatternOptionalBuilder {
         row: usize,
         ctx: &ExecutionContext<'_>,
     ) -> Result<Option<Box<[u8]>>> {
-        // Key on the substituted correlation bindings only.
-        // For the common case `OPTIONAL { ?s <p> ?o }` with `?s` coming from the left,
-        // this makes repeated `?s` values (fan-out on the left) reuse right-side results.
+        // Key on the FULL substituted correlation tuple — every position
+        // `substitute_pattern` reads, not just the subject. `OPTIONAL { ?s <p> ?o }`
+        // where `?o` also arrives from the left substitutes the object too, so a
+        // subject-only key served one row's answer to a row whose `?o` differed.
+        // For the common shape (a left-bound `?s`, a free `?o`) the tuple is still
+        // just the subject and left-side fan-out reuses right-side results as before.
+        let _ = ctx;
         if self.has_poisoned_binding(required_batch, row) {
             return Ok(None);
         }
 
-        // Today we support cache keys for subjects that are either already encoded
-        // or can be resolved to an IRI string without ambiguity.
-        // (Multi-ledger mode can still work without caching.)
-        for instr in &self.bind_instructions {
-            if instr.position != PatternPosition::Subject {
-                continue;
-            }
-            let binding = required_batch.get_by_col(row, instr.left_col);
-            return match binding {
-                Binding::EncodedSid { s_id, .. } => {
-                    let mut v = Vec::with_capacity(1 + 8);
-                    v.push(b'S');
-                    v.extend_from_slice(&s_id.to_le_bytes());
-                    Ok(Some(v.into_boxed_slice()))
-                }
-                Binding::Sid { sid, .. } => {
-                    // Fallback stable key: namespace code + suffix bytes.
-                    let mut v = Vec::with_capacity(1 + 2 + sid.name_str().len());
-                    v.push(b's');
-                    v.extend_from_slice(&sid.namespace_code.to_le_bytes());
-                    v.extend_from_slice(sid.name_str().as_bytes());
-                    Ok(Some(v.into_boxed_slice()))
-                }
-                Binding::IriMatch { iri, .. } | Binding::Iri(iri) => {
-                    let mut v = Vec::with_capacity(1 + iri.len());
-                    v.push(b'i');
-                    v.extend_from_slice(iri.as_bytes());
-                    Ok(Some(v.into_boxed_slice()))
-                }
-                Binding::Unbound | Binding::Poisoned => Ok(None),
-                Binding::EncodedPid { .. } | Binding::EncodedLit { .. } | Binding::Lit { .. } => {
-                    Ok(None)
-                }
-                Binding::Grouped(_)
-                | Binding::Path { .. }
-                | Binding::Rel(_)
-                | Binding::List(_)
-                | Binding::Map(_) => Ok(None),
-            };
+        if self.bind_instructions.is_empty() {
+            // No correlation => don't cache.
+            return Ok(None);
         }
 
-        // No subject correlation => don't cache.
-        let _ = ctx;
-        Ok(None)
+        let mut key = Vec::with_capacity(16 * self.bind_instructions.len());
+        for instr in &self.bind_instructions {
+            key.push(match instr.position {
+                PatternPosition::Subject => b'0',
+                PatternPosition::Predicate => b'1',
+                PatternPosition::Object => b'2',
+            });
+            let binding = required_batch.get_by_col(row, instr.left_col);
+            if !push_cache_key_component(&mut key, binding) {
+                return Ok(None);
+            }
+        }
+
+        Ok(Some(key.into_boxed_slice()))
     }
 
     fn schema(&self) -> &[VarId] {
@@ -1364,11 +1411,28 @@ impl OptionalBuilder for PlanTreeOptionalBuilder {
         let mut seed_rows: Vec<Vec<Binding>> = Vec::new();
         let mut seen_seed: HashSet<Vec<GroupKeyOwned>> = HashSet::new();
         for row in start_row..n {
-            let unmatchable = corr_cols.iter().any(|&c| {
+            // An UNBOUND correlation variable is compatible with every inner
+            // solution (§18.2.4), which a partition by correlation key cannot
+            // express — the key would have to match every bucket at once, and
+            // the optional-side batches carry only optional-only vars, so
+            // there is nothing for the merge to read the value back off. Hand
+            // the whole batch to the per-row path, which seeds the inner from
+            // the row and leaves the unbound variable free. Poison, by
+            // contrast, can never match anything.
+            let mut unbound_corr = false;
+            let mut poisoned_corr = false;
+            for &c in &corr_cols {
                 let b = required_batch.get_by_col(row, c);
-                b.is_poisoned() || matches!(b, Binding::Unbound)
-            });
-            if unmatchable {
+                if matches!(b, Binding::Unbound) {
+                    unbound_corr = true;
+                    break;
+                }
+                poisoned_corr |= b.is_poisoned();
+            }
+            if unbound_corr {
+                return Ok(None);
+            }
+            if poisoned_corr {
                 row_keys.push(None);
                 continue;
             }
@@ -2066,6 +2130,16 @@ pub struct OptionalOperator {
     pending_output: VecDeque<PendingOptionalMatch>,
     /// Variables required by downstream operators; if set, output is trimmed.
     out_schema: Option<Arc<[VarId]>>,
+    /// Required columns holding a variable the optional side can also bind,
+    /// as `(required column, variable)`.
+    ///
+    /// These are exactly the builder's unify columns. A required row that left
+    /// one of them UNBOUND is still compatible with an optional solution that
+    /// binds it, and SPARQL merge (§18.2.4) says the merged solution carries
+    /// the optional side's value — so `combine_rows` patches these columns.
+    /// Empty for the overwhelmingly common OPTIONAL that shares only
+    /// already-bound correlation vars, which keeps the merge off the hot path.
+    shared_merge_cols: Vec<(usize, VarId)>,
     /// Memoized optional-side results keyed by correlation bindings.
     ///
     /// This prevents repeated OPTIONAL evaluation when the left side has fan-out
@@ -2148,11 +2222,22 @@ impl OptionalOperator {
         combined.extend(optional_builder.optional_only_vars());
         let combined_schema: Arc<[VarId]> = Arc::from(combined.into_boxed_slice());
 
+        let shared_merge_cols: Vec<(usize, VarId)> = optional_builder
+            .unify_instructions()
+            .iter()
+            .filter_map(|instr| {
+                required_schema
+                    .get(instr.left_col)
+                    .map(|var| (instr.left_col, *var))
+            })
+            .collect();
+
         Self {
             required,
             optional_builder,
             required_schema,
             combined_schema,
+            shared_merge_cols,
             state: OperatorState::Created,
             current_required_batch: None,
             current_required_row: 0,
@@ -2245,6 +2330,13 @@ impl OptionalOperator {
     }
 
     /// Combine required row with optional row into output row
+    ///
+    /// This is SPARQL merge (§18.2.4): the required row wins on every variable
+    /// it binds, and a variable it left UNBOUND takes the optional side's value
+    /// when the optional side binds it. That second half only ever fires for a
+    /// shared variable an upstream UNION / OPTIONAL / VALUES could leave
+    /// unbound on some rows — a shared variable bound on every row costs one
+    /// `is_unbound` test per merge column.
     fn combine_rows(
         &self,
         required_batch: &Batch,
@@ -2261,6 +2353,23 @@ impl OptionalOperator {
 
         // Copy optional-only columns from optional batch
         let optional_schema = optional_batch.schema();
+
+        // Fill shared columns the required row left unbound from the optional
+        // side. `unify_check` has already accepted this pairing, and it accepts
+        // an unbound left value against any right value.
+        for &(col, var) in &self.shared_merge_cols {
+            if !matches!(result[col], Binding::Unbound) {
+                continue;
+            }
+            let Some(opt_col) = optional_schema.iter().position(|v| *v == var) else {
+                continue;
+            };
+            let candidate = optional_batch.get_by_col(optional_row, opt_col);
+            if !matches!(candidate, Binding::Unbound | Binding::Poisoned) {
+                result[col] = candidate.clone();
+            }
+        }
+
         for var in self.optional_builder.optional_only_vars() {
             if let Some(opt_col) = optional_schema.iter().position(|v| v == var) {
                 result.push(optional_batch.get_by_col(optional_row, opt_col).clone());

--- a/regression-budget.json
+++ b/regression-budget.json
@@ -64,6 +64,11 @@
         "small": 5.0,
         "medium": 3.0
       },
+      "query_hot_optional": {
+        "tiny": 10.0,
+        "small": 5.0,
+        "medium": 3.0
+      },
       "query_hot_property_path": {
         "tiny": 10.0,
         "small": 5.0,

--- a/testsuite-sparql/tests/registers/mod.rs
+++ b/testsuite-sparql/tests/registers/mod.rs
@@ -139,6 +139,15 @@ pub const SPARQL10_QUERY_EVAL: &[&str] = &[
     // (PR-W1-OPT). filter-nested-2 (nested-group FILTER scope) and join-scope-1
     // (sub-SELECT merge of an OPTIONAL-produced correlation var) are fixed
     // (PR-W1 Families A/B).
+    //
+    // nested-opt-1/2 are about WHERE the right operand is evaluated, not how it
+    // merges: §18.2.4 evaluates it independently and unifies afterwards, while
+    // every OptionalBuilder here seeds it from the required row. nested-opt-1
+    // wants `{ :x3 :q ?w . OPTIONAL { :x2 :p ?v } }` to bind ?v=2 on its own and
+    // so match nothing against ?v=1 (1 solution); correlating substitutes ?v=1,
+    // the inner OPTIONAL finds nothing and passes ?w=3/4 through, and we answer
+    // 2. #1713's unbound-merge fix does not move either one — verified, output
+    // byte-identical before and after.
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#join-combo-2",
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-1",
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-2",


### PR DESCRIPTION
Fixes #1713.

An `OPTIONAL` did nothing at all to the rows on which the required side had left the shared variable *unbound*. On the `seed_values_dataset` fixture:

```sparql
SELECT ?s ?f WHERE {
  ?s schema:name ?name .
  { { ?s ex:friend ?f } UNION { ?s schema:age ?age } }
  OPTIONAL { ?s ex:friend ?f }
}
```

returned 10 rows — byte-identical to the same query with the `OPTIONAL` deleted outright. §18.2.4 says 13: the UNION emits six solutions binding `?f` and four leaving it unbound, and a solution with `?f` unbound *is* compatible with one that binds it, so those four have to be extended rather than passed through.

The `UNION` is only how I found it. The merge asks whether the required row's column is `Binding::Unbound` and never asks how the column got that way, so the scope of the fix is **a shared variable the required row left unbound, however it got there** — and `VALUES … UNDEF` lowers to exactly that binding (`parse/lower.rs:491`). bplatz's `VALUES`-with-`UNDEF` repro on #1713, which has no `UNION` anywhere, is broken at the merge base in the same way and closed here by the same one-place change, on both surfaces and on both builder lanes. That's what the tests now pin, and it's why I think #1713 closes as the class rather than as one repro.

Five things had to be true at once, and I think all five are worth naming. The first is the "real" bug; the next three are what made it invisible on one lane and differently wrong on the others; the fifth is a fourth builder with the same defect and a worse symptom, which I found while checking that the first four really did cover every lane.

**The merge dropped the value it had just matched.** `OptionalOperator::combine_rows` (`fluree-db-query/src/optional.rs`) copied every required column verbatim and then appended only the *optional-only* columns. `unify_check` right above it already does the right thing — it treats an unbound left value as compatible with any right value — but nothing then read that right value back out, so a row the optional side genuinely matched came out exactly as it went in. It now fills the shared columns the required row left unbound from the optional side, which is just SPARQL merge. The patch is driven off a precomputed `shared_merge_cols` (the builder's own unify columns), for the canonical `OPTIONAL { ?s :email ?e }` it holds a single entry (`?s`), and the cost per output row is one `is_unbound` test per merge column — the fill scan itself only runs on a column that is actually `Unbound`.

**The result cache keyed on a third of the correlation.** `PatternOptionalBuilder::cache_key` keyed only on the subject, while `substitute_pattern` substitutes subject, predicate *and* object. So on the novelty lane the `(cam, ?f=alice)` row's answer — a one-row existence batch for `cam friend alice` — was served straight back to the `(cam, ?f=unbound)` row out of the LRU. That is what made the counts land exactly on the no-OPTIONAL answer, which is a nastier failure mode than being merely wrong: it's the cache making a wrong answer look self-consistent. The key is now the **substituted pattern**, mirroring `substitute_pattern` position by position: a slot that substitution pushes a value into keys by that value, and a slot it *leaves free* gets the same `u` token whatever the row held, so two rows that would drive the identical scan share one entry (`unify_check` re-applies the row's own correlation when the pending match drains, so sharing is sound). Concretely that means a late-materialized `EncodedSid`/`EncodedPid`/`EncodedLit` in the object slot now shares one scan instead of driving N identical ones or declining to cache at all. For the ordinary shape — left-bound `?s`, free `?o` — the key is still just the subject and left-side fan-out reuses right-side results exactly as before.

**The batched subject probe read the object off the plan-time template.** `PatternOptionalBuilder::build_batch` probes `(subject, predicate)` and takes the object slot from `self.pattern.o`, never from the row — sound while the object variable is optional-only, wrong the moment the required side carries values for it. On an indexed ledger the same query returned **21** rows: one bare existence row per matching triple, so a required row that *bound* `?f` was duplicated once per friend instead of filtered, and a required row that left it unbound was still passed through. `build_batch` and `supports_seed_coalescing` now decline when the object variable is shared with the required side, and the shape falls to the per-row substituted scan, which pins the row's own object exactly (and leaves an unbound one free). I went back and forth on instead widening `emit_object_var` so the probe materializes the object and lets `unify_check` filter — it's the faster shape — but that would newly rest object correlation on `Binding` equality across representations decoded from the index vs. produced upstream, and `Binding`'s `PartialEq` answers `false` rather than erroring across those pairs, so it would *silently drop* rows; #1729 is a live filed instance of exactly that on the `Lit`/`dtc` arm. For a P1 silent-wrong-results fix I'd rather not take that on. Worth being precise about what declining buys, though, and the code comment now says so: it **narrows** the exposure rather than removing it, because `substitute_pattern` still leaves a late-materialized `EncodedSid`/`EncodedPid`/`EncodedLit` object free and `unify_check`'s `left_val == right_val` is then what enforces the correlation on the per-row path too.

**`PlanTreeOptionalBuilder::build_batch` had the same class of problem one level up.** It marked a row with an unbound correlation variable "unmatchable" and emitted a no-match row. A hash partition by correlation key genuinely can't express "compatible with every bucket", and its optional-side batches carry only optional-only vars so there'd be nothing to read the value back off — so that path hands the batch to the per-row lane instead. Scoped, though, to a correlation variable the inner can actually **bind**. `corr_cols` is every required column *referenced* anywhere in the inner patterns, and `Pattern::Filter` is hash-join safe, so `OPTIONAL { ?s ex:friend ?f . FILTER(?age > 20) }` with `?age` unbound on half the rows would otherwise take the whole (coalesced, up to 512K-row) driving side off the lane while changing nothing — the inner can't bind `?age`, so the filter errors under correlated and independent evaluation alike and the old no-match row was already right. The gate is `inner_patterns.produced_vars()`, the same notion `PlanTreeOptionalBuilder::new` already uses for `optional_vars`, plus a small escape hatch: a filter that can still answer `true` with an unbound operand (`BOUND`, `COALESCE`, `IF`, `||`, `XOR`, `EXISTS`) keeps the per-row lane, because for those the row genuinely can still join. Everything else propagates the error — `&&` included, since `error && true` is an error and `error && false` is `false`, never `true`.

**`GroupedPatternOptionalBuilder` was the fourth lane, and it was fabricating solutions.** Two-or-more chained single-triple `OPTIONAL`s on one subject route here (`execute/where_plan.rs:2411-2426`), and its `unify_instructions()` was hardcoded `&[]` — so `shared_merge_cols` was empty for it and `combine_rows` never patched anything. Its object variables are structurally optional-only (`collect_grouped_single_triple_optionals` breaks on `required_schema.contains(&o_var)`), but its *subject* only has to be **present** in the required schema, not bound on every row. So:

```sparql
SELECT ?s ?e ?a WHERE {
  { { ?s schema:name ?n } UNION { ex:nikola schema:name ?nn } }
  OPTIONAL { ?s schema:email ?e }
  OPTIONAL { ?s schema:age ?a } }
```

answered nine rows, four of them `[null, "alice@example.org", 50]`, `[null, "brian@example.org", 50]` and so on — the right cardinality, the right `?e`/`?a` correlation, and the subject never written back. That's the *fabricated-solution* flavour bplatz called the nastier failure mode on #1713: a row asserting an email and an age for a subject it declines to name. It isn't a regression (the merge base answered a worse 21-row `?e`×`?a` cross-product for the same query), but it is exactly the class this change is named for, so it's fixed here rather than deferred. The builder now reports its subject as a merge column, and the `build_batch` gate that keeps that sound — the batched lane's own schema is optional-only, so it has no subject to read back — is now an *explicit* unbound-subject decline rather than an accident of `resolve_subject_id` returning `None`. The per-row chain's output does carry the subject at `subject_left_col`, which is where the merge picks it up.

## The remaining door: #1734

Under that sharper framing one ordinary shape is still wrong, and it is **not** fixed here: two `OPTIONAL`s on the same variable.

```sparql
?s schema:name ?name . OPTIONAL { ?s ex:greeting ?f } OPTIONAL { ?s ex:friend ?f }
```

answers 6 rows where §18.2.4 wants 9 — `ex:alice`/`ex:brian`/`ex:cam`/`ex:liam` all come back `[?s, null]`, so the friends are found and then dropped and the fan-out goes with them. Give the two `OPTIONAL`s distinct variables and the same fixture answers the correct 9. The reason is that a preceding `OPTIONAL` that matched nothing records `Binding::Poisoned`, not `Unbound` (`create_poisoned_row`, `optional.rs`), `unify_check` refuses poisoned pairings, and this merge deliberately skips a column that isn't `Unbound`. Poison-blocks-matching is a deliberate, documented engine semantic (`binding.rs:48-53`), so closing that door means deciding whether the blocking behaviour is right at all — which is a design call I don't think belongs inside a P1 silent-wrong-results fix. Filed as **#1734** (P1, `triage:needs-decision`); it is byte-identical at the merge base and here, so nothing in this PR moved it. Closing #1713 on the `Unbound` doors and naming #1734 as the `Poisoned` one seemed more honest than either claiming the whole class or leaving the gap implied.

## Performance

The `PlanTree` fallback is the only hunk that can cost anything, and the scoping above is what keeps it off the rows it buys nothing for. Measured on an IC5-shaped fixture (300 forums × 25 members × 6 posts, a 300-row `VALUES` driving a two-pattern correlated `OPTIONAL` with a `FILTER` on a `VALUES`-supplied `?age`, 7,500-row driving side, debug, same box and process):

| | all correlation bound | one `UNDEF` `?age` cell |
|---|---|---|
| scoped to what the inner can bind (this PR) | 50.8 s | **50.6 s** |
| bail on any unbound correlation column | 46.7 s | **555.2 s** |

One unbound filter operand in 300 driving rows was an 11.9× cliff, and every row it slowed down was already answering correctly before and after. The blast radius really is the driving side rather than a batch — `supports_seed_coalescing` can't see data, so the operator coalesces first and `build_batch` declines after. Putting the `UNDEF` at forum 150 of 300 landed roughly half the 7,500 rows on the per-row path, which is the ratio you'd expect against `FLUREE_OPTIONAL_HASH_JOIN=0` (that run came in at ~1,060 s, but it overlapped another build on this box so treat the ratio rather than the absolute as the signal). I confirmed the answers are identical either way — the new `optional_reading_an_unbound_filter_operand_pads_the_row` test passes with the scoping and with it forced off — and that the lane really does stay on, via the operator's own debug counters (`batched_builds=1`, `built_optionals=0` with the scoping; `built_optionals` non-zero plus a split batch without it).

Memory is neutral: `shared_merge_cols` is one `Vec<(usize, VarId)>` per operator with no per-row allocation, and the `combine_rows` position scan only runs for a column that is actually `Unbound`.

One cost I did *not* remove: a correlated **literal** object (`?s :p ?o . OPTIONAL { ?s :q ?o }` with `?o` a literal) now goes uncached, because substitution genuinely pushes that literal down and two rows carrying different literals must not share an entry. Keying it would need a stable byte encoding of every `FlakeValue`/datatype pair, which is more than this fix should be buying; the comment at the decline says so. It's wrong-but-cached → right-but-uncached, so nothing regressed against a *correct* baseline, but it is a real per-row cost on that one shape.

## Bench

Nothing in `regression-budget.json` covered `OptionalOperator` at all, which means CI could not have caught any of the five defects above — and the fallback lanes are an order of magnitude slower than the batched probes they replace, so this is a path where a scoping change is worth gating. `fluree-db-api/benches/query_hot_optional.rs` adds one scenario per lane — the batched subject probe, the object-correlated per-row scan (where a cache-hit-rate change shows up), the `PlanTree` batched hash join, and the unbound-filter-operand shape — on an indexed file-backed ledger, with the same build-once/reindex/warm-snapshot discipline as `query_hot_property_path.rs`. Budget entry at `tiny` 10% / `small` 5% / `medium` 3%, matching the other `query_hot_*` benches; `cargo test -p fluree-bench-support --test workspace_reconcile` is green.

The fourth scenario is a real sentinel rather than decoration: at `tiny` scale (200 persons, release) it runs in **382 µs**, and with the correlation scoping forced back to every correlation column it runs in **6.01 ms** — 15.7×, far outside any budget.

## Tests

`fluree-db-api/tests/it_optional_after_union.rs`, its own binary because the indexed case needs the background indexer. Ten tests:

- the SPARQL query above and its JSON-LD twin (`["union", …]` then `["optional", …]`) on novelty, and the same on an indexed view;
- a two-pattern `OPTIONAL` that routes to `PlanTreeOptionalBuilder` instead;
- one where the UNION's second branch binds neither correlation variable, so the left join has to extend a completely free row;
- **the `VALUES … UNDEF` door from bplatz's comment on #1713** — SPARQL, the JSON-LD twin, and a multi-pattern variant on the `PlanTree` lane. All three return the eight all-null rows he reported at the merge base and the correct eight here, matching the no-`VALUES` baseline exactly (the multi-pattern one returned five, all null, so the correlation-key partition was losing multiplicity as well as the binding);
- the grouped-lane chain, asserting both the exact nine rows and that no solution reports an email/age for a subject it leaves unbound. Pinned on novelty only: the grouped batched probe *declines* an unbound-subject batch outright, so both lanes reach the same per-row chain and an indexed twin would be a duplicate. I did check it by hand rather than assume — on an indexed view (`binary_store().is_some()`) the same query returns the same nine rows with `?s` bound on every one;
- the filter-only correlation shape, pinning the ten rows the scoping must preserve.

Plus unit tests in `optional.rs` for the grouped builder's merge column, the bindable-vs-read-only correlation split, the filter strictness classification (`?age > 20` and `a && b` strict; `!BOUND(?age)` and `a || true` not), and the cache key — that an object slot substitution leaves free keys identically to `Unbound` while a subject slot keys by value.

Each integration test asserts the exact row multiset *and* a property that can't be satisfied by accident: for the UNION form, that deleting the `OPTIONAL` changes the answer; for the `UNDEF` form, that the answer equals the no-`VALUES` baseline. A plan-shape or row-count check would have gone green on a half fix — the free-row case was already emitting the right *number* of rows before this change, just with `(null, null)` in every one of them.

Non-vacuity, per the repo's habit: reverting the `combine_rows` merge alone turns nine of the ten red — the tenth is the filter-operand test, which pins the *scoping* rather than the merge and correctly stays green. Reverting only the grouped builder's `unify_instructions` turns exactly the grouped test red and leaves the other nine green.

## W3C registers

`testsuite-sparql/tests/registers/mod.rs:143-144` registers `algebra/manifest#nested-opt-1` and `#nested-opt-2` under "correlated-OPTIONAL independence", and #1713 asked whether they'd flip. **They don't**, and I'm fairly confident that's correct rather than a half fix: they're about *where* the right operand is evaluated, not how it merges. `nested-opt-1` wants `{ :x3 :q ?w . OPTIONAL { :x2 :p ?v } }` evaluated independently, binding `?v=2` on its own and so matching nothing against `?v=1` — one solution. Every `OptionalBuilder` here instead seeds the inner subplan from the required row, so `?v=1` gets substituted, the inner `OPTIONAL` finds nothing, `?w=3/4` passes through, and we answer two. That's a genuinely separate defect from the unbound-merge one.

I checked rather than assumed: both tests' actual output is byte-identical before and after this change (unregistered them, ran `sparql10_query_eval_tests` on both sides, diffed). They stay registered, and I extended the register comment with the concrete mechanism so the next person doesn't have to re-derive it. Full `--test w3c_sparql` is green — 36/36 — with the register enforced both ways, which is also the evidence that nothing else in the suite moved.

## Follow-up

- **#1734** — the `Poisoned` door above. Needs a decision on poison-blocks-matching, not a patch.
- **#1701** is still open. Its test `a_union_binding_the_var_does_not_suppress_the_barrier` asserts plan shape rather than rows precisely because pinning rows there would have pinned this defect's output — once both land that should be upgraded to a row assertion, which is then the natural regression check for both issues at once.

## Gates

`cargo test -p fluree-db-api` green (full sweep — 43 targets, 3,269 tests, not just the query groups); `-p fluree-db-query` green; `-p fluree-db-cypher -p fluree-db-sparql -p fluree-db-reasoner` green; `cargo test -p fluree-bench-support --test workspace_reconcile` green; `cargo bench -p fluree-db-api --bench query_hot_optional -- --test` green; `testsuite-sparql --test w3c_sparql` 36/36; `cargo clippy --all-targets --no-deps -D warnings` clean on both touched crates and in `testsuite-sparql`; `cargo fmt --all` last, in the workspace and in `testsuite-sparql/`.

CI on this head: `fmt`, `clippy`, `testsuite-sparql`, `bench-paths`, `bench-compare` and `plan` all pass. `test` reports exactly one failure, `it_ledger_lifecycle::ledger_exists_on_file_storage` — inherited from `main` (`43d758610` in #1716 changed the semantics and its test wasn't updated), and nothing in this branch touches that path.

