### PR TITLE
fix(query): STR() on a double returns the canonical XSD lexical form

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,6 +3035,7 @@ dependencies = [
  "fluree-db-reasoner",
  "fluree-db-spatial",
  "fluree-db-tabular",
+ "fluree-graph-ir",
  "fluree-graph-json-ld",
  "fluree-search-protocol",
  "fluree-vocab",

--- a/fluree-db-api/tests/it_query_expression_semantics.rs
+++ b/fluree-db-api/tests/it_query_expression_semantics.rs
@@ -1979,6 +1979,41 @@ async fn jsonld_encoded_xsd_float_result_datatype() {
     );
 }
 
+// STR() on the encoded lane (#1695 float sibling): the decode folds the
+// stored xsd:float to a full-precision f64 and the #1470 re-tag then narrows
+// it to an f32 for the numeric lanes — but STR() must spell the STORED f64,
+// the same rendering the serializer gives the term. An f32-inexact value is
+// the discriminating case: through the f32 the lexical would come back
+// `3.1415927E0`.
+#[tokio::test]
+async fn sparql_encoded_xsd_float_str_matches_serializer() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let tx = json!({
+        "@context": ctx(),
+        "@graph": [{
+            "@id": "ex:n",
+            "ex:f": { "@value": "3.14159265358979", "@type": "xsd:float" }
+        }]
+    });
+    let ledger = seed_indexed(&fluree, "x2/encfloat:str", &tx).await;
+    let q = "PREFIX ex: <http://example.org/ns/> \
+             SELECT ?f (STR(?f) AS ?lex) WHERE { ex:n ex:f ?f }";
+    let result = support::query_sparql(&fluree, &ledger, q)
+        .await
+        .expect("STR over encoded float");
+    let sparql_json = result
+        .to_sparql_json(&ledger.snapshot)
+        .expect("to_sparql_json");
+    let row = &sparql_json["results"]["bindings"][0];
+    let serialized = row["f"]["value"].as_str().expect("serialized float");
+    let str_lex = row["lex"]["value"].as_str().expect("STR result");
+    assert_eq!(
+        str_lex, serialized,
+        "STR(?f) diverges from the serializer on the encoded lane: {sparql_json}"
+    );
+    assert_eq!(serialized, "3.14159265358979E0", "{sparql_json}");
+}
+
 fn lang_ebv_tx() -> JsonValue {
     json!({
         "@context": ctx(),

--- a/fluree-db-api/tests/it_query_jsonld.rs
+++ b/fluree-db-api/tests/it_query_jsonld.rs
@@ -26,6 +26,44 @@ async fn assert_query_bind_error(
     }
 }
 
+/// Issue #1695 twin (SPARQL↔JSON-LD parity): `(str ?d)` on an `xsd:double`
+/// binding must produce the W3C canonical lexical form (`1.0E0`) — the same
+/// string the SPARQL surface's `STR()` and the RDF-lexical serializers emit —
+/// while `?d` itself stays a native JSON number on this surface.
+#[tokio::test]
+async fn jsonld_bind_str_double_canonical_form() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "query/str-double-canonical");
+    let insert = json!({
+        "@context": {
+            "ex": "http://example.org/ns/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@id": "ex:y1",
+        "ex:d": {"@value": "1E0", "@type": "xsd:double"}
+    });
+    let ledger = fluree.insert(ledger0, &insert).await.expect("seed").ledger;
+
+    let query = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "where": [
+            {"@id": "ex:y1", "ex:d": "?d"},
+            ["bind", "?lex", "(str ?d)"]
+        ],
+        "select": ["?d", "?lex"]
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("bind str(double) query");
+    let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+    assert_eq!(json_rows, json!([[1.0, "1.0E0"]]));
+    assert!(
+        json_rows[0][0].is_number(),
+        "JSON-LD double must stay a native number: {json_rows}"
+    );
+}
+
 #[tokio::test]
 async fn jsonld_filter_single_filter() {
     // Mirrors `fluree.snapshot.query.filter-query-test/filter-test` ("single filter")

--- a/fluree-db-api/tests/it_query_jsonld.rs
+++ b/fluree-db-api/tests/it_query_jsonld.rs
@@ -64,6 +64,41 @@ async fn jsonld_bind_str_double_canonical_form() {
     );
 }
 
+/// Float sibling of the twin above (#1695, SPARQL↔JSON-LD parity): `(str ?f)`
+/// on a stored `xsd:float` must spell the STORED f64 — the same rendering the
+/// SPARQL surface's `STR()` and the serializers give the term — not the f32
+/// the numeric lanes narrow it to. The value is f32-inexact on purpose:
+/// through the f32 the lexical would come back `3.1415927E0`.
+#[tokio::test]
+async fn jsonld_bind_str_float_canonical_form() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "query/str-float-canonical");
+    let insert = json!({
+        "@context": {
+            "ex": "http://example.org/ns/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@id": "ex:y2",
+        "ex:f": {"@value": "3.14159265358979", "@type": "xsd:float"}
+    });
+    let ledger = fluree.insert(ledger0, &insert).await.expect("seed").ledger;
+
+    let query = json!({
+        "@context": {"ex": "http://example.org/ns/"},
+        "where": [
+            {"@id": "ex:y2", "ex:f": "?f"},
+            ["bind", "?lex", "(str ?f)"]
+        ],
+        "select": ["?lex"]
+    });
+
+    let result = support::query_jsonld(&fluree, &ledger, &query)
+        .await
+        .expect("bind str(float) query");
+    let json_rows = result.to_jsonld(&ledger.snapshot).expect("jsonld");
+    assert_eq!(json_rows, json!([["3.14159265358979E0"]]));
+}
+
 #[tokio::test]
 async fn jsonld_filter_single_filter() {
     // Mirrors `fluree.snapshot.query.filter-query-test/filter-test` ("single filter")

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -4711,11 +4711,12 @@ async fn sparql_double_canonical_lexical_form_across_formats() {
 /// drift apart again) plus the expected canonical spelling.
 ///
 /// The `xsd:string()` cast is pinned alongside precisely because it must NOT
-/// follow: SPARQL §17.5 defers casting to XPath, whose double→string rule is
-/// plain decimal notation in `[1e-6, 1e6)`, and W3C `cast-string` requires
-/// `xsd:string("1E0"^^xsd:double)` to be `"1"`. The two functions answer
-/// different questions; this test states both answers so neither drifts into
-/// the other.
+/// always follow: SPARQL §17.5 defers casting to XPath, whose double→string
+/// rule is plain decimal notation for absolute values in `[1e-6, 1e6)` — W3C
+/// `cast-string` requires `xsd:string("1E0"^^xsd:double)` to be `"1"` — and
+/// the canonical (scientific) lexical form outside that range, on BOTH sides
+/// (`1.0E-7` and `1.0E30` alike, never `0.0000001` or a 31-digit integer).
+/// This test states both answers so neither function drifts into the other.
 #[tokio::test]
 async fn sparql_str_double_matches_serializer_canonical_form() {
     let fluree = FlureeBuilder::memory().build_memory();
@@ -4727,9 +4728,15 @@ async fn sparql_str_double_matches_serializer_canonical_form() {
     let cases = [
         ("ex:d1", "1E0", "1.0E0", "1"),
         ("ex:d2", "5.0", "5.0E0", "5"),
-        ("ex:d3", "1.0E6", "1.0E6", "1000000"),
+        // 1e6 sits just OUTSIDE the XPath decimal-notation range (the upper
+        // bound is exclusive), so cast and canonical agree here.
+        ("ex:d3", "1.0E6", "1.0E6", "1.0E6"),
         ("ex:d4", "0.001", "1.0E-3", "0.001"),
         ("ex:d5", "-12.5", "-1.25E1", "-12.5"),
+        // Outside the XPath range on either side the cast is the canonical
+        // scientific form too — the range rule is two-sided.
+        ("ex:d9", "1.0E-7", "1.0E-7", "1.0E-7"),
+        ("ex:d10", "1.0E30", "1.0E30", "1.0E30"),
         // Specials share one spelling across both renderings — and neither is
         // Rust's `Display` ("inf"), which is a lexical form of nothing.
         ("ex:d6", "NaN", "NaN", "NaN"),
@@ -4793,10 +4800,13 @@ async fn sparql_str_double_matches_serializer_canonical_form() {
     }
 }
 
-/// Issue #1695 (float sibling): a stored `xsd:float` materializes as an f32 in
-/// expression evaluation, and `STR()` on it must likewise agree with the
-/// serializer's rendering of the same term (canonical form of the stored
-/// value).
+/// Issue #1695 (float sibling): a stored `xsd:float` is carried as a
+/// full-precision f64 (ingest never narrows) and the serializer prints THAT
+/// value; expression evaluation narrows the same binding to an f32. `STR()`
+/// must side with the serializer — it reads the stored f64 off the binding
+/// (`stored_float_f64`) rather than spelling the f32 truncation. The
+/// f32-inexact rows are the ones that catch it: for `3.14159265358979` the
+/// truncated spelling would be `3.1415927E0`.
 #[tokio::test]
 async fn sparql_str_float_matches_serializer_canonical_form() {
     let fluree = FlureeBuilder::memory().build_memory();
@@ -4806,6 +4816,12 @@ async fn sparql_str_float_matches_serializer_canonical_form() {
         ("ex:f1", "1E0", "1.0E0"),
         ("ex:f2", "33.33", "3.333E1"),
         ("ex:f3", "-0.5", "-5.0E-1"),
+        // f32-INEXACT: the stored f64 keeps more precision than an f32 can
+        // hold, so serializer-vs-STR() agreement is only possible if STR()
+        // reads the stored f64. (These rows go red if STR() ever routes
+        // through the f32 materialization again.)
+        ("ex:f4", "3.14159265358979", "3.14159265358979E0"),
+        ("ex:f5", "1.23456789012345E-5", "1.23456789012345E-5"),
     ];
     let graph: Vec<serde_json::Value> = cases
         .iter()

--- a/fluree-db-api/tests/it_query_sparql.rs
+++ b/fluree-db-api/tests/it_query_sparql.rs
@@ -4703,6 +4703,196 @@ async fn sparql_double_canonical_lexical_form_across_formats() {
     );
 }
 
+/// Issue #1695: `STR()` on an `xsd:double` must return the same W3C canonical
+/// lexical form the serializer emits for the very same term — the companion
+/// of `sparql_double_canonical_lexical_form_across_formats`, which pins the
+/// serializer side but never exercises expression evaluation. Each row
+/// asserts `STR(?d) == serialized ?d` (self-anchoring: the two paths cannot
+/// drift apart again) plus the expected canonical spelling.
+///
+/// The `xsd:string()` cast is pinned alongside precisely because it must NOT
+/// follow: SPARQL §17.5 defers casting to XPath, whose double→string rule is
+/// plain decimal notation in `[1e-6, 1e6)`, and W3C `cast-string` requires
+/// `xsd:string("1E0"^^xsd:double)` to be `"1"`. The two functions answer
+/// different questions; this test states both answers so neither drifts into
+/// the other.
+#[tokio::test]
+async fn sparql_str_double_matches_serializer_canonical_form() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "canon:str-double");
+
+    // Representative doubles: the issue's repro (1E0), an integral value,
+    // a large exponent, a small exponent, a negative, and the specials.
+    // Columns: id, stored lexical, canonical (STR + serializer), cast form.
+    let cases = [
+        ("ex:d1", "1E0", "1.0E0", "1"),
+        ("ex:d2", "5.0", "5.0E0", "5"),
+        ("ex:d3", "1.0E6", "1.0E6", "1000000"),
+        ("ex:d4", "0.001", "1.0E-3", "0.001"),
+        ("ex:d5", "-12.5", "-1.25E1", "-12.5"),
+        // Specials share one spelling across both renderings — and neither is
+        // Rust's `Display` ("inf"), which is a lexical form of nothing.
+        ("ex:d6", "NaN", "NaN", "NaN"),
+        ("ex:d7", "INF", "INF", "INF"),
+        ("ex:d8", "-INF", "-INF", "-INF"),
+    ];
+    let graph: Vec<serde_json::Value> = cases
+        .iter()
+        .map(|(id, lex, _, _)| {
+            json!({"@id": id, "ex:score": {"@value": lex, "@type": "xsd:double"}})
+        })
+        .collect();
+    let insert = json!({
+        "@context": {
+            "ex": "http://example.org/ns/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@graph": graph
+    });
+    let ledger = fluree.insert(ledger0, &insert).await.expect("seed").ledger;
+
+    let query = r"
+        PREFIX ex: <http://example.org/ns/>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        SELECT ?s ?d (STR(?d) AS ?lex) (xsd:string(?d) AS ?cast)
+        WHERE { ?s ex:score ?d }
+    ";
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("STR(double) query");
+    let sparql_json = result
+        .to_sparql_json(&ledger.snapshot)
+        .expect("to_sparql_json");
+    let bindings = sparql_json["results"]["bindings"]
+        .as_array()
+        .expect("bindings array");
+    assert_eq!(bindings.len(), cases.len(), "{sparql_json}");
+
+    for row in bindings {
+        let subject = row["s"]["value"].as_str().expect("subject IRI");
+        let serialized = row["d"]["value"].as_str().expect("serialized double");
+        let str_lex = row["lex"]["value"].as_str().expect("STR result");
+        let cast_lex = row["cast"]["value"].as_str().expect("xsd:string result");
+        // The core pin: expression evaluation agrees with the serializer on
+        // the SAME term in the SAME result set.
+        assert_eq!(
+            str_lex, serialized,
+            "STR(?d) diverges from the serializer for {subject}: {sparql_json}"
+        );
+        // And the shared form is the W3C canonical one.
+        let (_, _, canonical, cast) = cases
+            .iter()
+            .find(|(id, _, _, _)| subject.ends_with(&id[3..]))
+            .expect("known subject");
+        assert_eq!(serialized, *canonical, "{subject}: {sparql_json}");
+        // The cast keeps its own XPath-mandated rendering (W3C cast-string).
+        assert_eq!(
+            cast_lex, *cast,
+            "xsd:string(?d) must follow the XPath cast rule for {subject}: {sparql_json}"
+        );
+    }
+}
+
+/// Issue #1695 (float sibling): a stored `xsd:float` materializes as an f32 in
+/// expression evaluation, and `STR()` on it must likewise agree with the
+/// serializer's rendering of the same term (canonical form of the stored
+/// value).
+#[tokio::test]
+async fn sparql_str_float_matches_serializer_canonical_form() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "canon:str-float");
+
+    let cases = [
+        ("ex:f1", "1E0", "1.0E0"),
+        ("ex:f2", "33.33", "3.333E1"),
+        ("ex:f3", "-0.5", "-5.0E-1"),
+    ];
+    let graph: Vec<serde_json::Value> = cases
+        .iter()
+        .map(|(id, lex, _)| json!({"@id": id, "ex:reading": {"@value": lex, "@type": "xsd:float"}}))
+        .collect();
+    let insert = json!({
+        "@context": {
+            "ex": "http://example.org/ns/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@graph": graph
+    });
+    let ledger = fluree.insert(ledger0, &insert).await.expect("seed").ledger;
+
+    let query = r"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT ?s ?f (STR(?f) AS ?lex)
+        WHERE { ?s ex:reading ?f }
+    ";
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("STR(float) query");
+    let sparql_json = result
+        .to_sparql_json(&ledger.snapshot)
+        .expect("to_sparql_json");
+    let bindings = sparql_json["results"]["bindings"]
+        .as_array()
+        .expect("bindings array");
+    assert_eq!(bindings.len(), cases.len(), "{sparql_json}");
+
+    for row in bindings {
+        let subject = row["s"]["value"].as_str().expect("subject IRI");
+        let serialized = row["f"]["value"].as_str().expect("serialized float");
+        let str_lex = row["lex"]["value"].as_str().expect("STR result");
+        assert_eq!(
+            str_lex, serialized,
+            "STR(?f) diverges from the serializer for {subject}: {sparql_json}"
+        );
+        let expected = cases
+            .iter()
+            .find(|(id, _, _)| subject.ends_with(&id[3..]))
+            .map(|(_, _, canonical)| *canonical)
+            .expect("known subject");
+        assert_eq!(serialized, expected, "{subject}: {sparql_json}");
+    }
+}
+
+/// Issue #1695 (aggregate sibling): GROUP_CONCAT's lenient numeric coercion
+/// stringifies a double through the same seam, and must use the same
+/// canonical form the serializer would give the value.
+#[tokio::test]
+async fn sparql_group_concat_double_canonical_form() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, "canon:gc-double");
+
+    let insert = json!({
+        "@context": {
+            "ex": "http://example.org/ns/",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@id": "ex:s",
+        "ex:score": [
+            {"@value": "1E0", "@type": "xsd:double"},
+            {"@value": "1.0E6", "@type": "xsd:double"}
+        ]
+    });
+    let ledger = fluree.insert(ledger0, &insert).await.expect("seed").ledger;
+
+    let query = r#"
+        PREFIX ex: <http://example.org/ns/>
+        SELECT (GROUP_CONCAT(?d; separator="|") AS ?all)
+        WHERE { ex:s ex:score ?d }
+    "#;
+    let result = support::query_sparql(&fluree, &ledger, query)
+        .await
+        .expect("GROUP_CONCAT(double) query");
+    let sparql_json = result
+        .to_sparql_json(&ledger.snapshot)
+        .expect("to_sparql_json");
+    let all = sparql_json["results"]["bindings"][0]["all"]["value"]
+        .as_str()
+        .expect("group_concat result");
+    let mut parts: Vec<&str> = all.split('|').collect();
+    parts.sort_unstable();
+    assert_eq!(parts, vec!["1.0E0", "1.0E6"], "{sparql_json}");
+}
+
 #[tokio::test]
 async fn sparql_integer_division_yields_decimal() {
     // Per XPath op:numeric-divide, xsd:integer / xsd:integer yields xsd:decimal:

--- a/fluree-db-query/Cargo.toml
+++ b/fluree-db-query/Cargo.toml
@@ -15,6 +15,9 @@ fluree-db-r2rml = { path = "../fluree-db-r2rml" }
 fluree-db-reasoner = { path = "../fluree-db-reasoner" }
 fluree-search-protocol = { path = "../fluree-search-protocol" }
 fluree-vocab = { path = "../fluree-vocab" }
+# Canonical XSD lexical forms (xsd:double / xsd:float) — the same routines the
+# result serializers use, so STR()/casts can never drift from output formats.
+fluree-graph-ir = { path = "../fluree-graph-ir" }
 fluree-graph-json-ld = { path = "../fluree-graph-json-ld" }
 fluree-db-binary-index = { path = "../fluree-db-binary-index" }
 fluree-db-spatial = { path = "../fluree-db-spatial" }

--- a/fluree-db-query/src/aggregate.rs
+++ b/fluree-db-query/src/aggregate.rs
@@ -1015,7 +1015,9 @@ fn agg_group_concat(values: &[Binding], separator: &str) -> Binding {
                 FlakeValue::String(s) => Some(s.clone()),
                 FlakeValue::Json(s) => Some(s.clone()), // JSON as string
                 FlakeValue::Long(n) => Some(n.to_string()),
-                FlakeValue::Double(n) => Some(n.to_string()),
+                // Canonical xsd:double lexical form — the same string the
+                // serializer and STR() give this value (#1695).
+                FlakeValue::Double(n) => Some(fluree_graph_ir::canonical_xsd_double(*n)),
                 FlakeValue::Decimal(d) => Some(d.to_plain_string()),
                 FlakeValue::BigInt(n) => Some(n.to_string()),
                 FlakeValue::Boolean(b) => Some(b.to_string()),

--- a/fluree-db-query/src/eval.rs
+++ b/fluree-db-query/src/eval.rs
@@ -471,6 +471,50 @@ pub fn passes_filters(
     Ok(true)
 }
 
+/// The stored f64 behind a float-datatyped variable binding, when `var` is
+/// bound to one.
+///
+/// A stored `xsd:float` is carried as a full-precision `FlakeValue::Double`
+/// (ingest never narrows) and deliberately truncated to an f32 on the way into
+/// `ComparableValue` — the numeric lanes are single-precision, and
+/// `datatype()` keys off the `Float` variant. The lexical builders must NOT
+/// inherit that truncation: the serializer prints the stored f64
+/// (`canonical_xsd_double`, variant-keyed), so `STR()` has to read the f64
+/// from the binding itself or it spells the truncated value (#1695's float
+/// sibling). Returns `None` for anything that is not a stored-float binding —
+/// including a decode failure on the encoded path, which falls back to the
+/// generic (error-raising) evaluation.
+pub(crate) fn stored_float_f64<R: RowAccess>(
+    row: &R,
+    var: VarId,
+    ctx: Option<&ExecutionContext<'_>>,
+) -> Option<f64> {
+    match row.get(var)? {
+        Binding::Lit {
+            val: FlakeValue::Double(d),
+            dtc,
+            ..
+        } if is_xsd_float(dtc) => Some(*d),
+        Binding::EncodedLit {
+            o_kind,
+            o_key,
+            p_id,
+            dt_id,
+            lang_id,
+            ..
+        } if *dt_id == DatatypeDictId::FLOAT.as_u16() => {
+            match ctx?
+                .decode_encoded_value(*o_kind, *o_key, *p_id, *dt_id, *lang_id)?
+                .ok()?
+            {
+                FlakeValue::Double(d) => Some(d),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
 /// Convert a literal binding's value to a `ComparableValue`, carrying the
 /// datatype for the datatype-sensitive cases:
 /// - xsd:float (stored as an f64, tagged only by its datatype) becomes `Float`

--- a/fluree-db-query/src/eval/cast.rs
+++ b/fluree-db-query/src/eval/cast.rs
@@ -187,10 +187,15 @@ fn float_typed_literal(f: f32) -> ComparableValue {
     }
 }
 
-/// Format an f32 value for xsd:float output.
+/// Format an `f32` the way an XSD *cast* renders it.
 ///
-/// Rust's default f32 Display uses minimal decimal digits. This is acceptable
-/// for the W3C tests which compare float values numerically.
+/// Deliberately NOT the canonical XSD lexical form `STR()` produces
+/// (`fluree_graph_ir::canonical_xsd_float`): SPARQL §17.5 defers casting to
+/// XPath, whose float/double→string rule uses plain decimal notation for
+/// values in `[1e-6, 1e6)` rather than always-scientific. W3C `cast-string`
+/// pins it: `xsd:string("1E0"^^xsd:float)` is `"1"`, not `"1.0E0"`. The two
+/// renderings answer two different questions and must stay separate (#1695).
+/// Only the special values agree: `NaN`/`INF`/`-INF` in both.
 pub(crate) fn format_f32(f: f32) -> String {
     if f.is_nan() {
         "NaN".to_string()
@@ -203,6 +208,25 @@ pub(crate) fn format_f32(f: f32) -> String {
     } else {
         // Use f32 Display which gives minimal-length representation
         f.to_string()
+    }
+}
+
+/// `f64` counterpart of [`format_f32`], for the `xsd:string()` cast of a
+/// double. Rust's `Display` supplies the decimal mantissa; the special values
+/// take their XSD spellings — `f64::to_string()` alone yields `"inf"`, which
+/// is not a valid lexical form under either the cast rules or the canonical
+/// ones (#1695).
+fn format_f64(d: f64) -> String {
+    if d.is_nan() {
+        "NaN".to_string()
+    } else if d.is_infinite() {
+        if d.is_sign_positive() {
+            "INF".to_string()
+        } else {
+            "-INF".to_string()
+        }
+    } else {
+        d.to_string()
     }
 }
 
@@ -319,6 +343,21 @@ fn cast_to_string(
     if let ComparableValue::Decimal(ref d) = v {
         let s = canonical_decimal_string(d);
         return Some(ComparableValue::String(Arc::from(s)));
+    }
+    // Doubles and floats likewise render by the XPath *cast* rule, not the
+    // canonical XSD lexical form `STR()` returns — see `format_f32` (#1695).
+    // Without these arms the cast would fall through to `into_string_value`
+    // and pick up STR()'s canonical form, failing W3C `cast-string`.
+    match &v {
+        ComparableValue::Double(d)
+        | ComparableValue::TypedLiteral {
+            val: FlakeValue::Double(d),
+            ..
+        } => return Some(ComparableValue::String(Arc::from(format_f64(*d)))),
+        ComparableValue::Float(f) => {
+            return Some(ComparableValue::String(Arc::from(format_f32(*f))))
+        }
+        _ => {}
     }
     let namespace_codes = ctx.map(|c| c.active_snapshot.namespaces());
     v.into_string_value_with_namespaces(namespace_codes)

--- a/fluree-db-query/src/eval/cast.rs
+++ b/fluree-db-query/src/eval/cast.rs
@@ -189,42 +189,41 @@ fn float_typed_literal(f: f32) -> ComparableValue {
 
 /// Format an `f32` the way an XSD *cast* renders it.
 ///
-/// Deliberately NOT the canonical XSD lexical form `STR()` produces
+/// Deliberately NOT always the canonical XSD lexical form `STR()` produces
 /// (`fluree_graph_ir::canonical_xsd_float`): SPARQL §17.5 defers casting to
-/// XPath, whose float/double→string rule uses plain decimal notation for
-/// values in `[1e-6, 1e6)` rather than always-scientific. W3C `cast-string`
-/// pins it: `xsd:string("1E0"^^xsd:float)` is `"1"`, not `"1.0E0"`. The two
-/// renderings answer two different questions and must stay separate (#1695).
-/// Only the special values agree: `NaN`/`INF`/`-INF` in both.
+/// XPath, whose float/double→string rule converts a value with absolute
+/// value in `[1e-6, 1e6)` through `xs:decimal` — plain decimal notation,
+/// shortest round-trip digits (Rust's `Display`). W3C `cast-string` pins
+/// it: `xsd:string("1E0"^^xsd:float)` is `"1"`, not `"1.0E0"`. Outside that
+/// range (both sides — `1.0E-7` no less than `1.0E30`) XPath prescribes the
+/// canonical lexical representation, which IS the canonical form, so the two
+/// renderings converge there and this reuses the canonical writer. The
+/// special values agree everywhere: `NaN`/`INF`/`-INF` in both.
 pub(crate) fn format_f32(f: f32) -> String {
-    if f.is_nan() {
-        "NaN".to_string()
-    } else if f.is_infinite() {
-        if f.is_sign_positive() {
-            "INF".to_string()
-        } else {
-            "-INF".to_string()
-        }
+    if let Some(s) = fluree_graph_ir::XsdFloat::nonfinite_xsd(f) {
+        return s.to_string();
+    }
+    let a = f.abs();
+    if a != 0.0 && !(1e-6..1e6).contains(&a) {
+        fluree_graph_ir::canonical_xsd_float(f)
     } else {
-        // Use f32 Display which gives minimal-length representation
         f.to_string()
     }
 }
 
 /// `f64` counterpart of [`format_f32`], for the `xsd:string()` cast of a
-/// double. Rust's `Display` supplies the decimal mantissa; the special values
-/// take their XSD spellings — `f64::to_string()` alone yields `"inf"`, which
-/// is not a valid lexical form under either the cast rules or the canonical
+/// double: `xs:decimal` (plain, shortest round-trip) notation inside
+/// `[1e-6, 1e6)`, the canonical lexical form outside it, XSD spellings for
+/// the special values — `f64::to_string()` alone yields `"inf"`, which is
+/// not a valid lexical form under either the cast rules or the canonical
 /// ones (#1695).
 fn format_f64(d: f64) -> String {
-    if d.is_nan() {
-        "NaN".to_string()
-    } else if d.is_infinite() {
-        if d.is_sign_positive() {
-            "INF".to_string()
-        } else {
-            "-INF".to_string()
-        }
+    if let Some(s) = fluree_graph_ir::XsdFloat::nonfinite_xsd(d) {
+        return s.to_string();
+    }
+    let a = d.abs();
+    if a != 0.0 && !(1e-6..1e6).contains(&a) {
+        fluree_graph_ir::canonical_xsd_double(d)
     } else {
         d.to_string()
     }
@@ -349,6 +348,14 @@ fn cast_to_string(
     // Without these arms the cast would fall through to `into_string_value`
     // and pick up STR()'s canonical form, failing W3C `cast-string`.
     match &v {
+        // The `TypedLiteral` arm deliberately ignores `dtc`: no producer in
+        // the engine wraps a `FlakeValue::Double` in a `TypedLiteral` today
+        // (a stored float materializes as `Float` via `lit_to_comparable`;
+        // STRDT/cast results are string-backed; `TryFrom<FlakeValue>` maps
+        // `Double` to the bare variant), so a float-datatyped `Double`
+        // cannot reach the f64 branch. If such a producer ever appears,
+        // this arm must split on the datatype — the same variant-vs-datatype
+        // conflation the serializers carry (#1776).
         ComparableValue::Double(d)
         | ComparableValue::TypedLiteral {
             val: FlakeValue::Double(d),
@@ -838,5 +845,40 @@ mod tests {
             eval_xsd_double(&[double(-2.75)], &row, None).unwrap(),
             Some(ComparableValue::Double(-2.75))
         );
+    }
+
+    // === the XPath cast range, both sides (F&O: xs:decimal notation inside
+    // [1e-6, 1e6), canonical scientific outside) ===
+
+    #[test]
+    fn format_f64_xpath_range_is_two_sided() {
+        // Inside the range: plain decimal, shortest round-trip.
+        assert_eq!(format_f64(1.0), "1");
+        assert_eq!(format_f64(0.001), "0.001");
+        assert_eq!(format_f64(1e-6), "0.000001"); // lower bound is inclusive
+        assert_eq!(format_f64(999_999.5), "999999.5");
+        assert_eq!(format_f64(0.0), "0");
+        assert_eq!(format_f64(-12.5), "-12.5");
+        // Outside the range: the canonical (scientific) lexical form.
+        assert_eq!(format_f64(1e-7), "1.0E-7"); // NOT "0.0000001"
+        assert_eq!(format_f64(1e6), "1.0E6"); // upper bound is exclusive
+        assert_eq!(format_f64(1e30), "1.0E30"); // NOT a 31-digit integer
+        assert_eq!(format_f64(-2.5e6), "-2.5E6");
+        // Specials keep the XSD spellings on every path.
+        assert_eq!(format_f64(f64::NAN), "NaN");
+        assert_eq!(format_f64(f64::INFINITY), "INF");
+        assert_eq!(format_f64(f64::NEG_INFINITY), "-INF");
+    }
+
+    #[test]
+    fn format_f32_xpath_range_is_two_sided() {
+        assert_eq!(format_f32(1.0), "1");
+        assert_eq!(format_f32(33.33), "33.33");
+        assert_eq!(format_f32(0.0), "0");
+        assert_eq!(format_f32(1e-7), "1.0E-7");
+        assert_eq!(format_f32(1e6), "1.0E6");
+        assert_eq!(format_f32(1e30), "1.0E30");
+        assert_eq!(format_f32(f32::NAN), "NaN");
+        assert_eq!(format_f32(f32::NEG_INFINITY), "-INF");
     }
 }

--- a/fluree-db-query/src/eval/string.rs
+++ b/fluree-db-query/src/eval/string.rs
@@ -96,6 +96,22 @@ pub fn eval_str<R: RowAccess>(
     ctx: Option<&ExecutionContext<'_>>,
 ) -> Result<Option<ComparableValue>> {
     check_arity(args, 1, "STR")?;
+    // A stored xsd:float narrows to f32 on the way into `ComparableValue`
+    // (the numeric lanes are single-precision), but its lexical form belongs
+    // to the stored f64: the serializer prints `canonical_xsd_double` of it,
+    // and STR() must agree per-term (#1695's float sibling). For the
+    // bare-variable shape — the only one whose argument IS a stored term —
+    // read the f64 straight from the binding. No widening artifact can
+    // arise: this f64 was parsed from the lexical, never widened from an
+    // f32. (A float value computed inside the expression is a genuine f32
+    // and keeps `canonical_xsd_float` via `into_string_value`.)
+    if let Expression::Var(var_id) = &args[0] {
+        if let Some(d) = crate::eval::stored_float_f64(row, *var_id, ctx) {
+            return Ok(Some(ComparableValue::String(Arc::from(
+                fluree_graph_ir::canonical_xsd_double(d),
+            ))));
+        }
+    }
     let val = args[0].eval_to_comparable(row, ctx)?;
     Ok(val.and_then(|v| match &v {
         ComparableValue::Sid(..) => {

--- a/fluree-db-query/src/eval/value.rs
+++ b/fluree-db-query/src/eval/value.rs
@@ -505,6 +505,13 @@ impl ComparableValue {
             ComparableValue::Double(d) => Some(ComparableValue::String(Arc::from(
                 fluree_graph_ir::canonical_xsd_double(d),
             ))),
+            // A `Float` here is a value computed in f32 (arithmetic, casts);
+            // its canonical form is the f32 one. A STORED float never takes
+            // this arm for STR(): `Float` cannot recover the full-precision
+            // stored f64 (`lit_to_comparable` narrows), so `eval_str` reads
+            // the f64 off the binding first (`stored_float_f64`) and renders
+            // the serializer's `canonical_xsd_double` — see #1776 for the
+            // variant-vs-datatype conflation underneath.
             ComparableValue::Float(f) => Some(ComparableValue::String(Arc::from(
                 fluree_graph_ir::canonical_xsd_float(f),
             ))),
@@ -583,9 +590,19 @@ impl ComparableValue {
             // xsd:float renders its lexical form from the f32 (avoiding f64
             // display artifacts) and carries the xsd:float datatype. This
             // CONSTRUCTS a float literal, so it keeps the cast-side rendering
-            // (`format_f32`) rather than STR()'s canonical form — `STR()` of
-            // the result still agrees with how that result serializes, which
-            // is the invariant #1695 is about.
+            // (`format_f32`) rather than STR()'s canonical form.
+            //
+            // DELIBERATE consequence: one float VALUE can spell two ways by
+            // provenance — a stored `"1.0E0"^^xsd:float` serializes
+            // canonically while `BIND(?f + 0 AS ?y)` mints `"1"^^xsd:float`.
+            // The minted term is internally consistent (the serializer,
+            // `STR()`, and `xsd:string()` of it all return this one string
+            // verbatim, the per-term invariant #1695 is about), and minting
+            // the canonical form instead would break the cast on the rebound
+            // term: `xsd:string(?y)` reads the stored lexical verbatim, and
+            // XPath requires `"1"`, not `"1.0E0"`. Cross-provenance
+            // canonicalization is the serializer-side variant-vs-datatype
+            // conflation, tracked in #1776.
             ComparableValue::Float(f) => Ok(Binding::lit(
                 FlakeValue::String(super::cast::format_f32(f)),
                 datatypes.xsd_float.clone(),

--- a/fluree-db-query/src/eval/value.rs
+++ b/fluree-db-query/src/eval/value.rs
@@ -497,9 +497,16 @@ impl ComparableValue {
                 sid.namespace_code, sid.name
             )))),
             ComparableValue::Long(n) => Some(ComparableValue::String(Arc::from(n.to_string()))),
-            ComparableValue::Double(d) => Some(ComparableValue::String(Arc::from(d.to_string()))),
+            // STR() must return the literal's lexical form — the same W3C
+            // canonical form the RDF-lexical serializers emit for the same
+            // term (#1695; the serializer side was #1445). `f64::to_string()`
+            // gave "1" for 1.0 and "inf" for INF, so `STR(?d)` disagreed with
+            // the value printed two fields over in the same result set.
+            ComparableValue::Double(d) => Some(ComparableValue::String(Arc::from(
+                fluree_graph_ir::canonical_xsd_double(d),
+            ))),
             ComparableValue::Float(f) => Some(ComparableValue::String(Arc::from(
-                super::cast::format_f32(f),
+                fluree_graph_ir::canonical_xsd_float(f),
             ))),
             ComparableValue::Bool(b) => Some(ComparableValue::String(Arc::from(b.to_string()))),
             ComparableValue::BigInt(n) => Some(ComparableValue::String(Arc::from(n.to_string()))),
@@ -519,7 +526,10 @@ impl ComparableValue {
             ComparableValue::TypedLiteral { val, .. } => match val {
                 FlakeValue::String(s) => Some(ComparableValue::String(Arc::from(s))),
                 FlakeValue::Long(n) => Some(ComparableValue::String(Arc::from(n.to_string()))),
-                FlakeValue::Double(d) => Some(ComparableValue::String(Arc::from(d.to_string()))),
+                // Same canonical form as the bare `Double` arm above (#1695).
+                FlakeValue::Double(d) => Some(ComparableValue::String(Arc::from(
+                    fluree_graph_ir::canonical_xsd_double(d),
+                ))),
                 FlakeValue::Boolean(b) => Some(ComparableValue::String(Arc::from(b.to_string()))),
                 _ => None,
             },
@@ -571,7 +581,11 @@ impl ComparableValue {
                 datatypes.xsd_double.clone(),
             )),
             // xsd:float renders its lexical form from the f32 (avoiding f64
-            // display artifacts) and carries the xsd:float datatype.
+            // display artifacts) and carries the xsd:float datatype. This
+            // CONSTRUCTS a float literal, so it keeps the cast-side rendering
+            // (`format_f32`) rather than STR()'s canonical form — `STR()` of
+            // the result still agrees with how that result serializes, which
+            // is the invariant #1695 is about.
             ComparableValue::Float(f) => Ok(Binding::lit(
                 FlakeValue::String(super::cast::format_f32(f)),
                 datatypes.xsd_float.clone(),
@@ -1013,6 +1027,50 @@ mod tests {
         let cv = ComparableValue::Long(42);
         let sv = cv.into_string_value();
         assert_eq!(sv, Some(ComparableValue::String(Arc::from("42"))));
+    }
+
+    /// #1695: STR()'s stringification of doubles/floats must be the W3C
+    /// canonical XSD lexical form — the exact routine the RDF-lexical
+    /// serializers use — never Rust `Display` ("1", "inf").
+    #[test]
+    fn test_into_string_value_double_float_canonical() {
+        let cases: &[(f64, &str)] = &[
+            (1.0, "1.0E0"),
+            (5.0, "5.0E0"),
+            (1_000_000.0, "1.0E6"),
+            (0.001, "1.0E-3"),
+            (-12.5, "-1.25E1"),
+            (f64::NAN, "NaN"),
+            (f64::INFINITY, "INF"),
+            (f64::NEG_INFINITY, "-INF"),
+        ];
+        for &(d, expected) in cases {
+            assert_eq!(
+                ComparableValue::Double(d).into_string_value(),
+                Some(ComparableValue::String(Arc::from(expected))),
+                "Double({d:?})"
+            );
+            // A double wrapped in a TypedLiteral takes the same form.
+            let tl = ComparableValue::TypedLiteral {
+                val: FlakeValue::Double(d),
+                dtc: None,
+            };
+            assert_eq!(
+                tl.into_string_value(),
+                Some(ComparableValue::String(Arc::from(expected))),
+                "TypedLiteral(Double({d:?}))"
+            );
+        }
+        // A stored xsd:float materializes as `Float`; its canonical form uses
+        // the f32 shortest-round-trip mantissa.
+        assert_eq!(
+            ComparableValue::Float(33.33).into_string_value(),
+            Some(ComparableValue::String(Arc::from("3.333E1")))
+        );
+        assert_eq!(
+            ComparableValue::Float(f32::NEG_INFINITY).into_string_value(),
+            Some(ComparableValue::String(Arc::from("-INF")))
+        );
     }
 
     #[test]

--- a/fluree-graph-ir/src/lib.rs
+++ b/fluree-graph-ir/src/lib.rs
@@ -49,4 +49,7 @@ pub use graph::Graph;
 pub use sink::{GraphCollectorSink, GraphSink, SinkError, SinkResult, TermId};
 pub use term::{BlankId, LiteralValue, Term};
 pub use triple::Triple;
-pub use xsd_double::{canonical_xsd_double, push_canonical_xsd_double, write_canonical_xsd_double};
+pub use xsd_double::{
+    canonical_xsd_double, canonical_xsd_float, push_canonical_xsd_double,
+    write_canonical_xsd_double,
+};

--- a/fluree-graph-ir/src/lib.rs
+++ b/fluree-graph-ir/src/lib.rs
@@ -51,5 +51,5 @@ pub use term::{BlankId, LiteralValue, Term};
 pub use triple::Triple;
 pub use xsd_double::{
     canonical_xsd_double, canonical_xsd_float, push_canonical_xsd_double,
-    write_canonical_xsd_double,
+    write_canonical_xsd_double, XsdFloat,
 };

--- a/fluree-graph-ir/src/xsd_double.rs
+++ b/fluree-graph-ir/src/xsd_double.rs
@@ -54,18 +54,21 @@ impl fmt::Write for StackBuf {
     }
 }
 
-/// Render the canonical form of a *finite* `f64` into a stack buffer.
+/// Render the canonical form of a *finite* float (`f64` or `f32`) into a
+/// stack buffer.
 ///
 /// Builds on Rust's shortest-round-trip scientific formatter (`{:e}`), which
 /// already produces exactly one (nonzero, unless the value is zero) digit
 /// before the optional decimal point and an exponent with no `+`/leading
 /// zeros. Canonicalization is then purely syntactic: ensure the mantissa
 /// contains a `.` (insert `.0`) and uppercase the exponent marker.
-fn finite_canonical(d: f64) -> StackBuf {
-    debug_assert!(d.is_finite());
-
+///
+/// Callers must exclude NaN/±INF first — their `{:e}` forms carry no
+/// exponent, and their XSD spellings (`NaN`, `INF`, `-INF`) differ from
+/// Rust's.
+fn finite_canonical<F: fmt::LowerExp>(d: F) -> StackBuf {
     let mut sci = StackBuf::new();
-    write!(sci, "{d:e}").expect("`{:e}` of an f64 fits in 32 bytes");
+    write!(sci, "{d:e}").expect("`{:e}` of a float fits in 32 bytes");
 
     let s = sci.as_bytes();
     let e_pos = s
@@ -100,6 +103,29 @@ pub fn canonical_xsd_double(d: f64) -> String {
     // The canonical form is pure ASCII.
     std::str::from_utf8(buf.as_bytes())
         .expect("canonical xsd:double form is ASCII")
+        .to_string()
+}
+
+/// The canonical XSD lexical form of an `xsd:float` value, as a `String`.
+///
+/// Same grammar as [`canonical_xsd_double`] — mantissa with a decimal point,
+/// uppercase `E`, no `+`/leading zeros in the exponent, and the XSD special
+/// spellings `NaN`/`INF`/`-INF` — but the mantissa is the f32
+/// shortest-round-trip form, so a single-precision value never picks up
+/// double-precision widening artifacts (`33.33f32` stays `3.333E1`, not
+/// `3.333000183105469E1`).
+#[must_use]
+pub fn canonical_xsd_float(f: f32) -> String {
+    if f.is_nan() {
+        return "NaN".to_string();
+    }
+    if f.is_infinite() {
+        return if f.is_sign_positive() { "INF" } else { "-INF" }.to_string();
+    }
+    let buf = finite_canonical(f);
+    // The canonical form is pure ASCII.
+    std::str::from_utf8(buf.as_bytes())
+        .expect("canonical xsd:float form is ASCII")
         .to_string()
 }
 
@@ -211,6 +237,48 @@ mod tests {
     fn canonical_form_round_trips() {
         for &(input, _) in CASES {
             let parsed: f64 = canonical_xsd_double(input).parse().expect("parse back");
+            assert_eq!(parsed.to_bits(), input.to_bits(), "round trip of {input:?}");
+        }
+    }
+
+    /// Same forms table shape for the f32 (`xsd:float`) variant, including
+    /// the single-precision-mantissa guarantee and range extremes.
+    const F32_CASES: &[(f32, &str)] = &[
+        (1.0, "1.0E0"),
+        (5.0, "5.0E0"),
+        (33.33, "3.333E1"),
+        (0.001, "1.0E-3"),
+        (0.0, "0.0E0"),
+        (-0.0, "-0.0E0"),
+        (-12.5, "-1.25E1"),
+        (1e30, "1.0E30"),
+        (f32::MAX, "3.4028235E38"),
+        (f32::MIN_POSITIVE, "1.1754944E-38"),
+        (1e-45, "1.0E-45"), // subnormal minimum
+    ];
+
+    #[test]
+    fn float_canonical_forms() {
+        for &(input, expected) in F32_CASES {
+            assert_eq!(
+                canonical_xsd_float(input),
+                expected,
+                "canonical_xsd_float({input:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn float_special_values_keep_xsd_spellings() {
+        assert_eq!(canonical_xsd_float(f32::NAN), "NaN");
+        assert_eq!(canonical_xsd_float(f32::INFINITY), "INF");
+        assert_eq!(canonical_xsd_float(f32::NEG_INFINITY), "-INF");
+    }
+
+    #[test]
+    fn float_canonical_form_round_trips() {
+        for &(input, _) in F32_CASES {
+            let parsed: f32 = canonical_xsd_float(input).parse().expect("parse back");
             assert_eq!(parsed.to_bits(), input.to_bits(), "round trip of {input:?}");
         }
     }

--- a/fluree-graph-ir/src/xsd_double.rs
+++ b/fluree-graph-ir/src/xsd_double.rs
@@ -15,6 +15,71 @@
 
 use std::fmt::{self, Write as _};
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for f32 {}
+    impl Sealed for f64 {}
+}
+
+/// Float scalar admitted to the XSD lexical formatters (`f32`/`f64`); sealed.
+///
+/// Carries the two facts every formatter needs and `LowerExp` alone cannot
+/// provide: whether the value is finite (so [`finite_canonical`]'s contract
+/// stays machine-checked now that the writer is generic) and the XSD spelling
+/// of the non-finite values, written once here for every call site — the
+/// canonical formatters below and the XPath cast renderers in
+/// `fluree-db-query` alike.
+pub trait XsdFloat: sealed::Sealed + fmt::LowerExp + Copy {
+    #[doc(hidden)]
+    fn is_nan_v(self) -> bool;
+    #[doc(hidden)]
+    fn is_infinite_v(self) -> bool;
+    #[doc(hidden)]
+    fn is_sign_positive_v(self) -> bool;
+
+    /// The XSD lexical spelling of a non-finite value — `NaN`, `INF`,
+    /// `-INF` — or `None` when the value is finite. Static strings only;
+    /// allocates nothing.
+    #[inline]
+    fn nonfinite_xsd(self) -> Option<&'static str> {
+        if self.is_nan_v() {
+            Some("NaN")
+        } else if self.is_infinite_v() {
+            Some(if self.is_sign_positive_v() {
+                "INF"
+            } else {
+                "-INF"
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl XsdFloat for f64 {
+    fn is_nan_v(self) -> bool {
+        self.is_nan()
+    }
+    fn is_infinite_v(self) -> bool {
+        self.is_infinite()
+    }
+    fn is_sign_positive_v(self) -> bool {
+        self.is_sign_positive()
+    }
+}
+
+impl XsdFloat for f32 {
+    fn is_nan_v(self) -> bool {
+        self.is_nan()
+    }
+    fn is_infinite_v(self) -> bool {
+        self.is_infinite()
+    }
+    fn is_sign_positive_v(self) -> bool {
+        self.is_sign_positive()
+    }
+}
+
 /// Upper bound for the canonical form of any finite `f64`:
 /// sign (1) + 17-digit shortest-round-trip mantissa with dot (18) +
 /// inserted ".0" (2) + 'E' (1) + exponent up to "-308" (4) = 26. Rounded up.
@@ -63,10 +128,14 @@ impl fmt::Write for StackBuf {
 /// zeros. Canonicalization is then purely syntactic: ensure the mantissa
 /// contains a `.` (insert `.0`) and uppercase the exponent marker.
 ///
-/// Callers must exclude NaN/±INF first — their `{:e}` forms carry no
-/// exponent, and their XSD spellings (`NaN`, `INF`, `-INF`) differ from
-/// Rust's.
-fn finite_canonical<F: fmt::LowerExp>(d: F) -> StackBuf {
+/// Callers must exclude NaN/±INF first (via [`XsdFloat::nonfinite_xsd`]) —
+/// their `{:e}` forms carry no exponent, and their XSD spellings (`NaN`,
+/// `INF`, `-INF`) differ from Rust's.
+fn finite_canonical<F: XsdFloat>(d: F) -> StackBuf {
+    debug_assert!(
+        d.nonfinite_xsd().is_none(),
+        "finite_canonical requires a finite input"
+    );
     let mut sci = StackBuf::new();
     write!(sci, "{d:e}").expect("`{:e}` of a float fits in 32 bytes");
 
@@ -93,11 +162,8 @@ fn finite_canonical<F: fmt::LowerExp>(d: F) -> StackBuf {
 /// `0.0 → "0.0E0"`, `-0.0 → "-0.0E0"`, `NaN → "NaN"`, `f64::INFINITY → "INF"`.
 #[must_use]
 pub fn canonical_xsd_double(d: f64) -> String {
-    if d.is_nan() {
-        return "NaN".to_string();
-    }
-    if d.is_infinite() {
-        return if d.is_sign_positive() { "INF" } else { "-INF" }.to_string();
+    if let Some(s) = d.nonfinite_xsd() {
+        return s.to_string();
     }
     let buf = finite_canonical(d);
     // The canonical form is pure ASCII.
@@ -116,11 +182,8 @@ pub fn canonical_xsd_double(d: f64) -> String {
 /// `3.333000183105469E1`).
 #[must_use]
 pub fn canonical_xsd_float(f: f32) -> String {
-    if f.is_nan() {
-        return "NaN".to_string();
-    }
-    if f.is_infinite() {
-        return if f.is_sign_positive() { "INF" } else { "-INF" }.to_string();
+    if let Some(s) = f.nonfinite_xsd() {
+        return s.to_string();
     }
     let buf = finite_canonical(f);
     // The canonical form is pure ASCII.
@@ -133,12 +196,8 @@ pub fn canonical_xsd_float(f: f32) -> String {
 ///
 /// Allocation-free apart from growing `out`.
 pub fn push_canonical_xsd_double(out: &mut String, d: f64) {
-    if d.is_nan() {
-        out.push_str("NaN");
-        return;
-    }
-    if d.is_infinite() {
-        out.push_str(if d.is_sign_positive() { "INF" } else { "-INF" });
+    if let Some(s) = d.nonfinite_xsd() {
+        out.push_str(s);
         return;
     }
     let buf = finite_canonical(d);
@@ -149,16 +208,8 @@ pub fn push_canonical_xsd_double(out: &mut String, d: f64) {
 ///
 /// Zero-allocation variant for the delimited (CSV/TSV) writer's cell buffers.
 pub fn write_canonical_xsd_double(out: &mut Vec<u8>, d: f64) {
-    if d.is_nan() {
-        out.extend_from_slice(b"NaN");
-        return;
-    }
-    if d.is_infinite() {
-        out.extend_from_slice(if d.is_sign_positive() {
-            b"INF" as &[u8]
-        } else {
-            b"-INF"
-        });
+    if let Some(s) = d.nonfinite_xsd() {
+        out.extend_from_slice(s.as_bytes());
         return;
     }
     let buf = finite_canonical(d);

--- a/testsuite-sparql/Cargo.lock
+++ b/testsuite-sparql/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "fluree-db-reasoner",
  "fluree-db-spatial",
  "fluree-db-tabular",
+ "fluree-graph-ir",
  "fluree-graph-json-ld",
  "fluree-search-protocol",
  "fluree-vocab",


### PR DESCRIPTION
Fixes #1695.

`STR()` on an `xsd:double` was routing through Rust's `Display`, so `STR(?d)` came back `"1"` for the same term the serializer printed as `"1.0E0"` two fields over in the same result set — and `"inf"` for a value that no RDF format spells that way. #1445 fixed this for the six RDF output sites by adding `canonical_xsd_double`; expression evaluation was simply never on that list, so we've had two renderings of one concept since then.

The mechanism is the one the issue traced: `ComparableValue::into_string_value` (`fluree-db-query/src/eval/value.rs`) formatted the `Double` arm with `d.to_string()`. Rather than derive a second formatter next to it, `fluree-db-query` picks up a dependency on `fluree-graph-ir` and calls the serializer's own `canonical_xsd_double` — the same function `export.rs`, `format/sparql.rs`, `format/sparql_xml.rs` and `format/delimited.rs` already call. The `TypedLiteral { val: FlakeValue::Double, .. }` arm the issue flagged takes it too.

Two siblings turned out to be the same defect and are folded in:

- **`STR()` on an `xsd:float`.** There are two layers here. The visible one is the same as the double's: the serializer gave `1.0E0` where `STR()` gave `1`. The subtle one is that a stored `xsd:float` is carried as a *full-precision* `FlakeValue::Double` (ingest never narrows), and expression evaluation narrows the binding to an f32 on the way into `ComparableValue` (`lit_to_comparable`, and the `EncodedLit` re-tag from #1470) — which is right for arithmetic and `datatype()`, and irreversible for lexical purposes. For an f32-inexact value like `"3.14159265358979"^^xsd:float` the serializer prints the stored f64 (`3.14159265358979E0`), so no rendering of the f32 can ever agree with it. `STR()` therefore reads the stored f64 straight off the binding (`stored_float_f64` in `eval.rs`, covering both the `Lit` and the late-materialized `EncodedLit` lanes) and renders `canonical_xsd_double` — exactly the serializer's string, and no widening artifact can arise there because that f64 was parsed from the lexical, never widened from an f32. A float computed *inside* an expression is a genuine f32 and renders `canonical_xsd_float`, which joins its sibling in `fluree-graph-ir/src/xsd_double.rs` — both share the one `finite_canonical` writer behind a small sealed `XsdFloat` trait that keeps the finite-input contract machine-checked (`debug_assert!`) and the `NaN`/`INF`/`-INF` spellings written exactly once, for the cast renderers too.
- **`GROUP_CONCAT`'s numeric coercion** (`aggregate.rs`), which stringified doubles the same way — `GROUP_CONCAT(?d)` produced `1|1000000` where the serializer renders those same two terms `1.0E0` and `1.0E6`.

**One sibling I deliberately did *not* fold in, and I think this is the more interesting part of the PR.** My first pass also routed the `xsd:string()` cast through the canonical form, on the theory that it was the same seam. The W3C suite said otherwise, and it's right: SPARQL §17.5 defers casting to XPath, whose float/double→string rule casts through `xs:decimal` — plain decimal notation — for absolute values in `[1e-6, 1e6)`, and `data-sparql11/cast/cast-string.srx` requires `xsd:string("1E0"^^xsd:double)` to be `"1"`, not `"1.0E0"`. So the cast and `STR()` are answering genuinely different questions and need to stay apart. Since `cast_to_string` was reaching the canonical form only by falling through to `into_string_value`, it now has explicit `Double`/`Float` arms of its own (`eval/cast.rs`) — which also picks up the one part of the cast that was broken under *every* reading of the spec: it was emitting Rust's `"inf"`/`"-inf"` rather than `INF`/`-INF`.

But the XPath range rule is exactly that — a range, and it is **two-sided**: outside `[1e-6, 1e6)` XPath prescribes the canonical lexical representation, which with the canonical writers in hand is a two-line check rather than "implementing XPath's algorithm". So `format_f32`/`format_f64` apply it: `xsd:string(1.0E-7)` is `1.0E-7` (not `0.0000001`), just as `xsd:string(1.0E30)` is `1.0E30` (not a 31-digit integer). Nothing in the W3C corpus moves in either direction — the suite is 36/0 on both sides of the change; the cast columns in the tests pin both bounds.

The invariant that came out of all this, and the one the tests actually assert, is **`STR(?x)` equals what we serialize for `?x`** — checked per-row against the serialized value of the same binding rather than against a hardcoded string, so the two paths can't drift apart again without a red test.

**What stays open, deliberately, in #1776:** the conflation underneath all three symptoms — float renderers keying on the `Double` *variant* rather than the declared datatype. Concretely: whether the serializer should print an `xsd:float` term at f32 precision at all (a user-visible output decision, same shape as #1445's); the group-key `GROUP_CONCAT` lane, whose aggregate input round-trips through `to_binding` and mints a third spelling; `STR(COALESCE(?f))`, which evaluates the inner expression to an f32 before `STR()` can see the binding; and the stored-vs-computed provenance split at `to_binding` (a computed float mints its XPath-cast lexical — each such term is internally consistent across serializer/`STR`/cast, and switching it to the canonical spelling would break `xsd:string()` on the rebound term, so it stays, documented at the site). The unreachable `TypedLiteral { val: Double, .. }` cast arm carries a guarding comment pointing at the same issue.

Follow-up: #1776.

### Tests

- `sparql_str_double_matches_serializer_canonical_form` sits right beside the existing serializer pin `sparql_double_canonical_lexical_form_across_formats`, so the two can't drift. It covers the issue's repro (`1E0`), an integral value, both exponent directions, a negative, `NaN`/`INF`/`-INF` — and pins the cast column alongside on both sides of the XPath range (`1.0E-7`, `1.0E6`, `1.0E30`), precisely so the deliberate relationship between the two functions is stated rather than left for someone to "fix" later.
- `sparql_str_float_matches_serializer_canonical_form` includes f32-INEXACT rows (`3.14159265358979`, `1.23456789012345E-5`) — the discriminating cases: an f32-exact row passes under any implementation, an inexact one only if `STR()` reads the stored f64.
- `sparql_encoded_xsd_float_str_matches_serializer` pins the same agreement on the late-materialized `EncodedLit` lane (reindexed ledger), next to the #1470 re-tag tests it extends.
- `sparql_group_concat_double_canonical_form` for the aggregate sibling.
- `jsonld_bind_str_double_canonical_form` and `jsonld_bind_str_float_canonical_form` are the JSON-LD twins per the parity rule — `(str ?d)` gives the same canonical string while the value itself stays a native JSON number.
- Unit coverage on `into_string_value` and `canonical_xsd_float` in `fluree-graph-ir`, plus `format_f32`/`format_f64` range pins (`format_f64_xpath_range_is_two_sided`) including the inclusive/exclusive bounds and zero.

Non-vacuity checked by revert, one lever at a time: with the `eval_str` fast path disabled, the inexact float rows and both float twins go red (`left: "3.1415927E0"` / `right: "3.14159265358979E0"`) while the f32-exact rows stay green; with only the `EncodedLit` arm of `stored_float_f64` disabled, the encoded-lane test goes red with the same truncation while the `Lit`-lane test stays green — proving that lane actually fires; with the cast range check disabled, the unit and integration cast pins go red (`left: "0.0000001"`). All green on restore.

### Gates

`-p fluree-db-query` (1488 lib, all green), `-p fluree-graph-ir` (51), `-p fluree-db-api` `grp_query_sparql` (372) and `grp_query` (425), the W3C suite (`36 passed; 0 failed`), workspace check (minus the excluded search crates), clippy `-D warnings` clean on all three touched crates, `cargo fmt --all` last and `testsuite-sparql`'s own fmt clean. No register movement in either direction — `testsuite-sparql/tests/registers/mod.rs` is untouched, which is the honest answer here: the cast register never moved because I corrected the scope rather than registering a regression.
