### PR TITLE
perf(query): count NumBig distinct objects from arenas, drop the row cap

### DIFF
--- a/docs/query/explain.md
+++ b/docs/query/explain.md
@@ -338,6 +338,24 @@ fallback, and the exact index permutation (SPOT/POST/OPST/PSOT) a scan chooses.
 Surfacing those requires actually running the query (a future `EXPLAIN ANALYZE`
 mode), which `EXPLAIN` deliberately does not do.
 
+### Whole-graph distinct object counts
+
+For `SELECT (COUNT(DISTINCT ?o) AS ?n) WHERE { ?s ?p ?o }`, the indexed fast
+path counts overflow integers and decimals exactly using their NumBig arenas.
+`FLUREE_NUMBIG_EXACT_MAX_ENTRIES` optionally caps the total arena entries in
+the queried graph, including stale entries and values repeated across
+predicates. It is unset by default. Setting it to `0` forces queries with
+NumBig objects to the general pipeline; exceeding any configured cap does the
+same. This fallback scans the whole graph and can be substantially slower.
+The former `FLUREE_NUMBIG_EXACT_MAX_ROWS` setting is no longer used.
+
+The exact branch builds and sorts keys on every execution. Modern arenas
+already store normalized values; legacy arenas require normalization. Key
+storage scales with live entries across predicates before deduplication, plus
+wide-value allocations and temporary buffers. Predicates with stale arena
+handles require scanning their NumBig rows; mixed-type or legacy leaflets may
+also need decoding to establish liveness.
+
 ### Execution Hints
 
 Explain responses may also include an `execution-hints` array. These are not

--- a/fluree-db-api/tests/it_distinct_object_numbig_gate.rs
+++ b/fluree-db-api/tests/it_distinct_object_numbig_gate.rs
@@ -1,5 +1,6 @@
-//! Regression pin: the whole-graph `COUNT(DISTINCT ?o)` fast path must decline
-//! a graph whose objects include a NumBig arena handle.
+//! Regression pin: the whole-graph `COUNT(DISTINCT ?o)` fast path must count
+//! a graph whose objects include a NumBig arena handle exactly — from the
+//! arenas, without declining to the general pipeline.
 //!
 //! `SELECT (COUNT(DISTINCT ?o) AS ?n) WHERE { ?s ?p ?o }` is answered from OPST
 //! leaflet directory metadata by grouping on the 10-byte lead `o_type(2) +
@@ -27,12 +28,12 @@
 
 #![cfg(feature = "native")]
 
-#[path = "support/span_capture.rs"]
-mod span_capture;
+mod support;
 
 use fluree_db_api::{set_fast_paths_disabled, FlureeBuilder};
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::io::Write;
+use support::span_capture;
 use tempfile::TempDir;
 
 /// Operator label the whole-graph distinct-object count stamps.
@@ -126,6 +127,17 @@ const F_BIGINT_CROSS: &str = r#"
 <http://ex/s2> <http://ex/p2> "170141183460469231731687303715884105999"^^<http://www.w3.org/2001/XMLSchema#integer> .
 "#;
 
+/// Decimals, a string and a small integer under ONE predicate: the predicate's
+/// POST leaflet carries an `o_type` column and straddles the NumBig range, so
+/// its live handles must be decoded rather than read from `lead_group_count`.
+const F_MIXED_PRED: &str = r#"
+<http://ex/s1> <http://ex/p1> "1.1000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/s2> <http://ex/p1> "2.2000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+<http://ex/s3> <http://ex/p1> "alpha" .
+<http://ex/s4> <http://ex/p1> 7 .
+<http://ex/s5> <http://ex/p2> "2.2000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
+"#;
+
 /// `xsd:integer` within `i64`: an inline, value-faithful `o_key`.
 const F_INT_CROSS: &str = r#"
 <http://ex/s1> <http://ex/p1> "514"^^<http://www.w3.org/2001/XMLSchema#integer> .
@@ -144,8 +156,8 @@ const F_STR_CROSS: &str = r#"
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Routing {
-    /// The graph holds NumBig objects within the cap: the operator proceeds and
-    /// the exact branch is what answers the arena slice.
+    /// The graph holds NumBig objects: the operator proceeds and the exact
+    /// branch is what answers the arena slice.
     ExactBranch,
     /// No NumBig object anywhere: the operator proceeds from directory metadata
     /// alone and the exact branch must not run — it would be pure added cost.
@@ -207,6 +219,12 @@ const CASES: &[Case] = &[
         name: "overflow xsd:integer across two predicates",
         ttl: F_BIGINT_CROSS,
         truth: 2,
+        routing: Routing::ExactBranch,
+    },
+    Case {
+        name: "decimals, string and integer under one predicate",
+        ttl: F_MIXED_PRED,
+        truth: 4,
         routing: Routing::ExactBranch,
     },
     Case {
@@ -367,8 +385,8 @@ async fn distinct_object_count_declines_numbig_object_keys() {
         let took_exact = sites.iter().any(|s| s == EXACT_SITE);
         if !did_proceed {
             failures.push(format!(
-                "{}: expected `{OBJECT_SITE}` to proceed — every fixture here is \
-                 within the exact branch's row cap [proceeded: {sites:?}]",
+                "{}: expected `{OBJECT_SITE}` to proceed — the exact branch has \
+                 no row cap, so nothing here may decline [proceeded: {sites:?}]",
                 case.name
             ));
         }
@@ -534,22 +552,21 @@ async fn distinct_object_count_declines_numbig_object_keys() {
         }
     }
 
-    // ---- Phase 4: the rollout cap still declines --------------------------
-    // Above the cap the whole count falls to the general pipeline. That bound
-    // is a rollout guard on a new read path rather than a crossover — the
-    // fallback is measured slower at every size — but it has to actually work,
-    // or the cap is decoration.
+    // ---- Phase 4: the kill switch still declines --------------------------
+    // With the entries cap set and exceeded the whole count falls to the
+    // general pipeline. There is no default cap — declining is the slow
+    // outcome — but the switch has to actually work, or it is decoration.
     {
         let (_db, _data, fluree, ledger_id) = build_indexed(F_LOSS3, "over-cap").await;
         let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
-        // The 3-and-3 fixture holds 6 NumBig rows; a cap of 1 puts it over.
-        std::env::set_var("FLUREE_NUMBIG_EXACT_MAX_ROWS", "1");
+        // The 3-and-3 fixture holds 6 arena entries; a cap of 1 puts it over.
+        std::env::set_var("FLUREE_NUMBIG_EXACT_MAX_ENTRIES", "1");
         let (store, tracing_guard) = span_capture::init_test_tracing();
         set_fast_paths_disabled(false);
         let got = scalar(&run(&fluree, &ledger, Q_COUNT).await);
         let sites = proceeded(&store, 0);
         drop(tracing_guard);
-        std::env::remove_var("FLUREE_NUMBIG_EXACT_MAX_ROWS");
+        std::env::remove_var("FLUREE_NUMBIG_EXACT_MAX_ENTRIES");
 
         if got != "6" {
             failures.push(format!(
@@ -565,9 +582,100 @@ async fn distinct_object_count_declines_numbig_object_keys() {
         }
     }
 
+    // ---- Phase 5: arenas keep retracted values ----------------------------
+    // A full rebuild replays retractions through the arena insert path and an
+    // incremental build carries arenas forward, so both leave handles with no
+    // live row. The exact branch must count only handles POST still holds —
+    // and must notice from directory metadata alone that an arena is not
+    // fully live.
+    {
+        let (_db, _data, fluree, ledger_id) = build_indexed(F_LIFECYCLE, "liveness").await;
+        let ctx = json!({"ex": "http://ex/", "xsd": "http://www.w3.org/2001/XMLSchema#"});
+
+        // Retract 5.5 (p1 only: the term is gone) and p2's 9.9 (the term
+        // survives under p1). Union 8 → 7; both arenas keep a stale handle.
+        let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
+        fluree
+            .update(
+                ledger,
+                &json!({
+                    "@context": ctx,
+                    "delete": [
+                        {"@id": "ex:a1", "ex:p1": {"@value": "5.5000", "@type": "xsd:decimal"}},
+                        {"@id": "ex:b1", "ex:p2": {"@value": "9.9000", "@type": "xsd:decimal"}},
+                    ]
+                }),
+            )
+            .await
+            .expect("retract two decimals");
+        support::rebuild_and_publish_index(&fluree, &ledger_id).await;
+        check_liveness(&fluree, &ledger_id, "7", "after rebuild", &mut failures).await;
+
+        // Retract every remaining p2 value: p2's arena has no live handle at
+        // all, and the incremental build carries it forward unchanged.
+        let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
+        fluree
+            .update(
+                ledger,
+                &json!({
+                    "@context": ctx,
+                    "delete": [
+                        {"@id": "ex:b2", "ex:p2": {"@value": "1.1000", "@type": "xsd:decimal"}},
+                        {"@id": "ex:b3", "ex:p2": {"@value": "2.2000", "@type": "xsd:decimal"}},
+                        {"@id": "ex:b4", "ex:p2": {"@value": "3.3000", "@type": "xsd:decimal"}},
+                    ]
+                }),
+            )
+            .await
+            .expect("retract p2");
+        support::build_and_publish_index(&fluree, &ledger_id).await;
+        check_liveness(&fluree, &ledger_id, "4", "after incremental", &mut failures).await;
+    }
+
     assert!(
         failures.is_empty(),
         "distinct-object NumBig gate failures:\n  {}",
         failures.join("\n  ")
     );
+}
+
+/// Fast lane and general pipeline must both answer `truth`, and the fast lane
+/// must have taken the exact branch — a decline here would pass on the answer
+/// alone while silently losing the lane.
+async fn check_liveness(
+    fluree: &fluree_db_api::Fluree,
+    ledger_id: &str,
+    truth: &str,
+    when: &str,
+    failures: &mut Vec<String>,
+) {
+    let ledger = fluree.ledger(ledger_id).await.expect("load ledger");
+    let (store, tracing_guard) = span_capture::init_test_tracing();
+    set_fast_paths_disabled(false);
+    let fast = scalar(&run(fluree, &ledger, Q_COUNT).await);
+    let sites = proceeded(&store, 0);
+    drop(tracing_guard);
+    set_fast_paths_disabled(true);
+    let generic = scalar(&run(fluree, &ledger, Q_COUNT).await);
+    set_fast_paths_disabled(false);
+
+    if fast != truth {
+        failures.push(format!(
+            "{when}: fast lane COUNT(DISTINCT ?o) = {fast}, expected {truth} \
+             (generic {generic}) [proceeded: {sites:?}]"
+        ));
+    }
+    if generic != truth {
+        failures.push(format!(
+            "{when}: generic pipeline = {generic}, expected {truth}"
+        ));
+    }
+    for site in [OBJECT_SITE, EXACT_SITE] {
+        if !sites.iter().any(|s| s == site) {
+            failures.push(format!(
+                "{when}: expected `{site}` to proceed on the reindexed ledger \
+                 [proceeded: {sites:?}]"
+            ));
+        }
+    }
 }

--- a/fluree-db-api/tests/it_distinct_object_numbig_gate.rs
+++ b/fluree-db-api/tests/it_distinct_object_numbig_gate.rs
@@ -57,8 +57,8 @@ const F_REPORTED: &str = r#"
 "#;
 
 /// Two decimals under ONE predicate: handles 0 and 1 in a single arena, so this
-/// answered correctly even unfixed. It still declines now — the gate is on the
-/// presence of a NumBig row, not on a collision it cannot see from metadata.
+/// answered correctly even unfixed. It now takes the exact arena branch, as
+/// does every graph with NumBig objects and no explicit entries cap.
 const F_ONE_PRED: &str = r#"
 <http://ex/s1> <http://ex/p1> "514.0000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
 <http://ex/s2> <http://ex/p1> "640.0000"^^<http://www.w3.org/2001/XMLSchema#decimal> .
@@ -336,7 +336,7 @@ impl Drop for FastPathGuard {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn distinct_object_count_declines_numbig_object_keys() {
+async fn distinct_object_count_counts_numbig_object_keys_exactly() {
     // The kill switch OR's with this env var, so with it set the fast lane
     // would run generically and every assertion below would be vacuous.
     assert!(
@@ -409,7 +409,7 @@ async fn distinct_object_count_declines_numbig_object_keys() {
     // ---- Phase 2: the over-broad-fix guards, on a decimal-bearing ledger --
     // Only the whole-graph OPST object arm is unsound. Declining its siblings
     // would be a gratuitous perf regression, so both must still fire on the
-    // very ledger that makes the object arm decline.
+    // very ledger that requires the exact object-count branch.
     {
         let (_db, _data, fluree, ledger_id) = build_indexed(F_LOSS3, "must-fire-guards").await;
         let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
@@ -588,12 +588,21 @@ async fn distinct_object_count_declines_numbig_object_keys() {
     // live row. The exact branch must count only handles POST still holds —
     // and must notice from directory metadata alone that an arena is not
     // fully live.
-    {
-        let (_db, _data, fluree, ledger_id) = build_indexed(F_LIFECYCLE, "liveness").await;
+    // Keep the decimal-only fixture for the numeric ordering pin. Adding a
+    // string here exercises the stale lane's per-row o_type filter on a real
+    // column, while the original fixture still covers type-pure leaflets.
+    let mixed_lifecycle = format!("{F_LIFECYCLE}\n<http://ex/a6> <http://ex/p1> \"alpha\" .\n");
+    for (ttl, slug, initial, rebuilt, incremental) in [
+        (F_LIFECYCLE, "liveness", "8", "7", "4"),
+        (mixed_lifecycle.as_str(), "mixed-liveness", "9", "8", "5"),
+    ] {
+        let (_db, _data, fluree, ledger_id) = build_indexed(ttl, slug).await;
         let ctx = json!({"ex": "http://ex/", "xsd": "http://www.w3.org/2001/XMLSchema#"});
+        check_liveness(&fluree, &ledger_id, initial, slug, &mut failures).await;
 
         // Retract 5.5 (p1 only: the term is gone) and p2's 9.9 (the term
-        // survives under p1). Union 8 → 7; both arenas keep a stale handle.
+        // survives under p1). Decimal union 8 → 7, plus the mixed fixture's
+        // string; both arenas keep a stale handle.
         let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
         fluree
             .update(
@@ -609,7 +618,14 @@ async fn distinct_object_count_declines_numbig_object_keys() {
             .await
             .expect("retract two decimals");
         support::rebuild_and_publish_index(&fluree, &ledger_id).await;
-        check_liveness(&fluree, &ledger_id, "7", "after rebuild", &mut failures).await;
+        check_liveness(
+            &fluree,
+            &ledger_id,
+            rebuilt,
+            &format!("{slug} after rebuild"),
+            &mut failures,
+        )
+        .await;
 
         // Retract every remaining p2 value: p2's arena has no live handle at
         // all, and the incremental build carries it forward unchanged.
@@ -629,7 +645,14 @@ async fn distinct_object_count_declines_numbig_object_keys() {
             .await
             .expect("retract p2");
         support::build_and_publish_index(&fluree, &ledger_id).await;
-        check_liveness(&fluree, &ledger_id, "4", "after incremental", &mut failures).await;
+        check_liveness(
+            &fluree,
+            &ledger_id,
+            incremental,
+            &format!("{slug} after incremental"),
+            &mut failures,
+        )
+        .await;
     }
 
     assert!(

--- a/fluree-db-binary-index/src/arena/numbig.rs
+++ b/fluree-db-binary-index/src/arena/numbig.rs
@@ -71,6 +71,26 @@ pub enum StoredBigValue {
 }
 
 impl StoredBigValue {
+    /// The value's dedup key, normalized the way [`NumBigArena::get_or_insert_bigdec`]
+    /// keys it: a BigDecimal has its trailing zeros stripped so `1.5` and
+    /// `1.50` map to one repr, whatever scale the entry was persisted under
+    /// (legacy pre-normalization arenas keep the original scale on disk).
+    /// Two entries — in one arena or across arenas — denote the same term iff
+    /// their normalized reprs are equal.
+    pub fn normalized_repr(&self) -> NumBigRepr {
+        match self {
+            Self::BigInt(bytes) => NumBigRepr::BigIntBytes(bytes.clone()),
+            Self::BigDec { unscaled, scale } => {
+                let bd = BigDecimal::new(BigInt::from_signed_bytes_le(unscaled), *scale);
+                let (norm_unscaled, norm_scale) = bd.normalized().as_bigint_and_exponent();
+                NumBigRepr::BigDecBytes {
+                    unscaled: norm_unscaled.to_signed_bytes_le(),
+                    scale: norm_scale,
+                }
+            }
+        }
+    }
+
     /// Reconstruct a `FlakeValue` from the stored bytes.
     pub fn to_flake_value(&self) -> fluree_db_core::value::FlakeValue {
         use fluree_db_core::value::FlakeValue;
@@ -398,20 +418,12 @@ pub fn read_numbig_arena_from_bytes(data: &[u8]) -> io::Result<NumBigArena> {
                     unscaled: unscaled_bytes.to_vec(),
                     scale,
                 };
-                let bd = BigDecimal::new(BigInt::from_signed_bytes_le(unscaled_bytes), scale);
-                let normalized = bd.normalized();
-                let (norm_unscaled, norm_scale) = normalized.as_bigint_and_exponent();
-                let norm_repr = NumBigRepr::BigDecBytes {
-                    unscaled: norm_unscaled.to_signed_bytes_le(),
-                    scale: norm_scale,
+                let stored = StoredBigValue::BigDec {
+                    unscaled: unscaled_bytes.to_vec(),
+                    scale,
                 };
-                arena.push_stored(
-                    StoredBigValue::BigDec {
-                        unscaled: unscaled_bytes.to_vec(),
-                        scale,
-                    },
-                    [raw_repr, norm_repr],
-                );
+                let norm_repr = stored.normalized_repr();
+                arena.push_stored(stored, [raw_repr, norm_repr]);
             }
             _ => {
                 return Err(io::Error::new(

--- a/fluree-db-binary-index/src/arena/numbig.rs
+++ b/fluree-db-binary-index/src/arena/numbig.rs
@@ -125,6 +125,9 @@ pub struct NumBigArena {
     dedup: HashMap<NumBigRepr, u32>,
     /// Forward: handle -> stored value.
     values: Vec<StoredBigValue>,
+    /// True when every stored decimal already has its normalized repr.
+    /// Legacy arenas may contain a non-normalized value even without duplicates.
+    values_normalized: bool,
     /// Extra handles per repr beyond the first (legacy pre-normalization
     /// arenas only: the same decimal value persisted under several scales,
     /// each with its own positional handle). Empty for arenas written after
@@ -139,6 +142,7 @@ impl NumBigArena {
         Self {
             dedup: HashMap::new(),
             values: Vec::new(),
+            values_normalized: true,
             dup_handles: HashMap::new(),
         }
     }
@@ -252,6 +256,13 @@ impl NumBigArena {
     /// complete.
     pub fn has_duplicate_handles(&self) -> bool {
         !self.dup_handles.is_empty()
+    }
+
+    /// Whether stored values can be used directly as normalized dedup keys.
+    /// New inserts are normalized; loading checks every decimal's stored repr.
+    /// This is independent of whether the arena has duplicate handles.
+    pub fn values_are_normalized(&self) -> bool {
+        self.values_normalized
     }
 
     /// Number of entries.
@@ -423,6 +434,7 @@ pub fn read_numbig_arena_from_bytes(data: &[u8]) -> io::Result<NumBigArena> {
                     scale,
                 };
                 let norm_repr = stored.normalized_repr();
+                arena.values_normalized &= raw_repr == norm_repr;
                 arena.push_stored(stored, [raw_repr, norm_repr]);
             }
             _ => {
@@ -456,6 +468,7 @@ mod tests {
     #[test]
     fn test_empty_arena() {
         let arena = NumBigArena::new();
+        assert!(arena.values_are_normalized());
         assert_eq!(arena.len(), 0);
         assert!(arena.is_empty());
         assert!(arena.get_by_handle(0).is_none());
@@ -529,6 +542,7 @@ mod tests {
         bigdec_entry(&mut buf, 1999, 2); // 19.99 -> handle 2
 
         let arena = read_numbig_arena_from_bytes(&buf).unwrap();
+        assert!(!arena.values_are_normalized());
 
         // Handles are positional: a duplicate-value legacy entry must NOT
         // shift subsequent handles.
@@ -571,10 +585,51 @@ mod tests {
         arena.get_or_insert_bigdec(&"1.5".parse::<BigDecimal>().unwrap());
         arena.get_or_insert_bigdec(&"19.99".parse::<BigDecimal>().unwrap());
         assert!(!arena.has_duplicate_handles());
+        assert!(arena.values_are_normalized());
+        let loaded =
+            read_numbig_arena_from_bytes(&write_numbig_arena_to_bytes(&arena).unwrap()).unwrap();
+        assert!(loaded.values_are_normalized());
         assert_eq!(
             arena.find_bigdec_handles(&"1.500".parse::<BigDecimal>().unwrap()),
             vec![0]
         );
+    }
+
+    #[test]
+    fn test_legacy_normalization_is_independent_of_duplicate_handles() {
+        for lexical in ["1.50", "0.000", "-10.00"] {
+            // A single legacy value cannot have duplicate handles, but still
+            // needs normalization. Test both entry orders so later normalized
+            // entries cannot accidentally reset the arena-wide flag.
+            for legacy_first in [false, true] {
+                let decimal: BigDecimal = lexical.parse().unwrap();
+                let (unscaled, scale) = decimal.as_bigint_and_exponent();
+                let legacy = StoredBigValue::BigDec {
+                    unscaled: unscaled.to_signed_bytes_le(),
+                    scale,
+                };
+                let normalized = StoredBigValue::BigDec {
+                    unscaled: vec![23],
+                    scale: 1,
+                };
+                let mut original = NumBigArena::new();
+                original.values = if legacy_first {
+                    vec![legacy, normalized]
+                } else {
+                    vec![normalized, legacy]
+                };
+                let bytes = write_numbig_arena_to_bytes(&original).unwrap();
+                let mut loaded = read_numbig_arena_from_bytes(&bytes).unwrap();
+                assert!(!loaded.has_duplicate_handles());
+                assert!(!loaded.values_are_normalized(), "{lexical}");
+                loaded.get_or_insert_bigdec(&"9.90".parse().unwrap());
+                assert!(!loaded.values_are_normalized());
+                let reloaded =
+                    read_numbig_arena_from_bytes(&write_numbig_arena_to_bytes(&loaded).unwrap())
+                        .unwrap();
+                assert!(!reloaded.values_are_normalized());
+            }
+        }
     }
 
     #[test]

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -1958,6 +1958,18 @@ impl BinaryIndexStore {
     }
 
     /// Reverse subject lookup by namespace parts (avoids IRI construction).
+    /// Every NumBig arena held for `g_id`, keyed by predicate. Arenas are
+    /// loaded whole at store open, so iterating them touches no storage.
+    pub fn numbig_arenas(
+        &self,
+        g_id: GraphId,
+    ) -> impl Iterator<Item = (u32, &crate::arena::numbig::NumBigArena)> + '_ {
+        self.graph_indexes
+            .get(&g_id)
+            .into_iter()
+            .flat_map(|gi| gi.numbig.iter().map(|(p_id, arena)| (*p_id, arena)))
+    }
+
     /// Find the NumBig arena handle for an already-indexed big numeric value
     /// (overflow `xsd:integer` / typed `xsd:decimal`) under `(g_id, p_id)`.
     ///

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -1957,7 +1957,6 @@ impl BinaryIndexStore {
         &self.dicts.dt_sids
     }
 
-    /// Reverse subject lookup by namespace parts (avoids IRI construction).
     /// Every NumBig arena held for `g_id`, keyed by predicate. Arenas are
     /// loaded whole at store open, so iterating them touches no storage.
     pub fn numbig_arenas(

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -19,7 +19,7 @@ use crate::ir::triple::{Ref, TriplePattern};
 use crate::operator::inline::InlineOperator;
 use crate::operator::BoxedOperator;
 use crate::var_registry::VarId;
-use fluree_db_binary_index::arena::numbig::{NumBigArena, NumBigRepr};
+use fluree_db_binary_index::arena::numbig::{NumBigArena, NumBigRepr, StoredBigValue};
 use fluree_db_binary_index::format::branch::LeafEntry;
 use fluree_db_binary_index::format::run_record::RunSortOrder;
 use fluree_db_binary_index::format::run_record_v2::{
@@ -1186,10 +1186,10 @@ const NUMBIG_EXACT_SITE: &str = "distinct object COUNT (numbig exact)";
 /// arenas hold more entries than this in total declines the whole count to
 /// the general pipeline. Unset means no cap.
 ///
-/// There is deliberately no default. The branch's cost is bounded by arena
-/// entries — already resident in memory — plus cached directory reads, never
-/// by row count, and declining is the expensive outcome: the general pipeline
-/// scans and materializes every object in the graph. The predecessor of this
+/// There is deliberately no default. The branch reads resident arena entries
+/// and directory metadata, decoding mixed-type or legacy leaflets and scanning
+/// NumBig rows for predicates with stale handles. Declining instead scans and
+/// materializes every object in the graph. The predecessor of this
 /// branch capped on NumBig *rows* (25M) and declined above it, which on a
 /// Wikidata-scale ledger turned a 20 ms count into a full scan that timed out
 /// at 300 s.
@@ -1265,6 +1265,12 @@ pub(crate) fn count_distinct_objects(
 ///
 /// Returns `None` when the index is inconsistent (NumBig rows with no arena to
 /// decode them) or when [`numbig_exact_max_entries`] is set and exceeded.
+///
+/// Keys are built and sorted on every execution; the count is not cached.
+/// Before cross-predicate dedup, the vector holds one key per live arena
+/// entry, including repeated values across predicates. On typical 64-bit targets
+/// each key occupies 48 bytes, plus allocations for wide values and temporary
+/// buffers. Legacy arenas also pay for normalization during key construction.
 fn count_distinct_numbig_objects(store: &BinaryIndexStore, g_id: GraphId) -> Result<Option<u64>> {
     use rayon::prelude::*;
 
@@ -1282,6 +1288,7 @@ fn count_distinct_numbig_objects(store: &BinaryIndexStore, g_id: GraphId) -> Res
 
     let mut keys: Vec<NumBigDistinctKey> = Vec::new();
     for (p_id, arena) in arenas {
+        let normalized = arena.values_are_normalized();
         let live = count_live_numbig_handles(store, g_id, p_id)?;
         if live == 0 {
             continue;
@@ -1291,7 +1298,7 @@ fn count_distinct_numbig_objects(store: &BinaryIndexStore, g_id: GraphId) -> Res
                 arena
                     .values()
                     .par_iter()
-                    .map(|v| NumBigDistinctKey::from_repr(v.normalized_repr())),
+                    .map(|v| NumBigDistinctKey::from_stored(v, normalized)),
             );
             continue;
         }
@@ -1301,7 +1308,7 @@ fn count_distinct_numbig_objects(store: &BinaryIndexStore, g_id: GraphId) -> Res
             .map(|&h| {
                 arena
                     .get_by_handle(h)
-                    .map(|v| NumBigDistinctKey::from_repr(v.normalized_repr()))
+                    .map(|v| NumBigDistinctKey::from_stored(v, normalized))
                     .ok_or_else(|| {
                         QueryError::Internal(format!(
                             "NumBig handle {h} beyond arena for g_id={g_id}, p_id={p_id}"
@@ -1321,7 +1328,7 @@ fn count_distinct_numbig_objects(store: &BinaryIndexStore, g_id: GraphId) -> Res
 /// Canonical signed little-endian bytes of at most 16 bytes fold into an
 /// `i128`; anything wider keeps its bytes. The encoding is minimal, so a value
 /// that fits `i128` never appears in the wide arm and the mapping is injective.
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum NumBigDistinctKey {
     Int(i128),
     IntWide(Vec<u8>),
@@ -1330,6 +1337,25 @@ enum NumBigDistinctKey {
 }
 
 impl NumBigDistinctKey {
+    /// Only bypass normalization when the arena proves all stored values are
+    /// normalized. Inline keys borrow bytes without allocating; wide keys own
+    /// a copy so they can be sorted together across arenas.
+    fn from_stored(value: &StoredBigValue, normalized: bool) -> Self {
+        if !normalized {
+            return Self::from_repr(value.normalized_repr());
+        }
+        match value {
+            StoredBigValue::BigInt(bytes) => match i128_from_signed_le(bytes) {
+                Some(v) => Self::Int(v),
+                None => Self::IntWide(bytes.clone()),
+            },
+            StoredBigValue::BigDec { unscaled, scale } => match i128_from_signed_le(unscaled) {
+                Some(v) => Self::Dec(v, *scale),
+                None => Self::DecWide(unscaled.clone(), *scale),
+            },
+        }
+    }
+
     fn from_repr(repr: NumBigRepr) -> Self {
         match repr {
             NumBigRepr::BigIntBytes(bytes) => match i128_from_signed_le(&bytes) {
@@ -2136,6 +2162,109 @@ mod tests {
     use super::*;
     use fluree_db_core::index_stats::{GraphPropertyStatEntry, GraphStatsEntry};
     use fluree_db_core::IndexStats;
+
+    #[test]
+    fn numbig_signed_keys_preserve_boundaries() {
+        use num_bigint::BigInt;
+        for value in [
+            0,
+            127,
+            128,
+            -128,
+            -129,
+            i64::MIN as i128,
+            i64::MAX as i128,
+            i128::MIN,
+            i128::MAX,
+        ] {
+            let bytes = BigInt::from(value).to_signed_bytes_le();
+            assert_eq!(i128_from_signed_le(&bytes), Some(value));
+            assert_eq!(
+                NumBigDistinctKey::from_stored(&StoredBigValue::BigInt(bytes), true),
+                NumBigDistinctKey::Int(value)
+            );
+        }
+        for value in [BigInt::from(i128::MIN) - 1u8, BigInt::from(i128::MAX) + 1u8] {
+            let bytes = value.to_signed_bytes_le();
+            assert_eq!(i128_from_signed_le(&bytes), None);
+            let int = NumBigDistinctKey::from_stored(&StoredBigValue::BigInt(bytes.clone()), true);
+            let dec = NumBigDistinctKey::from_stored(
+                &StoredBigValue::BigDec {
+                    unscaled: bytes.clone(),
+                    scale: 0,
+                },
+                true,
+            );
+            assert_eq!(int, NumBigDistinctKey::IntWide(bytes.clone()));
+            assert_eq!(dec, NumBigDistinctKey::DecWide(bytes, 0));
+            assert_ne!(int, dec);
+        }
+    }
+
+    #[test]
+    fn numbig_stored_keys_match_normalized_keys() {
+        use fluree_db_binary_index::arena::numbig::{
+            read_numbig_arena_from_bytes, write_numbig_arena_to_bytes,
+        };
+        let mut arena = NumBigArena::new();
+        for lexical in [
+            "1.50",
+            "-1.500",
+            "0.000",
+            "1000.00",
+            "170141183460469231731687303715884105728.1",
+        ] {
+            arena.get_or_insert_bigdec(&lexical.parse().unwrap());
+        }
+        arena.get_or_insert_bigint(&"170141183460469231731687303715884105728".parse().unwrap());
+        let loaded =
+            read_numbig_arena_from_bytes(&write_numbig_arena_to_bytes(&arena).unwrap()).unwrap();
+        for arena in [&arena, &loaded] {
+            assert!(arena.values_are_normalized());
+            for value in arena.values() {
+                assert_eq!(
+                    NumBigDistinctKey::from_stored(value, arena.values_are_normalized()),
+                    NumBigDistinctKey::from_repr(value.normalized_repr())
+                );
+            }
+        }
+        for (unscaled, scale, expected) in [
+            (150i128, 2, NumBigDistinctKey::Dec(15, 1)),
+            (0, 3, NumBigDistinctKey::Dec(0, 0)),
+            (-1000, 2, NumBigDistinctKey::Dec(-1, -1)),
+        ] {
+            let value = StoredBigValue::BigDec {
+                unscaled: num_bigint::BigInt::from(unscaled).to_signed_bytes_le(),
+                scale,
+            };
+            assert_eq!(NumBigDistinctKey::from_stored(&value, false), expected);
+        }
+        assert_ne!(NumBigDistinctKey::Dec(15, 1), NumBigDistinctKey::Int(15));
+    }
+
+    #[test]
+    fn numbig_handle_partials_dedup_seams_and_preserve_empty_chunks() {
+        let mut left = NumBigHandlePartial::default();
+        left.push_run(2, 0, 1);
+        left.push_run(2, 1, 2);
+        assert_eq!((left.count, left.first, left.last), (3, Some(0), Some(2)));
+        let left = NumBigHandlePartial::combine(NumBigHandlePartial::default(), left);
+        let left = NumBigHandlePartial::combine(left, NumBigHandlePartial::default());
+        let mut right = NumBigHandlePartial::default();
+        right.push_run(2, 2, 3);
+        let merged = NumBigHandlePartial::combine(left, right);
+        assert_eq!(
+            (merged.count, merged.first, merged.last),
+            (4, Some(0), Some(3))
+        );
+        let mut disjoint = NumBigHandlePartial::default();
+        disjoint.push_run(2, 5, 6);
+        let merged = NumBigHandlePartial::combine(merged, disjoint);
+        assert_eq!(
+            (merged.count, merged.first, merged.last),
+            (6, Some(0), Some(6))
+        );
+    }
 
     fn prop(p_id: u32, datatypes: Vec<(u8, u64)>) -> GraphPropertyStatEntry {
         let count = datatypes.iter().map(|&(_, c)| c).sum();

--- a/fluree-db-query/src/fast_count.rs
+++ b/fluree-db-query/src/fast_count.rs
@@ -12,13 +12,14 @@ use crate::fast_path_common::{
     cursor_fast_path_for_predicate, fast_path_store, fast_path_store_policy_cleared,
     leaf_entries_for_predicate, normalize_pred_sid, parallel_leaf_chunk_count,
     parallel_leaf_chunk_reduce, parallel_overlay_psot_filter_count, projection_okey_only,
-    projection_otype_only, projection_sid_only, projection_sid_otype_okey, FastPathOperator,
-    PredicateFastPath,
+    projection_otype_okey, projection_otype_only, projection_sid_only, projection_sid_otype_okey,
+    FastPathOperator, PredicateFastPath,
 };
 use crate::ir::triple::{Ref, TriplePattern};
 use crate::operator::inline::InlineOperator;
 use crate::operator::BoxedOperator;
 use crate::var_registry::VarId;
+use fluree_db_binary_index::arena::numbig::{NumBigArena, NumBigRepr};
 use fluree_db_binary_index::format::branch::LeafEntry;
 use fluree_db_binary_index::format::run_record::RunSortOrder;
 use fluree_db_binary_index::format::run_record_v2::{
@@ -30,7 +31,6 @@ use fluree_db_core::subject_id::SubjectId;
 use fluree_db_core::value_id::{ObjKey, ValueTypeTag};
 use fluree_db_core::{FlakeValue, GraphId};
 use fluree_vocab::namespaces;
-use std::collections::HashSet;
 use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
@@ -1103,9 +1103,9 @@ pub fn count_distinct_position_operator(
                 // OPST key layout: o_type(2) + o_key(8) + o_i(4) + p_id(4) + s_id(8).
                 // Distinct objects = lead bytes [0..10] — which excludes p_id,
                 // and so is not an object identity for a NumBig arena handle.
-                // Those rows are counted exactly from the arena slice up to
-                // `numbig_exact_max_rows`; only a graph holding more NumBig
-                // rows than that declines to the general pipeline.
+                // Those terms are counted exactly from the in-memory arenas
+                // (see `count_distinct_numbig_objects`); declining is reserved
+                // for an inconsistent index or the explicit kill switch.
                 DistinctPosition::Objects => {
                     let Some(count) = count_distinct_objects(store, ctx.binary_g_id)? else {
                         return Ok(None);
@@ -1182,63 +1182,25 @@ pub(crate) fn count_distinct_lead_groups(
 /// from "counted the arena slice exactly".
 const NUMBIG_EXACT_SITE: &str = "distinct object COUNT (numbig exact)";
 
-/// Row cap above which the exact branch declines to the general pipeline.
+/// Kill switch for the exact NumBig branch: when set, a graph whose NumBig
+/// arenas hold more entries than this in total declines the whole count to
+/// the general pipeline. Unset means no cap.
 ///
-/// **This is a rollout guard, not a crossover threshold.** Timing the two lanes
-/// over synthetic ledgers (NumBig rows split across two predicates, plus a
-/// non-NumBig slice half its size) found no crossover at any size tried:
-///
-/// | NumBig rows | exact | general | ratio |
-/// |---|---|---|---|
-/// | 1 000 | 0.39 ms | 1.21 ms | 3.1x |
-/// | 10 000 | 3.39 ms | 13.31 ms | 3.9x |
-/// | 50 000 | 17.54 ms | 69.35 ms | 4.0x |
-/// | 200 000 | 72.73 ms | 345.04 ms | 4.7x |
-/// | 1 000 000 | 485.56 ms | 2774.54 ms | 5.7x |
-///
-/// The advantage *grows* with the slice, which is structural rather than
-/// lucky: the general pipeline scans and materializes every object in the
-/// graph, while this branch pays payload reads for the NumBig slice only and
-/// still answers the rest from directory metadata.
-///
-/// So declining is not the cheap option above the cap — the fallback scans and
-/// materializes every object in the graph rather than the NumBig slice alone,
-/// and pays for it in time.
-///
-/// The comparison is deliberately about time only. On memory the two are not
-/// ordered by entry count: the fallback holds more entries, but keys them as
-/// `GroupKeyOwned::Lit`, a small `Copy` struct, where this branch's set holds a
-/// `MaterializedLitKey` carrying an `Arc<str>` per distinct value. Which side
-/// wins depends on how many of those rows are distinct, so no claim is made.
-///
-/// Nothing here is being protected by the cap except the rollout itself: this
-/// is a new read path
-/// (branch seek, payload decode, arena mapping) and the cap bounds how much of
-/// a graph it can be responsible for while it soaks. It is a removal
-/// candidate after a release in production, not a number to tune.
-///
-/// The table is not reproduced by anything in the tree — there is no bench on
-/// this path, and `FLUREE_NUMBIG_EXACT_MAX_ROWS` appears only here and in
-/// `it_distinct_object_numbig_gate`. To re-derive it: build a ledger of N
-/// NumBig rows split across two predicates plus a non-NumBig slice of N/2,
-/// index it, and time `COUNT(DISTINCT ?o)` twice — once as-is for the exact
-/// lane, once with `FLUREE_NUMBIG_EXACT_MAX_ROWS=1` to force the decline. Treat
-/// the numbers as a recorded observation, not a maintained benchmark.
-///
-/// Overridable so the regression suite can sweep both sides, and so the timing
-/// above can be re-derived.
-fn numbig_exact_max_rows() -> u64 {
-    std::env::var("FLUREE_NUMBIG_EXACT_MAX_ROWS")
+/// There is deliberately no default. The branch's cost is bounded by arena
+/// entries — already resident in memory — plus cached directory reads, never
+/// by row count, and declining is the expensive outcome: the general pipeline
+/// scans and materializes every object in the graph. The predecessor of this
+/// branch capped on NumBig *rows* (25M) and declined above it, which on a
+/// Wikidata-scale ledger turned a 20 ms count into a full scan that timed out
+/// at 300 s.
+fn numbig_exact_max_entries() -> Option<u64> {
+    std::env::var("FLUREE_NUMBIG_EXACT_MAX_ENTRIES")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(NUMBIG_EXACT_MAX_ROWS_DEFAULT)
 }
 
-const NUMBIG_EXACT_MAX_ROWS_DEFAULT: u64 = 25_000_000;
-
 /// Whole-graph distinct **objects** from OPST leaflet directories, or `None`
-/// when the graph holds an object whose `(o_type, o_key)` lead is not a
-/// graph-wide identity.
+/// when the count cannot be established without the general pipeline.
 ///
 /// The 10-byte OPST lead is `o_type(2) + o_key(8)` and stops immediately before
 /// `p_id` (bytes `[14..18]`). For a `NUM_BIG_OVERFLOW` row that lead is a
@@ -1250,25 +1212,13 @@ const NUMBIG_EXACT_MAX_ROWS_DEFAULT: u64 = 25_000_000;
 /// undercount, never an over-report.
 ///
 /// The metadata walk therefore counts only the identifying part of the graph and
-/// reports the NumBig slice's row count separately; [`count_distinct_objects`]
-/// decides what to do with it.
+/// reports the NumBig slice's row count separately. When that slice is non-empty
+/// its distinct terms come from [`count_distinct_numbig_objects`], which reads
+/// the arenas rather than the rows.
 ///
 /// The per-predicate distinct-object count is unaffected and stays on its fast
 /// path: its 14-byte POST lead starts with `p_id`, which scopes the handle
 /// correctly. So is the distinct-subject count, whose SPOT lead is `s_id`.
-///
-/// Rather than decline the whole query over that slice, it is counted exactly.
-/// Three outcomes, in the order they are cheapest to establish:
-///
-/// * no NumBig rows — the metadata walk already answered, unchanged;
-/// * NumBig rows within [`numbig_exact_max_rows`] — add the exact count of the
-///   arena slice, which costs a two-column payload read over *only* those rows;
-/// * more than that — decline, because the general pipeline is scanning
-///   everything anyway and an in-memory distinct set over the slice stops being
-///   the cheaper way to answer.
-///
-/// The row tally comes from leaflet directory entries, so the threshold is
-/// decided before any payload is touched.
 pub(crate) fn count_distinct_objects(
     store: &BinaryIndexStore,
     g_id: GraphId,
@@ -1280,10 +1230,9 @@ pub(crate) fn count_distinct_objects(
     if walk.skipped_non_identifying_rows == 0 {
         return Ok(Some(walk.count));
     }
-    if walk.skipped_non_identifying_rows > numbig_exact_max_rows() {
+    let Some(exact) = count_distinct_numbig_objects(store, g_id)? else {
         return Ok(None);
-    }
-    let exact = count_distinct_numbig_objects(store, g_id)?;
+    };
     crate::fast_path_outcome::stamp_fast_path(
         NUMBIG_EXACT_SITE,
         crate::fast_path_outcome::FastPathOutcome::Proceed,
@@ -1291,135 +1240,346 @@ pub(crate) fn count_distinct_objects(
     Ok(Some(walk.count.saturating_add(exact)))
 }
 
-/// Exact distinct-value count over the `NUM_BIG_OVERFLOW` slice of the OPST
-/// index.
+/// Exact distinct-term count over the graph's `NUM_BIG_OVERFLOW` objects,
+/// answered from the arenas rather than the rows.
 ///
-/// Two things make this more than "count the arena":
+/// Every NumBig arena is resident in memory from store open and keyed on a
+/// normalized value repr, so the union of the arenas' entries *is* the set of
+/// distinct big-numeric terms the index has ever held — with one catch: an
+/// arena keeps a handle for a value whose rows have since been retracted (a
+/// full rebuild replays retractions through the same insert path), so arena
+/// membership alone over-counts. Liveness is proved per predicate from POST
+/// directory metadata: the number of distinct live handles under `p` is the
+/// predicate's lead-group count over its NumBig leaflets, and when that equals
+/// the arena's size every entry is live and nothing is read beyond directories.
+/// Only a predicate with stale handles pays for a column read, and only over
+/// its own NumBig rows, to learn *which* handles survive.
 ///
-/// * an arena keeps a handle for a value whose rows have since been retracted,
-///   so the pairs must come from rows present in the index — this walks the
-///   rows and never reads arena membership;
-/// * one value under two predicates is two handles in two arenas, and within a
-///   legacy arena two handles can decode to the same value, so dedup happens on
-///   the decoded value rather than on `(p_id, handle)`.
+/// Dedup keys on the normalized repr, exactly as the general pipeline keys
+/// these rows (normalized decimal lexical, BigInt separate from BigDecimal), so
+/// the same value under two predicates — two handles in two arenas — and a
+/// legacy arena's scale-variant duplicates each count once. A BigInt entry that
+/// happens to fit `i64` is keyed as a big value here and as `Long` by the
+/// general pipeline; the resolver never routes such a value to the arena, so
+/// this cannot arise on a written index.
 ///
-/// Values are keyed with [`crate::group_aggregate::flake_value_to_key`], the
-/// general pipeline's own key function, so the two lanes partition a value set
-/// the same way.
-///
-/// The datatype passed to it is a constant `xsd:decimal` for the whole slice,
-/// which is *not* what the general pipeline resolves per row — there,
-/// `resolve_datatype_sid_for_value` falls through to
-/// `FlakeValue::overflow_numeric_datatype_sid` and tags an overflow BigInt
-/// `xsd:integer` and a BigDecimal `xsd:decimal`. The constant is still sound,
-/// for a reason worth stating exactly: `flake_value_to_key` already gives
-/// `Decimal` and `BigInt` distinct discriminants, and in the general lane the
-/// datatype is a function of that same variant, so it separates nothing the
-/// discriminant has not separated. Both choices yield the same partition, and
-/// only its size is read here.
-fn count_distinct_numbig_objects(store: &BinaryIndexStore, g_id: GraphId) -> Result<u64> {
-    use fluree_db_binary_index::format::column_block::ColumnId;
-    use fluree_db_binary_index::read::column_types::{ColumnProjection, ColumnSet};
+/// Returns `None` when the index is inconsistent (NumBig rows with no arena to
+/// decode them) or when [`numbig_exact_max_entries`] is set and exceeded.
+fn count_distinct_numbig_objects(store: &BinaryIndexStore, g_id: GraphId) -> Result<Option<u64>> {
+    use rayon::prelude::*;
 
-    let Some(branch) = store.branch_for_order(g_id, RunSortOrder::Opst) else {
-        return Ok(0);
-    };
-    let numbig = OType::NUM_BIG_OVERFLOW;
-    let (min_key, max_key) = o_type_range_keys(numbig, g_id);
-    let cmp = fluree_db_binary_index::format::run_record_v2::cmp_v2_for_order(RunSortOrder::Opst);
-    let leaf_range = branch.find_leaves_in_range(&min_key, &max_key, cmp);
+    let arenas: Vec<(u32, &NumBigArena)> = store
+        .numbig_arenas(g_id)
+        .filter(|(_, arena)| !arena.is_empty())
+        .collect();
+    if arenas.is_empty() {
+        return Ok(None);
+    }
+    let total_entries: u64 = arenas.iter().map(|(_, a)| a.len() as u64).sum();
+    if numbig_exact_max_entries().is_some_and(|cap| total_entries > cap) {
+        return Ok(None);
+    }
 
-    let projection = ColumnProjection {
-        output: ColumnSet::EMPTY,
-        internal: {
-            let mut s = ColumnSet::EMPTY;
-            s.insert(ColumnId::PId);
-            s.insert(ColumnId::OKey);
-            s
-        },
-    };
-    // `dtc` is constant for the whole slice. It does not have to match what the
-    // general pipeline resolves per row (`resolve_datatype_sid_for_value` gives
-    // an overflow BigInt `xsd:integer` and a BigDecimal `xsd:decimal`) because
-    // it cannot separate anything the key does not already separate:
-    // `flake_value_to_key` assigns `Decimal` and `BigInt` distinct
-    // discriminants, and in the general lane `dtc` is a function of that same
-    // variant. A constant therefore yields an identical partition, and only the
-    // partition's size is read here.
-    let dtc = fluree_db_core::DatatypeConstraint::Explicit(
-        store
-            .dt_sids()
-            .get(fluree_db_core::ids::DatatypeDictId::DECIMAL.as_u16() as usize)
-            .cloned()
-            .unwrap_or_else(|| fluree_db_core::Sid::new(0, "")),
-    );
-
-    // Pass 1: collect the distinct `(p_id, o_key)` handles. A handle repeats
-    // once per row that carries the value — one value under one predicate is a
-    // row per subject — so decoding per row would allocate a BigInt/BigDecimal
-    // plus a `String` and an `Arc<str>` for each of them. Deduping the `Copy`
-    // pair first costs one `u64`-ish hash per row and bounds the decodes by the
-    // arena's size rather than the slice's row count.
-    let mut handles: HashSet<(u32, u64)> = HashSet::new();
-    for leaf_entry in &branch.leaves[leaf_range] {
-        let handle = store
-            .open_leaf_handle(&leaf_entry.leaf_cid, leaf_entry.sidecar_cid.as_ref(), false)
-            .map_err(|e| QueryError::from_io("leaf open", e))?;
-        for (idx, entry) in handle.dir().entries.iter().enumerate() {
-            if entry.row_count == 0 || entry.o_type_const != Some(numbig.as_u16()) {
-                continue;
-            }
-            let batch = handle
-                .load_columns(idx, &projection, RunSortOrder::Opst)
-                .map_err(|e| QueryError::Internal(format!("leaflet columns: {e}")))?;
-            for row in 0..batch.row_count {
-                handles.insert((batch.p_id.get_or(row, 0), batch.o_key.get(row)));
-            }
+    let mut keys: Vec<NumBigDistinctKey> = Vec::new();
+    for (p_id, arena) in arenas {
+        let live = count_live_numbig_handles(store, g_id, p_id)?;
+        if live == 0 {
+            continue;
         }
+        if live == arena.len() as u64 {
+            keys.par_extend(
+                arena
+                    .values()
+                    .par_iter()
+                    .map(|v| NumBigDistinctKey::from_repr(v.normalized_repr())),
+            );
+            continue;
+        }
+        let handles = live_numbig_handles(store, g_id, p_id)?;
+        let mapped: Result<Vec<NumBigDistinctKey>> = handles
+            .par_iter()
+            .map(|&h| {
+                arena
+                    .get_by_handle(h)
+                    .map(|v| NumBigDistinctKey::from_repr(v.normalized_repr()))
+                    .ok_or_else(|| {
+                        QueryError::Internal(format!(
+                            "NumBig handle {h} beyond arena for g_id={g_id}, p_id={p_id}"
+                        ))
+                    })
+            })
+            .collect();
+        keys.extend(mapped?);
     }
-
-    // Pass 2: decode the survivors. Two handles in a legacy arena can decode to
-    // the same value, and one value under two predicates is two handles in two
-    // arenas, so the distinct count still has to come from the decoded values —
-    // deduping handles only removes the repeats that cannot possibly differ.
-    let mut distinct: HashSet<crate::group_aggregate::MaterializedLitKey> = HashSet::new();
-    for (p_id, o_key) in handles {
-        let val = store
-            .decode_value_v3(numbig.as_u16(), o_key, p_id, g_id)
-            .map_err(|e| QueryError::Internal(format!("numbig decode: {e}")))?;
-        distinct.insert(crate::group_aggregate::flake_value_to_key(&val, &dtc));
-    }
-    Ok(distinct.len() as u64)
+    keys.par_sort_unstable();
+    keys.dedup();
+    Ok(Some(keys.len() as u64))
 }
 
-/// Min/max OPST keys bracketing a single `o_type`.
-fn o_type_range_keys(
-    o_type: OType,
-    g_id: GraphId,
-) -> (
-    fluree_db_binary_index::format::run_record_v2::RunRecordV2,
-    fluree_db_binary_index::format::run_record_v2::RunRecordV2,
-) {
-    use fluree_db_binary_index::format::run_record_v2::RunRecordV2;
-    let min_key = RunRecordV2 {
-        s_id: SubjectId(0),
-        o_key: 0,
-        p_id: 0,
-        t: 0,
-        o_i: 0,
-        o_type: o_type.as_u16(),
-        g_id,
+/// Compact, totally ordered form of [`NumBigRepr`] for sort-based dedup.
+///
+/// Canonical signed little-endian bytes of at most 16 bytes fold into an
+/// `i128`; anything wider keeps its bytes. The encoding is minimal, so a value
+/// that fits `i128` never appears in the wide arm and the mapping is injective.
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+enum NumBigDistinctKey {
+    Int(i128),
+    IntWide(Vec<u8>),
+    Dec(i128, i64),
+    DecWide(Vec<u8>, i64),
+}
+
+impl NumBigDistinctKey {
+    fn from_repr(repr: NumBigRepr) -> Self {
+        match repr {
+            NumBigRepr::BigIntBytes(bytes) => match i128_from_signed_le(&bytes) {
+                Some(v) => Self::Int(v),
+                None => Self::IntWide(bytes),
+            },
+            NumBigRepr::BigDecBytes { unscaled, scale } => match i128_from_signed_le(&unscaled) {
+                Some(v) => Self::Dec(v, scale),
+                None => Self::DecWide(unscaled, scale),
+            },
+        }
+    }
+}
+
+fn i128_from_signed_le(bytes: &[u8]) -> Option<i128> {
+    if bytes.len() > 16 {
+        return None;
+    }
+    let negative = bytes.last().is_some_and(|b| b & 0x80 != 0);
+    let mut buf = [if negative { 0xFF } else { 0x00 }; 16];
+    buf[..bytes.len()].copy_from_slice(bytes);
+    Some(i128::from_le_bytes(buf))
+}
+
+/// How one predicate's POST leaflet relates to the `NUM_BIG_OVERFLOW` range.
+enum NumBigLeaflet {
+    /// Holds no NumBig row, or belongs to another predicate.
+    Outside,
+    /// Every row is NumBig: `lead_group_count` is its distinct-handle count.
+    Pure,
+    /// Straddles the NumBig range (or predates `lead_group_count`): rows
+    /// must be decoded to find its NumBig handles.
+    Decode,
+}
+
+fn classify_numbig_leaflet(
+    entry: &fluree_db_binary_index::format::leaf::LeafletDirEntryV3,
+    p_id: u32,
+) -> NumBigLeaflet {
+    if entry.row_count == 0 || entry.p_const != Some(p_id) {
+        return NumBigLeaflet::Outside;
+    }
+    let numbig = OType::NUM_BIG_OVERFLOW.as_u16();
+    if entry.o_type_const == Some(numbig) {
+        return if entry.lead_group_count > 0 {
+            NumBigLeaflet::Pure
+        } else {
+            NumBigLeaflet::Decode
+        };
+    }
+    // POST keys sort by `(p_id, o_type, o_key, …)`, so the entry's own key
+    // interval bounds every o_type it holds.
+    let lo = read_ordered_key_v2(RunSortOrder::Post, &entry.first_key).o_type;
+    let hi = read_ordered_key_v2(RunSortOrder::Post, &entry.last_key).o_type;
+    if lo <= numbig && numbig <= hi {
+        NumBigLeaflet::Decode
+    } else {
+        NumBigLeaflet::Outside
+    }
+}
+
+/// Per-chunk partial for a run of NumBig handles under one predicate: distinct
+/// handles seen, plus the first and last handle for seam dedup.
+#[derive(Default)]
+struct NumBigHandlePartial {
+    count: u64,
+    first: Option<u64>,
+    last: Option<u64>,
+}
+
+impl NumBigHandlePartial {
+    fn push_run(&mut self, count: u64, first: u64, last: u64) {
+        self.count = self.count.saturating_add(count);
+        if self.last == Some(first) {
+            self.count = self.count.saturating_sub(1);
+        }
+        if self.first.is_none() {
+            self.first = Some(first);
+        }
+        self.last = Some(last);
+    }
+
+    fn combine(left: Self, right: Self) -> Self {
+        if right.first.is_none() {
+            return left;
+        }
+        if left.first.is_none() {
+            return right;
+        }
+        let seam_dedup = u64::from(left.last == right.first);
+        Self {
+            count: left
+                .count
+                .saturating_add(right.count)
+                .saturating_sub(seam_dedup),
+            first: left.first,
+            last: right.last,
+        }
+    }
+}
+
+/// Distinct NumBig handles in one decoded POST leaflet: `(count, first, last)`
+/// over its NumBig rows only, or `None` when it holds none. Rows are sorted by
+/// `(o_type, o_key, …)` within the predicate, so equal handles are adjacent.
+fn decode_numbig_handle_run(
+    handle: &dyn fluree_db_binary_index::read::leaf_access::LeafHandle,
+    leaflet_idx: usize,
+    o_type_const: Option<u16>,
+) -> Result<Option<(u64, u64, u64)>> {
+    let numbig = OType::NUM_BIG_OVERFLOW.as_u16();
+    let batch = handle
+        .load_columns(leaflet_idx, &projection_otype_okey(), RunSortOrder::Post)
+        .map_err(|e| QueryError::Internal(format!("leaflet columns: {e}")))?;
+    let o_type_default = o_type_const.unwrap_or(0);
+    let mut count = 0u64;
+    let mut first = None;
+    let mut prev = None;
+    for row in 0..batch.row_count {
+        if batch.o_type.get_or(row, o_type_default) != numbig {
+            continue;
+        }
+        let k = batch.o_key.get(row);
+        if prev != Some(k) {
+            count += 1;
+            prev = Some(k);
+            first.get_or_insert(k);
+        }
+    }
+    Ok(first.zip(prev).map(|(f, l)| (count, f, l)))
+}
+
+/// Number of distinct NumBig handles with a live row under `p_id`, from POST
+/// leaflet directories: `lead_group_count` over type-pure NumBig leaflets with
+/// seam dedup on the handle, decoding only a leaflet that straddles the NumBig
+/// range or predates `lead_group_count`. Compared against the arena's size, this
+/// says whether every arena entry is still live without reading a row.
+fn count_live_numbig_handles(store: &BinaryIndexStore, g_id: GraphId, p_id: u32) -> Result<u64> {
+    let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Post, p_id);
+    if leaves.is_empty() {
+        return Ok(0);
+    }
+
+    let map = |chunk: &[LeafEntry]| -> Result<Option<NumBigHandlePartial>> {
+        let mut partial = NumBigHandlePartial::default();
+        for leaf_entry in chunk {
+            let dir = store
+                .open_leaf_dir(&leaf_entry.leaf_cid)
+                .map_err(|e| QueryError::Internal(format!("leaf dir open: {e}")))?;
+            let mut handle = None;
+            for (idx, entry) in dir.entries.iter().enumerate() {
+                match classify_numbig_leaflet(entry, p_id) {
+                    NumBigLeaflet::Outside => {}
+                    NumBigLeaflet::Pure => {
+                        let first = read_ordered_key_v2(RunSortOrder::Post, &entry.first_key).o_key;
+                        let last = read_ordered_key_v2(RunSortOrder::Post, &entry.last_key).o_key;
+                        partial.push_run(u64::from(entry.lead_group_count), first, last);
+                    }
+                    NumBigLeaflet::Decode => {
+                        let handle = match &handle {
+                            Some(h) => h,
+                            None => handle.insert(
+                                store
+                                    .open_leaf_handle(
+                                        &leaf_entry.leaf_cid,
+                                        leaf_entry.sidecar_cid.as_ref(),
+                                        false,
+                                    )
+                                    .map_err(|e| QueryError::from_io("leaf open", e))?,
+                            ),
+                        };
+                        if let Some((count, first, last)) =
+                            decode_numbig_handle_run(handle.as_ref(), idx, entry.o_type_const)?
+                        {
+                            partial.push_run(count, first, last);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(Some(partial))
     };
-    let max_key = RunRecordV2 {
-        s_id: SubjectId(u64::MAX),
-        o_key: u64::MAX,
-        p_id: u32::MAX,
-        t: u32::MAX,
-        o_i: u32::MAX,
-        o_type: o_type.as_u16(),
-        g_id,
+
+    let parallel = leaves.len() >= crate::fast_path_common::parallel_dir_walk_min_leaves();
+    Ok(
+        parallel_leaf_chunk_reduce(leaves, parallel, map, NumBigHandlePartial::combine)?
+            .map_or(0, |p| p.count),
+    )
+}
+
+/// The set of NumBig handles with a live row under `p_id`, sorted and
+/// deduplicated. Reads the `o_key` column (plus `o_type` for a straddling
+/// leaflet) over the predicate's NumBig leaflets only — the fallback for a
+/// predicate whose arena holds retracted values.
+fn live_numbig_handles(store: &BinaryIndexStore, g_id: GraphId, p_id: u32) -> Result<Vec<u32>> {
+    let leaves = leaf_entries_for_predicate(store, g_id, RunSortOrder::Post, p_id);
+    if leaves.is_empty() {
+        return Ok(Vec::new());
+    }
+    let numbig = OType::NUM_BIG_OVERFLOW.as_u16();
+
+    let map = |chunk: &[LeafEntry]| -> Result<Option<Vec<u32>>> {
+        let mut handles: Vec<u32> = Vec::new();
+        for leaf_entry in chunk {
+            let dir = store
+                .open_leaf_dir(&leaf_entry.leaf_cid)
+                .map_err(|e| QueryError::Internal(format!("leaf dir open: {e}")))?;
+            let wanted: Vec<usize> = dir
+                .entries
+                .iter()
+                .enumerate()
+                .filter(|(_, e)| {
+                    !matches!(classify_numbig_leaflet(e, p_id), NumBigLeaflet::Outside)
+                })
+                .map(|(i, _)| i)
+                .collect();
+            if wanted.is_empty() {
+                continue;
+            }
+            let handle = store
+                .open_leaf_handle(&leaf_entry.leaf_cid, leaf_entry.sidecar_cid.as_ref(), false)
+                .map_err(|e| QueryError::from_io("leaf open", e))?;
+            for idx in wanted {
+                let entry = &dir.entries[idx];
+                let batch = handle
+                    .load_columns(idx, &projection_otype_okey(), RunSortOrder::Post)
+                    .map_err(|e| QueryError::Internal(format!("leaflet columns: {e}")))?;
+                let o_type_default = entry.o_type_const.unwrap_or(0);
+                for row in 0..batch.row_count {
+                    if batch.o_type.get_or(row, o_type_default) != numbig {
+                        continue;
+                    }
+                    let h = batch.o_key.get(row) as u32;
+                    if handles.last() != Some(&h) {
+                        handles.push(h);
+                    }
+                }
+            }
+        }
+        Ok(Some(handles))
     };
-    (min_key, max_key)
+
+    let parallel = leaves.len() >= crate::fast_path_common::parallel_dir_walk_min_leaves();
+    let mut handles = parallel_leaf_chunk_reduce(leaves, parallel, map, |mut l, r| {
+        l.extend(r);
+        l
+    })?
+    .unwrap_or_default();
+    handles.sort_unstable();
+    handles.dedup();
+    Ok(handles)
 }
 
 /// Outcome of a lead-group walk: distinct groups over the leaflets that were


### PR DESCRIPTION
## Problem

The 4.2.0 Sparqloscope refresh on Wikidata Truthy lost `number-of-objects` (`SELECT (COUNT(DISTINCT ?o) AS ?count) WHERE { ?s ?p ?o }`): 20.8 ms on 4.0.6, no response within the 300 s client limit on 4.2.0. Report: `benchmark-db/runs/v420-suite-refresh-20260907/truthy-regression-report.md`.

The whole-graph distinct-object fast path was gated on NumBig objects in 388bbd54c / 0b41e8b4d (in 4.1.6 and 4.2.0). That gate was correct to add: the 10-byte OPST lead is a per-predicate arena handle for `NUM_BIG_OVERFLOW` rows, so the 4.0.6 answer was a silent undercount. But the exact branch row-scanned the NumBig slice and declined above 25M NumBig rows as a rollout guard. Every `xsd:decimal` is arena-routed, Wikidata quantities exceed the cap, and the query fell to the general pipeline over 8.18B rows.

## Fix

The NumBig arenas are already resident in memory, one per `(g_id, p_id)`, deduplicated on a normalized value repr. The branch now reads arenas instead of rows and dedups across predicates on a compact key with a parallel sort.

Arena membership cannot say liveness: an arena keeps a handle for a value whose rows were retracted (a full rebuild replays retractions through the same insert path; an incremental build carries arenas forward). Liveness is proved per predicate from POST directory metadata: distinct live handles is the lead-group count over the predicate's type-pure NumBig leaflets with seam dedup, and when it equals the arena's size every entry is live with no column read. Only a predicate with stale handles reads its `o_key` column, over its own NumBig rows. A leaflet that straddles the NumBig range (a predicate carrying several datatypes) is decoded.

The row cap is removed. `FLUREE_NUMBIG_EXACT_MAX_ENTRIES` caps total arena entries and is unset by default: declining is the expensive outcome, since the fallback materializes every object in the graph.

The loader records whether every stored decimal is already normalized. Those arenas build distinct keys directly from stored bytes, without allocating for inline keys. Legacy arenas retain normalization during key construction; having no duplicate handles is not sufficient to take the shortcut.

New surface: `StoredBigValue::normalized_repr`, `NumBigArena::values_are_normalized`, `BinaryIndexStore::numbig_arenas`.

## Measurements

Measurements recorded before the stored-byte shortcut; these timings have not been rerun for that optimization.

Release build, 1M decimal rows across 4 predicates (values overlapping across predicates) plus 500k strings:

| Lane | Time |
|---|---|
| Fast lane | 20 ms |
| Stale-handle lane (after retractions, every arena stale) | 33 ms |
| General pipeline (forced decline) | ~1.5 s |

Not run against the Wikidata ledger (terminated after the suite). On a graph with tens of millions of live arena entries, every execution builds keys and pays a parallel sort over those entries; the result is not cached. Expect hundreds of milliseconds rather than the old 20 ms, which was a wrong answer. The acceptance target should be agreement with the general pipeline, not the 4.0.6 number.

The key vector holds one key per live arena entry before cross-predicate deduplication, so repeated values across predicates each occupy a slot. On typical 64-bit targets, keys occupy 48 bytes each (about 1.44 GB for 30M live entries), excluding wide-value allocations, spare vector capacity, and temporary buffers. This is not a guarantee that peak memory is always lower than the general pipeline. Predicates with stale handles also scan their NumBig rows, and mixed-type or legacy leaflets may require decoding to establish liveness.

## Tests

`it_distinct_object_numbig_gate` gains a mixed-datatype predicate fixture (POST leaflets are predicate-homogeneous but not type-homogeneous, so this yields an `o_type`-column leaflet that takes the decode arm) and a retract → rebuild → retract → incremental phase pinning fast == general == truth with the exact-branch stamp on each. Both were verified non-vacuous by sabotaging the liveness proof and the decode classification separately; a combined sabotage masks the second, which is worth knowing if the test is revisited.

The lifecycle checks now run against both decimal-only and mixed-datatype fixtures, covering the stale-handle lane with a real `o_type` column while preserving the numeric ordering fixture. Removing only the stale-lane datatype filter makes the mixed fixture return 9 instead of 8 after rebuild and 6 instead of 5 after incremental indexing; restoring the filter returns the test to green.

Unit tests cover normalization status on loaded modern and legacy arenas (including legacy values without duplicate handles), signed and wide key boundaries, normalized key agreement, and handle-count seams and empty chunks. All 15 targeted NumBig unit tests, the all-features API integration test, package-scoped clippy with `-D warnings`, formatting, and diff checks pass locally.

End-to-end integration coverage still does not construct leaves that predate `lead_group_count` or legacy scale-variant arenas. Per-store count caching and a maintained whole-graph NumBig distinct-count benchmark with a regression-budget entry remain deferred.
