### PR TITLE
fix(consensus): park queued submissions on entry liveness, not a fixed clock

### DIFF
--- a/docs/design/raft-command-queue.md
+++ b/docs/design/raft-command-queue.md
@@ -103,6 +103,15 @@ Apply receipts come in two flavors:
 
 The split keeps the log encoding small (the heavy receipt fields don't replicate) while still giving the proposing client the rich result on the happy path. Followers that forwarded the original request see the leader's full response; followers reading the head independently see the minimal version.
 
+### Waiting for the outcome
+
+The leader's `QueuedTransactor` parks on its waiter ticket in probe intervals (default 8 s; `EmbeddedRaftConfig::with_submit_wait`). A probe that fires is a check, not a verdict: while the entry is still in the replicated per-branch queue and the cluster has a leader, the submission is alive and the wait continues without spending a retry attempt. Only a probe that finds the entry gone, or the node leaderless, spends an attempt on the idempotent re-propose path. A ceiling on total parked time (default 10 minutes; `with_submit_max_wait`) backstops a worker that never finishes, and reports the outcome as unknown rather than failed, because the commit may still land.
+
+Two consequences of that shape:
+
+- The entry leaves the queue under the state lock, but the waiter resolves in the observer's effects, after the lock drops. A probe can see the entry gone a moment before the receipt lands, so a gone-entry probe waits a short grace on the ticket before spending an attempt.
+- The ceiling is longer than every other timeout on the path. The follower → leader forward middleware gives up after 60 s (`FORWARD_REQUEST_TIMEOUT` in `fluree-raft-core`), and the server binary applies no request timeout of its own, so a forwarded write whose stage outlasts 60 s returns a 504 at the follower while the leader commits it. Load balancers in front of the server usually sever idle requests sooner still. Aligning these is tracked in #1382.
+
 ## Log entry types
 
 `Command` variants are grouped by purpose:

--- a/docs/design/raft-command-queue.md
+++ b/docs/design/raft-command-queue.md
@@ -107,6 +107,8 @@ The split keeps the log encoding small (the heavy receipt fields don't replicate
 
 The leader's `QueuedTransactor` parks on its waiter ticket in probe intervals (default 8 s; `EmbeddedRaftConfig::with_submit_wait`). A probe that fires is a check, not a verdict: while the entry is still in the replicated per-branch queue and the cluster has a leader, the submission is alive and the wait continues without spending a retry attempt. Only a probe that finds the entry gone, or the node leaderless, spends an attempt on the idempotent re-propose path. A ceiling on total parked time (default 10 minutes; `with_submit_max_wait`) backstops a worker that never finishes, and reports the outcome as unknown rather than failed, because the commit may still land.
 
+Each waiter sleep is capped at the remaining ceiling budget, so a shorter ceiling takes effect before the next scheduled probe. An already-ready receipt still wins; a missing entry retains its outcome grace and retry handling.
+
 Two consequences of that shape:
 
 - The entry leaves the queue under the state lock, but the waiter resolves in the observer's effects, after the lock drops. A probe can see the entry gone a moment before the receipt lands, so a gone-entry probe waits a short grace on the ticket before spending an attempt.

--- a/fluree-db-consensus/src/raft/embedded.rs
+++ b/fluree-db-consensus/src/raft/embedded.rs
@@ -79,14 +79,16 @@ pub struct EmbeddedRaftConfig {
     /// See [`LeaderTaskFactory`]. Defaults to none, which means
     /// **nothing indexes**.
     pub extra_leader_tasks: Option<LeaderTaskFactory>,
-    /// Per-attempt waiter timeout and attempt count for queued
-    /// submissions (`None` = the transactor's defaults, 8 s × 3). The
-    /// default is sized for leader transitions on a cluster; a
-    /// single-node host whose per-branch queue can run tens of seconds
-    /// deep (bulk publishes, sequential upsert chunks) wants a longer
-    /// wait, or a submission still queued gets reported stranded and
-    /// then commits anyway.
+    /// Waiter probe interval and retry-attempt count for queued
+    /// submissions (`None` = the transactor's defaults, 8 s × 3). A
+    /// probe that finds the entry still queued keeps waiting without
+    /// spending an attempt, so these bound leader-transition recovery,
+    /// not commit latency — see `QueuedTransactor`.
     pub submit_wait: Option<(Duration, usize)>,
+    /// Ceiling on total time a submission may stay parked on a live
+    /// queue entry (`None` = the transactor's default, 10 minutes)
+    /// before its outcome is reported unknown.
+    pub submit_max_wait: Option<Duration>,
 }
 
 impl EmbeddedRaftConfig {
@@ -97,13 +99,21 @@ impl EmbeddedRaftConfig {
             liveness: LivenessConfig::default(),
             extra_leader_tasks: None,
             submit_wait: None,
+            submit_max_wait: None,
         }
     }
 
-    /// Override the queued transactor's per-attempt wait and attempt
+    /// Override the queued transactor's probe interval and attempt
     /// count — see [`Self::submit_wait`].
     pub fn with_submit_wait(mut self, timeout: Duration, max_retries: usize) -> Self {
         self.submit_wait = Some((timeout, max_retries));
+        self
+    }
+
+    /// Override the ceiling on total parked time — see
+    /// [`Self::submit_max_wait`].
+    pub fn with_submit_max_wait(mut self, max_wait: Duration) -> Self {
+        self.submit_max_wait = Some(max_wait);
         self
     }
 
@@ -168,6 +178,9 @@ impl EmbeddedRaftNode {
             queued = queued
                 .with_wait_timeout(timeout)
                 .with_max_retries(max_retries);
+        }
+        if let Some(max_wait) = config.submit_max_wait {
+            queued = queued.with_max_wait(max_wait);
         }
         let committer: Arc<dyn SubmittingCommitter> = Arc::new(CachingCommitter::wrapping(queued));
 

--- a/fluree-db-consensus/src/raft/embedded.rs
+++ b/fluree-db-consensus/src/raft/embedded.rs
@@ -79,6 +79,14 @@ pub struct EmbeddedRaftConfig {
     /// See [`LeaderTaskFactory`]. Defaults to none, which means
     /// **nothing indexes**.
     pub extra_leader_tasks: Option<LeaderTaskFactory>,
+    /// Per-attempt waiter timeout and attempt count for queued
+    /// submissions (`None` = the transactor's defaults, 8 s × 3). The
+    /// default is sized for leader transitions on a cluster; a
+    /// single-node host whose per-branch queue can run tens of seconds
+    /// deep (bulk publishes, sequential upsert chunks) wants a longer
+    /// wait, or a submission still queued gets reported stranded and
+    /// then commits anyway.
+    pub submit_wait: Option<(Duration, usize)>,
 }
 
 impl EmbeddedRaftConfig {
@@ -88,7 +96,15 @@ impl EmbeddedRaftConfig {
             index_config: fluree.default_index_config(),
             liveness: LivenessConfig::default(),
             extra_leader_tasks: None,
+            submit_wait: None,
         }
+    }
+
+    /// Override the queued transactor's per-attempt wait and attempt
+    /// count — see [`Self::submit_wait`].
+    pub fn with_submit_wait(mut self, timeout: Duration, max_retries: usize) -> Self {
+        self.submit_wait = Some((timeout, max_retries));
+        self
     }
 
     pub fn with_liveness(mut self, liveness: LivenessConfig) -> Self {
@@ -142,12 +158,17 @@ impl EmbeddedRaftNode {
         // through `EnqueueCommand` plus the per-process waiter and
         // staged-receipt maps; `CachingCommitter` on top dedupes keyed
         // retries before the queue propose.
-        let queued = QueuedTransactor::new(
+        let mut queued = QueuedTransactor::new(
             Arc::clone(&integration.raft),
             Arc::clone(&fluree),
             Arc::clone(&integration.waiter_map),
             integration.shared_state.clone(),
         );
+        if let Some((timeout, max_retries)) = config.submit_wait {
+            queued = queued
+                .with_wait_timeout(timeout)
+                .with_max_retries(max_retries);
+        }
         let committer: Arc<dyn SubmittingCommitter> = Arc::new(CachingCommitter::wrapping(queued));
 
         let release_task = integration

--- a/fluree-db-consensus/src/raft/queued_transactor.rs
+++ b/fluree-db-consensus/src/raft/queued_transactor.rs
@@ -246,7 +246,7 @@ impl QueuedTransactor {
                                     ProbeVerdict::KeepWaiting => continue,
                                     ProbeVerdict::SpendAttempt => break,
                                     ProbeVerdict::CeilingReached => {
-                                        return Err(self.ceiling_error());
+                                        return Err(self.ceiling_error(retry_eligible));
                                     }
                                 }
                             }
@@ -334,12 +334,17 @@ impl QueuedTransactor {
         entry_queued(&state, ref_key, queue_id)
     }
 
-    fn ceiling_error(&self) -> SubmissionError {
+    fn ceiling_error(&self, retry_eligible: bool) -> SubmissionError {
+        let recourse = if retry_eligible {
+            "poll with the idempotency key"
+        } else {
+            "it carried no idempotency key, so check the ledger head before retrying"
+        };
         SubmissionError::Execution {
             status: 504,
             message: format!(
                 "submission still queued after {:?}; its outcome is unknown and it may \
-                 still commit — poll with the idempotency key",
+                 still commit — {recourse}",
                 self.max_wait
             ),
         }

--- a/fluree-db-consensus/src/raft/queued_transactor.rs
+++ b/fluree-db-consensus/src/raft/queued_transactor.rs
@@ -69,6 +69,15 @@ const DEFAULT_MAX_RETRIES: usize = 3;
 /// costs is a still-progressing commit reported as a 504.
 const DEFAULT_MAX_WAIT: Duration = Duration::from_secs(600);
 
+/// How long a probe that found its entry gone waits for the outcome
+/// before spending an attempt. The entry leaves the replicated queue
+/// under the state lock, but its terminal apply resolves the waiter in
+/// the observer's effects, after that lock drops — so a probe can read
+/// the queue in between and see the entry gone while the receipt is
+/// moments from landing. A genuinely stranded entry just times out
+/// again; the cost is paid only on that path.
+const GONE_ENTRY_GRACE: Duration = Duration::from_millis(250);
+
 /// Committer that routes transactions through the per-branch Raft
 /// queue.
 ///
@@ -235,7 +244,9 @@ impl QueuedTransactor {
                     // resolves when the new leader's worker finishes it.
                     // Displaced (a duplicate submission took the slot)
                     // and a timeout that finds the entry gone are handled
-                    // the same: retry if eligible, error otherwise.
+                    // the same: retry if eligible, error otherwise. A gone
+                    // entry first gets `GONE_ENTRY_GRACE` for its outcome
+                    // to land.
                     loop {
                         match ticket.wait(self.wait_timeout).await {
                             Ok(outcome) => return Ok(SubmissionOutcome::Waiter(outcome)),
@@ -244,7 +255,12 @@ impl QueuedTransactor {
                                 let alive = self.entry_alive(&ref_key, ticket.queue_id()).await;
                                 match probe_verdict(alive, parked_since.elapsed(), self.max_wait) {
                                     ProbeVerdict::KeepWaiting => continue,
-                                    ProbeVerdict::SpendAttempt => break,
+                                    ProbeVerdict::SpendAttempt => {
+                                        if let Ok(outcome) = ticket.wait(GONE_ENTRY_GRACE).await {
+                                            return Ok(SubmissionOutcome::Waiter(outcome));
+                                        }
+                                        break;
+                                    }
                                     ProbeVerdict::CeilingReached => {
                                         return Err(self.ceiling_error(retry_eligible));
                                     }

--- a/fluree-db-consensus/src/raft/queued_transactor.rs
+++ b/fluree-db-consensus/src/raft/queued_transactor.rs
@@ -21,11 +21,11 @@
 
 use crate::raft::staged_receipt::AppliedReceipt;
 use crate::raft::state_machine::{
-    ApplyOutcome, ApplyRecord, BodyKind, Command as SmCommand, PoisonRecord, QueueSubmission,
-    RefKey, Response as SmResponse,
+    ApplyOutcome, ApplyRecord, BodyKind, Command as SmCommand, NameServiceState, PoisonRecord,
+    QueueSubmission, RefKey, Response as SmResponse,
 };
 use crate::raft::state_machine_adapter::SharedState;
-use crate::raft::waiter::{AbortReason, WaiterMap, WaiterOutcome};
+use crate::raft::waiter::{AbortReason, WaitError, WaiterMap, WaiterOutcome};
 use crate::raft::TypeConfig;
 use crate::{
     CommittedSubmission, Committer, IdempotencyCacheKey, IdempotencyKey, MergeReceipt,
@@ -45,10 +45,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// How long a single waiter `await` blocks before the transactor
-/// considers the call stranded by a leader transition and either
-/// re-issues (idempotent submissions) or errors out (anonymous
-/// submissions). Conservative — the typical Raft round-trip is
-/// sub-second; this is the budget for "something went wrong."
+/// checks on the submission. A timeout is a *probe*, not a verdict:
+/// while the entry is still in the replicated queue and the cluster
+/// has a leader, the submission is alive — a slow stage, a deep
+/// per-branch queue — and the wait simply continues. Only a timeout
+/// that finds the entry gone (or the cluster leaderless) spends one of
+/// the retry attempts, which is the leader-transition case this budget
+/// was always meant for.
 const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(8);
 
 /// Number of (propose → register waiter → await) attempts before the
@@ -56,6 +59,15 @@ const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(8);
 /// re-proposes the same `EnqueueCommand`; the state machine's
 /// idempotency cache makes repeats safe.
 const DEFAULT_MAX_RETRIES: usize = 3;
+
+/// Ceiling on the total time a submission may stay parked on a live
+/// queue entry before the transactor reports its outcome unknown. This
+/// is the backstop for a worker that never finishes — a wedged stage,
+/// a former leader partitioned away from the cluster with a stale copy
+/// of the queue. The number is deliberately generous: a submission
+/// that hits it has already survived every probe, so the only thing it
+/// costs is a still-progressing commit reported as a 504.
+const DEFAULT_MAX_WAIT: Duration = Duration::from_secs(600);
 
 /// Committer that routes transactions through the per-branch Raft
 /// queue.
@@ -74,6 +86,7 @@ pub struct QueuedTransactor {
     shared_state: SharedState,
     wait_timeout: Duration,
     max_retries: usize,
+    max_wait: Duration,
 }
 
 impl QueuedTransactor {
@@ -90,12 +103,21 @@ impl QueuedTransactor {
             shared_state,
             wait_timeout: DEFAULT_WAIT_TIMEOUT,
             max_retries: DEFAULT_MAX_RETRIES,
+            max_wait: DEFAULT_MAX_WAIT,
         }
     }
 
-    /// Override the per-attempt waiter timeout (default 8s).
+    /// Override the waiter probe interval (default 8s) — how often a
+    /// parked submission checks that its queue entry is still alive.
     pub fn with_wait_timeout(mut self, timeout: Duration) -> Self {
         self.wait_timeout = timeout;
+        self
+    }
+
+    /// Override the ceiling on total time parked on a live queue entry
+    /// (default 10 minutes). See [`DEFAULT_MAX_WAIT`].
+    pub fn with_max_wait(mut self, max_wait: Duration) -> Self {
+        self.max_wait = max_wait;
         self
     }
 
@@ -158,7 +180,8 @@ impl QueuedTransactor {
         // applies the enqueue and binds it — which is what lets a fast
         // worker's ApplyHead find a waiter, and what keeps followers
         // from tracking anything at all. Dropped on every return path.
-        let mut ticket = self.waiter_map.arm(request_cid.clone(), ref_key);
+        let mut ticket = self.waiter_map.arm(request_cid.clone(), ref_key.clone());
+        let parked_since = std::time::Instant::now();
         for attempt in 0..attempts_allowed {
             let response = match self.raft.client_write(cmd.clone()).await {
                 Ok(response) => response,
@@ -204,16 +227,33 @@ impl QueuedTransactor {
                     // enqueue, so there is nothing to register here.
                     // On a retry the response is `InFlight` for the same
                     // entry and the ticket is already bound to it.
-                    match ticket.wait(self.wait_timeout).await {
-                        Ok(outcome) => return Ok(SubmissionOutcome::Waiter(outcome)),
-                        // Displaced (a duplicate submission took the
-                        // slot) and timed-out are handled the same:
-                        // retry if eligible, error otherwise.
-                        Err(_) => {
-                            if attempt + 1 >= attempts_allowed {
-                                return Err(self.stranded_error(retry_eligible));
+                    // Park until the outcome lands. A probe timeout that
+                    // finds the entry still queued keeps waiting without
+                    // spending an attempt — the entry is alive, and the
+                    // former-leader case is covered too: `ApplyHead`
+                    // replicates to every node, so a waiter bound here
+                    // resolves when the new leader's worker finishes it.
+                    // Displaced (a duplicate submission took the slot)
+                    // and a timeout that finds the entry gone are handled
+                    // the same: retry if eligible, error otherwise.
+                    loop {
+                        match ticket.wait(self.wait_timeout).await {
+                            Ok(outcome) => return Ok(SubmissionOutcome::Waiter(outcome)),
+                            Err(WaitError::Displaced) => break,
+                            Err(WaitError::TimedOut) => {
+                                let alive = self.entry_alive(&ref_key, ticket.queue_id()).await;
+                                match probe_verdict(alive, parked_since.elapsed(), self.max_wait) {
+                                    ProbeVerdict::KeepWaiting => continue,
+                                    ProbeVerdict::SpendAttempt => break,
+                                    ProbeVerdict::CeilingReached => {
+                                        return Err(self.ceiling_error());
+                                    }
+                                }
                             }
                         }
+                    }
+                    if attempt + 1 >= attempts_allowed {
+                        return Err(self.stranded_error(retry_eligible));
                     }
                 }
                 SmResponse::IdempotencyHit { record } => {
@@ -275,6 +315,34 @@ impl QueuedTransactor {
             }
         }
         Err(self.stranded_error(retry_eligible))
+    }
+
+    /// Whether the submission bound to `queue_id` is still alive: its
+    /// entry is present in the replicated per-branch queue and the
+    /// cluster has a leader to drive it. An unbound ticket (this node
+    /// never applied the enqueue) and a leaderless view — which is also
+    /// what a partitioned former leader sees — both read as not alive,
+    /// so the retry path gets to surface the real condition.
+    async fn entry_alive(&self, ref_key: &RefKey, queue_id: Option<u64>) -> bool {
+        let Some(queue_id) = queue_id else {
+            return false;
+        };
+        if self.raft.current_leader().await.is_none() {
+            return false;
+        }
+        let state = self.shared_state.read().await;
+        entry_queued(&state, ref_key, queue_id)
+    }
+
+    fn ceiling_error(&self) -> SubmissionError {
+        SubmissionError::Execution {
+            status: 504,
+            message: format!(
+                "submission still queued after {:?}; its outcome is unknown and it may \
+                 still commit — poll with the idempotency key",
+                self.max_wait
+            ),
+        }
     }
 
     fn stranded_error(&self, retry_eligible: bool) -> SubmissionError {
@@ -1044,6 +1112,36 @@ fn rebase_receipt_from(
     }
 }
 
+/// What a probe timeout means for the parked submission.
+#[derive(Debug, PartialEq, Eq)]
+enum ProbeVerdict {
+    /// The entry is alive; park again without spending an attempt.
+    KeepWaiting,
+    /// The entry is gone or the cluster is leaderless; spend an attempt
+    /// on a re-propose (idempotent) or report stranded (anonymous).
+    SpendAttempt,
+    /// Alive, but parked longer than the ceiling allows.
+    CeilingReached,
+}
+
+fn probe_verdict(alive: bool, parked_for: Duration, max_wait: Duration) -> ProbeVerdict {
+    if !alive {
+        ProbeVerdict::SpendAttempt
+    } else if parked_for >= max_wait {
+        ProbeVerdict::CeilingReached
+    } else {
+        ProbeVerdict::KeepWaiting
+    }
+}
+
+/// Whether `queue_id` is still an entry of `ref_key`'s replicated queue.
+fn entry_queued(state: &NameServiceState, ref_key: &RefKey, queue_id: u64) -> bool {
+    state
+        .queues
+        .get(ref_key)
+        .is_some_and(|queue| queue.iter().any(|entry| entry.queue_id == queue_id))
+}
+
 fn submission_error_from_abort(reason: AbortReason) -> SubmissionError {
     match reason {
         AbortReason::BranchDropped => SubmissionError::Execution {
@@ -1078,7 +1176,94 @@ fn submission_error_from_abort(reason: AbortReason) -> SubmissionError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::raft::state_machine::PoisonReason;
+    use crate::raft::state_machine::{PoisonReason, QueueEntry};
+
+    #[test]
+    fn a_probe_timeout_on_a_live_entry_keeps_waiting() {
+        let ceiling = Duration::from_secs(600);
+        assert_eq!(
+            probe_verdict(true, Duration::from_secs(30), ceiling),
+            ProbeVerdict::KeepWaiting,
+            "a slow stage on a queued entry must not spend an attempt"
+        );
+        assert_eq!(
+            probe_verdict(true, Duration::from_secs(599), ceiling),
+            ProbeVerdict::KeepWaiting
+        );
+    }
+
+    #[test]
+    fn a_probe_timeout_on_a_missing_entry_spends_an_attempt() {
+        let ceiling = Duration::from_secs(600);
+        assert_eq!(
+            probe_verdict(false, Duration::from_millis(1), ceiling),
+            ProbeVerdict::SpendAttempt
+        );
+        // Gone beats the ceiling: the retry path gets to surface why.
+        assert_eq!(
+            probe_verdict(false, Duration::from_secs(601), ceiling),
+            ProbeVerdict::SpendAttempt
+        );
+    }
+
+    #[test]
+    fn the_ceiling_only_applies_to_a_live_entry() {
+        let ceiling = Duration::from_secs(600);
+        assert_eq!(
+            probe_verdict(true, ceiling, ceiling),
+            ProbeVerdict::CeilingReached
+        );
+        assert_eq!(
+            probe_verdict(true, Duration::from_secs(601), ceiling),
+            ProbeVerdict::CeilingReached
+        );
+    }
+
+    #[test]
+    fn entry_queued_finds_the_entry_only_on_its_own_branch() {
+        fn cid(seed: u8) -> ContentId {
+            ContentId::new(ContentKind::Commit, &[seed])
+        }
+        let entry = |queue_id: u64| QueueEntry {
+            queue_id,
+            enqueued_index: 1,
+            enqueued_at_millis: 0,
+            idempotency: None,
+            request_cid: cid(queue_id as u8),
+            body_cid: cid(queue_id as u8),
+            body_kind: BodyKind::JsonLdInsert,
+        };
+        let main = RefKey::new("db", "main");
+        let dev = RefKey::new("db", "dev");
+        let mut state = NameServiceState::default();
+        state
+            .queues
+            .entry(main.clone())
+            .or_default()
+            .extend([entry(1), entry(2)]);
+        state
+            .queues
+            .entry(dev.clone())
+            .or_default()
+            .push_back(entry(3));
+
+        assert!(entry_queued(&state, &main, 1));
+        assert!(
+            entry_queued(&state, &main, 2),
+            "a second entry is still queued behind the front"
+        );
+        assert!(
+            !entry_queued(&state, &main, 3),
+            "another branch's entry does not count"
+        );
+        assert!(!entry_queued(&state, &dev, 1));
+        assert!(
+            !entry_queued(&state, &RefKey::new("other", "main"), 1),
+            "an absent queue reads as gone"
+        );
+        state.queues.get_mut(&main).unwrap().pop_front();
+        assert!(!entry_queued(&state, &main, 1), "a popped entry is gone");
+    }
 
     fn status(err: &SubmissionError) -> u16 {
         match err {

--- a/fluree-db-consensus/src/raft/queued_transactor.rs
+++ b/fluree-db-consensus/src/raft/queued_transactor.rs
@@ -248,7 +248,12 @@ impl QueuedTransactor {
                     // entry first gets `GONE_ENTRY_GRACE` for its outcome
                     // to land.
                     loop {
-                        match ticket.wait(self.wait_timeout).await {
+                        // The ceiling must wake a live waiter even when it
+                        // falls before the next probe. Keep polling the ticket
+                        // at zero remaining time so an already-ready outcome
+                        // still wins over the ceiling.
+                        let remaining = self.max_wait.saturating_sub(parked_since.elapsed());
+                        match ticket.wait(self.wait_timeout.min(remaining)).await {
                             Ok(outcome) => return Ok(SubmissionOutcome::Waiter(outcome)),
                             Err(WaitError::Displaced) => break,
                             Err(WaitError::TimedOut) => {

--- a/fluree-db-consensus/src/raft/waiter.rs
+++ b/fluree-db-consensus/src/raft/waiter.rs
@@ -30,10 +30,15 @@
 //!
 //! ## Scope
 //!
-//! Per-process. A leader transition strands waiters from the former
-//! leader — the new leader's adapter does not know they exist. The
-//! transactor recovers via a per-call timeout plus idempotency-keyed
-//! re-issue (see the design doc, "Leader transition mid-flight").
+//! Per-process, but not leader-only: `ApplyHead` replicates to every
+//! node, so a waiter bound on a former leader still resolves when the
+//! new leader's worker finishes the entry. What strands a waiter is the
+//! entry leaving the replicated queue without a terminal apply this
+//! node observes (a snapshot install, a partition). The transactor
+//! parks on the ticket in probe intervals: a timeout that finds the
+//! entry still queued keeps waiting; one that finds it gone spends a
+//! retry attempt on an idempotency-keyed re-issue (see
+//! `QueuedTransactor`).
 
 use crate::raft::staged_receipt::AppliedReceipt;
 use crate::raft::state_machine::{PoisonReason, RefKey};

--- a/fluree-db-consensus/src/raft/waiter.rs
+++ b/fluree-db-consensus/src/raft/waiter.rs
@@ -36,9 +36,9 @@
 //! entry leaving the replicated queue without a terminal apply this
 //! node observes (a snapshot install, a partition). The transactor
 //! parks on the ticket in probe intervals: a timeout that finds the
-//! entry still queued keeps waiting; one that finds it gone spends a
-//! retry attempt on an idempotency-keyed re-issue (see
-//! `QueuedTransactor`).
+//! entry still queued keeps waiting; one that finds it gone waits a
+//! short grace for the outcome, then spends a retry attempt on an
+//! idempotency-keyed re-issue (see `QueuedTransactor`).
 
 use crate::raft::staged_receipt::AppliedReceipt;
 use crate::raft::state_machine::{PoisonReason, RefKey};

--- a/fluree-db-consensus/tests/it_embedded_node.rs
+++ b/fluree-db-consensus/tests/it_embedded_node.rs
@@ -223,10 +223,16 @@ async fn stand_up(
 /// A transaction large enough that staging plus the Raft round trip
 /// always outlasts a probe interval measured in milliseconds.
 fn bulk_request(ledger_id: &str, nodes: usize) -> TransactionRequest {
+    bulk_request_round(ledger_id, nodes, 0)
+}
+
+/// [`bulk_request`] with subjects unique to `round`, so consecutive
+/// submissions to one ledger each assert new data.
+fn bulk_request_round(ledger_id: &str, nodes: usize, round: usize) -> TransactionRequest {
     let graph: Vec<serde_json::Value> = (0..nodes)
         .map(|i| {
             serde_json::json!({
-                "@id": format!("ex:item{i}"),
+                "@id": format!("ex:round{round}-item{i}"),
                 "@type": "ex:Item",
                 "ex:name": format!("Item {i}"),
                 "ex:rank": i as i64
@@ -311,4 +317,38 @@ async fn the_wait_ceiling_bounds_a_live_submission_and_reports_it_unknown() {
             .is_some_and(|record| record.commit_t >= 1)
     })
     .await;
+}
+
+/// The entry leaves the replicated queue under the state lock, but its
+/// terminal apply resolves the waiter only after that lock drops. A probe
+/// that reads in between sees the entry gone while the receipt is moments
+/// from landing, and must wait for that receipt rather than report the
+/// submission stranded. One submission at a 1 ms probe hits the window
+/// roughly one time in six; twenty in a row make missing it the exception.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_probe_that_finds_the_entry_just_popped_still_returns_the_receipt() {
+    let (_integration, fluree, node, _dirs) = stand_up(13, |config| {
+        config.with_submit_wait(Duration::from_millis(1), 1)
+    })
+    .await;
+    fluree
+        .create_ledger("embedded/popped")
+        .await
+        .expect("create ledger");
+
+    let mut last_t = 0;
+    for round in 0..20 {
+        let receipt = node
+            .committer
+            .transact(bulk_request_round("embedded/popped:main", 200, round))
+            .await
+            .unwrap_or_else(|err| {
+                panic!("round {round}: a receipt landing right behind the probe must not be reported stranded: {err:?}")
+            });
+        assert!(
+            receipt.commit.t > last_t,
+            "round {round}: head must advance: {receipt:?}"
+        );
+        last_t = receipt.commit.t;
+    }
 }

--- a/fluree-db-consensus/tests/it_embedded_node.rs
+++ b/fluree-db-consensus/tests/it_embedded_node.rs
@@ -157,3 +157,158 @@ async fn an_embedder_can_stand_up_a_raft_node_and_write_through_it() {
     // 9. Teardown in the order the node owns.
     node.shutdown().await;
 }
+
+/// Stand up a single-voter embedded node with `configure` applied to the
+/// attach config, and return the pieces a test drives.
+async fn stand_up(
+    node_id: u64,
+    configure: impl FnOnce(EmbeddedRaftConfig) -> EmbeddedRaftConfig,
+) -> (
+    Arc<RaftIntegration>,
+    Arc<fluree_db_api::Fluree>,
+    EmbeddedRaftNode,
+    (tempfile::TempDir, tempfile::TempDir),
+) {
+    let raft_dir = tempfile::tempdir().expect("raft dir");
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let integration = Arc::new(
+        RaftIntegration::bootstrap(RaftBootstrapConfig::new(node_id, raft_dir.path()))
+            .await
+            .expect("bootstrap"),
+    );
+    let app = axum::Router::new()
+        .nest("/raft/nameservice", integration.raft_rpc_router())
+        .nest("/cluster/nameservice", integration.cluster_admin_router());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let ns: Arc<dyn NameServicePublisher> = integration.nameservice();
+    let fluree = Arc::new(
+        FlureeBuilder::file(data_dir.path().to_string_lossy().as_ref())
+            .with_event_bus(Arc::clone(&integration.event_bus))
+            .build_client_with_nameservice(NameServiceMode::ReadWrite(ns))
+            .await
+            .expect("engine builds"),
+    );
+    let node = EmbeddedRaftNode::attach(
+        Arc::clone(&integration),
+        Arc::clone(&fluree),
+        configure(EmbeddedRaftConfig::for_engine(&fluree)),
+    )
+    .await;
+    let mut members = BTreeMap::new();
+    members.insert(
+        node_id,
+        fluree_db_consensus::raft::ClusterNode::new(
+            format!("http://127.0.0.1:{port}/raft/nameservice"),
+            format!("http://127.0.0.1:{port}"),
+        ),
+    );
+    integration
+        .raft
+        .initialize(members)
+        .await
+        .expect("initialize");
+    eventually("self-election", async || {
+        integration.raft.current_leader().await == Some(node_id)
+    })
+    .await;
+    (integration, fluree, node, (raft_dir, data_dir))
+}
+
+/// A transaction large enough that staging plus the Raft round trip
+/// always outlasts a probe interval measured in milliseconds.
+fn bulk_request(ledger_id: &str, nodes: usize) -> TransactionRequest {
+    let graph: Vec<serde_json::Value> = (0..nodes)
+        .map(|i| {
+            serde_json::json!({
+                "@id": format!("ex:item{i}"),
+                "@type": "ex:Item",
+                "ex:name": format!("Item {i}"),
+                "ex:rank": i as i64
+            })
+        })
+        .collect();
+    TransactionRequest {
+        idempotency_key: None,
+        ledger_id: ledger_id.into(),
+        body: TransactionBody::JsonLdInsert(serde_json::json!({
+            "@context": {"ex": "http://example.org/"},
+            "@graph": graph
+        })),
+        txn_opts: Default::default(),
+        commit_opts: Default::default(),
+        tracking: None,
+        governance: Default::default(),
+    }
+}
+
+/// The waiter's probe interval bounds leader-transition recovery, not
+/// commit latency: a submission whose stage outlasts the interval — by a
+/// wide margin here, with a 1 ms probe and a single attempt — stays
+/// parked while its entry is queued and comes back with a receipt.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_queued_submission_outlives_the_probe_interval_while_its_entry_is_queued() {
+    let (_integration, fluree, node, _dirs) = stand_up(11, |config| {
+        config.with_submit_wait(Duration::from_millis(1), 1)
+    })
+    .await;
+    fluree
+        .create_ledger("embedded/slow")
+        .await
+        .expect("create ledger");
+
+    let receipt = node
+        .committer
+        .transact(bulk_request("embedded/slow:main", 2_000))
+        .await
+        .expect("a slow but live submission must not be reported stranded");
+    assert!(
+        receipt.commit.t >= 1,
+        "the commit must carry a t: {receipt:?}"
+    );
+    assert_eq!(receipt.commit.flake_count, 2_000 * 3);
+}
+
+/// The ceiling is the only clock that turns a live, still-queued entry
+/// into a 504 — and it says so, naming the outcome as unknown rather
+/// than failed, because the worker commits regardless.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_wait_ceiling_bounds_a_live_submission_and_reports_it_unknown() {
+    let (integration, fluree, node, _dirs) = stand_up(12, |config| {
+        config
+            .with_submit_wait(Duration::from_millis(1), 1)
+            .with_submit_max_wait(Duration::from_millis(1))
+    })
+    .await;
+    fluree
+        .create_ledger("embedded/ceiling")
+        .await
+        .expect("create ledger");
+
+    let err = node
+        .committer
+        .transact(bulk_request("embedded/ceiling:main", 2_000))
+        .await
+        .expect_err("a 1 ms ceiling cannot outlast a 2,000-node stage");
+    let text = format!("{err:?}");
+    assert!(
+        text.contains("504") && text.contains("outcome is unknown"),
+        "ceiling must surface as a 504 with the outcome unknown: {text}"
+    );
+
+    // The submission the caller gave up on still commits.
+    let ns: Arc<dyn NameServiceLookup> = integration.nameservice();
+    eventually("the abandoned submission commits anyway", async || {
+        ns.lookup("embedded/ceiling:main")
+            .await
+            .ok()
+            .flatten()
+            .is_some_and(|record| record.commit_t >= 1)
+    })
+    .await;
+}

--- a/fluree-db-consensus/tests/it_embedded_node.rs
+++ b/fluree-db-consensus/tests/it_embedded_node.rs
@@ -319,6 +319,75 @@ async fn the_wait_ceiling_bounds_a_live_submission_and_reports_it_unknown() {
     .await;
 }
 
+/// A ceiling shorter than the probe must wake a live waiter on its own.
+/// Hold the ledger write lock so completion cannot race the ceiling, and
+/// release it after the caller times out to prove the queued write still
+/// commits.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_wait_ceiling_bounds_a_submission_before_its_next_probe() {
+    use fluree_db_consensus::raft::state_machine::RefKey;
+
+    let (integration, fluree, node, _dirs) = stand_up(14, |config| {
+        config
+            .with_submit_wait(Duration::from_secs(10), 1)
+            .with_submit_max_wait(Duration::from_millis(20))
+    })
+    .await;
+    let ledger_id = "embedded/short-ceiling:main";
+    fluree
+        .create_ledger("embedded/short-ceiling")
+        .await
+        .expect("create ledger");
+    let handle = fluree
+        .ledger_manager()
+        .expect("ledger manager")
+        .get_or_load(ledger_id)
+        .await
+        .expect("load ledger");
+    let guard = handle.lock_for_write().await;
+    let committer = Arc::clone(&node.committer);
+    let mut submission =
+        tokio::spawn(async move { committer.transact(bulk_request(ledger_id, 1)).await });
+
+    eventually("the blocked submission is queued", async || {
+        integration
+            .shared_state
+            .read()
+            .await
+            .queues
+            .get(&RefKey::new("embedded/short-ceiling", "main"))
+            .is_some_and(|queue| !queue.is_empty())
+    })
+    .await;
+
+    // Allow scheduling slack, but stay well below the 10-second probe.
+    let result = tokio::time::timeout(Duration::from_secs(1), &mut submission).await;
+    drop(guard);
+    let err = result
+        .expect("the 20 ms ceiling must wake the waiter before its 10 s probe")
+        .expect("submission task")
+        .expect_err("a blocked worker must reach the ceiling");
+    assert!(
+        matches!(err, fluree_db_consensus::SubmissionError::Execution { status: 504, ref message }
+            if message.contains("outcome is unknown")),
+        "ceiling must report a 504 with the outcome unknown: {err:?}"
+    );
+
+    let ns: Arc<dyn NameServiceLookup> = integration.nameservice();
+    eventually(
+        "the timed-out write commits after the lock is released",
+        async || {
+            ns.lookup(ledger_id)
+                .await
+                .ok()
+                .flatten()
+                .is_some_and(|record| record.commit_t >= 1)
+        },
+    )
+    .await;
+    node.shutdown().await;
+}
+
 /// The entry leaves the replicated queue under the state lock, but its
 /// terminal apply resolves the waiter only after that lock drops. A probe
 /// that reads in between sees the entry gone while the receipt is moments

--- a/fluree-db-server/src/lib.rs
+++ b/fluree-db-server/src/lib.rs
@@ -822,6 +822,10 @@ impl FlureeServerBuilder {
                         .expect("index_config set by AppState::new"),
                     liveness: self.liveness_config.clone(),
                     extra_leader_tasks: Some(Box::new(leader_tasks)),
+                    // Transactor defaults. Operator tuning of the write
+                    // path's timeouts is tracked under #1382.
+                    submit_wait: None,
+                    submit_max_wait: None,
                 };
                 let node = fluree_db_consensus::raft::embedded::EmbeddedRaftNode::attach(
                     Arc::clone(integration),


### PR DESCRIPTION
## Problem

`QueuedTransactor` used a fixed 8-second per-attempt wait and up to three attempts, treating expiry as a stranded submission even when execution was still progressing.

The reported incident was a single `where/delete` retracting 26,839 stale edges over a roughly 4.6-million-triple ledger on a release build. Staging exceeded the synchronous wait budget: the caller received a 504 while processing continued and the write completed. This was a large-statement staging cost plus a misleading timeout response. The reporter's chunked publish/canonicalize paths used an identity commit barrier and did not hit this budget. Novelty-at-maximum refusals after restore were a separate backpressure/reindexing issue.

`EmbeddedRaftConfig` also gave a host no way to tune the queued submission wait.

## Change

- Treat waiter timeouts as probes. While the entry remains in the replicated per-branch queue and the node knows a leader, keep waiting without spending a retry attempt. Missing entries or a leaderless view use the existing retry path.
- Bound waiting on a live entry with a configurable ceiling, defaulting to 10 minutes. Cap each waiter sleep at the remaining ceiling budget so it takes effect even when shorter than the probe interval. An already-ready receipt still wins.
- Report a ceiling expiry as an unknown outcome because the write may still commit. Keyed callers are told to poll with their key; anonymous callers are told to check the ledger head before retrying.
- Give missing entries a 250 ms outcome grace: queue removal happens under the state lock, and observer effects deliver the receipt after that lock drops.
- Expose probe/attempt and ceiling settings through `EmbeddedRaftConfig`; wire defaults at the server attach site. Document the wait and surrounding timeouts.
- Clarify that `ApplyHead` replicates to every node, allowing a waiter on a former leader to resolve when another worker completes its entry.

## Validation

- `cargo test -p fluree-db-consensus --features raft`: 332 library tests and 14 integration tests (including 5 embedded-node tests) pass.
- The new regression holds the ledger write lock with a 20 ms ceiling and a 10-second probe. It requires the queued caller to receive an unknown-outcome 504 before the probe, then releases the lock and verifies that the write commits. It fails before the fix and passes after it.
- Existing coverage verifies live submissions outlasting probe intervals, ceiling reporting with eventual commit, and receipt delivery across the queue-pop/observer window.
- `cargo fmt --all -- --check` and `cargo clippy -p fluree-db-consensus --features raft --all-targets -- -D warnings` pass.

## Follow-up

- #1382 tracks the follower-to-leader forwarding timeout (60 seconds) and server exposure of the submit wait settings. A forwarded write can still time out before the transactor's default ceiling.
- Investigate the large statement's `where` execution and retraction staging separately. This PR changes waiting/reporting, not staging performance.
- Raft finalization also retains an extra dictionary reference that forces copying accumulated dictionary entries per commit. Ownership probes confirmed the copies, but their contribution to the reported latency is unmeasured; that performance work remains separate.
