### PR TITLE
fix(query): prevent Unicode panic in dictionary error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,6 +3864,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
+ "tracing-subscriber",
  "winnow 0.7.14",
 ]
 

--- a/fluree-db-api/src/import.rs
+++ b/fluree-db-api/src/import.rs
@@ -111,6 +111,15 @@ async fn publish_import_commit_head(
 const IMPORT_PIPELINE_WAIT_LOG_THRESHOLD_MS: u128 = 50;
 const LOCAL_RECHUNK_EVENT_CHANNEL_CAPACITY: usize = 2;
 
+fn log_ttl_chunk(idx: usize, ttl: &str) {
+    tracing::debug!(
+        chunk_idx = idx,
+        chunk_text_len = ttl.len(),
+        starts_with = ttl.chars().take(200).collect::<String>(),
+        "about to parse chunk"
+    );
+}
+
 // ============================================================================
 // Configuration
 // ============================================================================
@@ -4603,12 +4612,7 @@ where
                         };
 
                         let t = (idx + 1) as i64;
-                        tracing::debug!(
-                            chunk_idx = idx,
-                            chunk_text_len = ttl.len(),
-                            starts_with = &ttl[..ttl.len().min(200)],
-                            "about to parse chunk"
-                        );
+                        log_ttl_chunk(idx, &ttl);
                         // This arm streams a SINGLE local file, so every chunk
                         // belongs to the same document; `idx` is its sub-chunk
                         // index inside that document.
@@ -7275,6 +7279,34 @@ where
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod logging_tests {
+    use super::log_ttl_chunk;
+
+    #[test]
+    fn unicode_chunk_logging_at_byte_200() {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(std::io::sink)
+            .finish();
+        tracing::subscriber::with_default(subscriber, || {
+            assert!(tracing::enabled!(tracing::Level::DEBUG));
+            for character in ['±', '界', '🦀'] {
+                let start = "<http://example.org/s> <http://example.org/p> \"";
+                let ttl = format!(
+                    "{start}{}{character} trailing text\" .\n",
+                    "a".repeat(199 - start.len())
+                );
+                assert!(!ttl.is_char_boundary(200));
+                log_ttl_chunk(0, &ttl);
+            }
+            for ttl in ["", "short ±界🦀", &"a".repeat(201), &"界".repeat(100)] {
+                log_ttl_chunk(0, ttl);
+            }
+        });
+    }
 }
 
 #[cfg(test)]

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -3539,15 +3539,18 @@ fn resolve_string_v3(
     store: &BinaryIndexStore,
     dict_novelty: Option<&Arc<fluree_db_core::dict_novelty::DictNovelty>>,
 ) -> std::io::Result<u32> {
-    find_string_id_v3(value, store, dict_novelty)?.ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!(
-                "string not found in dict: {}",
-                &value[..value.len().min(50)]
-            ),
-        )
-    })
+    find_string_id_v3(value, store, dict_novelty)?.ok_or_else(|| string_not_found_error(value))
+}
+
+fn string_not_found_error(value: &str) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!(
+            "string not found in dict: {}",
+            // A byte limit can split a UTF-8 character and panic while reporting the miss.
+            value.chars().take(50).collect::<String>()
+        ),
+    )
 }
 
 /// Convert a FlakeValue to `(OType, o_key)` in V3 encoding.
@@ -4504,6 +4507,46 @@ mod bounded_overlay_walk_tests {
 mod tests {
     use super::*;
     use fluree_db_core::{stats_view::GraphPropertyStatData, StatsView, ValueTypeTag};
+
+    #[test]
+    fn string_not_found_error_preserves_short_values_and_truncates_ascii() {
+        for (value, preview) in [
+            (String::new(), String::new()),
+            ("tolerance ±0.1".to_owned(), "tolerance ±0.1".to_owned()),
+            ("a".repeat(50), "a".repeat(50)),
+            ("a".repeat(51), "a".repeat(50)),
+        ] {
+            let error = string_not_found_error(&value);
+            assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+            assert_eq!(
+                error.to_string(),
+                format!("string not found in dict: {preview}")
+            );
+        }
+    }
+
+    #[test]
+    fn string_not_found_error_handles_multibyte_characters_at_truncation_boundary() {
+        // Byte 50 splits each of these UTF-8 characters. Formatting the
+        // dictionary miss must return an error rather than panic.
+        for character in ['±', '界', '🦀'] {
+            let preview = format!("{}{character}", "a".repeat(49));
+            let value = format!("{preview} trailing text");
+            let error = string_not_found_error(&value);
+            assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+            assert_eq!(
+                error.to_string(),
+                format!("string not found in dict: {preview}")
+            );
+        }
+
+        // Fewer than 50 characters can still exceed 50 bytes.
+        let value = "界".repeat(20);
+        assert_eq!(
+            string_not_found_error(&value).to_string(),
+            format!("string not found in dict: {value}")
+        );
+    }
 
     fn stats_with(
         datatypes: Vec<(ValueTypeTag, u64)>,

--- a/fluree-graph-turtle/Cargo.toml
+++ b/fluree-graph-turtle/Cargo.toml
@@ -17,6 +17,7 @@ rustc-hash = "2"
 
 [dev-dependencies]
 tempfile = "3"
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/fluree-graph-turtle/src/splitter.rs
+++ b/fluree-graph-turtle/src/splitter.rs
@@ -235,7 +235,7 @@ fn extract_prefix_block_from_bytes(buf: &[u8]) -> Result<(String, u64), SplitErr
     tracing::info!(
         prefix_len = prefix_text.len(),
         data_start,
-        prefix_first_500 = &prefix_text[..prefix_text.len().min(500)],
+        prefix_first_500 = prefix_text.chars().take(500).collect::<String>(),
         "prefix block extracted"
     );
 
@@ -991,7 +991,7 @@ impl StreamingTurtleReader {
             chunk_size_mb = chunk_size_bytes / (1024 * 1024),
             prefix_bytes = prefix_block.len(),
             data_start,
-            prefix_first_200 = &prefix_block[..prefix_block.len().min(200)],
+            prefix_first_200 = prefix_block.chars().take(200).collect::<String>(),
             "streaming reader: prefix extracted, spawning reader thread"
         );
 
@@ -2068,6 +2068,44 @@ ex:bob ex:name \"Bob\" .
     }
 
     // ---- StreamingTurtleReader tests ----
+
+    fn assert_unicode_prefix_logging(limit: usize) {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(std::io::sink)
+            .finish();
+        tracing::subscriber::with_default(subscriber, || {
+            assert!(tracing::enabled!(tracing::Level::INFO));
+            for character in ['±', '界', '🦀'] {
+                let start = "@prefix ex: <http://example.org/";
+                // Put a multibyte character across the old byte cutoff.
+                let prefix = format!(
+                    "{start}{}{character}/> .\n",
+                    "a".repeat(limit - 1 - start.len())
+                );
+                assert!(!prefix.is_char_boundary(limit));
+                let data = "ex:alice ex:name \"Alice\" .\n";
+                let f = write_temp(&format!("{prefix}{data}"));
+                let mut reader = StreamingTurtleReader::new(f.path(), 64 * 1024, 2, None)
+                    .expect("Unicode prefix logging must not panic");
+                assert_eq!(reader.prefix_block(), prefix);
+                let (_, raw) = reader.recv_chunk().unwrap().unwrap();
+                assert_eq!(String::from_utf8(raw).unwrap(), data);
+                assert!(reader.recv_chunk().unwrap().is_none());
+                assert_eq!(reader.join().unwrap(), 1);
+            }
+        });
+    }
+
+    #[test]
+    fn unicode_prefix_logging_at_byte_500() {
+        assert_unicode_prefix_logging(500);
+    }
+
+    #[test]
+    fn unicode_prefix_logging_at_byte_200() {
+        assert_unicode_prefix_logging(200);
+    }
 
     /// Helper: receive a chunk from the reader, prepend prefix, return full TTL text.
     fn recv_as_text(reader: &StreamingTurtleReader) -> Option<(usize, String)> {


### PR DESCRIPTION
When a missing dictionary string has a multibyte UTF-8 character spanning byte 50, `resolve_string_v3` panics while formatting its `NotFound` error. For example, 49 ASCII characters followed by `±` trigger the panic; with `panic=abort`, this terminates the server.

Truncate the error preview to 50 Unicode characters and extract the error construction into a helper for regression coverage. Dictionary lookup behavior is unchanged.

Validation:
- Reproduced the original panic with the regression test before restoring the fix.
- Added coverage for two-, three-, and four-byte characters at the truncation boundary, short Unicode strings, empty strings, and ASCII truncation.
- `cargo test -p fluree-db-query --lib --locked`: 1,553 passed, 1 ignored.
- `cargo fmt --all --check` and `git diff --check` passed.
- `RUSTC_WRAPPER= cargo clippy -p fluree-db-query --lib --tests --locked --no-deps -- -D warnings` passed (the local sccache wrapper failed to start).
