### PR TITLE
fix: fail closed on unencodable datatype IRIs; keep the membership-join lane join-equivalent on list rows

### DIFF
--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -502,6 +502,13 @@ path = "tests/it_literal_identity.rs"
 required-features = ["native"]
 
 # Standalone (NOT in a grp_ bin): toggles the process-global fast-path kill
+# switch AND asserts membership-join routing via span capture.
+[[test]]
+name = "it_membership_join_list_rows"
+path = "tests/it_membership_join_list_rows.rs"
+required-features = ["native"]
+
+# Standalone (NOT in a grp_ bin): toggles the process-global fast-path kill
 # switch AND asserts stats-merge routing via span capture.
 [[test]]
 name = "it_fast_stats_1391_regression"

--- a/fluree-db-api/tests/it_fastpath_1652_regression.rs
+++ b/fluree-db-api/tests/it_fastpath_1652_regression.rs
@@ -447,10 +447,11 @@ fn cases() -> Vec<Case> {
         // settling it may change this number. What the case does assert is
         // that the count lane cannot express the shape in an
         // (s, o_type, o_key) key, so it must decline and agree with whatever
-        // the generic join answers. (The membership lane would answer as a
+        // the generic join answers. (The membership lane used to answer as a
         // semi-join — one row per driving row, 3 — which the planner's
-        // driving-size gate now keeps it away from at this fixture's size;
-        // the lane's answer at or above the gate is unpinned.)
+        // driving-size gate keeps away from this fixture's size; its answer
+        // at or above the gate is pinned to the generic one by
+        // `it_membership_join_list_rows`, #1687.)
         Case {
             name: "composite join, list rows (declines to generic)",
             ledger: CompositeList,

--- a/fluree-db-api/tests/it_literal_identity.rs
+++ b/fluree-db-api/tests/it_literal_identity.rs
@@ -499,3 +499,110 @@ async fn language_tags_are_case_insensitive() {
         })
         .await;
 }
+
+/// A datatype IRI whose namespace is not registered on the ledger can match
+/// NOTHING: ingest registers every namespace it stores, so no stored term
+/// carries such a datatype. SPARQL lowering used to rewrite the unresolvable
+/// datatype to `xsd:string`, so `"a"^^ex:NoSuchType` matched every
+/// plain-string `"a"` row — fail-open — while the JSON-LD surface already
+/// answered the empty result (#1686). Both surfaces are pinned in both
+/// lanes, on the triple-pattern site and its `term_to_binding` VALUES twin,
+/// with a registered-custom-datatype control that must keep matching.
+#[tokio::test]
+async fn unencodable_datatype_matches_nothing_in_novelty_and_index() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let mut fluree = FlureeBuilder::file(tmp.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let id = "it/literal-identity-unenc:main";
+            let ledger = fluree.create_ledger(id).await.unwrap();
+            let data = json!({"@context": {"ex": "http://example.org/ns/"}, "@graph": [
+                {"@id": "ex:u1", "ex:q": "a"},
+                {"@id": "ex:u2", "ex:q": {"@value": "a", "@language": "en"}},
+                {"@id": "ex:u3", "ex:q": {"@value": "z", "@type": "http://custom.example.com/T"}}
+            ]});
+            let r = fluree.insert(ledger, &data).await.unwrap();
+
+            const BOGUS: &str = "http://no-such-namespace.example.com/NoSuchType";
+            for phase in ["novelty", "indexed"] {
+                if phase == "indexed" {
+                    trigger_index_and_wait_outcome(&handle, id, r.receipt.t).await;
+                }
+                let view = fluree.ledger(id).await.unwrap();
+                assert_eq!(
+                    view.snapshot.range_provider.is_some(),
+                    phase == "indexed",
+                    "{phase}: setup"
+                );
+
+                let bogus_pattern = format!(r#"SELECT ?s WHERE {{ ?s ex:q "a"^^<{BOGUS}> }}"#);
+                let bogus_values =
+                    format!(r#"SELECT ?s WHERE {{ VALUES ?o {{ "a"^^<{BOGUS}> }} ?s ex:q ?o }}"#);
+                let cases: &[(&str, &str, Value)] = &[
+                    (
+                        "unregistered datatype in a triple pattern matches nothing",
+                        &bogus_pattern,
+                        json!([]),
+                    ),
+                    (
+                        "unregistered datatype in a VALUES row matches nothing",
+                        &bogus_values,
+                        json!([]),
+                    ),
+                    // Controls: a custom datatype whose namespace WAS
+                    // registered by ingest still matches exactly its row.
+                    (
+                        "registered custom datatype still matches (pattern)",
+                        r#"SELECT ?s WHERE { ?s ex:q "z"^^<http://custom.example.com/T> }"#,
+                        json!([["ex:u3"]]),
+                    ),
+                    (
+                        "registered custom datatype still matches (VALUES)",
+                        r#"SELECT ?s WHERE { VALUES ?o { "z"^^<http://custom.example.com/T> } ?s ex:q ?o }"#,
+                        json!([["ex:u3"]]),
+                    ),
+                ];
+                for (name, body, expected) in cases {
+                    let got = sparql(&fluree, &view, body).await;
+                    assert_eq!(&got, expected, "{phase}: {name}");
+                }
+
+                // JSON-LD parity: the surface that always used the
+                // non-strict encoder answers the same on both shapes.
+                let jl = |o: Value| {
+                    json!({"@context": {"ex": "http://example.org/ns/"},
+                           "select": "?s", "where": {"@id": "?s", "ex:q": o}})
+                };
+                let bogus_jl = query_jsonld_formatted(
+                    &fluree,
+                    &view,
+                    &jl(json!({"@value": "a", "@type": BOGUS})),
+                )
+                .await
+                .unwrap();
+                assert_eq!(bogus_jl, json!([]), "{phase}: json-ld unregistered datatype");
+                let control_jl = query_jsonld_formatted(
+                    &fluree,
+                    &view,
+                    &jl(json!({"@value": "z", "@type": "http://custom.example.com/T"})),
+                )
+                .await
+                .unwrap();
+                assert_eq!(
+                    control_jl,
+                    json!(["ex:u3"]),
+                    "{phase}: json-ld registered custom datatype"
+                );
+            }
+        })
+        .await;
+}

--- a/fluree-db-api/tests/it_membership_join_list_rows.rs
+++ b/fluree-db-api/tests/it_membership_join_list_rows.rs
@@ -1,0 +1,234 @@
+//! Membership-join lane at or above its driving-size gate (#1687).
+//!
+//! `MembershipJoinOperator` answers a right triple that binds nothing new as
+//! a hash keep/drop, on the premise that a fully-ground triple matches at
+//! most once. RDF list rows break that premise inside a single graph: the
+//! same `(s, p, o)` recurs at multiple `o_i` positions, so the generic join
+//! emits one row per matching flake where keep/drop emits one per driving
+//! row. Below `MEMBERSHIP_JOIN_MIN_DRIVING` (256) the planner already
+//! declines; at or above it the lane used to answer the shape as a semi-join
+//! and silently diverge from the generic pipeline (3 vs 5 on the #1652
+//! fixture — a scale-dependent wrong answer).
+//!
+//! Two cases, both sized past the gate so the planner genuinely admits the
+//! lane, with routing asserted via the lane's `membership-join` stamps so
+//! neither can silently degrade into a below-gate case:
+//!
+//! * **List rows** — the build drain detects duplicate ground rows, routes
+//!   every row through the exact per-row fallback, and the lane's answer
+//!   equals the generic pipeline's. Must NOT stamp `proceed`; must stamp
+//!   `fallback:gate_declined` (proof the lane was reached at all).
+//! * **Ordinary multi-valued rows** — the perf guard: the decline is
+//!   surgical, so a non-list shape of the same size keeps the hash path.
+//!   Must stamp `proceed`.
+//!
+//! Phase 2 reruns both queries under `FLUREE_DISABLE_QUERY_FAST_PATHS`
+//! (which now reaches this lane) and requires identical rows — the
+//! join-equivalence pin the lane's module docs claim.
+//!
+//! Own test binary: toggles the process-global kill switch AND asserts
+//! fast-path routing via span capture, so it must not share a process with
+//! other tests.
+
+#![cfg(feature = "native")]
+
+#[path = "support/span_capture.rs"]
+mod span_capture;
+
+use fluree_db_api::admin::ReindexOptions;
+use fluree_db_api::{set_fast_paths_disabled, Fluree, FlureeBuilder, FormatterConfig};
+use serde_json::{json, Value};
+
+const PREFIX: &str = "PREFIX ex: <http://example.org/ns/>\n";
+const SITE: &str = "membership-join";
+const QUERY: &str = "SELECT ?s ?o WHERE { ?s ex:createdBy ?o . ?s ex:authoredBy ?o }";
+
+const N_DUP: usize = 128;
+const N_PLAIN: usize = 20;
+const N_ORDINARY: usize = 140;
+
+/// List ledger: every subject carries 2-element `@list` values on both
+/// predicates, so the driving side is `(N_DUP + N_PLAIN) × 2 = 296` rows —
+/// past the planner's 256-row gate.
+///
+/// * `s-dup-i`: `createdBy [v-i, v-i]`, `authoredBy [v-i, v-i]`. The generic
+///   join pairs each of the 2 driving rows with each of the 2 matching
+///   flakes → 4 rows per subject; keep/drop would emit 2.
+/// * `s-pln-i`: `createdBy [a-i, b-i]`, `authoredBy [a-i, c-i]` — one shared
+///   value, all distinct within each list → 1 row per subject either way.
+///
+/// Generic (correct) total: 128×4 + 20×1 = 532. The old semi-join answer
+/// was 128×2 + 20×1 = 276.
+fn list_graph() -> Value {
+    let mut nodes = Vec::new();
+    for i in 0..N_DUP {
+        nodes.push(json!({
+            "@id": format!("ex:s-dup-{i:03}"),
+            "ex:createdBy": [format!("v-{i}"), format!("v-{i}")],
+            "ex:authoredBy": [format!("v-{i}"), format!("v-{i}")]
+        }));
+    }
+    for i in 0..N_PLAIN {
+        nodes.push(json!({
+            "@id": format!("ex:s-pln-{i:03}"),
+            "ex:createdBy": [format!("a-{i}"), format!("b-{i}")],
+            "ex:authoredBy": [format!("a-{i}"), format!("c-{i}")]
+        }));
+    }
+    json!({
+        "@context": [
+            {"ex": "http://example.org/ns/"},
+            {"ex:createdBy": {"@container": "@list"},
+             "ex:authoredBy": {"@container": "@list"}}
+        ],
+        "@graph": nodes
+    })
+}
+
+/// Ordinary ledger: the same size and join shape with plain multi-valued
+/// (non-list) predicates — every ground triple matches at most once, so the
+/// hash path is join-equivalent and must keep firing. Driving side is
+/// `140 × 2 = 280` rows; each subject shares exactly one value across the
+/// two predicates → 140 result rows.
+fn ordinary_graph() -> Value {
+    let nodes: Vec<Value> = (0..N_ORDINARY)
+        .map(|i| {
+            json!({
+                "@id": format!("ex:t-{i:03}"),
+                "ex:createdBy": [format!("x-{i}"), format!("shared-{i}")],
+                "ex:authoredBy": [format!("shared-{i}"), format!("y-{i}")]
+            })
+        })
+        .collect();
+    json!({"@context": {"ex": "http://example.org/ns/"}, "@graph": nodes})
+}
+
+/// Insert + reindex so the ledger has statistics — `membership_join_key_vars`
+/// requires stats to bound the build side, so an unindexed ledger would keep
+/// the lane out of the plan and every assertion below would be vacuous.
+async fn setup(alias: &str, data: &Value) -> (tempfile::TempDir, Fluree) {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let path = dir.path().to_string_lossy().to_string();
+    let fluree = FlureeBuilder::file(path).build().expect("build Fluree");
+    let ledger = fluree.create_ledger(alias).await.expect("create_ledger");
+    fluree.insert(ledger, data).await.expect("insert");
+    fluree
+        .reindex(alias, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    (dir, fluree)
+}
+
+async fn run_query(fluree: &Fluree, alias: &str) -> Vec<String> {
+    let full = format!("{PREFIX}{QUERY}");
+    let snapshot = fluree.graph(alias).load().await.expect("load");
+    let rows = snapshot
+        .query()
+        .sparql(&full)
+        .format(FormatterConfig::jsonld())
+        .execute_formatted()
+        .await
+        .expect("query");
+    let mut out: Vec<String> = rows
+        .as_array()
+        .expect("array of rows")
+        .iter()
+        .map(|r| serde_json::to_string(r).expect("serialize row"))
+        .collect();
+    out.sort();
+    out
+}
+
+/// RAII restore of the process-global kill switch, including on panic.
+struct FastPathGuard;
+impl Drop for FastPathGuard {
+    fn drop(&mut self) {
+        set_fast_paths_disabled(false);
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn membership_join_agrees_with_generic_on_list_rows_and_keeps_firing() {
+    assert!(
+        std::env::var_os("FLUREE_DISABLE_QUERY_FAST_PATHS").is_none(),
+        "FLUREE_DISABLE_QUERY_FAST_PATHS is set — the fast phase below would \
+         run generically and pin nothing. Unset it."
+    );
+    let _guard = FastPathGuard;
+
+    let (_d1, list) = setup("mj1687:list", &list_graph()).await;
+    let (_d2, ordinary) = setup("mj1687:ordinary", &ordinary_graph()).await;
+
+    // Phase 1 — fast paths on, under span capture so engagement is proven,
+    // not assumed (a fixture that quietly lands below the driving-size gate
+    // would otherwise pass without ever exercising the lane).
+    let (store, tracing_guard) = span_capture::init_test_tracing();
+    set_fast_paths_disabled(false);
+
+    let before = store.find_events("fast-path outcome").len();
+    let list_fast = run_query(&list, "mj1687:list").await;
+    let list_outcomes: Vec<String> = store.find_events("fast-path outcome")[before..]
+        .iter()
+        .filter(|e| e.fields.get("site").map(String::as_str) == Some(SITE))
+        .filter_map(|e| e.fields.get("outcome").cloned())
+        .collect();
+
+    let before = store.find_events("fast-path outcome").len();
+    let ordinary_fast = run_query(&ordinary, "mj1687:ordinary").await;
+    let ordinary_outcomes: Vec<String> = store.find_events("fast-path outcome")[before..]
+        .iter()
+        .filter(|e| e.fields.get("site").map(String::as_str) == Some(SITE))
+        .filter_map(|e| e.fields.get("outcome").cloned())
+        .collect();
+    drop(tracing_guard);
+
+    // Phase 2 — the generic reference: the kill switch keeps the lane out
+    // of the plan, so the nested-loop join answers.
+    set_fast_paths_disabled(true);
+    let list_generic = run_query(&list, "mj1687:list").await;
+    let ordinary_generic = run_query(&ordinary, "mj1687:ordinary").await;
+    set_fast_paths_disabled(false);
+
+    // List rows: identical answers, with the lane engaged and declining.
+    assert_eq!(
+        list_fast.len(),
+        N_DUP * 4 + N_PLAIN,
+        "list rows: the generic bag join pairs each duplicate driving row \
+         with each matching flake (got {} rows)",
+        list_fast.len()
+    );
+    assert_eq!(
+        list_fast, list_generic,
+        "list rows: the membership lane's answer diverged from the generic \
+         pipeline's — its join-equivalence invariant is broken again"
+    );
+    assert!(
+        list_outcomes.iter().any(|o| o == "fallback:gate_declined"),
+        "list rows: expected the lane to be reached and decline its hash \
+         path — no `{SITE}` gate_declined stamp means the fixture no longer \
+         engages the lane and this test pins nothing [outcomes: {list_outcomes:?}]"
+    );
+    assert!(
+        !list_outcomes.iter().any(|o| o == "proceed"),
+        "list rows: the hash keep/drop path served a shape whose ground \
+         triples match more than once [outcomes: {list_outcomes:?}]"
+    );
+
+    // Ordinary rows: the perf guard — the decline must be surgical.
+    assert_eq!(
+        ordinary_fast.len(),
+        N_ORDINARY,
+        "ordinary rows: one shared value per subject (got {} rows)",
+        ordinary_fast.len()
+    );
+    assert_eq!(
+        ordinary_fast, ordinary_generic,
+        "ordinary rows: fast and generic answers must agree"
+    );
+    assert!(
+        ordinary_outcomes.iter().any(|o| o == "proceed"),
+        "ordinary rows: expected the hash membership path to keep firing on \
+         a non-list shape of the same size — the list decline must not \
+         disable the lane [outcomes: {ordinary_outcomes:?}]"
+    );
+}

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -2862,12 +2862,28 @@ pub(crate) fn build_scan_or_join(
                 if let Some(key_vars) =
                     membership_join_key_vars(&left_schema, tp, planning, hash_planner, driving_rows)
                 {
-                    return Box::new(crate::membership_join::MembershipJoinOperator::new(
-                        left,
-                        tp.clone(),
-                        key_vars,
-                        *planning,
-                    ));
+                    // The lane honors the differential kill switch
+                    // (`FLUREE_DISABLE_QUERY_FAST_PATHS`) like the other
+                    // fast paths, so a harness can compare it against the
+                    // generic nested-loop join. Checked here rather than in
+                    // `membership_join_key_vars` so the eligibility predicate
+                    // stays pure and the stamp fires only on shapes the lane
+                    // would actually have taken.
+                    if super::fast_paths_disabled() {
+                        crate::fast_path_outcome::stamp_fast_path(
+                            crate::membership_join::MEMBERSHIP_JOIN_SITE,
+                            crate::fast_path_outcome::FastPathOutcome::Fallback(
+                                crate::fast_path_outcome::FastPathFallback::KillSwitch,
+                            ),
+                        );
+                    } else {
+                        return Box::new(crate::membership_join::MembershipJoinOperator::new(
+                            left,
+                            tp.clone(),
+                            key_vars,
+                            *planning,
+                        ));
+                    }
                 }
             }
 

--- a/fluree-db-query/src/fast_path_outcome.rs
+++ b/fluree-db-query/src/fast_path_outcome.rs
@@ -54,7 +54,10 @@ impl FastPathOutcome {
 /// Stamp a fast-path `outcome` for the named gate `site`.
 ///
 /// Emits on [`FAST_PATH_TARGET`]; no allocation, no lock. Called at plan time
-/// from the kill-switch gate sites and at `open()` time from `FastPathOperator`.
+/// from the kill-switch gate sites, at `open()` time from `FastPathOperator`,
+/// and mid-execution from gates that can only decide once they have seen data
+/// (`MembershipJoinOperator::build_key_set` stamps on its first fully-bound
+/// row). A new site may stamp at whichever point its gate actually decides.
 #[inline]
 pub fn stamp_fast_path(site: &'static str, outcome: FastPathOutcome) {
     tracing::debug!(

--- a/fluree-db-query/src/membership_join.rs
+++ b/fluree-db-query/src/membership_join.rs
@@ -224,9 +224,11 @@ impl MembershipJoinOperator {
         Ok(())
     }
 
-    /// Exact join fallback for a row that does NOT fully ground the
-    /// pattern: evaluate the triple seeded with the row and emit one
-    /// output row per match, with produced bindings filled in.
+    /// Exact join for a row the keep/drop drain cannot answer: one that
+    /// does NOT fully ground the pattern, or — once the drain declines
+    /// (`exact_only`: duplicate ground rows in the key set) — every row.
+    /// Evaluates the triple seeded with the row and emits one output row
+    /// per match, with produced bindings filled in.
     async fn per_row_join(
         &self,
         ctx: &ExecutionContext<'_>,
@@ -369,7 +371,17 @@ impl Operator for MembershipJoinOperator {
     }
 
     fn estimated_rows(&self) -> Option<usize> {
-        // A filter: at most the child's cardinality (ground rows match ≤ once).
+        // Drain lane (keep/drop): a filter — at most the child's cardinality.
+        // Per-row-join fallback (`exact_only`, entered mid-execution when the
+        // drain finds duplicate ground rows): a bag join whose output can
+        // exceed the child's cardinality (the #1687 fixture emits 532 rows
+        // from 296 driving rows), making this an under-estimate. The regime
+        // isn't known yet when this is read (EXPLAIN `describe()` and lane
+        // gates run at plan/open time, before `build_key_set`), and every
+        // consumer treats a low value conservatively — a lane gate that reads
+        // it (`SubqueryOperator` materialize eligibility, the annotation-edge
+        // hash probe) declines its optimization and stays on the exact generic
+        // path — so the child estimate remains the honest upper-bound hint.
         self.child.estimated_rows()
     }
 }

--- a/fluree-db-query/src/membership_join.rs
+++ b/fluree-db-query/src/membership_join.rs
@@ -21,6 +21,25 @@
 //! scope. So the lane is join-equivalent unconditionally, and the hash fast
 //! path engages only where the premise provably holds.
 //!
+//! **The premise can also fail inside one graph: RDF list rows.** A
+//! list-valued predicate stores one flake per position, so the same
+//! `(s, p, o)` recurs at multiple `o_i` values and the generic join emits
+//! one row per matching flake where keep/drop would emit one per driving
+//! row (#1687). Stats carry no list-ness, so this is not plan-detectable;
+//! instead the one-shot drain that builds the key set doubles as the
+//! detector — a key tuple inserted twice IS the premise's counterexample
+//! (two flakes matched one ground triple). When that happens the hash set
+//! is discarded and every row takes the exact per-row fallback, keeping
+//! the lane join-equivalent without ruling on what a var-object join over
+//! list positions should mean (that semantics call stays with #1687).
+//!
+//! Engagement is observable via [`MEMBERSHIP_JOIN_SITE`] routing stamps
+//! (the repo's `MustFire`/`MustNotFire` oracle): `Proceed` when the hash
+//! path serves probes, `Fallback(GateDeclined)` when the drain disproves
+//! the premise or a multi-graph scope forces exact mode, and
+//! `Fallback(KillSwitch)` from the planner when
+//! `FLUREE_DISABLE_QUERY_FAST_PATHS` suppresses the lane.
+//!
 //! **Rows with an unbound key var keep exact join semantics** — a join
 //! against a partially-ground pattern EXTENDS the row (possibly multiplying
 //! it), which a keep/drop semijoin cannot reproduce. Such rows fall back to
@@ -52,6 +71,14 @@ use async_trait::async_trait;
 use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
+/// Routing-stamp site for this lane (see `fast_path_outcome`). Stamped
+/// `Proceed` when the hash membership path serves probes,
+/// `Fallback(GateDeclined)` when the operator routes rows through the exact
+/// per-row join instead (multi-graph scope, or the build drain disproved
+/// the matches-at-most-once premise), and `Fallback(KillSwitch)` at plan
+/// time when the kill switch keeps the lane out of the plan.
+pub const MEMBERSHIP_JOIN_SITE: &str = "membership-join";
+
 pub struct MembershipJoinOperator {
     child: BoxedOperator,
     /// The right-side triple (all vars ∈ child schema).
@@ -65,9 +92,11 @@ pub struct MembershipJoinOperator {
     /// lazily on the first fully-bound row, so a stream that never grounds
     /// the pattern (or is empty) never pays for the scan.
     key_set: Option<FxHashSet<CompositeGroupKey>>,
-    /// Set at `open()` when more than one graph is in the active scope: the
-    /// hash set is never built and every row takes the exact per-row join
-    /// (see the multi-graph note in the module docs).
+    /// When set, every row takes the exact per-row join instead of the hash
+    /// keep/drop path. Set at `open()` when more than one graph is in the
+    /// active scope, and by `build_key_set` when the drain finds a duplicate
+    /// key tuple — proof that some ground triple matches more than one flake
+    /// (RDF list positions), so keep/drop is not join-equivalent (#1687).
     exact_only: bool,
     planning: PlanningContext,
     norm: Option<EqualityNorm>,
@@ -142,6 +171,7 @@ impl MembershipJoinOperator {
             &self.planning,
         )?;
         let mut set = FxHashSet::default();
+        let mut duplicate_ground_rows = false;
         inner.open(ctx).await?;
         while let Some(batch) = inner.next_batch(ctx).await? {
             ctx.check_cancelled()?;
@@ -155,15 +185,41 @@ impl MembershipJoinOperator {
                         binding_to_group_key_normalized(binding, store, gv)
                     })
                     .collect();
-                set.insert(CompositeGroupKey(key));
+                duplicate_ground_rows |= !set.insert(CompositeGroupKey(key));
             }
         }
         inner.close();
-        tracing::debug!(
-            keys = set.len(),
-            pattern = ?self.pattern,
-            "membership join key set built"
-        );
+        if duplicate_ground_rows {
+            // A key tuple drained twice means one ground triple matched more
+            // than one flake — RDF list positions (`o_i`) are the known case.
+            // The generic join emits one row per matching flake; keep/drop
+            // would collapse them. Discard the hash path and route every row
+            // through the exact per-row fallback so the lane's answer stays
+            // identical to the generic pipeline's (#1687).
+            tracing::debug!(
+                keys = set.len(),
+                pattern = ?self.pattern,
+                "membership join key set has duplicate ground rows; \
+                 falling back to exact per-row joins"
+            );
+            self.exact_only = true;
+            crate::fast_path_outcome::stamp_fast_path(
+                MEMBERSHIP_JOIN_SITE,
+                crate::fast_path_outcome::FastPathOutcome::Fallback(
+                    crate::fast_path_outcome::FastPathFallback::GateDeclined,
+                ),
+            );
+        } else {
+            tracing::debug!(
+                keys = set.len(),
+                pattern = ?self.pattern,
+                "membership join key set built"
+            );
+            crate::fast_path_outcome::stamp_fast_path(
+                MEMBERSHIP_JOIN_SITE,
+                crate::fast_path_outcome::FastPathOutcome::Proceed,
+            );
+        }
         self.key_set = Some(set);
         Ok(())
     }
@@ -226,6 +282,14 @@ impl Operator for MembershipJoinOperator {
             crate::dataset::ActiveGraphs::Single => false,
             crate::dataset::ActiveGraphs::Many(graphs) => graphs.len() > 1,
         };
+        if self.exact_only {
+            crate::fast_path_outcome::stamp_fast_path(
+                MEMBERSHIP_JOIN_SITE,
+                crate::fast_path_outcome::FastPathOutcome::Fallback(
+                    crate::fast_path_outcome::FastPathFallback::GateDeclined,
+                ),
+            );
+        }
         self.child.open(ctx).await?;
         self.key_set = None;
         self.state = OperatorState::Open;
@@ -260,28 +324,35 @@ impl Operator for MembershipJoinOperator {
                     if self.key_set.is_none() {
                         self.build_key_set(ctx).await?;
                     }
-                    self.probed_rows += 1;
-                    let key = self.extract_key(&input_batch, row_idx);
-                    let keep = self
-                        .key_set
-                        .as_ref()
-                        .expect("key set built above")
-                        .contains(&key);
-                    if keep {
-                        self.kept_rows += 1;
-                        for (col_idx, var) in self.schema.iter().enumerate() {
-                            let binding = input_batch
-                                .get(row_idx, *var)
-                                .cloned()
-                                .unwrap_or(Binding::Unbound);
-                            columns[col_idx].push(binding);
+                    // The build drain may have just disproved the
+                    // matches-at-most-once premise (duplicate ground rows —
+                    // list positions) and flipped `exact_only`; re-check so
+                    // no row is ever answered by a keep/drop the premise
+                    // does not cover.
+                    if !self.exact_only {
+                        self.probed_rows += 1;
+                        let key = self.extract_key(&input_batch, row_idx);
+                        let keep = self
+                            .key_set
+                            .as_ref()
+                            .expect("key set built above")
+                            .contains(&key);
+                        if keep {
+                            self.kept_rows += 1;
+                            for (col_idx, var) in self.schema.iter().enumerate() {
+                                let binding = input_batch
+                                    .get(row_idx, *var)
+                                    .cloned()
+                                    .unwrap_or(Binding::Unbound);
+                                columns[col_idx].push(binding);
+                            }
                         }
+                        continue;
                     }
-                } else {
-                    self.fallback_rows += 1;
-                    self.per_row_join(ctx, &input_batch, row_idx, &mut columns)
-                        .await?;
                 }
+                self.fallback_rows += 1;
+                self.per_row_join(ctx, &input_batch, row_idx, &mut columns)
+                    .await?;
             }
 
             if columns.first().is_none_or(std::vec::Vec::is_empty) {

--- a/fluree-db-sparql/src/lower/mod.rs
+++ b/fluree-db-sparql/src/lower/mod.rs
@@ -1134,6 +1134,67 @@ mod tests {
         }
     }
 
+    /// A datatype IRI whose namespace is not registered lowers to the
+    /// EMPTY-namespace full-IRI Sid — a constraint no stored row carries,
+    /// so the pattern matches nothing (#1686). The old fallback rewrote it
+    /// to `xsd:string`, silently matching every plain-string row. Both
+    /// term-identity sites take the same rule: triple-pattern constraints
+    /// and VALUES rows.
+    #[test]
+    fn unregistered_datatype_lowers_to_match_nothing_sid() {
+        use fluree_db_core::DatatypeConstraint;
+        use fluree_db_query::binding::Binding;
+        use fluree_vocab::namespaces::EMPTY;
+
+        let bogus = "http://no-such-namespace.example.com/NoSuchType";
+        let expected_sid = Sid::new(EMPTY, bogus);
+
+        let pattern = lower_query(&format!(
+            "PREFIX ex: <http://example.org/> SELECT ?s WHERE {{ ?s ex:p \"a\"^^<{bogus}> }}"
+        ))
+        .unwrap();
+        assert_eq!(
+            first_triple(&pattern).dtc,
+            Some(DatatypeConstraint::Explicit(expected_sid.clone())),
+            "triple-pattern constraint must name the unregistered IRI, not xsd:string"
+        );
+
+        let values = lower_query(&format!(
+            "PREFIX ex: <http://example.org/> \
+             SELECT ?s WHERE {{ VALUES ?o {{ \"a\"^^<{bogus}> }} ?s ex:p ?o }}"
+        ))
+        .unwrap();
+        let row_binding = values
+            .patterns
+            .iter()
+            .find_map(|p| match p {
+                Pattern::Values { rows, .. } => rows.first().and_then(|r| r.first()),
+                _ => None,
+            })
+            .expect("a VALUES row");
+        match row_binding {
+            Binding::Lit { dtc, .. } => assert_eq!(
+                dtc,
+                &DatatypeConstraint::Explicit(expected_sid),
+                "VALUES row must carry the unregistered IRI, not xsd:string"
+            ),
+            other => panic!("expected literal binding, got {other:?}"),
+        }
+
+        // Control: a datatype in a REGISTERED namespace keeps its canonical
+        // Sid (the fix must not widen to registered custom datatypes).
+        let custom = lower_query(
+            "PREFIX ex: <http://example.org/> \
+             SELECT ?s WHERE { ?s ex:p \"z\"^^ex:Custom }",
+        )
+        .unwrap();
+        assert_eq!(
+            first_triple(&custom).dtc,
+            Some(DatatypeConstraint::Explicit(Sid::new(100, "Custom"))),
+            "registered namespaces still resolve to their canonical Sid"
+        );
+    }
+
     fn lower_query(sparql: &str) -> Result<Query> {
         lower_query_with_vars(sparql).map(|(q, _)| q)
     }

--- a/fluree-db-sparql/src/lower/term.rs
+++ b/fluree-db-sparql/src/lower/term.rs
@@ -19,7 +19,7 @@ use fluree_db_query::binding::Binding;
 use fluree_db_query::ir::triple::{Ref, Term, TriplePattern};
 use fluree_db_query::parse::encode::IriEncoder;
 use fluree_db_query::var_registry::VarId;
-use fluree_vocab::namespaces::{FLUREE_DB, XSD};
+use fluree_vocab::namespaces::{EMPTY, FLUREE_DB, XSD};
 use fluree_vocab::{fluree, xsd, xsd_names};
 use std::sync::Arc;
 
@@ -261,15 +261,8 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
             ),
             LiteralValue::Typed { value, datatype } => {
                 let fv = self.lower_typed_literal(value, datatype)?;
-                // Resolve the datatype IRI to its canonical SID via the
-                // encoder. For custom (unencoded) datatypes the encoder
-                // returns None — fall back to `xsd:string`, matching
-                // the storage-side fallback in `term_to_binding`.
                 let dt_iri = self.expand_iri(datatype)?;
-                let dt_sid = self
-                    .encoder
-                    .encode_iri_strict(&dt_iri)
-                    .unwrap_or_else(|| Sid::new(XSD, xsd_names::STRING));
+                let dt_sid = self.datatype_sid(&dt_iri);
                 (fv, DatatypeConstraint::Explicit(dt_sid))
             }
             LiteralValue::Integer(i) => (
@@ -461,6 +454,25 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
         expand_iri_with(&self.prefixes, self.base.as_deref(), iri)
     }
 
+    /// Resolve a typed literal's datatype IRI to the Sid that names it in
+    /// term-identity positions (triple-pattern constraints, VALUES rows).
+    ///
+    /// A registered namespace resolves to its canonical Sid. An IRI whose
+    /// canonical prefix is NOT registered on this ledger resolves to the
+    /// EMPTY-namespace full-IRI Sid — the same form the storage side's
+    /// non-strict `encode_iri` produces, and the form the JSON-LD query
+    /// surface already uses (`fluree-db-query/src/parse/lower.rs`). Ingest
+    /// registers every namespace it stores, so no stored term can carry a
+    /// datatype in an unregistered namespace: the EMPTY-namespace Sid
+    /// matches nothing, which is the spec answer for a term that does not
+    /// exist. (The previous `xsd:string` fallback made
+    /// `"a"^^ex:NoSuchType` match every plain-string `"a"` row — #1686.)
+    fn datatype_sid(&self, dt_iri: &str) -> Sid {
+        self.encoder
+            .encode_iri(dt_iri)
+            .unwrap_or_else(|| Sid::new(EMPTY, dt_iri))
+    }
+
     /// Convert a SPARQL term to a Binding (for VALUES rows).
     pub(super) fn term_to_binding(&mut self, term: &SparqlTerm) -> Result<Binding> {
         match term {
@@ -512,13 +524,14 @@ impl<E: IriEncoder> LoweringContext<'_, E> {
                     // Bind the DECLARED datatype: Binding::Lit equality
                     // includes the datatype, so labeling every typed literal
                     // xsd:string made VALUES constants like
-                    // "…"^^xsd:integer unable to match stored values.
+                    // "…"^^xsd:integer unable to match stored values. An
+                    // unregistered datatype resolves to the match-nothing
+                    // EMPTY-namespace Sid (see `datatype_sid`), keeping this
+                    // site in lockstep with triple-pattern constraints.
                     let dt_sid = if dt_iri == fluree::EMBEDDING_VECTOR {
                         Sid::new(FLUREE_DB, "vector")
-                    } else if let Some(sid) = self.encoder.encode_iri_strict(&dt_iri) {
-                        sid
                     } else {
-                        Sid::new(XSD, xsd_names::STRING)
+                        self.datatype_sid(&dt_iri)
                     };
                     Ok(Binding::lit(fv, dt_sid))
                 }


### PR DESCRIPTION
Fixes #1686. Partially addresses #1687 — the join-equivalence half; the list-position semantics decision stays open there (details below).

Both of these came out of the same review pass over #1674/#1676 and sit on the same literal-identity seam — what a constant literal's datatype *means* when it meets the scan — so they ship together.

## Problem

**1. Unencodable datatype IRIs failed open (#1686).** Both term-identity sites in SPARQL lowering — the triple-pattern constraint in `lower_literal_with_constraint` and its `term_to_binding` VALUES twin (`fluree-db-sparql/src/lower/term.rs`) — resolved a typed literal's datatype with `encode_iri_strict` and fell back to `xsd:string` when the namespace wasn't registered. So `?s ex:p "a"^^ex:NoSuchType` matched every plain-string `"a"` row, and the VALUES form did the same. `encode_iri_strict` returning `None` means exactly "this ledger has no such namespace", and ingest registers every namespace it stores — so no stored term *on that ledger* can carry that datatype, and for a single-ledger query the empty result isn't just the spec answer, it's provably the only correct one. (In a multi-ledger dataset the constraint is resolved against the primary ledger only and a *non-primary* ledger can carry the datatype — that seam predates this PR and is #1771; see Not in this PR.) The JSON-LD surface already gave it (its `lower_triple_pattern` uses the non-strict encoder), which means the two query surfaces disagreed on the same question — verified live before the fix: SPARQL 1 row, JSON-LD 0.

**2. The membership-join lane silently diverged from the generic join on list rows (#1687).** `MembershipJoinOperator` answers a right triple that binds nothing new as a hash keep/drop, on the premise that a fully-ground triple matches at most once. RDF list rows break that premise inside a single graph — the same `(s, p, o)` recurs at multiple `o_i` positions — and nothing in `membership_join_key_vars` excluded them, so above the 256-row driving gate the lane answered a var-object join over list elements as a semi-join while the generic pipeline answers a bag join. Reproduced above the gate in the new fixture: 276 rows from the lane vs 532 from the generic pipeline on identical data — a scale-dependent silent wrong answer, and a break of the lane's own documented "join-equivalent unconditionally" invariant. On top of that the lane was untestable: no `stamp_fast_path` site, and `FLUREE_DISABLE_QUERY_FAST_PATHS` didn't reach it, so `MustFire`/`MustNotFire` couldn't express engagement at all.

## Changes

**Commit 1 — fail closed on unencodable datatypes (`fluree-db-sparql`)**
- Both sites now resolve through a shared `datatype_sid` helper: non-strict encode, so an unregistered namespace yields the EMPTY-namespace full-IRI Sid — a constraint no stored row carries. Every enforcement lane compares via `dt_compatible` (exact Sid equality outside the XSD numeric families: `range.rs:289` novelty, `binary_scan.rs:846` overlay, `binary_scan.rs:1287` indexed), so the pattern matches nothing in all of them, and the SPARQL answer now equals the JSON-LD one by construction.
- Registered custom datatypes are untouched — their query-time encode resolves to the same canonical Sid ingest stored, pinned by controls.
- A datatype IRI that canonically splits to the EMPTY prefix on *both* sides (a bare-string datatype actually stored that way) still matches by exact equality, as before.
- Unit test pins the lowered constraint form at both sites; integration guards in `it_literal_identity.rs` pin the empty result and the controls on both surfaces, in both lanes (novelty + indexed).

**Commit 2 — keep the membership lane join-equivalent (`fluree-db-query`)**
- Stats carry no list-ness, so the shape is not plan-detectable. Instead the one-shot drain that builds the key set doubles as the detector: a key tuple inserted twice **is** the premise's counterexample (two flakes matched one ground triple). When that happens the operator discards the hash path and routes every row through its existing exact per-row fallback — the same seeded evaluation the generic join runs — so lane and generic agree by construction, whatever the eventual list-semantics ruling says. The detection is exact, not heuristic: keep/drop diverges from the generic join iff some ground probe matches more than one flake, and that's precisely when the drain sees a duplicate key.
- The decline is surgical: on ordinary shapes the added cost is one bool OR per drained key, and the new fixture pins (via routing stamp) that a same-size non-list shape still takes the hash path.
- Testability: `membership_join.rs` now stamps the repo-standard fast-path outcome (site `membership-join` — `Proceed` when the hash path serves, `GateDeclined` on the duplicate-key or multi-graph fallback), and the planner honors `FLUREE_DISABLE_QUERY_FAST_PATHS` for the lane (stamping `KillSwitch`, checked at the choose site so `membership_join_key_vars` stays a pure predicate). The differential harness can finally compare this lane against the generic join.
- New own-binary test `it_membership_join_list_rows` runs both cases *above* the gate (296/280 driving rows) with span-captured stamps, so neither case can silently degrade into a below-gate run and pass vacuously; phase 2 re-answers both under the kill switch and requires identical rows. The stale "the lane's answer at or above the gate is unpinned" comment in `it_fastpath_1652_regression.rs` now points at the new pin.

Both fixes were reverted independently during development to confirm their tests fail for the right reason: the #1686 guards reproduce the 1-row fail-open match, and the #1687 fixture reproduces the 276-vs-532 divergence with the lane engaged.

## Behaviour changes (release notes)
- SPARQL: a typed literal whose datatype IRI has no registered namespace on the ledger now matches nothing (previously: matched plain `xsd:string` rows), in triple patterns and VALUES alike. Registered custom datatypes are unaffected.
- A var-object join over RDF list elements now returns the same rows whether or not the planner picks the membership lane. Below the driving gate nothing changes; above it the lane previously under-counted (one row per driving row instead of one per matching flake).
- `FLUREE_DISABLE_QUERY_FAST_PATHS` now also disables the membership-join lane.

## Not in this PR
- **The list-position semantics decision (#1687's step 1).** Whether a var-object join over list elements *should* be a bag join over positions (532/5-style answers) or a set join over distinct values is still the open product call — this PR only guarantees both pipelines give the same answer, which today is the generic bag join. The two fixtures pin today's numbers with comments saying exactly that, so settling the decision the other way means changing pinned expectations deliberately, not silently. That's why this is "partially addresses": the issue's remaining substance is that decision, and it shouldn't get closed as a side effect of the equivalence fix.
- `term_to_binding` special-cases `fluree:embeddingVector` → `Sid(FLUREE_DB, "vector")` before encoding while the triple-pattern site doesn't; that asymmetry predates this PR and is orthogonal to the fail-open bug, so I left it alone rather than touch vector matching without a vector rig.
- **Multi-ledger datasets: the constraint Sid is resolved against the primary ledger only.** `query_dataset` lowers against the first default graph's snapshot, and per-graph execution re-encodes `s`/`p`/`o` Sids but not `pattern.dtc` (`binary_scan.rs` `build_match_val_for_snapshot`), so a datatype registered only on a *non-primary* ledger constrains as the primary encoded it — confirmed by fixture: this PR turns that from matching the primary's plain-string rows (wrong rows) into matching nothing (silent drop), while registered-on-both datatypes with divergent namespace codes were already dropped before it. The re-encode fix belongs with the pre-existing gap, and this PR's EMPTY-namespace Sid keeps the datatype IRI recoverable for it where the `xsd:string` fallback destroyed it. Follow-up: #1771.

## Gates
- `cargo test -p fluree-db-query` (1,485 lib + integration bins) and `-p fluree-db-sparql` (641): green.
- `-p fluree-db-api --features native`: `it_literal_identity`, `it_fastpath_1652_regression`, `it_membership_join_list_rows`, `it_cyclic_bgp_string_dict`, `it_query_sparql_indexed`: green.
- W3C suite (`testsuite-sparql`, both-way registers): 36/36 groups green.
- `cargo clippy --all-targets --no-deps -- -D warnings` on all three touched crates; `cargo fmt --all --check` clean.

