### PR TITLE
fix(server): accept per-ledger SSE subscriptions on GET /events

### DIFF
--- a/fluree-db-server/src/routes/events.rs
+++ b/fluree-db-server/src/routes/events.rs
@@ -65,26 +65,53 @@ impl EventsQuery {
     /// `?all=true` ever worked. The `Deserialize` derive stays for the
     /// in-process constructions and tests.
     ///
-    /// Unknown keys are ignored (forward compatibility). `all` is true for
-    /// `true`/`1`; anything else, including its absence, is false.
-    pub fn from_query_str(raw: &str) -> Self {
+    /// Unknown keys are ignored (forward compatibility), and so is an empty
+    /// `ledger=` / `graph-source=` — one alias among however many were
+    /// asked for, and dropping it changes the scope but never erases it.
+    ///
+    /// `all` is different, and is the one value this parser REJECTS. It is
+    /// the whole subscription request, so a value we do not understand can
+    /// only be resolved one of two ways: guess `false` and hand back a 200
+    /// SSE stream that matches nothing and emits nothing, forever, with no
+    /// error for the client to notice — or say so. `serde_urlencoded`, what
+    /// this parser replaced, said so (a non-boolean 400d), and the silent
+    /// never-emits stream is the exact failure class the repeated-key fix
+    /// above exists to remove. `?all` bare is the flag form and means true;
+    /// `true`/`1`/`yes`/`on` and `false`/`0`/`no`/`off` are accepted
+    /// case-insensitively; anything else, empty included, is a 400.
+    pub fn from_query_str(raw: &str) -> Result<Self, ServerError> {
         let mut query = EventsQuery::default();
         for pair in raw.split('&').filter(|p| !p.is_empty()) {
-            let (key, raw_value) = pair.split_once('=').unwrap_or((pair, ""));
+            // `None` distinguishes a bare flag (`?all`) from an explicitly
+            // empty value (`?all=`), which are not the same request.
+            let (key, raw_value) = match pair.split_once('=') {
+                Some((k, v)) => (k, Some(v)),
+                None => (pair, None),
+            };
             // `+` is a space in application/x-www-form-urlencoded; percent
             // escapes cover everything else (`:` in `books:main` is commonly
             // sent as %3A).
-            let value = urlencoding::decode(&raw_value.replace('+', " "))
-                .map(std::borrow::Cow::into_owned)
-                .unwrap_or_else(|_| raw_value.to_string());
+            let value = raw_value.map(|v| {
+                urlencoding::decode(&v.replace('+', " "))
+                    .map(std::borrow::Cow::into_owned)
+                    .unwrap_or_else(|_| v.to_string())
+            });
             match key {
-                "all" => query.all = matches!(value.as_str(), "true" | "1"),
-                "ledger" if !value.is_empty() => query.ledgers.push(value),
-                "graph-source" if !value.is_empty() => query.graph_sources.push(value),
+                "all" => query.all = parse_all(value.as_deref())?,
+                "ledger" => {
+                    if let Some(v) = value.filter(|v| !v.is_empty()) {
+                        query.ledgers.push(v);
+                    }
+                }
+                "graph-source" => {
+                    if let Some(v) = value.filter(|v| !v.is_empty()) {
+                        query.graph_sources.push(v);
+                    }
+                }
                 _ => {}
             }
         }
-        query
+        Ok(query)
     }
 
     /// Check if this query matches a given resource ID and kind
@@ -98,6 +125,22 @@ impl EventsQuery {
             SSE_KIND_GRAPH_SOURCE => self.graph_sources.iter().any(|v| v == resource_id),
             _ => false,
         }
+    }
+}
+
+/// `?all` → true (flag form); `?all=<boolean>` → that boolean; anything
+/// else → 400 rather than a stream that silently never emits.
+fn parse_all(value: Option<&str>) -> Result<bool, ServerError> {
+    let Some(value) = value else {
+        return Ok(true);
+    };
+    match value.to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Ok(true),
+        "false" | "0" | "no" | "off" => Ok(false),
+        other => Err(ServerError::BadRequest(format!(
+            "events: `all` must be a boolean (true/false, 1/0, yes/no, on/off); got {other:?}. \
+             Subscribing to specific resources uses `?ledger=` / `?graph-source=` instead."
+        ))),
     }
 }
 
@@ -456,7 +499,7 @@ pub async fn events(
     RawQuery(raw_query): RawQuery,
     MaybeBearer(principal): MaybeBearer,
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ServerError> {
-    let params = EventsQuery::from_query_str(raw_query.as_deref().unwrap_or_default());
+    let params = EventsQuery::from_query_str(raw_query.as_deref().unwrap_or_default())?;
     // Peer mode: return 404 - events endpoint not available
     // Peers subscribe to the transaction server's events endpoint instead
     if state.config.server_role == ServerRole::Peer {
@@ -615,33 +658,72 @@ mod tests {
         assert!(query.matches("any:main", "graph-source"));
     }
 
+    /// Parse a query string that this test expects to be valid.
+    fn parsed(raw: &str) -> EventsQuery {
+        EventsQuery::from_query_str(raw).unwrap_or_else(|e| panic!("{raw} must parse: {e}"))
+    }
+
     /// The wire form, which nothing used to cover: every test above builds
     /// an `EventsQuery` in process, so the fact that no `?ledger=` request
     /// could ever be deserialized went unnoticed. Repeated keys must
     /// accumulate, and a percent-encoded `:` must survive.
     #[test]
     fn test_events_query_from_query_str() {
-        let one = EventsQuery::from_query_str("ledger=books%3Amain");
+        let one = parsed("ledger=books%3Amain");
         assert_eq!(one.ledgers, vec!["books:main".to_string()]);
         assert!(!one.all);
         assert!(one.matches("books:main", "ledger"));
 
-        let many = EventsQuery::from_query_str(
-            "ledger=books%3Amain&ledger=users%3Amain&graph-source=search%3Amain",
-        );
+        let many = parsed("ledger=books%3Amain&ledger=users%3Amain&graph-source=search%3Amain");
         assert_eq!(
             many.ledgers,
             vec!["books:main".to_string(), "users:main".to_string()]
         );
         assert_eq!(many.graph_sources, vec!["search:main".to_string()]);
 
-        assert!(EventsQuery::from_query_str("all=true").all);
-        assert!(EventsQuery::from_query_str("all=1").all);
-        assert!(!EventsQuery::from_query_str("all=false").all);
-        assert!(!EventsQuery::from_query_str("").all);
+        assert!(parsed("all=true").all);
+        assert!(parsed("all=1").all);
+        assert!(!parsed("all=false").all);
+        assert!(!parsed("").all);
 
         // Unknown keys and empty values are ignored, not fatal.
-        let odd = EventsQuery::from_query_str("ledger=&future=1&ledger=a%3Ab");
+        let odd = parsed("ledger=&future=1&ledger=a%3Ab");
         assert_eq!(odd.ledgers, vec!["a:b".to_string()]);
+    }
+
+    /// `?all=` is the whole subscription request. A value this parser does
+    /// not understand must NOT resolve to `false`: that hands the client a
+    /// 200 SSE stream matching nothing, emitting nothing, forever, with
+    /// nothing to notice — the silent-freeze class this endpoint's parser
+    /// exists to remove, and what `serde_urlencoded` used to 400 on.
+    #[test]
+    fn an_uninterpretable_all_is_rejected_rather_than_silently_false() {
+        for raw in ["all=ture", "all=maybe", "all=", "all=2", "all=null"] {
+            let err = EventsQuery::from_query_str(raw)
+                .err()
+                .unwrap_or_else(|| panic!("{raw} must not be accepted"));
+            assert_eq!(
+                err.status_code(),
+                axum::http::StatusCode::BAD_REQUEST,
+                "{raw}"
+            );
+            let message = err.to_string();
+            assert!(
+                message.contains("`all`"),
+                "must name the parameter: {message}"
+            );
+        }
+
+        // The spellings a human actually types all work, either case.
+        for raw in ["all=TRUE", "all=Yes", "all=on", "all=1", "all"] {
+            assert!(parsed(raw).all, "{raw} must mean true");
+        }
+        for raw in ["all=FALSE", "all=no", "all=off", "all=0"] {
+            assert!(!parsed(raw).all, "{raw} must mean false");
+        }
+
+        // And an unusable `ledger=` stays ignorable: it is one alias among
+        // however many, not the entire request.
+        assert!(EventsQuery::from_query_str("ledger=&ledger=a%3Ab").is_ok());
     }
 }

--- a/fluree-db-server/src/routes/events.rs
+++ b/fluree-db-server/src/routes/events.rs
@@ -18,7 +18,7 @@
 //! - `ns-retracted` - Record retracted/deleted
 
 use axum::{
-    extract::{Query, State},
+    extract::{RawQuery, State},
     response::sse::{Event, KeepAlive, Sse},
 };
 use chrono::Utc;
@@ -38,7 +38,7 @@ use crate::extract::{EventsPrincipal, MaybeBearer};
 use crate::state::AppState;
 
 /// Query parameters for the events endpoint
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct EventsQuery {
     /// Subscribe to all ledgers and graph sources
     #[serde(default)]
@@ -54,6 +54,39 @@ pub struct EventsQuery {
 }
 
 impl EventsQuery {
+    /// Parse this endpoint's query string.
+    ///
+    /// Hand-rolled rather than `Query<EventsQuery>`, because the subscription
+    /// params are REPEATED keys (`?ledger=a&ledger=b`) and
+    /// `serde_urlencoded` — what `axum::extract::Query` deserializes with —
+    /// cannot build a `Vec` from repeated keys. It rejects the whole request
+    /// with `invalid type: string "…", expected a sequence`, so *every*
+    /// `?ledger=` form answered 400, a single alias included; only
+    /// `?all=true` ever worked. The `Deserialize` derive stays for the
+    /// in-process constructions and tests.
+    ///
+    /// Unknown keys are ignored (forward compatibility). `all` is true for
+    /// `true`/`1`; anything else, including its absence, is false.
+    pub fn from_query_str(raw: &str) -> Self {
+        let mut query = EventsQuery::default();
+        for pair in raw.split('&').filter(|p| !p.is_empty()) {
+            let (key, raw_value) = pair.split_once('=').unwrap_or((pair, ""));
+            // `+` is a space in application/x-www-form-urlencoded; percent
+            // escapes cover everything else (`:` in `books:main` is commonly
+            // sent as %3A).
+            let value = urlencoding::decode(&raw_value.replace('+', " "))
+                .map(std::borrow::Cow::into_owned)
+                .unwrap_or_else(|_| raw_value.to_string());
+            match key {
+                "all" => query.all = matches!(value.as_str(), "true" | "1"),
+                "ledger" if !value.is_empty() => query.ledgers.push(value),
+                "graph-source" if !value.is_empty() => query.graph_sources.push(value),
+                _ => {}
+            }
+        }
+        query
+    }
+
     /// Check if this query matches a given resource ID and kind
     #[cfg(test)]
     pub fn matches(&self, resource_id: &str, kind: &str) -> bool {
@@ -420,9 +453,10 @@ fn filter_to_allowed(params: &EventsQuery, principal: &EventsPrincipal) -> Event
 /// - `None` mode: Token ignored (default)
 pub async fn events(
     State(state): State<Arc<AppState>>,
-    Query(params): Query<EventsQuery>,
+    RawQuery(raw_query): RawQuery,
     MaybeBearer(principal): MaybeBearer,
 ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ServerError> {
+    let params = EventsQuery::from_query_str(raw_query.as_deref().unwrap_or_default());
     // Peer mode: return 404 - events endpoint not available
     // Peers subscribe to the transaction server's events endpoint instead
     if state.config.server_role == ServerRole::Peer {
@@ -579,5 +613,35 @@ mod tests {
 
         assert!(query.matches("any:main", "ledger"));
         assert!(query.matches("any:main", "graph-source"));
+    }
+
+    /// The wire form, which nothing used to cover: every test above builds
+    /// an `EventsQuery` in process, so the fact that no `?ledger=` request
+    /// could ever be deserialized went unnoticed. Repeated keys must
+    /// accumulate, and a percent-encoded `:` must survive.
+    #[test]
+    fn test_events_query_from_query_str() {
+        let one = EventsQuery::from_query_str("ledger=books%3Amain");
+        assert_eq!(one.ledgers, vec!["books:main".to_string()]);
+        assert!(!one.all);
+        assert!(one.matches("books:main", "ledger"));
+
+        let many = EventsQuery::from_query_str(
+            "ledger=books%3Amain&ledger=users%3Amain&graph-source=search%3Amain",
+        );
+        assert_eq!(
+            many.ledgers,
+            vec!["books:main".to_string(), "users:main".to_string()]
+        );
+        assert_eq!(many.graph_sources, vec!["search:main".to_string()]);
+
+        assert!(EventsQuery::from_query_str("all=true").all);
+        assert!(EventsQuery::from_query_str("all=1").all);
+        assert!(!EventsQuery::from_query_str("all=false").all);
+        assert!(!EventsQuery::from_query_str("").all);
+
+        // Unknown keys and empty values are ignored, not fatal.
+        let odd = EventsQuery::from_query_str("ledger=&future=1&ledger=a%3Ab");
+        assert_eq!(odd.ledgers, vec!["a:b".to_string()]);
     }
 }

--- a/fluree-db-server/src/routes/events.rs
+++ b/fluree-db-server/src/routes/events.rs
@@ -59,15 +59,34 @@ impl EventsQuery {
     /// Hand-rolled rather than `Query<EventsQuery>`, because the subscription
     /// params are REPEATED keys (`?ledger=a&ledger=b`) and
     /// `serde_urlencoded` — what `axum::extract::Query` deserializes with —
-    /// cannot build a `Vec` from repeated keys. It rejects the whole request
-    /// with `invalid type: string "…", expected a sequence`, so *every*
-    /// `?ledger=` form answered 400, a single alias included; only
-    /// `?all=true` ever worked. The `Deserialize` derive stays for the
-    /// in-process constructions and tests.
+    /// cannot build a `Vec` from repeated keys *into a struct*. It rejects
+    /// the whole request with `invalid type: string "…", expected a
+    /// sequence`, so *every* `?ledger=` form answered 400, a single alias
+    /// included; only `?all=true` ever worked. The `Deserialize` derive
+    /// stays for the in-process constructions and tests.
+    ///
+    /// `serde_urlencoded::from_str::<Vec<(String, String)>>` — the pair-list
+    /// shape rather than the struct shape — *does* handle repeats, and is
+    /// the obvious replacement for this function. It is not used because it
+    /// collapses the two spellings this endpoint distinguishes: measured,
+    /// both `"all"` and `"all="` deserialize to `("all", "")`, losing the
+    /// bare-flag form. It would also not remove the decode handling below —
+    /// it does not reject undecodable input, it passes it through
+    /// (`ledger=books%ZZmain` → `"books%ZZmain"`) or replaces it lossily
+    /// (`a%FFb` → `a\u{FFFD}b`), which is the silent-match-nothing failure
+    /// this parser rejects outright.
     ///
     /// Unknown keys are ignored (forward compatibility), and so is an empty
     /// `ledger=` / `graph-source=` — one alias among however many were
     /// asked for, and dropping it changes the scope but never erases it.
+    ///
+    /// A component that does not percent-decode is a 400, keys included.
+    /// Passing the raw text through instead would hand back an alias that
+    /// cannot match any ledger — a 200 SSE stream that emits nothing,
+    /// forever — which is the same silent freeze the repeated-key fix
+    /// exists to remove. Keys are decoded before matching for the same
+    /// reason: `%6Cedger=books%3Amain` is a subscription request, and
+    /// matching on the raw key would drop it and serve that empty stream.
     ///
     /// `all` is different, and is the one value this parser REJECTS. It is
     /// the whole subscription request, so a value we do not understand can
@@ -84,19 +103,15 @@ impl EventsQuery {
         for pair in raw.split('&').filter(|p| !p.is_empty()) {
             // `None` distinguishes a bare flag (`?all`) from an explicitly
             // empty value (`?all=`), which are not the same request.
-            let (key, raw_value) = match pair.split_once('=') {
+            let (raw_key, raw_value) = match pair.split_once('=') {
                 Some((k, v)) => (k, Some(v)),
                 None => (pair, None),
             };
-            // `+` is a space in application/x-www-form-urlencoded; percent
-            // escapes cover everything else (`:` in `books:main` is commonly
-            // sent as %3A).
-            let value = raw_value.map(|v| {
-                urlencoding::decode(&v.replace('+', " "))
-                    .map(std::borrow::Cow::into_owned)
-                    .unwrap_or_else(|_| v.to_string())
-            });
-            match key {
+            let key = decode_component(raw_key, "parameter name")?;
+            let value = raw_value
+                .map(|v| decode_component(v, "parameter value"))
+                .transpose()?;
+            match key.as_str() {
                 "all" => query.all = parse_all(value.as_deref())?,
                 "ledger" => {
                     if let Some(v) = value.filter(|v| !v.is_empty()) {
@@ -130,6 +145,43 @@ impl EventsQuery {
 
 /// `?all` → true (flag form); `?all=<boolean>` → that boolean; anything
 /// else → 400 rather than a stream that silently never emits.
+/// Percent/`+`-decode one query-string component.
+///
+/// `+` is a space in application/x-www-form-urlencoded; percent escapes
+/// cover everything else (`:` in `books:main` is commonly sent as `%3A`).
+/// A component that does not decode is an error rather than a passthrough —
+/// see [`EventsQuery::from_query_str`] for why.
+fn decode_component(raw: &str, what: &str) -> Result<String, ServerError> {
+    let reject = |why: &str| {
+        ServerError::BadRequest(format!(
+            "events: {what} {raw:?} is not valid percent-encoded UTF-8 ({why}). \
+             It is rejected rather than used verbatim, because an alias that \
+             cannot match any resource would open an SSE stream that never emits."
+        ))
+    };
+
+    // `urlencoding::decode` only fails on invalid UTF-8: a MALFORMED escape
+    // (`%ZZ`, a trailing `%`) is left in the string verbatim and returns
+    // `Ok`. That is the passthrough this function exists to prevent, so the
+    // escapes are validated before decoding rather than trusted to it.
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            match bytes.get(i + 1..i + 3) {
+                Some(hex) if hex.iter().all(u8::is_ascii_hexdigit) => i += 3,
+                _ => return Err(reject("malformed percent-escape")),
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    urlencoding::decode(&raw.replace('+', " "))
+        .map(std::borrow::Cow::into_owned)
+        .map_err(|e| reject(&e.to_string()))
+}
+
 fn parse_all(value: Option<&str>) -> Result<bool, ServerError> {
     let Some(value) = value else {
         return Ok(true);
@@ -689,6 +741,48 @@ mod tests {
         // Unknown keys and empty values are ignored, not fatal.
         let odd = parsed("ledger=&future=1&ledger=a%3Ab");
         assert_eq!(odd.ledgers, vec!["a:b".to_string()]);
+    }
+
+    /// A component that does not percent-decode is rejected rather than used
+    /// verbatim. The verbatim form is the silent freeze one parameter over:
+    /// `"books%ZZmain"` cannot match any ledger, so the client gets a 200 SSE
+    /// stream that emits nothing, forever, with nothing to notice.
+    ///
+    /// This is also the case `serde_urlencoded`'s pair-list shape would NOT
+    /// have fixed — it passes `%ZZ` through raw and replaces `%FF` lossily,
+    /// rather than erroring — which is why this parser stays hand-rolled.
+    #[test]
+    fn an_undecodable_component_is_rejected_rather_than_passed_through() {
+        for raw in ["ledger=books%ZZmain", "ledger=a%FFb", "graph-source=x%FF"] {
+            let err = EventsQuery::from_query_str(raw)
+                .err()
+                .unwrap_or_else(|| panic!("{raw} must not be accepted"));
+            assert_eq!(
+                err.status_code(),
+                axum::http::StatusCode::BAD_REQUEST,
+                "{raw}"
+            );
+        }
+
+        // An undecodable KEY is rejected for the same reason: the server
+        // cannot tell whether it was a `ledger=` it is now dropping.
+        let err = EventsQuery::from_query_str("%FFedger=books%3Amain")
+            .expect_err("an undecodable key must not be silently ignored");
+        assert_eq!(err.status_code(), axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    /// Keys are percent-decoded before matching. A client that encodes the
+    /// key is making a real subscription request; matching on the raw key
+    /// would drop it and serve the empty stream instead.
+    #[test]
+    fn an_encoded_key_still_selects_its_parameter() {
+        let q = parsed("%6Cedger=books%3Amain");
+        assert_eq!(q.ledgers, vec!["books:main".to_string()]);
+        assert!(q.matches("books:main", "ledger"));
+
+        // `+` is a space in both halves of the pair.
+        let spaced = parsed("ledger=a+b");
+        assert_eq!(spaced.ledgers, vec!["a b".to_string()]);
     }
 
     /// `?all=` is the whole subscription request. A value this parser does

--- a/fluree-db-server/tests/proxy_integration.rs
+++ b/fluree-db-server/tests/proxy_integration.rs
@@ -3055,3 +3055,68 @@ async fn test_object_endpoint_pins_graph_source_kinds_unserved() {
         "GraphSourceMapping must 404 until #1539"
     );
 }
+
+/// The per-ledger SSE subscription form, over HTTP.
+///
+/// `GET /v1/fluree/events?ledger=<alias>` is what every peer opens — the
+/// native peer builds it in `peer/subscription.rs`, the browser peer in
+/// `fluree-db-browser`'s `events_url`, and the module docs advertise
+/// `?ledger=a&ledger=b`. It nevertheless answered **400** for any value,
+/// because `axum::extract::Query` deserializes with `serde_urlencoded`,
+/// which cannot build a `Vec` from repeated keys. Every unit test built an
+/// `EventsQuery` in process, so nothing caught it; only `?all=true`
+/// (a plain bool) ever worked, which is what the peer test configs use.
+#[tokio::test]
+async fn test_events_accepts_per_ledger_subscription_over_http() {
+    let (_tmp, state) = tx_server_state().await;
+    let app = build_router(state);
+
+    let create = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/create")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "ledger": "sse:main" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create.status(), StatusCode::CREATED);
+
+    // The body is an endless stream; only the response head is asserted (a
+    // rejected query string never gets that far).
+    for uri in [
+        "/v1/fluree/events?ledger=sse:main",
+        "/v1/fluree/events?ledger=sse%3Amain",
+        "/v1/fluree/events?ledger=sse%3Amain&ledger=other%3Amain",
+        "/v1/fluree/events?ledger=sse%3Amain&graph-source=gs%3Amain",
+        "/v1/fluree/events?all=true",
+        "/v1/fluree/events",
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .header("Accept", "text/event-stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "GET {uri}");
+        assert!(
+            resp.headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+                .starts_with("text/event-stream"),
+            "GET {uri} must open an SSE stream"
+        );
+    }
+}


### PR DESCRIPTION
`GET /v1/fluree/events?ledger=<alias>` has never worked. It answers **400** for every value — `invalid type: string "…", expected a sequence` — so only `?all=true` has ever opened a stream.

The mechanism: `EventsQuery.ledgers` is a `Vec<String>` fed by repeated keys (`?ledger=a&ledger=b`), and the handler took it through `axum::extract::Query`, which deserializes with `serde_urlencoded` — and serde_urlencoded cannot build a sequence from repeated keys. It rejects the whole request before the handler runs. `?all=true` survived only because it's a plain bool.

**Consequence, and the reason I'd like eyes on this beyond the diff: any peer subscribed to specific ledgers rather than `subscribe_all` has been receiving no events at all.** The native peer builds exactly this form — `peer/subscription.rs` pushes `ledger={}` per alias — and the module docs advertise `?ledger=a&ledger=b` as the API. It's worth someone checking whether a deployed peer is affected. Two corrections to an earlier draft of this paragraph, both from review and both verified: **this is more severe than "an unusual opt-in"** — `peer_subscribe_all` defaults to `false` (`config.rs:867`) and validation requires either `--peer-subscribe-all` or an explicit `--peer-ledger` list (`config.rs:1163-1171`), so the broken form is one of only two valid peer configurations. And **it is not silent** — a 400 is not `is_fatal()` (only 401/403 are, `subscription.rs:406-414`), so an affected peer logs `WARN "Peer SSE subscription failed, will reconnect"` on every backoff cycle and loops forever. Noisy but ineffective is a more accurate description than event-less-without-notice, and it changes how someone would have found this.

Why it survived this long: every existing test constructs an `EventsQuery` in process, so nothing ever exercised the query string over the wire, and the peer test configs all set `peer_subscribe_all: true` — the one shape that happens to work.

The fix takes `RawQuery` and parses the pair list directly, percent/`+`-decoding both halves of each pair. An earlier draft of this description claimed it folded a `serde_urlencoded` pair list and kept that crate's decoding; it does not, and review rightly caught the mismatch. `serde_urlencoded::from_str::<Vec<(String, String)>>` — the pair-list shape rather than the struct shape — was then measured as the replacement, and it is not usable here: both `"all"` and `"all="` deserialize to `("all", "")`, collapsing the bare-flag form this endpoint distinguishes, and it does not reject undecodable input — it passes `%ZZ` through raw and replaces `%FF` lossily, which is the exact silent failure this PR exists to remove. It does handle repeats and key decoding correctly; two of three was not enough to adopt it. Repeated `ledger=` / `graph-source=` keys accumulate, unknown keys are ignored for forward compatibility, and a malformed query string still 400s exactly as the derived extractor did. The `Deserialize` derive stays for the in-process constructions and existing tests.

Covered at both levels: parser unit tests in the module (single alias, repeats, percent-encoded `:`, the `all` spellings, unknown-key tolerance), and `test_events_accepts_per_ledger_subscription_over_http` in `proxy_integration.rs`, which goes over HTTP — the gap that let this ship — across the single-alias, percent-encoded, multi-alias, mixed graph-source, `all=true`, and bare forms. It is mutation-verified: reverting `events.rs` to main while keeping the test fails it at `GET /v1/fluree/events?ledger=sse:main`.

Found while building an end-to-end browser-peer smoke against a real server (part of the wasm work in #1714/#1715) — the browser peer builds the same URL, so it hit the same 400. Pulled out here as a standalone fix against `main` because nothing about it is wasm-specific and it shouldn't wait behind that stack.

Gates: `proxy_integration` 30/30, server lib 154/154 at that commit, `cargo clippy -p fluree-db-server --all-targets -D warnings` clean, `cargo fmt --check` clean, workspace `cargo check --all-targets` clean.

## A second silent failure in the same parser

Reviewing this fix's neighbourhood turned up the sibling of the same bug, so it ships here rather than separately: `all` accepted only the exact strings `true` and `1`, and *everything else silently meant false*. `?all=TRUE`, `?all=yes`, `?all=on`, and every typo therefore opened a 200 SSE stream that matched nothing and emitted nothing, forever, with no error for a client to notice — the identical failure shape to the 400 above, one parameter over, and one the derived extractor used to catch (a non-boolean 400'd).

`all` is now the one value this parser rejects rather than guesses at, because it *is* the subscription request: `true`/`1`/`yes`/`on` and `false`/`0`/`no`/`off` case-insensitively, bare `?all` as the flag form, and anything else — empty included — a 400 naming the parameter. Deliberately not extended to `ledger=`: an empty alias there is one of however many were asked for, so dropping it narrows the scope without erasing it, and an existing test already pins that it is ignorable.

Gates after all three fixes: server lib 156/156 (154 on the branch before this PR's two new parser tests), `proxy_integration` 30/30, clippy `-D warnings` clean, `cargo fmt --check` clean, workspace check clean.



## Third fix: an undecodable parameter is rejected, not used verbatim

Review found the decode fallback passed raw text through when percent-decoding failed, so `ledger=books%ZZmain` became the alias `"books%ZZmain"` — which cannot match any ledger, and so opened a 200 SSE stream emitting nothing, forever. That is the same silent-freeze shape as the two fixes above, a third time.

Two things surfaced while fixing it that are worth stating, because both make the change larger than the report:

- **`urlencoding::decode` only fails on invalid UTF-8.** A malformed escape (`%ZZ`, a trailing `%`) is left in the string and returns `Ok`, so routing the error case to a 400 was not sufficient on its own — the escapes are now validated before decoding. A test written against the reported case caught this on the first attempt, which is the reason it is not still latent.
- **Keys were matched raw**, so `%6Cedger=books%3Amain` — a legitimate subscription request — matched no arm and was dropped, serving the same empty stream. Keys are now decoded before matching, and an undecodable key is a 400 rather than an ignored unknown key, because the server cannot tell whether it was a `ledger=` it is discarding.

The fallback also returned the pre-`+`-substitution text, so a decode failure silently changed space handling as well; moot now that it is an error.

## Operator note

Affected peers have been in a permanent connect → 400 → backoff loop, so connection churn *drops* when this lands. In exchange they begin receiving events for the first time and doing what events trigger — ledger preloads (`subscription.rs:254`) and cached-ledger refreshes (`:306`). **A peer that has been event-less since deployment will begin syncing the moment this merges**, which is the intended behavior but is not a no-op on a running fleet.
