### PR TITLE
fix(core): make FlakeMeta's Ord agree with its Eq

### DIFF
--- a/fluree-db-api/tests/it_filtered_delete_list_meta.rs
+++ b/fluree-db-api/tests/it_filtered_delete_list_meta.rs
@@ -816,22 +816,225 @@ async fn novelty_only_predicate_resolves_metadata_siblings() {
                 "the @en fact goes; the @fr fact sharing its lexical form stays"
             );
 
-            // The COMBINATION of the two legs above — one list position
-            // carrying two language tags — is pinned at the unit level
-            // instead (`binary_range::tests::
-            // one_list_position_under_two_language_tags_resolves_independently`),
-            // because it cannot currently be built through this path at all.
-            //
-            // `FlakeMeta`'s `Ord` ignores `lang` whenever both sides carry a
-            // list index, so `{en, i: 0}` and `{fr, i: 0}` compare equal
-            // without being equal (#1711). Asserting the second tag at the
-            // same position commits (receipt says one flake at its own `t`)
-            // but never appears in the live view: novelty keys the fact by
-            // that same ordering and folds it onto the first tag. So the
-            // write side collapses the shape before the read side can be
-            // asked about it. Worth knowing when #1711 is fixed — repairing
-            // the type will make this shape constructible, and this is the
-            // test that should then grow an end-to-end leg.
+            // The COMBINATION of the two legs above: one list position
+            // carrying two language tags. Until #1711 this shape could not be
+            // built through this path at all — `FlakeMeta`'s `Ord` ignored
+            // `lang` whenever both sides carried a list index, so `{en, i: 0}`
+            // and `{fr, i: 0}` compared equal without being equal, and novelty
+            // (which keys facts by that ordering) folded the second tag onto
+            // the first. Now that the type's `Ord` agrees with its `Eq`, both
+            // facts reach the overlay and the resolver has to tell them apart.
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:pair", "ex:names": {"@list": [
+                        {"@value": "hello", "@language": "en"}
+                    ]}}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            let _ = fluree
+                .insert_with_opts(
+                    ledger,
+                    &json!({"@context": ctx(), "@id": "ex:pair", "ex:names": {"@list": [
+                        {"@value": "hello", "@language": "fr"}
+                    ]}}),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_items(&fluree, &ledger, "ex:pair", "ex:names").await,
+                vec!["hello@en", "hello@fr"],
+                "a second language tag at an occupied list position is its own \
+                 fact, not a duplicate of the first"
+            );
+
+            // And the resolver splits them: retracting one tag at position 0
+            // must leave its twin at position 0 alone. Deleting the one that
+            // sorts FIRST is the failing direction, as with the legs above.
+            let del_pair_en = json!({
+                "@context": ctx(),
+                "where": [{"@id": "ex:pair", "ex:names": {"@value": "hello", "@language": "en"}}],
+                "delete": [{"@id": "ex:pair", "ex:names": {"@value": "hello", "@language": "en"}}]
+            });
+            let r = fluree
+                .update_with_opts(ledger, &del_pair_en, TxnOpts::default(), CommitOpts::default(), &index_cfg())
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 1);
+            let ledger = fluree.ledger(ledger_id).await.unwrap();
+            assert_eq!(
+                list_items(&fluree, &ledger, "ex:pair", "ex:names").await,
+                vec!["hello@fr"],
+                "one tag goes; its twin at the same list position stays"
+            );
+        })
+        .await;
+}
+
+/// Two language tags at one list position must read the same from the novelty
+/// overlay, from a rebuilt index, and from a replayed commit chain.
+///
+/// This is the end-to-end shape behind #1711, and the divergence is the point.
+/// Novelty keyed facts through `FlakeMeta`'s `Ord`, which used to ignore `lang`
+/// whenever both sides carried a list index — so `{en, i: 0}` and `{fr, i: 0}`
+/// were one slot and the second tag was folded onto the first. The persisted
+/// index keys by its own integer columns (`o_type` absorbs the language id,
+/// `o_i` the position) and always kept them apart. Nothing was durably lost:
+/// the flake was in the commit blob and the index build recovered it. What the
+/// user saw was the same query returning one entry before indexing and two
+/// after, with no write in between — an answer that flipped on a background
+/// maintenance event.
+///
+/// So each leg asserts the two views are EQUAL, not merely that each is right.
+/// Equality is the sharper assertion: it fails whichever side regresses.
+#[tokio::test]
+async fn language_tagged_list_entries_agree_across_the_index_boundary() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().to_string_lossy().to_string();
+    let mut fluree = FlureeBuilder::file(dir.clone()).build().unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            // Leg A: two separate commits, each a one-entry `@list` under the
+            // same predicate — both entries land at position 0.
+            let seq_a = json!({"@context": ctx(), "@id": "ex:seq", "ex:names": {"@list": [
+                {"@value": "hello", "@language": "en"}
+            ]}});
+            let seq_b = json!({"@context": ctx(), "@id": "ex:seq", "ex:names": {"@list": [
+                {"@value": "hello", "@language": "fr"}
+            ]}});
+            // Leg B: ONE commit carrying two sibling `@list`s under one
+            // predicate. Within a single batch both flakes always survived
+            // novelty, so this leg exercises the read side rather than the
+            // per-commit dedup.
+            let sib = json!({"@context": ctx(), "@id": "ex:sib", "ex:names": [
+                {"@list": [{"@value": "bonjour", "@language": "en"}]},
+                {"@list": [{"@value": "bonjour", "@language": "fr"}]}
+            ]});
+
+            let write_legs = |fluree: &fluree_db_api::Fluree, id: &'static str| {
+                let (seq_a, seq_b, sib) = (seq_a.clone(), seq_b.clone(), sib.clone());
+                let fluree = fluree.clone();
+                async move {
+                    let mut last_t = 0;
+                    for doc in [&seq_a, &seq_b, &sib] {
+                        let ledger = fluree.ledger(id).await.unwrap();
+                        last_t = fluree
+                            .insert_with_opts(
+                                ledger,
+                                doc,
+                                TxnOpts::default(),
+                                CommitOpts::default(),
+                                &index_cfg(),
+                            )
+                            .await
+                            .unwrap()
+                            .receipt
+                            .t;
+                    }
+                    last_t
+                }
+            };
+
+            // ---- index boundary ----
+            let indexed_id = "it/list-meta-tag-boundary:main";
+            fluree.create_ledger(indexed_id).await.unwrap();
+            let last_t = write_legs(&fluree, indexed_id).await;
+
+            let ledger = fluree.ledger(indexed_id).await.unwrap();
+            let nov_seq = list_items(&fluree, &ledger, "ex:seq", "ex:names").await;
+            let nov_sib = list_items(&fluree, &ledger, "ex:sib", "ex:names").await;
+            assert_eq!(nov_seq, vec!["hello@en", "hello@fr"]);
+            assert_eq!(nov_sib, vec!["bonjour@en", "bonjour@fr"]);
+
+            trigger_index_and_wait_outcome(&handle, indexed_id, last_t).await;
+            let ledger = fluree.ledger(indexed_id).await.unwrap();
+            assert!(ledger.snapshot.range_provider.is_some(), "index built");
+            assert_eq!(
+                list_items(&fluree, &ledger, "ex:seq", "ex:names").await,
+                nov_seq,
+                "leg A: the index build must not change the answer"
+            );
+            assert_eq!(
+                list_items(&fluree, &ledger, "ex:sib", "ex:names").await,
+                nov_sib,
+                "leg B: the index build must not change the answer"
+            );
+
+            // Retracting one tag once both are indexed leaves the twin — the
+            // half that was already correct before the fix, kept so a change
+            // in the other direction is caught too.
+            let del_en = json!({
+                "@context": ctx(),
+                "where": [{"@id": "ex:seq", "ex:names": {"@value": "hello", "@language": "en"}}],
+                "delete": [{"@id": "ex:seq", "ex:names": {"@value": "hello", "@language": "en"}}]
+            });
+            let r = fluree
+                .update_with_opts(
+                    ledger,
+                    &del_en,
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(r.receipt.flake_count, 1);
+            let ledger = fluree.ledger(indexed_id).await.unwrap();
+            assert_eq!(
+                list_items(&fluree, &ledger, "ex:seq", "ex:names").await,
+                vec!["hello@fr"],
+                "retracting one tag over an indexed base leaves its twin"
+            );
+
+            // ---- cold reload: a second ledger that is never indexed, so the
+            // reload replays the commit chain into a fresh novelty ----
+            let cold_id = "it/list-meta-tag-cold:main";
+            fluree.create_ledger(cold_id).await.unwrap();
+            write_legs(&fluree, cold_id).await;
+            let ledger = fluree.ledger(cold_id).await.unwrap();
+            assert_eq!(
+                list_items(&fluree, &ledger, "ex:seq", "ex:names").await,
+                nov_seq
+            );
+            assert_eq!(
+                list_items(&fluree, &ledger, "ex:sib", "ex:names").await,
+                nov_sib
+            );
+
+            drop(fluree);
+            let reloaded = FlureeBuilder::file(dir).build().unwrap();
+            let ledger = reloaded.ledger(cold_id).await.unwrap();
+            assert!(
+                ledger.snapshot.range_provider.is_none(),
+                "the cold ledger must have no index, so this really is a \
+                 commit-chain replay"
+            );
+            assert_eq!(
+                list_items(&reloaded, &ledger, "ex:seq", "ex:names").await,
+                nov_seq,
+                "leg E: replayed novelty must agree with the live view"
+            );
+            assert_eq!(
+                list_items(&reloaded, &ledger, "ex:sib", "ex:names").await,
+                nov_sib,
+                "leg E: replayed novelty must agree with the live view"
+            );
         })
         .await;
 }

--- a/fluree-db-core/src/edge.rs
+++ b/fluree-db-core/src/edge.rs
@@ -54,6 +54,29 @@ pub fn xsd_string_datatype_sid() -> Sid {
 /// Fields mirror [`Flake`] one-for-one (minus `t`/`op`/`ann`-side bits) so
 /// the conversion from a base flake is mechanical and the round-trip
 /// encoding via `f:reifies*` system facts is lossless.
+///
+/// ## Field order is a persisted on-disk key order — do not reorder
+///
+/// `Ord` is derived, so declaration order *is* comparison priority, and the
+/// edge-annotation arenas persist that order: forward-leaf rows are stored
+/// sorted by `(EdgeKey, ann_sid, t, op)`, and branch entries carry
+/// `first_edge`/`last_edge` bounds that readers seek against in `EdgeKey`
+/// order (the sort contract and `AnnotationForwardBranchEntry` in
+/// `fluree-db-binary-index/src/annotation_arena/format.rs`; the branch
+/// cursor and the `partition_point` leaf seeks in `reader.rs`). Reordering
+/// these fields changes the derived comparator out from under every
+/// persisted arena — seeks against leaves sorted by the old order silently
+/// return wrong rows — so a reorder requires an arena format migration, at
+/// minimum an `ARENA_VERSION` bump plus a rebuild of existing arenas.
+///
+/// In particular, `lang` sorting before `list_i` here is the *opposite*
+/// nesting from [`FlakeMeta`]'s `Ord`, which compares the list index first
+/// and breaks ties on the language tag. That mismatch is deliberate, not an
+/// oversight to fix: nothing compares an `EdgeKey` with `FlakeMeta::cmp`,
+/// so the two relations never have to agree. `list_i` is always `None` in
+/// v1, which keeps the divergence invisible today — it becomes observable
+/// exactly when list-occurrence annotations land, and "harmonizing" the
+/// nesting then would invalidate every arena written before it.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct EdgeKey {
     /// Named graph the edge lives in. `None` = default graph.

--- a/fluree-db-core/src/flake.rs
+++ b/fluree-db-core/src/flake.rs
@@ -93,6 +93,16 @@ impl FlakeMeta {
     }
 
     /// Maximum metadata for range bounds
+    ///
+    /// This is an upper bound for the metadata a query can reach, **not** a
+    /// maximum over the whole type: `{lang: Some(_), i: Some(i32::MAX)}`
+    /// sorts strictly above it, because [`Ord`] breaks an `i` tie on `lang`
+    /// and `None < Some`. An inclusive upper bound built from this therefore
+    /// excludes a language-tagged value sitting at list index `i32::MAX`.
+    /// Unreachable through [`Flake::max_for_subject`] and its siblings — those
+    /// also pin `o`, `dt`, `t` and `op` to their maxima, every one of which is
+    /// compared before the metadata tiebreak — but do not assume this value
+    /// dominates every [`FlakeMeta`].
     pub fn max() -> Self {
         Self {
             lang: None,
@@ -110,23 +120,21 @@ impl PartialOrd for FlakeMeta {
 impl Ord for FlakeMeta {
     /// Compare metadata for ordering
     ///
-    /// Compares by list index, then by presence/absence of fields.
+    /// List index first — it is the discriminator a `@list` range walks —
+    /// then the language tag as a tiebreak. `None` sorts before `Some` on
+    /// both fields.
+    ///
+    /// The tiebreak is what makes this relation agree with the derived
+    /// [`Eq`]: `cmp(a, b) == Equal` if and only if `a == b`. Without it,
+    /// `{lang: Some("en"), i: Some(0)}` and `{lang: Some("fr"), i: Some(0)}`
+    /// compared `Equal` while being unequal, and every caller that expressed
+    /// identity through this ordering — an `OrdMap` key, a `cmp(..) == Equal`
+    /// test, an exclusive `partition_point` seek — folded the two distinct
+    /// facts into one.
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // Compare by i (list index) - primary discriminator
-        match (&self.i, &other.i) {
-            (Some(a), Some(b)) => a.cmp(b),
-            (Some(_), None) => std::cmp::Ordering::Greater,
-            (None, Some(_)) => std::cmp::Ordering::Less,
-            (None, None) => {
-                // Compare by lang
-                match (&self.lang, &other.lang) {
-                    (Some(a), Some(b)) => a.cmp(b),
-                    (Some(_), None) => std::cmp::Ordering::Greater,
-                    (None, Some(_)) => std::cmp::Ordering::Less,
-                    (None, None) => std::cmp::Ordering::Equal,
-                }
-            }
-        }
+        self.i
+            .cmp(&other.i)
+            .then_with(|| self.lang.cmp(&other.lang))
     }
 }
 
@@ -647,5 +655,178 @@ mod tests {
 
         assert!(m1 < m2);
         assert!(m3 < m1); // None < Some for i
+    }
+
+    // ===== `FlakeMeta` ordering laws =====
+    //
+    // `FlakeMeta` derives `PartialEq`/`Eq`/`Hash` over both fields but hand
+    // writes `Ord`, so the two can drift apart. They did (#1711): the old
+    // `cmp` compared `lang` only when neither side carried a list index, so
+    // `{en, 0}` and `{fr, 0}` were `Equal` without being equal. These three
+    // tests pin the relation the type now promises, and pin it against the
+    // relation it used to have.
+
+    /// Every `(lang, i)` combination that matters, as a domain to quantify
+    /// the laws below over. Two `Option` states on `i` plus the extremes the
+    /// sentinels use, crossed with absent/present language tags.
+    fn meta_domain() -> Vec<FlakeMeta> {
+        let langs = [None, Some("de"), Some("en"), Some("fr")];
+        let indices = [
+            None,
+            Some(i32::MIN),
+            Some(-1),
+            Some(0),
+            Some(1),
+            Some(i32::MAX),
+        ];
+        let mut out = Vec::with_capacity(langs.len() * indices.len());
+        for lang in &langs {
+            for i in &indices {
+                out.push(FlakeMeta {
+                    lang: lang.map(str::to_string),
+                    i: *i,
+                });
+            }
+        }
+        out
+    }
+
+    /// `FlakeMeta::cmp` as it stood before #1711, held verbatim so the change
+    /// can be checked rather than taken on trust.
+    fn legacy_cmp(a: &FlakeMeta, b: &FlakeMeta) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match (&a.i, &b.i) {
+            (Some(x), Some(y)) => x.cmp(y),
+            (Some(_), None) => Ordering::Greater,
+            (None, Some(_)) => Ordering::Less,
+            (None, None) => match (&a.lang, &b.lang) {
+                (Some(x), Some(y)) => x.cmp(y),
+                (Some(_), None) => Ordering::Greater,
+                (None, Some(_)) => Ordering::Less,
+                (None, None) => Ordering::Equal,
+            },
+        }
+    }
+
+    /// The new ordering is a strict *refinement* of the old one: wherever the
+    /// old comparator was decisive it still decides the same way, and the
+    /// entire change is pairs it called `Equal` while `Eq` called them
+    /// distinct. Nothing is reordered, so nothing that merely sorts by this
+    /// relation can observe the change.
+    ///
+    /// This is the test that makes the one-line comparator edit reviewable.
+    #[test]
+    fn new_ord_refines_old_ord() {
+        use std::cmp::Ordering;
+        let domain = meta_domain();
+        let mut newly_split = 0usize;
+
+        for a in &domain {
+            for b in &domain {
+                let old = legacy_cmp(a, b);
+                let new = a.cmp(b);
+                if old != Ordering::Equal {
+                    assert_eq!(
+                        new, old,
+                        "a decision the old comparator made was reversed: \
+                         {a:?} vs {b:?} was {old:?}, is now {new:?}"
+                    );
+                    continue;
+                }
+                if new != Ordering::Equal {
+                    newly_split += 1;
+                    assert_ne!(
+                        a, b,
+                        "the refinement may only separate values that are \
+                         genuinely unequal: {a:?} vs {b:?}"
+                    );
+                }
+            }
+        }
+
+        // Non-vacuity: the refinement has to actually refine something, or
+        // this test would pass against the very bug it exists to pin.
+        assert!(
+            newly_split > 0,
+            "no pair was newly separated — the ordering fix is not in effect"
+        );
+
+        // The one behavioral consequence of the refinement, pinned where the
+        // change is described. `FlakeMeta::max()` is a query range bound, not
+        // a maximum of the type: a language-tagged value at list index
+        // `i32::MAX` now sorts strictly above it, so an inclusive upper bound
+        // built from it no longer admits that (unreachable) case. See the doc
+        // on `FlakeMeta::max`.
+        let sentinel = FlakeMeta::max();
+        let tagged_at_max = FlakeMeta {
+            lang: Some("en".to_string()),
+            i: Some(i32::MAX),
+        };
+        assert_eq!(legacy_cmp(&tagged_at_max, &sentinel), Ordering::Equal);
+        assert_eq!(tagged_at_max.cmp(&sentinel), Ordering::Greater);
+    }
+
+    /// The law the type was violating: `cmp` returns `Equal` exactly when
+    /// `==` says equal. Callers that express identity through this ordering —
+    /// an `OrdMap` key, a `cmp(..) == Equal` test, an exclusive seek — are
+    /// only correct while this holds.
+    #[test]
+    fn ord_agrees_with_eq() {
+        use std::cmp::Ordering;
+        for a in &meta_domain() {
+            for b in &meta_domain() {
+                assert_eq!(
+                    a.cmp(b) == Ordering::Equal,
+                    a == b,
+                    "Ord and Eq disagree on {a:?} vs {b:?}"
+                );
+            }
+        }
+    }
+
+    /// `Ord`'s own contract: antisymmetric, and transitive on both the
+    /// strict relation and equality.
+    #[test]
+    fn ord_is_a_total_order() {
+        use std::cmp::Ordering;
+        let domain = meta_domain();
+
+        for a in &domain {
+            assert_eq!(a.cmp(a), Ordering::Equal, "not reflexive at {a:?}");
+            for b in &domain {
+                assert_eq!(
+                    a.cmp(b),
+                    b.cmp(a).reverse(),
+                    "not antisymmetric: {a:?} vs {b:?}"
+                );
+                // `PartialOrd` must agree with `Ord`, since it delegates.
+                assert_eq!(a.partial_cmp(b), Some(a.cmp(b)));
+            }
+        }
+
+        for a in &domain {
+            for b in &domain {
+                let ab = a.cmp(b);
+                for c in &domain {
+                    let bc = b.cmp(c);
+                    // Whenever `a?b` and `b?c` force `a?c`, check the forced
+                    // answer: equality composes both ways, and two strict
+                    // steps in the same direction compose.
+                    let forced = match (ab, bc) {
+                        (Ordering::Equal, _) => Some(bc),
+                        (_, Ordering::Equal) => Some(ab),
+                        _ if ab == bc => Some(ab),
+                        _ => None,
+                    };
+                    if let Some(expected) = forced {
+                        assert_eq!(
+                            a.cmp(c),
+                            expected,
+                            "not transitive: {a:?} {ab:?} {b:?} {bc:?} {c:?}"
+                        );
+                    }
+                }
+            }
+        }
     }
 }

--- a/fluree-db-core/src/flake.rs
+++ b/fluree-db-core/src/flake.rs
@@ -111,6 +111,13 @@ impl FlakeMeta {
     /// and `dt` to `Sid::max()` when the pattern has one. A new bound builder
     /// that does not pin `t` to `i64::MAX` would reach the narrowing, so do not
     /// assume this value dominates every [`FlakeMeta`].
+    ///
+    /// The six-builder pin is enforced by
+    /// `every_bound_builder_pins_the_sentinel_guard` in
+    /// `fluree-db-query/src/binary_scan.rs`, which asserts `t == i64::MAX`
+    /// and `op == true` on each builder's upper bound — this paragraph is a
+    /// pointer to that gate, not the gate itself. A new bound builder
+    /// belongs in that test's list.
     pub fn max() -> Self {
         Self {
             lang: None,

--- a/fluree-db-core/src/flake.rs
+++ b/fluree-db-core/src/flake.rs
@@ -99,10 +99,18 @@ impl FlakeMeta {
     /// sorts strictly above it, because [`Ord`] breaks an `i` tie on `lang`
     /// and `None < Some`. An inclusive upper bound built from this therefore
     /// excludes a language-tagged value sitting at list index `i32::MAX`.
-    /// Unreachable through [`Flake::max_for_subject`] and its siblings — those
-    /// also pin `o`, `dt`, `t` and `op` to their maxima, every one of which is
-    /// compared before the metadata tiebreak — but do not assume this value
-    /// dominates every [`FlakeMeta`].
+    ///
+    /// Unreachable through every bound builder in the tree — [`Flake::max_spot`],
+    /// [`Flake::max_for_subject`], [`Flake::max_for_subject_predicate`] and
+    /// [`Flake::max_for_predicate`] here, plus `predicate_walk_bounds` and
+    /// `overlay_walk_bounds` in `fluree-db-query`. What guards them is `t`: all
+    /// six pin `t` to `i64::MAX` and `op` to `true`, both compared before the
+    /// metadata tiebreak in all four comparators, and no real flake carries
+    /// `t == i64::MAX`. The `o`/`dt` maxima are incidental and are *not*
+    /// universal — `overlay_walk_bounds` pins `o` to the pattern's bound object
+    /// and `dt` to `Sid::max()` when the pattern has one. A new bound builder
+    /// that does not pin `t` to `i64::MAX` would reach the narrowing, so do not
+    /// assume this value dominates every [`FlakeMeta`].
     pub fn max() -> Self {
         Self {
             lang: None,

--- a/fluree-db-core/src/range.rs
+++ b/fluree-db-core/src/range.rs
@@ -380,9 +380,13 @@ pub fn resolve_current_flakes(mut flakes: Vec<Flake>, index: IndexType) -> Vec<F
 /// Hashing the full identity is what makes that robust: it needs no
 /// adjacency between a fact's own flakes, so it does not care that the
 /// comparators order `t` before `m` and therefore interleave metadata
-/// siblings (see #1703), nor that `FlakeMeta`'s `Ord` disagrees with its
-/// `Eq` when both sides carry a list index (see #1711). `Hash`/`Eq` are
-/// derived together and agree.
+/// siblings (see #1703), nor that `FlakeMeta`'s `Ord` used to disagree with
+/// its `Eq` when both sides carried a list index (#1711, fixed in #1727).
+/// `Hash`/`Eq` are derived together and agree.
+///
+/// That fix does not make any of this redundant: this function was already
+/// correct — it never leaned on `Ord` in the first place — so the hashed
+/// fact key stays, and the #1273 collapse it prevents is unrelated to #1711.
 ///
 /// The winner is chosen explicitly rather than by taking the first hit of a
 /// reverse scan, so the equal-`t` tie resolves to the retraction (see
@@ -545,10 +549,11 @@ mod tests {
         assert_eq!(positions, vec![1, 2], "only position 0 goes");
     }
 
-    /// One list position under two language tags: `FlakeMeta::cmp` consults
-    /// only `i` when both sides carry a list index, so those two compare
-    /// `Equal` without being equal (#1711). The fact key hashes `Hash`/`Eq`,
-    /// which agree, so they stay distinct facts here.
+    /// One list position under two language tags. `FlakeMeta::cmp` used to
+    /// consult only `i` when both sides carried a list index, so those two
+    /// compared `Equal` without being equal (#1711, fixed in #1727). This
+    /// test never depended on that fix: the fact key hashes `Hash`/`Eq`,
+    /// which agree, so the two stayed distinct facts here either way.
     #[test]
     fn resolve_current_flakes_one_position_two_language_tags() {
         let tagged = |lang: &str, t: i64, op: bool| Flake {

--- a/fluree-db-novelty/src/fact_state.rs
+++ b/fluree-db-novelty/src/fact_state.rs
@@ -192,4 +192,49 @@ mod tests {
             "no-meta = different identity"
         );
     }
+
+    /// Two language tags at the SAME list position are two identities.
+    ///
+    /// [`meta_is_part_of_identity`] above reads as if it covers this, and does
+    /// not: every meta it builds has `i: None`, and `FlakeMeta`'s ordering only
+    /// used to consult `lang` when neither side carried a list index. So
+    /// `{en, i: 0}` and `{fr, i: 0}` were one `FactKey` slot, `is_asserted`
+    /// answered `true` for a fact this map had never seen, and the per-commit
+    /// dedup dropped it (#1711). The key carries no `t`, so it bit across any
+    /// two commits, not only same-`t` ones.
+    #[test]
+    fn one_list_position_under_two_language_tags_is_two_identities() {
+        fn at(lang: &str, i: i32, t: i64, op: bool) -> Flake {
+            Flake::new(
+                Sid::new(1, "s1"),
+                Sid::new(1, "p"),
+                FlakeValue::Long(7),
+                Sid::new(2, "long"),
+                t,
+                op,
+                Some(FlakeMeta {
+                    lang: Some(lang.to_string()),
+                    i: Some(i),
+                }),
+            )
+        }
+
+        let mut fs = NoveltyFactState::new();
+        fs.record(0, &at("en", 0, 1, true));
+        assert!(fs.is_asserted(0, &at("en", 0, 1, true)));
+        assert!(
+            !fs.is_asserted(0, &at("fr", 0, 1, true)),
+            "a second tag at the same list position is a distinct fact, \
+             not one already asserted"
+        );
+
+        // Both recorded: retracting one must not tombstone the other.
+        fs.record(0, &at("fr", 0, 2, true));
+        fs.record(0, &at("en", 0, 3, false));
+        assert!(!fs.is_asserted(0, &at("en", 0, 3, false)), "@en retracted");
+        assert!(
+            fs.is_asserted(0, &at("fr", 0, 2, true)),
+            "@fr must survive its twin's retraction"
+        );
+    }
 }

--- a/fluree-db-novelty/src/lib.rs
+++ b/fluree-db-novelty/src/lib.rs
@@ -2235,6 +2235,42 @@ mod tests {
             "identity must split on differing metadata values"
         );
 
+        // The three metas above all have `i: None`, so they only exercise the
+        // branch where the ordering consults `lang` unconditionally. Two tags
+        // at the SAME list position are the case that used to collapse:
+        // `FlakeMeta::cmp` compared `lang` only when neither side carried an
+        // index, so `{en, 0}` and `{fr, 0}` were `Equal` without being equal,
+        // and `same_identity` — which tests `cmp_meta(..) == Equal` — folded
+        // two distinct facts into one (#1711). Read the assertions above as
+        // covering this and you would be wrong; this is the case that pins it.
+        let at = |lang: &str, i: i32| FlakeMeta {
+            lang: Some(lang.to_string()),
+            i: Some(i),
+        };
+        let f_en0 = make_flake_with_meta(101, 200, 42, 1, true, Some(at("en", 0)));
+        let f_fr0 = make_flake_with_meta(101, 200, 42, 1, true, Some(at("fr", 0)));
+        let f_en1 = make_flake_with_meta(101, 200, 42, 1, true, Some(at("en", 1)));
+        assert_eq!(
+            cmp_meta(&f_en0, &f_fr0),
+            Ordering::Less,
+            "one list position under two tags must order, not tie"
+        );
+        assert!(
+            !same_identity(&f_en0, &f_fr0),
+            "two language tags at the same list position are two facts"
+        );
+        assert_ne!(
+            IndexType::Spot.compare(&f_en0, &f_fr0),
+            Ordering::Equal,
+            "SPOT comparator must disagree when only the language tag differs"
+        );
+        // The index still dominates the tag: position orders first.
+        assert_eq!(
+            cmp_meta(&f_fr0, &f_en1),
+            Ordering::Less,
+            "list index remains the primary discriminator"
+        );
+
         // `cmp_object` mixes value and datatype: equal value + differing
         // datatype must order. Use distinct datatype Sids on otherwise
         // identical flakes.

--- a/fluree-db-novelty/src/lib.rs
+++ b/fluree-db-novelty/src/lib.rs
@@ -1994,6 +1994,72 @@ mod tests {
         assert_eq!(slice.len(), 3);
     }
 
+    /// [`Segment::range`]'s exclusive lower bound is the third site #1711
+    /// reached, and the only one no other test in this crate covers: the
+    /// `partition_point` skips every flake the ordering calls `<= first`, so a
+    /// sibling the comparator wrongly tied with `first` was skipped along with
+    /// it. Here `first` is the `@en` flake at list position 0 and `@fr` at the
+    /// same position is its sibling — pre-fix the seek returns `[]`.
+    ///
+    /// The two in-repo callers that pass `leftmost: false` today both build a
+    /// synthetic bound with `m: None` and `t: i64::MIN`
+    /// (`fluree-db-query`'s `predicate_walk_bounds` / `overlay_walk_bounds`),
+    /// and `t` is compared before the metadata tiebreak — so this hazard is
+    /// **latent** through today's callers rather than live. It is pinned
+    /// anyway because [`Novelty::range_flakes`] is `pub` and takes an
+    /// arbitrary `first`: the seek has to be correct on its own terms, not on
+    /// its callers'.
+    ///
+    /// Deliberately one commit, so `fact_state`'s dedup (updated only *after*
+    /// the accept loop) never sees either flake. That keeps this assertion
+    /// independent of the `FactKey` / `same_identity` route the other #1711
+    /// regression tests exercise — it fails for a different reason than they do.
+    #[test]
+    fn exclusive_seek_past_a_tagged_bound_keeps_its_sibling_tag() {
+        let tagged = |lang: &str| {
+            make_flake_with_meta(
+                1,
+                1,
+                100,
+                1,
+                true,
+                Some(FlakeMeta {
+                    lang: Some(lang.to_string()),
+                    i: Some(0),
+                }),
+            )
+        };
+        let en = tagged("en");
+        let fr = tagged("fr");
+
+        let mut novelty = Novelty::new(0);
+        novelty
+            .apply_commit(vec![en.clone(), fr.clone()], 1, &no_graphs())
+            .unwrap();
+        assert_eq!(
+            novelty.len(),
+            2,
+            "both language tags must land in the segment for the seek to be the thing under test"
+        );
+
+        let ids = novelty.slice_for_range(0, IndexType::Spot, Some(&en), None, false);
+        let langs: Vec<Option<String>> = ids
+            .iter()
+            .map(|&id| {
+                novelty
+                    .get_flake(id)
+                    .m
+                    .as_ref()
+                    .and_then(|m| m.lang.clone())
+            })
+            .collect();
+        assert_eq!(
+            langs,
+            vec![Some("fr".to_string())],
+            "seeking strictly past `@en` at list position 0 must still yield its `@fr` sibling"
+        );
+    }
+
     #[test]
     fn test_clear_up_to() {
         let mut novelty = Novelty::new(0);

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -3703,4 +3703,76 @@ mod tests {
         )
         .is_none());
     }
+
+    /// Every upper-bound builder in the tree must pin `t` to `i64::MAX` and
+    /// `op` to `true`.
+    ///
+    /// That pin is what makes the `FlakeMeta::max()` narrowing unreachable
+    /// (see its doc in `fluree-db-core/src/flake.rs`): `{lang: Some(_),
+    /// i: Some(i32::MAX)}` sorts strictly above `FlakeMeta::max()`, so an
+    /// inclusive upper bound would exclude it — except that all four index
+    /// comparators compare `t` and `op` *before* the metadata tiebreak, and
+    /// no real flake carries `t == i64::MAX`. The guard therefore lives in
+    /// the builders, and this test quantifies over all six of them: the four
+    /// `Flake::max_*` in `fluree-db-core` (`max_psot` delegates to
+    /// `max_spot`, asserted anyway so de-aliasing it can't drop the pin),
+    /// plus `predicate_walk_bounds` in `fast_path_common` and
+    /// `overlay_walk_bounds` here.
+    ///
+    /// A new bound builder belongs in this list; one that deliberately does
+    /// not pin `t` must instead show why reaching the narrowing is safe.
+    #[test]
+    fn every_bound_builder_pins_the_sentinel_guard() {
+        let s = Sid::new(3, "s");
+        let p = Sid::new(5, "p");
+
+        let assert_pinned = |name: &str, upper: &Flake| {
+            assert_eq!(
+                upper.t,
+                i64::MAX,
+                "{name} must pin t to i64::MAX — it is the guard that keeps \
+                 FlakeMeta::max()'s narrowing unreachable"
+            );
+            assert!(upper.op, "{name} must pin op to true");
+        };
+
+        // The four core builders (plus the max_spot alias).
+        assert_pinned("Flake::max_spot", &Flake::max_spot());
+        assert_pinned("Flake::max_psot", &Flake::max_psot());
+        assert_pinned("Flake::max_for_subject", &Flake::max_for_subject(s.clone()));
+        assert_pinned(
+            "Flake::max_for_subject_predicate",
+            &Flake::max_for_subject_predicate(s.clone(), p.clone()),
+        );
+        assert_pinned(
+            "Flake::max_for_predicate",
+            &Flake::max_for_predicate(p.clone()),
+        );
+
+        // The two query-side builders.
+        let (_, rhs) = crate::fast_path_common::predicate_walk_bounds(&p);
+        assert_pinned("predicate_walk_bounds", &rhs);
+
+        // `overlay_walk_bounds` needs an operator instance; a bound-s/bound-p
+        // pattern routes to Spot, whose leading component is pinned, so the
+        // builder returns bounds. Exercise both `o_bounds` arms — the
+        // unbound-object full range and the bound-object pin — since each
+        // constructs its own `rhs`.
+        let pattern = TriplePattern::new(
+            Ref::Sid(s.clone()),
+            Ref::Sid(p.clone()),
+            Term::Var(VarId(0)),
+        );
+        let mut operator = BinaryScanOperator::new(pattern, None, vec![]);
+        let (_, rhs) = operator
+            .overlay_walk_bounds(&Some(s.clone()), &Some(p.clone()))
+            .expect("Spot with a bound subject must produce walk bounds");
+        assert_pinned("overlay_walk_bounds (unbound object)", &rhs);
+
+        operator.bound_o = Some(FlakeValue::Long(42));
+        let (_, rhs) = operator
+            .overlay_walk_bounds(&Some(s), &Some(p))
+            .expect("bound-object arm must still produce walk bounds");
+        assert_pinned("overlay_walk_bounds (bound object)", &rhs);
+    }
 }

--- a/fluree-db-query/src/fast_path_common.rs
+++ b/fluree-db-query/src/fast_path_common.rs
@@ -2074,7 +2074,11 @@ pub fn build_range_cursor(
 /// before any flake of a higher predicate. The bounds are a superset
 /// optimization for `for_each_overlay_flake` — callers must still filter the
 /// callback by predicate.
-fn predicate_walk_bounds(pred: &Sid) -> (fluree_db_core::Flake, fluree_db_core::Flake) {
+///
+/// `pub(crate)` only so `binary_scan`'s
+/// `every_bound_builder_pins_the_sentinel_guard` can quantify over it; the
+/// sole production caller is [`collect_resolved_overlay_ops`] below.
+pub(crate) fn predicate_walk_bounds(pred: &Sid) -> (fluree_db_core::Flake, fluree_db_core::Flake) {
     use fluree_db_core::flake::FlakeMeta;
     use fluree_db_core::Flake;
     let first = Flake::new(


### PR DESCRIPTION
`FlakeMeta` derives `PartialEq`/`Eq`/`Hash` over both of its fields but hand-writes `Ord`, and the two had quietly drifted apart. `cmp` compared `lang` only when *neither* side carried a list index, so `{lang: "en", i: 0}` and `{lang: "fr", i: 0}` came back `Equal` while `==` said they were different values. `Ord`'s contract says that can't happen, and the places that trusted it are exactly the places that broke.

The whole change is a tiebreak, replacing the `match` in `fluree-db-core/src/flake.rs`:

```rust
self.i.cmp(&other.i).then_with(|| self.lang.cmp(&other.lang))
```

`Option`'s derived `Ord` reproduces the old explicit arms (`None < Some`) on both fields, so this is the old comparator plus a tiebreak — nothing gets reordered.

## What it actually broke

Three sites, all of which express *identity* through this ordering rather than through `Eq`:

- `fluree-db-novelty/src/fact_state.rs:45` — `FactKey` is an `imbl::OrdMap` key, so `{en, 0}` and `{fr, 0}` were literally the same map slot. `is_asserted` answered `true` for a fact the map had never seen, and the per-commit dedup at `fluree-db-novelty/src/lib.rs:886` dropped it. Worth noting the key carries no `t`, so this bit across any two commits, not only same-`t` ones.
- `fluree-db-novelty/src/lib.rs:1561` — `same_identity` tests `cmp_meta(a, b) == Ordering::Equal`, which drives the `bulk_apply_commits` dedup walk on the cold-load / commit-replay path.
- `Segment::range`'s exclusive lower bound (`fluree-db-novelty/src/lib.rs:237-268`, the `partition_point` at `:252`). With an ordering that calls the twins `Equal`, seeking past the `@en` flake also skips the distinct `@fr` flake. This one I'd rather understate than oversell: tracing every in-repo caller, the two that pass `leftmost: false` (`fluree-db-query/src/fast_path_common.rs:2077` and `fluree-db-query/src/binary_scan.rs:1575`) both build a synthetic bound with `m: None` and `t: i64::MIN`, and `t` is compared before the metadata tiebreak — so nothing in the tree reaches it today. **It's latent, not live**, unlike the first two. It still decides the shape of the fix, though, for a reason that doesn't lean on today's callers: `Novelty::range_flakes` (`:1352`) is `pub` and takes an arbitrary `first`, and "strictly after this flake" is inherently an ordering predicate — no identity helper and no amount of caller discipline can express it. It's pinned by a test now rather than left to a hand-check.

## The user-visible shape is a novelty↔index divergence, not a lost write

Worth being precise about, because earlier descriptions of this bug (mine included) said the write was silently discarded, and that overstates it.

The persisted index contains no `Flake` and no `FlakeMeta` at all. It's built from `RunRecordV2` (`fluree-db-binary-index/src/format/run_record_v2.rs:66`), a 32-byte `#[repr(C)]` POD of integer columns where `m.lang` is folded into `o_type` (tag `0b11` = `rdf:langString`, payload = `lang_id`) and `m.i` is its own `o_i` column — so the index always kept the two apart. The flake is durable in the commit blob, and the index build recovers it.

So what a user saw was the same query against the same ledger returning **one** entry before indexing and **two** after, with no write in between — an answer that flips on a background maintenance event. That's worse than a plain missing write in one respect (it's nondeterministic, and read-your-writes is violated until the indexer runs) and better in one that matters for landing this: nothing is durably lost, so there's **no data repair and no migration** here. The facts simply become visible consistently.

## Why it's safe to touch a comparator every crate reads

`cmp_meta` is the last tiebreak in all four index comparators (`fluree-db-core/src/comparator.rs:167,179,191,206`), after `s`, `p`, `o`, `dt`, `t`, `op` — two flakes only reach it if they're identical in every one of those. And `lang: Some(_)` implies `dt == rdf:langString` on every parser path, so the metadata tiebreak is only reachable between two language-tagged flakes of the same lexical form. Within that, exactly one branch changes: both sides `Some(i)` with equal `i` and differing `lang`.

Rather than just assert that, `new_ord_refines_old_ord` holds the old comparator verbatim beside the new one and quantifies both over the `(lang, i)` domain. Every pair the old comparator *decided* is decided identically, and the entire change is pairs it called `Equal` that `Eq` already called distinct. That's the blast radius, and it's checkable from the test rather than taken on trust.

Nothing on disk is ordered by this relation either. Across `fluree-db-binary-index/src` and `fluree-db-indexer/src` the only reference to `fluree_db_core::comparator` is an `IndexType` enum import in `stats/class_property.rs` — no comparator function from core is called on any index write or read path, so `FlakeMeta::cmp` can't participate in branch routing, a leaflet seek, a range bound, or a leaflet-skip predicate. I checked it the other way round as well, by building a real persisted indexed ledger under the *old* comparator and then reading the identical bytes back under the new one (subject crawl, predicate-value lookup, an ordered range with `orderBy`/`limit`, a full scan, a bound-object lookup, and `select *` crawls of the lang/list-heavy subjects) — results identical. So: no format bump, no reindex, no dual-read, no migration.

## The one behavioral edge

`FlakeMeta::max()` is `{lang: None, i: Some(i32::MAX)}`. Under the old relation `{lang: Some(_), i: i32::MAX}` compared `Equal` to it, so an inclusive upper-bound test admitted it; now it compares `Greater` and is excluded — the inclusive bound narrows by exactly that pathological case.

It's unreachable through all six bound builders in the tree: the four `Flake::max_*` here, plus `predicate_walk_bounds` and `overlay_walk_bounds` in `fluree-db-query`. What guards them is `t`, not the object — all six pin `t` to `i64::MAX` and `op` to `true`, both compared before the metadata tiebreak in every one of the four comparators, and no real flake carries `t == i64::MAX`. The `o`/`dt` maxima look like they're doing the work and mostly aren't: `overlay_walk_bounds` pins `o` to the pattern's bound object and `dt` to `Sid::max()` whenever the pattern carries one, so at that site the object half of the argument is simply false. Since "`max()` dominates every meta" stops being true here, the doc at `FlakeMeta::max` names `t` as the load-bearing guard and says what a new bound builder would have to do to reach the narrowing — and the guard is now enforced rather than described: `every_bound_builder_pins_the_sentinel_guard` in `fluree-db-query/src/binary_scan.rs` quantifies over all six builders (the four `Flake::max_*` — with the `max_psot` alias asserted separately, so de-aliasing it can't silently drop the pin — plus `predicate_walk_bounds` and `overlay_walk_bounds`, the latter across both of its object arms) and asserts each pins `t == i64::MAX` and `op == true`. The doc points at the test by name, so the paragraph is a pointer to a gate rather than the gate itself. `predicate_walk_bounds` goes `pub(crate)` solely so the test can reach it; its one production caller is unchanged. The narrowing itself is pinned in `new_ord_refines_old_ord` too. (`min()` is unaffected: `{lang: None, i: None}` sorted below it under both relations.)

## `EdgeKey` is deliberately left alone — and now says so itself

`fluree-db-core/src/edge.rs` has its own `lang`/`list_i` fields whose *derived* `Ord` nests them in the opposite order from `FlakeMeta::cmp`'s, and that must not be "harmonized": the field order is a persisted on-disk key order for the edge-annotation arenas, and reordering it would invalidate every arena already written. The full argument — including why the mismatch only becomes observable when list-occurrence annotations land, which is exactly when someone might be tempted to fix it — now lives where the next reader will actually be, as a doc comment on `EdgeKey` itself, rather than only in this description.

## `remove_stale_flakes` is not a workaround to unwind

Two comments in `fluree-db-core/src/range.rs` described #1711 in the present tense, and after this they'd read as false, so they move to the past tense. Their *argument* is untouched and still worth keeping: `remove_stale_flakes` hashes the full fact identity, which is robust precisely *because* it never consults `Ord` at all.

Which is also why it was already correct, and I've said so in the comment rather than leaving it implicit. "The `Ord` bug is fixed, so this is no longer necessary" is the wrong thing for the next reader to conclude — dropping `m` from that key is what silently collapses language variants on insert (#1273), a separate hazard this change does nothing about.

## Tests

- `fluree-db-core/src/flake.rs` — the three laws: `new_ord_refines_old_ord`, `ord_agrees_with_eq`, `ord_is_a_total_order`.
- `fluree-db-novelty` — both `fact_state::meta_is_part_of_identity` and the `local_identity_helpers_match_core_spot_comparator_semantics` drift guard *read* as though they already covered this and didn't: every meta they build has `i: None`, which is the one branch the old ordering compared `lang` on. Both grow the missing case, and the `fact_state` one also pins that retracting one tag doesn't tombstone the other.
- `fluree-db-novelty/src/lib.rs` — `exclusive_seek_past_a_tagged_bound_keeps_its_sibling_tag` pins the seek directly, since it's the one of the three sites nothing else in the suite would notice regressing. It builds a one-segment novelty holding both tags at list position 0 and seeks strictly past `@en`; pre-fix that comes back `[]`. It goes through a single `apply_commit` on purpose, so `fact_state`'s dedup — updated only *after* the accept loop — never sees either flake. That keeps the assertion independent of the `FactKey`/`same_identity` route every other test here takes, and it's why the pre-fix failure lands on the seek rather than on the segment-population guard above it.
- `fluree-db-api/tests/it_filtered_delete_list_meta.rs` — the note in there reserved an end-to-end leg for whenever this shape became constructible. It is now, so the novelty-only sibling test builds it and retracts the tag that sorts first, and a new test asserts the novelty view and the post-index view are **equal** across three legs: two commits landing at the same position, one commit with two sibling `@list`s, and a cold reload replaying the commit chain. Equality is the sharper assertion here — the divergence *was* the defect, so agreement fails whichever side regresses.
- `fluree-db-query/src/binary_scan.rs` — `every_bound_builder_pins_the_sentinel_guard`, described above: the six-builder `t`/`op` pin as a gate instead of prose. It isn't a comparator regression test (it passes under either comparator, by design), so its non-vacuity check is its own: dropping the `t` pin from `Flake::max_for_predicate`, and separately from `overlay_walk_bounds`, each fails the test naming exactly that builder; restored, the suite is green.

Every one of the new and extended comparator regression tests fails on the pre-fix comparator, which I verified by reverting the one-line change and re-running before restoring it: the two api tests with the symptom `["hello@en"]` where both tags are expected, the seek with `[]` where `["fr"]` is.

The number worth recording, though, is the one that *didn't* move. Under the pre-fix comparator **887 of the 892 tests in `fluree-db-core` + `fluree-db-novelty` still pass, and 7 of the 9 in `it_filtered_delete_list_meta`** — the five and the two being exactly the ones written for this bug. So nothing else in either suite depended on the old fold, which is a considerably better argument that the ordering change is inert than "the tests pass" is.

## Unblocked, not done here

`fluree-db-novelty/src/fact_state.rs:26-31` argues for moving its `OrdMap` to `imbl::HashMap`, and correctly flags that switching key equality from `Ord` to `Hash`/`Eq` is a semantic change. Now that `FlakeMeta`'s two relations agree, that switch is a pure performance change as far as metadata goes — and it deserves more weight than a footnote: `is_asserted`/`record` run per accepted flake on the per-commit path, and the switch takes them from O(log novelty_facts) to amortized O(1). That's a larger effect than anything this PR's tiebreak costs, which is two `Option` compares over a short tag at the very tail of the key, reached only when everything before it already ties. What's left before making the switch is `FlakeValue`'s cross-representation numerics (`Long(3) == Double(3.0) == BigInt(3)`), which still wants its own cross-type dedup tests. Deliberately not doing it in this PR, but it's a much better place to make that change from than it was, and I didn't want the option to get lost.

Fixes #1711
