### PR TITLE
group integration tests into grp_* harnesses

### DIFF
--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -50,7 +50,7 @@ fn test_query_workflow() {
 }
 ```
 
-#### Grouped integration binaries (`fluree-db-api`)
+#### Grouped integration binaries (`fluree-db-api`, `fluree-db-server`)
 
 Every top-level `tests/*.rs` file is a **separate test binary** that links the
 entire crate dependency graph. With ~160 integration files that meant ~160 full
@@ -97,6 +97,19 @@ binary. No new `[[test]]` entry is needed unless you are creating a new group.
   callsite-interest cache is process-global and the capture is thread-local,
   so these assertions are only reliable when the test is alone in its
   process. (Same caveat as above: bites bare `cargo test` only.)
+
+`fluree-db-server` uses the same pattern and the same standalone rules, with
+harnesses named for its domains (`grp_http`, `grp_query`, `grp_proxy`,
+`grp_policy`, `grp_search`, `grp_raft`, `grp_bolt`). It has no shared
+`support/` module, so its case files are self-contained; `telemetry_test` and
+`multi_query_tracing_integration` are kept standalone under the
+instrumentation-assertion rule above.
+
+Because `autotests = false` means an unwired file silently never compiles and
+never runs — with `cargo test` still reporting success —
+`fluree-db-server/tests/harness_coverage.rs` asserts that every `tests/*.rs` is
+either pulled into a harness or declared as its own `[[test]]`. Add the same
+guard to any other crate that adopts this layout.
 
 ### Example Tests
 

--- a/fluree-db-server/Cargo.toml
+++ b/fluree-db-server/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+autotests = false
 
 [package.metadata.dist]
 dist = false
@@ -182,3 +183,58 @@ fluree-db-novelty = { path = "../fluree-db-novelty" }
 
 [lints]
 workspace = true
+
+# Integration tests are grouped into grp_* harnesses so the crate links a
+# handful of test binaries instead of one per tests/*.rs file. `autotests =
+# false` above is what stops each file from also becoming its own binary;
+# the test files themselves are unchanged, pulled in via #[path]/mod.
+#
+# `raft` is the only non-default feature here (default = native, credential,
+# iceberg, shacl, bolt), so grp_raft is the only harness that compiles to an
+# empty binary on a default build. The rest group by domain, not by feature.
+#
+# tests/harness_coverage.rs (in grp_http) fails if any tests/*.rs is neither
+# pulled into a harness nor declared below — without it, `autotests = false`
+# would let a new integration file silently never run.
+
+[[test]]
+name = "grp_http"
+path = "tests/grp_http.rs"
+
+[[test]]
+name = "grp_query"
+path = "tests/grp_query.rs"
+
+[[test]]
+name = "grp_proxy"
+path = "tests/grp_proxy.rs"
+
+[[test]]
+name = "grp_policy"
+path = "tests/grp_policy.rs"
+
+[[test]]
+name = "grp_search"
+path = "tests/grp_search.rs"
+
+[[test]]
+name = "grp_raft"
+path = "tests/grp_raft.rs"
+
+[[test]]
+name = "grp_bolt"
+path = "tests/grp_bolt.rs"
+
+# Standalone: their assertions are about instrumentation. Both install a
+# tracing subscriber and assert on the events captured through it. Tracing's
+# callsite-interest cache is process-global while the capture is thread-local,
+# so those assertions are only reliable when the test is alone in its process
+# under bare `cargo test`. Same rule fluree-db-api follows — see
+# docs/contributing/tests.md.
+[[test]]
+name = "telemetry_test"
+path = "tests/telemetry_test.rs"
+
+[[test]]
+name = "multi_query_tracing_integration"
+path = "tests/multi_query_tracing_integration.rs"

--- a/fluree-db-server/tests/grp_bolt.rs
+++ b/fluree-db-server/tests/grp_bolt.rs
@@ -1,0 +1,4 @@
+#[path = "bolt_auth_integration.rs"]
+mod bolt_auth_integration;
+#[path = "bolt_integration.rs"]
+mod bolt_integration;

--- a/fluree-db-server/tests/grp_http.rs
+++ b/fluree-db-server/tests/grp_http.rs
@@ -1,0 +1,16 @@
+#[path = "admin_auth_layering.rs"]
+mod admin_auth_layering;
+#[path = "cross_ledger_http_integration.rs"]
+mod cross_ledger_http_integration;
+#[path = "harness_coverage.rs"]
+mod harness_coverage;
+#[path = "iceberg_track_durability.rs"]
+mod iceberg_track_durability;
+#[path = "integration.rs"]
+mod integration;
+#[path = "mcp_agent_json.rs"]
+mod mcp_agent_json;
+#[path = "oidc_auth_integration.rs"]
+mod oidc_auth_integration;
+#[path = "validate_http_integration.rs"]
+mod validate_http_integration;

--- a/fluree-db-server/tests/grp_policy.rs
+++ b/fluree-db-server/tests/grp_policy.rs
@@ -1,0 +1,6 @@
+#[path = "connection_dataset_query_auth.rs"]
+mod connection_dataset_query_auth;
+#[path = "data_auth_integration.rs"]
+mod data_auth_integration;
+#[path = "policy_integration.rs"]
+mod policy_integration;

--- a/fluree-db-server/tests/grp_proxy.rs
+++ b/fluree-db-server/tests/grp_proxy.rs
@@ -1,0 +1,4 @@
+#[path = "flpack_import_integration.rs"]
+mod flpack_import_integration;
+#[path = "proxy_integration.rs"]
+mod proxy_integration;

--- a/fluree-db-server/tests/grp_query.rs
+++ b/fluree-db-server/tests/grp_query.rs
@@ -1,0 +1,16 @@
+#[path = "cypher_http_integration.rs"]
+mod cypher_http_integration;
+#[path = "graph_source_format_gating.rs"]
+mod graph_source_format_gating;
+#[path = "multi_ledger_query_dispatch.rs"]
+mod multi_ledger_query_dispatch;
+#[path = "multi_query_auth_integration.rs"]
+mod multi_query_auth_integration;
+#[path = "multi_query_integration.rs"]
+mod multi_query_integration;
+#[path = "sparql_construct_jsonld_accept.rs"]
+mod sparql_construct_jsonld_accept;
+#[path = "sparql_dataset_semantics.rs"]
+mod sparql_dataset_semantics;
+#[path = "stream_query_integration.rs"]
+mod stream_query_integration;

--- a/fluree-db-server/tests/grp_raft.rs
+++ b/fluree-db-server/tests/grp_raft.rs
@@ -1,0 +1,4 @@
+#[path = "raft_integration.rs"]
+mod raft_integration;
+#[path = "raft_multi_node.rs"]
+mod raft_multi_node;

--- a/fluree-db-server/tests/grp_search.rs
+++ b/fluree-db-server/tests/grp_search.rs
@@ -1,0 +1,4 @@
+#[path = "bm25_auto_sync.rs"]
+mod bm25_auto_sync;
+#[path = "bm25_http_integration.rs"]
+mod bm25_http_integration;

--- a/fluree-db-server/tests/harness_coverage.rs
+++ b/fluree-db-server/tests/harness_coverage.rs
@@ -1,0 +1,69 @@
+//! Guards `autotests = false`.
+//!
+//! With auto-discovery off, a new `tests/*.rs` that nobody wires into a
+//! `grp_*` harness (or declares as its own `[[test]]`) is never compiled and
+//! never run — and `cargo test` still reports success. This test fails loudly
+//! in that case instead.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn every_test_file_is_reachable() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let tests_dir = root.join("tests");
+    let manifest = fs::read_to_string(root.join("Cargo.toml")).expect("read Cargo.toml");
+
+    // Files pulled into a harness via `#[path = "..."]`.
+    let mut grouped: HashSet<String> = HashSet::new();
+    for entry in fs::read_dir(&tests_dir).expect("read tests/") {
+        let path = entry.expect("tests/ entry").path();
+        let is_harness = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("grp_") && n.ends_with(".rs"));
+        if !is_harness {
+            continue;
+        }
+        let src = fs::read_to_string(&path).expect("read harness");
+        for line in src.lines() {
+            if let Some(rest) = line.trim().strip_prefix("#[path = \"") {
+                if let Some(file) = rest.split('"').next() {
+                    grouped.insert(file.to_string());
+                }
+            }
+        }
+    }
+
+    let mut orphans: Vec<String> = Vec::new();
+    for entry in fs::read_dir(&tests_dir).expect("read tests/") {
+        let path = entry.expect("tests/ entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("utf-8 filename")
+            .to_string();
+
+        // Harnesses are `[[test]]` targets in their own right.
+        if name.starts_with("grp_") || grouped.contains(&name) {
+            continue;
+        }
+        // Otherwise it must be declared as its own `[[test]]` target.
+        if manifest.contains(&format!("path = \"tests/{name}\"")) {
+            continue;
+        }
+        orphans.push(name);
+    }
+
+    orphans.sort();
+    assert!(
+        orphans.is_empty(),
+        "unreachable under `autotests = false` — add a `#[path = \"<file>\"] \
+         mod <name>;` line to the right grp_* harness, or declare a [[test]] \
+         target: {orphans:?}"
+    );
+}

--- a/fluree-db-server/tests/harness_coverage.rs
+++ b/fluree-db-server/tests/harness_coverage.rs
@@ -1,13 +1,68 @@
 //! Guards `autotests = false`.
 //!
-//! With auto-discovery off, a new `tests/*.rs` that nobody wires into a
-//! `grp_*` harness (or declares as its own `[[test]]`) is never compiled and
-//! never run — and `cargo test` still reports success. This test fails loudly
-//! in that case instead.
+//! With auto-discovery off, a `tests/*.rs` that nobody declares as a `[[test]]`
+//! target and nobody pulls into a declared harness is never compiled and never
+//! run — and `cargo test` still reports success. This test fails loudly in that
+//! case instead.
+//!
+//! Reachability is derived from `Cargo.toml` outwards, never from the file
+//! names: an undeclared `tests/grp_foo.rs` is itself an orphan, and the files it
+//! references do not count as covered just because something on disk mentions
+//! them. Trusting a `grp_` prefix to mean "surely declared" is exactly how a
+//! whole harness goes missing without the guard noticing.
 
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
+
+/// `path` values of every `[[test]]` target in the manifest, relative to the
+/// crate root. A target may omit `path`, in which case Cargo infers
+/// `tests/<name>.rs`.
+fn declared_test_paths(manifest: &str) -> HashSet<String> {
+    let mut declared = HashSet::new();
+    let mut in_test = false;
+    let mut name: Option<String> = None;
+    let mut path: Option<String> = None;
+
+    let mut flush = |name: &mut Option<String>, path: &mut Option<String>| {
+        if let Some(p) = path.take() {
+            declared.insert(p);
+        } else if let Some(n) = name.take() {
+            declared.insert(format!("tests/{n}.rs"));
+        }
+        *name = None;
+        *path = None;
+    };
+
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            if in_test {
+                flush(&mut name, &mut path);
+            }
+            in_test = line == "[[test]]";
+            continue;
+        }
+        if !in_test {
+            continue;
+        }
+        if let Some(v) = line
+            .strip_prefix("name = \"")
+            .and_then(|r| r.split('"').next())
+        {
+            name = Some(v.to_string());
+        } else if let Some(v) = line
+            .strip_prefix("path = \"")
+            .and_then(|r| r.split('"').next())
+        {
+            path = Some(v.to_string());
+        }
+    }
+    if in_test {
+        flush(&mut name, &mut path);
+    }
+    declared
+}
 
 #[test]
 fn every_test_file_is_reachable() {
@@ -15,23 +70,23 @@ fn every_test_file_is_reachable() {
     let tests_dir = root.join("tests");
     let manifest = fs::read_to_string(root.join("Cargo.toml")).expect("read Cargo.toml");
 
-    // Files pulled into a harness via `#[path = "..."]`.
-    let mut grouped: HashSet<String> = HashSet::new();
-    for entry in fs::read_dir(&tests_dir).expect("read tests/") {
-        let path = entry.expect("tests/ entry").path();
-        let is_harness = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|n| n.starts_with("grp_") && n.ends_with(".rs"));
-        if !is_harness {
-            continue;
-        }
-        let src = fs::read_to_string(&path).expect("read harness");
+    let declared = declared_test_paths(&manifest);
+
+    // Files pulled in via `#[path = "..."]` by a *declared* target. Harvesting
+    // from every file on disk instead would let an undeclared harness launder
+    // its members into the covered set.
+    let mut referenced: HashSet<String> = HashSet::new();
+    for rel in &declared {
+        let Ok(src) = fs::read_to_string(root.join(rel)) else {
+            continue; // a declared path that does not exist is Cargo's error to report
+        };
         for line in src.lines() {
-            if let Some(rest) = line.trim().strip_prefix("#[path = \"") {
-                if let Some(file) = rest.split('"').next() {
-                    grouped.insert(file.to_string());
-                }
+            if let Some(file) = line
+                .trim()
+                .strip_prefix("#[path = \"")
+                .and_then(|r| r.split('"').next())
+            {
+                referenced.insert(file.to_string());
             }
         }
     }
@@ -48,12 +103,7 @@ fn every_test_file_is_reachable() {
             .expect("utf-8 filename")
             .to_string();
 
-        // Harnesses are `[[test]]` targets in their own right.
-        if name.starts_with("grp_") || grouped.contains(&name) {
-            continue;
-        }
-        // Otherwise it must be declared as its own `[[test]]` target.
-        if manifest.contains(&format!("path = \"tests/{name}\"")) {
+        if declared.contains(&format!("tests/{name}")) || referenced.contains(&name) {
             continue;
         }
         orphans.push(name);
@@ -62,8 +112,46 @@ fn every_test_file_is_reachable() {
     orphans.sort();
     assert!(
         orphans.is_empty(),
-        "unreachable under `autotests = false` — add a `#[path = \"<file>\"] \
-         mod <name>;` line to the right grp_* harness, or declare a [[test]] \
-         target: {orphans:?}"
+        "unreachable under `autotests = false` — every tests/*.rs must be \
+         declared as a [[test]] target or pulled into one via `#[path = \
+         \"<file>\"] mod <name>;`. Orphaned: {orphans:?}"
     );
+}
+
+#[test]
+fn declared_paths_cover_both_declaration_forms() {
+    let manifest = r#"
+[package]
+name = "x"
+
+[[test]]
+name = "grp_http"
+path = "tests/grp_http.rs"
+
+[[test]]
+name = "inferred_path_target"
+
+[[test]]
+name = "gated"
+path = "tests/gated.rs"
+required-features = ["f"]
+
+[[bench]]
+name = "not_a_test"
+path = "benches/not_a_test.rs"
+
+[lints]
+workspace = true
+"#;
+    let declared = declared_test_paths(manifest);
+
+    assert!(declared.contains("tests/grp_http.rs"));
+    // `path` omitted — Cargo infers tests/<name>.rs. fluree-db-api declares two
+    // targets this way, so the port depends on this case.
+    assert!(declared.contains("tests/inferred_path_target.rs"));
+    // Keys after `path` must not spill the target into the next block.
+    assert!(declared.contains("tests/gated.rs"));
+    // Other target kinds are not [[test]] targets.
+    assert!(!declared.contains("benches/not_a_test.rs"));
+    assert_eq!(declared.len(), 3);
 }


### PR DESCRIPTION
`fluree-db-server` had 28 auto-discovered integration test targets — one per `tests/*.rs` file. Every one of them is a `bin` that links the entire workspace dependency graph, so the crate paid 28 full link steps on every test build. This groups them by domain into 7 harnesses plus 2 deliberately standalone binaries, taking the crate from **28 test binaries to 9**, using the same pattern `fluree-db-api` already established: `autotests = false`, explicit `[[test]]` declarations, and each case file pulled in as a module via `#[path]`.

No test code moves and no test file is edited. All 338 integration tests are preserved exactly, verified by name rather than by count.

## What changed

- **7 domain harnesses added** — `grp_http`, `grp_query`, `grp_proxy`, `grp_policy`, `grp_search`, `grp_raft`, `grp_bolt`. Each is a short list of `#[path = "…"] mod …;` lines, matching the existing style in `fluree-db-api/tests/grp_*.rs`.
- **`fluree-db-server/Cargo.toml`** — `autotests = false` in `[package]`, plus 9 `[[test]]` declarations and comments explaining why auto-discovery is off and why two suites stay standalone.
- **`tests/harness_coverage.rs`** — a new guard test (see below).
- **`docs/contributing/tests.md`** — the grouped-binary section now documents `fluree-db-server` alongside `fluree-db-api`.

## How this improves the codebase

**Fewer link steps.** 19 fewer full links of the workspace dependency tree per test build of this crate. Linking is the dominant cost of building this test suite, and it is work that no incremental-compilation or compiler-cache scheme can avoid — `sccache`, for instance, explicitly cannot cache crates that invoke the system linker.

**Less disk per build.** Measured on this branch, each linked server test binary is 436–463 MB (with `split-debuginfo = "unpacked"` from the base branch already applied). Removing 19 of them cuts roughly **8 GB of linked output** from a full `--all-features` test build. That figure is derived from the measured per-binary size rather than a direct before/after of the whole tree, but every removed binary was a full link, so it is a sound multiplication rather than a guess.

**The disk saving multiplies across working copies.** Each git worktree, CI cache entry, and developer checkout carries its own `target/`. Three worktrees previously carried three independent copies of those 19 redundant binaries.

**Closes a silent-failure hole that `autotests = false` opens.** This is the one real hazard the pattern introduces: with auto-discovery off, a new `tests/*.rs` that nobody wires into a harness is never compiled and never run — and `cargo test` still reports success. `tests/harness_coverage.rs` asserts that every `tests/*.rs` is either pulled into a harness or declared as its own `[[test]]` target, failing with the list of orphans. This is not hypothetical: an untracked `tests/ledger_route_config_defaults.rs` exists on another branch and would have silently stopped running once this merged. The guard was verified against a synthetic orphan file — it fails naming the file, and passes once the file is wired up.

**Brings the crate in line with a documented convention that previously covered only one crate.** `docs/contributing/tests.md` described the grouping pattern and its standalone rules for `fluree-db-api` alone. It now covers `fluree-db-server` too, so a contributor adding a server integration test finds the rule instead of discovering `autotests = false` by surprise from a `Cargo.toml` comment.

**Preserves history.** The 28 test files are neither moved nor edited, so `git blame` is intact across all 22k lines of test code. The entire diff is 193 added lines.

**Grouping reflects what the code actually does.** Harnesses are organised by domain, not by feature flag. `raft` is the only non-default feature in this crate (`default = ["native", "credential", "iceberg", "shacl", "bolt"]`), so `grp_raft` is the only harness that compiles to an empty binary on a default build.

## Two suites intentionally left standalone

`telemetry_test` and `multi_query_tracing_integration` keep their own binaries. Both install a tracing subscriber and assert on the events captured through it. Tracing's callsite-interest cache is process-global while the capture is thread-local, so those assertions are only reliable when the test is alone in its process under bare `cargo test`. This is exactly the rule `docs/contributing/tests.md` already states for `fluree-db-api`, now applied consistently here.

They do pass inside a shared harness today, because their captures happen to sit on `current_thread` runtimes — but that is a coincidence of the current test bodies, not a property the tests guarantee, so they are kept isolated by rule rather than by luck.

## Safety of sharing a process

Grouping means tests that previously had a process each now share one under bare `cargo test`. (Under `cargo nextest`, which CI uses, every test still gets its own process, so CI semantics are unchanged.) All 28 files were audited for process-global hazards:

- No `set_var` / `remove_var` anywhere.
- No `OnceLock` / `OnceCell` / `LazyLock` / lazy statics latching process state.
- No `set_current_dir`, no `RLIMIT` manipulation, no self re-exec.
- No tests that are process-fatal by construction (e.g. deliberate stack-overflow probes).
- The only global subscriber install is `raft_multi_node`, which is `Once`-guarded with `try_init()` and therefore idempotent.
- The only two suites asserting on captured instrumentation are kept standalone, as above.

Filesystem isolation was already sound — the suites use `tempfile`/`TempDir` throughout — and every real listener binds an ephemeral `127.0.0.1:0` port, so there are no fixed-port collisions between concurrently running tests.

## Notes for reviewers and after merge

- Adding `[[test]]` targets and turning off auto-discovery changes which artifacts Cargo produces. The 28 old per-file test binaries linger in existing `target/` directories as unreferenced garbage until a `cargo clean`. Harmless, but worth running once if you care about the disk reclaim this PR is about.
- `fluree-db-api` has the same `autotests = false` silent-drop exposure and no coverage guard. That is pre-existing and out of scope here, but `tests/harness_coverage.rs` is written to be portable — dropping a copy into that crate would protect its ~160 test files too.
