### PR TITLE
ci: speed up tests, benchmarks, and Apple releases

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+# Organization-managed GitHub larger runner used by CI and benchmarks.
+self-hosted-runner:
+  labels:
+    - ci-cd-large

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,8 +18,8 @@ on:
           Repeat runs to fold into the captured baseline. 1 is a single
           measurement with no noise estimate; >= 5 records a median + MAD, which
           is what a baseline intended to GATE on shared runners needs — the
-          compare gate widens each budget to 3*MAD/median, and ubuntu-latest
-          flap is the whole reason the per-PR compare is advisory today.
+          compare gate widens each budget to 3*MAD/median, and shared-runner
+          variability is the whole reason the per-PR compare is advisory today.
         required: false
         default: "1"
 
@@ -43,24 +43,23 @@ jobs:
     #
     # A cold cache must compile the whole workspace's benches in release
     # (consensus / search-service / search-httpd and their heavy deps);
-    # `timeout-minutes` caps the job so a genuinely hung bench fails fast.
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Use 8 cores / 32 GB and allow cold builds 60 minutes. The previous
+    # 4-core job repeatedly timed out during compilation at 45 minutes.
+    runs-on: ci-cd-large
+    timeout-minutes: 60
     env:
       FLUREE_BENCH_PROFILE: quick
       FLUREE_BENCH_SCALE: tiny
       # Baseline is host_class=local, so the nightly compare treats time and
       # memory as advisory until a ci-* baseline is committed (bench-capture).
       # (FLUREE_BENCH_RUNNER_CLASS is still read as the pre-rename spelling.)
-      FLUREE_BENCH_HOST_CLASS: ci-ubuntu-latest
+      FLUREE_BENCH_HOST_CLASS: ci-cd-large-8core
     steps:
-      - name: Free disk space
+      - name: Runner capacity
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
+          nproc
+          free -h
+          df -h /
 
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.97.0
@@ -68,6 +67,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Reconcile first — failure here is fast (no compile needed) and
       # tells the contributor exactly which bench / budget entry is
@@ -78,6 +78,9 @@ jobs:
       # Build all benches in release. Heavy on cold cache; rust-cache
       # makes subsequent runs cheap.
       - name: Build benches
+        id: build-benches
+        # Leave time for rust-cache's post step even if a cold build times out.
+        timeout-minutes: 45
         run: cargo bench --workspace --no-run
 
       # Smoke-run every bench's scenarios at `tiny` scale via criterion's
@@ -88,50 +91,49 @@ jobs:
         run: cargo bench --workspace -- --test
 
       # Real per-bench compare of the captured subset against the committed
-      # baseline (the nightly perf-regression gate). `if: always()` so it runs
-      # even when an unrelated workspace bench trips the smoke step above.
+      # baseline even if an unrelated bench fails its smoke test. Do not start
+      # more builds after cancellation or a failed build: `always()` previously
+      # kept a timed-out job alive for another ten minutes.
       # Follow-up (ROADMAP.md §7 cost caveat): the full workspace compare at
-      # +medium against a phase post-baseline needs the 45-min cap raised or the
+      # +medium against a phase post-baseline needs its runtime measured or the
       # workflow split, so it is deliberately NOT wired here yet.
       - name: Compare captured subset against committed baseline
-        if: always()
+        if: ${{ !cancelled() && steps.build-benches.outcome == 'success' }}
         run: |
-          rm -rf target/fluree-bench-mem target/fluree-bench-meta
-          cargo bench -p fluree-db-api --bench query_overlay_matrix
-          cargo bench -p fluree-db-api --bench query_hot_bsbm
+          rm -rf target/criterion target/fluree-bench-mem target/fluree-bench-meta
+          cargo bench -p fluree-db-api --bench query_overlay_matrix --bench query_hot_bsbm
           cargo run -p fluree-bench-support --bin bench-baseline -- \
             compare --baseline bench-baselines/guardrails-pre.json \
             --allow-host-mismatch
 
   bench-capture:
     # On-demand CI-class baseline capture (review item 1c). Captures the cheap
-    # subset on ubuntu-latest with runner_class=ci-ubuntu-latest and uploads the
+    # subset on ci-cd-large with runner_class=ci-cd-large-8core and uploads the
     # JSON as an artifact. Committing it to bench-baselines/ is a human follow-up
     # — once a ci-* baseline lands, the per-PR compare's TIME half enforces
     # automatically (runner classes match). workflow_dispatch only (not on the
     # nightly schedule) to avoid the extra cost every night.
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ci-cd-large
     timeout-minutes: 30
     env:
       FLUREE_BENCH_PROFILE: quick
       FLUREE_BENCH_SCALE: tiny
-      FLUREE_BENCH_HOST_CLASS: ci-ubuntu-latest
+      FLUREE_BENCH_HOST_CLASS: ci-cd-large-8core
     steps:
-      - name: Free disk space
+      - name: Runner capacity
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
+          nproc
+          free -h
+          df -h /
 
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Same cheap subset and scales (tiny+small) as the committed baseline, so
       # the artifact is a drop-in ci-* replacement once a human commits it.
@@ -154,10 +156,9 @@ jobs:
           rm -f bench-baselines/guardrails-pre-ci.json
           for pass in $(seq 1 "$samples"); do
             echo "::group::capture pass $pass/$samples"
-            rm -rf target/fluree-bench-mem target/fluree-bench-meta
+            rm -rf target/criterion target/fluree-bench-mem target/fluree-bench-meta
             for scale in tiny small; do
-              FLUREE_BENCH_SCALE=$scale cargo bench -p fluree-db-api --bench query_overlay_matrix
-              FLUREE_BENCH_SCALE=$scale cargo bench -p fluree-db-api --bench query_hot_bsbm
+              FLUREE_BENCH_SCALE=$scale cargo bench -p fluree-db-api --bench query_overlay_matrix --bench query_hot_bsbm
             done
             cargo run -p fluree-bench-support --bin bench-baseline -- \
               capture --label guardrails-pre-ci --out bench-baselines/guardrails-pre-ci.json \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,7 +39,9 @@ env:
 
 jobs:
   bench-gate:
-    if: ${{ !inputs.compare_only }}
+    # `inputs` is empty on the nightly schedule; say so explicitly instead of
+    # relying on `!null`. Mirrors the bench-capture guard below.
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.compare_only }}
     # Failure modes:
     #   - A bench no longer compiles (real API regression).
     #   - A bench's `--test` mode panics or never returns.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -75,20 +75,23 @@ jobs:
       - name: Reconcile workspace [[bench]] entries with regression-budget.json
         run: cargo test -p fluree-bench-support --test workspace_reconcile
 
-      # Build all benches in release. Heavy on cold cache; rust-cache
-      # makes subsequent runs cheap.
+      # Select every explicit benchmark target. Bare `cargo bench --workspace`
+      # also builds libraries/binaries as libtest benchmark harnesses under fat
+      # LTO, even though this workspace has no inline #[bench] functions.
+      # The per-PR nextest job already runs the unit and integration tests.
+      # Enable the GraphQL bench's required feature explicitly.
       - name: Build benches
         id: build-benches
         # Leave time for rust-cache's post step even if a cold build times out.
         timeout-minutes: 45
-        run: cargo bench --workspace --no-run
+        run: cargo bench --workspace --bench '*' --features fluree-db-api/graphql --no-run
 
       # Smoke-run every bench's scenarios at `tiny` scale via criterion's
       # `--test` mode (one iteration per scenario, no statistics collected).
       # Catches benches that compile but panic at runtime (bad SPARQL,
       # broken setup, missing API surface).
       - name: Smoke-run benches at tiny scale
-        run: cargo bench --workspace -- --test
+        run: cargo bench --workspace --bench '*' --features fluree-db-api/graphql --no-fail-fast -- --test
 
       # Real per-bench compare of the captured subset against the committed
       # baseline even if an unrelated bench fails its smoke test. Do not start

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,9 +13,13 @@ on:
     - cron: "0 7 * * *" # 07:00 UTC daily
   workflow_dispatch:
     inputs:
+      capture_baseline:
+        description: Also capture a replacement baseline artifact
+        type: boolean
+        default: false
       capture_samples:
         description: >-
-          Repeat runs to fold into the captured baseline. 1 is a single
+          Repeat runs (1–10) to fold into the captured baseline. 1 is a single
           measurement with no noise estimate; >= 5 records a median + MAD, which
           is what a baseline intended to GATE on shared runners needs — the
           compare gate widens each budget to 3*MAD/median, and shared-runner
@@ -61,7 +65,7 @@ jobs:
           free -h
           df -h /
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.97.0
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
@@ -113,12 +117,13 @@ jobs:
     # On-demand CI-class baseline capture (review item 1c). Captures the cheap
     # subset on ci-cd-large with runner_class=ci-cd-large-8core and uploads the
     # JSON as an artifact. Committing it to bench-baselines/ is a human follow-up
-    # — once a ci-* baseline lands, the per-PR compare's TIME half enforces
+    # — once a ci-* baseline lands, time and memory comparisons enforce
     # automatically (runner classes match). workflow_dispatch only (not on the
     # nightly schedule) to avoid the extra cost every night.
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.capture_baseline
     runs-on: ci-cd-large
-    timeout-minutes: 30
+    # Up to ten sequential tiny+small passes, plus a cold build.
+    timeout-minutes: 90
     env:
       FLUREE_BENCH_PROFILE: quick
       FLUREE_BENCH_SCALE: tiny
@@ -130,7 +135,7 @@ jobs:
           free -h
           df -h /
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.97.0
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
@@ -146,14 +151,16 @@ jobs:
       # MAD. Passes must NOT be parallelised and the sidecars are cleared each
       # time: a sample has to be an independent measurement of the same thing.
       - name: Capture cheap subset (CI-class)
+        env:
+          CAPTURE_SAMPLES: ${{ inputs.capture_samples || '1' }}
         run: |
-          samples="${{ github.event.inputs.capture_samples || '1' }}"
+          samples="$CAPTURE_SAMPLES"
           # `seq 1 0` runs zero passes, so a 0 (or any non-number) would produce
           # no baseline at all while the job still reported success. Fail loudly
           # instead — a capture job that captures nothing is worse than one that
           # errors, because the artifact step would then upload nothing quietly.
-          if ! [[ "$samples" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::capture_samples must be a positive integer, got '$samples'"
+          if ! [[ "$samples" =~ ^([1-9]|10)$ ]]; then
+            echo "::error::capture_samples must be an integer from 1 to 10, got '$samples'"
             exit 1
           fi
           rm -f bench-baselines/guardrails-pre-ci.json
@@ -170,7 +177,7 @@ jobs:
           done
 
       - name: Upload CI-class baseline artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: guardrails-pre-ci-baseline
           path: bench-baselines/guardrails-pre-ci.json

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -41,8 +41,8 @@ jobs:
     #   - A `[[bench]]` is declared in Cargo.toml without a matching
     #     entry in `regression-budget.json` (or vice versa).
     #
-    # A cold cache must compile the whole workspace's benches in release
-    # (consensus / search-service / search-httpd and their heavy deps);
+    # A cold cache must compile all explicit workspace benchmarks and their
+    # dependencies in release.
     # Use 8 cores / 32 GB and allow cold builds 60 minutes. The previous
     # 4-core job repeatedly timed out during compilation at 45 minutes.
     runs-on: ci-cd-large

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,18 +1,18 @@
 name: Bench (nightly)
 
-# Bench smoke + reconcile. Runs on a nightly schedule (and on demand via
-# workflow_dispatch) — NOT per-PR. It compiles the whole workspace's benches
-# in release, which is the long pole and was never meant to gate every PR
-# (it had been wired into ci.yml by mistake). Per-PR coverage is preserved:
-# `clippy --all --all-features --all-targets` in ci.yml still compiles every
-# bench on every PR, so API/compile breakage is caught there; this nightly
-# adds the runtime smoke and the [[bench]] <-> regression-budget.json reconcile.
+# Benchmark execution runs nightly and on demand. Normal CI checks benchmark
+# compilation through Clippy; release builds and statistical measurements stay
+# off the PR critical path. Full smoke and subset comparison run independently.
 
 on:
   schedule:
     - cron: "0 7 * * *" # 07:00 UTC daily
   workflow_dispatch:
     inputs:
+      compare_only:
+        description: Only run the quick benchmark comparison (skip full smoke)
+        type: boolean
+        default: false
       capture_baseline:
         description: Also capture a replacement baseline artifact
         type: boolean
@@ -23,7 +23,7 @@ on:
           measurement with no noise estimate; >= 5 records a median + MAD, which
           is what a baseline intended to GATE on shared runners needs — the
           compare gate widens each budget to 3*MAD/median, and shared-runner
-          variability is the whole reason the per-PR compare is advisory today.
+          variability is the whole reason time/memory comparison is advisory today.
         required: false
         default: "1"
 
@@ -39,6 +39,7 @@ env:
 
 jobs:
   bench-gate:
+    if: ${{ !inputs.compare_only }}
     # Failure modes:
     #   - A bench no longer compiles (real API regression).
     #   - A bench's `--test` mode panics or never returns.
@@ -97,18 +98,55 @@ jobs:
       - name: Smoke-run benches at tiny scale
         run: cargo bench --workspace --bench '*' --features fluree-db-api/graphql --no-fail-fast -- --test
 
-      # Real per-bench compare of the captured subset against the committed
-      # baseline even if an unrelated bench fails its smoke test. Do not start
-      # more builds after cancellation or a failed build: `always()` previously
-      # kept a timed-out job alive for another ten minutes.
-      # Follow-up (ROADMAP.md §7 cost caveat): the full workspace compare at
-      # +medium against a phase post-baseline needs its runtime measured or the
-      # workflow split, so it is deliberately NOT wired here yet.
-      - name: Compare captured subset against committed baseline
-        if: ${{ !cancelled() && steps.build-benches.outcome == 'success' }}
+  bench-compare:
+    # Nightly and on demand. Run independently of the full benchmark build so
+    # comparison results are available sooner, even if a smoke benchmark fails.
+    runs-on: ci-cd-large
+    timeout-minutes: 30
+    env:
+      FLUREE_BENCH_PROFILE: quick
+      FLUREE_BENCH_SCALE: tiny
+      # CI-class marker. The committed baseline is host_class=local, so this
+      # mismatch is what makes both metrics advisory today.
+      # (FLUREE_BENCH_RUNNER_CLASS is still read as the pre-rename spelling.)
+      FLUREE_BENCH_HOST_CLASS: ci-cd-large-8core
+    steps:
+      - name: Runner capacity
+        run: |
+          nproc
+          free -h
+          df -h /
+
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.97.0
+      - uses: rui314/setup-mold@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # Clear stale sidecars first: rust-cache persists target/ across runs, and
+      # compare must not merge a mem number from a bench not rerun this session
+      # (review item 10), nor a corpus block from a run that never read that
+      # corpus. Clear Criterion's cached comparisons too: rust-cache prunes
+      # sample.json, leaving dangling comparisons. One Cargo invocation builds
+      # both binaries in parallel, then measures them sequentially.
+      - name: Run cheap benches (tiny, quick)
         run: |
           rm -rf target/criterion target/fluree-bench-mem target/fluree-bench-meta
           cargo bench -p fluree-db-api --bench query_overlay_matrix --bench query_hot_bsbm
+
+      # Compare against the committed baseline. Exit 1 on any breach of a metric
+      # the host-class match makes enforcing, 2 on a refusal to compare.
+      #
+      # --allow-host-mismatch is the phase-1 posture and nothing else: the
+      # committed baseline is host_class=local, this runner is
+      # ci-cd-large-8core, and without the flag the job would refuse outright.
+      # DROP THIS FLAG once a ci-cd-large-8core baseline is committed (bench.yml's
+      # bench-capture job) — the flag is what stands between annotations and a
+      # real gate. Phase-share drift enforces either way.
+      - name: Compare against committed baseline
+        run: |
           cargo run -p fluree-bench-support --bin bench-baseline -- \
             compare --baseline bench-baselines/guardrails-pre.json \
             --allow-host-mismatch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
       - name: Clippy
         run: cargo clippy --all --all-features --all-targets -- -D warnings
 
+      # Clippy and the nextest job are both --all-features, so a target
+      # that only fails to compile under DEFAULT features (e.g. an example
+      # using feature-gated API without a `required-features` gate) is
+      # invisible to them. This compiles the shape a contributor's bare
+      # `cargo test -p <crate>` reaches first. Keep it alongside Clippy so it
+      # runs in parallel with nextest instead of extending the test job.
+      - name: Check (default features)
+        run: cargo check --workspace --all-targets
+
   test:
     # 8 cores / 32 GB: the workspace compile and nextest run are the CI critical path.
     runs-on: ci-cd-large
@@ -108,14 +117,6 @@ jobs:
       - name: Documentation tests
         timeout-minutes: 10
         run: cargo test --workspace --all-features --doc --locked
-
-      # Clippy and the nextest run above are both --all-features, so a target
-      # that only fails to compile under DEFAULT features (e.g. an example
-      # using feature-gated API without a `required-features` gate) is
-      # invisible to them. This compiles the shape a contributor's bare
-      # `cargo test -p <crate>` reaches first.
-      - name: Check (default features)
-        run: cargo check --workspace --all-targets
 
   testsuite-sparql:
     runs-on: ubuntu-24.04
@@ -261,124 +262,6 @@ jobs:
           FLUREE_SQL_BRIDGE_POSTGRES_URL: http://127.0.0.1:18081
           FLUREE_SQL_BRIDGE_MYSQL_URL: http://127.0.0.1:18082
         run: cargo test -p fluree-db-api --features sql,native --test it_sql_pushdown_lane --test it_sql_graph_source live_bridge
-
-  bench-paths:
-    # Cost gate for bench-compare below. GitHub's
-    # `paths:` filter is workflow-scoped and the rest of this workflow must run
-    # on every PR, so the filter lives here as a job output instead. Kept in
-    # ci.yml (rather than split into its own workflow) so the perf gate stays
-    # visible alongside the other required checks.
-    #
-    # Deliberately inclusive — a false positive costs one bench run, a false
-    # negative lets a regression through. Cargo.toml/Cargo.lock are in the list
-    # because a dependency or profile change moves timings without touching a
-    # single engine file.
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    outputs:
-      run: ${{ steps.filter.outputs.run }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - id: filter
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          set -euo pipefail
-          # Pushes to main always run: main is where baselines are captured from.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "not a pull_request — running bench-compare"
-            exit 0
-          fi
-          changed="$(git diff --name-only "$BASE_SHA"...HEAD)"
-          echo "changed files:"; echo "$changed"
-          # A here-string avoids grep -q closing a pipe early: with pipefail,
-          # SIGPIPE from echo made large PRs incorrectly skip benchmarks.
-          if grep -qE '^fluree-[^/]+/|^bench-baselines/|^regression-budget\.json$|^Cargo\.(toml|lock)$|^rust-toolchain(\.toml)?$|^\.cargo/|^\.github/(workflows|scripts)/' <<< "$changed"; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "no perf-relevant paths changed — skipping bench-compare"
-          fi
-
-  bench-compare:
-    # Cheap per-PR perf gate. Runs the two cheapest benches at tiny/quick and
-    # compares against the committed baseline.
-    #
-    # Both metrics enforce ONLY when the baseline's host_class matches this
-    # runner's. It currently does not — the committed baseline is
-    # host_class=local — so on every PR today both wall-clock TIME and
-    # PEAK_MEM breaches print as ::warning:: annotations and the job exits 0.
-    # That downgrade is now explicit (`--allow-host-mismatch`) rather than
-    # implicit: comparing absolute numbers across host classes is a refusal by
-    # default, and a job that wants the annotations has to say so.
-    #
-    # Why not gate on memory now: shared hosted runners vary, and a
-    # tracking allocator's peak moves with allocator behaviour, page size, and
-    # background load. The ±2.2% cross-machine figure this gate was first built
-    # on is one measurement between two specific machines, not a portability
-    # result — gating on it would fail unrelated PRs with no obvious cause, and
-    # it would be the LESS portable of the two signals doing the blocking.
-    #
-    # Capture a ci-cd-large-8core baseline (bench.yml's workflow_dispatch capture
-    # job) and commit it, and both metrics flip to enforcing automatically —
-    # no code change. See BENCHMARKING.md, "Baselines: capture & compare".
-    #
-    # The committed baseline contains exactly this cheap subset, so `compare`
-    # needs no `--only`. Full workspace benchmark smoke runs nightly at tiny.
-    needs: bench-paths
-    if: needs.bench-paths.outputs.run == 'true'
-    runs-on: ci-cd-large
-    timeout-minutes: 30
-    env:
-      FLUREE_BENCH_PROFILE: quick
-      FLUREE_BENCH_SCALE: tiny
-      # CI-class marker. The committed baseline is host_class=local, so this
-      # mismatch is what makes both metrics advisory today.
-      # (FLUREE_BENCH_RUNNER_CLASS is still read as the pre-rename spelling.)
-      FLUREE_BENCH_HOST_CLASS: ci-cd-large-8core
-    steps:
-      - name: Runner capacity
-        run: |
-          nproc
-          free -h
-          df -h /
-
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@1.97.0
-      - uses: rui314/setup-mold@v1
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      # Clear stale sidecars first: rust-cache persists target/ across runs, and
-      # compare must not merge a mem number from a bench not rerun this session
-      # (review item 10), nor a corpus block from a run that never read that
-      # corpus. Clear Criterion's cached comparisons too: rust-cache prunes
-      # sample.json, leaving dangling comparisons. One Cargo invocation builds
-      # both binaries in parallel, then measures them sequentially.
-      - name: Run cheap benches (tiny, quick)
-        run: |
-          rm -rf target/criterion target/fluree-bench-mem target/fluree-bench-meta
-          cargo bench -p fluree-db-api --bench query_overlay_matrix --bench query_hot_bsbm
-
-      # Compare against the committed baseline. Exit 1 on any breach of a metric
-      # the host-class match makes enforcing, 2 on a refusal to compare.
-      #
-      # --allow-host-mismatch is the phase-1 posture and nothing else: the
-      # committed baseline is host_class=local, this runner is
-      # ci-cd-large-8core, and without the flag the job would refuse outright.
-      # DROP THIS FLAG once a ci-cd-large-8core baseline is committed (bench.yml's
-      # bench-capture job) — the flag is what stands between annotations and a
-      # real gate. Phase-share drift enforces either way.
-      - name: Compare against committed baseline
-        run: |
-          cargo run -p fluree-bench-support --bin bench-baseline -- \
-            compare --baseline bench-baselines/guardrails-pre.json \
-            --allow-host-mismatch
 
   # Keeps the wasm32-unknown-unknown build honest: the whole engine stack must
   # keep compiling for the browser target (fluree-db-api pulls every wasm-path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
     # no code change. See BENCHMARKING.md, "Baselines: capture & compare".
     #
     # The committed baseline contains exactly this cheap subset, so `compare`
-    # needs no `--only`. Full workspace + medium: nightly.
+    # needs no `--only`. Full workspace benchmark smoke runs nightly at tiny.
     needs: bench-paths
     if: needs.bench-paths.outputs.run == 'true'
     runs-on: ci-cd-large

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     branches: [main]
 
 # Superseded pushes to main should cancel stale CI just like PR updates do.
+# Cache note: `save-if: main` still fires on a cancelled main job, because
+# `cache-on-failure: true` makes rust-cache's post step run on any status.
+# A burst of merges can therefore save a partially built target dir under
+# the exact key; later main runs hit that key and skip saving until
+# Cargo.lock, the toolchain, or another keyed input changes. Degraded, not
+# cold: PRs still restore whatever was saved.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -73,7 +79,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Clippy
-        run: cargo clippy --all --all-features --all-targets -- -D warnings
+        run: cargo clippy --all --all-features --all-targets --locked -- -D warnings
 
       # Clippy and the nextest job are both --all-features, so a target
       # that only fails to compile under DEFAULT features (e.g. an example
@@ -82,7 +88,7 @@ jobs:
       # `cargo test -p <crate>` reaches first. Keep it alongside Clippy so it
       # runs in parallel with nextest instead of extending the test job.
       - name: Check (default features)
-        run: cargo check --workspace --all-targets
+        run: cargo check --workspace --all-targets --locked
 
   test:
     # 8 cores / 32 GB: the workspace compile and nextest run are the CI critical path.
@@ -110,7 +116,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Test
-        run: cargo nextest run --workspace --all-features --no-fail-fast
+        run: cargo nextest run --workspace --all-features --no-fail-fast --locked
 
       # Nextest does not execute rustdoc examples. Reuse the all-feature build
       # above so public API examples cannot silently stop compiling or running.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,16 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: actionlint@1.7.12
+      - name: Install actionlint
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl --fail --silent --show-error --location --retry 3 \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz \
+            --output actionlint.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz" | sha256sum --check
+          mkdir -p actionlint-bin
+          tar -xzf actionlint.tar.gz -C actionlint-bin actionlint
+          echo "$RUNNER_TEMP/actionlint-bin" >> "$GITHUB_PATH"
       - name: Validate GitHub Actions workflows
         run: actionlint -shellcheck= -pyflakes=
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+# Superseded pushes to main should cancel stale CI just like PR updates do.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -22,26 +23,41 @@ env:
 # Save dependency caches on main; PRs restore them without filling the cache
 # quota with copies that other PRs and main cannot reuse.
 jobs:
-  fmt:
-    runs-on: ubuntu-latest
+  workflow-lint:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: actionlint@1.7.12
+      - name: Validate GitHub Actions workflows
+        run: actionlint -shellcheck= -pyflakes=
+
+  fmt:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.97.0
       - name: Format
         run: cargo fmt --all -- --check
 
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
+          # Avoid spending a minute deleting SDKs when the runner has room.
+          available_kb=$(df -Pk / | awk 'NR == 2 {print $4}')
+          if [ "$available_kb" -lt 15728640 ]; then
+            sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+            sudo docker image prune --all --force
+          fi
+          df -h /
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.97.0
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
@@ -66,7 +82,7 @@ jobs:
           free -h
           df -h /
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.97.0
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
@@ -80,6 +96,12 @@ jobs:
       - name: Test
         run: cargo nextest run --workspace --all-features --no-fail-fast
 
+      # Nextest does not execute rustdoc examples. Reuse the all-feature build
+      # above so public API examples cannot silently stop compiling or running.
+      - name: Documentation tests
+        timeout-minutes: 10
+        run: cargo test --workspace --all-features --doc --locked
+
       # Clippy and the nextest run above are both --all-features, so a target
       # that only fails to compile under DEFAULT features (e.g. an example
       # using feature-gated API without a `required-features` gate) is
@@ -89,17 +111,20 @@ jobs:
         run: cargo check --workspace --all-targets
 
   testsuite-sparql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 55
     steps:
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
+          # Avoid spending a minute deleting SDKs when the runner has room.
+          available_kb=$(df -Pk / | awk 'NR == 2 {print $4}')
+          if [ "$available_kb" -lt 15728640 ]; then
+            sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+            sudo docker image prune --all --force
+          fi
+          df -h /
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -133,7 +158,8 @@ jobs:
     # fluree-sql-bridge is a standalone workspace (it links sqlx + three
     # database drivers, none of which belong in the fluree binary), so the
     # workspace gates above never reach it.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     # SQLite exercises the protocol in-process, but it is the one backend whose
     # string literals cannot misbehave. The escaping rule the bridge enforces
     # (NO_BACKSLASH_ESCAPES on MySQL) is only observable against a real server,
@@ -169,7 +195,7 @@ jobs:
           --health-timeout=5s
           --health-retries=30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.97.0
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
@@ -230,7 +256,7 @@ jobs:
         run: cargo test -p fluree-db-api --features sql,native --test it_sql_pushdown_lane --test it_sql_graph_source live_bridge
 
   bench-paths:
-    # Cost gate for bench-compare below, which recently took 12–14 minutes. GitHub's
+    # Cost gate for bench-compare below. GitHub's
     # `paths:` filter is workflow-scoped and the rest of this workflow must run
     # on every PR, so the filter lives here as a job output instead. Kept in
     # ci.yml (rather than split into its own workflow) so the perf gate stays
@@ -240,11 +266,12 @@ jobs:
     # negative lets a regression through. Cargo.toml/Cargo.lock are in the list
     # because a dependency or profile change moves timings without touching a
     # single engine file.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - id: filter
@@ -260,7 +287,9 @@ jobs:
           fi
           changed="$(git diff --name-only "$BASE_SHA"...HEAD)"
           echo "changed files:"; echo "$changed"
-          if echo "$changed" | grep -qE '^(fluree-db-query|fluree-db-api|fluree-db-core|fluree-db-novelty|fluree-db-binary-index|fluree-db-indexer|fluree-bench-[a-z-]+)/|^bench-baselines/|^regression-budget\.json$|^Cargo\.(toml|lock)$|^\.github/workflows/(ci|bench)\.yml$'; then
+          # A here-string avoids grep -q closing a pipe early: with pipefail,
+          # SIGPIPE from echo made large PRs incorrectly skip benchmarks.
+          if grep -qE '^fluree-[^/]+/|^bench-baselines/|^regression-budget\.json$|^Cargo\.(toml|lock)$|^rust-toolchain(\.toml)?$|^\.cargo/|^\.github/(workflows|scripts)/' <<< "$changed"; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -310,7 +339,7 @@ jobs:
           free -h
           df -h /
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.97.0
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
@@ -353,7 +382,7 @@ jobs:
   # otherwise mask the target-scoped `getrandom_backend` cfg from
   # .cargo/config.toml — so the cfg is restated explicitly.
   wasm32:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
       # -D warnings: `cargo check` exits 0 on warnings, so without this the
@@ -361,7 +390,7 @@ jobs:
       # stay cap-linted, so only workspace code is gated).
       RUSTFLAGS: -D warnings --cfg getrandom_backend="wasm_js"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: wasm32-unknown-unknown
@@ -375,7 +404,7 @@ jobs:
             wasm-probe -> target
       - uses: taiki-e/install-action@v2
         with:
-          tool: wasm-pack
+          tool: wasm-pack@0.13.1
 
       # clippy, not check: `cargo check` cannot see clippy-only lints, and
       # nothing else runs clippy against the wasm32 target. Three of those
@@ -409,15 +438,15 @@ jobs:
   # 2. The SHIPPED npm package (main-thread proxy → module worker → wasm) is
   #    driven end to end over the DevTools protocol with no COOP/COEP headers,
   #    which is the package's hosting contract.
-  # ubuntu-latest ships a matching Chrome + chromedriver pair. Same RUSTFLAGS
+  # ubuntu-24.04 ships a matching Chrome + chromedriver pair. Same RUSTFLAGS
   # restatement as the wasm32 job (an env RUSTFLAGS masks .cargo/config.toml).
   wasm-smoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
       RUSTFLAGS: --cfg getrandom_backend="wasm_js"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: wasm32-unknown-unknown
@@ -425,7 +454,7 @@ jobs:
         with:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ env:
   # every compiling job below installs it via `rui314/setup-mold`.
   RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
 
+# Save dependency caches on main; PRs restore them without filling the cache
+# quota with copies that other PRs and main cannot reuse.
 jobs:
   fmt:
     runs-on: ubuntu-latest
@@ -45,24 +47,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Clippy
         run: cargo clippy --all --all-features --all-targets -- -D warnings
 
   test:
-    runs-on: ubuntu-latest
+    # 8 cores / 32 GB: the workspace compile and nextest run are the CI critical path.
+    runs-on: ci-cd-large
     # Backstop so a hung/deadlocked test can never hold a runner for the full
     # 6h default again. Per-test kills are handled by `slow-timeout` in
     # `.config/nextest.toml`; this is the job-level safety net.
     timeout-minutes: 45
     steps:
-      - name: Free disk space
+      - name: Runner capacity
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
+          nproc
+          free -h
+          df -h /
 
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.97.0
@@ -70,6 +72,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
@@ -105,6 +108,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: "testsuite-sparql -> target"
 
       - name: Format
@@ -171,6 +175,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             fluree-sql-bridge -> target
             . -> target
@@ -225,7 +230,7 @@ jobs:
         run: cargo test -p fluree-db-api --features sql,native --test it_sql_pushdown_lane --test it_sql_graph_source live_bridge
 
   bench-paths:
-    # Cost gate for bench-compare below, which is a ~30-minute job. GitHub's
+    # Cost gate for bench-compare below, which recently took 12–14 minutes. GitHub's
     # `paths:` filter is workflow-scoped and the rest of this workflow must run
     # on every PR, so the filter lives here as a job output instead. Kept in
     # ci.yml (rather than split into its own workflow) so the perf gate stays
@@ -274,14 +279,14 @@ jobs:
     # implicit: comparing absolute numbers across host classes is a refusal by
     # default, and a job that wants the annotations has to say so.
     #
-    # Why not gate on memory now: shared ubuntu-latest runners flap, and a
+    # Why not gate on memory now: shared hosted runners vary, and a
     # tracking allocator's peak moves with allocator behaviour, page size, and
     # background load. The ±2.2% cross-machine figure this gate was first built
     # on is one measurement between two specific machines, not a portability
     # result — gating on it would fail unrelated PRs with no obvious cause, and
     # it would be the LESS portable of the two signals doing the blocking.
     #
-    # Capture a ci-ubuntu-latest baseline (bench.yml's workflow_dispatch capture
+    # Capture a ci-cd-large-8core baseline (bench.yml's workflow_dispatch capture
     # job) and commit it, and both metrics flip to enforcing automatically —
     # no code change. See BENCHMARKING.md, "Baselines: capture & compare".
     #
@@ -289,7 +294,7 @@ jobs:
     # needs no `--only`. Full workspace + medium: nightly.
     needs: bench-paths
     if: needs.bench-paths.outputs.run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ci-cd-large
     timeout-minutes: 30
     env:
       FLUREE_BENCH_PROFILE: quick
@@ -297,41 +302,40 @@ jobs:
       # CI-class marker. The committed baseline is host_class=local, so this
       # mismatch is what makes both metrics advisory today.
       # (FLUREE_BENCH_RUNNER_CLASS is still read as the pre-rename spelling.)
-      FLUREE_BENCH_HOST_CLASS: ci-ubuntu-latest
+      FLUREE_BENCH_HOST_CLASS: ci-cd-large-8core
     steps:
-      - name: Free disk space
+      - name: Runner capacity
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
+          nproc
+          free -h
+          df -h /
 
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Clear stale sidecars first: rust-cache persists target/ across runs, and
       # compare must not merge a mem number from a bench not rerun this session
       # (review item 10), nor a corpus block from a run that never read that
-      # corpus. Then run the two cheap benches (writes criterion timings + fresh
-      # sidecars).
+      # corpus. Clear Criterion's cached comparisons too: rust-cache prunes
+      # sample.json, leaving dangling comparisons. One Cargo invocation builds
+      # both binaries in parallel, then measures them sequentially.
       - name: Run cheap benches (tiny, quick)
         run: |
-          rm -rf target/fluree-bench-mem target/fluree-bench-meta
-          cargo bench -p fluree-db-api --bench query_overlay_matrix
-          cargo bench -p fluree-db-api --bench query_hot_bsbm
+          rm -rf target/criterion target/fluree-bench-mem target/fluree-bench-meta
+          cargo bench -p fluree-db-api --bench query_overlay_matrix --bench query_hot_bsbm
 
       # Compare against the committed baseline. Exit 1 on any breach of a metric
       # the host-class match makes enforcing, 2 on a refusal to compare.
       #
       # --allow-host-mismatch is the phase-1 posture and nothing else: the
       # committed baseline is host_class=local, this runner is
-      # ci-ubuntu-latest, and without the flag the job would refuse outright.
-      # DROP THIS FLAG once a ci-ubuntu-latest baseline is committed (bench.yml's
+      # ci-cd-large-8core, and without the flag the job would refuse outright.
+      # DROP THIS FLAG once a ci-cd-large-8core baseline is committed (bench.yml's
       # bench-capture job) — the flag is what stands between annotations and a
       # real gate. Phase-share drift enforces either way.
       - name: Compare against committed baseline
@@ -365,6 +369,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             . -> target
             wasm-probe -> target
@@ -419,6 +424,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,10 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v2

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -152,15 +152,18 @@ on-demand):
    The job previously took 12–14 minutes on the standard runner; a `bench-paths`
    job skips it
    when a PR touches nothing perf-relevant (engine crates, bench crates,
-   `bench-baselines/`, `regression-budget.json`, `Cargo.toml`/`Cargo.lock`, or the
-   CI/bench workflows). The list errs inclusive: a false positive costs one bench
-   run, a false negative lets a regression through.
+   `bench-baselines/`, `regression-budget.json`, Cargo manifests/lockfiles,
+   the Rust toolchain, `.cargo/` settings, or workflow/scripts under `.github/`).
+   The list errs inclusive: a false positive costs one bench run, a false
+   negative lets a regression through.
 
 3. **CI-class capture (`bench.yml` `bench-capture`, `workflow_dispatch`).**
-   Captures the cheap subset on `ci-cd-large` (8 cores / 32 GB), tagged with
+   Enable the `capture_baseline` dispatch checkbox to run this additional job;
+   ordinary manual runs only run the nightly checks. Captures the cheap subset
+   on `ci-cd-large` (8 cores / 32 GB), tagged with
    `host_class=ci-cd-large-8core`, and uploads it as an artifact. Committing it plus dropping
    `--allow-host-mismatch` from the compare step lands a real per-PR gate. The
-   `capture_samples` dispatch input controls how many repeat runs are folded into
+   `capture_samples` dispatch input (1–10) controls how many repeat runs are folded into
    one median + MAD — use ≥ 5 for a baseline meant to gate, since without a noise
    estimate the budget has to absorb shared-runner flap on its own.
 
@@ -347,7 +350,7 @@ Two ways to reach phase 2:
 
    ```bash
    # 1. Run bench.yml's workflow_dispatch `bench-capture` job with
-   #    capture_samples: 5, and download the artifact.
+   #    capture_baseline: true and capture_samples: 5, and download the artifact.
    # 2. REPLACE the committed baseline — do not add it alongside:
    mv guardrails-pre-ci.json bench-baselines/guardrails-pre.json
    # 3. Drop `--allow-host-mismatch` from ci.yml's and bench.yml's compare steps.

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -134,20 +134,27 @@ on-demand):
    against the committed baseline via the `bench-baseline` bin. **Time and peak
    memory enforce only when the baseline's `host_class` matches the runner's**
    (see [Baselines](#baselines-capture--compare) for why). Today's committed
-   baseline is `host_class=local` and the runner is `ci-ubuntu-latest`, so the
+   baseline is `host_class=local` and the runner is `ci-cd-large-8core`, so the
    step passes `--allow-host-mismatch` and both metrics annotate rather than
    gate; **phase-share drift enforces regardless of host class.** The nightly
-   `bench-gate` runs the same compare over a larger sample.
+   `bench-gate` runs the same subset and sampling profile after workspace smoke tests.
 
-   The job costs ~30 minutes, so it is gated on a `bench-paths` job that skips it
+   All three benchmark jobs use `ci-cd-large` (8 cores / 32 GB), Rust 1.97.0,
+   and `host_class=ci-cd-large-8core`. Keep their runner and host-class settings
+   aligned; changing hardware requires a newly captured baseline. They retain
+   the normal release optimization profile. The two selected binaries build in
+   one Cargo invocation; benchmark measurements still execute sequentially.
+
+   The job previously took 12–14 minutes on the standard runner; a `bench-paths`
+   job skips it
    when a PR touches nothing perf-relevant (engine crates, bench crates,
    `bench-baselines/`, `regression-budget.json`, `Cargo.toml`/`Cargo.lock`, or the
    CI/bench workflows). The list errs inclusive: a false positive costs one bench
    run, a false negative lets a regression through.
 
 3. **CI-class capture (`bench.yml` `bench-capture`, `workflow_dispatch`).**
-   Captures the cheap subset on `ubuntu-latest` (`host_class=ci-ubuntu-latest`)
-   and uploads it as an artifact. Committing it plus dropping
+   Captures the cheap subset on `ci-cd-large` (8 cores / 32 GB), tagged with
+   `host_class=ci-cd-large-8core`, and uploads it as an artifact. Committing it plus dropping
    `--allow-host-mismatch` from the compare step lands a real per-PR gate. The
    `capture_samples` dispatch input controls how many repeat runs are folded into
    one median + MAD — use ≥ 5 for a baseline meant to gate, since without a noise
@@ -311,7 +318,7 @@ portable of the two signals in the blocking position.
 So the gate runs in two phases:
 
 - **Phase 1 (today).** The committed `guardrails-pre.json` is `host_class=local`,
-  CI runs as `ci-ubuntu-latest`, the classes don't match, and the compare step
+  CI runs as `ci-cd-large-8core`, the classes don't match, and the compare step
   passes `--allow-host-mismatch` so both absolute metrics annotate without
   gating. The job still earns its keep: the annotations surface real movement on
   the PR that caused it, share drift gates for any bench that records phases, and
@@ -324,7 +331,7 @@ deliberately coarse and deliberately not a promise: an M1 and an M4 both derive
 `macos-aarch64` and their absolute numbers are not interchangeable. A class is a
 claim *a human makes* that two machines' numbers may be compared, so any host
 whose numbers are meant to gate should set `FLUREE_BENCH_HOST_CLASS` explicitly
-(`ci-ubuntu-latest`, `bench-m8gd`, …) rather than inherit the default.
+(`ci-cd-large-8core`, `bench-m8gd`, …) rather than inherit the default.
 
 Two ways to reach phase 2:
 
@@ -342,7 +349,7 @@ Two ways to reach phase 2:
    # 3. Drop `--allow-host-mismatch` from ci.yml's and bench.yml's compare steps.
    ```
 
-   The replaced file's `host_class=ci-ubuntu-latest` then matches CI and its
+   The replaced file's `host_class=ci-cd-large-8core` then matches CI and its
    noise floor absorbs runner flap, so both metrics enforce. (Keeping the
    `-ci` suffix instead would work only if you also repoint every
    `--baseline` path; one rename is the smaller change.)

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -126,9 +126,13 @@ on-demand):
      asserts every `[[bench]]` declared in a workspace member's `Cargo.toml`
      has a matching entry in `regression-budget.json`, and vice versa. A
      missing or stale entry fails with a message naming the `crate/bench` pair.
-   - **Smoke.** `cargo bench --workspace -- --test` runs each bench's
-     scenarios once at `tiny` scale — catches benches that compile but panic
-     at runtime (bad SPARQL, broken setup, missing API surface).
+   - **Smoke.** `cargo bench --workspace --bench '*' --features fluree-db-api/graphql --no-fail-fast -- --test`
+     runs each explicit benchmark's scenarios once at `tiny` scale, catching
+     runtime failures (bad SPARQL, broken setup, missing API surface).
+     The quoted target glob includes all declared benches without also building
+     every library/binary's libtest harness under fat LTO. Unit and integration
+     tests run in the per-PR nextest job. All benchmark binaries are attempted
+     even if an earlier one fails.
 2. **Per-PR compare (`ci.yml` `bench-compare`).** Runs the cheap subset
    (`query_overlay_matrix` + `query_hot_bsbm`) at `tiny`/`quick` and compares
    against the committed baseline via the `bench-baseline` bin. **Time and peak

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -118,8 +118,24 @@ not explicitly listed.
 
 ### CI gate — phases
 
-The gate runs across `ci.yml` (per-PR) and `bench.yml` (nightly +
-on-demand):
+Normal CI runs correctness checks on every PR and push to main: workspace
+nextest, documentation tests, Clippy, default-feature compilation, SPARQL and
+SQL bridge tests, and WASM/browser checks. Default-feature compilation runs
+alongside Clippy, in parallel with the workspace test job.
+
+Benchmark execution runs in `bench.yml` on the nightly schedule and on demand.
+Clippy still checks benchmark compilation on every PR. Runtime and performance
+regressions specific to benchmarks are detected nightly, or before merge by
+manually running the workflow against the PR branch:
+
+```bash
+# Quick comparison only, without compiling all workspace benchmarks:
+gh workflow run bench.yml --ref <branch> -f compare_only=true
+# Full benchmark smoke and comparison:
+gh workflow run bench.yml --ref <branch>
+```
+
+The benchmark workflow has three jobs:
 
 1. **Reconcile + smoke (`bench.yml` `bench-gate`, nightly).**
    - **Reconcile.** `cargo test -p fluree-bench-support --test workspace_reconcile`
@@ -133,15 +149,17 @@ on-demand):
      every library/binary's libtest harness under fat LTO. Unit and integration
      tests run in the per-PR nextest job. All benchmark binaries are attempted
      even if an earlier one fails.
-2. **Per-PR compare (`ci.yml` `bench-compare`).** Runs the cheap subset
+2. **Nightly/on-demand compare (`bench.yml` `bench-compare`).** Runs the cheap subset
    (`query_overlay_matrix` + `query_hot_bsbm`) at `tiny`/`quick` and compares
    against the committed baseline via the `bench-baseline` bin. **Time and peak
    memory enforce only when the baseline's `host_class` matches the runner's**
    (see [Baselines](#baselines-capture--compare) for why). Today's committed
    baseline is `host_class=local` and the runner is `ci-cd-large-8core`, so the
    step passes `--allow-host-mismatch` and both metrics annotate rather than
-   gate; **phase-share drift enforces regardless of host class.** The nightly
-   `bench-gate` runs the same subset and sampling profile after workspace smoke tests.
+   gate; **phase-share drift enforces regardless of host class.** Comparison
+   runs in parallel with `bench-gate`, on its own runner, so it does not wait
+   for the full workspace smoke build or add to its duration. `compare_only`
+   skips `bench-gate` for a faster manual check.
 
    All three benchmark jobs use `ci-cd-large` (8 cores / 32 GB), Rust 1.97.0,
    and `host_class=ci-cd-large-8core`. Keep their runner and host-class settings
@@ -149,40 +167,21 @@ on-demand):
    the normal release optimization profile. The two selected binaries build in
    one Cargo invocation; benchmark measurements still execute sequentially.
 
-   The job previously took 12–14 minutes on the standard runner; a `bench-paths`
-   job skips it
-   when a PR touches nothing perf-relevant (engine crates, bench crates,
-   `bench-baselines/`, `regression-budget.json`, Cargo manifests/lockfiles,
-   the Rust toolchain, `.cargo/` settings, or workflow/scripts under `.github/`).
-   The list errs inclusive: a false positive costs one bench run, a false
-   negative lets a regression through.
-
 3. **CI-class capture (`bench.yml` `bench-capture`, `workflow_dispatch`).**
    Enable the `capture_baseline` dispatch checkbox to run this additional job;
    ordinary manual runs only run the nightly checks. Captures the cheap subset
    on `ci-cd-large` (8 cores / 32 GB), tagged with
    `host_class=ci-cd-large-8core`, and uploads it as an artifact. Committing it plus dropping
-   `--allow-host-mismatch` from the compare step lands a real per-PR gate. The
-   `capture_samples` dispatch input (1–10) controls how many repeat runs are folded into
+   `--allow-host-mismatch` from the compare step makes nightly/on-demand
+   comparisons enforce. The `capture_samples` dispatch input (1–10) controls
+   how many repeat runs are folded into
    one median + MAD — use ≥ 5 for a baseline meant to gate, since without a noise
    estimate the budget has to absorb shared-runner flap on its own.
 
-> **Visibility gap (documented; fix is a follow-up).** The per-PR gate only
-> *compiles* benches — `clippy --all --all-features --all-targets` in `ci.yml`
-> builds every bench, and `bench-compare` runs only the two cheap ones. Every
-> other bench is *executed* nightly-only (`bench.yml`), visible to the last
-> default-branch committer rather than to the PR that introduced a break. So a
-> bench that compiles cleanly but panics at runtime — bad SPARQL, or a setup
-> that matches zero data — sails through every PR and only reddens the nightly.
-> This is exactly how the `query_hot_whole_graph_agg` `@vocab` bug reached main
-> (its class scenarios matched zero nodes; the filtered-histogram sanity assert
-> panicked). Two consequences: historical numbers for that bench's
-> `SCALARS_CLASS`/`HISTOGRAM_CLASS` scenarios predate the fix, measured empty
-> scans, and are void — re-baseline them the first time a committed baseline
-> includes `whole_graph_agg` (the current committed baseline covers only the
-> cheap subset, which is unaffected); and whether to promote a tiny `-- --test`
-> runtime smoke into per-PR CI is an open follow-up, costed against the same
-> budget that keeps the compare subset cheap.
+> Benchmark runtime failures and phase/performance regressions are detected
+> nightly rather than on every PR. Run the workflow manually for changes to
+> benchmark setup or performance-sensitive engine code. The ordinary correctness
+> suite still runs on every PR.
 
 To intentionally accept a regression (or tighten a budget), edit
 `regression-budget.json` in the same PR and explain in the PR body.
@@ -313,9 +312,9 @@ provenance — so there would be nothing left for a later `compare` to catch.
 ### Why the gate has two phases
 
 Neither metric survives a cross-machine comparison. `ubuntu-latest` shared
-runners flap, so a 5–10% threshold on a single PR run comparing absolute
+runners flap, so a 5–10% threshold on a single run comparing absolute
 nanoseconds against a baseline captured on different (local Apple-silicon)
-hardware false-positives every few PRs. Peak memory is steadier but not
+hardware can produce false positives. Peak memory is steadier but not
 portable either: allocator behaviour, page size, and background load all move a
 tracking allocator's peak, and the ±2.2% local-vs-CI figure this gate was first
 built on is one measurement between two specific machines — not a portability
@@ -328,10 +327,10 @@ So the gate runs in two phases:
   CI runs as `ci-cd-large-8core`, the classes don't match, and the compare step
   passes `--allow-host-mismatch` so both absolute metrics annotate without
   gating. The job still earns its keep: the annotations surface real movement on
-  the PR that caused it, share drift gates for any bench that records phases, and
+  the tested commit, share drift gates for any bench that records phases, and
   the compare itself exercises the capture/compare machinery.
 - **Phase 2.** Commit a CI-class baseline and drop `--allow-host-mismatch`, and
-  both absolute metrics gate from the next PR on.
+  both absolute metrics enforce on subsequent nightly/on-demand runs.
 
 A note on `host_class` values. The derived default is `{os}-{arch}`, which is
 deliberately coarse and deliberately not a promise: an M1 and an M4 both derive
@@ -343,7 +342,7 @@ whose numbers are meant to gate should set `FLUREE_BENCH_HOST_CLASS` explicitly
 Two ways to reach phase 2:
 
 1. **Committed CI-class baseline (implemented).** Note the **filename change** —
-   the capture job writes `guardrails-pre-ci.json`, but both compare jobs read
+   the capture job writes `guardrails-pre-ci.json`, but the compare job reads
    `guardrails-pre.json`. Committing the artifact under its own name leaves CI
    reading the old `host_class=local` file, which without
    `--allow-host-mismatch` refuses every run. So:
@@ -353,7 +352,7 @@ Two ways to reach phase 2:
    #    capture_baseline: true and capture_samples: 5, and download the artifact.
    # 2. REPLACE the committed baseline — do not add it alongside:
    mv guardrails-pre-ci.json bench-baselines/guardrails-pre.json
-   # 3. Drop `--allow-host-mismatch` from ci.yml's and bench.yml's compare steps.
+   # 3. Drop `--allow-host-mismatch` from bench.yml's compare step.
    ```
 
    The replaced file's `host_class=ci-cd-large-8core` then matches CI and its
@@ -420,8 +419,8 @@ fluree-bench-alloc/          # tracking allocator behind the peak_mem metric
 <crate>/benches/<name>.rs    # one file per bench; criterion harness=false
 regression-budget.json       # per-bench, per-scale budgets at the workspace root
 bench-baselines/             # committed reference points (see its README)
-.github/workflows/ci.yml     # bench-paths + bench-compare (per-PR, cheap subset)
-.github/workflows/bench.yml  # bench-gate (nightly) + bench-capture (on demand)
+.github/workflows/ci.yml     # correctness checks (every PR and main push)
+.github/workflows/bench.yml  # smoke + compare (nightly/on demand), optional capture
 target/criterion/            # criterion estimates — what `capture` reads
 target/fluree-bench-mem/     # peak/total allocation sidecars
 target/fluree-bench-meta/    # corpus identity + phase timing sidecars

--- a/bench-baselines/README.md
+++ b/bench-baselines/README.md
@@ -38,7 +38,7 @@ Conventions:
 `guardrails-pre.json` is the PR-1 (guardrails net) reference — captured at the
 merge-base engine, quick profile, tiny+small, schema 1. It predates the host
 block, so its `runner_class: "local"` is read as `host.class = "local"`: an
-honest "some developer machine, unspecified". That is why the per-PR compare
+honest "some developer machine, unspecified". That is why the nightly/on-demand compare
 still runs with `--allow-host-mismatch`.
 
 Capture (the `--label`/`--out` name the phase reference; capture at the

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -53,6 +53,9 @@ build = [
 ]
 
 [dist.github-custom-runners]
+# Use the larger Apple silicon runner (5-core/14GB) for release builds.
+# The default macos-14 runner (3-core/7GB) took ~3h for v4.2.0.
+aarch64-apple-darwin = "macos-14-xlarge"
 # Native ARM64 build on the org's larger hosted runner (8-core/32GB). The
 # default 4-core/16GB ubuntu-24.04-arm OOM'd at link time under fat LTO
 # (runner lost communication ~59min); 32GB gives ~2x headroom.


### PR DESCRIPTION
Normal CI now completes in **7m34s**, down from **14m48s** in the sampled pre-change run (about **49% less elapsed time**). Correctness checks remain on every PR/main push; benchmark execution moves to nightly/on-demand runs. The nightly benchmark workflow now completes its smoke tests instead of timing out, and Apple releases select a larger Apple silicon runner.

Measured results:

| Workload | Before | Validated result |
| --- | --- | --- |
| Normal CI, end to end | 14m48s | **7m34s** |
| Workspace test job | 14m44s | **7m29s**, with 47 additional doctests |
| Subset benchmark comparison | 12m13s in normal CI | **9m07s**, now nightly/on demand |
| Full nightly benchmark run | ~55m, timed out before smoke tests | **29m43s**, all 23 smoke targets passed |

Sources: [pre-change CI](https://github.com/fluree/db/actions/runs/34056135395), [final CI](https://github.com/fluree/db/actions/runs/34136552156), [on-demand comparison](https://github.com/fluree/db/actions/runs/34136563920), [previous timed-out nightly](https://github.com/fluree/db/actions/runs/34094885376), and [successful full nightly validation](https://github.com/fluree/db/actions/runs/34131584670). These are observed runs, not guaranteed durations.

The **29m43s nightly measurement predates the final parallel split**: its smoke build took 21m20s, smoke execution 17s, and comparison added 7m39s sequentially. In the final layout, smoke and comparison run independently, so comparison no longer extends the smoke job. The comparison-only path passed on the final commit; the final combined nightly duration has not been measured. The Apple runner mapping is validated, but its release-build speedup is also not yet measured.

Changes:
- Run workspace tests on `ci-cd-large` (8 cores / 32 GB). Run default-feature compilation alongside Clippy, in parallel with nextest; retain all 12,361 tests, SPARQL compliance, SQL database integration tests, WASM/browser checks, and formatting. Add the previously missing workspace doctests.
- Remove benchmark execution and its path-filter job from normal CI. Nightly runs full workspace benchmark smoke and subset performance comparison as independent jobs. `gh workflow run bench.yml --ref <branch> -f compare_only=true` runs just the comparison before merge when needed. Benchmark runtime/performance regressions are now detected nightly or on demand; Clippy still checks benchmark compilation on every PR.
- Use `ci-cd-large` for benchmarks, align Rust 1.97.0 and host identity, build the selected binaries in one command, and clear stale Criterion output/sidecars. Preserve release optimization, benchmark scale, and sampling settings.
- Select all 23 explicit nightly benchmark targets with `--bench '*'` and the GraphQL feature. Avoid extra libtest benchmark harnesses under fat LTO. Bound cold builds and prevent cancellation from starting more work.
- Make baseline capture opt-in, validate 1–10 sequential samples, and allow 90 minutes for repeat capture. The committed local-machine baseline remains advisory for time/memory; phase-share drift still enforces.
- Save Rust caches only on main; PRs restore shared dependencies. Run disk cleanup only below 15 GiB free, cancel superseded main CI, add workflow linting and job timeouts, pin Ubuntu 24.04/wasm-pack, and update handwritten checkout/setup-node/upload-artifact actions to v7.
- Select `macos-14-xlarge` (5 cores / 14 GB) for Apple release builds through cargo-dist. Other release runner mappings and organization budgets remain unchanged.

Validation:
- [Final normal CI](https://github.com/fluree/db/actions/runs/34136552156) passed all eight jobs on `99bfce245` in **7m34s end to end**. The test job took **7m29s** (previous layout: 8m50s); Clippy plus relocated default-feature compilation finished in **4m18s**, in parallel. [On-demand comparison](https://github.com/fluree/db/actions/runs/34136563920) passed in **9m07s** independently of normal CI; full smoke and capture were correctly skipped with `compare_only=true`. All 12,361 tests and 47 doctests passed on the final commit.
- actionlint 1.7.12 and `git diff --check` pass. Structural checks verify that all correctness jobs/commands are retained, default-feature compilation moved intact, comparison moved intact, and full benchmark smoke/capture commands are preserved. Main branch protection/rulesets do not require either removed job.
- [Previous hosted validation](https://github.com/fluree/db/actions/runs/34135406542) passed all jobs: 12,361 tests (30 skipped), 47 doctests (163 explicitly ignored). Doctests added 18s. Conditional cleanup took under one second versus 35–68s; Clippy finished in 2m07s and SPARQL compliance in 2m30s.
- [Full benchmark smoke validation](https://github.com/fluree/db/actions/runs/34131584670) passed all 23 targets; compilation took 21m20s and smoke 17s. Comparison previously added 7m39s sequentially; it now runs independently. Earlier nightlies timed out before smoke and consumed about 55m.
- cargo-dist 0.31.0 planning verified the Apple runner mapping. No release build was triggered. The previous [Apple release build](https://github.com/fluree/db/actions/runs/34056153732) took 2h53m; the new machine's release duration is not yet measured.

Remaining coverage limitation: the standalone `testsuite-shacl` workspace has documented conformance failures and reports them without failing by default. A useful CI gate requires an expected-failure register; see `docs/contributing/shacl-compliance.md`.
