### PR TITLE
fix(transact): give staged views dictionaries that cover their own flakes

### DIFF
--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -277,6 +277,13 @@ name = "it_staged_view_dict"
 path = "tests/it_staged_view_dict.rs"
 required-features = ["native", "shacl"]
 
+# Own binary: installs a process-global tracing probe over the scan lane's
+# `overlay_translate` spans to pin cross-query translation cache hits.
+[[test]]
+name = "it_overlay_content_version"
+path = "tests/it_overlay_content_version.rs"
+required-features = ["native"]
+
 # Own binary for the same reason (process-global `fluree::cow_probe` capture),
 # covering the branch-op (merge / revert) commit flows.
 [[test]]

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -270,6 +270,13 @@ name = "it_cached_handle_cow"
 path = "tests/it_cached_handle_cow.rs"
 required-features = ["native"]
 
+# Own binary: installs a process-global tracing probe over overlay-translation
+# WARN events emitted while a transaction's SHACL pass queries the staged view.
+[[test]]
+name = "it_staged_view_dict"
+path = "tests/it_staged_view_dict.rs"
+required-features = ["native", "shacl"]
+
 # Own binary for the same reason (process-global `fluree::cow_probe` capture),
 # covering the branch-op (merge / revert) commit flows.
 [[test]]

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -450,7 +450,7 @@ impl Fluree {
 
             // 4.3 Stage flakes (policy/backpressure). No WHERE/cancellation; flakes are prebuilt.
             let evolving_state = base_state.clone_with_novelty(Arc::new(evolving_novelty.clone()));
-            let staged_view = match stage_commit_flakes(
+            let mut staged_view = match stage_commit_flakes(
                 evolving_state,
                 &c.commit.flakes,
                 index_config,
@@ -492,7 +492,7 @@ impl Fluree {
             #[cfg(feature = "shacl")]
             {
                 crate::tx::apply_shacl_policy_to_staged_view(
-                    &staged_view,
+                    &mut staged_view,
                     crate::tx::StagedShaclContext {
                         graph_delta: Some(&routing.graph_iris),
                         graph_sids: Some(&routing.graph_sids),
@@ -1237,6 +1237,11 @@ fn apply_pushed_commits_to_state(
 
     // Apply all flakes to novelty (we already validated them; re-apply for state).
     let mut novelty = (*base.novelty).clone();
+    // Detach the range provider first: it pins `dict_novelty`, so mutating
+    // with it attached deep-clones the dictionary and leaves the provider —
+    // the copy every read through `base.snapshot` resolves against — without
+    // the subjects and strings these commits introduce.
+    let provider_store = fluree_db_transact::detach_binary_provider(&mut base);
     let mut dict_novelty = base.dict_novelty.clone();
 
     let store_opt: Option<&BinaryIndexStore> = base
@@ -1264,6 +1269,9 @@ fn apply_pushed_commits_to_state(
 
     base.novelty = Arc::new(novelty);
     base.dict_novelty = dict_novelty;
+    if let Some(store) = provider_store {
+        fluree_db_transact::attach_binary_provider(&mut base, store);
+    }
     base.head_commit_id = stored_commits.last().map(|c| c.commit_id.clone());
     if let Some(ref mut r) = base.ns_record {
         if let Some(last) = stored_commits.last() {

--- a/fluree-db-api/src/commit_transfer.rs
+++ b/fluree-db-api/src/commit_transfer.rs
@@ -450,7 +450,7 @@ impl Fluree {
 
             // 4.3 Stage flakes (policy/backpressure). No WHERE/cancellation; flakes are prebuilt.
             let evolving_state = base_state.clone_with_novelty(Arc::new(evolving_novelty.clone()));
-            let mut staged_view = match stage_commit_flakes(
+            let staged_view = match stage_commit_flakes(
                 evolving_state,
                 &c.commit.flakes,
                 index_config,
@@ -489,6 +489,9 @@ impl Fluree {
             // the binary store) are intentionally absent from `graph_iris` and
             // therefore fall back to the ledger-wide baseline, which is the
             // correct behavior: config cannot exist for a graph not yet known.
+            // The SHACL pass attaches the staged dictionaries to the view.
+            #[cfg(feature = "shacl")]
+            let mut staged_view = staged_view;
             #[cfg(feature = "shacl")]
             {
                 crate::tx::apply_shacl_policy_to_staged_view(

--- a/fluree-db-api/src/ledger_manager.rs
+++ b/fluree-db-api/src/ledger_manager.rs
@@ -1970,12 +1970,18 @@ impl UpdatePlan {
             // Large gap — full reload
             UpdatePlan::Reload
         } else {
-            // ns.commit_t < local_t - shouldn't happen (time travel?)
-            // Treat as noop - local is somehow ahead
-            tracing::warn!(
+            // ns.commit_t < local_t: the record is older than the cached
+            // state. Routine under the raft commit worker — `notify` reads
+            // the record before taking the ledger's state lock, and the
+            // worker holds that lock's write side across the next chunk's
+            // stage + publish + install, so a reconciliation queued behind
+            // it wakes to a local state one commit newer than the record
+            // it fetched. Local is the fresher of the two; the next lookup
+            // catches the record up. Nothing to do.
+            tracing::debug!(
                 local_t = local_t,
                 ns_commit_t = ns.commit_t,
-                "Local t is ahead of nameservice commit_t - unexpected"
+                "nameservice record older than local state; ignoring"
             );
             UpdatePlan::Noop
         }
@@ -2627,7 +2633,9 @@ mod tests {
 
     #[test]
     fn test_update_plan_noop_when_local_ahead() {
-        // Edge case: local is somehow ahead of ns (shouldn't happen, but be safe)
+        // The record is older than the cached state: a reconciliation that
+        // fetched it, then waited on the state lock across the raft worker's
+        // next install. Stale record, nothing to do — never a reload.
         let local_idx = make_index_cid("index:5");
         let ns = make_ns_record(5, 5, Some(make_cid("commit:5")), Some(local_idx.clone()));
         let plan = UpdatePlan::plan(10, 5, Some(&local_idx), &ns);

--- a/fluree-db-api/src/overlay.rs
+++ b/fluree-db-api/src/overlay.rs
@@ -13,6 +13,9 @@ use fluree_db_core::{Flake, GraphId, IndexType, OverlayProvider};
 /// to the callback.
 pub struct CompositeOverlay {
     epoch: u64,
+    /// Composed from the parts' versions, in order; `None` when any part
+    /// cannot vouch for its own.
+    content_version: Option<u64>,
     overlays: Vec<std::sync::Arc<dyn OverlayProvider>>,
 }
 
@@ -23,7 +26,16 @@ impl CompositeOverlay {
         for o in &overlays {
             epoch = epoch.wrapping_mul(1_000_003).wrapping_add(o.epoch());
         }
-        Self { epoch, overlays }
+        let content_version = overlays
+            .iter()
+            .map(|o| o.content_version())
+            .collect::<Option<Vec<u64>>>()
+            .map(|parts| fluree_db_core::overlay::compose_content_version(&parts));
+        Self {
+            epoch,
+            content_version,
+            overlays,
+        }
     }
 }
 
@@ -34,6 +46,10 @@ impl OverlayProvider for CompositeOverlay {
 
     fn epoch(&self) -> u64 {
         self.epoch
+    }
+
+    fn content_version(&self) -> Option<u64> {
+        self.content_version
     }
 
     fn is_effectively_empty(&self) -> bool {

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -190,11 +190,20 @@ impl SequentialStager {
         }
 
         if advance {
+            // Detach the range provider around the in-place dictionary
+            // mutation: attached, it pins the dictionaries (so `make_mut`
+            // deep-clones them) and would keep reading the pre-op copies,
+            // leaving the next operation's WHERE unable to translate the
+            // subjects this one introduced.
+            let store = fluree_db_transact::detach_binary_provider(&mut state_i);
             state_i.apply_staged_flakes_for_sequential_staging(
                 flakes_i,
                 &ns_delta,
                 graph_iris.iter().map(String::as_str),
             )?;
+            if let Some(store) = store {
+                fluree_db_transact::attach_binary_provider(&mut state_i, store);
+            }
             self.current = Some(state_i);
         }
         Ok(staged_count)
@@ -949,7 +958,7 @@ pub(crate) fn resolve_shapes_source_g_ids(
 /// is API-layer policy, not a staging primitive.
 #[cfg(feature = "shacl")]
 pub(crate) async fn apply_shacl_policy_to_staged_view(
-    view: &StagedLedger,
+    view: &mut StagedLedger,
     ctx: StagedShaclContext<'_>,
     preresolved_config: Option<Arc<LedgerConfig>>,
 ) -> std::result::Result<(), fluree_db_transact::TransactError> {
@@ -1228,6 +1237,14 @@ pub(crate) async fn apply_shacl_policy_to_staged_view(
         return Ok(());
     }
 
+    // Validation reads the staged view on the binary lane; its dictionaries
+    // must cover the subjects this transaction introduces, or every probe
+    // re-translates the whole graph novelty and merges the new subjects'
+    // flakes raw. Mutably re-borrowed here so `base` (an immutable borrow of
+    // the view) is released first.
+    fluree_db_transact::attach_staged_dicts(view)?;
+    let view: &StagedLedger = view;
+
     // 5. Validate. `per_graph_policy` drives which graphs participate and
     //    what mode their violations carry. `None` = shapes-exist heuristic
     //    path → every graph validated in reject mode (the transact helper's
@@ -1437,7 +1454,7 @@ async fn stage_with_config_shacl(
     let cross_ledger_schema =
         resolve_cross_ledger_schema_for_tx(&ledger, config.as_ref(), resolve_ctx).await?;
 
-    let (view, mut ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
+    let (mut view, mut ns_registry) = stage_txn(ledger, txn, ns_registry, options).await?;
 
     // Parse inline shapes (if any) against the staged namespace
     // registry. The bundle becomes an additional shape DB in
@@ -1494,7 +1511,7 @@ async fn stage_with_config_shacl(
     };
 
     apply_shacl_policy_to_staged_view(
-        &view,
+        &mut view,
         StagedShaclContext {
             graph_delta: Some(&graph_delta),
             graph_sids: Some(&graph_sids),
@@ -3549,7 +3566,7 @@ impl crate::Fluree {
         if let Some(policy) = policy {
             options = options.with_policy(policy);
         }
-        let view = match stage_flakes(ledger, flakes, options).await {
+        let mut view = match stage_flakes(ledger, flakes, options).await {
             Ok(view) => view,
             Err(e) => {
                 self.request_index_after_novelty_rejection(&ledger_id_owned, base_t, &e)
@@ -3590,7 +3607,7 @@ impl crate::Fluree {
                 _ => None,
             };
             apply_shacl_policy_to_staged_view(
-                &view,
+                &mut view,
                 StagedShaclContext {
                     graph_delta: None,
                     graph_sids: None,

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -1232,8 +1232,10 @@ pub(crate) async fn apply_shacl_policy_to_staged_view(
     };
     let shacl_cache = engine.shared_cache();
 
-    // No config + no shapes → skip (backward compat: shapes-exist heuristic).
-    if !has_config && shacl_cache.is_empty() {
+    // No shapes → nothing to validate, whether config enabled SHACL or the
+    // shapes-exist heuristic applies. Skipping here keeps a shapeless
+    // transaction from paying the staged-dictionary clone below.
+    if shacl_cache.is_empty() {
         return Ok(());
     }
 

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -1234,7 +1234,7 @@ pub(crate) async fn apply_shacl_policy_to_staged_view(
 
     // No shapes → nothing to validate, whether config enabled SHACL or the
     // shapes-exist heuristic applies. Skipping here keeps a shapeless
-    // transaction from paying the staged-dictionary clone below.
+    // transaction from paying for the staged dictionary layer below.
     if shacl_cache.is_empty() {
         return Ok(());
     }

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -3566,7 +3566,7 @@ impl crate::Fluree {
         if let Some(policy) = policy {
             options = options.with_policy(policy);
         }
-        let mut view = match stage_flakes(ledger, flakes, options).await {
+        let view = match stage_flakes(ledger, flakes, options).await {
             Ok(view) => view,
             Err(e) => {
                 self.request_index_after_novelty_rejection(&ledger_id_owned, base_t, &e)
@@ -3579,6 +3579,9 @@ impl crate::Fluree {
         // metadata (that's TriG), so we pass `None` for graph_delta/graph_sids —
         // validation falls back to default-graph (g_id=0), matching how flakes
         // are produced by `FlakeSink`.
+        // The SHACL pass attaches the staged dictionaries to the view.
+        #[cfg(feature = "shacl")]
+        let mut view = view;
         #[cfg(feature = "shacl")]
         {
             // D's namespace codes → IRI prefixes (base + this document's

--- a/fluree-db-api/src/view/types.rs
+++ b/fluree-db-api/src/view/types.rs
@@ -407,18 +407,39 @@ impl GraphDb {
                 .map_err(|e| crate::ApiError::internal(e.to_string()))?;
         }
 
+        // The binary lane resolves overlay flakes through the persisted
+        // dictionary plus `DictNovelty`, both committed-state artefacts: the
+        // subjects and strings this transaction introduces are in neither.
+        // Read through a view-local extension of the base dictionaries, as
+        // SHACL and post-state policy do, so a preview neither fails to
+        // translate its own flakes nor re-walks the whole novelty per scan.
+        let staged_flakes = staged.view.staged_flakes();
+        let (dict_novelty, runtime_small_dicts) =
+            match fluree_db_transact::staged_dicts(base, staged_flakes)? {
+                Some(dicts) => {
+                    let provider = dicts.provider(snapshot.shared_namespaces());
+                    Arc::make_mut(&mut snapshot).range_provider = Some(provider);
+                    (dicts.dict_novelty, dicts.runtime_small_dicts)
+                }
+                None => {
+                    let mut runtime_small_dicts = (*base.runtime_small_dicts).clone();
+                    runtime_small_dicts.populate_from_flakes(staged_flakes);
+                    (
+                        Arc::clone(&base.dict_novelty),
+                        Arc::new(runtime_small_dicts),
+                    )
+                }
+            };
+
         // Clone base novelty and merge staged flakes into it so queries see
         // both committed and staged data.
         let mut combined = (*base.novelty).clone();
-        let staged_flakes = staged.view.staged_flakes().to_vec();
-        let mut runtime_small_dicts = (*base.runtime_small_dicts).clone();
         if !staged_flakes.is_empty() {
-            runtime_small_dicts.populate_from_flakes(&staged_flakes);
             let reverse_graph = snapshot
                 .build_reverse_graph()
                 .map_err(|e| crate::ApiError::internal(e.to_string()))?;
             combined
-                .apply_commit(staged_flakes, staged_t, &reverse_graph)
+                .apply_commit(staged_flakes.to_vec(), staged_t, &reverse_graph)
                 .map_err(|e| {
                     crate::ApiError::internal(format!(
                         "Failed to merge staged flakes into novelty: {e}"
@@ -435,8 +456,8 @@ impl GraphDb {
             staged_t,
             base.ledger_id(),
         );
-        gdb.dict_novelty = Some(base.dict_novelty.clone());
-        gdb.runtime_small_dicts = Some(Arc::new(runtime_small_dicts));
+        gdb.dict_novelty = Some(dict_novelty);
+        gdb.runtime_small_dicts = Some(runtime_small_dicts);
         // Carry binary store from the base ledger state
         gdb.binary_store = base
             .binary_store

--- a/fluree-db-api/tests/it_overlay_content_version.rs
+++ b/fluree-db-api/tests/it_overlay_content_version.rs
@@ -1,0 +1,267 @@
+//! Overlay content versions as cross-query cache keys.
+//!
+//! Two process-global caches key on `OverlayProvider::content_version`: the
+//! overlay→V3 translation cache the binary scan lane shares across query
+//! executions, and the OWL2-RL materialization cache. Both used to key on the
+//! overlay *epoch*, which is only unique within one overlay's lineage: a
+//! composed overlay (reasoning over novelty) that cannot vouch for a content
+//! version is silently never cached, and a staged preview's novelty reports
+//! the very epoch the committed novelty reports once those flakes commit.
+//!
+//! Run with:
+//!   cargo test -p fluree-db-api --test it_overlay_content_version
+
+#![cfg(feature = "native")]
+
+use std::sync::Mutex;
+
+use fluree_db_api::{
+    CommitOpts, Fluree, FlureeBuilder, GraphDb, IndexConfig, QueryInput, ReindexOptions, TxnOpts,
+};
+use serde_json::{json, Value};
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+
+/// `cache_hit` values recorded on `overlay_translate` spans since the last
+/// drain, in recording order.
+static TRANSLATE_HITS: Mutex<Vec<bool>> = Mutex::new(Vec::new());
+/// The probe is process-global, so tests run one at a time.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct CacheHit(Option<bool>);
+
+impl Visit for CacheHit {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == "cache_hit" {
+            self.0 = Some(value);
+        }
+    }
+    fn record_debug(&mut self, _: &Field, _: &dyn std::fmt::Debug) {}
+}
+
+struct TranslateProbe;
+
+impl<S> Layer<S> for TranslateProbe
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+        if attrs.metadata().name() != "overlay_translate" {
+            return;
+        }
+        let mut visit = CacheHit(None);
+        attrs.record(&mut visit);
+        if let Some(hit) = visit.0 {
+            TRANSLATE_HITS.lock().expect("probe lock").push(hit);
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        if span.name() != "overlay_translate" {
+            return;
+        }
+        let mut visit = CacheHit(None);
+        values.record(&mut visit);
+        if let Some(hit) = visit.0 {
+            TRANSLATE_HITS.lock().expect("probe lock").push(hit);
+        }
+    }
+}
+
+fn install_probe() {
+    let _ = tracing_subscriber::registry()
+        .with(TranslateProbe)
+        .try_init();
+}
+
+fn drain_hits() -> Vec<bool> {
+    std::mem::take(&mut *TRANSLATE_HITS.lock().expect("probe lock"))
+}
+
+fn ctx() -> Value {
+    json!({
+        "ex": "http://example.org/ns/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+    })
+}
+
+/// Background indexing stays out of the way: a reindex would swap the
+/// snapshot and store under a view mid-test.
+fn quiet_index_cfg() -> IndexConfig {
+    IndexConfig {
+        reindex_min_bytes: 1 << 30,
+        reindex_max_bytes: 1 << 31,
+    }
+}
+
+async fn quiet_insert(
+    fluree: &Fluree,
+    ledger: fluree_db_api::LedgerState,
+    data: &Value,
+) -> fluree_db_api::LedgerState {
+    fluree
+        .insert_with_opts(
+            ledger,
+            data,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &quiet_index_cfg(),
+        )
+        .await
+        .expect("commit")
+        .ledger
+}
+
+async fn new_fluree() -> (Fluree, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fluree = FlureeBuilder::file(dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build");
+    (fluree, dir)
+}
+
+/// An ontology (`ex:Dog ⊑ ex:Animal`) plus `n` dogs, indexed and reloaded so
+/// the returned state carries a binary range provider, then one more dog
+/// committed on top so the novelty is non-empty.
+async fn indexed_ledger(fluree: &Fluree, ledger_id: &str, n: usize) -> fluree_db_api::LedgerState {
+    let ledger = fluree.create_ledger(ledger_id).await.expect("create");
+    let mut nodes = vec![json!({
+        "@id": "ex:Dog",
+        "rdfs:subClassOf": {"@id": "ex:Animal"}
+    })];
+    nodes.extend((0..n).map(|i| json!({"@id": format!("ex:dog{i}"), "@type": "ex:Dog"})));
+    let seed = json!({"@context": ctx(), "@graph": nodes});
+    fluree.insert(ledger, &seed).await.expect("seed");
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let ledger = fluree.ledger(ledger_id).await.expect("load");
+    assert!(ledger.snapshot.range_provider.is_some());
+    let extra = json!({"@context": ctx(), "@id": "ex:fido", "@type": "ex:Dog"});
+    quiet_insert(fluree, ledger, &extra).await
+}
+
+fn animals_query() -> Value {
+    json!({
+        "@context": ctx(),
+        "select": "?s",
+        "where": {"@id": "?s", "@type": "ex:Animal"},
+        "reasoning": "owl2rl"
+    })
+}
+
+async fn animals(fluree: &Fluree, view: &GraphDb) -> Vec<String> {
+    let q = animals_query();
+    let out = fluree
+        .query(view, QueryInput::JsonLd(&q))
+        .await
+        .expect("reasoning query");
+    let rows = out.to_jsonld(&view.snapshot).expect("jsonld");
+    let mut names: Vec<String> = rows
+        .as_array()
+        .expect("rows")
+        .iter()
+        .map(|v| v.as_str().expect("iri").to_string())
+        .collect();
+    names.sort();
+    names
+}
+
+/// A reasoning query's overlay is a `ReasoningOverlay` over the novelty. It
+/// must vouch for a content version, or the whole-overlay translation is
+/// rebuilt on every execution — the multi-second floor the cross-query
+/// translation cache exists to remove for large materializations.
+#[tokio::test]
+async fn reasoning_query_reuses_overlay_translation_across_executions() {
+    let _serial = SERIAL.lock().await;
+    install_probe();
+    let (fluree, _dir) = new_fluree().await;
+    const LEDGER: &str = "overlay-content-version/reuse:main";
+    let ledger = indexed_ledger(&fluree, LEDGER, 4).await;
+    let view = GraphDb::from_ledger_state(&ledger);
+
+    // Unbounded: the whole-graph product is built and cached.
+    let scan = json!({
+        "@context": ctx(),
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"},
+        "reasoning": "owl2rl"
+    });
+
+    let _ = drain_hits();
+    let out = fluree
+        .query(&view, QueryInput::JsonLd(&scan))
+        .await
+        .expect("first execution");
+    let rows = out.to_jsonld(&view.snapshot).expect("jsonld").to_string();
+    assert!(
+        rows.contains("\"ex:Animal\""),
+        "derived facts visible: {rows}"
+    );
+    let cold = drain_hits();
+    assert!(
+        cold.contains(&false),
+        "first execution must translate the overlay (probe saw {cold:?})"
+    );
+
+    let out = fluree
+        .query(&view, QueryInput::JsonLd(&scan))
+        .await
+        .expect("second execution");
+    let again = out.to_jsonld(&view.snapshot).expect("jsonld").to_string();
+    assert_eq!(rows, again);
+    let warm = drain_hits();
+    assert!(
+        warm.contains(&true) && !warm.contains(&false),
+        "second execution must be served from the cross-query translation cache (probe saw {warm:?})"
+    );
+}
+
+/// The OWL2-RL materialization cache must never serve a preview's derived
+/// facts for the committed state. A discarded preview's novelty reports the
+/// epoch and `t` the next commit will report; keyed on the epoch, the
+/// committed state would inherit the preview's entailments and miss its own.
+#[tokio::test]
+async fn reasoning_cache_never_serves_a_discarded_preview() {
+    let _serial = SERIAL.lock().await;
+    install_probe();
+    let (fluree, _dir) = new_fluree().await;
+    const LEDGER: &str = "overlay-content-version/preview:main";
+    let ledger = indexed_ledger(&fluree, LEDGER, 1).await;
+
+    let ghost = json!({"@context": ctx(), "@id": "ex:ghost", "@type": "ex:Dog"});
+    let staged = fluree
+        .stage_owned(ledger.clone())
+        .insert(&ghost)
+        .stage()
+        .await
+        .expect("stage");
+    let preview = GraphDb::from_staged(&staged).expect("preview view");
+    let previewed = animals(&fluree, &preview).await;
+    assert!(
+        previewed.iter().any(|s| s == "ex:ghost"),
+        "preview derives the staged dog's type: {previewed:?}"
+    );
+    drop(preview);
+    drop(staged);
+
+    let real = json!({"@context": ctx(), "@id": "ex:real", "@type": "ex:Dog"});
+    let committed = quiet_insert(&fluree, ledger, &real).await;
+
+    let view = GraphDb::from_ledger_state(&committed);
+    let committed = animals(&fluree, &view).await;
+    assert!(
+        committed.iter().any(|s| s == "ex:real"),
+        "committed state derives its own dog's type: {committed:?}"
+    );
+    assert!(
+        !committed.iter().any(|s| s == "ex:ghost"),
+        "committed state must not inherit the discarded preview's entailments: {committed:?}"
+    );
+}

--- a/fluree-db-api/tests/it_staged_view_dict.rs
+++ b/fluree-db-api/tests/it_staged_view_dict.rs
@@ -364,7 +364,7 @@ async fn post_state_policy_over_staged_view_translates_new_subjects() {
     // alone takes the overlay-only seek and never translates). The city is
     // one the indexed seed already holds: a join on a string the same
     // transaction introduces is denied on a staged view with or without a
-    // staged dictionary layer, which is a separate gap.
+    // staged dictionary layer, which is a separate gap (#1790).
     let policies = json!([
         {"@id": "ex:viewAll", "f:action": "f:view", "f:allow": true},
         {

--- a/fluree-db-api/tests/it_staged_view_dict.rs
+++ b/fluree-db-api/tests/it_staged_view_dict.rs
@@ -1,0 +1,449 @@
+//! Staged-view dictionary coverage.
+//!
+//! A transaction's SHACL and post-state policy probes query a `StagedLedger`:
+//! committed state plus the transaction's own staged flakes. Those probes run
+//! on the binary lane once the ledger has a persisted index, and the lane
+//! translates every overlay flake through the persisted dictionary plus
+//! `DictNovelty`. The subjects and strings a transaction is *creating* are in
+//! neither, so without a staged dictionary layer every such flake fails
+//! translation ("subject not found in persisted or novelty dict"), is logged
+//! at WARN, and is merged as a raw flake — once per probe, per new-subject
+//! flake, with the whole graph novelty re-walked each time.
+//!
+//! These tests pin the translation outcome through a tracing probe rather
+//! than timings, and pin post-commit reads so a staged product can never be
+//! served for the committed state.
+//!
+//! Run with:
+//!   cargo test -p fluree-db-api --test it_staged_view_dict --features shacl
+
+#![cfg(all(feature = "native", feature = "shacl"))]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use fluree_db_api::TxnOpts;
+use fluree_db_api::{CommitOpts, Fluree, FlureeBuilder, IndexConfig, QueryInput, ReindexOptions};
+use serde_json::{json, Value};
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::Layer;
+
+/// Overlay-translation failures observed since the last drain, one entry per
+/// WARN event, with the event's fields flattened for the assertion message.
+static TRANSLATE_FAILURES: Mutex<Vec<String>> = Mutex::new(Vec::new());
+/// Staging completions observed — proves the probe layer is the active
+/// subscriber, so an empty failure list is a real observation.
+static STAGING_SEEN: AtomicUsize = AtomicUsize::new(0);
+/// The probe is process-global, so tests run one at a time to keep every
+/// captured event attributable to the transaction under test.
+static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn serialize() -> tokio::sync::MutexGuard<'static, ()> {
+    SERIAL.lock().await
+}
+
+#[derive(Default)]
+struct Flatten {
+    text: String,
+}
+
+impl Visit for Flatten {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        use std::fmt::Write as _;
+        let _ = write!(self.text, "{}={:?} ", field.name(), value);
+    }
+}
+
+struct ProbeLayer;
+
+impl<S: tracing::Subscriber> Layer<S> for ProbeLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut flat = Flatten::default();
+        event.record(&mut flat);
+        if flat.text.contains("transaction staging completed") {
+            STAGING_SEEN.fetch_add(1, Ordering::SeqCst);
+        }
+        let translate_failure = flat.text.contains("failed to translate overlay flake")
+            || flat.text.contains("failed V3 translation")
+            || flat.text.contains("not found in persisted or novelty dict");
+        if translate_failure && *event.metadata().level() <= tracing::Level::WARN {
+            TRANSLATE_FAILURES
+                .lock()
+                .expect("probe capture lock never poisoned")
+                .push(flat.text);
+        }
+    }
+}
+
+fn install_probe() {
+    let _ = tracing_subscriber::registry().with(ProbeLayer).try_init();
+}
+
+fn drain_failures() -> Vec<String> {
+    std::mem::take(
+        &mut *TRANSLATE_FAILURES
+            .lock()
+            .expect("probe capture lock never poisoned"),
+    )
+}
+
+fn ctx() -> Value {
+    json!({
+        "ex": "http://example.org/ns/",
+        "sh": "http://www.w3.org/ns/shacl#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    })
+}
+
+/// Background indexing stays out of the way: the tests reindex explicitly.
+fn quiet_index_cfg() -> IndexConfig {
+    IndexConfig {
+        reindex_min_bytes: 1 << 30,
+        reindex_max_bytes: 1 << 31,
+    }
+}
+
+fn person_shape() -> Value {
+    json!({
+        "@context": ctx(),
+        "@graph": [
+            {
+                "@id": "ex:PersonShape",
+                "@type": "sh:NodeShape",
+                "sh:targetClass": {"@id": "ex:Person"},
+                "sh:property": {"@id": "ex:pshape_name"}
+            },
+            {
+                "@id": "ex:pshape_name",
+                "sh:path": {"@id": "ex:name"},
+                "sh:minCount": 1,
+                "sh:datatype": {"@id": "xsd:string"}
+            }
+        ]
+    })
+}
+
+fn seed(n: usize) -> Value {
+    let nodes: Vec<Value> = (0..n)
+        .map(|i| {
+            json!({
+                "@id": format!("ex:person{i}"),
+                "@type": "ex:Person",
+                "ex:name": format!("Person {i}"),
+                "ex:city": format!("City {}", i % 5)
+            })
+        })
+        .collect();
+    json!({"@context": ctx(), "@graph": nodes})
+}
+
+fn person(id: &str, name: Option<&str>) -> Value {
+    let mut node = json!({
+        "@context": ctx(),
+        "@id": id,
+        "@type": "ex:Person",
+        "ex:city": "City new",
+        "ex:knows": {"@id": "ex:person1"}
+    });
+    if let Some(name) = name {
+        node["ex:name"] = json!(name);
+    }
+    node
+}
+
+async fn new_fluree() -> (Fluree, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fluree = FlureeBuilder::file(dir.path().to_string_lossy().to_string())
+        .build()
+        .expect("build");
+    (fluree, dir)
+}
+
+/// Seed, reindex, and reload so the returned state carries a binary range
+/// provider (the lane under test).
+async fn indexed_ledger(fluree: &Fluree, ledger_id: &str) -> fluree_db_api::LedgerState {
+    let ledger = fluree.create_ledger(ledger_id).await.expect("create");
+    fluree.insert(ledger, &seed(40)).await.expect("seed");
+    fluree
+        .reindex(ledger_id, ReindexOptions::default())
+        .await
+        .expect("reindex");
+    let ledger = fluree.ledger(ledger_id).await.expect("load");
+    assert!(
+        ledger.snapshot.range_provider.is_some(),
+        "reindexed ledger must expose a binary range provider"
+    );
+    ledger
+}
+
+async fn name_of(fluree: &Fluree, ledger_id: &str, subject: &str) -> Vec<Value> {
+    let view = fluree.db(ledger_id).await.expect("db view");
+    let q = json!({
+        "@context": ctx(),
+        "select": ["?name"],
+        "where": {"@id": subject, "ex:name": "?name"}
+    });
+    let out = fluree
+        .query(&view, QueryInput::JsonLd(&q))
+        .await
+        .expect("query");
+    out.to_jsonld(&view.snapshot)
+        .expect("jsonld")
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// SHACL probes over the staged view must translate the transaction's own
+/// new subjects instead of degrading to raw-flake merging with a WARN per
+/// flake per probe.
+#[tokio::test]
+async fn shacl_over_staged_view_translates_new_subjects() {
+    let _serial = serialize().await;
+    install_probe();
+    let (fluree, _dir) = new_fluree().await;
+    const LEDGER: &str = "staged-view-dict/shacl:main";
+    let ledger = indexed_ledger(&fluree, LEDGER).await;
+
+    let opts = TxnOpts {
+        shapes: Some(person_shape()),
+        ..TxnOpts::default()
+    };
+    let _ = drain_failures();
+    let staging_before = STAGING_SEEN.load(Ordering::SeqCst);
+
+    fluree
+        .insert_with_opts(
+            ledger,
+            &person("ex:newcomer", Some("Newcomer")),
+            opts,
+            CommitOpts::default(),
+            &quiet_index_cfg(),
+        )
+        .await
+        .expect("valid Person under shape must be accepted");
+
+    assert!(
+        STAGING_SEEN.load(Ordering::SeqCst) > staging_before,
+        "probe layer is not the active subscriber; the assertion below would be vacuous"
+    );
+    let failures = drain_failures();
+    assert!(
+        failures.is_empty(),
+        "{} overlay flake(s) failed V3 translation during the staged SHACL pass; first: {}",
+        failures.len(),
+        failures.first().map(String::as_str).unwrap_or("")
+    );
+
+    // The staged dictionary is a view-local layer: the committed state must
+    // read back through the canonical dictionaries.
+    let rows = name_of(&fluree, LEDGER, "ex:newcomer").await;
+    assert_eq!(rows, vec![json!(["Newcomer"])]);
+}
+
+/// The staged view must still *see* the new subject: a violating transaction
+/// is rejected, proving the probes read the staged flakes rather than skipping
+/// them.
+#[tokio::test]
+async fn shacl_over_staged_view_still_rejects_violations() {
+    let _serial = serialize().await;
+    install_probe();
+    let (fluree, _dir) = new_fluree().await;
+    const LEDGER: &str = "staged-view-dict/reject:main";
+    let ledger = indexed_ledger(&fluree, LEDGER).await;
+
+    let opts = TxnOpts {
+        shapes: Some(person_shape()),
+        ..TxnOpts::default()
+    };
+    let err = fluree
+        .insert_with_opts(
+            ledger,
+            &person("ex:nameless", None),
+            opts,
+            CommitOpts::default(),
+            &quiet_index_cfg(),
+        )
+        .await
+        .expect_err("Person without ex:name must be rejected by the shape");
+    assert!(
+        matches!(
+            err,
+            fluree_db_api::ApiError::Transact(fluree_db_transact::TransactError::ShaclViolation(_))
+        ),
+        "expected ShaclViolation, got: {err:?}"
+    );
+}
+
+/// Whole-graph scans after a commit must decode against the committed
+/// dictionaries. A staged view reports the same overlay epoch and `to_t`
+/// the committed novelty will report, so a translation product cached under
+/// an epoch-only key during staging would be served for the committed state.
+#[tokio::test]
+async fn post_commit_whole_graph_scan_reads_committed_dictionaries() {
+    let _serial = serialize().await;
+    install_probe();
+    let (fluree, _dir) = new_fluree().await;
+    const LEDGER: &str = "staged-view-dict/post-commit:main";
+    let ledger = indexed_ledger(&fluree, LEDGER).await;
+
+    let opts = TxnOpts {
+        shapes: Some(person_shape()),
+        ..TxnOpts::default()
+    };
+    let batch = json!({
+        "@context": ctx(),
+        "@graph": [
+            person("ex:alpha", Some("Alpha")),
+            person("ex:beta", Some("Beta")),
+            person("ex:gamma", Some("Gamma"))
+        ]
+    });
+    fluree
+        .insert_with_opts(
+            ledger,
+            &batch,
+            opts,
+            CommitOpts::default(),
+            &quiet_index_cfg(),
+        )
+        .await
+        .expect("batch accepted");
+
+    let view = fluree.db(LEDGER).await.expect("db view");
+    let q = json!({
+        "@context": ctx(),
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"}
+    });
+    let out = fluree
+        .query(&view, QueryInput::JsonLd(&q))
+        .await
+        .expect("whole-graph scan");
+    let rows = out.to_jsonld(&view.snapshot).expect("jsonld");
+    let text = rows.to_string();
+    for (id, name) in [
+        ("ex:alpha", "Alpha"),
+        ("ex:beta", "Beta"),
+        ("ex:gamma", "Gamma"),
+    ] {
+        assert!(
+            text.contains(&format!("\"{id}\"")) && text.contains(&format!("\"{name}\"")),
+            "post-commit whole-graph scan lost {id}/{name}: {text}"
+        );
+    }
+    let failures = drain_failures();
+    assert!(
+        failures.is_empty(),
+        "post-commit scan hit translation failures; first: {}",
+        failures.first().map(String::as_str).unwrap_or("")
+    );
+}
+
+/// `f:queryState f:postState` policy conditions are the other binary-lane
+/// reader of the staged view: the condition's ASK must resolve the subject
+/// being created (and the reference it asserts) through the staged
+/// dictionaries, not fall back to raw merging with a WARN per probe.
+#[tokio::test]
+async fn post_state_policy_over_staged_view_translates_new_subjects() {
+    use fluree_db_api::{policy_builder, GovernanceOptions, TrackedTransactionInput, TxnType};
+    use std::collections::HashMap;
+
+    let _serial = serialize().await;
+    install_probe();
+    let (fluree, _dir) = new_fluree().await;
+    const LEDGER: &str = "staged-view-dict/post-state:main";
+    let ledger = indexed_ledger(&fluree, LEDGER).await;
+
+    // "May create a Person only when it is owned by the caller and shares a
+    // city with an existing Person" — the ex:owner edge exists only in the
+    // staged flakes, and the predicate-bound neighbour pattern makes the
+    // engine translate every staged `ex:city` flake (a subject-bound pattern
+    // alone takes the overlay-only seek and never translates). The city is
+    // one the indexed seed already holds: a join on a string the same
+    // transaction introduces is denied on a staged view with or without a
+    // staged dictionary layer, which is a separate gap.
+    let policies = json!([
+        {"@id": "ex:viewAll", "f:action": "f:view", "f:allow": true},
+        {
+            "@id": "ex:ownOnly",
+            "f:onClass": [{"@id": "http://example.org/ns/Person"}],
+            "f:action": "f:create",
+            "f:queryState": {"@id": "f:postState"},
+            "f:query": {
+                "@type": "f:sparql",
+                "@value": "ASK { $this <http://example.org/ns/owner> $identity . \
+                           $this <http://example.org/ns/city> ?city . \
+                           ?neighbour <http://example.org/ns/city> ?city }"
+            }
+        }
+    ]);
+    let opts = GovernanceOptions {
+        policy: Some(policies),
+        policy_values: Some(HashMap::from([(
+            "?$identity".to_string(),
+            json!({"@id": "http://example.org/ns/person1"}),
+        )])),
+        default_allow: Some(false),
+        ..Default::default()
+    };
+    let policy_ctx = policy_builder::build_policy_context_from_opts(
+        &ledger.snapshot,
+        ledger.novelty.as_ref(),
+        Some(ledger.novelty.as_ref()),
+        ledger.t(),
+        &opts,
+        &[0],
+    )
+    .await
+    .expect("build policy context");
+
+    let owned = json!({
+        "@context": ctx(),
+        "@id": "ex:owned",
+        "@type": "ex:Person",
+        "ex:name": "Owned",
+        "ex:city": "City 1",
+        "ex:owner": {"@id": "ex:person1"}
+    });
+    let _ = drain_failures();
+    let staging_before = STAGING_SEEN.load(Ordering::SeqCst);
+    let input =
+        TrackedTransactionInput::new(TxnType::Insert, &owned, TxnOpts::default(), &policy_ctx);
+    fluree
+        .transact_tracked_with_policy(
+            ledger.clone(),
+            input,
+            CommitOpts::default(),
+            &quiet_index_cfg(),
+        )
+        .await
+        .expect("post-state condition must see the staged ex:owner edge");
+    assert!(
+        STAGING_SEEN.load(Ordering::SeqCst) > staging_before,
+        "probe layer is not the active subscriber; the assertion below would be vacuous"
+    );
+    let failures = drain_failures();
+    assert!(
+        failures.is_empty(),
+        "{} overlay flake(s) failed V3 translation during the post-state policy pass; first: {}",
+        failures.len(),
+        failures.first().map(String::as_str).unwrap_or("")
+    );
+
+    // The condition still discriminates: no owner edge → denied.
+    let unowned = json!({
+        "@context": ctx(),
+        "@id": "ex:unowned",
+        "@type": "ex:Person",
+        "ex:name": "Unowned"
+    });
+    let input =
+        TrackedTransactionInput::new(TxnType::Insert, &unowned, TxnOpts::default(), &policy_ctx);
+    let denied = fluree
+        .transact_tracked_with_policy(ledger, input, CommitOpts::default(), &quiet_index_cfg())
+        .await;
+    assert!(denied.is_err(), "ownerless create must be denied");
+}

--- a/fluree-db-api/tests/it_staged_view_dict.rs
+++ b/fluree-db-api/tests/it_staged_view_dict.rs
@@ -11,8 +11,8 @@
 //! flake, with the whole graph novelty re-walked each time.
 //!
 //! These tests pin the translation outcome through a tracing probe rather
-//! than timings, and pin post-commit reads so a staged product can never be
-//! served for the committed state.
+//! than timings, and pin post-commit reads so a product built over
+//! uncommitted state can never be served for the committed state.
 //!
 //! Run with:
 //!   cargo test -p fluree-db-api --test it_staged_view_dict --features shacl
@@ -312,6 +312,8 @@ async fn post_commit_whole_graph_scan_reads_committed_dictionaries() {
         .await
         .expect("batch accepted");
 
+    // Observe this scan only, not the staging pass above.
+    let _ = drain_failures();
     let view = fluree.db(LEDGER).await.expect("db view");
     let q = json!({
         "@context": ctx(),
@@ -339,6 +341,163 @@ async fn post_commit_whole_graph_scan_reads_committed_dictionaries() {
         failures.is_empty(),
         "post-commit scan hit translation failures; first: {}",
         failures.first().map(String::as_str).unwrap_or("")
+    );
+}
+
+/// A staged preview (`GraphDb::from_staged`) is the third binary-lane reader
+/// of uncommitted state: its scans must resolve the transaction's own
+/// subjects through a staged dictionary layer rather than fall back to raw
+/// merging with a WARN per flake per scan.
+#[tokio::test]
+async fn preview_over_staged_transaction_translates_new_subjects() {
+    use fluree_db_api::GraphDb;
+
+    let _serial = serialize().await;
+    install_probe();
+    let (fluree, _dir) = new_fluree().await;
+    const LEDGER: &str = "staged-view-dict/preview:main";
+    let ledger = indexed_ledger(&fluree, LEDGER).await;
+
+    let staged = fluree
+        .stage_owned(ledger)
+        .insert(&person("ex:previewed", Some("Previewed")))
+        .stage()
+        .await
+        .expect("stage");
+    let preview = GraphDb::from_staged(&staged).expect("preview view");
+
+    // Predicate-bound: the scan translates every staged `ex:name` flake (a
+    // subject-bound pattern alone takes the overlay-only seek and never
+    // translates).
+    let _ = drain_failures();
+    let q = json!({
+        "@context": ctx(),
+        "select": ["?s", "?name"],
+        "where": {"@id": "?s", "ex:name": "?name"}
+    });
+    let out = fluree
+        .query(&preview, QueryInput::JsonLd(&q))
+        .await
+        .expect("preview query");
+    let rows = out
+        .to_jsonld(&preview.snapshot)
+        .expect("jsonld")
+        .to_string();
+    assert!(
+        rows.contains("\"ex:previewed\"") && rows.contains("\"Previewed\""),
+        "preview must see the staged subject: {rows}"
+    );
+    let failures = drain_failures();
+    assert!(
+        failures.is_empty(),
+        "{} overlay flake(s) failed V3 translation during the preview scan; first: {}",
+        failures.len(),
+        failures.first().map(String::as_str).unwrap_or("")
+    );
+}
+
+/// The cross-query translation cache must never serve a product built over
+/// uncommitted state for the committed state. A discarded preview's novelty
+/// reports the very epoch and `to_t` the next commit will report, so an
+/// epoch-keyed cache would hand that commit the preview's product: the
+/// preview's values under the committed subject's freshly minted ids.
+///
+/// Integer objects are inline in a translated op (no dictionary), so the
+/// aliased product decodes cleanly to the *wrong* value instead of failing.
+#[tokio::test]
+async fn post_commit_scan_is_never_served_a_discarded_previews_product() {
+    use fluree_db_api::GraphDb;
+
+    let _serial = serialize().await;
+    install_probe();
+    let (fluree, _dir) = new_fluree().await;
+    const LEDGER: &str = "staged-view-dict/discarded-preview:main";
+    let ledger = indexed_ledger(&fluree, LEDGER).await;
+
+    let scan = json!({
+        "@context": ctx(),
+        "select": ["?s", "?p", "?o"],
+        "where": {"@id": "?s", "?p": "?o"}
+    });
+
+    // Preview a transaction with an unbounded scan (a whole-graph product is
+    // built and cached), then discard it.
+    let discarded = json!({
+        "@context": ctx(),
+        "@id": "ex:ghost",
+        "@type": "ex:Person",
+        "ex:name": "Ghost",
+        "ex:age": 1
+    });
+    let staged = fluree
+        .stage_owned(ledger.clone())
+        .insert(&discarded)
+        .stage()
+        .await
+        .expect("stage");
+    let preview = GraphDb::from_staged(&staged).expect("preview view");
+    let out = fluree
+        .query(&preview, QueryInput::JsonLd(&scan))
+        .await
+        .expect("preview scan");
+    let rows = out
+        .to_jsonld(&preview.snapshot)
+        .expect("jsonld")
+        .to_string();
+    assert!(
+        rows.contains("\"Ghost\""),
+        "preview sees its own flakes: {rows}"
+    );
+    drop(preview);
+    drop(staged);
+
+    // Commit a different transaction at the same epoch and t. Indexing is
+    // quiesced so the committed view keeps the preview's snapshot and store,
+    // the state an epoch key cannot tell apart.
+    let committed = json!({
+        "@context": ctx(),
+        "@id": "ex:real",
+        "@type": "ex:Person",
+        "ex:name": "Real",
+        "ex:age": 2
+    });
+    let committed = fluree
+        .insert_with_opts(
+            ledger,
+            &committed,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &quiet_index_cfg(),
+        )
+        .await
+        .expect("commit")
+        .ledger;
+
+    // The same unbounded scan (same index order as the cached product). The
+    // committed subject's and string's ids line up positionally with the
+    // preview's, so an aliased product decodes to the committed subject
+    // carrying the preview's age.
+    let view = GraphDb::from_ledger_state(&committed);
+    let out = fluree
+        .query(&view, QueryInput::JsonLd(&scan))
+        .await
+        .expect("committed whole-graph scan");
+    let rows = out.to_jsonld(&view.snapshot).expect("jsonld");
+    let ages: Vec<Value> = rows
+        .as_array()
+        .expect("rows")
+        .iter()
+        .filter(|row| row[1] == json!("ex:age"))
+        .map(|row| json!([&row[0], &row[2]]))
+        .collect();
+    assert_eq!(
+        ages,
+        vec![json!(["ex:real", 2])],
+        "committed state must read its own flakes, not the discarded preview's"
+    );
+    assert!(
+        !rows.to_string().contains("\"Ghost\""),
+        "whole-graph scan after commit: {rows}"
     );
 }
 

--- a/fluree-db-api/tests/it_staged_view_dict.rs
+++ b/fluree-db-api/tests/it_staged_view_dict.rs
@@ -396,6 +396,92 @@ async fn preview_over_staged_transaction_translates_new_subjects() {
     );
 }
 
+/// The staged extension is a layer over the committed dictionary, not a
+/// copy of it: the cost of covering a transaction's own subjects is
+/// proportional to the staged flakes, however far the indexer trails the
+/// head, and the committed dictionary is never touched.
+#[tokio::test]
+async fn staged_dictionaries_layer_over_the_committed_dictionary() {
+    use fluree_db_api::GraphDb;
+    use fluree_db_query::BinaryRangeProvider;
+    use std::sync::Arc;
+
+    let _serial = serialize().await;
+    install_probe();
+    let (fluree, _dir) = new_fluree().await;
+    const LEDGER: &str = "staged-view-dict/layer:main";
+    let ledger = indexed_ledger(&fluree, LEDGER).await;
+    // One commit past the index, so the committed dictionary holds an entry
+    // the layer must find through its parent.
+    let ledger = fluree
+        .insert_with_opts(
+            ledger,
+            &person("ex:committed", Some("Committed")),
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &quiet_index_cfg(),
+        )
+        .await
+        .expect("commit")
+        .ledger;
+    let canonical = Arc::clone(&ledger.dict_novelty);
+    let committed = ledger
+        .snapshot
+        .encode_iri("http://example.org/ns/committed")
+        .expect("known namespace");
+    let committed_id = canonical
+        .subjects
+        .find_subject(committed.namespace_code, &committed.name)
+        .expect("committed subject is in the canonical dictionary");
+
+    let staged = fluree
+        .stage_owned(ledger.clone())
+        .insert(&person("ex:staged", Some("Staged")))
+        .stage()
+        .await
+        .expect("stage");
+    let preview = GraphDb::from_staged(&staged).expect("preview view");
+    let provider = preview
+        .snapshot
+        .range_provider
+        .as_ref()
+        .expect("preview carries a range provider")
+        .as_any()
+        .downcast_ref::<BinaryRangeProvider>()
+        .expect("binary provider");
+    let layer = provider.dict_novelty();
+
+    let parent = layer.parent().expect("staged dictionary is a layer");
+    assert!(
+        Arc::ptr_eq(parent, &canonical),
+        "the layer shares the committed dictionary rather than copying it"
+    );
+    assert_eq!(
+        layer
+            .subjects
+            .find_subject(committed.namespace_code, &committed.name),
+        Some(committed_id),
+        "committed entries resolve through the parent"
+    );
+    let staged_subject = ledger
+        .snapshot
+        .encode_iri("http://example.org/ns/staged")
+        .expect("known namespace");
+    let staged_id = layer
+        .subjects
+        .find_subject(staged_subject.namespace_code, &staged_subject.name)
+        .expect("the staged subject is minted in the layer");
+    assert_ne!(staged_id, committed_id);
+    assert_eq!(
+        canonical
+            .subjects
+            .find_subject(staged_subject.namespace_code, &staged_subject.name),
+        None,
+        "the committed dictionary is untouched by staging"
+    );
+    assert!(canonical.parent().is_none());
+}
+
 /// The cross-query translation cache must never serve a product built over
 /// uncommitted state for the committed state. A discarded preview's novelty
 /// reports the very epoch and `to_t` the next commit will report, so an

--- a/fluree-db-core/src/dict_novelty.rs
+++ b/fluree-db-core/src/dict_novelty.rs
@@ -315,16 +315,22 @@ impl SubjectDictNovelty {
     /// Query-time overlay translation reverse-looks-up exactly these entries
     /// against the persisted subject dictionary; residency-mode loads
     /// prefetch the reverse-tree leaves they will touch.
-    pub fn iter_entries(&self) -> Box<dyn Iterator<Item = (u16, &str)> + '_> {
-        match self.parent.as_ref() {
-            Some(parent) => Box::new(
-                parent
-                    .subjects
-                    .iter_entries()
-                    .chain(self.inner.iter_entries()),
-            ),
-            None => Box::new(self.inner.iter_entries()),
+    pub fn iter_entries(&self) -> impl Iterator<Item = (u16, &str)> + '_ {
+        self.chain_root_first()
+            .into_iter()
+            .flat_map(|dict| dict.inner.iter_entries())
+    }
+
+    /// This dictionary and its parents, root first.
+    fn chain_root_first(&self) -> Vec<&SubjectDictNovelty> {
+        let mut chain = vec![self];
+        let mut dict = self;
+        while let Some(parent) = dict.parent.as_ref() {
+            dict = &parent.subjects;
+            chain.push(dict);
         }
+        chain.reverse();
+        chain
     }
 }
 
@@ -393,12 +399,17 @@ impl StringDictNovelty {
 
     /// Iterate every novel string value, parents first. Mirror of
     /// [`SubjectDictNovelty::iter_entries`] for the string dictionary.
-    pub fn iter_values(&self) -> Box<dyn Iterator<Item = &str> + '_> {
-        let own = self.inner.iter().map(|(_, s)| s);
-        match self.parent.as_ref() {
-            Some(parent) => Box::new(parent.strings.iter_values().chain(own)),
-            None => Box::new(own),
+    pub fn iter_values(&self) -> impl Iterator<Item = &str> + '_ {
+        let mut chain = vec![self];
+        let mut dict = self;
+        while let Some(parent) = dict.parent.as_ref() {
+            dict = &parent.strings;
+            chain.push(dict);
         }
+        chain.reverse();
+        chain
+            .into_iter()
+            .flat_map(|dict| dict.inner.iter().map(|(_, s)| s))
     }
 
     /// Number of entries in the novelty layer, parents included.

--- a/fluree-db-core/src/dict_novelty.rs
+++ b/fluree-db-core/src/dict_novelty.rs
@@ -13,6 +13,19 @@
 //! 3. **Query** → read-only: `find_subject`, `resolve_subject`, watermark routing.
 //! 4. **Next index build** → discard and recreate with new watermarks.
 //!
+//! # Layers
+//!
+//! A read over uncommitted state (SHACL validation, a post-state policy
+//! condition, a staged preview) needs the committed dictionary plus the
+//! subjects and strings that transaction introduces. [`DictNovelty::layered_over`]
+//! builds that as an empty delta over a shared `Arc` of the committed
+//! dictionary: lookups probe the delta then fall through to the parent, the
+//! delta allocates from the parent's frontier so its ids never collide with
+//! the parent's, and the persisted watermarks are the parent's. Nothing is
+//! copied, whatever the parent's size, and the parent is never mutated. The
+//! layer's ids are view-local: commit re-derives its own from the canonical
+//! dictionary.
+//!
 //! # Key invariants
 //!
 //! - Reverse lookup keys use the same compressed encoding as the persisted
@@ -24,7 +37,9 @@
 //! - `initialized` must be true before any commit on a non-genesis ledger.
 //!   `ensure_initialized()` panics unconditionally (debug and release).
 
-use crate::ns_vec_bi_dict::NsVecBiDict;
+use std::sync::Arc;
+
+use crate::ns_vec_bi_dict::{lookup_key, NsVecBiDict};
 use crate::vec_bi_dict::VecBiDict;
 use crate::{Flake, FlakeValue};
 
@@ -113,13 +128,36 @@ impl DictNovelty {
         Self {
             subjects: SubjectDictNovelty {
                 inner: NsVecBiDict::with_watermarks(trimmed_wm, overflow_wm),
+                parent: None,
             },
             strings: StringDictNovelty {
                 inner: VecBiDict::new(string_wm + 1),
                 watermark: string_wm,
+                parent: None,
             },
             initialized: true,
         }
+    }
+
+    /// An empty delta over `parent` (see the module doc on layers).
+    pub fn layered_over(parent: Arc<DictNovelty>) -> Self {
+        Self {
+            subjects: SubjectDictNovelty {
+                inner: parent.subjects.inner.layer_above(),
+                parent: Some(Arc::clone(&parent)),
+            },
+            strings: StringDictNovelty {
+                inner: VecBiDict::new(parent.strings.inner.next_id()),
+                watermark: parent.strings.watermark,
+                parent: Some(Arc::clone(&parent)),
+            },
+            initialized: parent.initialized,
+        }
+    }
+
+    /// The dictionary this one is layered over, if any.
+    pub fn parent(&self) -> Option<&Arc<DictNovelty>> {
+        self.subjects.parent.as_ref()
     }
 
     /// Returns true if watermarks have been initialized.
@@ -195,56 +233,98 @@ impl Default for DictNovelty {
 /// Subject dictionary novelty: `(ns_code, suffix)` ↔ `sid64`.
 ///
 /// Backed by [`NsVecBiDict`]: Vec-indexed forward lookups (zero hashing),
-/// single-HashMap reverse lookups. Arc-shared string storage.
+/// single-HashMap reverse lookups. Arc-shared string storage. A layered
+/// dictionary (see [`DictNovelty::layered_over`]) probes its own entries
+/// first and falls through to `parent`.
 #[derive(Clone, Debug, Default)]
 pub struct SubjectDictNovelty {
     inner: NsVecBiDict,
+    parent: Option<Arc<DictNovelty>>,
 }
 
 impl SubjectDictNovelty {
     /// Look up or assign a sid64 for `(ns_code, suffix)`.
     ///
-    /// If already present, returns the existing sid64.
+    /// If already present here or in a parent, returns the existing sid64.
     /// Otherwise allocates a new sid64 with the next local_id for this
     /// namespace.
     pub fn assign_or_lookup(&mut self, ns_code: u16, suffix: &str) -> u64 {
-        self.inner.assign_or_lookup(ns_code, suffix)
+        let key = lookup_key(ns_code, suffix);
+        if let Some(id) = self.find_by_key(&key) {
+            return id;
+        }
+        self.inner.insert_new(ns_code, suffix, key)
     }
 
     /// Reverse lookup: find sid64 by `(ns_code, suffix)`.
     pub fn find_subject(&self, ns_code: u16, suffix: &str) -> Option<u64> {
-        self.inner.find_subject(ns_code, suffix)
+        self.find_by_key(&lookup_key(ns_code, suffix))
+    }
+
+    /// Reverse lookup through the layer chain with the key encoded once.
+    fn find_by_key(&self, key: &[u8]) -> Option<u64> {
+        let mut dict = self;
+        loop {
+            if let Some(id) = dict.inner.find_by_key(key) {
+                return Some(id);
+            }
+            dict = &dict.parent.as_ref()?.subjects;
+        }
     }
 
     /// Forward lookup: resolve sid64 → `(ns_code, &suffix)`.
     pub fn resolve_subject(&self, sid64: u64) -> Option<(u16, &str)> {
-        self.inner.resolve_subject(sid64)
+        let mut dict = self;
+        loop {
+            if let Some(hit) = dict.inner.resolve_subject(sid64) {
+                return Some(hit);
+            }
+            dict = &dict.parent.as_ref()?.subjects;
+        }
     }
 
     /// Get the watermark (max persisted local_id) for a namespace code.
     ///
-    /// Returns 0 for unknown/out-of-range namespace codes.
+    /// Returns 0 for unknown/out-of-range namespace codes. A layer answers
+    /// from its root: its own floor is the parent's allocation frontier, not
+    /// a persisted boundary.
     pub fn watermark_for_ns(&self, ns_code: u16) -> u64 {
-        self.inner.watermark_for_ns(ns_code)
+        self.root().inner.watermark_for_ns(ns_code)
     }
 
-    /// Number of entries in the novelty layer.
+    fn root(&self) -> &SubjectDictNovelty {
+        let mut dict = self;
+        while let Some(parent) = dict.parent.as_ref() {
+            dict = &parent.subjects;
+        }
+        dict
+    }
+
+    /// Number of entries in the novelty layer, parents included.
     pub fn len(&self) -> usize {
-        self.inner.len()
+        self.inner.len() + self.parent.as_ref().map_or(0, |p| p.subjects.len())
     }
 
-    /// True if no novel subjects have been registered.
+    /// True if no novel subjects have been registered here or in a parent.
     pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+        self.len() == 0
     }
 
-    /// Iterate every novel `(ns_code, suffix)` entry.
+    /// Iterate every novel `(ns_code, suffix)` entry, parents first.
     ///
     /// Query-time overlay translation reverse-looks-up exactly these entries
     /// against the persisted subject dictionary; residency-mode loads
     /// prefetch the reverse-tree leaves they will touch.
-    pub fn iter_entries(&self) -> impl Iterator<Item = (u16, &str)> {
-        self.inner.iter_entries()
+    pub fn iter_entries(&self) -> Box<dyn Iterator<Item = (u16, &str)> + '_> {
+        match self.parent.as_ref() {
+            Some(parent) => Box::new(
+                parent
+                    .subjects
+                    .iter_entries()
+                    .chain(self.inner.iter_entries()),
+            ),
+            None => Box::new(self.inner.iter_entries()),
+        }
     }
 }
 
@@ -259,8 +339,10 @@ impl SubjectDictNovelty {
 #[derive(Clone, Debug)]
 pub struct StringDictNovelty {
     inner: VecBiDict<u32>,
-    /// Max persisted string_id from the last index build.
+    /// Max persisted string_id from the last index build (a layer copies
+    /// its parent's).
     watermark: u32,
+    parent: Option<Arc<DictNovelty>>,
 }
 
 impl Default for StringDictNovelty {
@@ -268,24 +350,40 @@ impl Default for StringDictNovelty {
         Self {
             inner: VecBiDict::new(1),
             watermark: 0,
+            parent: None,
         }
     }
 }
 
 impl StringDictNovelty {
-    /// Look up or assign a string_id for `value`.
+    /// Look up or assign a string_id for `value`, here or in a parent.
     pub fn assign_or_lookup(&mut self, value: &str) -> u32 {
+        if let Some(id) = self.find_string(value) {
+            return id;
+        }
         self.inner.assign_or_lookup(value)
     }
 
     /// Reverse lookup: find string_id by value.
     pub fn find_string(&self, value: &str) -> Option<u32> {
-        self.inner.find(value)
+        let mut dict = self;
+        loop {
+            if let Some(id) = dict.inner.find(value) {
+                return Some(id);
+            }
+            dict = &dict.parent.as_ref()?.strings;
+        }
     }
 
     /// Forward lookup: resolve string_id → value.
     pub fn resolve_string(&self, id: u32) -> Option<&str> {
-        self.inner.resolve(id)
+        let mut dict = self;
+        loop {
+            if let Some(value) = dict.inner.resolve(id) {
+                return Some(value);
+            }
+            dict = &dict.parent.as_ref()?.strings;
+        }
     }
 
     /// Get the watermark (max persisted string_id).
@@ -293,20 +391,24 @@ impl StringDictNovelty {
         self.watermark
     }
 
-    /// Iterate every novel string value. Mirror of
+    /// Iterate every novel string value, parents first. Mirror of
     /// [`SubjectDictNovelty::iter_entries`] for the string dictionary.
-    pub fn iter_values(&self) -> impl Iterator<Item = &str> {
-        self.inner.iter().map(|(_, s)| s)
+    pub fn iter_values(&self) -> Box<dyn Iterator<Item = &str> + '_> {
+        let own = self.inner.iter().map(|(_, s)| s);
+        match self.parent.as_ref() {
+            Some(parent) => Box::new(parent.strings.iter_values().chain(own)),
+            None => Box::new(own),
+        }
     }
 
-    /// Number of entries in the novelty layer.
+    /// Number of entries in the novelty layer, parents included.
     pub fn len(&self) -> usize {
-        self.inner.len()
+        self.inner.len() + self.parent.as_ref().map_or(0, |p| p.strings.len())
     }
 
-    /// True if no novel strings have been registered.
+    /// True if no novel strings have been registered here or in a parent.
     pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+        self.len() == 0
     }
 }
 
@@ -563,6 +665,138 @@ mod tests {
         assert_eq!(dn.subjects.watermark_for_ns(0), 10);
         assert_eq!(dn.subjects.watermark_for_ns(1), 20);
         assert_eq!(dn.subjects.watermark_for_ns(NS_OVERFLOW), 0); // no overflow wm set
+    }
+
+    // -----------------------------------------------------------------------
+    // Layers
+    // -----------------------------------------------------------------------
+
+    fn committed_parent() -> Arc<DictNovelty> {
+        let mut dn = DictNovelty::with_watermarks(vec![0, 0, 100], 500);
+        dn.subjects.assign_or_lookup(2, "alice"); // 2:101
+        dn.subjects.assign_or_lookup(2, "bob"); // 2:102
+        dn.subjects.assign_or_lookup(NS_OVERFLOW, "http://full/iri"); // ovf:1
+        dn.strings.assign_or_lookup("hello"); // 501
+        Arc::new(dn)
+    }
+
+    #[test]
+    fn layer_copies_nothing_and_falls_through_to_its_parent() {
+        let parent = committed_parent();
+        let layer = DictNovelty::layered_over(Arc::clone(&parent));
+        assert!(Arc::ptr_eq(layer.parent().unwrap(), &parent));
+        // One `Arc` per sub-dictionary; nothing is copied.
+        assert_eq!(Arc::strong_count(&parent), 3);
+        assert!(layer.is_initialized());
+
+        let alice = parent.subjects.find_subject(2, "alice").unwrap();
+        assert_eq!(layer.subjects.find_subject(2, "alice"), Some(alice));
+        assert_eq!(layer.subjects.resolve_subject(alice), Some((2, "alice")));
+        assert_eq!(
+            layer.subjects.find_subject(NS_OVERFLOW, "http://full/iri"),
+            parent.subjects.find_subject(NS_OVERFLOW, "http://full/iri")
+        );
+        assert_eq!(layer.strings.find_string("hello"), Some(501));
+        assert_eq!(layer.strings.resolve_string(501), Some("hello"));
+        assert_eq!(layer.subjects.len(), parent.subjects.len());
+        assert_eq!(layer.strings.len(), parent.strings.len());
+        assert!(!layer.subjects.is_empty());
+    }
+
+    #[test]
+    fn layer_allocates_above_the_parent_and_never_re_mints_a_parent_entry() {
+        let parent = committed_parent();
+        let mut layer = DictNovelty::layered_over(Arc::clone(&parent));
+
+        // Known to the parent: same id, nothing minted.
+        let alice = parent.subjects.find_subject(2, "alice").unwrap();
+        assert_eq!(layer.subjects.assign_or_lookup(2, "alice"), alice);
+        assert_eq!(layer.strings.assign_or_lookup("hello"), 501);
+
+        // Novel: allocated from the parent's frontier.
+        let carol = layer.subjects.assign_or_lookup(2, "carol");
+        assert_eq!(SubjectId::from_u64(carol).local_id(), 103);
+        let ovf = layer
+            .subjects
+            .assign_or_lookup(NS_OVERFLOW, "http://other/iri");
+        assert_eq!(SubjectId::from_u64(ovf).local_id(), 2);
+        assert_eq!(layer.strings.assign_or_lookup("world"), 502);
+
+        // Resolvable through the layer, absent from the parent.
+        assert_eq!(layer.subjects.resolve_subject(carol), Some((2, "carol")));
+        assert_eq!(layer.strings.resolve_string(502), Some("world"));
+        assert_eq!(parent.subjects.find_subject(2, "carol"), None);
+        assert_eq!(parent.subjects.resolve_subject(carol), None);
+        assert_eq!(parent.strings.find_string("world"), None);
+        assert_eq!(parent.subjects.len(), 3);
+        assert_eq!(parent.strings.len(), 1);
+        assert_eq!(layer.subjects.len(), 5);
+        assert_eq!(layer.strings.len(), 2);
+    }
+
+    #[test]
+    fn layer_reports_persisted_watermarks_not_the_parent_frontier() {
+        let parent = committed_parent();
+        let mut layer = DictNovelty::layered_over(Arc::clone(&parent));
+        let carol = layer.subjects.assign_or_lookup(2, "carol");
+
+        // Persisted boundary, unchanged by either dictionary's allocations.
+        assert_eq!(layer.subjects.watermark_for_ns(2), 100);
+        assert_eq!(layer.subjects.watermark_for_ns(NS_OVERFLOW), 0);
+        assert_eq!(layer.strings.watermark(), 500);
+        // Everything above it, in either layer, classifies as novel.
+        assert!(SubjectId::from_u64(carol).local_id() > layer.subjects.watermark_for_ns(2));
+        let alice = parent.subjects.find_subject(2, "alice").unwrap();
+        assert!(SubjectId::from_u64(alice).local_id() > layer.subjects.watermark_for_ns(2));
+    }
+
+    #[test]
+    fn sibling_layers_allocate_independently_and_do_not_see_each_other() {
+        let parent = committed_parent();
+        let mut a = DictNovelty::layered_over(Arc::clone(&parent));
+        let mut b = DictNovelty::layered_over(Arc::clone(&parent));
+
+        let a_id = a.subjects.assign_or_lookup(2, "from-a");
+        let b_id = b.subjects.assign_or_lookup(2, "from-b");
+        assert_eq!(
+            a_id, b_id,
+            "view-local ids may coincide; they never reach a committed state"
+        );
+        assert_eq!(a.subjects.resolve_subject(a_id), Some((2, "from-a")));
+        assert_eq!(b.subjects.resolve_subject(b_id), Some((2, "from-b")));
+        assert_eq!(a.subjects.find_subject(2, "from-b"), None);
+        assert_eq!(b.subjects.find_subject(2, "from-a"), None);
+
+        // Dropping a layer (an aborted staging) leaves the parent as it was.
+        drop(a);
+        assert_eq!(
+            Arc::strong_count(&parent),
+            3,
+            "only b's two references remain"
+        );
+        assert_eq!(parent.subjects.len(), 3);
+        assert_eq!(parent.subjects.find_subject(2, "from-a"), None);
+    }
+
+    #[test]
+    fn layer_iteration_covers_parent_then_own_entries() {
+        let parent = committed_parent();
+        let mut layer = DictNovelty::layered_over(Arc::clone(&parent));
+        layer.subjects.assign_or_lookup(3, "new");
+        layer.strings.assign_or_lookup("world");
+
+        let subjects: Vec<(u16, &str)> = layer.subjects.iter_entries().collect();
+        assert_eq!(
+            subjects,
+            vec![
+                (2, "alice"),
+                (2, "bob"),
+                (NS_OVERFLOW, "http://full/iri"),
+                (3, "new")
+            ]
+        );
+        let strings: Vec<&str> = layer.strings.iter_values().collect();
+        assert_eq!(strings, vec!["hello", "world"]);
     }
 
     // -----------------------------------------------------------------------

--- a/fluree-db-core/src/ns_vec_bi_dict.rs
+++ b/fluree-db-core/src/ns_vec_bi_dict.rs
@@ -114,10 +114,23 @@ impl NsVecBiDict {
     /// namespace and inserts into both forward and reverse structures.
     pub fn assign_or_lookup(&mut self, ns_code: u16, suffix: &str) -> u64 {
         let key = lookup_key(ns_code, suffix);
-        if let Some(&id) = self.reverse.get(key.as_slice()) {
+        if let Some(id) = self.find_by_key(&key) {
             return id;
         }
+        self.insert_new(ns_code, suffix, key)
+    }
 
+    /// Reverse lookup by an already-encoded key (see [`lookup_key`]), so a
+    /// caller probing several dictionaries encodes the suffix once.
+    #[inline]
+    pub fn find_by_key(&self, key: &[u8]) -> Option<u64> {
+        self.reverse.get(key).copied()
+    }
+
+    /// Allocate the next local_id for `ns_code` and insert `(key, suffix)`.
+    /// The caller has established the key is absent (see [`Self::find_by_key`]).
+    pub fn insert_new(&mut self, ns_code: u16, suffix: &str, key: Vec<u8>) -> u64 {
+        debug_assert!(self.find_by_key(&key).is_none());
         let local_id = if ns_code == NS_OVERFLOW {
             if self.overflow_next_local_id <= self.overflow_watermark {
                 self.overflow_next_local_id = self.overflow_watermark + 1;
@@ -169,8 +182,53 @@ impl NsVecBiDict {
 
     /// Reverse lookup: find sid64 by `(ns_code, suffix)`.
     pub fn find_subject(&self, ns_code: u16, suffix: &str) -> Option<u64> {
-        let key = lookup_key(ns_code, suffix);
-        self.reverse.get(key.as_slice()).copied()
+        self.find_by_key(&lookup_key(ns_code, suffix))
+    }
+
+    /// The local_id the next allocation in `ns_code` would take, following
+    /// the same rules as [`Self::assign_or_lookup`].
+    fn next_local_id(&self, ns_code: u16) -> u64 {
+        if ns_code == NS_OVERFLOW {
+            return self.overflow_next_local_id.max(self.overflow_watermark + 1);
+        }
+        let ns_idx = ns_code as usize;
+        let mut wm = self.watermarks.get(ns_idx).copied().unwrap_or(0);
+        if wm == 0 && self.local_base > 1 {
+            wm = self.local_base - 1;
+        }
+        let mut next = self
+            .next_local_ids
+            .get(ns_idx)
+            .copied()
+            .unwrap_or(self.local_base);
+        if next == 0 && self.local_base > 1 {
+            next = self.local_base;
+        }
+        next.max(wm + 1)
+    }
+
+    /// An empty dictionary whose allocation starts where this one's ends:
+    /// every namespace's first new local_id is `self.next_local_id(ns)`, so
+    /// ids minted in the layer never collide with ids this dictionary holds
+    /// or would mint next. The layer's internal per-namespace floor is this
+    /// dictionary's allocation frontier, not the persisted watermark; a
+    /// layered [`crate::DictNovelty`] reports the persisted watermark from
+    /// its parent.
+    pub fn layer_above(&self) -> Self {
+        let n = self.watermarks.len().max(self.next_local_ids.len());
+        let watermarks: Vec<u64> = (0..n).map(|ns| self.next_local_id(ns as u16) - 1).collect();
+        let next_local_ids: Vec<u64> = watermarks.iter().map(|&wm| wm + 1).collect();
+        let overflow_watermark = self.next_local_id(NS_OVERFLOW) - 1;
+        Self {
+            entries: vec![Vec::new(); n],
+            reverse: HashMap::new(),
+            local_base: self.local_base,
+            watermarks,
+            next_local_ids,
+            overflow_watermark,
+            overflow_next_local_id: overflow_watermark + 1,
+            overflow_entries: Vec::new(),
+        }
     }
 
     /// Forward lookup: resolve sid64 → `(ns_code, &suffix)`.
@@ -249,7 +307,7 @@ impl Default for NsVecBiDict {
 
 /// Build a lookup key as `Vec<u8>`: `[ns_code BE 2 bytes][suffix UTF-8 bytes]`.
 #[inline]
-fn lookup_key(ns_code: u16, suffix: &str) -> Vec<u8> {
+pub fn lookup_key(ns_code: u16, suffix: &str) -> Vec<u8> {
     let mut key = Vec::with_capacity(2 + suffix.len());
     key.extend_from_slice(&ns_code.to_be_bytes());
     key.extend_from_slice(suffix.as_bytes());
@@ -372,6 +430,40 @@ mod tests {
         assert_eq!(d.watermark_for_ns(2), 30);
         assert_eq!(d.watermark_for_ns(3), 0); // out of range
         assert_eq!(d.watermark_for_ns(NS_OVERFLOW), 50);
+    }
+
+    #[test]
+    fn layer_above_allocates_past_the_parent_frontier() {
+        let mut parent = NsVecBiDict::with_watermarks(vec![0, 0, 100], 7);
+        let a = parent.assign_or_lookup(2, "a"); // 101
+        let b = parent.assign_or_lookup(2, "b"); // 102
+        let o = parent.assign_or_lookup(NS_OVERFLOW, "http://x/full"); // 8
+        let fresh_ns = parent.assign_or_lookup(9, "z"); // ns 9, local 1
+
+        let mut layer = parent.layer_above();
+        assert!(layer.is_empty());
+        let c = layer.assign_or_lookup(2, "c");
+        assert_eq!(SubjectId::from_u64(c).local_id(), 103);
+        let o2 = layer.assign_or_lookup(NS_OVERFLOW, "http://y/full");
+        assert_eq!(SubjectId::from_u64(o2).local_id(), 9);
+        let z2 = layer.assign_or_lookup(9, "z2");
+        assert_eq!(SubjectId::from_u64(z2).local_id(), 2);
+        // A namespace the parent never touched starts at 1.
+        let n = layer.assign_or_lookup(12, "n");
+        assert_eq!(SubjectId::from_u64(n).local_id(), 1);
+
+        // The layer holds only its own ids; parent ids resolve to None here.
+        for id in [a, b, o, fresh_ns] {
+            assert!(layer.resolve_subject(id).is_none());
+        }
+        assert_eq!(layer.resolve_subject(c), Some((2, "c")));
+        assert_eq!(
+            layer.resolve_subject(o2),
+            Some((NS_OVERFLOW, "http://y/full"))
+        );
+        // The parent is untouched.
+        assert_eq!(parent.len(), 4);
+        assert_eq!(parent.find_subject(2, "c"), None);
     }
 
     #[test]

--- a/fluree-db-core/src/overlay.rs
+++ b/fluree-db-core/src/overlay.rs
@@ -62,6 +62,21 @@ pub struct OverlaySegmentMeta {
 /// without core depending on novelty types.
 ///
 /// Uses a push-based API to avoid `Box<dyn Iterator>` allocations in hot path.
+/// Process-wide counter behind [`next_overlay_content_version`]. Starts at 1
+/// so `0` can mean "empty since construction" for overlays that want it.
+static NEXT_CONTENT_VERSION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+/// Allocate a process-unique [`OverlayProvider::content_version`] stamp.
+///
+/// Every overlay type that reports a content version draws from this one
+/// counter, which is what makes the version unique across overlay *types* —
+/// a staged view and the committed novelty it will become must never share
+/// one, or a cache keyed on it would serve the staged product for the
+/// committed state.
+pub fn next_overlay_content_version() -> u64 {
+    NEXT_CONTENT_VERSION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
 pub trait OverlayProvider: Send + Sync {
     fn as_any(&self) -> &dyn Any;
 

--- a/fluree-db-core/src/overlay.rs
+++ b/fluree-db-core/src/overlay.rs
@@ -38,6 +38,7 @@ use crate::comparator::IndexType;
 use crate::flake::Flake;
 use crate::ids::GraphId;
 use std::any::Any;
+use std::collections::HashMap;
 
 /// Identity + transaction-time span of one overlay segment.
 ///
@@ -56,12 +57,6 @@ pub struct OverlaySegmentMeta {
     pub max_t: i64,
 }
 
-/// Overlay provider trait for external flake sources
-///
-/// Allows external crates to inject extra flakes at leaf resolution time
-/// without core depending on novelty types.
-///
-/// Uses a push-based API to avoid `Box<dyn Iterator>` allocations in hot path.
 /// Process-wide counter behind [`next_overlay_content_version`]. Starts at 1
 /// so `0` can mean "empty since construction" for overlays that want it.
 static NEXT_CONTENT_VERSION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
@@ -77,6 +72,43 @@ pub fn next_overlay_content_version() -> u64 {
     NEXT_CONTENT_VERSION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
+/// Remembered compositions, at most this many. Past the cap the table is
+/// dropped wholesale: a composition seen again afterwards draws a fresh stamp,
+/// which can only miss a cache, never alias one.
+const COMPOSED_VERSIONS_CAP: usize = 4096;
+
+static COMPOSED_VERSIONS: once_cell::sync::Lazy<parking_lot::Mutex<HashMap<Box<[u64]>, u64>>> =
+    once_cell::sync::Lazy::new(|| parking_lot::Mutex::new(HashMap::new()));
+
+/// The [`OverlayProvider::content_version`] of an overlay whose output is a
+/// function of its parts' versions — a reasoning overlay over a novelty, a
+/// schema bundle over a novelty, a dataset composite over several.
+///
+/// Two u64 stamps cannot be packed into one injectively, so compositions are
+/// interned: the same ordered `parts` always map to the same stamp, and every
+/// stamp comes from [`next_overlay_content_version`], so a composition can
+/// never collide with a leaf overlay's version or with a different
+/// composition. Ordered, because the same parts in another order describe a
+/// different overlay type's output.
+pub fn compose_content_version(parts: &[u64]) -> u64 {
+    let mut table = COMPOSED_VERSIONS.lock();
+    if let Some(&version) = table.get(parts) {
+        return version;
+    }
+    if table.len() >= COMPOSED_VERSIONS_CAP {
+        table.clear();
+    }
+    let version = next_overlay_content_version();
+    table.insert(parts.into(), version);
+    version
+}
+
+/// Overlay provider trait for external flake sources
+///
+/// Allows external crates to inject extra flakes at leaf resolution time
+/// without core depending on novelty types.
+///
+/// Uses a push-based API to avoid `Box<dyn Iterator>` allocations in hot path.
 pub trait OverlayProvider: Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
@@ -219,6 +251,12 @@ impl OverlayProvider for NoOverlay {
         true
     }
 
+    /// `0` is the stamp every never-mutated novelty reports; sharing it is
+    /// allowed because both outputs are empty.
+    fn content_version(&self) -> Option<u64> {
+        Some(0)
+    }
+
     fn for_each_overlay_flake(
         &self,
         _g_id: GraphId,
@@ -290,9 +328,30 @@ mod tests {
     }
 
     #[test]
+    fn composed_content_version_is_stable_ordered_and_never_a_leaf_stamp() {
+        let a = next_overlay_content_version();
+        let b = next_overlay_content_version();
+
+        let ab = compose_content_version(&[a, b]);
+        assert_eq!(
+            ab,
+            compose_content_version(&[a, b]),
+            "same parts, same stamp"
+        );
+        assert_ne!(ab, compose_content_version(&[b, a]), "order is identity");
+        assert_ne!(ab, compose_content_version(&[a, b, b]), "arity is identity");
+        assert!(ab != a && ab != b, "a composition is not one of its parts");
+
+        // Leaf stamps drawn before and after can never equal the composition.
+        let c = next_overlay_content_version();
+        assert!(ab != c && ab < c);
+    }
+
+    #[test]
     fn test_no_overlay() {
         let overlay = NoOverlay;
         assert_eq!(overlay.epoch(), 0);
+        assert_eq!(overlay.content_version(), Some(0));
 
         let mut count = 0;
         overlay.for_each_overlay_flake(0, IndexType::Spot, None, None, true, 100, &mut |_| {

--- a/fluree-db-core/src/vec_bi_dict.rs
+++ b/fluree-db-core/src/vec_bi_dict.rs
@@ -180,6 +180,12 @@ impl<Id: DictId> VecBiDict<Id> {
         self.base_id
     }
 
+    /// The ID the next allocation would take.
+    #[inline]
+    pub fn next_id(&self) -> Id {
+        self.next_id
+    }
+
     /// Number of entries.
     #[inline]
     pub fn len(&self) -> usize {

--- a/fluree-db-ledger/src/staged.rs
+++ b/fluree-db-ledger/src/staged.rs
@@ -179,6 +179,19 @@ pub struct StagedLedger {
     staged: StagedOverlay,
     /// Unique epoch for cache keys (different from base novelty)
     staged_epoch: u64,
+    /// Process-unique content stamp (see [`OverlayProvider::content_version`]).
+    ///
+    /// `staged_epoch` is only unique within the base novelty's lineage: it is
+    /// exactly the epoch the novelty reports once these flakes commit, at the
+    /// same `to_t`. Any cross-query cache keyed on the epoch would therefore
+    /// serve this view's translation for the committed state.
+    content_version: u64,
+    /// Whether the base snapshot's range provider has been given dictionaries
+    /// that cover the staged flakes (see `attach_staged_dicts` in
+    /// `fluree-db-transact`). Off by default: the base provider's
+    /// dictionaries know nothing of subjects and strings this transaction is
+    /// introducing.
+    dicts_cover_staged: bool,
 }
 
 impl StagedLedger {
@@ -198,8 +211,22 @@ impl StagedLedger {
         Ok(Self {
             staged: StagedOverlay::from_flakes(flakes, reverse_graph)?,
             staged_epoch,
+            content_version: fluree_db_core::overlay::next_overlay_content_version(),
+            dicts_cover_staged: false,
             base,
         })
+    }
+
+    /// Whether the base snapshot's range provider dictionaries cover the
+    /// staged flakes' novel subjects and strings.
+    pub fn dicts_cover_staged(&self) -> bool {
+        self.dicts_cover_staged
+    }
+
+    /// Record that a provider whose dictionaries cover the staged flakes has
+    /// been attached to the base snapshot.
+    pub fn set_dicts_cover_staged(&mut self) {
+        self.dicts_cover_staged = true;
     }
 
     /// Get the base ledger state
@@ -283,6 +310,10 @@ impl OverlayProvider for StagedLedger {
         self.staged_epoch
     }
 
+    fn content_version(&self) -> Option<u64> {
+        Some(self.content_version)
+    }
+
     fn for_each_overlay_flake(
         &self,
         g_id: GraphId,
@@ -362,6 +393,43 @@ mod tests {
             true,
             None,
         )
+    }
+
+    /// A staged view reports the epoch its flakes will carry once committed,
+    /// so only `content_version` can tell the two apart in a cache key.
+    #[test]
+    fn content_version_is_unique_per_view_and_distinct_from_base() {
+        use fluree_db_core::LedgerSnapshot;
+
+        let mut novelty = Novelty::new(0);
+        novelty
+            .apply_commit(vec![make_flake(1, 1, 100, 1)], 1, &HashMap::new())
+            .unwrap();
+        let base_version = OverlayProvider::content_version(&novelty).expect("novelty vouches");
+        let base_epoch = novelty.epoch;
+        let state = LedgerState::new(LedgerSnapshot::genesis("test:main"), novelty);
+
+        let a = StagedLedger::new(
+            state.clone(),
+            vec![make_flake(2, 1, 200, 2)],
+            &HashMap::new(),
+        )
+        .unwrap();
+        let b = StagedLedger::new(state, vec![make_flake(2, 1, 200, 2)], &HashMap::new()).unwrap();
+
+        assert_eq!(
+            a.epoch(),
+            base_epoch + 1,
+            "staged epoch is the post-commit epoch"
+        );
+        let va = OverlayProvider::content_version(&a).expect("staged view vouches");
+        let vb = OverlayProvider::content_version(&b).expect("staged view vouches");
+        assert_ne!(va, base_version);
+        assert_ne!(
+            va, vb,
+            "identical staged content on the same base is still a distinct stamp"
+        );
+        assert!(!a.dicts_cover_staged());
     }
 
     #[test]

--- a/fluree-db-novelty/src/lib.rs
+++ b/fluree-db-novelty/src/lib.rs
@@ -524,10 +524,6 @@ pub struct Novelty {
     fact_state: NoveltyFactState,
 }
 
-/// Process-wide counter backing [`Novelty::content_version`]. Starts at 1 so
-/// `0` uniquely means "empty since construction".
-static NEXT_CONTENT_VERSION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
-
 #[inline]
 fn flake_has_list_meta(flake: &Flake) -> bool {
     flake.m.as_ref().is_some_and(|m| m.i.is_some())
@@ -570,8 +566,9 @@ impl Novelty {
     /// the content version keys cross-instance caches (see
     /// [`OverlayProvider::content_version`]).
     fn refresh_content_version(&mut self) {
-        self.content_version =
-            NEXT_CONTENT_VERSION.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // Drawn from the process-wide allocator shared by every overlay type
+        // (see `next_overlay_content_version`); `0` = empty since construction.
+        self.content_version = fluree_db_core::overlay::next_overlay_content_version();
     }
 
     /// Append a freshly built segment to a graph, growing the graphs vec.

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -2418,10 +2418,18 @@ impl Operator for BinaryScanOperator {
             // Single source of truth for the cross-query key, shared by the
             // warm probe and the build path below so the two can never
             // disagree on a key dimension.
-            let make_global_key = || GlobalTranslationKey {
+            // The cross-query layer is keyed on the overlay's process-unique
+            // content version, never its epoch: a `StagedLedger` reports the
+            // very epoch and `to_t` the committed novelty reports right after
+            // its flakes commit, so an epoch key would serve the staged
+            // translation (ids from a view-local dictionary) for the
+            // committed state. An overlay that cannot vouch for a content
+            // version is not cached across queries at all.
+            let content_version = ctx.overlay().content_version();
+            let make_global_key = |content_version: u64| GlobalTranslationKey {
                 ledger_id: ctx.active_snapshot.ledger_id.as_str().into(),
                 snapshot_t: ctx.active_snapshot.t,
-                overlay_epoch: epoch,
+                content_version,
                 store_id: store_arc.store_id(),
                 to_t: ctx.to_t,
                 g_id: self.g_id,
@@ -2440,7 +2448,7 @@ impl Operator for BinaryScanOperator {
                         return Some(Arc::clone(hit));
                     }
                 }
-                let hit = global_translation_cache().get(&make_global_key())?;
+                let hit = global_translation_cache().get(&make_global_key(content_version?))?;
                 translate_span.record("cache_hit", true);
                 ctx.translated_overlay_cache
                     .lock()
@@ -2469,7 +2477,7 @@ impl Operator for BinaryScanOperator {
                 // materializations) cost O(overlay × dict lookups) to
                 // translate, which would otherwise put a flat multi-second
                 // floor under every query at scale.
-                let global_key = make_global_key();
+                let global_key = content_version.map(make_global_key);
                 // Segment-aware path (raw Novelty): assemble from
                 // per-segment caches so a write burst re-translates only
                 // new segments. Falls back to the whole-graph translate
@@ -2503,7 +2511,9 @@ impl Operator for BinaryScanOperator {
                     untranslated,
                     ephemeral_preds,
                 });
-                global_translation_cache().insert(global_key, Arc::clone(&entry));
+                if let Some(global_key) = global_key {
+                    global_translation_cache().insert(global_key, Arc::clone(&entry));
+                }
                 ctx.translated_overlay_cache
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -2876,8 +2886,11 @@ pub type EphemeralPredicateMap = HashMap<Sid, u32>;
 /// Identity of an overlay translation across query executions.
 ///
 /// Every component that can change the translated product is included:
-/// commits bump the overlay epoch (covering novelty contents, dict novelty,
-/// and runtime small dicts), snapshot/store swaps change `snapshot_t` /
+/// `content_version` is the overlay's process-unique content stamp (see
+/// [`fluree_db_core::OverlayProvider::content_version`] — it moves on every
+/// commit, covering novelty contents, dict novelty, and runtime small dicts,
+/// and it is what separates a staged view from the committed novelty it
+/// becomes, which share an epoch), snapshot/store swaps change `snapshot_t` /
 /// `store_id`, and `to_t` bounds which overlay flakes are visible.
 ///
 /// `store_id` (process-unique per store instance) is used instead of
@@ -2889,7 +2902,7 @@ pub type EphemeralPredicateMap = HashMap<Sid, u32>;
 pub struct GlobalTranslationKey {
     pub ledger_id: Arc<str>,
     pub snapshot_t: i64,
-    pub overlay_epoch: u64,
+    pub content_version: u64,
     pub store_id: u64,
     pub to_t: i64,
     pub g_id: GraphId,

--- a/fluree-db-query/src/datalog_rules.rs
+++ b/fluree-db-query/src/datalog_rules.rs
@@ -1974,6 +1974,10 @@ impl OverlayProvider for OverlayRef<'_> {
         self.0.epoch()
     }
 
+    fn content_version(&self) -> Option<u64> {
+        self.0.content_version()
+    }
+
     fn overlay_flake_count(&self, g_id: fluree_db_core::GraphId) -> Option<usize> {
         self.0.overlay_flake_count(g_id)
     }

--- a/fluree-db-query/src/policy/executor.rs
+++ b/fluree-db-query/src/policy/executor.rs
@@ -38,6 +38,12 @@ pub struct QueryPolicyExecutor<'a> {
     pub post_overlay: Option<&'a dyn OverlayProvider>,
     /// Target transaction time for the post-state overlay (the staged t)
     pub post_to_t: i64,
+    /// Snapshot to pair with `post_overlay`. A staged view can carry a range
+    /// provider whose dictionaries cover the staged flakes; post-state
+    /// conditions must read through it, or the binary lane cannot translate
+    /// the very subjects the transaction is introducing. Falls back to
+    /// `snapshot` when absent.
+    pub post_snapshot: Option<&'a LedgerSnapshot>,
 }
 
 impl<'a> QueryPolicyExecutor<'a> {
@@ -50,6 +56,7 @@ impl<'a> QueryPolicyExecutor<'a> {
             g_id: 0,
             post_overlay: None,
             post_to_t: snapshot.t,
+            post_snapshot: None,
         }
     }
 
@@ -66,6 +73,7 @@ impl<'a> QueryPolicyExecutor<'a> {
             g_id: 0,
             post_overlay: None,
             post_to_t: to_t,
+            post_snapshot: None,
         }
     }
 
@@ -82,6 +90,14 @@ impl<'a> QueryPolicyExecutor<'a> {
     pub fn with_post_state(mut self, overlay: &'a dyn OverlayProvider, to_t: i64) -> Self {
         self.post_overlay = Some(overlay);
         self.post_to_t = to_t;
+        self
+    }
+
+    /// Pair the post-state overlay with the snapshot it should be read
+    /// through (the staged view's, once its dictionaries cover the staged
+    /// flakes).
+    pub fn with_post_state_snapshot(mut self, snapshot: &'a LedgerSnapshot) -> Self {
+        self.post_snapshot = Some(snapshot);
         self
     }
 }
@@ -510,21 +526,25 @@ impl QueryPolicyExecutor<'_> {
         // Per-condition state selection: `f:postState` reads through the
         // staged overlay when one is attached; otherwise (read paths, no
         // transaction in flight) pre and post coincide with current state.
-        let (overlay, to_t) = match state {
+        let (snapshot, overlay, to_t) = match state {
             ConditionState::Post => match self.post_overlay {
-                Some(post) => (Some(post), self.post_to_t),
-                None => (self.overlay, self.to_t),
+                Some(post) => (
+                    self.post_snapshot.unwrap_or(self.snapshot),
+                    Some(post),
+                    self.post_to_t,
+                ),
+                None => (self.snapshot, self.overlay, self.to_t),
             },
-            ConditionState::Pre => (self.overlay, self.to_t),
+            ConditionState::Pre => (self.snapshot, self.overlay, self.to_t),
         };
 
         // Create the execution context WITHOUT policy (root context)
         // This is critical - policy queries must not be filtered by policy
         let ctx = if let Some(overlay) = overlay {
-            ExecutionContext::with_time_and_overlay(self.snapshot, vars, to_t, None, overlay)
+            ExecutionContext::with_time_and_overlay(snapshot, vars, to_t, None, overlay)
                 .with_graph_id(self.g_id)
         } else {
-            ExecutionContext::with_time(self.snapshot, vars, to_t, None).with_graph_id(self.g_id)
+            ExecutionContext::with_time(snapshot, vars, to_t, None).with_graph_id(self.g_id)
         };
 
         // Build the where clause operators (VALUES is now part of the patterns).

--- a/fluree-db-query/src/reasoning.rs
+++ b/fluree-db-query/src/reasoning.rs
@@ -3,6 +3,7 @@
 //! This module provides helpers for integrating OWL2-RL materialization
 //! with query execution, including overlay composition for derived facts.
 
+use fluree_db_core::overlay::compose_content_version;
 use fluree_db_core::{Flake, GraphId, IndexType, OverlayProvider};
 use fluree_db_reasoner::{DerivedFactsOverlay, ReasoningCache};
 use std::sync::Arc;
@@ -18,11 +19,18 @@ pub struct ReasoningOverlay<'a> {
     derived: Arc<DerivedFactsOverlay>,
     /// Combined epoch for cache invalidation
     epoch: u64,
+    /// Composed content version (see [`compose_content_version`]); `None`
+    /// when the base cannot vouch for its own.
+    content_version: Option<u64>,
 }
 
 impl<'a> ReasoningOverlay<'a> {
     /// Create a new reasoning overlay combining base and derived facts.
     pub fn new(base: &'a dyn OverlayProvider, derived: Arc<DerivedFactsOverlay>) -> Self {
+        let content_version = match (base.content_version(), derived.content_version()) {
+            (Some(b), Some(d)) => Some(compose_content_version(&[b, d])),
+            _ => None,
+        };
         // Combine the base epoch with the materialization's process-unique
         // instance id, and tag the high bit so the combined value can never
         // collide with a plain novelty epoch (a small counter). The derived
@@ -40,6 +48,7 @@ impl<'a> ReasoningOverlay<'a> {
             base,
             derived,
             epoch,
+            content_version,
         }
     }
 
@@ -56,6 +65,10 @@ impl OverlayProvider for ReasoningOverlay<'_> {
 
     fn epoch(&self) -> u64 {
         self.epoch
+    }
+
+    fn content_version(&self) -> Option<u64> {
+        self.content_version
     }
 
     fn for_each_overlay_flake(
@@ -148,6 +161,68 @@ mod tests {
 
         // Epoch should be deterministic and non-zero
         assert_ne!(combined.epoch(), 0);
+    }
+
+    /// A base that vouches for a version, or one that cannot.
+    struct Stamped(Option<u64>);
+
+    impl OverlayProvider for Stamped {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn epoch(&self) -> u64 {
+            0
+        }
+        fn content_version(&self) -> Option<u64> {
+            self.0
+        }
+        fn for_each_overlay_flake(
+            &self,
+            _: GraphId,
+            _: IndexType,
+            _: Option<&Flake>,
+            _: Option<&Flake>,
+            _: bool,
+            _: i64,
+            _: &mut dyn FnMut(&Flake),
+        ) {
+        }
+    }
+
+    /// The cross-query translation cache is keyed on this: the same
+    /// (base, materialization) pair must report one stable version across
+    /// constructions, and any change to either part must move it.
+    #[test]
+    fn content_version_is_stable_per_pair_and_moves_with_either_part() {
+        let base = Stamped(Some(fluree_db_core::overlay::next_overlay_content_version()));
+        let derived = Arc::new(DerivedFactsOverlay::empty());
+
+        let first = ReasoningOverlay::new(&base, derived.clone())
+            .content_version()
+            .expect("vouching base + derived vouch");
+        let again = ReasoningOverlay::new(&base, derived.clone()).content_version();
+        assert_eq!(Some(first), again, "same pair, same version");
+
+        let other_derived = Arc::new(DerivedFactsOverlay::empty());
+        assert_ne!(
+            ReasoningOverlay::new(&base, other_derived).content_version(),
+            Some(first),
+            "a different materialization is a different version"
+        );
+
+        let other_base = Stamped(Some(fluree_db_core::overlay::next_overlay_content_version()));
+        assert_ne!(
+            ReasoningOverlay::new(&other_base, derived.clone()).content_version(),
+            Some(first),
+            "a different base is a different version"
+        );
+
+        let silent = Stamped(None);
+        assert_eq!(
+            ReasoningOverlay::new(&silent, derived).content_version(),
+            None,
+            "a base that cannot vouch leaves the composite unvouched"
+        );
     }
 
     #[test]

--- a/fluree-db-query/src/schema_bundle.rs
+++ b/fluree-db-query/src/schema_bundle.rs
@@ -44,7 +44,9 @@ use std::sync::Arc;
 use fluree_db_core::comparator::IndexType;
 use fluree_db_core::flake::Flake;
 use fluree_db_core::ids::GraphId;
-use fluree_db_core::overlay::OverlayProvider;
+use fluree_db_core::overlay::{
+    compose_content_version, next_overlay_content_version, OverlayProvider,
+};
 use fluree_db_core::range::range_with_overlay;
 use fluree_db_core::value::FlakeValue;
 use fluree_db_core::{
@@ -66,6 +68,11 @@ pub struct SchemaBundleFlakes {
     opst: Arc<[Flake]>,
     /// Stable identifier for cache composition with other overlays.
     epoch: u64,
+    /// Process-unique stamp drawn at construction (shared by clones); the
+    /// bundle is immutable, so it is also its
+    /// [`OverlayProvider::content_version`]. `epoch` is derived from the
+    /// flake count and cannot separate two bundles of the same size.
+    content_version: u64,
 }
 
 impl SchemaBundleFlakes {
@@ -77,6 +84,7 @@ impl SchemaBundleFlakes {
             post: Arc::from([]),
             opst: Arc::from([]),
             epoch: 0,
+            content_version: next_overlay_content_version(),
         }
     }
 
@@ -125,6 +133,7 @@ impl SchemaBundleFlakes {
             post: post.into(),
             opst: opst.into(),
             epoch,
+            content_version: next_overlay_content_version(),
         })
     }
 
@@ -141,6 +150,11 @@ impl SchemaBundleFlakes {
     /// Epoch value used for `OverlayProvider::epoch` composition.
     pub fn epoch(&self) -> u64 {
         self.epoch
+    }
+
+    /// Process-unique content stamp (see the field doc).
+    pub fn content_version(&self) -> u64 {
+        self.content_version
     }
 
     /// Return the projected flakes as a flat `Vec`, suitable for
@@ -334,6 +348,7 @@ where
         post: post.into(),
         opst: opst.into(),
         epoch,
+        content_version: next_overlay_content_version(),
     })
 }
 
@@ -345,6 +360,9 @@ pub struct SchemaBundleOverlay<'a> {
     base: &'a dyn OverlayProvider,
     bundle: Arc<SchemaBundleFlakes>,
     epoch: u64,
+    /// Composed content version (see [`compose_content_version`]); `None`
+    /// when the base cannot vouch for its own.
+    content_version: Option<u64>,
 }
 
 impl<'a> SchemaBundleOverlay<'a> {
@@ -354,10 +372,14 @@ impl<'a> SchemaBundleOverlay<'a> {
             .epoch()
             .wrapping_mul(1_000_003)
             .wrapping_add(bundle.epoch());
+        let content_version = base
+            .content_version()
+            .map(|b| compose_content_version(&[b, bundle.content_version()]));
         Self {
             base,
             bundle,
             epoch,
+            content_version,
         }
     }
 }
@@ -369,6 +391,10 @@ impl OverlayProvider for SchemaBundleOverlay<'_> {
 
     fn epoch(&self) -> u64 {
         self.epoch
+    }
+
+    fn content_version(&self) -> Option<u64> {
+        self.content_version
     }
 
     fn for_each_overlay_flake(
@@ -453,6 +479,28 @@ mod tests {
             count += 1;
         });
         assert_eq!(count, 0);
+    }
+
+    /// Same (base, bundle) pair → one stable version across constructions;
+    /// a different bundle of the same size → a different version (the
+    /// length-derived epoch cannot tell those apart).
+    #[test]
+    fn content_version_is_stable_per_pair_and_separates_equal_sized_bundles() {
+        let base = NoOverlay;
+        let bundle = Arc::new(SchemaBundleFlakes::empty());
+        let first = SchemaBundleOverlay::new(&base, bundle.clone())
+            .content_version()
+            .expect("NoOverlay vouches");
+        assert_eq!(
+            SchemaBundleOverlay::new(&base, bundle.clone()).content_version(),
+            Some(first)
+        );
+        let same_size = Arc::new(SchemaBundleFlakes::empty());
+        assert_eq!(same_size.epoch(), bundle.epoch());
+        assert_ne!(
+            SchemaBundleOverlay::new(&base, same_size).content_version(),
+            Some(first)
+        );
     }
 
     #[test]

--- a/fluree-db-reasoner/src/cache.rs
+++ b/fluree-db-reasoner/src/cache.rs
@@ -25,8 +25,13 @@ pub struct ReasoningCacheKey {
     pub db_epoch: u64,
     /// Query "as-of" time (historical query support)
     pub to_t: i64,
-    /// Novelty/staged overlay epoch for execute_with_overlay_*
-    pub overlay_epoch: u64,
+    /// The overlay's process-unique content stamp
+    /// ([`OverlayProvider::content_version`](fluree_db_core::OverlayProvider::content_version)),
+    /// never its epoch: a staged preview reports the very epoch the committed
+    /// novelty reports once those flakes commit, at the same `to_t`, so an
+    /// epoch key would serve the preview's materialization for the committed
+    /// state. Overlays that cannot vouch for a version are not cached.
+    pub overlay_version: u64,
     /// Schema version that affects rules
     pub ontology_epoch: u64,
     /// Hash of rule-specific options
@@ -42,7 +47,7 @@ impl Hash for ReasoningCacheKey {
         self.ledger_id.hash(state);
         self.db_epoch.hash(state);
         self.to_t.hash(state);
-        self.overlay_epoch.hash(state);
+        self.overlay_version.hash(state);
         self.ontology_epoch.hash(state);
         self.rule_config_hash.hash(state);
     }
@@ -53,7 +58,7 @@ impl PartialEq for ReasoningCacheKey {
         self.ledger_id == other.ledger_id
             && self.db_epoch == other.db_epoch
             && self.to_t == other.to_t
-            && self.overlay_epoch == other.overlay_epoch
+            && self.overlay_version == other.overlay_version
             && self.ontology_epoch == other.ontology_epoch
             && self.rule_config_hash == other.rule_config_hash
     }
@@ -280,7 +285,7 @@ mod tests {
             ledger_id: alias.into(),
             db_epoch: epoch,
             to_t: 0,
-            overlay_epoch: 0,
+            overlay_version: 0,
             ontology_epoch: 0,
             rule_config_hash: 0,
         }

--- a/fluree-db-reasoner/src/lib.rs
+++ b/fluree-db-reasoner/src/lib.rs
@@ -202,8 +202,10 @@ impl ReasoningOptions {
 ///
 /// # Cache Behavior
 ///
-/// Results are cached by (ledger_id, db_epoch, to_t, overlay_epoch, ontology_epoch, config).
-/// Cache hits return immediately without recomputation.
+/// Results are cached by (ledger_id, db_epoch, to_t, overlay content version,
+/// ontology_epoch, config). Cache hits return immediately without
+/// recomputation. An overlay that cannot vouch for a content version is
+/// materialized fresh and never cached.
 pub async fn reason_owl2rl(
     db: GraphDbRef<'_>,
     opts: &ReasoningOptions,
@@ -215,17 +217,20 @@ pub async fn reason_owl2rl(
     let ontology_epoch = db.snapshot.schema_epoch().unwrap_or(0);
 
     // Build cache key with real values from snapshot and execution context
-    let key = ReasoningCacheKey {
-        ledger_id: db.snapshot.ledger_id.as_str().into(),
-        db_epoch: db.snapshot.t as u64,
-        to_t: db.t,
-        overlay_epoch: db.overlay.epoch(),
-        ontology_epoch,
-        rule_config_hash: opts.config_hash(),
-    };
+    let key = db
+        .overlay
+        .content_version()
+        .map(|overlay_version| ReasoningCacheKey {
+            ledger_id: db.snapshot.ledger_id.as_str().into(),
+            db_epoch: db.snapshot.t as u64,
+            to_t: db.t,
+            overlay_version,
+            ontology_epoch,
+            rule_config_hash: opts.config_hash(),
+        });
 
     // Check cache
-    if let Some(cached) = cache.get(&key) {
+    if let Some(cached) = key.as_ref().and_then(|key| cache.get(key)) {
         return Ok(cached);
     }
 
@@ -242,7 +247,9 @@ pub async fn reason_owl2rl(
     let result = Arc::new(ReasoningResult::new(derived_overlay, diagnostics));
 
     // Store in cache
-    cache.insert(key, result.clone());
+    if let Some(key) = key {
+        cache.insert(key, result.clone());
+    }
 
     Ok(result)
 }

--- a/fluree-db-reasoner/src/overlay.rs
+++ b/fluree-db-reasoner/src/overlay.rs
@@ -35,16 +35,15 @@ pub struct DerivedFactsOverlay {
     same_as: FrozenSameAs,
     /// Epoch for cache key differentiation
     epoch: u64,
-    /// Process-unique id assigned at construction (shared by clones).
+    /// Process-unique id assigned at construction (shared by clones), drawn
+    /// from the overlay-wide content-version allocator so it doubles as this
+    /// immutable overlay's [`OverlayProvider::content_version`].
     ///
     /// The `epoch` alone cannot distinguish two materializations built at the
     /// same base-overlay epoch under different rule configs / ontologies —
     /// caches keyed on overlay identity must incorporate this id.
     instance_id: u64,
 }
-
-/// Process-wide counter for [`DerivedFactsOverlay::instance_id`].
-static OVERLAY_INSTANCE_IDS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
 impl DerivedFactsOverlay {
     /// Create an empty overlay (no derived facts) with default epoch and empty sameAs
@@ -66,7 +65,7 @@ impl DerivedFactsOverlay {
             opst: Arc::from([]),
             same_as,
             epoch,
-            instance_id: OVERLAY_INSTANCE_IDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            instance_id: fluree_db_core::overlay::next_overlay_content_version(),
         }
     }
 
@@ -95,7 +94,7 @@ impl DerivedFactsOverlay {
             opst: opst.into(),
             same_as,
             epoch,
-            instance_id: OVERLAY_INSTANCE_IDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            instance_id: fluree_db_core::overlay::next_overlay_content_version(),
         }
     }
 
@@ -155,6 +154,10 @@ impl OverlayProvider for DerivedFactsOverlay {
 
     fn epoch(&self) -> u64 {
         self.epoch
+    }
+
+    fn content_version(&self) -> Option<u64> {
+        Some(self.instance_id)
     }
 
     fn for_each_overlay_flake(

--- a/fluree-db-transact/src/lib.rs
+++ b/fluree-db-transact/src/lib.rs
@@ -81,7 +81,9 @@ pub use parse::{
 };
 pub use raw_txn_upload::PendingRawTxnUpload;
 pub use stage::{generate_txn_id, stage, stage_flakes, StageOptions};
-pub use staged_dicts::{attach_binary_provider, attach_staged_dicts, detach_binary_provider};
+pub use staged_dicts::{
+    attach_binary_provider, attach_staged_dicts, detach_binary_provider, staged_dicts, StagedDicts,
+};
 
 #[cfg(feature = "shacl")]
 pub use stage::{

--- a/fluree-db-transact/src/lib.rs
+++ b/fluree-db-transact/src/lib.rs
@@ -44,6 +44,7 @@ pub mod namespace;
 pub mod parse;
 pub mod raw_txn_upload;
 pub mod stage;
+pub mod staged_dicts;
 pub mod value_convert;
 
 #[cfg(feature = "import")]
@@ -80,6 +81,7 @@ pub use parse::{
 };
 pub use raw_txn_upload::PendingRawTxnUpload;
 pub use stage::{generate_txn_id, stage, stage_flakes, StageOptions};
+pub use staged_dicts::{attach_binary_provider, attach_staged_dicts, detach_binary_provider};
 
 #[cfg(feature = "shacl")]
 pub use stage::{

--- a/fluree-db-transact/src/stage.rs
+++ b/fluree-db-transact/src/stage.rs
@@ -1986,11 +1986,9 @@ async fn enforce_modify_policies(
     // StagedLedger overlay (the same view SHACL validates against) provides
     // it. Built only when such a condition is loaded.
     let staged_view = if policy.wrapper().has_post_state_conditions() {
-        Some(StagedLedger::new(
-            ledger.clone(),
-            flakes.to_vec(),
-            reverse_graph,
-        )?)
+        let mut view = StagedLedger::new(ledger.clone(), flakes.to_vec(), reverse_graph)?;
+        crate::staged_dicts::attach_staged_dicts(&mut view)?;
+        Some(view)
     } else {
         None
     };
@@ -2119,7 +2117,9 @@ async fn enforce_modify_policy_per_flake(
             )
             .with_graph_id(g_id);
             if let Some(staged) = staged_view {
-                ex = ex.with_post_state(staged, staged.staged_t());
+                ex = ex
+                    .with_post_state(staged, staged.staged_t())
+                    .with_post_state_snapshot(staged.db());
             }
             ex
         });
@@ -3230,13 +3230,17 @@ pub async fn stage_with_shacl(
     let tracker = options.tracker;
 
     // First, perform regular staging
-    let (view, mut ns_registry) = stage(ledger, txn, ns_registry, options).await?;
+    let (mut view, mut ns_registry) = stage(ledger, txn, ns_registry, options).await?;
 
     // Fast path: if there are no SHACL shapes, elide validation entirely.
     // This ensures SHACL has *zero* transaction-time overhead unless rules exist.
     if shacl_cache.is_empty() {
         return Ok((view, ns_registry));
     }
+
+    // Validation reads the staged view on the binary lane; its dictionaries
+    // must cover the subjects this transaction introduces.
+    crate::staged_dicts::attach_staged_dicts(&mut view)?;
 
     // Rebuild graph_sids from the cloned graph_delta + returned ns_registry.
     // These IRIs were already resolved during stage(), so sid_for_iri will find

--- a/fluree-db-transact/src/staged_dicts.rs
+++ b/fluree-db-transact/src/staged_dicts.rs
@@ -9,11 +9,13 @@
 //! to raw-flake merging of the whole graph novelty.
 //!
 //! [`attach_staged_dicts`] gives a staged view a provider whose dictionaries
-//! are the base ones extended by the staged flakes. The extension is
-//! view-local: commit rebuilds the provider from the ledger's canonical
-//! dictionaries (see `commit_txn`), so the ids minted here never reach a
-//! committed state, and the staged view's own
-//! [`content_version`](fluree_db_core::OverlayProvider::content_version)
+//! are the base ones extended by the staged flakes: a
+//! [`DictNovelty::layered_over`] delta over a shared `Arc` of the committed
+//! dictionary, so the cost is proportional to the staged flakes however far
+//! the indexer trails the head. The extension is view-local: commit rebuilds
+//! the provider from the ledger's canonical dictionaries (see `commit_txn`),
+//! so the ids minted here never reach a committed state, and the staged
+//! view's own [`content_version`](fluree_db_core::OverlayProvider::content_version)
 //! keeps every cross-query translation cache from serving its products for
 //! the committed state.
 //!
@@ -68,11 +70,10 @@ impl StagedDicts {
 ///
 /// `None` when there is nothing to cover: no staged flakes, no binary
 /// provider on the base (genesis / overlay-only state — the range path there
-/// never translates), or an uninitialized dictionary. The base dictionaries
-/// are cloned and extended, persisted-first, so an id is minted only for
-/// entries in neither the persisted dictionary nor the committed novelty
-/// layer. Cost is one dictionary clone per call, against the per-probe
-/// whole-novelty re-translation it replaces.
+/// never translates), or an uninitialized dictionary. The extension is a
+/// layer over the base dictionary, populated persisted-first, so an id is
+/// minted only for entries in neither the persisted dictionary nor the
+/// committed novelty layer, and nothing of the base is copied.
 pub fn staged_dicts(base: &LedgerState, staged: &[Flake]) -> Result<Option<StagedDicts>> {
     if staged.is_empty() {
         return Ok(None);
@@ -84,7 +85,7 @@ pub fn staged_dicts(base: &LedgerState, staged: &[Flake]) -> Result<Option<Stage
         return Ok(None);
     }
     let store = Arc::clone(brp.store());
-    let mut dict_novelty: DictNovelty = (**brp.dict_novelty()).clone();
+    let mut dict_novelty = DictNovelty::layered_over(Arc::clone(brp.dict_novelty()));
     populate_dict_novelty_safe(&mut dict_novelty, Some(&store), staged.iter())
         .map_err(|e| TransactError::FlakeGeneration(format!("staged dict novelty layer: {e}")))?;
     let mut runtime_small_dicts = (**brp.runtime_small_dicts()).clone();

--- a/fluree-db-transact/src/staged_dicts.rs
+++ b/fluree-db-transact/src/staged_dicts.rs
@@ -1,0 +1,106 @@
+//! Dictionary coverage for reads over uncommitted state.
+//!
+//! A [`BinaryRangeProvider`] resolves overlay flakes through the persisted
+//! dictionaries plus the ledger's [`DictNovelty`]. Both are committed-state
+//! artefacts: the subjects and strings a transaction is *introducing* are in
+//! neither, so any binary-lane read over a [`StagedLedger`] — SHACL
+//! validation, `f:postState` policy conditions — fails to translate exactly
+//! the flakes the transaction is about, logs a WARN per probe, and falls back
+//! to raw-flake merging of the whole graph novelty.
+//!
+//! [`attach_staged_dicts`] gives a staged view a provider whose dictionaries
+//! are the base ones extended by the staged flakes. The extension is
+//! view-local: commit rebuilds the provider from the ledger's canonical
+//! dictionaries (see `commit_txn`), so the ids minted here never reach a
+//! committed state, and the staged view's own
+//! [`content_version`](fluree_db_core::OverlayProvider::content_version)
+//! keeps every cross-query translation cache from serving its products for
+//! the committed state.
+//!
+//! [`detach_binary_provider`] / [`attach_binary_provider`] bracket in-place
+//! dictionary mutation on a [`LedgerState`] whose snapshot already carries a
+//! provider: the provider pins `Arc` clones of the dictionaries, so mutating
+//! with it attached both deep-clones them (`Arc::make_mut`) and leaves the
+//! provider reading the pre-mutation copies.
+
+use crate::error::{Result, TransactError};
+use fluree_db_binary_index::dict_novelty_safe::populate_dict_novelty_safe;
+use fluree_db_binary_index::BinaryIndexStore;
+use fluree_db_core::DictNovelty;
+use fluree_db_ledger::{LedgerState, StagedLedger};
+use fluree_db_query::BinaryRangeProvider;
+use std::sync::Arc;
+
+fn provider_of(state: &LedgerState) -> Option<&BinaryRangeProvider> {
+    state
+        .snapshot
+        .range_provider
+        .as_ref()
+        .and_then(|rp| rp.as_any().downcast_ref::<BinaryRangeProvider>())
+}
+
+/// Attach a range provider whose dictionaries cover the staged flakes.
+///
+/// No-op when the view has no staged flakes, no binary provider (genesis /
+/// overlay-only state — the range path there never translates), an
+/// uninitialized dictionary, or when it has already been attached. The base
+/// dictionaries are cloned and extended, persisted-first, so an id is minted
+/// only for entries in neither the persisted dictionary nor the committed
+/// novelty layer. Cost is one dictionary clone per transaction that actually
+/// reads its own staged state, against the per-probe whole-novelty
+/// re-translation it replaces.
+pub fn attach_staged_dicts(view: &mut StagedLedger) -> Result<()> {
+    if view.dicts_cover_staged() || !view.has_staged() {
+        return Ok(());
+    }
+    let provider = {
+        let base = view.base();
+        let Some(brp) = provider_of(base) else {
+            return Ok(());
+        };
+        if !brp.dict_novelty().is_initialized() {
+            return Ok(());
+        }
+        let store = Arc::clone(brp.store());
+        let mut dict_novelty: DictNovelty = (**brp.dict_novelty()).clone();
+        populate_dict_novelty_safe(&mut dict_novelty, Some(&store), view.staged_flakes().iter())
+            .map_err(|e| {
+                TransactError::FlakeGeneration(format!("staged dict novelty layer: {e}"))
+            })?;
+        let mut runtime_small_dicts = (**brp.runtime_small_dicts()).clone();
+        runtime_small_dicts.populate_from_flakes(view.staged_flakes());
+        Arc::new(BinaryRangeProvider::new(
+            store,
+            Arc::new(dict_novelty),
+            Arc::new(runtime_small_dicts),
+            Some(base.snapshot.shared_namespaces()),
+        ))
+    };
+    Arc::make_mut(&mut view.base_mut().snapshot).range_provider = Some(provider);
+    view.set_dicts_cover_staged();
+    Ok(())
+}
+
+/// Detach the snapshot's binary range provider, returning its store so
+/// [`attach_binary_provider`] can rebuild it once the dictionaries have been
+/// mutated in place. `None` when no binary provider was attached — callers
+/// must then leave the state provider-less, preserving the genesis /
+/// no-index shape.
+pub fn detach_binary_provider(state: &mut LedgerState) -> Option<Arc<BinaryIndexStore>> {
+    let store = provider_of(state).map(|brp| Arc::clone(brp.store()))?;
+    Arc::make_mut(&mut state.snapshot).range_provider = None;
+    Some(store)
+}
+
+/// Rebuild the binary range provider over `store` and the state's current
+/// dictionaries, so reads through the snapshot resolve every subject and
+/// string the state's `dict_novelty` now knows.
+pub fn attach_binary_provider(state: &mut LedgerState, store: Arc<BinaryIndexStore>) {
+    let provider = Arc::new(BinaryRangeProvider::new(
+        store,
+        Arc::clone(&state.dict_novelty),
+        Arc::clone(&state.runtime_small_dicts),
+        Some(state.snapshot.shared_namespaces()),
+    ));
+    Arc::make_mut(&mut state.snapshot).range_provider = Some(provider);
+}

--- a/fluree-db-transact/src/staged_dicts.rs
+++ b/fluree-db-transact/src/staged_dicts.rs
@@ -26,9 +26,10 @@
 use crate::error::{Result, TransactError};
 use fluree_db_binary_index::dict_novelty_safe::populate_dict_novelty_safe;
 use fluree_db_binary_index::BinaryIndexStore;
-use fluree_db_core::DictNovelty;
+use fluree_db_core::{DictNovelty, Flake, RuntimeSmallDicts};
 use fluree_db_ledger::{LedgerState, StagedLedger};
 use fluree_db_query::BinaryRangeProvider;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 fn provider_of(state: &LedgerState) -> Option<&BinaryRangeProvider> {
@@ -39,43 +40,76 @@ fn provider_of(state: &LedgerState) -> Option<&BinaryRangeProvider> {
         .and_then(|rp| rp.as_any().downcast_ref::<BinaryRangeProvider>())
 }
 
+/// A base state's dictionaries extended, view-locally, by a set of staged
+/// flakes (see [`staged_dicts`]).
+pub struct StagedDicts {
+    pub store: Arc<BinaryIndexStore>,
+    pub dict_novelty: Arc<DictNovelty>,
+    pub runtime_small_dicts: Arc<RuntimeSmallDicts>,
+}
+
+impl StagedDicts {
+    /// A range provider over these dictionaries.
+    pub fn provider(
+        &self,
+        namespace_codes_fallback: Arc<HashMap<u16, String>>,
+    ) -> Arc<BinaryRangeProvider> {
+        Arc::new(BinaryRangeProvider::new(
+            Arc::clone(&self.store),
+            Arc::clone(&self.dict_novelty),
+            Arc::clone(&self.runtime_small_dicts),
+            Some(namespace_codes_fallback),
+        ))
+    }
+}
+
+/// Extend `base`'s dictionaries with the subjects and strings `staged`
+/// introduces.
+///
+/// `None` when there is nothing to cover: no staged flakes, no binary
+/// provider on the base (genesis / overlay-only state — the range path there
+/// never translates), or an uninitialized dictionary. The base dictionaries
+/// are cloned and extended, persisted-first, so an id is minted only for
+/// entries in neither the persisted dictionary nor the committed novelty
+/// layer. Cost is one dictionary clone per call, against the per-probe
+/// whole-novelty re-translation it replaces.
+pub fn staged_dicts(base: &LedgerState, staged: &[Flake]) -> Result<Option<StagedDicts>> {
+    if staged.is_empty() {
+        return Ok(None);
+    }
+    let Some(brp) = provider_of(base) else {
+        return Ok(None);
+    };
+    if !brp.dict_novelty().is_initialized() {
+        return Ok(None);
+    }
+    let store = Arc::clone(brp.store());
+    let mut dict_novelty: DictNovelty = (**brp.dict_novelty()).clone();
+    populate_dict_novelty_safe(&mut dict_novelty, Some(&store), staged.iter())
+        .map_err(|e| TransactError::FlakeGeneration(format!("staged dict novelty layer: {e}")))?;
+    let mut runtime_small_dicts = (**brp.runtime_small_dicts()).clone();
+    runtime_small_dicts.populate_from_flakes(staged);
+    Ok(Some(StagedDicts {
+        store,
+        dict_novelty: Arc::new(dict_novelty),
+        runtime_small_dicts: Arc::new(runtime_small_dicts),
+    }))
+}
+
 /// Attach a range provider whose dictionaries cover the staged flakes.
 ///
-/// No-op when the view has no staged flakes, no binary provider (genesis /
-/// overlay-only state — the range path there never translates), an
-/// uninitialized dictionary, or when it has already been attached. The base
-/// dictionaries are cloned and extended, persisted-first, so an id is minted
-/// only for entries in neither the persisted dictionary nor the committed
-/// novelty layer. Cost is one dictionary clone per transaction that actually
-/// reads its own staged state, against the per-probe whole-novelty
-/// re-translation it replaces.
+/// No-op when [`staged_dicts`] has nothing to cover or when it has already
+/// been attached. Runs only before a read of the staged view (SHACL
+/// validation, post-state policy conditions), so a transaction that never
+/// reads its own staged state pays nothing.
 pub fn attach_staged_dicts(view: &mut StagedLedger) -> Result<()> {
-    if view.dicts_cover_staged() || !view.has_staged() {
+    if view.dicts_cover_staged() {
         return Ok(());
     }
-    let provider = {
-        let base = view.base();
-        let Some(brp) = provider_of(base) else {
-            return Ok(());
-        };
-        if !brp.dict_novelty().is_initialized() {
-            return Ok(());
-        }
-        let store = Arc::clone(brp.store());
-        let mut dict_novelty: DictNovelty = (**brp.dict_novelty()).clone();
-        populate_dict_novelty_safe(&mut dict_novelty, Some(&store), view.staged_flakes().iter())
-            .map_err(|e| {
-                TransactError::FlakeGeneration(format!("staged dict novelty layer: {e}"))
-            })?;
-        let mut runtime_small_dicts = (**brp.runtime_small_dicts()).clone();
-        runtime_small_dicts.populate_from_flakes(view.staged_flakes());
-        Arc::new(BinaryRangeProvider::new(
-            store,
-            Arc::new(dict_novelty),
-            Arc::new(runtime_small_dicts),
-            Some(base.snapshot.shared_namespaces()),
-        ))
+    let Some(dicts) = staged_dicts(view.base(), view.staged_flakes())? else {
+        return Ok(());
     };
+    let provider = dicts.provider(view.base().snapshot.shared_namespaces());
     Arc::make_mut(&mut view.base_mut().snapshot).range_provider = Some(provider);
     view.set_dicts_cover_staged();
     Ok(())


### PR DESCRIPTION
## Problem

A transaction's SHACL and `f:postState` policy probes read a `StagedLedger` (committed state plus the transaction's own staged flakes). Once the ledger has a persisted index those probes run on the binary lane, which resolves every overlay flake through the persisted dictionary plus `DictNovelty`. Both are committed-state artefacts, so the subjects and strings the transaction is *introducing* resolve in neither.

The effect on every publish that creates new IRIs, observed on a production ledger as ~230k warnings in 83 minutes and multi-second commits:

- every probe failed to translate exactly the transaction's own flakes (`subject not found in persisted or novelty dict`), logged a WARN, and merged them as raw flakes;
- the staged view reported no `content_version`, so the range-provider translation cache never served it and every probe re-walked and re-translated the whole graph novelty — O(probes × novelty) per transaction.

There was also a latent cache-key collision: a staged view reports the very overlay epoch and `to_t` the committed novelty reports right after its flakes commit, and the query engine's cross-query translation cache was keyed on the epoch, so a product built during staging could be served for the committed state.

## Change

- `fluree-db-transact/src/staged_dicts.rs`: `attach_staged_dicts` clones the base dictionaries, extends them persisted-first with the staged flakes, and attaches a `BinaryRangeProvider` over them to the staged view. Runs before SHACL validation (`stage_with_shacl`, `apply_shacl_policy_to_staged_view`) and post-state policy evaluation only, so transactions that never read their own staged state pay nothing. Commit still rebuilds the provider from the ledger's canonical dictionaries, so the view-local ids never reach a committed state.
- `QueryPolicyExecutor::with_post_state_snapshot` pairs post-state conditions with that snapshot.
- `StagedLedger` reports a process-unique `content_version`, drawn from a new core allocator (`next_overlay_content_version`) that `Novelty` now shares. `GlobalTranslationKey` is keyed on it instead of the epoch; overlays without a content version are no longer cached across queries.
- Two paths that mutated `dict_novelty` in place with the provider still attached — sequential multi-operation SPARQL staging and commit-transfer apply — now detach and reattach it (`detach_binary_provider` / `attach_binary_provider`), so reads through the state resolve the subjects those operations introduce rather than the pre-mutation copies.
- `UpdatePlan::plan`: the "local t ahead of nameservice" branch logs at debug instead of WARN. It fires routinely under the raft commit worker (`notify` reads the record before taking the ledger state lock, which the worker holds across the next chunk's publish and install) and the plan was already a no-op.

## Tests

New standalone bin `it_staged_view_dict` (`cargo test -p fluree-db-api --features shacl --test it_staged_view_dict`) pins the translation outcome through a tracing probe over an indexed ledger for the SHACL pass, the post-state policy pass, and a post-commit whole-graph scan, plus a rejection control proving the staged view is still read. Each assertion was watched failing with the fix reverted. `StagedLedger` gains a unit test for content-version uniqueness.

Sweep run locally: unit suites for novelty, ledger, transact, query; API groups `grp_policy`, `grp_transact`, `grp_misc`, `grp_query`, `grp_ledger`; `it_cached_handle_cow`. Clippy clean under default and `shacl` features.

## Notes

- Stacked on `feat/stats-kernel` (#1789) because that is the branch the work started from; the diff does not touch the stats crate.
- Cost model: one dictionary clone plus one novelty-sized translation per transaction that reads its own staged state, replacing one whole-novelty re-translation per probe. Not benchmarked.

Follow-up: #1790 — a post-state ASK that joins on a string value the same transaction introduces is denied on the staged view both before and after this change; the new test deliberately joins on an indexed value.
