### PR TITLE
fix(import): publish bulk-import commit heads via ref fast-forward, not the queue contract

### DIFF
--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -43,6 +43,45 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::Instrument;
 
+/// Publish the import's commit head by fast-forwarding the ref directly.
+///
+/// Bulk import is a one-shot admin flow: nothing is staged on the
+/// per-branch transaction queue, so `publish_commit` — whose contract on
+/// queue-backed nameservices (the raft data plane) is "apply the staged
+/// queue front" — fails there with "per-branch queue is empty". A
+/// ref-level fast-forward carries the exact strictly-newer semantics the
+/// file/S3 nameservices give `publish_commit`, and every nameservice
+/// implements it via `RefPublisher`, so the bulk importer works under
+/// all data planes without touching the transactor's queue contract.
+///
+/// An equal-or-newer head is a no-op success, mirroring `publish_commit`:
+/// the final publish re-states the last checkpoint's `t`, and a re-run
+/// may find its own earlier head already in place.
+async fn publish_import_commit_head(
+    nameservice: &dyn crate::NameServicePublisher,
+    alias: &str,
+    t: i64,
+    commit_id: &ContentId,
+) -> std::result::Result<(), ImportError> {
+    use fluree_db_nameservice::{CasResult, RefValue};
+
+    let new_ref = RefValue {
+        id: Some(commit_id.clone()),
+        t,
+    };
+    match nameservice
+        .fast_forward_commit(alias, &new_ref, 5)
+        .await
+        .map_err(|e| ImportError::Storage(e.to_string()))?
+    {
+        CasResult::Updated => Ok(()),
+        CasResult::Conflict { actual } if actual.as_ref().is_some_and(|a| a.t >= t) => Ok(()),
+        CasResult::Conflict { actual } => Err(ImportError::Storage(format!(
+            "import commit-head publish for {alias} lost a race: head is {actual:?}, wanted t={t}"
+        ))),
+    }
+}
+
 const IMPORT_PIPELINE_WAIT_LOG_THRESHOLD_MS: u128 = 50;
 const LOCAL_RECHUNK_EVENT_CHANNEL_CAPACITY: usize = 2;
 
@@ -4180,10 +4219,13 @@ where
                 if env.config.publish_every > 0
                     && (next_expected + 1).is_multiple_of(env.config.publish_every)
                 {
-                    env.nameservice
-                        .publish_commit(env.alias, result.t, &result.commit_id)
-                        .await
-                        .map_err(|e| ImportError::Storage(e.to_string()))?;
+                    publish_import_commit_head(
+                        env.nameservice,
+                        env.alias,
+                        result.t,
+                        &result.commit_id,
+                    )
+                    .await?;
                     tracing::info!(
                         t = result.t,
                         chunk = next_expected + 1,
@@ -5050,10 +5092,7 @@ where
                 elapsed_secs: run_start.elapsed().as_secs_f64(),
             });
             if config.publish_every > 0 && (idx + 1).is_multiple_of(config.publish_every) {
-                nameservice
-                    .publish_commit(alias, result.t, &result.commit_id)
-                    .await
-                    .map_err(|e| ImportError::Storage(e.to_string()))?;
+                publish_import_commit_head(nameservice, alias, result.t, &result.commit_id).await?;
             }
         }
 
@@ -5312,10 +5351,8 @@ where
                     elapsed_secs: run_start.elapsed().as_secs_f64(),
                 });
                 if config.publish_every > 0 && (i + 1).is_multiple_of(config.publish_every) {
-                    nameservice
-                        .publish_commit(alias, result.t, &result.commit_id)
-                        .await
-                        .map_err(|e| ImportError::Storage(e.to_string()))?;
+                    publish_import_commit_head(nameservice, alias, result.t, &result.commit_id)
+                        .await?;
                 }
             }
         }
@@ -5327,10 +5364,7 @@ where
         .clone()
         .ok_or_else(|| ImportError::Storage("no commit head after import".to_string()))?;
 
-    nameservice
-        .publish_commit(alias, state.t, &commit_head_id)
-        .await
-        .map_err(|e| ImportError::Storage(e.to_string()))?;
+    publish_import_commit_head(nameservice, alias, state.t, &commit_head_id).await?;
     tracing::info!(t = state.t, "published final commit head");
 
     // ---- Spawn txn-meta "meta chunk" build in background ----
@@ -7608,5 +7642,61 @@ mod resource_model_tests {
         assert_eq!(parallel[0].0, 0);
         assert_eq!(parallel[1].0, 1);
         assert_eq!(parallel[2].0, 2);
+    }
+}
+
+#[cfg(test)]
+mod publish_import_commit_head_tests {
+    use super::*;
+    use fluree_db_nameservice::memory::MemoryNameService;
+    use fluree_db_nameservice::{LedgerLifecycle, RefKind, RefLookup};
+
+    fn cid(label: &str) -> ContentId {
+        ContentId::new(ContentKind::Commit, label.as_bytes())
+    }
+
+    /// The four publish shapes the import pipeline produces: creation on
+    /// a freshly-initialized ledger, a checkpoint fast-forwarding past
+    /// the importer's own head, the final publish restating the last
+    /// checkpoint's `t`, and a stale republish — the last two are no-op
+    /// successes, mirroring `publish_commit`'s advance-if-newer contract.
+    #[tokio::test]
+    async fn creates_advances_and_tolerates_republishes() {
+        let ns = MemoryNameService::new();
+        let alias = "importdb:main";
+
+        // The importer initializes the ledger before its first publish.
+        ns.init(alias).await.expect("init");
+
+        publish_import_commit_head(&ns, alias, 1, &cid("t1"))
+            .await
+            .expect("initial publish creates the head");
+        let head = ns
+            .get_ref(alias, RefKind::CommitHead)
+            .await
+            .expect("get_ref")
+            .expect("head exists");
+        assert_eq!(head.t, 1);
+        assert_eq!(head.id, Some(cid("t1")));
+
+        publish_import_commit_head(&ns, alias, 5, &cid("t5"))
+            .await
+            .expect("checkpoint fast-forwards");
+
+        publish_import_commit_head(&ns, alias, 5, &cid("t5"))
+            .await
+            .expect("equal-t republish is a no-op success");
+
+        publish_import_commit_head(&ns, alias, 3, &cid("t3"))
+            .await
+            .expect("stale republish is a no-op success");
+
+        let head = ns
+            .get_ref(alias, RefKind::CommitHead)
+            .await
+            .expect("get_ref")
+            .expect("head exists");
+        assert_eq!(head.t, 5, "no-op republishes leave the head alone");
+        assert_eq!(head.id, Some(cid("t5")));
     }
 }

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -54,9 +54,12 @@ use tracing::Instrument;
 /// implements it via `RefPublisher`, so the bulk importer works under
 /// all data planes without touching the transactor's queue contract.
 ///
-/// An equal-or-newer head is a no-op success, mirroring `publish_commit`:
-/// the final publish re-states the last checkpoint's `t`, and a re-run
-/// may find its own earlier head already in place.
+/// Import runs against a fresh ledger and publishes serially, so the one
+/// benign conflict is the final publish restating the last checkpoint's
+/// exact `(t, commit_id)`. Any other conflict is surfaced as an error:
+/// a head at a different `t`/id means a foreign writer got ahead of the
+/// import, and a head still behind `t` means the CAS retry budget ran
+/// out under contention.
 async fn publish_import_commit_head(
     nameservice: &dyn crate::NameServicePublisher,
     alias: &str,
@@ -75,10 +78,33 @@ async fn publish_import_commit_head(
         .map_err(|e| ImportError::Storage(e.to_string()))?
     {
         CasResult::Updated => Ok(()),
-        CasResult::Conflict { actual } if actual.as_ref().is_some_and(|a| a.t >= t) => Ok(()),
-        CasResult::Conflict { actual } => Err(ImportError::Storage(format!(
-            "import commit-head publish for {alias} lost a race: head is {actual:?}, wanted t={t}"
-        ))),
+        CasResult::Conflict { actual }
+            if actual
+                .as_ref()
+                .is_some_and(|a| a.t == t && a.id.as_ref() == Some(commit_id)) =>
+        {
+            Ok(())
+        }
+        CasResult::Conflict { actual } => Err(ImportError::Storage(match actual.as_ref() {
+            // `fast_forward_commit` returns the same `Conflict` shape when
+            // its retry budget runs out while the fast-forward is still
+            // valid — the head never reached `t`, so this is contention,
+            // not divergence.
+            None => format!(
+                "import commit-head publish for {alias} gave up after contended CAS \
+                 attempts: head is still unborn, wanted t={t}"
+            ),
+            Some(a) if a.t < t => format!(
+                "import commit-head publish for {alias} gave up after contended CAS \
+                 attempts: head is at t={}, wanted t={t}",
+                a.t
+            ),
+            Some(a) => format!(
+                "import commit-head publish for {alias} found a diverged head: \
+                 head is t={} id={:?}, wanted t={t} id={commit_id}",
+                a.t, a.id
+            ),
+        })),
     }
 }
 
@@ -7655,13 +7681,14 @@ mod publish_import_commit_head_tests {
         ContentId::new(ContentKind::Commit, label.as_bytes())
     }
 
-    /// The four publish shapes the import pipeline produces: creation on
-    /// a freshly-initialized ledger, a checkpoint fast-forwarding past
-    /// the importer's own head, the final publish restating the last
-    /// checkpoint's `t`, and a stale republish — the last two are no-op
-    /// successes, mirroring `publish_commit`'s advance-if-newer contract.
+    /// The publish shapes the import pipeline produces — creation on a
+    /// freshly-initialized ledger, a checkpoint fast-forwarding past the
+    /// importer's own head, and the final publish restating the last
+    /// checkpoint's exact `(t, commit_id)` — plus the two conflicts it
+    /// never produces (equal `t` under a different id, lower `t`), which
+    /// must fail loudly instead of reporting success over a foreign head.
     #[tokio::test]
-    async fn creates_advances_and_tolerates_republishes() {
+    async fn creates_advances_tolerates_exact_republish_rejects_divergence() {
         let ns = MemoryNameService::new();
         let alias = "importdb:main";
 
@@ -7685,18 +7712,30 @@ mod publish_import_commit_head_tests {
 
         publish_import_commit_head(&ns, alias, 5, &cid("t5"))
             .await
-            .expect("equal-t republish is a no-op success");
+            .expect("republish of the exact head is a no-op success");
 
-        publish_import_commit_head(&ns, alias, 3, &cid("t3"))
+        let err = publish_import_commit_head(&ns, alias, 5, &cid("other"))
             .await
-            .expect("stale republish is a no-op success");
+            .expect_err("equal t under a different id is a divergence");
+        assert!(
+            err.to_string().contains("diverged"),
+            "unexpected error: {err}"
+        );
+
+        let err = publish_import_commit_head(&ns, alias, 3, &cid("t3"))
+            .await
+            .expect_err("a head past the published t is a divergence");
+        assert!(
+            err.to_string().contains("diverged"),
+            "unexpected error: {err}"
+        );
 
         let head = ns
             .get_ref(alias, RefKind::CommitHead)
             .await
             .expect("get_ref")
             .expect("head exists");
-        assert_eq!(head.t, 5, "no-op republishes leave the head alone");
+        assert_eq!(head.t, 5, "failed publishes leave the head alone");
         assert_eq!(head.id, Some(cid("t5")));
     }
 }

--- a/fluree-db-consensus/src/raft/state_machine.rs
+++ b/fluree-db-consensus/src/raft/state_machine.rs
@@ -4848,6 +4848,35 @@ mod tests {
     }
 
     #[test]
+    fn cas_ref_commit_initial_creation_with_expected_unborn_ref_value() {
+        // The shape `RefPublisher::fast_forward_commit` actually produces
+        // for creation: `get_ref` reports a registered-but-unborn branch as
+        // `Some(RefValue { id: None, t: 0 })` (never `None`), so the CAS
+        // arrives with that as `expected` rather than `expected = None`.
+        // This is the bulk importer's first publish under raft.
+        let mut state = NameServiceState::new();
+        apply(&mut state, create_ledger("test/db"), 0);
+        let resp = apply(
+            &mut state,
+            cas_ref_cmd(
+                "test/db",
+                "main",
+                RefKind::CommitHead,
+                Some(RefValue { id: None, t: 0 }),
+                RefValue {
+                    id: Some(cid(1)),
+                    t: 1,
+                },
+            ),
+            1,
+        );
+        assert_eq!(resp, Response::RefCasUpdated);
+        let entry = state.refs.get(&RefKey::new("test/db", "main")).unwrap();
+        assert_eq!(entry.head, cid(1));
+        assert_eq!(entry.t, 1);
+    }
+
+    #[test]
     fn cas_ref_commit_conflict_when_expected_doesnt_match() {
         let mut state = NameServiceState::new();
         create_ledger_with_genesis(&mut state, "test/db");


### PR DESCRIPTION
## Problem

Bulk import fails on every publish when the nameservice is the raft data plane:

```
storage: Storage error: publish_commit on <ledger>:main: per-branch queue is empty — nothing staged for this branch
```

`RefPublisher::publish_commit` means two different things depending on the implementation. The file/S3/Dynamo nameservices implement it as a plain strictly-newer head update — the semantics `fluree-db-api`'s bulk importer was written against. The raft nameservice (added with the consensus work) implements it as the second half of the transactor worker's two-phase protocol: *apply the staged front of the per-branch queue*. Bulk import is a one-shot admin flow that stages nothing, so under raft its very first head publish hits `peek_queue_front_id` on an empty queue and the whole import is rolled up as failed — after the chunks committed fine.

The combination simply had never been exercised: imports work everywhere the older nameservices run, and the raft posture is new. First hit in the standalone server with `FLUREE_AI_DATA_RAFT=true`, where the embedded importer is the only load path.

## Fix

Import stops calling the queue-contract verb it never satisfied and advances the ref directly: a new `publish_import_commit_head` helper wraps `RefPublisher::fast_forward_commit` and replaces the four `publish_commit` call sites (three periodic checkpoints, one final head).

- **Same semantics file mode always gave import**: advance if strictly newer. The one benign conflict is the final publish restating the last checkpoint's exact `(t, commit_id)` — import runs against a fresh ledger and publishes serially, so any other conflict (equal `t` under a different id, or a head past `t`) is a foreign writer and errors loudly; a head still behind `t` reports CAS-contention exhaustion. (Narrowed from equal-or-newer per review.)
- **Creation is the degenerate first fast-forward**: the importer `init()`s the ledger, `get_ref` reports the unborn head, and the CAS lands `t=1`. On the raft side this is `Command::CompareAndSetRef`; raft's `get_ref` reports a registered-but-unborn branch as `Some(RefValue { id: None, t: 0 })` (never `None`), so the creation CAS carries that as `expected` — pinned by the new `cas_ref_commit_initial_creation_with_expected_unborn_ref_value` state-machine test alongside the existing `expected = None` variant.
- **The raft queue contract is untouched** — `publish_commit` keeps protecting the transactor worker's stage→publish protocol; import just no longer pretends to be a worker.
- Works uniformly across every `NameServicePublisher` (file, S3, memory, raft), so there is no per-backend branching in the importer.

## Testing

- New unit test `publish_import_commit_head_tests::creates_advances_tolerates_exact_republish_rejects_divergence` covers the publish shapes the pipeline produces — creation on a fresh ledger, checkpoint fast-forward, exact `(t, commit_id)` republish as a no-op success — plus the two divergence shapes it never produces (equal `t` under a different id, stale `t`), which now fail loudly.
- Root-caused live on a standalone raft-mode server where every UI `.ttl` import failed with the queue error above (chunks committed, publish refused); the raft-side CAS behavior the fix relies on is pinned by the existing state-machine tests.
- `cargo check` / `cargo clippy` / the new test green on this branch.

