### PR TITLE
fix(ingest): store an object-position empty collection as the rdf:nil triple it denotes

### DIFF
--- a/docs/audit/burn-down/ROADMAP.md
+++ b/docs/audit/burn-down/ROADMAP.md
@@ -383,13 +383,15 @@ pr-1; BASE↔G1 joint entries resolve at whichever lands second.
 
 **Post-implementation corrections to this roadmap:**
 
-- **`basic#list-1..4` do NOT green via PR-1** (contra §2's PR-1 row): Turtle
-  *ingest* stores object-position collections as Fluree `list_index` items and
-  drops `()` objects entirely (`parse_collection_as_list`,
-  fluree-graph-turtle), so the `rdf:first/rest` triples never exist in
-  storage. This is a new, owned-by-no-one ingest/model gap — **decision D-13**:
-  materialize first/rest at ingest vs translate at query time vs documented
-  divergence. Register comments updated in PR-1.
+- **`basic#list-2..4` do NOT green via PR-1** (contra §2's PR-1 row): Turtle
+  *ingest* stores object-position collections as Fluree `list_index` items
+  (`parse_collection_as_list`, fluree-graph-turtle), so the `rdf:first/rest`
+  triples never exist in storage. This is a new, owned-by-no-one ingest/model
+  gap — **decision D-13**: materialize first/rest at ingest vs translate at
+  query time vs documented divergence. Register comments updated in PR-1.
+  (When this was written ingest also dropped `()` objects entirely; the issue
+  #1694 fix now stores them as the `rdf:nil` triple they denote, which greened
+  `list-1` — its pattern needs no spine — and took it off this register.)
 - **`subquery12` is resolved by PR-1** (bare-`{SELECT}` misparse executing
   through error recovery) — remove it from PR-X2's scope; its probe item is
   closed, and it further evidences the diagnostic-swallowing hole PR-3 must

--- a/fluree-db-api/tests/grp_transact.rs
+++ b/fluree-db-api/tests/grp_transact.rs
@@ -9,6 +9,8 @@ mod it_cached_handle_cow_recovery;
 mod it_concurrent_update_reconcile;
 #[path = "it_enforce_unique_upsert_indexed.rs"]
 mod it_enforce_unique_upsert_indexed;
+#[path = "it_jsonld_empty_list.rs"]
+mod it_jsonld_empty_list;
 #[path = "it_raw_txn_parallel_upload.rs"]
 mod it_raw_txn_parallel_upload;
 #[path = "it_stable_blank_nodes.rs"]

--- a/fluree-db-api/tests/grp_transact.rs
+++ b/fluree-db-api/tests/grp_transact.rs
@@ -33,6 +33,8 @@ mod it_transact_update_indexed;
 mod it_transact_upsert;
 #[path = "it_transact_upsert_indexed.rs"]
 mod it_transact_upsert_indexed;
+#[path = "it_turtle_empty_collection.rs"]
+mod it_turtle_empty_collection;
 #[path = "it_txn_meta.rs"]
 mod it_txn_meta;
 #[path = "it_update_wildcard_delete_indexed.rs"]

--- a/fluree-db-api/tests/it_jsonld_empty_list.rs
+++ b/fluree-db-api/tests/it_jsonld_empty_list.rs
@@ -1,0 +1,173 @@
+//! JSON-LD empty-`@list` ingest — the twin of the Turtle `()` fix (issue
+//! #1694).
+//!
+//! Per JSON-LD 1.1 → RDF deserialization ("List to RDF Conversion"), an
+//! empty `@list` denotes the IRI `rdf:nil`. The transact JSON-LD parser used
+//! to produce ZERO triple templates for `{"@list": []}` — the same
+//! silent-loss class as the Turtle bug: the statement vanished with no
+//! diagnostic. These tests pin the fix end-to-end through the public
+//! transact surface and prove the two ingest surfaces agree: an empty
+//! `@list` stores the one `rdf:nil` triple, identically to Turtle's `()`,
+//! while non-empty `@list`s keep their `list_index` storage shape.
+
+use crate::support;
+use crate::support::normalize_rows;
+use fluree_db_api::FlureeBuilder;
+use serde_json::json;
+
+const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
+
+async fn rows(
+    fluree: &support::MemoryFluree,
+    ledger: &support::MemoryLedger,
+    sparql: &str,
+) -> Vec<serde_json::Value> {
+    let out = support::query_sparql(fluree, ledger, sparql)
+        .await
+        .expect("sparql query")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    normalize_rows(&out)
+}
+
+/// The issue-#1694 repro shape, spoken in JSON-LD: three list members under
+/// `ex:s` and an empty list under `ex:s2`. As RDF this denotes
+/// `ex:s2 ex:items rdf:nil` — before the fix `ex:s2` never reached the
+/// database at all.
+#[tokio::test]
+async fn empty_jsonld_list_object_stores_rdf_nil() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = fluree
+        .create_ledger("tx/jsonld-empty-list:main")
+        .await
+        .expect("genesis");
+    let txn = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:s", "ex:items": {"@list": [
+                {"@id": "ex:a"}, {"@id": "ex:b"}, {"@id": "ex:c"}
+            ]}},
+            {"@id": "ex:s2", "ex:items": {"@list": []}}
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &txn).await.expect("insert").ledger;
+
+    let nil_rows = rows(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT ?o WHERE { ex:s2 ex:items ?o }",
+    )
+    .await;
+    assert_eq!(nil_rows.len(), 1, "ex:s2 must exist: {nil_rows:?}");
+    let obj = nil_rows[0]
+        .as_array()
+        .and_then(|r| r.first())
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("expected an IRI object row, got {nil_rows:?}"));
+    assert!(
+        obj == RDF_NIL || obj == "rdf:nil",
+        "object must be rdf:nil, got {obj}"
+    );
+
+    // Non-empty lists keep the list_index storage shape: members stay
+    // direct objects and no rdf:first/rest spine is materialized.
+    let items = rows(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT ?o WHERE { ex:s ex:items ?o }",
+    )
+    .await;
+    assert_eq!(items.len(), 3, "list members stay direct: {items:?}");
+
+    // The whole graph: 3 indexed list items + the nil edge.
+    let all = rows(&fluree, &ledger, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }").await;
+    assert_eq!(all.len(), 4, "expected 4 stored statements: {all:?}");
+}
+
+/// The two ingest surfaces must agree: the same statements through Turtle
+/// (`()`) and through JSON-LD (`{"@list": []}`) store identical graphs.
+#[tokio::test]
+async fn empty_jsonld_list_matches_turtle_empty_collection() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let ttl_ledger0 = fluree
+        .create_ledger("tx/jsonld-empty-list:ttl")
+        .await
+        .expect("genesis");
+    let ttl_ledger = fluree
+        .insert_turtle(
+            ttl_ledger0,
+            r"@prefix ex: <http://example.org/> .
+ex:s  ex:items ( ex:a ex:b ex:c ) .
+ex:s2 ex:items () .
+",
+        )
+        .await
+        .expect("insert turtle")
+        .ledger;
+
+    let json_ledger0 = fluree
+        .create_ledger("tx/jsonld-empty-list:json")
+        .await
+        .expect("genesis");
+    let txn = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@graph": [
+            {"@id": "ex:s", "ex:items": {"@list": [
+                {"@id": "ex:a"}, {"@id": "ex:b"}, {"@id": "ex:c"}
+            ]}},
+            {"@id": "ex:s2", "ex:items": {"@list": []}}
+        ]
+    });
+    let json_ledger = fluree
+        .insert(json_ledger0, &txn)
+        .await
+        .expect("insert jsonld")
+        .ledger;
+
+    let q = "SELECT ?s ?p ?o WHERE { ?s ?p ?o }";
+    assert_eq!(
+        rows(&fluree, &ttl_ledger, q).await,
+        rows(&fluree, &json_ledger, q).await,
+        "Turtle `()` and JSON-LD `{{\"@list\": []}}` must store identically"
+    );
+}
+
+/// An empty `@list` in explicit array position (`[{"@list": []}]`) is the
+/// same value and must store the same `rdf:nil` triple. This spelling had a
+/// DIFFERENT defect from the bare-object one: JSON-LD expansion dropped the
+/// `@list` key (any key whose values expand to nothing was dropped), turning
+/// the item into `{}` — which then stored a spurious BLANK NODE object
+/// instead of `rdf:nil`.
+#[tokio::test]
+async fn empty_jsonld_list_in_array_position_stores_rdf_nil() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = fluree
+        .create_ledger("tx/jsonld-empty-list:arr")
+        .await
+        .expect("genesis");
+    let txn = json!({
+        "@context": {"ex": "http://example.org/"},
+        "@id": "ex:s2",
+        "ex:items": [{"@list": []}]
+    });
+    let ledger = fluree.insert(ledger0, &txn).await.expect("insert").ledger;
+
+    let all = rows(&fluree, &ledger, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }").await;
+    assert_eq!(
+        all.len(),
+        1,
+        "exactly the rdf:nil triple, nothing else: {all:?}"
+    );
+    let obj = all[0]
+        .as_array()
+        .and_then(|r| r.get(2))
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("expected an IRI object, got {all:?}"));
+    assert_eq!(
+        obj, RDF_NIL,
+        "array-position empty @list must store rdf:nil, not a blank node"
+    );
+}

--- a/fluree-db-api/tests/it_turtle_empty_collection.rs
+++ b/fluree-db-api/tests/it_turtle_empty_collection.rs
@@ -1,0 +1,178 @@
+//! Turtle empty-collection (`()`) ingest — issue #1694, the silent-loss half.
+//!
+//! An object-position `()` in Turtle denotes the IRI `rdf:nil`
+//! (`ex:s2 ex:items ()` IS `ex:s2 ex:items rdf:nil`). The default
+//! `CollectionStyle::IndexedItems` parser used to consume the statement and
+//! emit NOTHING — the subject never reached the database and no diagnostic
+//! fired. These tests pin the fix end-to-end through the public transact
+//! surface: `()` now stores the `rdf:nil` triple, identically to the same
+//! statement written with an explicit `rdf:nil`, while non-empty collections
+//! keep their `list_index` storage shape (the D-13 spine decision is
+//! deliberately NOT taken here — `?l rdf:first ?x` still matches nothing).
+
+use crate::support;
+use crate::support::normalize_rows;
+use fluree_db_api::FlureeBuilder;
+
+const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
+
+/// The issue's repro document: as RDF it denotes eight triples — three list
+/// members under `ex:s` (stored as indexed list items) and
+/// `ex:s2 ex:items rdf:nil`.
+const REPRO_TTL: &str = r"@prefix ex: <http://example.org/> .
+ex:s  ex:items ( ex:a ex:b ex:c ) .
+ex:s2 ex:items () .
+";
+
+/// The same statements with the empty collection written as the IRI it
+/// denotes. `()` must lower to exactly this.
+const CONTROL_TTL: &str = r"@prefix ex: <http://example.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+ex:s  ex:items ( ex:a ex:b ex:c ) .
+ex:s2 ex:items rdf:nil .
+";
+
+async fn seed_turtle(
+    fluree: &support::MemoryFluree,
+    ledger_id: &str,
+    ttl: &str,
+) -> support::MemoryLedger {
+    let ledger0 = fluree.create_ledger(ledger_id).await.expect("genesis");
+    fluree
+        .insert_turtle(ledger0, ttl)
+        .await
+        .expect("insert turtle")
+        .ledger
+}
+
+async fn rows(
+    fluree: &support::MemoryFluree,
+    ledger: &support::MemoryLedger,
+    sparql: &str,
+) -> Vec<serde_json::Value> {
+    let out = support::query_sparql(fluree, ledger, sparql)
+        .await
+        .expect("sparql query")
+        .to_jsonld(&ledger.snapshot)
+        .expect("to_jsonld");
+    normalize_rows(&out)
+}
+
+/// Issue #1694 repro: `ex:s2 ex:items ()` must store `ex:s2 ex:items rdf:nil`
+/// rather than vanishing.
+#[tokio::test]
+async fn empty_collection_object_stores_rdf_nil() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_turtle(&fluree, "tx/turtle-empty-coll:main", REPRO_TTL).await;
+
+    // The subject exists and its object is rdf:nil.
+    let nil_rows = rows(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT ?o WHERE { ex:s2 ex:items ?o }",
+    )
+    .await;
+    assert_eq!(nil_rows.len(), 1, "ex:s2 must exist: {nil_rows:?}");
+    let obj = nil_rows[0]
+        .as_array()
+        .and_then(|r| r.first())
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("expected an IRI object row, got {nil_rows:?}"));
+    assert!(
+        obj == RDF_NIL || obj == "rdf:nil",
+        "object must be rdf:nil, got {obj}"
+    );
+
+    // And it is reachable through the SPARQL `()` pattern (which lowers to
+    // the rdf:nil constant — the W3C basic#list-1 shape).
+    let by_nil_pattern = rows(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT ?s WHERE { ?s ex:items () }",
+    )
+    .await;
+    assert_eq!(
+        by_nil_pattern.len(),
+        1,
+        "`?s ex:items ()` must find ex:s2: {by_nil_pattern:?}"
+    );
+
+    // The whole graph: 3 indexed list items + the nil edge. Before the fix
+    // this document committed 3 flakes and ex:s2 did not exist at all.
+    let all = rows(&fluree, &ledger, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }").await;
+    assert_eq!(all.len(), 4, "expected 4 stored statements: {all:?}");
+}
+
+/// `()` and a literally-written `rdf:nil` must produce identical graphs —
+/// the empty collection is only surface syntax for that IRI.
+#[tokio::test]
+async fn empty_collection_matches_literal_rdf_nil() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let from_sugar = seed_turtle(&fluree, "tx/turtle-empty-coll:sugar", REPRO_TTL).await;
+    let from_iri = seed_turtle(&fluree, "tx/turtle-empty-coll:iri", CONTROL_TTL).await;
+
+    let q = "SELECT ?s ?p ?o WHERE { ?s ?p ?o }";
+    assert_eq!(
+        rows(&fluree, &from_sugar, q).await,
+        rows(&fluree, &from_iri, q).await,
+        "`()` and explicit rdf:nil must store identically"
+    );
+}
+
+/// Non-empty collections keep the `list_index` storage shape: members are
+/// direct objects of the enclosing predicate and NO rdf:first/rest spine is
+/// materialized. This is the D-13 decision left exactly where it was.
+#[tokio::test]
+async fn non_empty_collections_unchanged_no_spine() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_turtle(&fluree, "tx/turtle-empty-coll:nospine", REPRO_TTL).await;
+
+    let items = rows(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT ?o WHERE { ex:s ex:items ?o }",
+    )
+    .await;
+    assert_eq!(
+        items.len(),
+        3,
+        "list members stay direct objects: {items:?}"
+    );
+
+    let spine = rows(
+        &fluree,
+        &ledger,
+        r"PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+          SELECT ?l ?x WHERE { ?l rdf:first ?x }",
+    )
+    .await;
+    assert!(spine.is_empty(), "no spine must be materialized: {spine:?}");
+}
+
+/// `()` in SUBJECT position (`() ex:p ex:o .`) already parsed as the IRI
+/// `rdf:nil` before this fix — pinned here so the two positions stay
+/// consistent.
+#[tokio::test]
+async fn empty_collection_subject_is_rdf_nil() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_turtle(
+        &fluree,
+        "tx/turtle-empty-coll:subject",
+        r"@prefix ex: <http://example.org/> .
+          () ex:p ex:o .
+",
+    )
+    .await;
+
+    let found = rows(
+        &fluree,
+        &ledger,
+        r"PREFIX ex: <http://example.org/>
+          SELECT ?o WHERE { () ex:p ?o }",
+    )
+    .await;
+    assert_eq!(found.len(), 1, "rdf:nil subject must be stored: {found:?}");
+}

--- a/fluree-db-transact/src/parse/jsonld.rs
+++ b/fluree-db-transact/src/parse/jsonld.rs
@@ -1873,8 +1873,8 @@ fn convert_typed_value_with_meta(
 /// @list objects and uses `parse_list_values` instead to get all elements with indices.
 ///
 /// This function only handles the fallback case and returns the first element.
-/// Empty lists produce an error here since we can't return "no value" - the proper
-/// empty list handling happens in `parse_expanded_objects` via `parse_list_values`.
+/// An empty @list denotes the IRI rdf:nil and returns that single term, in
+/// both this fallback and the `parse_list_values` path (issue #1694 twin).
 #[allow(clippy::too_many_arguments)]
 fn parse_list_value_with_ctx(
     list_val: &Value,
@@ -1891,15 +1891,13 @@ fn parse_list_value_with_ctx(
         }
     };
 
-    // Empty list: we can't return "no value" from this function.
-    // The proper path for empty lists is through parse_expanded_objects which
-    // uses parse_list_values and filters empty results. If we get here with an
-    // empty list, it's an edge case where @list wasn't detected at the array level.
+    // An empty @list denotes the IRI rdf:nil (JSON-LD 1.1 § List to RDF
+    // Conversion) — same as `parse_list_values_with_ctx`. This position used
+    // to error ("Empty @list in unexpected position").
     if items.is_empty() {
-        return Err(TransactError::Parse(
-            "Empty @list in unexpected position (should be handled by parse_expanded_objects)"
-                .to_string(),
-        ));
+        return Ok(ParsedValue::new(TemplateTerm::Sid(
+            ctx.ns_registry.sid_for_iri(rdf::NIL),
+        )));
     }
 
     // Parse the first element with index 0
@@ -1926,9 +1924,14 @@ fn parse_list_values_with_ctx(
         }
     };
 
-    // Empty list produces zero triples
+    // An empty @list denotes the IRI rdf:nil (JSON-LD 1.1 § List to RDF
+    // Conversion): store the one triple, as an ordinary IRI object with no
+    // list index — the twin of the Turtle `()` fix (issue #1694). It used
+    // to produce zero templates, silently losing the statement.
     if items.is_empty() {
-        return Ok(Vec::new());
+        return Ok(vec![ParsedValue::new(TemplateTerm::Sid(
+            ctx.ns_registry.sid_for_iri(rdf::NIL),
+        ))]);
     }
 
     // Parse each item with its index
@@ -2510,7 +2513,9 @@ mod tests {
         let mut ns_registry = test_registry();
         let ctx = ParsedContext::new();
 
-        // Empty @list produces zero ParsedValues
+        // An empty @list denotes rdf:nil: ONE ParsedValue, an ordinary IRI
+        // object with no list index (issue #1694 twin — it used to produce
+        // zero values, silently losing the statement).
         let list_val = json!([]);
         let mut templates = Vec::new();
         let mut graph_ids = GraphIdAssigner::new();
@@ -2528,7 +2533,49 @@ mod tests {
             &mut blank_counter,
         )
         .unwrap();
-        assert!(results.is_empty());
+        assert_eq!(results.len(), 1);
+        assert!(results[0].list_index.is_none());
+        let nil_sid = ns_registry.sid_for_iri(rdf::NIL);
+        assert!(
+            matches!(&results[0].term, TemplateTerm::Sid(sid) if *sid == nil_sid),
+            "empty @list must parse to the rdf:nil IRI"
+        );
+        assert!(templates.is_empty(), "no side-emitted templates");
+    }
+
+    /// The singular fallback (`parse_expanded_value` reaching a `@list`
+    /// object outside the array position) must agree with the plural path:
+    /// an empty `@list` is the single term rdf:nil. It used to error with
+    /// "Empty @list in unexpected position".
+    #[test]
+    fn test_parse_empty_list_single_value_position() {
+        let mut vars = VarRegistry::new();
+        let mut ns_registry = test_registry();
+        let mut templates: Vec<TripleTemplate> = Vec::new();
+        let ctx = ParsedContext::new();
+        let mut graph_ids = GraphIdAssigner::new();
+        let mut blank_counter: usize = 0;
+
+        let val = json!({"@list": []});
+        let result = parse_expanded_value(
+            &val,
+            &ctx,
+            &mut vars,
+            &mut ns_registry,
+            &mut templates,
+            true,
+            &mut graph_ids,
+            None,
+            &HashMap::new(),
+            &mut blank_counter,
+        )
+        .unwrap();
+        assert!(result.list_index.is_none());
+        let nil_sid = ns_registry.sid_for_iri(rdf::NIL);
+        assert!(
+            matches!(&result.term, TemplateTerm::Sid(sid) if *sid == nil_sid),
+            "empty @list must parse to the rdf:nil IRI"
+        );
     }
 
     #[test]

--- a/fluree-graph-json-ld/src/adapter.rs
+++ b/fluree-graph-json-ld/src/adapter.rs
@@ -295,6 +295,14 @@ fn process_list<S: GraphSink>(list_val: &Value, sink: &mut S) -> Result<Processe
         }
     };
 
+    // An empty @list denotes the IRI rdf:nil (JSON-LD 1.1 § List to RDF
+    // Conversion): the statement stores as one ordinary triple, the twin of
+    // Turtle's `()` fix (issue #1694). It used to produce zero events,
+    // silently losing the statement.
+    if items.is_empty() {
+        return Ok(ProcessedValue::Single(sink.term_iri(rdf::NIL)));
+    }
+
     let mut indexed_items = Vec::with_capacity(items.len());
 
     for (index, item) in items.iter().enumerate() {
@@ -989,8 +997,16 @@ mod tests {
         to_graph_events(&expanded, &mut sink).unwrap();
 
         let graph = sink.into_graph();
-        // Empty list produces no triples
-        assert_eq!(graph.len(), 0, "Empty list should produce no triples");
+        // An empty @list denotes rdf:nil: one ordinary triple, no list
+        // metadata (issue #1694 twin — it used to produce zero events).
+        assert_eq!(graph.len(), 1, "empty @list must store the rdf:nil triple");
+        let triple = graph.iter().next().unwrap();
+        assert!(!triple.is_list_element());
+        assert!(
+            matches!(&triple.o, Term::Iri(iri) if iri.as_ref() == rdf::NIL),
+            "expected rdf:nil object, got {:?}",
+            triple.o
+        );
     }
 
     #[test]

--- a/fluree-graph-json-ld/src/expand.rs
+++ b/fluree-graph-json-ld/src/expand.rs
@@ -642,7 +642,15 @@ fn expand_node_internal(
                 let expanded_values =
                     parse_node_value(v, entry.as_ref(), &context_with_types, &key_idx, strict)?;
 
-                if !expanded_values.is_empty() {
+                // A key whose values expand to nothing is dropped — EXCEPT
+                // `@list`: `{"@list": []}` is a value, the empty list, which
+                // denotes the IRI rdf:nil. Dropping the key here turned
+                // `[{"@list": []}]` into `[{}]` — a spurious blank node
+                // downstream instead of the rdf:nil triple (issue #1694
+                // twin). This branch is how an array-position `{"@list": …}`
+                // item expands (it routes through `expand_node_internal`
+                // rather than `parse_node_value`'s `@list` arm).
+                if !expanded_values.is_empty() || expanded_key == "@list" {
                     // Check for @reverse
                     if let Some(ref e) = entry {
                         if e.reverse.is_some() {
@@ -851,6 +859,27 @@ mod tests {
         // Without external context mapping, https://schema.org stays as https
         assert_eq!(obj["@type"], json!(["https://schema.org/Movie"]));
         assert!(obj.contains_key("https://schema.org/name"));
+    }
+
+    /// An empty `@list` survives expansion in every spelling. The
+    /// array-position item routes through `expand_node_internal`, whose
+    /// drop-empty-keys rule used to strip the `@list` key — `[{"@list": []}]`
+    /// expanded to `[{}]`, which downstream stored a spurious blank node
+    /// instead of the `rdf:nil` the empty list denotes (issue #1694 twin).
+    #[test]
+    fn test_expand_empty_list_keeps_list_key() {
+        for doc in [
+            json!({"@id": "http://example.org/s", "http://example.org/p": {"@list": []}}),
+            json!({"@id": "http://example.org/s", "http://example.org/p": [{"@list": []}]}),
+        ] {
+            let result = node(&doc, &ParsedContext::new()).unwrap();
+            let obj = result.as_object().unwrap();
+            assert_eq!(
+                obj["http://example.org/p"],
+                json!([{"@list": []}]),
+                "empty @list must expand to itself, not vanish: {result}"
+            );
+        }
     }
 
     #[test]

--- a/fluree-graph-turtle/src/options.rs
+++ b/fluree-graph-turtle/src/options.rs
@@ -16,14 +16,16 @@
 pub enum CollectionStyle {
     /// Object-position collections become indexed
     /// [`emit_list_item`](fluree_graph_ir::GraphSink::emit_list_item) events
-    /// on the enclosing subject/predicate, and an object-position `()` emits
-    /// nothing.
+    /// on the enclosing subject/predicate. An object-position `()` is the
+    /// IRI `rdf:nil` and emits that one triple, exactly as if `rdf:nil` had
+    /// been written out (issue #1694 — it used to emit nothing, silently
+    /// losing the statement).
     ///
     /// This is Fluree's storage shape — a list is metadata on the edge, not a
-    /// chain of blank nodes — and it is lossy as RDF: the W3C-defined three
-    /// triples of a one-item collection arrive as one event, and the empty
-    /// collection's `rdf:nil` triple is dropped entirely. Subject-position
-    /// collections are unaffected; they have always emitted a spine.
+    /// chain of blank nodes — and it is lossy as RDF for non-empty
+    /// collections: the W3C-defined three triples of a one-item collection
+    /// arrive as one event. Subject-position collections are unaffected;
+    /// they have always emitted a spine.
     #[default]
     IndexedItems,
 
@@ -33,9 +35,10 @@ pub enum CollectionStyle {
     /// Turtle suite tests.
     ///
     /// In this mode a collection has a single object term (the spine head),
-    /// so an RDF 1.2 annotation may follow one — the deferral that applies in
-    /// [`CollectionStyle::IndexedItems`] exists only because indexed items
-    /// leave nothing to reify.
+    /// so an RDF 1.2 annotation may follow one — the deferral that applies to
+    /// non-empty collections in [`CollectionStyle::IndexedItems`] exists only
+    /// because indexed items leave nothing to reify. (`()` is a single term —
+    /// `rdf:nil` — in both styles, and annotations on it work in both.)
     Spine,
 }
 

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -807,13 +807,19 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
 
     /// Parse an object list (comma-separated objects).
     ///
-    /// Under [`CollectionStyle::IndexedItems`] (the default), collections in
-    /// object position are emitted as indexed list items via
-    /// `emit_list_item()` instead of rdf:first/rdf:rest linked lists, and an
-    /// object-position `()` emits nothing. Under [`CollectionStyle::Spine`]
-    /// both fall through to the ordinary object path, which already builds a
-    /// spine for `( … )` and resolves `()` to `rdf:nil` — so the two
-    /// positions share one code path and one grammar.
+    /// Under [`CollectionStyle::IndexedItems`] (the default), non-empty
+    /// collections in object position are emitted as indexed list items via
+    /// `emit_list_item()` instead of rdf:first/rdf:rest linked lists. Under
+    /// [`CollectionStyle::Spine`] they fall through to the ordinary object
+    /// path, which builds a spine for `( … )` — so the two positions share
+    /// one code path and one grammar.
+    ///
+    /// An object-position `()` is NOT special-cased in either style: it
+    /// reaches [`Self::parse_object`], which resolves it to the IRI
+    /// `rdf:nil` — the term the empty collection denotes — and the triple is
+    /// emitted like any other IRI object (issue #1694: the `IndexedItems`
+    /// path used to consume the statement and emit nothing, silently losing
+    /// it).
     ///
     /// Each object may carry an RDF 1.2 annotation tail (`~ reifier` and/or
     /// `{| … |}` blocks) — see [`Self::parse_annotation_tail`].
@@ -823,10 +829,6 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
             match self.current().kind {
                 TokenKind::LParen if indexed_lists => {
                     self.parse_collection_as_list(subject, predicate)?;
-                    self.reject_annotation_on_collection()?;
-                }
-                TokenKind::Nil if indexed_lists => {
-                    self.advance()?;
                     self.reject_annotation_on_collection()?;
                 }
                 _ => {
@@ -1831,7 +1833,16 @@ mod tests {
         ";
         let graph = parse_to_graph(input).unwrap();
 
-        assert_eq!(graph.len(), 0);
+        // `()` denotes the IRI rdf:nil; the statement stores as one ordinary
+        // triple (issue #1694: it used to emit nothing).
+        assert_eq!(graph.len(), 1);
+        let triple = graph.iter().next().unwrap();
+        assert!(!triple.is_list_element());
+        assert!(
+            matches!(&triple.o, Term::Iri(iri) if iri.as_ref() == RDF_NIL),
+            "expected rdf:nil object, got {:?}",
+            triple.o
+        );
     }
 
     #[test]
@@ -2797,12 +2808,88 @@ mod tests {
         );
     }
 
-    /// Documented (lossy) default: an object-position `()` emits nothing.
-    /// Changing this is exactly what `Spine` is for.
+    /// Issue #1694: an object-position `()` used to emit NOTHING in the
+    /// default mode — the statement was consumed and silently lost. `()`
+    /// denotes the IRI `rdf:nil`, so it must store that one triple in every
+    /// mode; only the non-empty shape differs between the styles.
     #[test]
-    fn default_empty_object_collection_still_emits_nothing() {
+    fn default_empty_object_collection_is_rdf_nil() {
         let graph = parse_to_graph(&format!("@prefix ex: <{EX}> .\nex:s ex:p () .")).unwrap();
-        assert_eq!(graph.len(), 0);
+        assert_eq!(
+            rendered(&graph),
+            vec![(
+                format!("<{EX}s>"),
+                format!("<{EX}p>"),
+                format!("<{RDF_NIL}>")
+            )]
+        );
+        assert!(!graph.iter().next().unwrap().is_list_element());
+    }
+
+    /// `()` must lower to EXACTLY what a literally-written `rdf:nil` object
+    /// lowers to — they are one term, so the graphs are indistinguishable.
+    #[test]
+    fn default_empty_collection_equals_written_rdf_nil() {
+        let sugar = parse_to_graph(&format!("@prefix ex: <{EX}> .\nex:s ex:p () .")).unwrap();
+        let explicit = parse_to_graph(&format!(
+            "@prefix ex: <{EX}> .\n\
+             @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\
+             ex:s ex:p rdf:nil ."
+        ))
+        .unwrap();
+        assert_eq!(rendered(&sugar), rendered(&explicit));
+    }
+
+    /// A nested `()` inside a non-empty collection was never dropped — it is
+    /// an item, and `parse_object` resolves it to `rdf:nil`. Pinned so the
+    /// two `()` sites stay consistent.
+    #[test]
+    fn default_nested_empty_collection_is_a_nil_item() {
+        let graph =
+            parse_to_graph(&format!("@prefix ex: <{EX}> .\nex:s ex:p ( ex:a () ) .")).unwrap();
+        assert_eq!(graph.len(), 2);
+        assert!(graph.iter().all(fluree_graph_ir::Triple::is_list_element));
+        assert!(
+            graph
+                .iter()
+                .any(|t| matches!(&t.o, Term::Iri(iri) if iri.as_ref() == RDF_NIL)),
+            "the nested () must arrive as an rdf:nil item: {:#?}",
+            rendered(&graph)
+        );
+    }
+
+    /// `()` in SUBJECT position already parsed as `rdf:nil` before #1694 was
+    /// fixed (`parse_subject` has always resolved the `Nil` token); pinned so
+    /// the positions cannot diverge again.
+    #[test]
+    fn default_empty_subject_collection_is_rdf_nil() {
+        let graph = parse_to_graph(&format!("@prefix ex: <{EX}> .\n() ex:p ex:o .")).unwrap();
+        assert_eq!(
+            rendered(&graph),
+            vec![(
+                format!("<{RDF_NIL}>"),
+                format!("<{EX}p>"),
+                format!("<{EX}o>")
+            )]
+        );
+    }
+
+    /// With `()` lowering to the single term `rdf:nil`, an RDF 1.2
+    /// annotation on it has a triple to reify — so it works in the default
+    /// mode too, exactly as on a written `rdf:nil`. (Annotations on
+    /// NON-empty collections stay refused there; see
+    /// `spine_mode_admits_annotations_on_collections`.)
+    #[test]
+    fn default_mode_admits_annotations_on_empty_collections() {
+        let mut sink = StarSink::default();
+        parse(&format!("{P}:s :p () {{| :q :z |}} ."), &mut sink)
+            .expect("() is the single term rdf:nil; its triple can be reified");
+        assert_eq!(sink.reified.len(), 1);
+        let nil = RecTerm::Iri(RDF_NIL.to_string());
+        assert!(sink.triples.contains(&(iri("s"), iri("p"), nil.clone())));
+        let (s, p, o, _r) = &sink.reified[0];
+        assert_eq!((s, p, o), (&iri("s"), &iri("p"), &nil));
+        assert_eq!(sink.triples.len(), 2, "the base triple + the annotation");
     }
 
     /// Subject-position collections emitted a spine before this change and
@@ -2968,6 +3055,11 @@ mod tests {
                 format!("<{EX}s>"),
                 format!("<{EX}list>"),
                 format!("<{EX}b>"),
+            ),
+            (
+                format!("<{EX}s>"),
+                format!("<{EX}empty>"),
+                format!("<{RDF_NIL}>"),
             ),
             (
                 format!("<{EX}s>"),

--- a/fluree-graph-turtle/src/parser.rs
+++ b/fluree-graph-turtle/src/parser.rs
@@ -814,12 +814,14 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
     /// path, which builds a spine for `( … )` — so the two positions share
     /// one code path and one grammar.
     ///
-    /// An object-position `()` is NOT special-cased in either style: it
-    /// reaches [`Self::parse_object`], which resolves it to the IRI
-    /// `rdf:nil` — the term the empty collection denotes — and the triple is
-    /// emitted like any other IRI object (issue #1694: the `IndexedItems`
-    /// path used to consume the statement and emit nothing, silently losing
-    /// it).
+    /// An object-position `()` denotes the IRI `rdf:nil` and stores that one
+    /// triple in both styles (issue #1694: the `IndexedItems` path used to
+    /// consume the statement and emit nothing, silently losing it). The
+    /// `NIL`-token spelling reaches [`Self::parse_object`], which resolves it
+    /// like any other IRI object; the comment spelling `( # c\n )` lexes as
+    /// `LParen`/`RParen` instead and is handled by the zero-item guard in
+    /// [`Self::parse_collection_as_list`] — same triple, same annotation
+    /// admission.
     ///
     /// Each object may carry an RDF 1.2 annotation tail (`~ reifier` and/or
     /// `{| … |}` blocks) — see [`Self::parse_annotation_tail`].
@@ -828,8 +830,21 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
         loop {
             match self.current().kind {
                 TokenKind::LParen if indexed_lists => {
-                    self.parse_collection_as_list(subject, predicate)?;
-                    self.reject_annotation_on_collection()?;
+                    match self.parse_collection_as_list(subject, predicate)? {
+                        // The collection was `()` spelled with a comment
+                        // inside the parens: its object is the single term
+                        // `rdf:nil`, whose triple an annotation can reify —
+                        // exactly as on the `NIL`-token path below.
+                        Some(nil) => {
+                            if matches!(
+                                self.current().kind,
+                                TokenKind::Tilde | TokenKind::AnnotationOpen
+                            ) {
+                                self.parse_annotation_tail(subject, predicate, nil)?;
+                            }
+                        }
+                        None => self.reject_annotation_on_collection()?,
+                    }
                 }
                 _ => {
                     let object = self.parse_object()?;
@@ -853,7 +868,22 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
     }
 
     /// Parse a collection in object position as indexed list items.
-    fn parse_collection_as_list(&mut self, subject: TermId, predicate: TermId) -> Result<()> {
+    ///
+    /// Returns the emitted `rdf:nil` term when the collection had zero
+    /// items. Only one input reaches this path with zero items: `()` spelled
+    /// with a comment inside the parens (`( # c\n )`) — the `NIL` token is
+    /// `'(' WS* ')'` and comments are not WS, so the comment spelling lexes
+    /// as `LParen`/`RParen` instead. It denotes the same term, so it emits
+    /// the same `rdf:nil` triple as the `NIL`-token path (issue #1694: it
+    /// used to fall out of the loop and emit nothing, re-opening the silent
+    /// loss through that one spelling), and the caller admits an annotation
+    /// tail on it. Non-empty collections return `None`: their items are
+    /// indexed events with no single term to annotate.
+    fn parse_collection_as_list(
+        &mut self,
+        subject: TermId,
+        predicate: TermId,
+    ) -> Result<Option<TermId>> {
         self.with_nesting(|p| {
             p.expect(&TokenKind::LParen)?;
             let mut index: i32 = 0;
@@ -863,7 +893,12 @@ impl<'a, 'input, S: GraphSink> Parser<'a, 'input, S> {
                 index += 1;
             }
             p.expect(&TokenKind::RParen)?;
-            Ok(())
+            if index == 0 {
+                let nil = p.rdf_nil();
+                p.sink_emit_triple(subject, predicate, nil)?;
+                return Ok(Some(nil));
+            }
+            Ok(None)
         })
     }
 
@@ -2824,6 +2859,46 @@ mod tests {
             )]
         );
         assert!(!graph.iter().next().unwrap().is_list_element());
+    }
+
+    /// The `NIL` token is `'(' WS* ')'` and a comment is not WS, so
+    /// `( # c\n )` lexes as `LParen`/`RParen` and reaches the collection
+    /// path with zero items — the ONE spelling of the empty collection that
+    /// bypasses `TokenKind::Nil`. It denotes the same term and must emit
+    /// the same triple; without the zero-item guard in
+    /// `parse_collection_as_list` it re-opened issue #1694 through this
+    /// spelling.
+    #[test]
+    fn default_empty_collection_with_comment_is_rdf_nil() {
+        let graph = parse_to_graph(&format!(
+            "@prefix ex: <{EX}> .\nex:s ex:p ( # nothing here\n ) ."
+        ))
+        .unwrap();
+        assert_eq!(
+            rendered(&graph),
+            vec![(
+                format!("<{EX}s>"),
+                format!("<{EX}p>"),
+                format!("<{RDF_NIL}>")
+            )]
+        );
+        assert!(!graph.iter().next().unwrap().is_list_element());
+    }
+
+    /// The comment spelling of `()` is the same term, so an RDF 1.2
+    /// annotation on it must be admitted exactly as on the `NIL`-token
+    /// spelling (see `default_mode_admits_annotations_on_empty_collections`).
+    #[test]
+    fn default_mode_admits_annotations_on_comment_spelled_empty_collection() {
+        let mut sink = StarSink::default();
+        parse(&format!("{P}:s :p ( # c\n ) {{| :q :z |}} ."), &mut sink)
+            .expect("( #c\\n ) is the single term rdf:nil; its triple can be reified");
+        assert_eq!(sink.reified.len(), 1);
+        let nil = RecTerm::Iri(RDF_NIL.to_string());
+        assert!(sink.triples.contains(&(iri("s"), iri("p"), nil.clone())));
+        let (s, p, o, _r) = &sink.reified[0];
+        assert_eq!((s, p, o), (&iri("s"), &iri("p"), &nil));
+        assert_eq!(sink.triples.len(), 2, "the base triple + the annotation");
     }
 
     /// `()` must lower to EXACTLY what a literally-written `rdf:nil` object

--- a/testsuite-sparql/tests/registers/mod.rs
+++ b/testsuite-sparql/tests/registers/mod.rs
@@ -152,13 +152,15 @@ pub const SPARQL10_QUERY_EVAL: &[&str] = &[
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-1",
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/algebra/manifest#nested-opt-2",
     // PR-BASE: relative-IRI/BASE resolution in query output (2)
-    // list-1..4: the SPARQL parser now desugars `( ... )` patterns to
+    // list-2..4: the SPARQL parser now desugars `( ... )` patterns to
     // rdf:first/rest/nil triples, but Fluree's Turtle ingest emits
-    // OBJECT-position collections as Fluree list_index items (and drops
-    // `()` objects entirely) — `parse_collection_as_list`,
-    // fluree-graph-turtle/src/parser.rs — so the first/rest triples the
-    // query needs are never stored. Eval-side ingest/model gap, not parser.
-    "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-1",
+    // OBJECT-position collections as Fluree list_index items —
+    // `parse_collection_as_list`, fluree-graph-turtle/src/parser.rs — so
+    // the first/rest triples the query needs are never stored. Eval-side
+    // ingest/model gap (D-13), not parser. list-1 came OFF this register
+    // with the #1694 empty-collection fix: `()` now ingests as the
+    // `rdf:nil` triple it denotes (`:x :list0 rdf:nil`), and `:x ?p ()`
+    // needs no spine — the pattern lowers to the rdf:nil constant.
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-2",
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-3",
     "http://www.w3.org/2001/sw/DataAccess/tests/data-r2/basic/manifest#list-4",


### PR DESCRIPTION
Partially addresses #1694 — this takes the *silent statement loss* half only; the D-13 decision about how non-empty collection **structure** is stored (materialize the `rdf:first`/`rdf:rest` spine vs documented divergence) stays open and this PR deliberately does not touch it.

## The bug — one silent-loss class, two ingest surfaces

An object-position empty collection denotes the IRI `rdf:nil` — `ex:s2 ex:items ()` IS `ex:s2 ex:items rdf:nil`, and `{"ex:items": {"@list": []}}` is the same statement spoken in JSON-LD. Both ingest surfaces lost it silently:

**Turtle.** The default `CollectionStyle::IndexedItems` path had a `Nil` arm in `parse_object_list` (`fluree-graph-turtle/src/parser.rs`) that advanced the lexer and emitted **nothing**: the statement was consumed, zero flakes were written, no diagnostic fired, and the subject simply never existed in the database. The issue's repro (an 8-triple document committing 3 flakes, `ex:s2` unqueryable) reproduces exactly, end-to-end through `insert_turtle` — the e2e test failed at the merge base with `ex:s2 must exist: []` before the fix went in. And the `NIL` token is `'(' WS* ')'` with comments not counting as WS, so `ex:s ex:p ( # c\n ) .` lexes as `LParen`/`RParen` instead and reached `parse_collection_as_list` with zero items — a second spelling of the same loss that bypasses the `Nil` token entirely (credit to @bplatz for catching it; the repro emits zero triples exactly as described).

**JSON-LD.** Three sites, same class. `parse_list_values_with_ctx` (`fluree-db-transact/src/parse/jsonld.rs`) produced zero triple templates for `{"@list": []}` — pinned, at the time, by `test_parse_empty_list` as intended behavior — and the singular fallback `parse_list_value_with_ctx` errored with `Empty @list in unexpected position`. The import-path adapter (`fluree-graph-json-ld/src/adapter.rs`, `process_list`, feeding bulk import and the inline shapes/ontology loaders) emitted zero events. And the expansion itself (`fluree-graph-json-ld/src/expand.rs`) drops any key whose values expand to nothing, `@list` included — so the explicit-array spelling `[{"@list": []}]` expanded to `[{}]` and stored a spurious **blank node** object: not even a loss, but wrong data.

## The fix

**Turtle**: delete the special case. With the `Nil` arm gone, the token falls through to `parse_object`, which already resolves `()` to the `rdf:nil` term — the **exact code path a literally-written `rdf:nil` object takes**, in both collection styles. I verified the downstream premise first: an explicit `ex:s2 ex:items rdf:nil .` already stored and queried fine (it's just an IRI object; the control test pins it), so lowering `()` to that same path is provably consistent rather than a new behavior — one code path, indistinguishable output (`default_empty_collection_equals_written_rdf_nil` asserts the two graphs are identical). For the comment spelling, `parse_collection_as_list` now emits the `rdf:nil` triple when the item loop ran zero times and returns the term so `parse_object_list` can admit an RDF 1.2 annotation tail on it — making `( # c\n )` fully equivalent to `()`: same triple, same annotation admission, which is what keeps the `CollectionStyle` doc's "single term in both styles" claim true for every spelling. I weighed the fail-loudly alternative (refuse the statement) and I don't think it survives contact: it rejects valid Turtle and breaks previously-accepted documents at a release boundary, and there's nothing structural forcing us there — the nil triple just works.

**JSON-LD**: the same term at each site. `parse_list_values_with_ctx` yields one `rdf:nil` template (ordinary IRI object, no `list_index`), the singular fallback returns the same term instead of erroring, `process_list` emits the `rdf:nil` triple, and the expansion's drop-empty-keys rule now exempts `@list` so `[{"@list": []}]` expands to itself. Every spelling — bare object, explicit array position — now stores exactly the one triple, and it is byte-identical to what the Turtle surface stores (the parity e2e asserts the two ledgers' full `?s ?p ?o` row sets are equal). SPARQL needed nothing: `term.rs:642` already lowers a pattern-position `()` to the `rdf:nil` constant, which is exactly why `basic#list-1` greens below.

On the hot path this is a deletion plus a zero-item branch, not per-item work — documents without collections see no new per-statement cost, and non-empty collections take the same arms they always did on both surfaces. `default_mode_output_is_pinned_triple_for_triple` pins the full default-mode Turtle surface triple-for-triple (now including the nil edge), and the e2e suites assert non-empty collections keep their `list_index` shape with **no** spine materialized (`?l rdf:first ?x` still matches nothing — that's D-13, not this PR).

## Fallout taken deliberately

**W3C `basic#list-1` flips green and comes off the register.** Its query (`:x ?p ()`) lowers to the `rdf:nil` constant on the SPARQL side (no spine needed), and its data (`:x :list0 ()`) now ingests as `:x :list0 rdf:nil` — so it passes outright. The both-way register check would have failed the run on the stale entry; `list-1` is removed and the comment rewritten. `list-2..4` genuinely need the first/rest spine and **stay registered** — they come off with D-13, whichever way it lands. Full suite is green: 36/36 with the updated register. The matching stale note in `docs/audit/burn-down/ROADMAP.md` (where D-13 is tracked) is corrected in the same spirit: ingest no longer drops `()` objects, `list-1` greens, `list-2..4` remain D-13's.

**RDF 1.2 annotations on `()` now parse in the default mode.** Previously `:s :p () {| :q :z |}` was refused alongside non-empty collections; with the base triple existing there's a term to reify, and refusing it while accepting the identical `:s :p rdf:nil {| :q :z |}` would be an inconsistency. This holds for the comment spelling too. Annotations on **non-empty** collections stay refused in `IndexedItems` (nothing to reify there) — that existing test is untouched.

**Empty `@list` stops erroring in the singular position.** The `Empty @list in unexpected position` error is gone; the fallback returns the term the value denotes, consistent with the array path. `test_parse_empty_list` is updated to pin the new single-`rdf:nil`-template behavior, with a new sibling pinning the singular fallback.

**Subject position was already correct.** `() ex:p ex:o .` has always parsed as an `rdf:nil` subject (`parse_subject` resolves the `Nil` token) — so it's not the same bug class, but it's now pinned at both the parser and e2e level so the two positions can't diverge again. Nested `()` inside a non-empty collection was also already handled (it arrives as an `rdf:nil` list item) and is now pinned too.

## Verification

- Turtle e2e suite `fluree-db-api/tests/it_turtle_empty_collection.rs` (grp_transact): the issue's repro document, the literal-`rdf:nil` control (identical row sets), the SPARQL `()`-pattern lookup finding `ex:s2`, no-spine-materialized, and subject-position `()`. Non-vacuity proven both directions: written first and failed at the merge base, and re-failed when I temporarily reinstated the deleted arm on the final tree.
- JSON-LD e2e suite `fluree-db-api/tests/it_jsonld_empty_list.rs` (grp_transact): the repro shape via `{"@list": []}`, the Turtle↔JSON-LD parity assertion (byte-identical graphs), and the array-position spelling pinned to `rdf:nil`-not-a-blank-node. All written first and failed before the fixes (the bare-object tests with `ex:s2 must exist: []`; the array-position test by storing a blank node).
- Parser/unit level: the stale pins (`test_empty_collection`, `default_empty_object_collection_still_emits_nothing`, transact `test_parse_empty_list`, adapter `test_empty_list`) updated to assert the nil triple; new pins for `()`≡`rdf:nil` equivalence, the comment spelling (`default_empty_collection_with_comment_is_rdf_nil`), nested-`()` items, subject position, annotation behavior on both spellings, the singular `@list` fallback, and expansion keeping the `@list` key (`test_expand_empty_list_keeps_list_key`). Each of the three JSON-LD fixes was individually reverted to watch its test fail, then restored. Spine/conformant tests untouched and green — `ParserOptions::conformant()` behavior is unchanged.
- Gates: `-p fluree-graph-turtle` (139 lib + integration suites), `-p fluree-graph-json-ld` (143 lib + 12 + 23 + 8), `-p fluree-db-transact` (306 + 46), `-p fluree-db-api` grp_transact/grp_query/grp_query_sparql/grp_import/grp_misc/grp_policy/grp_graphsource (197/422/369/101/263/96/143), full W3C SPARQL suite 36/36 with the updated register, workspace `cargo check --all-targets` clean, per-crate clippy `-D warnings` clean on all four touched crates, fmt checked in both the root and `testsuite-sparql` workspaces.

## What this closes and what it doesn't

Closed: an object-position empty collection can no longer vanish (or mint a spurious blank node) on **either** ingest surface. The Turtle parser path serves `insert_turtle`, bulk/chunked import of Turtle, and the `fluree rdf` tooling; the JSON-LD path is its own pipeline — `insert`/transact via the template parser, and import/inline-shapes/inline-ontology via `expand` + `to_graph_events` — and each of its three lossy sites is fixed and pinned. SPARQL pattern position needed no change (`term.rs:642`). Not closed: whether Fluree materializes the first/rest spine for non-empty collections (`basic#list-2..4`, round-trip fidelity) — that's the product call the issue tracks as D-13, and nothing here prejudices either answer. Also untouched, deliberately: `<< :s :p () >>` inside an RDF 1.2 reified-triple term stays rejected — the RDF 1.2 grammar's `rtObject` excludes collections, so that's conformant behavior, not a gap.
