### PR TITLE
test(ledger): a soft-dropped ledger reads as absent from exists()

### DIFF
--- a/fluree-db-api/tests/it_ledger_lifecycle.rs
+++ b/fluree-db-api/tests/it_ledger_lifecycle.rs
@@ -210,15 +210,18 @@ async fn ledger_exists_on_file_storage() {
         "a malformed id must be an Err, so callers cannot mistake it for absence",
     );
 
-    // A soft-dropped ledger still has a (retracted) record: `exists`
-    // is "is there a record", not "is it live".
+    // A soft-dropped ledger reads as absent. The record survives on a
+    // tombstoning nameservice so admin tooling can read the retracted
+    // flag, but `exists` is a query-path question: a dropped ledger must
+    // not load or serve queries, so it must not report as existing
+    // either. See 43d758610.
     fluree
         .drop_ledger("x", fluree_db_api::DropMode::Soft)
         .await
         .unwrap();
     assert!(
-        fluree.ledger_exists("x:main").await.unwrap(),
-        "exists() reports the record, which a soft drop keeps",
+        !fluree.ledger_exists("x:main").await.unwrap(),
+        "a retracted record is not a live ledger, so exists() reports false",
     );
 }
 

--- a/fluree-db-api/tests/it_ledger_lifecycle.rs
+++ b/fluree-db-api/tests/it_ledger_lifecycle.rs
@@ -214,7 +214,7 @@ async fn ledger_exists_on_file_storage() {
     // tombstoning nameservice so admin tooling can read the retracted
     // flag, but `exists` is a query-path question: a dropped ledger must
     // not load or serve queries, so it must not report as existing
-    // either. See 43d758610.
+    // either. See 43d758610 (#1716).
     fluree
         .drop_ledger("x", fluree_db_api::DropMode::Soft)
         .await


### PR DESCRIPTION
`main`'s `test` job has been red since #1716 merged, on a single assertion.

`43d758610` made `ledger_exists` treat a retracted record as not-found on the query path — matching `LedgerState::load`, so that a dropped ledger can neither load nor serve queries. `it_ledger_lifecycle::ledger_exists_on_file_storage:219` still encoded the older contract, that `exists` answers "is there a record" rather than "is it live":

```rust
assert!(
    fluree.ledger_exists("x:main").await.unwrap(),
    "exists() reports the record, which a soft drop keeps",
);
```

This flips the assertion and rewrites the comment to say why both halves are true at once: the record genuinely survives on a tombstoning nameservice so admin tooling can read the retracted flag, *and* `exists` answers false because it's a query-path question. It cites the commit, so the next reader gets the reasoning rather than re-deriving it.

Nothing else in the test changes — the create/commit/unknown-name/malformed-id assertions above it are untouched, and they're the reason the test exists.

Worth knowing this is currently inherited by every open PR whose CI has run since 01:35, since CI merges `main` into each head. It's the only failure in those runs.

I've written this as the smaller of the two readings — that the test was stale and the change was intended. If the older contract was the right one and `exists` should keep reporting retracted records, then this should be closed and `43d758610` revisited instead; that's a call for @bplatz rather than me.

One related note: this settles a sub-question of #1670, which is still open and carries the wider delete-semantics decision — init-reclaims versus reject, whether an un-retract path exists, and branch-scoped hard purge. Worth recording there that the `exists` half is now decided, so whoever picks up the rest doesn't re-derive it and the two don't drift apart, which is what that issue is about in the first place.
