### PR TITLE
Add trusted policy delegation across SDK and server interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3499,6 +3499,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "clap",
+ "criterion",
  "dashmap",
  "ed25519-dalek",
  "fluree-db-api",

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -156,6 +156,7 @@
 
 - [Security and policy](security/README.md)
   - [Authentication](security/authentication.md)
+  - [Trusted policy authorization](security/policy-authorization.md)
   - [Storage encryption](security/encryption.md)
   - [Commit signing and attestation](security/commit-signing.md)
   - [Policy model and inputs](security/policy-model.md)

--- a/docs/cli/token.md
+++ b/docs/cli/token.md
@@ -31,6 +31,7 @@ fluree token create --private-key <KEY> [OPTIONS]
 | `--subject <SUB>` | Subject claim (`sub`) - identity of the token holder |
 | `--audience <AUD>` | Audience claim (`aud`) - repeatable for multiple audiences |
 | `--identity <ID>` | Fluree identity claim (`fluree.identity`) - takes precedence over `sub` for policy |
+| `--policy-select` | Allow request policy selection (`"fluree.policy": "request"`); requires `--audience` and an issuer trusted as a policy authority by the server |
 | `--all` | Grant full access to all ledgers (events, storage, read, and write) |
 | `--events-ledger <ALIAS>` | Grant events access to specific ledger (repeatable) |
 | `--storage-ledger <ALIAS>` | Grant storage access to specific ledger (repeatable) |

--- a/docs/contributing/benches.md
+++ b/docs/contributing/benches.md
@@ -229,6 +229,7 @@ future micro-bench wants to exercise `fluree-db-indexer`,
 | `vector_query` | end-to-end vector similarity through the query engine | `fluree-db-api/benches/vector_query.rs` |
 | `fulltext_query` | full-text scoring through novelty + index | `fluree-db-api/benches/fulltext_query.rs` |
 | `graphql_schema` | GraphQL schema derivation + registration, and the GraphQL request path against the JSON-LD query it lowers to | `fluree-db-api/benches/graphql_schema.rs` |
+| `policy` | verified-claim parsing and request authorization binding | `fluree-db-api/benches/policy_authorization.rs` |
 
 **Reserved categories** (not yet in use; add a row here when you ship
 the first bench under that prefix): `core` (foundational ops —

--- a/docs/contributing/benches.md
+++ b/docs/contributing/benches.md
@@ -482,3 +482,17 @@ When reviewing someone else's bench, check:
   integration test (`fluree-bench-support/tests/workspace_reconcile.rs`)
   and is invoked by the `bench-gate` CI job — there is no library
   function for it.
+
+## Policy authorization
+
+Run `cargo bench -p fluree-db-api --features credential --bench policy_authorization`
+to measure fixed policy binding. It compares ordinary and delegated claim parsing
+and simple/multiple-source normalization, reporting latency and allocation bytes.
+Tracking-allocator overhead is included; signature verification, issuer lookup,
+networking, and database policy evaluation are excluded. Use `CRITERION_HOME` to
+choose the output directory.
+
+Authorization reuses token verification and adds claim parsing, an authority check,
+and request validation/normalization. It adds no ledger lookup, network request,
+or per-fact authorization work. Embedded binding clones query JSON; large inline
+policies increase parsing and cloning cost.

--- a/docs/contributing/benches.md
+++ b/docs/contributing/benches.md
@@ -496,3 +496,22 @@ Authorization reuses token verification and adds claim parsing, an authority che
 and request validation/normalization. It adds no ledger lookup, network request,
 or per-fact authorization work. Embedded binding clones query JSON; large inline
 policies increase parsing and cloning cost.
+
+### Full HTTP policy path
+
+Run `cargo bench -p fluree-db-server --bench policy_http` to compare warm,
+in-process HTTP queries with auth disabled, ordinary credentials, fixed
+selections, request selections, and 32 inline rules. Every case must return the
+same one-row result before timing. This benchmark includes signature verification,
+credential validation, body/header binding, config resolution, database execution,
+and response serialization. Socket/TLS costs are excluded. The fixture uses 256
+novelty-resident records with indexing disabled; these numbers do not characterize
+cold storage, indexed workloads, or large federated queries.
+
+Use the same benchmark source, build features, and machine on both revisions
+when comparing the no-auth case against `main`. For a quick correctness check,
+run `cargo test -p fluree-db-server --bench policy_http -- --test`. The bench
+declares `required-features = ["native", "credential"]`; both are default
+features, so it is silently skipped only under `--no-default-features`. Config
+absence is cached on each view, and regression tests verify that wrapping
+followed by execution does not repeat the config scan.

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -563,10 +563,11 @@ Bearer token scopes:
 
 Back-compat: `fluree.storage.*` claims imply **read** scope for data endpoints.
 
-Application gateways may select policies through the signed `fluree.policy`
-claim only when the verified issuer is also a configured policy authority.
-This repeatable setting requires a nonempty data-auth audience; it does not
-replace ordinary issuer trust. See [Trusted policy authorization](../security/policy-authorization.md)
+Applications may select request policies using a credential with
+`"fluree.policy": "request"`, or issue a fixed signed `fluree.policy`
+selection for downstream clients. Both require the verified issuer to be a
+configured policy authority.
+This repeatable setting requires a nonempty data-auth audience; policy authorities also establish ordinary issuer trust. See [Trusted policy authorization](../security/policy-authorization.md)
 for the TOML configuration, claim format, and embedded SDK equivalent.
 
 ```bash
@@ -780,7 +781,7 @@ fluree-server \
 
 > **JWKS support**: When `--jwks-issuer` is configured, storage proxy endpoints accept RS256 OIDC tokens in addition to Ed25519 JWS tokens. The `--jwks-issuer` flag is shared with data, admin, and events endpoints — a single flag enables OIDC across all endpoint groups.
 
-Storage proxy rejects tokens containing a signed `fluree.policy` context. Delegated policy selection is supported by the data API, not storage-proxy endpoints. Use separate replication credentials for storage access; see [Trusted policy authorization](../security/policy-authorization.md).
+Storage proxy rejects fixed `fluree.policy` delegation and `"fluree.policy": "request"` credentials. Delegated policy selection is supported by the data API, not storage-proxy endpoints. Use separate replication credentials for storage access; see [Trusted policy authorization](../security/policy-authorization.md).
 
 ## Complete Configuration Examples
 

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -547,6 +547,7 @@ Protect query/transaction endpoints (including `/v1/fluree/query/{ledger...}`,
 | `--data-auth-mode`                 | `FLUREE_DATA_AUTH_MODE`                 | `none`  |
 | `--data-auth-audience`             | `FLUREE_DATA_AUTH_AUDIENCE`             | None    |
 | `--data-auth-trusted-issuer`       | `FLUREE_DATA_AUTH_TRUSTED_ISSUERS`      | None    |
+| `--data-auth-policy-authority`     | `FLUREE_DATA_AUTH_POLICY_AUTHORITIES`  | None    |
 | `--data-auth-default-policy-class` | `FLUREE_DATA_AUTH_DEFAULT_POLICY_CLASS` | None    |
 
 Modes:
@@ -561,6 +562,12 @@ Bearer token scopes:
 - **Write**: `fluree.ledger.write.all=true` or `fluree.ledger.write.ledgers=[...]`
 
 Back-compat: `fluree.storage.*` claims imply **read** scope for data endpoints.
+
+Application gateways may select policies through the signed `fluree.policy`
+claim only when the verified issuer is also a configured policy authority.
+This repeatable setting requires a nonempty data-auth audience; it does not
+replace ordinary issuer trust. See [Trusted policy authorization](../security/policy-authorization.md)
+for the TOML configuration, claim format, and embedded SDK equivalent.
 
 ```bash
 fluree-server \

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -780,6 +780,8 @@ fluree-server \
 
 > **JWKS support**: When `--jwks-issuer` is configured, storage proxy endpoints accept RS256 OIDC tokens in addition to Ed25519 JWS tokens. The `--jwks-issuer` flag is shared with data, admin, and events endpoints — a single flag enables OIDC across all endpoint groups.
 
+Storage proxy rejects tokens containing a signed `fluree.policy` context. Delegated policy selection is supported by the data API, not storage-proxy endpoints. Use separate replication credentials for storage access; see [Trusted policy authorization](../security/policy-authorization.md).
+
 ## Complete Configuration Examples
 
 ### Development (Memory Storage)

--- a/docs/query/graphql.md
+++ b/docs/query/graphql.md
@@ -126,6 +126,11 @@ Every mutation is an ordinary Fluree transaction, so SHACL validation and policy
 apply unchanged and a rejected write comes back as a GraphQL error having
 written nothing.
 
+On a server running Raft consensus, GraphQL mutations return HTTP 501 before
+execution. Use the [transaction endpoints](../api/endpoints.md#transaction-endpoints) for writes in
+that deployment. GraphQL reads remain available, even when mutations are
+enabled in the ledger's schema.
+
 ## Explain
 
 Pass `?explain=true`, or `extensions: {"explain": true}` in the request body, to

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -13,6 +13,10 @@ Fluree's authentication model, covering:
 - Replication vs query access boundary
 - Token verification paths (Ed25519 + OIDC/JWKS)
 
+### [Trusted policy authorization](policy-authorization.md)
+
+Application-selected policy contexts for embedded hosts and signed, scoped gateway delegation.
+
 ## Data Encryption
 
 ### [Storage Encryption](encryption.md)

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -4,6 +4,8 @@ Fluree supports multiple authentication mechanisms to cover different deployment
 
 This document describes the authentication model, the supported modes, the bearer token claim set, and the access boundary between replication and query operations.
 
+See [Trusted policy authorization](policy-authorization.md) for the separation between authenticated identity, caller options, and explicit application delegation.
+
 ## Identity vs transport
 
 ### Identity (who)

--- a/docs/security/policy-authorization.md
+++ b/docs/security/policy-authorization.md
@@ -1,60 +1,72 @@
 # Trusted policy authorization
 
-Authenticated data requests use policy inputs chosen by verified authority. A request body, query source, or `fluree-policy-*` header cannot select a different identity, class set, inline policy, variable binding, or permissive default. Having a ledger identity record without `f:policyClass` assignments does not grant impersonation privileges.
+An application can select users and policies dynamically, or give a downstream client a fixed signed selection. Fluree enforces those policies at the data layer. Ledger scopes and configured policy-override controls still apply.
 
-Ordinary identity-bearing tokens resolve their identity's policies, or the server's configured default policy class. Signed request bodies use the signing identity and do not inherit a bearer token's delegation. Explicit caller `default-allow: false` remains available to narrow the default; other caller policy selections are replaced, rather than merged into the authoritative policy set. Ledger configuration's override controls still apply.
+| Request | Who selects the policy? | Request policy options | No selection supplied |
+| --- | --- | --- | --- |
+| No credential, auth disabled or optional | Caller | Accepted directly | Ledger defaults; unrestricted if unconfigured |
+| Application credential: `"fluree.policy": "request"` | Trusted application, per request | Accepted | Deny |
+| Fixed credential: `"fluree.policy": {...}` | Credential issuer | Matching values and `default-allow: false` narrowing accepted; conflicts return 403 | Signed selection applies; an empty context denies |
+| Ordinary identity credential or signed request body | Verified identity plus server defaults | Matching values and narrowing accepted; conflicts return 403 | Identity/server-selected policies apply |
+| Scope-only credential, without identity or server policy class | Server/ledger configuration | Policy selections rejected; `default-allow: false` accepted | Ledger defaults within signed scopes |
 
-An authenticated scope-only service token (neither `fluree.identity` nor `sub`, and no server default class) retains coarse read/write access within its signed scopes. Issuing such a token authorizes unrestricted data access within those scopes, subject to mandatory ledger configuration. For end-user filtering, issue an identity-bearing token or a delegated policy selection. Anonymous requests allowed by `data_auth.mode=none` or `optional` retain direct policy options; those modes are appropriate only when the host intentionally allows anonymous access.
+## Fluree behind your application
 
-## Embedded applications
+For local development or a private deployment where the application/network is the trust boundary, run with data authentication disabled. Ordinary request options work directly; no application credential or issuer configuration is required.
 
-After authenticating the user and resolving their grants, construct a `PolicyAuthorization` from application-owned values:
-
-```rust,ignore
-use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
-
-let authorization = PolicyAuthorization::from_trusted_options(GovernanceOptions {
-    identity: Some("https://app.example/users/123".into()),
-    policy_class: Some(vec!["https://app.example/policies/Employee".into()]),
-    ..Default::default()
-});
-let result = fluree.query_from()
-    .jsonld(&caller_query)
-    .authorization(&authorization)
-    .execute_formatted()
-    .await?;
-```
-
-The builder enforces this selection across its raw, formatted, string, and tracked terminals, including SPARQL. Source-specific policy overrides are removed. A prebuilt `.policy(...)` cannot be combined with `.authorization(...)`.
-
-The type intentionally does not implement `Deserialize`. Constructing it is a trust decision by the embedding application. An empty context engages default-deny enforcement; an application that authorizes an unrestricted default must explicitly set `default_allow: Some(true)`.
-
-The application must separately authorize every ledger/action requested. One context applies uniformly to the query's sources. If sources need different grants, split the requests or select a policy set valid for all of them. For transactions and already-resolved views, use `authorization.options()` with the governance/policy builder. For GraphQL mutations, `graphql_transact_with_authorization` retains the context through schema derivation, each write, and the returned data, rebuilding policy against each new state. `apply_to_jsonld` can bind a JSON request after the application's final option merge. Do not subsequently replace it with caller policy options.
-
-## Application gateways over HTTP
-
-A gateway can place its selected policies in the existing signed data bearer token. The receiver must both trust the token issuer for ordinary data authentication and explicitly permit that issuer to select policies:
+For an authenticated deployment, authorize the backend's issuer once:
 
 ```toml
 [server.auth.data]
 mode = "required"
 audience = "fluree-production"
-trusted_issuers = ["did:key:<gateway-signing-key>"]
-policy_authorities = ["did:key:<gateway-signing-key>"]
+policy_authorities = ["did:key:<app-signing-key>"]
 ```
 
-The CLI equivalent is `--data-auth-policy-authority`, repeatable; the environment variable is `FLUREE_DATA_AUTH_POLICY_AUTHORITIES`. Configuring authorities requires `--data-auth-audience` / `FLUREE_DATA_AUTH_AUDIENCE`. For OIDC, configure the issuer/JWKS pair through the existing OIDC settings and list that issuer URL as a policy authority. The development setting that accepts any issuer does **not** grant policy-authority status.
+A policy authority is also a trusted issuer; do not list it twice. Additional login-only issuers belong in `trusted_issuers` and cannot issue policy capabilities. OIDC authorities still need configured JWKS verification. Only designate an issuer that controls the policy claim, rather than allowing users to set it through profile data.
 
-Example decoded JWT payload (timestamps must be current when issuing):
+Create a reusable application credential:
+
+```bash
+fluree token create --private-key @app.key --subject backend \
+  --audience fluree-production --expires-in 1h \
+  --read-ledger customer/data:main --write-ledger customer/data:main \
+  --policy-controller
+```
+
+The CLI signs `"fluree.policy": "request"` together with the audience, expiry, and ledger scopes. Keep this credential in the backend and renew it before expiry. The application authenticates its users, resolves their grants, and supplies the resulting context:
+
+```bash
+curl -X POST https://db.example/v1/fluree/query/customer/data:main \
+  -H "Authorization: Bearer $APP_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "opts": {
+      "identity": "https://app.example/users/123",
+      "policy-class": ["https://app.example/policies/Employee"]
+    },
+    "select": ["?name"],
+    "where": {"@id": "?s", "https://schema.org/name": "?name"}
+  }'
+```
+
+Change `identity`, `policy-class`, inline `policy`, or `policy-values` on the next request without issuing another token. Explicit classes select rules; identity binds `?$identity`. Identity alone selects that identity's classes. Use fully qualified identity and class IRIs.
+
+An omitted or empty application selection denies access. An empty class list selects no stored rules and defaults to deny. For intentionally permissive access, explicitly select `default-allow: true`; shared policy sources can still supply rules. Where overrides are permitted, `policy-class: []` plus `default-allow: true` explicitly selects no stored class rules. Configured override restrictions still govern these choices.
+
+The `fluree-identity`, `fluree-policy-class`, `fluree-policy`, `fluree-policy-values`, and `fluree-default-allow` headers carry policy options for SPARQL, Cypher, GraphQL, push, and commit show. JSON body options override header defaults. Multi-query aliases retain envelope/sub-query precedence. One selection applies across a query's sources; conflicting per-source selections are rejected. A signed request body uses its signing identity and does not inherit an accompanying application's credential authority.
+
+## Fixed signed delegation
+
+Use an object-valued `fluree.policy` when a browser, partner, or other downstream client should carry a fixed selection:
 
 ```json
 {
-  "iss": "did:key:<gateway-signing-key>",
+  "iss": "did:key:<app-signing-key>",
   "aud": "fluree-production",
   "sub": "https://app.example/users/123",
-  "exp": 1788739500,
+  "exp": 1789142400,
   "fluree.ledger.read.ledgers": ["customer/data:main"],
-  "fluree.ledger.write.ledgers": ["customer/data:main"],
   "fluree.policy": {
     "policy-class": ["https://app.example/policies/Employee"],
     "default-allow": false
@@ -62,24 +74,33 @@ Example decoded JWT payload (timestamps must be current when issuing):
 }
 ```
 
-`fluree.identity`, if present, overrides `sub` for the policy subject. The `fluree.policy` object accepts only `policy-class` (array of strings), `policy` (inline policy JSON), `policy-values` (variable-binding object), and `default-allow` (boolean). Unknown fields and a present null context are rejected; omit `fluree.policy` entirely for ordinary authentication. Prefer fully qualified class and identity IRIs. Explicit classes select policies and identity binds `?$identity`; local identity-to-class assignments are not required for this application contract.
+`fluree.identity` overrides `sub` for the selected identity. The policy object accepts `policy-class` (string array), `policy` (inline JSON), `policy-values` (binding object), and `default-allow` (boolean). Unknown fields, unknown string modes, and a null claim are rejected. Omit the claim for ordinary authentication.
 
-The signature covers the selection and its ledger/action scopes, audience, and expiry. The existing token verifier checks those claims; the policy-authority allowlist adds a separate receiver-side capability check. Invalid delegation is rejected rather than silently downgraded to an ordinary token. The receiver trusts an authorized issuer to issue grants within the server's existing issuer/scoping model; it does not independently re-evaluate the gateway's application grants. Do not designate a general login issuer as a policy authority unless it controls these claims appropriately.
+Both claim forms require a verified signature, a configured policy authority, a matching audience, and valid expiry/scopes. Being an ordinary trusted issuer does not confer policy authority. A policy-free identity record in ledger data confers no delegation authority.
 
-This same selection is used by JSON-LD, SPARQL, Cypher, GraphQL, streaming queries, multi-query aliases, transaction routes, push ingestion, and Bolt sessions. Query source and envelope options cannot replace it. The token authorizes a uniform selection over its signed scopes, not a map of different policy sets per ledger.
+## Embedded applications
 
-Storage-proxy endpoints reject tokens containing `fluree.policy`, including tokens with storage scopes, because that surface does not implement delegated policy selection. Use data-query endpoints for delegated access and separate replication credentials for storage access. GraphQL mutations return HTTP 501 on Raft-enabled servers; submit writes through transaction endpoints. GraphQL reads remain available.
+The embedded host already owns the authentication boundary. It can keep using `GovernanceOptions`, or bind a resolved application selection explicitly:
 
-## Authorization logging
+```rust,ignore
+let authorization = PolicyAuthorization::from_trusted_options(GovernanceOptions {
+    identity: Some(user_iri),
+    policy_class: Some(granted_classes),
+    default_allow: Some(false),
+    ..Default::default()
+});
+let result = fluree.query_from()
+    .jsonld(&query)
+    .authorization(&authorization)
+    .execute_formatted().await?;
+```
 
-Enable `RUST_LOG=fluree_db_server::authorization=debug` to record bearer-token scope checks. Each event includes `issuer`, `effective_identity`, `authorization_mode` (`delegated`, `server-default`, `identity`, or `scope-only`), `ledger`, `action`, and `scope_allowed`. Add this target to your existing log filter to retain other logging, for example `RUST_LOG=info,fluree_db_server::authorization=debug`.
+`PolicyAuthorization` always holds a fixed context. Empty trusted inputs deny; the host authorizes each ledger separately. No token or issuer configuration is required inside the process. The helper replaces query-supplied selections with the host's selection; credential conflict errors are enforced at the server boundary.
 
-These events describe the credential's ledger/action scope decision. Subsequent policy evaluation can still filter results or reject a write. A request may check multiple sources or perform several scope checks; the events are not a count of completed requests. Signed request-body authentication uses its signing identity separately. The events omit tokens, inline policies, and policy-variable values. They are disabled at the default info level; enabling them adds log formatting and output work per scope check.
+## Transport support and migration
 
-## Cost and migration
+HTTP queries, streaming, transactions, GraphQL, push, and commit show use the same credential selection rules. Bolt supports fixed selections; request-selected credentials without a selection deny, and explicit `imp_user` requests are rejected until impersonation is supported. MCP and storage proxy reject either policy claim because they cannot enforce the complete selection contract. Use separate replication credentials for storage access. `/log` returns read-scoped commit metadata, not policy-filtered flakes. GraphQL mutations on Raft servers return 501; use transaction endpoints.
 
-The HTTP token is verified once through the existing verification path. Policy authorization adds claim parsing, an issuer allowlist check, and request-level option normalization. It adds no ledger lookup, second token verification, per-fact work, network request, or Raft proposal. A follower forwards the bearer credential and the leader verifies it before submitting the selected governance through the replicated command queue. Policy construction and enforcement remain separate costs. The embedded query builder clones caller JSON once when binding a context; large inline policy documents also increase token and normalization cost.
+Clients that previously used policy-free identities to impersonate must use an application credential or fixed delegation. Conflicting `--as` and policy options now return 403 rather than silently displaying another view. Plain and streaming connection reads honor configured defaults, including an explicit deny default with no class selection. Applications that used omitted options for privileged reads must select their intended privileged context explicitly. No-auth, unconfigured deployments remain unrestricted.
 
-To measure request binding locally, run `cargo bench -p fluree-db-api --features credential --bench policy_authorization`. The benchmark compares ordinary and delegated claims selecting the same policy class, with simple and multiple-source requests. It reports latency and allocation bytes, including tracking-allocator overhead. It excludes signature verification, issuer lookup, networking, and database policy evaluation, so its results describe normalization cost rather than end-to-end query latency. Set `CRITERION_HOME` to choose the results directory.
-
-Applications that relied on policy-free identities to override policy headers must migrate to explicit contexts. Embedded applications construct typed contexts after resolving user grants. HTTP gateways issue scoped tokens and configure the receiving server's issuer, policy-authority, and audience settings. Preserve the selected governance through queued writes and credential forwarding. Cluster transport authentication is configured independently of policy delegation.
+Enable `RUST_LOG=info,fluree_db_server::authorization=debug` for credential scope events: issuer, effective identity for fixed contexts, mode (`fixed`, `request-selected`, `scope-only`), ledger, action, and scope decision. These precede policy evaluation; request-selected scope events do not identify the dynamically selected user. Tokens, inline policies, and policy values are omitted. See [Benchmarks](../contributing/benches.md) for measuring authorization overhead.

--- a/docs/security/policy-authorization.md
+++ b/docs/security/policy-authorization.md
@@ -23,7 +23,7 @@ audience = "fluree-production"
 policy_authorities = ["did:key:<app-signing-key>"]
 ```
 
-A policy authority is also a trusted issuer; do not list it twice. Additional login-only issuers belong in `trusted_issuers` and cannot issue policy capabilities. OIDC authorities still need configured JWKS verification. Only designate an issuer that controls the policy claim, rather than allowing users to set it through profile data.
+A policy authority is also a trusted issuer and need not be listed again in `trusted_issuers`. Additional login-only issuers belong in `trusted_issuers` and cannot issue policy capabilities. OIDC authorities still need configured JWKS verification. Only designate an issuer that controls the policy claim, rather than allowing users to set it through profile data.
 
 Create a reusable application credential:
 
@@ -31,7 +31,7 @@ Create a reusable application credential:
 fluree token create --private-key @app.key --subject backend \
   --audience fluree-production --expires-in 1h \
   --read-ledger customer/data:main --write-ledger customer/data:main \
-  --policy-controller
+  --policy-select
 ```
 
 The CLI signs `"fluree.policy": "request"` together with the audience, expiry, and ledger scopes. Keep this credential in the backend and renew it before expiry. The application authenticates its users, resolves their grants, and supplies the resulting context:
@@ -95,12 +95,19 @@ let result = fluree.query_from()
     .execute_formatted().await?;
 ```
 
-`PolicyAuthorization` always holds a fixed context. Empty trusted inputs deny; the host authorizes each ledger separately. No token or issuer configuration is required inside the process. The helper replaces query-supplied selections with the host's selection; credential conflict errors are enforced at the server boundary.
+`PolicyAuthorization` always holds a fixed context. Empty trusted inputs deny; the host authorizes each ledger separately. No token or issuer configuration is required inside the process. The embedded helper silently replaces query-supplied selections with the host's fixed selection, preserving `default-allow: false` narrowing; it does not report selection conflicts. HTTP credential binding instead rejects conflicting selections with 403.
 
 ## Transport support and migration
 
 HTTP queries, streaming, transactions, GraphQL, push, and commit show use the same credential selection rules. Bolt supports fixed selections; request-selected credentials without a selection deny, and explicit `imp_user` requests are rejected until impersonation is supported. MCP and storage proxy reject either policy claim because they cannot enforce the complete selection contract. Use separate replication credentials for storage access. `/log` returns read-scoped commit metadata, not policy-filtered flakes. GraphQL mutations on Raft servers return 501; use transaction endpoints.
 
 Clients that previously used policy-free identities to impersonate must use an application credential or fixed delegation. Conflicting `--as` and policy options now return 403 rather than silently displaying another view. Plain and streaming connection reads honor configured defaults, including an explicit deny default with no class selection. Applications that used omitted options for privileged reads must select their intended privileged context explicitly. No-auth, unconfigured deployments remain unrestricted.
+
+Other user-visible changes:
+
+- An explicit `default-allow: false` is now an enforcement input, closing the unrestricted shortcut when it is the only policy option. Configured rules still apply; unmatched access is denied.
+- `policy-class: []` explicitly selects no stored class rules instead of being treated as absent. It does not fall back to the identity's classes; configured override restrictions still apply.
+- A non-string `identity` or non-boolean `default-allow` in JSON policy options now returns HTTP 400 instead of being silently ignored. Omission and JSON `null` still leave either field unset.
+- Policy headers (`fluree-identity`, `fluree-policy-class`, `fluree-policy`, `fluree-policy-values`, and `fluree-default-allow`) now supply defaults for JSON-LD transaction body options even when tracking is disabled. This intentional bug fix also applies to anonymous/no-auth requests. Body options retain precedence, and credential checks still apply.
 
 Enable `RUST_LOG=info,fluree_db_server::authorization=debug` for credential scope events: issuer, effective identity for fixed contexts, mode (`fixed`, `request-selected`, `scope-only`), ledger, action, and scope decision. These precede policy evaluation; request-selected scope events do not identify the dynamically selected user. Tokens, inline policies, and policy values are omitted. See [Benchmarks](../contributing/benches.md) for measuring authorization overhead.

--- a/docs/security/policy-authorization.md
+++ b/docs/security/policy-authorization.md
@@ -52,7 +52,7 @@ curl -X POST https://db.example/v1/fluree/query/customer/data:main \
 
 Change `identity`, `policy-class`, inline `policy`, or `policy-values` on the next request without issuing another token. Explicit classes select rules; identity binds `?$identity`. Identity alone selects that identity's classes. Use fully qualified identity and class IRIs.
 
-An omitted or empty application selection denies access. An empty class list selects no stored rules and defaults to deny. For intentionally permissive access, explicitly select `default-allow: true`; shared policy sources can still supply rules. Where overrides are permitted, `policy-class: []` plus `default-allow: true` explicitly selects no stored class rules. Configured override restrictions still govern these choices.
+An omitted or empty application selection denies access, including when locked ledger defaults select allowing rules. An empty class list selects no stored rules and defaults to deny. An explicit empty class list with a deny default and no inline rules is an absolute narrowing: configured grants cannot widen it. For intentionally permissive access, explicitly select `default-allow: true`; shared policy sources can still supply rules. Where overrides are permitted, `policy-class: []` plus `default-allow: true` explicitly selects no stored class rules. Configured override restrictions still govern these choices.
 
 The `fluree-identity`, `fluree-policy-class`, `fluree-policy`, `fluree-policy-values`, and `fluree-default-allow` headers carry policy options for SPARQL, Cypher, GraphQL, push, and commit show. JSON body options override header defaults. Multi-query aliases retain envelope/sub-query precedence. One selection applies across a query's sources; conflicting per-source selections are rejected. A signed request body uses its signing identity and does not inherit an accompanying application's credential authority.
 
@@ -111,3 +111,15 @@ Other user-visible changes:
 - Policy headers (`fluree-identity`, `fluree-policy-class`, `fluree-policy`, `fluree-policy-values`, and `fluree-default-allow`) now supply defaults for JSON-LD transaction body options even when tracking is disabled. This intentional bug fix also applies to anonymous/no-auth requests. Body options retain precedence, and credential checks still apply.
 
 Enable `RUST_LOG=info,fluree_db_server::authorization=debug` for credential scope events: issuer, effective identity for fixed contexts, mode (`fixed`, `request-selected`, `scope-only`), ledger, action, and scope decision. These precede policy evaluation; request-selected scope events do not identify the dynamically selected user. Tokens, inline policies, and policy values are omitted. See [Benchmarks](../contributing/benches.md) for measuring authorization overhead.
+
+### Ledger configuration reads fail closed
+
+Query, streaming, transaction, and explain paths return an error when the ledger's config graph cannot be read. An unreadable config graph is never treated as "no configuration": doing so would run the request unrestricted on a ledger whose operator may have configured a deny default or a mandatory policy class. Previously such reads were best-effort and fell back to system defaults.
+
+In practice this only surfaces on snapshots that cannot serve any range read, such as a metadata-only historical view loaded without its binary index, where data queries already fail with the same error. A ledger with no config graph is unaffected: a successful read that finds nothing is cached on the view as absent and is not repeated for that snapshot.
+
+### Policy-scoped explain withholds statistics
+
+Explain on a policy-scoped view (any view that is not root, including a plain `default-allow: false` narrowing) returns a plan built without ledger or annotation statistics, and `plan.reason` states that statistics were withheld by policy. A caller who can only see a filtered subset must not learn unfiltered cardinalities from the planner. Unrestricted explains retain their statistics.
+
+The trade-off is that the explained plan may differ from the executed plan: execution still uses the full statistics, so a scoped caller may see a heuristic join order that the engine does not actually choose. When diagnosing performance under policy, run explain with an unrestricted credential against the same query.

--- a/docs/security/policy-authorization.md
+++ b/docs/security/policy-authorization.md
@@ -116,7 +116,7 @@ Enable `RUST_LOG=info,fluree_db_server::authorization=debug` for credential scop
 
 Query, streaming, transaction, and explain paths return an error when the ledger's config graph cannot be read. An unreadable config graph is never treated as "no configuration": doing so would run the request unrestricted on a ledger whose operator may have configured a deny default or a mandatory policy class. Previously such reads were best-effort and fell back to system defaults.
 
-In practice this only surfaces on snapshots that cannot serve any range read, such as a metadata-only historical view loaded without its binary index, where data queries already fail with the same error. A ledger with no config graph is unaffected: a successful read that finds nothing is cached on the view as absent and is not repeated for that snapshot.
+For example, a metadata-only historical view loaded without its binary index cannot serve the config read. Other config-read failures also return errors. A successful read that finds no config graph is cached on the view as absent and is not repeated for that snapshot.
 
 ### Policy-scoped explain withholds statistics
 

--- a/docs/security/policy-authorization.md
+++ b/docs/security/policy-authorization.md
@@ -1,0 +1,75 @@
+# Trusted policy authorization
+
+Authenticated data requests use policy inputs chosen by verified authority. A request body, query source, or `fluree-policy-*` header cannot select a different identity, class set, inline policy, variable binding, or permissive default. Having a ledger identity record without `f:policyClass` assignments does not grant impersonation privileges.
+
+Ordinary identity-bearing tokens resolve their identity's policies, or the server's configured default policy class. Signed request bodies use the signing identity and do not inherit a bearer token's delegation. Explicit caller `default-allow: false` remains available to narrow the default; other caller policy selections are replaced, rather than merged into the authoritative policy set. Ledger configuration's override controls still apply.
+
+An authenticated scope-only service token (neither `fluree.identity` nor `sub`, and no server default class) retains coarse read/write access within its signed scopes. Issuing such a token authorizes unrestricted data access within those scopes, subject to mandatory ledger configuration. For end-user filtering, issue an identity-bearing token or a delegated policy selection. Anonymous requests allowed by `data_auth.mode=none` or `optional` retain direct policy options; those modes are appropriate only when the host intentionally allows anonymous access.
+
+## Embedded applications
+
+After authenticating the user and resolving their grants, construct a `PolicyAuthorization` from application-owned values:
+
+```rust,ignore
+use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
+
+let authorization = PolicyAuthorization::from_trusted_options(GovernanceOptions {
+    identity: Some("https://app.example/users/123".into()),
+    policy_class: Some(vec!["https://app.example/policies/Employee".into()]),
+    ..Default::default()
+});
+let result = fluree.query_from()
+    .jsonld(&caller_query)
+    .authorization(&authorization)
+    .execute_formatted()
+    .await?;
+```
+
+The builder enforces this selection across its raw, formatted, string, and tracked terminals, including SPARQL. Source-specific policy overrides are removed. A prebuilt `.policy(...)` cannot be combined with `.authorization(...)`.
+
+The type intentionally does not implement `Deserialize`. Constructing it is a trust decision by the embedding application. An empty context engages default-deny enforcement; an application that authorizes an unrestricted default must explicitly set `default_allow: Some(true)`.
+
+The application must separately authorize every ledger/action requested. One context applies uniformly to the query's sources. If sources need different grants, split the requests or select a policy set valid for all of them. For transactions and already-resolved views, use `authorization.options()` with the governance/policy builder. For GraphQL mutations, `graphql_transact_with_authorization` retains the context through schema derivation, each write, and the returned data, rebuilding policy against each new state. `apply_to_jsonld` can bind a JSON request after the application's final option merge. Do not subsequently replace it with caller policy options.
+
+## Application gateways over HTTP
+
+A gateway can place its selected policies in the existing signed data bearer token. The receiver must both trust the token issuer for ordinary data authentication and explicitly permit that issuer to select policies:
+
+```toml
+[auth.data]
+mode = "required"
+audience = "fluree-production"
+trusted_issuers = ["did:key:<gateway-signing-key>"]
+policy_authorities = ["did:key:<gateway-signing-key>"]
+```
+
+The CLI equivalent is `--data-auth-policy-authority`, repeatable; the environment variable is `FLUREE_DATA_AUTH_POLICY_AUTHORITIES`. Configuring authorities requires `--data-auth-audience` / `FLUREE_DATA_AUTH_AUDIENCE`. For OIDC, configure the issuer/JWKS pair through the existing OIDC settings and list that issuer URL as a policy authority. The development setting that accepts any issuer does **not** grant policy-authority status.
+
+Example decoded JWT payload (timestamps must be current when issuing):
+
+```json
+{
+  "iss": "did:key:<gateway-signing-key>",
+  "aud": "fluree-production",
+  "sub": "https://app.example/users/123",
+  "exp": 1788739500,
+  "fluree.ledger.read.ledgers": ["customer/data:main"],
+  "fluree.ledger.write.ledgers": ["customer/data:main"],
+  "fluree.policy": {
+    "policy-class": ["https://app.example/policies/Employee"],
+    "default-allow": false
+  }
+}
+```
+
+`fluree.identity`, if present, overrides `sub` for the policy subject. The `fluree.policy` object accepts only `policy-class` (array of strings), `policy` (inline policy JSON), `policy-values` (variable-binding object), and `default-allow` (boolean). Unknown fields and a present null context are rejected; omit `fluree.policy` entirely for ordinary authentication. Prefer fully qualified class and identity IRIs. Explicit classes select policies and identity binds `?$identity`; local identity-to-class assignments are not required for this application contract.
+
+The signature covers the selection and its ledger/action scopes, audience, and expiry. The existing token verifier checks those claims; the policy-authority allowlist adds a separate receiver-side capability check. Invalid delegation is rejected rather than silently downgraded to an ordinary token. The receiver trusts an authorized issuer to issue grants within the server's existing issuer/scoping model; it does not independently re-evaluate the gateway's application grants. Do not designate a general login issuer as a policy authority unless it controls these claims appropriately.
+
+This same selection is used by JSON-LD, SPARQL, Cypher, GraphQL, streaming queries, multi-query aliases, transaction routes, push ingestion, and Bolt sessions. Query source and envelope options cannot replace it. The token authorizes a uniform selection over its signed scopes, not a map of different policy sets per ledger.
+
+## Cost and migration
+
+The HTTP token is verified once through the existing verification path. Policy authorization adds claim parsing, an issuer allowlist check, and request-level option normalization. It adds no ledger lookup, second token verification, per-fact work, network request, or Raft proposal. Policy construction and enforcement remain separate costs. The embedded query builder clones caller JSON once when binding a context; large inline policy documents also increase token and normalization cost. No latency benchmark is claimed here.
+
+Applications that relied on policy-free identities to override policy headers must migrate to explicit contexts. Embedded applications construct typed contexts after resolving user grants. HTTP gateways issue scoped tokens and configure the receiving server's issuer, policy-authority, and audience settings. Preserve the selected governance through queued writes and credential forwarding. Cluster transport authentication is configured independently of policy delegation.

--- a/docs/security/policy-authorization.md
+++ b/docs/security/policy-authorization.md
@@ -36,7 +36,7 @@ The application must separately authorize every ledger/action requested. One con
 A gateway can place its selected policies in the existing signed data bearer token. The receiver must both trust the token issuer for ordinary data authentication and explicitly permit that issuer to select policies:
 
 ```toml
-[auth.data]
+[server.auth.data]
 mode = "required"
 audience = "fluree-production"
 trusted_issuers = ["did:key:<gateway-signing-key>"]
@@ -68,8 +68,18 @@ The signature covers the selection and its ledger/action scopes, audience, and e
 
 This same selection is used by JSON-LD, SPARQL, Cypher, GraphQL, streaming queries, multi-query aliases, transaction routes, push ingestion, and Bolt sessions. Query source and envelope options cannot replace it. The token authorizes a uniform selection over its signed scopes, not a map of different policy sets per ledger.
 
+Storage-proxy endpoints reject tokens containing `fluree.policy`, including tokens with storage scopes, because that surface does not implement delegated policy selection. Use data-query endpoints for delegated access and separate replication credentials for storage access. GraphQL mutations return HTTP 501 on Raft-enabled servers; submit writes through transaction endpoints. GraphQL reads remain available.
+
+## Authorization logging
+
+Enable `RUST_LOG=fluree_db_server::authorization=debug` to record bearer-token scope checks. Each event includes `issuer`, `effective_identity`, `authorization_mode` (`delegated`, `server-default`, `identity`, or `scope-only`), `ledger`, `action`, and `scope_allowed`. Add this target to your existing log filter to retain other logging, for example `RUST_LOG=info,fluree_db_server::authorization=debug`.
+
+These events describe the credential's ledger/action scope decision. Subsequent policy evaluation can still filter results or reject a write. A request may check multiple sources or perform several scope checks; the events are not a count of completed requests. Signed request-body authentication uses its signing identity separately. The events omit tokens, inline policies, and policy-variable values. They are disabled at the default info level; enabling them adds log formatting and output work per scope check.
+
 ## Cost and migration
 
-The HTTP token is verified once through the existing verification path. Policy authorization adds claim parsing, an issuer allowlist check, and request-level option normalization. It adds no ledger lookup, second token verification, per-fact work, network request, or Raft proposal. Policy construction and enforcement remain separate costs. The embedded query builder clones caller JSON once when binding a context; large inline policy documents also increase token and normalization cost. No latency benchmark is claimed here.
+The HTTP token is verified once through the existing verification path. Policy authorization adds claim parsing, an issuer allowlist check, and request-level option normalization. It adds no ledger lookup, second token verification, per-fact work, network request, or Raft proposal. A follower forwards the bearer credential and the leader verifies it before submitting the selected governance through the replicated command queue. Policy construction and enforcement remain separate costs. The embedded query builder clones caller JSON once when binding a context; large inline policy documents also increase token and normalization cost.
+
+To measure request binding locally, run `cargo bench -p fluree-db-api --features credential --bench policy_authorization`. The benchmark compares ordinary and delegated claims selecting the same policy class, with simple and multiple-source requests. It reports latency and allocation bytes, including tracking-allocator overhead. It excludes signature verification, issuer lookup, networking, and database policy evaluation, so its results describe normalization cost rather than end-to-end query latency. Set `CRITERION_HOME` to choose the results directory.
 
 Applications that relied on policy-free identities to override policy headers must migrate to explicit contexts. Embedded applications construct typed contexts after resolving user grants. HTTP gateways issue scoped tokens and configure the receiving server's issuer, policy-authority, and audience settings. Preserve the selected governance through queued writes and credential forwarding. Cluster transport authentication is configured independently of policy delegation.

--- a/docs/security/policy-in-queries.md
+++ b/docs/security/policy-in-queries.md
@@ -364,7 +364,7 @@ The flags work in both modes:
 
 ### Remote impersonation: how it's authorized
 
-Authenticated requests use verified policy selection. `--as`, class, inline-policy, and policy-value options cannot override a bearer or signed-request identity. A policy-free identity record does not confer delegation authority. Application gateways select policies through the signed `fluree.policy` claim from a configured policy authority; embedded applications construct a typed context. See [Trusted policy authorization](policy-authorization.md) for configuration, scopes, and migration.
+Authenticated requests use verified policy selection. With ordinary or fixed-delegation credentials, `--as`, class, inline-policy, and policy-value options must match that selection; conflicts return HTTP 403. Signed request bodies use their signing identity. A policy-free identity record does not confer delegation authority. Applications with an explicit `"fluree.policy": "request"` credential may select request policies dynamically. Downstream clients use a fixed signed `fluree.policy` selection from a configured policy authority; embedded applications construct a typed context. See [Trusted policy authorization](policy-authorization.md) for configuration, scopes, and migration.
 
 Direct local queries and intentionally anonymous private-server requests retain caller-selected policy options. Explicit caller default-deny can narrow an authenticated selection's default.
 

--- a/docs/security/policy-in-queries.md
+++ b/docs/security/policy-in-queries.md
@@ -364,25 +364,9 @@ The flags work in both modes:
 
 ### Remote impersonation: how it's authorized
 
-When you run against a remote server with `--as <iri>`, the server treats the request as **impersonation** and gates it as follows:
+Authenticated requests use verified policy selection. `--as`, class, inline-policy, and policy-value options cannot override a bearer or signed-request identity. A policy-free identity record does not confer delegation authority. Application gateways select policies through the signed `fluree.policy` claim from a configured policy authority; embedded applications construct a typed context. See [Trusted policy authorization](policy-authorization.md) for configuration, scopes, and migration.
 
-1. Your bearer token's identity is resolved on the target ledger.
-2. If that identity has **no** `f:policyClass` assignments (the `FoundNoPolicies` outcome — your service account is unrestricted on this ledger), the server honors `--as` and runs the query as the target identity.
-3. If your bearer identity is itself policy-constrained (`FoundWithPolicies`) or unknown to this ledger (`NotFound`), the server force-overrides `--as` with your bearer identity. You see your own filtered view, not the target's.
-
-Each successful impersonation is logged at `info` level on the server:
-
-```
-policy impersonation: bearer=<svc-id> target=<as-iri> ledger=<name>
-```
-
-This is the standard service-account pattern: register your CLI/app-server identity in the ledger with no `f:policyClass`, and it gains the right to delegate to any end-user identity for testing or per-request enforcement. Assigning a policy class to that identity revokes the delegation right with no config change.
-
-### Limitations
-
-- Inline policy rules (`opts.policy`) and policy variable bindings (`opts.policy-values`) are not yet exposed as CLI flags — use a JSON-LD query body with an `"opts"` block when you need those.
-- For SPARQL queries against a remote, only `--as`, single-value `--policy-class`, and `--default-allow` are wired (via headers). Multi-value `--policy-class` works on JSON-LD only.
-- Proxy-mode servers fall back to the legacy non-impersonation behavior — the upstream server performs the impersonation check.
+Direct local queries and intentionally anonymous private-server requests retain caller-selected policy options. Explicit caller default-deny can narrow an authenticated selection's default.
 
 ## Related documentation
 

--- a/docs/security/policy-in-transactions.md
+++ b/docs/security/policy-in-transactions.md
@@ -313,13 +313,11 @@ fluree insert --as ex:readOnlyIdentity --policy-class ex:CorpPolicy -f new-data.
 fluree insert --as ex:writerIdentity --policy-class ex:CorpPolicy -f new-data.ttl
 ```
 
-The flags work locally and against remote servers. On remote, the CLI sends the policy options as HTTP headers (`fluree-identity`, `fluree-policy-class`, `fluree-default-allow`) and, for JSON-LD bodies, also injects them into `opts`. The server applies the **root-impersonation gate**: your bearer identity may delegate to `--as <iri>` only when the bearer identity itself has no `f:policyClass` on the target ledger. Restricted bearers have `--as` force-overridden back to their own identity (and writes only what their own policies permit).
-
-This is the standard service-account pattern — see [Policy in queries → Remote impersonation](policy-in-queries.md#remote-impersonation-how-its-authorized) for the full authorization rules and audit-log format.
+The CLI transports these options locally or through HTTP headers/body opts. Authenticated servers bind them to verified policy selection. Application-selected policies require explicit [trusted authorization](policy-authorization.md); policy-free identities do not confer impersonation privileges.
 
 ### Transaction enforcement is end-to-end
 
-Unsigned bearer-authenticated transactions build a `PolicyContext` from the (post-header-merge) opts and route through the policy-enforcing `transact_tracked_with_policy` path. A non-root bearer's `f:modify` constraints apply to their writes, matching the long-standing query-side behavior. SPARQL UPDATE inherits the same enforcement, with identity sourced from either the bearer or the `fluree-identity` header (impersonation-gated).
+JSON-LD transaction options are bound after header merging, then carried into consensus as governance. SPARQL UPDATE, Cypher, Turtle/TriG, and push ingestion use the same verified selection. Malformed JSON policy options are rejected rather than falling back to unrestricted governance. The resulting policy context enforces modify restrictions while staging the transaction.
 
 ## Related documentation
 

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -596,6 +596,11 @@ name = "it_values_object_bounds"
 workspace = true
 
 [[bench]]
+name = "policy_authorization"
+harness = false
+required-features = ["credential"]
+
+[[bench]]
 name = "annotation_hydration"
 harness = false
 

--- a/fluree-db-api/benches/policy_authorization.rs
+++ b/fluree-db-api/benches/policy_authorization.rs
@@ -1,0 +1,159 @@
+//! Request-level policy authorization overhead with identical effective grants.
+//!
+//! Measures parsing already-verified claims, constructing the typed context,
+//! and binding a cloned JSON request. Excludes signature verification, issuer
+//! lookup, network, ledger access, policy compilation, and fact evaluation.
+//! Ordinary claims use a server-selected class; delegated claims carry the
+//! same class. The query-clone baseline isolates the cost of binding.
+//!
+//! Uses the shared tracking allocator: timings include its counter overhead.
+//! Reports allocation churn/peak per operation to stderr; Criterion timings
+//! go to CRITERION_HOME (or its usual target/criterion default).
+//!
+//! Run: CRITERION_HOME=/tmp/policy-authorization cargo bench -p fluree-db-api
+//!      --features credential --bench policy_authorization
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
+use fluree_db_credential::jwt_claims::EventsTokenPayload;
+use serde_json::{json, Value};
+use std::hint::black_box;
+
+#[global_allocator]
+static ALLOC: fluree_bench_alloc::TrackingAllocator = fluree_bench_alloc::TrackingAllocator::new();
+
+const IDENTITY: &str = "https://app.example/users/123";
+const CLASS: &str = "https://app.example/policies/Employee";
+
+// This models context construction after a host has verified and authorized
+// the issuer. It is not a replacement for the server's token verifier.
+fn authorization(claims: &EventsTokenPayload) -> PolicyAuthorization {
+    let options = match &claims.fluree_policy {
+        Some(policy) => GovernanceOptions {
+            identity: claims.resolve_identity(),
+            policy_class: policy.policy_class.clone(),
+            policy: policy.policy.clone(),
+            policy_values: policy.policy_values.clone(),
+            default_allow: policy.default_allow,
+        },
+        None => GovernanceOptions {
+            identity: claims.resolve_identity(),
+            policy_class: Some(vec![CLASS.into()]),
+            ..Default::default()
+        },
+    };
+    PolicyAuthorization::from_trusted_options(options)
+}
+
+fn bind_request(claims: &str, request: &Value) -> Value {
+    let claims: EventsTokenPayload = serde_json::from_str(claims).unwrap();
+    let authorization = authorization(&claims);
+    let mut request = request.clone();
+    authorization.apply_to_jsonld(&mut request).unwrap();
+    request
+}
+
+fn memory<T>(scenario: &str, mut operation: impl FnMut() -> T) {
+    // Warm one invocation before measuring. No concurrent workloads or
+    // Criterion machinery run inside this allocation measurement.
+    drop(black_box(operation()));
+    let base = fluree_bench_alloc::reset_peak();
+    let result = black_box(operation());
+    let metrics = fluree_bench_alloc::snapshot();
+    drop(result);
+    eprintln!(
+        "{scenario}: allocated={}B peak={}B per operation",
+        metrics.total_allocated_bytes,
+        metrics.peak_bytes.saturating_sub(base)
+    );
+}
+
+fn bench_authorization(c: &mut Criterion) {
+    let ordinary = json!({
+        "iss": "https://issuer.example", "sub": IDENTITY,
+        "aud": "fluree-production", "exp": u64::MAX,
+        "fluree.ledger.read.ledgers": ["customer/data:main"]
+    });
+    let mut delegated = ordinary.clone();
+    delegated["fluree.policy"] = json!({"policy-class": [CLASS]});
+    let claims = [
+        ("ordinary", ordinary.to_string()),
+        ("delegated", delegated.to_string()),
+    ];
+    let ordinary_parsed: EventsTokenPayload = serde_json::from_str(&claims[0].1).unwrap();
+    let delegated_parsed: EventsTokenPayload = serde_json::from_str(&claims[1].1).unwrap();
+    let auth = authorization(&ordinary_parsed);
+
+    let mut parse = c.benchmark_group("policy_claims_parse");
+    for (mode, claims) in &claims {
+        memory(&format!("policy_claims_parse/{mode}"), || {
+            serde_json::from_str::<EventsTokenPayload>(claims).unwrap()
+        });
+        parse.bench_function(*mode, |b| {
+            b.iter(|| serde_json::from_str::<EventsTokenPayload>(black_box(claims)).unwrap())
+        });
+    }
+    parse.finish();
+
+    let simple =
+        json!({"select": ["?name"], "where": {"@id": "?s", "http://schema.org/name": "?name"}});
+    let mut multi = simple.clone();
+    multi["from"] = json!((0..8)
+        .map(|i| json!({
+            "@id": format!("customer/data{i}:main"), "policy": {"default-allow": true}
+        }))
+        .collect::<Vec<_>>());
+    for (shape, request) in [("simple", simple), ("eight_sources", multi)] {
+        // Correctness prerequisite: both modes enforce the exact same grants
+        // over the exact same request, including clearing source overrides.
+        let mut normal = request.clone();
+        auth.apply_to_jsonld(&mut normal).unwrap();
+        let mut delegated = request.clone();
+        authorization(&delegated_parsed)
+            .apply_to_jsonld(&mut delegated)
+            .unwrap();
+        assert_eq!(normal, delegated);
+
+        let mut binding = c.benchmark_group("policy_request_binding");
+        memory(&format!("policy_request_binding/clone/{shape}"), || {
+            request.clone()
+        });
+        binding.bench_with_input(BenchmarkId::new("clone", shape), &request, |b, q| {
+            b.iter(|| black_box(q).clone())
+        });
+        memory(
+            &format!("policy_request_binding/clone_and_bind/{shape}"),
+            || {
+                let mut q = request.clone();
+                auth.apply_to_jsonld(&mut q).unwrap();
+                q
+            },
+        );
+        binding.bench_with_input(
+            BenchmarkId::new("clone_and_bind", shape),
+            &request,
+            |b, q| {
+                b.iter(|| {
+                    let mut q = black_box(q).clone();
+                    auth.apply_to_jsonld(&mut q).unwrap();
+                    q
+                })
+            },
+        );
+        binding.finish();
+
+        let mut full = c.benchmark_group("policy_claims_and_binding");
+        for (mode, claims) in &claims {
+            memory(&format!("policy_claims_and_binding/{mode}/{shape}"), || {
+                bind_request(claims, &request)
+            });
+            full.bench_with_input(BenchmarkId::new(*mode, shape), &request, |b, q| {
+                b.iter(|| bind_request(black_box(claims), black_box(q)))
+            });
+        }
+        full.finish();
+    }
+}
+
+criterion_group!(benches, bench_authorization);
+criterion_main!(benches);

--- a/fluree-db-api/benches/policy_authorization.rs
+++ b/fluree-db-api/benches/policy_authorization.rs
@@ -15,7 +15,7 @@
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
-use fluree_db_credential::jwt_claims::EventsTokenPayload;
+use fluree_db_credential::jwt_claims::{EventsTokenPayload, PolicyClaim};
 use serde_json::{json, Value};
 use std::hint::black_box;
 
@@ -29,13 +29,14 @@ const CLASS: &str = "https://app.example/policies/Employee";
 // the issuer. It is not a replacement for the server's token verifier.
 fn authorization(claims: &EventsTokenPayload) -> PolicyAuthorization {
     let options = match &claims.fluree_policy {
-        Some(policy) => GovernanceOptions {
+        Some(PolicyClaim::Fixed(policy)) => GovernanceOptions {
             identity: claims.resolve_identity(),
             policy_class: policy.policy_class.clone(),
             policy: policy.policy.clone(),
             policy_values: policy.policy_values.clone(),
             default_allow: policy.default_allow,
         },
+        Some(PolicyClaim::Request(_)) => panic!("this benchmark measures fixed selections"),
         None => GovernanceOptions {
             identity: claims.resolve_identity(),
             policy_class: Some(vec![CLASS.into()]),

--- a/fluree-db-api/benches/policy_authorization.rs
+++ b/fluree-db-api/benches/policy_authorization.rs
@@ -90,7 +90,7 @@ fn bench_authorization(c: &mut Criterion) {
             serde_json::from_str::<EventsTokenPayload>(claims).unwrap()
         });
         parse.bench_function(*mode, |b| {
-            b.iter(|| serde_json::from_str::<EventsTokenPayload>(black_box(claims)).unwrap())
+            b.iter(|| serde_json::from_str::<EventsTokenPayload>(black_box(claims)).unwrap());
         });
     }
     parse.finish();
@@ -119,7 +119,7 @@ fn bench_authorization(c: &mut Criterion) {
             request.clone()
         });
         binding.bench_with_input(BenchmarkId::new("clone", shape), &request, |b, q| {
-            b.iter(|| black_box(q).clone())
+            b.iter(|| black_box(q).clone());
         });
         memory(
             &format!("policy_request_binding/clone_and_bind/{shape}"),
@@ -137,7 +137,7 @@ fn bench_authorization(c: &mut Criterion) {
                     let mut q = black_box(q).clone();
                     auth.apply_to_jsonld(&mut q).unwrap();
                     q
-                })
+                });
             },
         );
         binding.finish();
@@ -148,7 +148,7 @@ fn bench_authorization(c: &mut Criterion) {
                 bind_request(claims, &request)
             });
             full.bench_with_input(BenchmarkId::new(*mode, shape), &request, |b, q| {
-                b.iter(|| bind_request(black_box(claims), black_box(q)))
+                b.iter(|| bind_request(black_box(claims), black_box(q)));
             });
         }
         full.finish();

--- a/fluree-db-api/src/authorization.rs
+++ b/fluree-db-api/src/authorization.rs
@@ -38,6 +38,9 @@ impl PolicyAuthorization {
             options.default_allow = Some(false);
         }
         if !options.has_any_policy_inputs() {
+            // These ordinary fields survive JSON/consensus serialization.
+            // Empty classes also exclude rules supplied by a shared model.
+            options.policy_class = Some(Vec::new());
             options.policy = Some(Value::Array(Vec::new()));
             options.default_allow = Some(false);
         }
@@ -54,10 +57,6 @@ impl PolicyAuthorization {
     pub fn constrain_options(&self, requested: &GovernanceOptions) -> GovernanceOptions {
         let mut options = self.options.clone();
         if requested.default_allow == Some(false) {
-            options.default_allow = Some(false);
-        }
-        if !options.has_any_policy_inputs() {
-            options.policy = Some(Value::Array(Vec::new()));
             options.default_allow = Some(false);
         }
         options

--- a/fluree-db-api/src/authorization.rs
+++ b/fluree-db-api/src/authorization.rs
@@ -1,0 +1,221 @@
+//! Application-authored policy selection, separate from untrusted query options.
+//!
+//! Construct this only after authenticating a request and resolving its grants.
+//! It deliberately does not implement `Deserialize`: receiving JSON that names
+//! an authorization context does not make that context trusted. Network hosts
+//! must verify their credential before constructing it.
+
+use serde_json::{Map, Value};
+
+use crate::{ApiError, GovernanceOptions, Result};
+
+/// Immutable policy inputs selected by an authenticated host application.
+///
+/// This selects the policies to enforce; it does not itself grant ledger access
+/// or bypass configured policy-override controls. The host must authorize every
+/// ledger/source named by the request separately. A single instance applies the
+/// same policy selection to all sources in the query.
+#[derive(Debug, Clone)]
+pub struct PolicyAuthorization {
+    options: GovernanceOptions,
+}
+
+impl PolicyAuthorization {
+    /// Select policies using trusted application inputs.
+    ///
+    /// Explicit policy classes select rules and identity binds `?$identity`,
+    /// preserving the embedded application's grant-derived policy contract.
+    /// Empty inputs mean default-deny, rather than the SDK's unrestricted
+    /// no-policy shortcut. Use an explicit `default_allow: Some(true)` when the
+    /// application has authorized unrestricted data access.
+    pub fn from_trusted_options(mut options: GovernanceOptions) -> Self {
+        if options.policy.as_ref().is_some_and(Value::is_null) {
+            options.policy = None;
+        }
+        if !options.has_any_policy_inputs() {
+            options.policy = Some(Value::Array(Vec::new()));
+            options.default_allow = Some(false);
+        }
+        Self { options }
+    }
+
+    /// Policy inputs to pass to a view or transaction builder.
+    pub fn options(&self) -> &GovernanceOptions {
+        &self.options
+    }
+
+    /// Replace caller policy selection, retaining an explicit default-deny
+    /// request as a narrowing of the application's default.
+    pub fn constrain_options(&self, requested: &GovernanceOptions) -> GovernanceOptions {
+        let mut options = self.options.clone();
+        if requested.default_allow == Some(false) {
+            options.default_allow = Some(false);
+        }
+        if !options.has_any_policy_inputs() {
+            options.policy = Some(Value::Array(Vec::new()));
+            options.default_allow = Some(false);
+        }
+        options
+    }
+
+    /// Install trusted policy inputs into a JSON-LD query or transaction.
+    ///
+    /// Non-policy options (tracking, formatting, etc.) are preserved. Source
+    /// policy overrides are removed so they cannot replace the trusted global
+    /// selection. Canonical nulls intentionally shadow policy defaults that an
+    /// enclosing multi-query envelope or header merge might otherwise restore.
+    pub fn apply_to_jsonld(&self, query: &mut Value) -> Result<()> {
+        let requested =
+            GovernanceOptions::from_json(query).map_err(|e| ApiError::query(e.to_string()))?;
+        let options = self.constrain_options(&requested);
+        let object = query
+            .as_object_mut()
+            .ok_or_else(|| ApiError::query("Authorized JSON-LD request must be an object"))?;
+
+        remove_dataset_overrides(object);
+
+        let value = object
+            .entry("opts")
+            .or_insert_with(|| Value::Object(Map::new()));
+        // `from_json` permits null as an absent opts block.
+        if value.is_null() {
+            *value = Value::Object(Map::new());
+        }
+        let opts = value
+            .as_object_mut()
+            .ok_or_else(|| ApiError::query("Authorized request opts must be an object"))?;
+        remove_dataset_overrides(opts);
+        for alias in [
+            "policy_class",
+            "policyClass",
+            "policy_values",
+            "policyValues",
+            "default_allow",
+            "defaultAllow",
+        ] {
+            opts.remove(alias);
+        }
+        opts.insert("identity".into(), serde_json::to_value(&options.identity)?);
+        opts.insert(
+            "policy-class".into(),
+            serde_json::to_value(&options.policy_class)?,
+        );
+        opts.insert("policy".into(), options.policy.unwrap_or(Value::Null));
+        opts.insert(
+            "policy-values".into(),
+            serde_json::to_value(&options.policy_values)?,
+        );
+        opts.insert(
+            "default-allow".into(),
+            serde_json::to_value(options.default_allow)?,
+        );
+        Ok(())
+    }
+}
+
+fn remove_dataset_overrides(object: &mut Map<String, Value>) {
+    for field in ["from", "ledger", "to"] {
+        if let Some(sources) = object.get_mut(field) {
+            remove_source_overrides(sources);
+        }
+    }
+    for field in ["fromNamed", "from-named"] {
+        match object.get_mut(field) {
+            Some(Value::Object(named)) => {
+                for source in named.values_mut() {
+                    remove_source_overrides(source);
+                }
+            }
+            Some(sources) => remove_source_overrides(sources),
+            None => {}
+        }
+    }
+}
+
+fn remove_source_overrides(sources: &mut Value) {
+    match sources {
+        Value::Object(source) => {
+            source.remove("policy");
+        }
+        Value::Array(sources) => {
+            for source in sources {
+                remove_source_overrides(source);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn authorization_covers_source_forms_and_shadows_outer_defaults() {
+        let auth = PolicyAuthorization::from_trusted_options(GovernanceOptions {
+            identity: Some("http://example.org/employee".into()),
+            ..Default::default()
+        });
+        let mut query = json!({
+            "from": [{"@id": "db:main", "policy": {"default-allow": true}}],
+            "fromNamed": {"policy": {"@id": "db:main", "policy": {"default-allow": true}}},
+            "from-named": [{"@id": "db:main", "policy": {"default-allow": true}}],
+            "opts": {"policyClass": ["ex:Manager"], "policy_values": {}, "defaultAllow": true, "meta": true,
+                "from": {"@id": "db:main", "policy": {"default-allow": true}},
+                "from-named": {"g": {"@id": "db:main", "policy": {"default-allow": true}}}
+            },
+            "where": {"@id": "?s", "policy": "?data"}
+        });
+        auth.apply_to_jsonld(&mut query).unwrap();
+        let (spec, opts) = crate::query::helpers::parse_dataset_spec(&query).unwrap();
+        assert!(spec
+            .default_graphs
+            .iter()
+            .chain(spec.named_graphs.iter())
+            .all(|s| s.policy_override.is_none()));
+        assert_eq!(
+            opts.identity.as_deref(),
+            Some("http://example.org/employee")
+        );
+        assert!(opts.policy_class.is_none());
+        assert!(opts.policy_values.is_none());
+        assert_eq!(opts.default_allow, None);
+        assert_eq!(query["opts"]["meta"], true);
+        assert_eq!(query["where"]["policy"], "?data");
+        let outer = json!({"policy-class": ["ex:Manager"], "policy": [{"f:allow": true}], "default-allow": true});
+        let merged = crate::query::multi::merged_opts(Some(&outer), query.get("opts"));
+        let opts = GovernanceOptions::from_json(&json!({"opts": merged})).unwrap();
+        assert!(opts.policy_class.is_none() && opts.policy.is_none());
+        assert_eq!(opts.default_allow, None);
+    }
+
+    #[test]
+    fn empty_context_and_narrowed_unrestricted_context_engage_enforcement() {
+        let deny = PolicyAuthorization::from_trusted_options(GovernanceOptions::default());
+        assert!(deny.options().has_any_policy_inputs());
+        assert!(!deny.options().effective_default_allow());
+        let allow = PolicyAuthorization::from_trusted_options(GovernanceOptions {
+            default_allow: Some(true),
+            ..Default::default()
+        });
+        let narrowed = allow.constrain_options(&GovernanceOptions {
+            default_allow: Some(false),
+            ..Default::default()
+        });
+        assert!(narrowed.has_any_policy_inputs());
+        assert!(!narrowed.effective_default_allow());
+    }
+
+    #[test]
+    fn malformed_options_are_rejected_without_a_root_fallback() {
+        let auth = PolicyAuthorization::from_trusted_options(GovernanceOptions::default());
+        for mut query in [
+            json!({"opts": true}),
+            json!({"opts": {"policy-class": 1}}),
+            json!([]),
+        ] {
+            assert!(auth.apply_to_jsonld(&mut query).is_err());
+        }
+    }
+}

--- a/fluree-db-api/src/authorization.rs
+++ b/fluree-db-api/src/authorization.rs
@@ -9,7 +9,7 @@ use serde_json::{Map, Value};
 
 use crate::{ApiError, GovernanceOptions, Result};
 
-/// Immutable policy inputs selected by an authenticated host application.
+/// Host-established authority for selecting policy inputs.
 ///
 /// This selects the policies to enforce; it does not itself grant ledger access
 /// or bypass configured policy-override controls. The host must authorize every
@@ -32,6 +32,11 @@ impl PolicyAuthorization {
         if options.policy.as_ref().is_some_and(Value::is_null) {
             options.policy = None;
         }
+        if options.policy_class.as_ref().is_some_and(Vec::is_empty)
+            && options.default_allow.is_none()
+        {
+            options.default_allow = Some(false);
+        }
         if !options.has_any_policy_inputs() {
             options.policy = Some(Value::Array(Vec::new()));
             options.default_allow = Some(false);
@@ -39,13 +44,13 @@ impl PolicyAuthorization {
         Self { options }
     }
 
-    /// Policy inputs to pass to a view or transaction builder.
+    /// The fixed, host-established policy inputs.
     pub fn options(&self) -> &GovernanceOptions {
         &self.options
     }
 
-    /// Replace caller policy selection, retaining an explicit default-deny
-    /// request as a narrowing of the application's default.
+    /// Resolve request options against the established selection authority.
+    /// Replaces caller selections while preserving explicit default-deny narrowing.
     pub fn constrain_options(&self, requested: &GovernanceOptions) -> GovernanceOptions {
         let mut options = self.options.clone();
         if requested.default_allow == Some(false) {

--- a/fluree-db-api/src/config_resolver.rs
+++ b/fluree-db-api/src/config_resolver.rs
@@ -357,7 +357,13 @@ pub fn merge_policy_opts(
     };
 
     // Does the query specify any policy inputs?
-    let query_has_policy = opts.has_any_policy_inputs();
+    // A deny default alone narrows configured policies; it does not replace
+    // their class selection. It still engages enforcement at execution time.
+    let query_has_policy = opts.identity.is_some()
+        || opts.policy_class.is_some()
+        || opts.policy.as_ref().is_some_and(|p| !p.is_null())
+        || opts.policy_values.as_ref().is_some_and(|v| !v.is_empty())
+        || opts.default_allow == Some(true);
     let override_denied =
         query_has_policy && !policy.override_control.permits_override(server_identity);
 
@@ -375,7 +381,11 @@ pub fn merge_policy_opts(
         merged.policy_class = policy.policy_class.clone();
         merged.policy = None;
         merged.policy_values = None;
-        merged.default_allow = policy.default_allow;
+        merged.default_allow = if opts.default_allow == Some(false) {
+            Some(false)
+        } else {
+            policy.default_allow
+        };
         if !merged.has_any_policy_inputs() {
             merged.policy = Some(serde_json::json!([]));
         }
@@ -383,9 +393,7 @@ pub fn merge_policy_opts(
     }
 
     // Config fills only a genuine unset. An explicit `Some(false)` reaches here
-    // via a request that carries no *other* policy input (a per-source
-    // `SourcePolicyOverride` naming only `default_allow: false` is exactly that
-    // shape, since `has_any_policy_inputs` counts only `Some(true)`), and it
+    // via a request that carries no *other* policy selection, and it
     // must not be clobbered by config's `f:defaultAllow true`.
     if merged.default_allow.is_none() {
         merged.default_allow = policy.default_allow;
@@ -2580,12 +2588,9 @@ mod tests {
         );
     }
 
-    /// `Some(false)` is the fail-closed value, not a request to switch
-    /// enforcement on: it must not make an otherwise-anonymous request count as
-    /// carrying policy inputs. Only `Some(true)` does, matching the bare-bool
-    /// behavior this replaced.
+    /// Either explicit default engages enforcement; absent remains no input.
     #[test]
-    fn only_explicit_true_counts_as_a_policy_input() {
+    fn either_explicit_default_counts_as_a_policy_input() {
         let unset = GovernanceOptions::default();
         assert!(!unset.has_any_policy_inputs());
 
@@ -2593,7 +2598,7 @@ mod tests {
             default_allow: Some(false),
             ..Default::default()
         };
-        assert!(!explicit_false.has_any_policy_inputs());
+        assert!(explicit_false.has_any_policy_inputs());
 
         let explicit_true = GovernanceOptions {
             default_allow: Some(true),
@@ -2607,9 +2612,8 @@ mod tests {
     ///
     /// This is the shape a per-source `SourcePolicyOverride` takes when it names
     /// only `default_allow: false`: `SourcePolicyOverride::has_policy()` counts
-    /// `is_some()` so the override is applied, but `has_any_policy_inputs()`
-    /// counts only `Some(true)` so the merge sees "no policy inputs". Config
-    /// must fill genuine unset, not overwrite an explicit caller value.
+    /// `is_some()` so the override is applied. Config still supplies the
+    /// class selection, without overwriting the explicit deny default.
     #[test]
     fn explicit_false_survives_the_no_policy_input_path() {
         let resolved = ResolvedConfig {
@@ -2652,9 +2656,8 @@ mod tests {
 
         let opts = override_opts.to_query_connection_options();
         assert!(
-            !opts.has_any_policy_inputs(),
-            "precondition: Some(false) is not a policy input, so this lands on \
-             the config-defaults path"
+            opts.has_any_policy_inputs(),
+            "an explicit deny default engages enforcement"
         );
         assert_eq!(
             merge_policy_opts(&resolved, &opts, None).default_allow,

--- a/fluree-db-api/src/config_resolver.rs
+++ b/fluree-db-api/src/config_resolver.rs
@@ -356,16 +356,9 @@ pub fn merge_policy_opts(
         None => return opts.clone(),
     };
 
-    // Does the query specify any policy inputs?
-    // A deny default alone narrows configured policies; it does not replace
-    // their class selection. It still engages enforcement at execution time.
-    let query_has_policy = opts.identity.is_some()
-        || opts.policy_class.is_some()
-        || opts.policy.as_ref().is_some_and(|p| !p.is_null())
-        || opts.policy_values.as_ref().is_some_and(|v| !v.is_empty())
-        || opts.default_allow == Some(true);
+    let query_selects_policy = opts.selects_policy_set();
     let override_denied =
-        query_has_policy && !policy.override_control.permits_override(server_identity);
+        query_selects_policy && !policy.override_control.permits_override(server_identity);
 
     let mut merged = opts.clone();
 
@@ -400,10 +393,11 @@ pub fn merge_policy_opts(
     }
 
     // policy_class stays request-first: config supplies it only when the request
-    // carried no policy inputs at all. Widening this to "fill when unset" would
+    // did not select a policy set (a deny default alone only narrows it).
+    // Widening this to "fill when unset" would
     // start applying config's f:policyClass to identity-carrying requests on the
     // local path, which it never has — see the note in fluree_ext.rs::wrap_policy.
-    if !query_has_policy {
+    if !query_selects_policy {
         if let Some(ref classes) = policy.policy_class {
             merged.policy_class = Some(classes.clone());
         }
@@ -2593,18 +2587,28 @@ mod tests {
     fn either_explicit_default_counts_as_a_policy_input() {
         let unset = GovernanceOptions::default();
         assert!(!unset.has_any_policy_inputs());
+        assert!(!unset.selects_policy_set());
 
         let explicit_false = GovernanceOptions {
             default_allow: Some(false),
             ..Default::default()
         };
         assert!(explicit_false.has_any_policy_inputs());
+        assert!(!explicit_false.selects_policy_set());
 
         let explicit_true = GovernanceOptions {
             default_allow: Some(true),
             ..Default::default()
         };
         assert!(explicit_true.has_any_policy_inputs());
+        assert!(explicit_true.selects_policy_set());
+
+        let empty_classes = GovernanceOptions {
+            policy_class: Some(vec![]),
+            ..Default::default()
+        };
+        assert!(empty_classes.has_any_policy_inputs());
+        assert!(empty_classes.selects_policy_set());
     }
 
     /// An explicit `Some(false)` survives even though it carries no *other*

--- a/fluree-db-api/src/config_resolver.rs
+++ b/fluree-db-api/src/config_resolver.rs
@@ -356,6 +356,12 @@ pub fn merge_policy_opts(
         None => return opts.clone(),
     };
 
+    // No configured grant may widen an explicit deny-all selection. This is
+    // also how an empty host authorization survives the JSON/consensus wire.
+    if opts.denies_all() {
+        return opts.clone();
+    }
+
     let query_selects_policy = opts.selects_policy_set();
     let override_denied =
         query_selects_policy && !policy.override_control.permits_override(server_identity);

--- a/fluree-db-api/src/config_resolver.rs
+++ b/fluree-db-api/src/config_resolver.rs
@@ -369,12 +369,15 @@ pub fn merge_policy_opts(
             "Query-time policy override denied by config override control — applying config defaults"
         );
 
-        // Config wins outright, including over an explicit request value.
-        if let Some(default_allow) = policy.default_allow {
-            merged.default_allow = Some(default_allow);
-        }
-        if let Some(ref classes) = policy.policy_class {
-            merged.policy_class = Some(classes.clone());
+        // Denying an override must clear *all* caller-selected grants, even
+        // fields for which config has no replacement. Inline required grants
+        // and policy-values can otherwise weaken the configured policy set.
+        merged.policy_class = policy.policy_class.clone();
+        merged.policy = None;
+        merged.policy_values = None;
+        merged.default_allow = policy.default_allow;
+        if !merged.has_any_policy_inputs() {
+            merged.policy = Some(serde_json::json!([]));
         }
         return merged;
     }
@@ -2679,6 +2682,45 @@ mod tests {
             merge_policy_opts(&resolved, &opts, None).default_allow,
             Some(false)
         );
+    }
+
+    #[test]
+    fn denied_override_clears_inline_classes_values_and_permissive_defaults() {
+        let resolved = ResolvedConfig {
+            policy: Some(PolicyDefaults {
+                override_control: OverrideControl::None,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let opts = GovernanceOptions {
+            identity: Some("did:key:employee".into()),
+            policy_class: Some(vec!["ex:Manager".into()]),
+            policy: Some(serde_json::json!([{"f:required": true, "f:allow": true}])),
+            policy_values: Some(std::collections::HashMap::from([(
+                "?$identity".into(),
+                serde_json::json!({"@id": "did:key:manager"}),
+            )])),
+            default_allow: Some(true),
+        };
+        let merged = merge_policy_opts(&resolved, &opts, None);
+        assert_eq!(merged.identity, opts.identity);
+        assert!(
+            merged.policy_class.is_none()
+                && merged.policy.is_none()
+                && merged.policy_values.is_none()
+        );
+        assert!(!merged.effective_default_allow());
+        let anonymous = merge_policy_opts(
+            &resolved,
+            &GovernanceOptions {
+                default_allow: Some(true),
+                ..Default::default()
+            },
+            None,
+        );
+        assert!(anonymous.has_any_policy_inputs());
+        assert!(!anonymous.effective_default_allow());
     }
 
     // --- merge_reasoning ---

--- a/fluree-db-api/src/dataset.rs
+++ b/fluree-db-api/src/dataset.rs
@@ -899,14 +899,23 @@ impl GovernanceOptions {
         self.default_allow.unwrap_or(false)
     }
 
-    /// Whether the request explicitly selects policy enforcement. An empty
-    /// class selection and an explicit deny default are meaningful inputs.
-    pub fn has_any_policy_inputs(&self) -> bool {
+    /// Whether the request selects or changes the policy set, subject to
+    /// configured override controls. An empty class list selects no stored rules;
+    /// an allow default can widen access. A deny default alone only narrows the
+    /// configured set and does not count as a replacement selection.
+    pub fn selects_policy_set(&self) -> bool {
         self.identity.is_some()
             || self.policy_class.is_some()
             || self.policy.as_ref().is_some_and(|p| !p.is_null())
             || self.policy_values.as_ref().is_some_and(|m| !m.is_empty())
-            || self.default_allow.is_some()
+            || self.default_allow == Some(true)
+    }
+
+    /// Whether the request engages policy enforcement. Unlike
+    /// [`Self::selects_policy_set`], a deny default alone counts: it must not take
+    /// the unrestricted shortcut, even though it retains configured policies.
+    pub fn has_any_policy_inputs(&self) -> bool {
+        self.selects_policy_set() || self.default_allow == Some(false)
     }
 }
 

--- a/fluree-db-api/src/dataset.rs
+++ b/fluree-db-api/src/dataset.rs
@@ -899,6 +899,18 @@ impl GovernanceOptions {
         self.default_allow.unwrap_or(false)
     }
 
+    /// An explicitly empty rule selection with a deny default cannot grant
+    /// access. Preserve this narrowing even when config prohibits replacements.
+    /// Unlike a deny default alone, this also excludes configured class rules.
+    pub(crate) fn denies_all(&self) -> bool {
+        self.default_allow == Some(false)
+            && self.policy_class.as_ref().is_some_and(Vec::is_empty)
+            && self
+                .policy
+                .as_ref()
+                .is_none_or(|p| p.is_null() || p.as_array().is_some_and(Vec::is_empty))
+    }
+
     /// Whether the request selects or changes the policy set, subject to
     /// configured override controls. An empty class list selects no stored rules;
     /// an allow default can widen access. A deny default alone only narrows the

--- a/fluree-db-api/src/dataset.rs
+++ b/fluree-db-api/src/dataset.rs
@@ -301,13 +301,8 @@ impl SourcePolicyOverride {
     ///
     /// Returns true if at least one policy field is set.
     ///
-    /// Deliberately broader than [`GovernanceOptions::has_any_policy_inputs`],
-    /// which counts only `Some(true)` for `default_allow`: an override naming
-    /// only `default_allow: false` *is* an override and must be applied, even
-    /// though it does not by itself request enforcement. The two predicates
-    /// disagreeing is safe only because `merge_policy_opts` fills config into a
-    /// genuine unset rather than over an explicit value — see the precedence
-    /// note there before changing either one.
+    /// An explicit default or empty class selection must be applied even
+    /// without other policy inputs.
     pub fn has_policy(&self) -> bool {
         self.identity.is_some()
             || self.policy_class.is_some()
@@ -816,10 +811,15 @@ impl GovernanceOptions {
             }
         };
 
-        let identity = opts
-            .get("identity")
-            .and_then(|v| v.as_str())
-            .map(std::string::ToString::to_string);
+        let identity = match opts.get("identity") {
+            None | Some(JsonValue::Null) => None,
+            Some(JsonValue::String(value)) => Some(value.clone()),
+            Some(_) => {
+                return Err(DatasetParseError::InvalidOptions(
+                    "'identity' must be a string".into(),
+                ))
+            }
+        };
 
         let policy_class_val = opts
             .get("policy-class")
@@ -868,13 +868,19 @@ impl GovernanceOptions {
             }
         };
 
-        // Absent (or non-boolean) stays `None` so ledger config can fill it;
-        // an explicit `false` is preserved as an override of config.
-        let default_allow = opts
+        let default_allow = match opts
             .get("default-allow")
             .or_else(|| opts.get("default_allow"))
             .or_else(|| opts.get("defaultAllow"))
-            .and_then(serde_json::Value::as_bool);
+        {
+            None | Some(JsonValue::Null) => None,
+            Some(JsonValue::Bool(value)) => Some(*value),
+            Some(_) => {
+                return Err(DatasetParseError::InvalidOptions(
+                    "'default-allow' must be a boolean".into(),
+                ))
+            }
+        };
 
         Ok(Self {
             identity,
@@ -893,19 +899,14 @@ impl GovernanceOptions {
         self.default_allow.unwrap_or(false)
     }
 
-    /// Whether the request itself asked for policy enforcement.
-    ///
-    /// `Some(false)` deliberately does **not** count: it is the fail-closed
-    /// value, and treating it as a policy input would turn enforcement on for
-    /// an otherwise-anonymous request — the opposite of the pre-tri-state
-    /// behavior, where a literal `false` was indistinguishable from absent.
-    /// Only `Some(true)` contributes, exactly as the bare `bool` did.
+    /// Whether the request explicitly selects policy enforcement. An empty
+    /// class selection and an explicit deny default are meaningful inputs.
     pub fn has_any_policy_inputs(&self) -> bool {
         self.identity.is_some()
-            || self.policy_class.as_ref().is_some_and(|v| !v.is_empty())
-            || self.policy.is_some()
+            || self.policy_class.is_some()
+            || self.policy.as_ref().is_some_and(|p| !p.is_null())
             || self.policy_values.as_ref().is_some_and(|m| !m.is_empty())
-            || self.default_allow == Some(true)
+            || self.default_allow.is_some()
     }
 }
 
@@ -2649,14 +2650,13 @@ mod tests {
         }
     }
 
-    /// Non-boolean values are ignored rather than coerced, which leaves the
-    /// field unset (the pre-existing `as_bool` behavior, now visible as `None`).
+    /// Malformed values fail rather than silently falling back to config.
     #[test]
-    fn default_allow_non_boolean_stays_unset() {
-        assert_eq!(
-            parse_default_allow(&serde_json::json!({"opts": {"default-allow": "true"}})),
-            None
-        );
+    fn malformed_default_allow_is_rejected_and_null_stays_unset() {
+        assert!(GovernanceOptions::from_json(
+            &serde_json::json!({"opts": {"default-allow": "true"}})
+        )
+        .is_err());
         assert_eq!(
             parse_default_allow(&serde_json::json!({"opts": {"default-allow": null}})),
             None

--- a/fluree-db-api/src/graph_commit_builder.rs
+++ b/fluree-db-api/src/graph_commit_builder.rs
@@ -169,6 +169,7 @@ pub struct CommitBuilder<'a, 'g> {
     identity: Option<String>,
     /// Default policy class for policy filtering.
     policy_class: Option<String>,
+    governance: Option<GovernanceOptions>,
 }
 
 impl<'a, 'g> CommitBuilder<'a, 'g> {
@@ -179,6 +180,7 @@ impl<'a, 'g> CommitBuilder<'a, 'g> {
             user_context: None,
             identity: None,
             policy_class: None,
+            governance: None,
         }
     }
 
@@ -189,6 +191,7 @@ impl<'a, 'g> CommitBuilder<'a, 'g> {
             user_context: None,
             identity: None,
             policy_class: None,
+            governance: None,
         }
     }
 
@@ -199,6 +202,7 @@ impl<'a, 'g> CommitBuilder<'a, 'g> {
             user_context: None,
             identity: None,
             policy_class: None,
+            governance: None,
         }
     }
 
@@ -227,6 +231,14 @@ impl<'a, 'g> CommitBuilder<'a, 'g> {
     /// Set the default policy class for policy-based flake filtering.
     pub fn policy_class(mut self, policy_class: Option<&str>) -> Self {
         self.policy_class = policy_class.map(std::string::ToString::to_string);
+        self
+    }
+
+    /// Supply the full host-selected governance, including inline policies and
+    /// bindings. This takes precedence over the identity/class convenience
+    /// setters and resolves ledger defaults even when the options are empty.
+    pub fn governance(mut self, options: &GovernanceOptions) -> Self {
+        self.governance = Some(options.clone());
         self
     }
 
@@ -271,23 +283,22 @@ impl<'a, 'g> CommitBuilder<'a, 'g> {
         let mut commit = read_commit(&blob)
             .map_err(|e| ApiError::internal(format!("Failed to decode commit {commit_id}: {e}")))?;
 
-        // 6. Apply policy filtering (if identity or policy_class is set).
+        // 6. Apply policy filtering when governance or identity/class is supplied.
         //    Calls policy_builder and enforcer directly to preserve ApiError
         //    variants (query vs internal) instead of losing them through
         //    BlockFetchError's stringified intermediary.
-        if self.identity.is_some() || self.policy_class.is_some() {
-            let opts = GovernanceOptions {
+        if self.governance.is_some() || self.identity.is_some() || self.policy_class.is_some() {
+            let opts = self.governance.unwrap_or_else(|| GovernanceOptions {
                 identity: self.identity.clone(),
                 policy_class: self.policy_class.as_deref().map(|c| vec![c.to_string()]),
                 ..Default::default()
-            };
+            });
             // Use the novelty overlay so policy rules in uncommitted
             // transactions are visible to the policy builder. Config-aware:
             // a configured `f:policySource` (same-ledger named graph or
             // cross-ledger model reference) redirects the policy-rule
             // lookup instead of assuming the default graph. The
-            // identity/policy_class gate above is unchanged — commit-detail
-            // filtering stays opt-in per request.
+            // full governance also retains narrowing delegated selections.
             let overlay: &dyn OverlayProvider = snapshot.novelty.as_ref();
             let policy_ctx = crate::policy_view::build_transact_policy_context(
                 self.graph.fluree,

--- a/fluree-db-api/src/graphql.rs
+++ b/fluree-db-api/src/graphql.rs
@@ -996,19 +996,21 @@ impl RootExecutor for LedgerExecutor {
         // it started rather than destroying the state a later field needs.
         let unchanged = ledger.clone();
         let result = async {
-            let policy = if let Some(authorization) = &self.authorization {
-                crate::build_transact_policy_context(
-                    &self.fluree,
-                    &ledger.snapshot,
-                    ledger.novelty.as_ref(),
-                    Some(ledger.novelty.as_ref()),
-                    ledger.t(),
-                    authorization.options(),
-                )
-                .await?
-            } else {
-                None
-            };
+            let default_options = crate::GovernanceOptions::default();
+            let opts = self
+                .authorization
+                .as_ref()
+                .map(PolicyAuthorization::options)
+                .unwrap_or(&default_options);
+            let policy = crate::build_transact_policy_context(
+                &self.fluree,
+                &ledger.snapshot,
+                ledger.novelty.as_ref(),
+                Some(ledger.novelty.as_ref()),
+                ledger.t(),
+                opts,
+            )
+            .await?;
             let builder = self.fluree.stage_owned(ledger);
             let mut builder = match lowered.verb {
                 Verb::Insert => builder.insert(&lowered.transaction),
@@ -1044,7 +1046,10 @@ impl RootExecutor for LedgerExecutor {
                 .await
                 .map_err(|e| GqlError::Execution(e.to_string()))?
         } else {
-            view
+            self.fluree
+                .wrap_policy_defaults(view)
+                .await
+                .map_err(|e| GqlError::Execution(e.to_string()))?
         };
 
         self.read_back(&view, &request, &lowered.subjects).await
@@ -1281,7 +1286,7 @@ impl Fluree {
         let db = if let Some(authorization) = authorization {
             self.wrap_policy(db, authorization.options(), None).await?
         } else {
-            db
+            self.wrap_policy_defaults(db).await?
         };
         let slot = parking_lot::Mutex::new(Some(ledger));
         let envelope = self

--- a/fluree-db-api/src/graphql.rs
+++ b/fluree-db-api/src/graphql.rs
@@ -39,7 +39,7 @@ use fluree_db_query::policy::QueryPolicyEnforcer;
 use serde_json::{json, Value as JsonValue};
 
 use crate::error::ApiError;
-use crate::{Fluree, GraphDb, LedgerState, QueryExecutionOptions, Result};
+use crate::{Fluree, GraphDb, LedgerState, PolicyAuthorization, QueryExecutionOptions, Result};
 
 pub use fluree_db_graphql::limits::{Limits, DEFAULT_MAX_COMPLEXITY, DEFAULT_MAX_DEPTH};
 
@@ -904,6 +904,8 @@ struct LedgerExecutor {
     /// many queries; they share one handle so a timeout or a client disconnect
     /// cancels all of them, not whichever happens to check next.
     options: QueryExecutionOptions,
+    /// Host-selected authority, rebuilt against each mutation's current state.
+    authorization: Option<PolicyAuthorization>,
 }
 
 impl LedgerExecutor {
@@ -993,15 +995,41 @@ impl RootExecutor for LedgerExecutor {
         // nothing and means a refused mutation leaves the caller exactly where
         // it started rather than destroying the state a later field needs.
         let unchanged = ledger.clone();
-        let result = match lowered.verb {
-            Verb::Insert => self.fluree.insert(ledger, &lowered.transaction).await,
-            Verb::Upsert => self.fluree.upsert(ledger, &lowered.transaction).await,
-            Verb::Update => self.fluree.update(ledger, &lowered.transaction).await,
-        };
+        let result = async {
+            let policy = if let Some(authorization) = &self.authorization {
+                crate::build_transact_policy_context(
+                    &self.fluree,
+                    &ledger.snapshot,
+                    ledger.novelty.as_ref(),
+                    Some(ledger.novelty.as_ref()),
+                    ledger.t(),
+                    authorization.options(),
+                )
+                .await?
+            } else {
+                None
+            };
+            let builder = self.fluree.stage_owned(ledger);
+            let mut builder = match lowered.verb {
+                Verb::Insert => builder.insert(&lowered.transaction),
+                Verb::Upsert => builder.upsert(&lowered.transaction),
+                Verb::Update => builder.update(&lowered.transaction),
+            };
+            if let Some(policy) = policy {
+                builder = builder.policy(policy);
+            }
+            if let Some(authorization) = &self.authorization {
+                builder = builder.commit_opts(crate::CommitOpts {
+                    identity: authorization.options().identity.clone(),
+                    ..Default::default()
+                });
+            }
+            builder.execute().await
+        }
+        .await;
         // A SHACL violation, a policy denial, or any other rejection arrives
         // here as an ordinary transaction error and becomes a GraphQL error.
-        // Nothing on this path can bypass them: it is the same write API any
-        // other client uses.
+        // Restore the prior state on policy-build errors as well as rejected writes.
         let result = result.map_err(|e| {
             slot.lock().replace(unchanged);
             GqlError::Execution(e.to_string())
@@ -1010,6 +1038,14 @@ impl RootExecutor for LedgerExecutor {
         let view = GraphDb::from_ledger_state(&committed)
             .with_default_context(self.db.default_context.clone());
         slot.lock().replace(committed);
+        let view = if let Some(authorization) = &self.authorization {
+            self.fluree
+                .wrap_policy(view, authorization.options(), None)
+                .await
+                .map_err(|e| GqlError::Execution(e.to_string()))?
+        } else {
+            view
+        };
 
         self.read_back(&view, &request, &lowered.subjects).await
     }
@@ -1158,7 +1194,7 @@ impl Fluree {
         prepared: PreparedRequest<'_>,
         options: QueryExecutionOptions,
     ) -> Result<JsonValue> {
-        self.run_graphql(db, prepared, None, options).await
+        self.run_graphql(db, prepared, None, options, None).await
     }
 
     /// Execute a GraphQL request that may write.
@@ -1207,10 +1243,49 @@ impl Fluree {
         prepared: PreparedRequest<'_>,
         options: QueryExecutionOptions,
     ) -> Result<(JsonValue, LedgerState)> {
+        self.graphql_transact_authorized(ledger, default_context, prepared, options, None)
+            .await
+    }
+
+    /// Execute with host-verified policy selection for schema visibility,
+    /// every mutation, and each committed subject's read-back. Policy contexts
+    /// are rebuilt against the current state for serial mutation fields.
+    /// The host must separately authorize ledger read/write access.
+    pub async fn graphql_transact_with_authorization(
+        &self,
+        ledger: LedgerState,
+        default_context: Option<JsonValue>,
+        prepared: PreparedRequest<'_>,
+        options: QueryExecutionOptions,
+        authorization: &PolicyAuthorization,
+    ) -> Result<(JsonValue, LedgerState)> {
+        self.graphql_transact_authorized(
+            ledger,
+            default_context,
+            prepared,
+            options,
+            Some(authorization),
+        )
+        .await
+    }
+
+    async fn graphql_transact_authorized(
+        &self,
+        ledger: LedgerState,
+        default_context: Option<JsonValue>,
+        prepared: PreparedRequest<'_>,
+        options: QueryExecutionOptions,
+        authorization: Option<&PolicyAuthorization>,
+    ) -> Result<(JsonValue, LedgerState)> {
         let db = GraphDb::from_ledger_state(&ledger).with_default_context(default_context);
+        let db = if let Some(authorization) = authorization {
+            self.wrap_policy(db, authorization.options(), None).await?
+        } else {
+            db
+        };
         let slot = parking_lot::Mutex::new(Some(ledger));
         let envelope = self
-            .run_graphql(&db, prepared, Some(&slot), options)
+            .run_graphql(&db, prepared, Some(&slot), options, authorization)
             .await?;
         let ledger = slot.lock().take().ok_or_else(|| {
             ApiError::Internal("the ledger state was consumed by a failed mutation".to_string())
@@ -1224,6 +1299,7 @@ impl Fluree {
         prepared: PreparedRequest<'_>,
         ledger: Option<&parking_lot::Mutex<Option<LedgerState>>>,
         options: QueryExecutionOptions,
+        authorization: Option<&PolicyAuthorization>,
     ) -> Result<JsonValue> {
         let PreparedRequest { request, doc, .. } = prepared;
         let derived = derive_schema(db).await;
@@ -1248,6 +1324,7 @@ impl Fluree {
             ledger: ledger.map(|slot| parking_lot::Mutex::new(slot.lock().take())),
             explain: request.explain.then(|| parking_lot::Mutex::new(Vec::new())),
             options,
+            authorization: authorization.cloned(),
         });
         // Registering the schema costs thousands of allocations — 2.5 ms for a
         // hundred-class ledger — so it is cached beside the model rather than

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -35,6 +35,8 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod admin;
+pub mod authorization;
+pub use authorization::PolicyAuthorization;
 pub mod block_fetch;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod bm25_worker;

--- a/fluree-db-api/src/policy_builder.rs
+++ b/fluree-db-api/src/policy_builder.rs
@@ -507,21 +507,12 @@ async fn build_policy_context_from_opts_inner(
     Ok(PolicyContext::new(wrapper, identity_sid))
 }
 
-/// Returns `true` iff `identity_iri` exists as a subject in the ledger but has
-/// **no** `f:policyClass` assignments — meaning no policy restrictions apply to
-/// that identity.
+/// Returns `true` iff `identity_iri` exists as a subject in the default policy
+/// graph but has no `f:policyClass` assignments there.
 ///
-/// This is the predicate used to decide whether a bearer-authenticated identity
-/// may impersonate another identity via `opts.identity` for policy testing.
-/// The semantics are:
-///
-/// - `FoundNoPolicies` → `true`: the identity is known and unrestricted, so it
-///   may delegate / impersonate.
-/// - `FoundWithPolicies` → `false`: the identity is itself policy-constrained
-///   and must not be allowed to bypass its own constraints by acting as another
-///   identity.
-/// - `NotFound` → `false`: an unknown identity must not gain impersonation
-///   rights regardless of `default_allow`.
+/// This describes local assignments only. It does not prove unrestricted
+/// access or confer authority to impersonate: configured/model policies and
+/// default-deny may still apply. Hosts must establish delegation separately.
 pub async fn identity_has_no_policies(
     snapshot: &LedgerSnapshot,
     overlay: &dyn fluree_db_core::OverlayProvider,
@@ -555,9 +546,8 @@ pub async fn identity_has_no_policies(
 /// carries restrictions. `default_allow` governs access in all three cases — the
 /// "not found" / "found-no-policies" distinction is about SID availability, not gating.
 ///
-/// A separate predicate, [`identity_has_no_policies`], uses this enum to gate
-/// impersonation (only `FoundNoPolicies` qualifies); that gate is orthogonal to
-/// `default_allow`.
+/// [`identity_has_no_policies`] exposes the local-assignment distinction for
+/// inspection. It is not an authorization or delegation check.
 enum IdentityLookupResult {
     /// The identity IRI cannot be resolved (unregistered namespace) or has no subject
     /// node in this ledger. No identity SID is available to bind `?$identity`.

--- a/fluree-db-api/src/policy_builder.rs
+++ b/fluree-db-api/src/policy_builder.rs
@@ -305,15 +305,14 @@ async fn build_policy_context_from_opts_inner(
         };
 
         (identity_sid, merged)
-    } else if let (Some(identity_iri), Some(classes)) = (
-        &opts.identity,
-        opts.policy_class.as_ref().filter(|c| !c.is_empty()),
-    ) {
+    } else if let (Some(identity_iri), Some(classes)) = (&opts.identity, opts.policy_class.as_ref())
+    {
         // Same-ledger identity + explicit `policy-class`: the request's
         // classes select the policy set; the identity is BIND-ONLY — it
         // resolves to populate `?$identity` for f:query rules and never
         // drives rule selection. This mirrors the cross-ledger identity
-        // contract above.
+        // contract above. An explicitly empty class list selects no stored
+        // policies; it must not fall back to this identity's wider assignments.
         //
         // Without this arm, a request carrying both fields silently ignored
         // `policy-class` and fell through to identity-mode selection below —
@@ -477,10 +476,15 @@ async fn build_policy_context_from_opts_inner(
     // were provided. When an identity IS specified but has no matching policies, is_root must
     // be false so that `default_allow` (not a blanket bypass) governs access.
     let has_explicit_policy_input = opts.identity.is_some()
-        || opts.policy_class.as_ref().is_some_and(|v| !v.is_empty())
+        || opts.policy_class.is_some()
         || opts.policy.is_some()
+        || opts
+            .policy_values
+            .as_ref()
+            .is_some_and(|values| !values.is_empty())
         || has_cross_ledger_source;
     let is_root = !has_explicit_policy_input
+        && opts.default_allow != Some(false)
         && view_set.restrictions.is_empty()
         && modify_set.restrictions.is_empty();
 

--- a/fluree-db-api/src/policy_view.rs
+++ b/fluree-db-api/src/policy_view.rs
@@ -286,10 +286,8 @@ pub(crate) async fn resolve_cross_ledger_policy_restrictions(
     virtual_source: bool,
 ) -> Result<Vec<fluree_db_policy::PolicyRestriction>> {
     const DEFAULT_POLICY_CLASS_IRI: &str = fluree_vocab::policy_iris::ACCESS_POLICY;
-    let filter: std::collections::HashSet<String> = if let Some(classes) = effective_opts
-        .policy_class
-        .as_ref()
-        .filter(|v| !v.is_empty())
+    let filter: std::collections::HashSet<String> = if let Some(classes) =
+        effective_opts.policy_class.as_ref()
     {
         classes.iter().cloned().collect()
     } else if let Some(classes) = config_policy_class.filter(|v| !v.is_empty()) {

--- a/fluree-db-api/src/query/builder.rs
+++ b/fluree-db-api/src/query/builder.rs
@@ -752,6 +752,7 @@ pub struct FromQueryBuilder<'a> {
     core: QueryCore<'a>,
     policy: Option<Arc<PolicyContext>>,
     connection_opts: Option<GovernanceOptions>,
+    authorization: Option<&'a crate::PolicyAuthorization>,
 }
 
 impl<'a> FromQueryBuilder<'a> {
@@ -762,6 +763,7 @@ impl<'a> FromQueryBuilder<'a> {
             core: QueryCore::new(),
             policy: None,
             connection_opts: None,
+            authorization: None,
         }
     }
 
@@ -878,6 +880,12 @@ impl<'a> FromQueryBuilder<'a> {
     /// Only available on `FromQueryBuilder` — for view/dataset queries,
     /// policy is applied at the view level (Tier 1).
     pub fn policy(mut self, ctx: PolicyContext) -> Self {
+        if self.authorization.is_some() {
+            self.core.errors.push(BuilderError::Conflict {
+                field: "authorization",
+                message: "authorization cannot be combined with a prebuilt policy context".into(),
+            });
+        }
         self.policy = Some(Arc::new(ctx));
         self
     }
@@ -898,6 +906,40 @@ impl<'a> FromQueryBuilder<'a> {
         self
     }
 
+    /// Bind this request to host-verified policy selection. Caller JSON options,
+    /// source overrides and connection options cannot replace this selection.
+    /// The host must separately authorize every ledger named by the request.
+    pub fn authorization(mut self, authorization: &'a crate::PolicyAuthorization) -> Self {
+        if self.policy.is_some() {
+            self.core.errors.push(BuilderError::Conflict {
+                field: "authorization",
+                message: "authorization cannot be combined with a prebuilt policy context".into(),
+            });
+        }
+        self.authorization = Some(authorization);
+        self
+    }
+
+    fn prepare_authorization(&mut self) -> Result<Option<JsonValue>> {
+        let Some(authorization) = self.authorization else {
+            return Ok(None);
+        };
+        self.connection_opts = Some(
+            authorization.constrain_options(
+                self.connection_opts
+                    .as_ref()
+                    .unwrap_or(&GovernanceOptions::default()),
+            ),
+        );
+        if let Some(QueryInput::JsonLd(json)) = self.core.input {
+            let mut json = json.clone();
+            authorization.apply_to_jsonld(&mut json)?;
+            Ok(Some(json))
+        } else {
+            Ok(None)
+        }
+    }
+
     // --- Terminal operations ---
 
     /// Validate builder configuration without executing.
@@ -914,16 +956,21 @@ impl<'a> FromQueryBuilder<'a> {
     ///
     /// Resolves ledgers from the query body's `from` / `FROM` clauses,
     /// applies policy if set, and executes.
-    pub async fn execute(self) -> Result<QueryResult> {
+    pub async fn execute(mut self) -> Result<QueryResult> {
         let errs = self.core.validate();
         if !errs.is_empty() {
             return Err(ApiError::Builder(BuilderErrors(errs)));
         }
 
+        let authorized_json = self.prepare_authorization()?;
         let mut core = self.core;
         let r2rml = core.r2rml.take();
         let execution = core.execution.clone();
         let input = core.input.take().unwrap();
+        let input = authorized_json
+            .as_ref()
+            .map(QueryInput::JsonLd)
+            .unwrap_or(input);
         // SPARQL policy via connection opts (multi-query aliases): SPARQL has
         // no body opts, so the merged envelope/sub opts arrive here. Takes
         // precedence over `.policy()`; for JSON-LD input it's a no-op.
@@ -1022,6 +1069,7 @@ impl<'a> FromQueryBuilder<'a> {
             return Err(ApiError::Builder(BuilderErrors(errs)));
         }
 
+        let authorized_json = self.prepare_authorization()?;
         let r2rml = self.core.r2rml.take();
         let execution = self.core.execution.clone();
         let format_config = self
@@ -1030,6 +1078,10 @@ impl<'a> FromQueryBuilder<'a> {
             .take()
             .unwrap_or_else(|| self.core.default_format());
         let input = self.core.input.take().unwrap();
+        let input = authorized_json
+            .as_ref()
+            .map(QueryInput::JsonLd)
+            .unwrap_or(input);
         // Top-intercept a virtual-dataset subgraph crawl (JSON-LD only) BEFORE
         // the main query runs, so it is routed through R2RML rather than native
         // hydration (which returns `[]`). `as_jsonld()` borrows `input` (Copy),
@@ -1186,6 +1238,7 @@ impl<'a> FromQueryBuilder<'a> {
             return Err(ApiError::Builder(BuilderErrors(errs)));
         }
 
+        let authorized_json = self.prepare_authorization()?;
         let r2rml = self.core.r2rml.take();
         let execution = self.core.execution.clone();
         let format_config = self
@@ -1194,6 +1247,10 @@ impl<'a> FromQueryBuilder<'a> {
             .take()
             .unwrap_or_else(|| self.core.default_format());
         let input = self.core.input.take().unwrap();
+        let input = authorized_json
+            .as_ref()
+            .map(QueryInput::JsonLd)
+            .unwrap_or(input);
         // Top-intercept a virtual-dataset subgraph crawl (JSON-LD only) BEFORE
         // the main query runs; serialize the expanded documents to a string to
         // match this terminal's return type.
@@ -1371,11 +1428,18 @@ impl<'a> FromQueryBuilder<'a> {
             return Err(TrackedErrorResponse::new(400, msg, None));
         }
 
+        let authorized_json = self
+            .prepare_authorization()
+            .map_err(|e| TrackedErrorResponse::new(400, e.to_string(), None))?;
         let r2rml = self.core.r2rml.take();
         let format_config = self.core.format.take();
         let tracking = self.core.tracking.take();
         let execution = self.core.execution.clone();
         let input = self.core.input.take().unwrap();
+        let input = authorized_json
+            .as_ref()
+            .map(QueryInput::JsonLd)
+            .unwrap_or(input);
         // Top-intercept a virtual-dataset subgraph crawl (JSON-LD only) BEFORE
         // dispatching the tracked query. The crawl has no fuel/policy/time stats,
         // so it returns a 200 response with empty tracking. Boxed like the

--- a/fluree-db-api/src/query/builder.rs
+++ b/fluree-db-api/src/query/builder.rs
@@ -794,7 +794,7 @@ impl<'a> FromQueryBuilder<'a> {
         // Resolve the single target ledger from the query's own dataset spec. A
         // crawl over a federated multi-source dataset must not collapse to one
         // source, so bail unless exactly one graph is specified.
-        let (spec, _) = parse_dataset_spec(json)?;
+        let (spec, opts) = parse_dataset_spec(json)?;
         if spec.default_graphs.len() + spec.named_graphs.len() != 1 {
             return Ok(None);
         }
@@ -803,10 +803,19 @@ impl<'a> FromQueryBuilder<'a> {
             .first()
             .or_else(|| spec.named_graphs.first())
             .expect("exactly one graph checked above");
-        let view = self
-            .fluree
-            .db_or_graph_source(alias.identifier.as_str())
-            .await?;
+        let view = self.fluree.load_view_from_source(alias).await?;
+        if view.graph_source_id.is_none() {
+            return Ok(None);
+        }
+        // Expansion executes a rewritten query against this view, so bind
+        // policy here before the original JSON options disappear.
+        let view = if let Some(policy) = &self.policy {
+            view.with_policy(Arc::clone(policy))
+        } else {
+            self.fluree
+                .apply_source_or_global_policy(view, alias, &opts)
+                .await?
+        };
         crate::graph_source::crawl::maybe_expand_crawl(
             self.fluree,
             &view,

--- a/fluree-db-api/src/query/connection.rs
+++ b/fluree-db-api/src/query/connection.rs
@@ -1065,7 +1065,7 @@ impl Fluree {
     ///
     /// Per-source policy takes precedence if present, otherwise global policy is used.
     /// If neither has policy, applies configured ledger defaults.
-    async fn apply_source_or_global_policy(
+    pub(crate) async fn apply_source_or_global_policy(
         &self,
         view: crate::view::GraphDb,
         source: &crate::dataset::GraphSource,

--- a/fluree-db-api/src/query/connection.rs
+++ b/fluree-db-api/src/query/connection.rs
@@ -654,6 +654,16 @@ impl Fluree {
     /// time-travel suffix). Rejects `FROM NAMED` and multi-`FROM` queries,
     /// since the planner is single-ledger.
     pub async fn explain_connection_sparql(&self, sparql: &str) -> Result<JsonValue> {
+        self.explain_connection_sparql_with_opts(sparql, &GovernanceOptions::default())
+            .await
+    }
+
+    /// Explain with host-selected policy inputs, using the query's snapshot.
+    pub async fn explain_connection_sparql_with_opts(
+        &self,
+        sparql: &str,
+        opts: &GovernanceOptions,
+    ) -> Result<JsonValue> {
         let ast = parse_and_validate_sparql(sparql)?;
         let spec = extract_sparql_dataset_spec(&ast)?;
 
@@ -663,10 +673,7 @@ impl Fluree {
             ));
         }
 
-        let Some(view) = self
-            .prepare_single_view_for_connection(&spec, &crate::GovernanceOptions::default())
-            .await?
-        else {
+        let Some(view) = self.prepare_single_view_for_connection(&spec, opts).await? else {
             return Err(ApiError::query(
                 "Multi-ledger / FROM NAMED datasets are not supported for SPARQL explain; \
                  use a single `FROM <ledger:branch>` (with optional time-travel suffix).",

--- a/fluree-db-api/src/query/connection.rs
+++ b/fluree-db-api/src/query/connection.rs
@@ -1064,7 +1064,7 @@ impl Fluree {
     /// Apply per-source or global policy to a view.
     ///
     /// Per-source policy takes precedence if present, otherwise global policy is used.
-    /// If neither has policy, returns the view unchanged.
+    /// If neither has policy, applies configured ledger defaults.
     async fn apply_source_or_global_policy(
         &self,
         view: crate::view::GraphDb,
@@ -1082,7 +1082,7 @@ impl Fluree {
         if global_opts.has_any_policy_inputs() {
             self.wrap_policy(view, global_opts, None).await
         } else {
-            Ok(view)
+            self.wrap_policy_defaults(view).await
         }
     }
 }

--- a/fluree-db-api/src/view/dataset_builder.rs
+++ b/fluree-db-api/src/view/dataset_builder.rs
@@ -120,7 +120,7 @@ impl Fluree {
         build_dataset_view_from_spec!(
             self,
             spec,
-            history_transform = |view| async { Ok::<GraphDb, ApiError>(view) },
+            history_transform = |view| self.wrap_policy_defaults(view),
             load_view = |source| self.load_view_from_source(source),
             apply_policy = |view, source| self.maybe_apply_source_policy(view, source),
         )
@@ -151,7 +151,7 @@ impl Fluree {
         )
     }
 
-    /// Apply per-source policy if present, otherwise no policy.
+    /// Apply per-source policy if present, otherwise configured defaults.
     ///
     /// This is used by `build_dataset_view` when no global policy is provided.
     async fn maybe_apply_source_policy(
@@ -165,7 +165,7 @@ impl Fluree {
                 return self.wrap_policy(view, &opts, None).await;
             }
         }
-        Ok(view)
+        self.wrap_policy_defaults(view).await
     }
 
     /// Apply policy with per-source override taking precedence over global.

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -782,6 +782,29 @@ impl Fluree {
 // ============================================================================
 
 impl Fluree {
+    /// Apply configured policy defaults when no request policy was selected.
+    /// Unconfigured views keep their plain-query path. Unlike a synthetic
+    /// `default_allow: true`, empty governance lets config supply its classes.
+    pub async fn wrap_policy_defaults(&self, view: GraphDb) -> Result<GraphDb> {
+        if view.has_policy() {
+            return Ok(view);
+        }
+        let view = if view.resolved_config().is_some() {
+            view
+        } else {
+            self.resolve_and_attach_config(view).await?
+        };
+        if view
+            .resolved_config()
+            .is_some_and(|config| config.policy.is_some())
+        {
+            self.wrap_policy(view, &GovernanceOptions::default(), None)
+                .await
+        } else {
+            Ok(view)
+        }
+    }
+
     /// Build policy from options and wrap a view.
     ///
     /// If the view has a `ResolvedConfig`, config defaults are merged with query
@@ -806,6 +829,14 @@ impl Fluree {
         opts: &GovernanceOptions,
         server_identity: Option<&str>,
     ) -> Result<GraphDb> {
+        // Callers may construct a view directly from staged/loaded ledger state.
+        // Such a view must not bypass ledger override controls just because
+        // config has not been attached yet (for example GraphQL read-back).
+        let view = if view.resolved_config().is_some() {
+            view
+        } else {
+            self.resolve_and_attach_config(view).await?
+        };
         let effective_opts = if let Some(ref resolved) = view.resolved_config {
             config_resolver::merge_policy_opts(resolved, opts, server_identity)
         } else {

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -747,28 +747,12 @@ impl Fluree {
             fluree_db_ledger::LedgerState::new(snapshot, fluree_db_novelty::Novelty::new(0));
         let mut db = GraphDb::from_ledger_state(&state);
 
-        match graph_ref {
-            GraphRef::Default => {
-                // The virtual default graph: tag the view so query execution
-                // auto-wraps patterns in `GRAPH <gs_id> { ... }` and the configured
-                // provider (Iceberg / R2RML / BM25 / vector) resolves them.
-                // `resolved_config` rides with the tag — both say "this view IS
-                // the virtual source" — and `wrap_policy` reads the tag to decide
-                // that the model, not this empty genesis snapshot, holds the
-                // identity's `f:policyClass`.
-                db.resolved_config = Self::graph_source_model_config(&record);
-                db.graph_source_id = Some(gs_id.into());
-                Ok(Some(db))
-            }
-            // A graph source has no Fluree commit-metadata (`#txn-meta`) graph —
-            // that system graph is genuinely empty for a virtual dataset. Select
-            // the (empty) txn-meta graph on the genesis snapshot and deliberately
-            // DO NOT tag `graph_source_id`, so `maybe_wrap_for_graph_source` stays
-            // a no-op: the query reads the empty graph and returns [], rather than
-            // routing txn-meta patterns to the data provider (which has no such
-            // graph) or 500-ing on a NotFound alias.
-            other => Self::select_graph(db, other).map(Some),
-        }
+        // The default graph routes to the virtual provider and uses its model
+        // configuration. Shared graph selection removes both when selecting an
+        // empty system graph, for fragments and explicit dataset selectors alike.
+        db.resolved_config = Self::graph_source_model_config(&record);
+        db.graph_source_id = Some(gs_id.into());
+        Self::select_graph(db, graph_ref).map(Some)
     }
 }
 

--- a/fluree-db-api/src/view/fluree_ext.rs
+++ b/fluree-db-api/src/view/fluree_ext.rs
@@ -114,10 +114,10 @@ impl Fluree {
     /// via `config_resolver::merge_reasoning()`, which applies override
     /// control against whatever server-verified identity the caller supplies.
     pub(crate) async fn resolve_and_attach_config(&self, view: GraphDb) -> Result<GraphDb> {
-        // Config reads are best-effort. If the config graph is unqueryable
-        // (e.g., historical snapshot without a range_provider for g_id=2),
-        // treat it as "no config" and apply system defaults.
-        //
+        if view.config_is_resolved() {
+            return Ok(view);
+        }
+        // A read failure must never become an unrestricted policy view.
         // Resolved through the same marker-keyed cache the write path uses:
         // query preparation completes config defaults on every view that
         // arrives without them, which for the ledger-scoped server routes is
@@ -129,23 +129,18 @@ impl Fluree {
         // may be a composed reasoning overlay rather than a bare `Novelty`, in
         // which case the resolver's own downcast would find no marker and
         // silently stop caching.
-        let config = match crate::policy_view::resolve_ledger_config_cached(
+        let config = crate::policy_view::resolve_ledger_config_cached(
             self,
             &view.snapshot,
             &*view.overlay,
             view.novelty().map(|n| &**n),
             view.t,
         )
-        .await
-        {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::debug!(error = %e, "Config graph read failed — using system defaults");
-                return Ok(view);
-            }
-        };
+        .await?;
 
         let Some(config) = config else {
+            let mut view = view;
+            view.config_absent = true;
             return Ok(view);
         };
 
@@ -789,11 +784,7 @@ impl Fluree {
         if view.has_policy() {
             return Ok(view);
         }
-        let view = if view.resolved_config().is_some() {
-            view
-        } else {
-            self.resolve_and_attach_config(view).await?
-        };
+        let view = self.resolve_and_attach_config(view).await?;
         if view
             .resolved_config()
             .is_some_and(|config| config.policy.is_some())
@@ -832,11 +823,7 @@ impl Fluree {
         // Callers may construct a view directly from staged/loaded ledger state.
         // Such a view must not bypass ledger override controls just because
         // config has not been attached yet (for example GraphQL read-back).
-        let view = if view.resolved_config().is_some() {
-            view
-        } else {
-            self.resolve_and_attach_config(view).await?
-        };
+        let view = self.resolve_and_attach_config(view).await?;
         let effective_opts = if let Some(ref resolved) = view.resolved_config {
             config_resolver::merge_policy_opts(resolved, opts, server_identity)
         } else {
@@ -1133,10 +1120,7 @@ impl Fluree {
         view: &GraphDb,
         server_identity: Option<&str>,
     ) -> Result<GraphDb> {
-        let view = match view.resolved_config() {
-            Some(_) => view.clone(),
-            None => self.resolve_and_attach_config(view.clone()).await?,
-        };
+        let view = self.resolve_and_attach_config(view.clone()).await?;
         Ok(self.apply_config_defaults(view, server_identity))
     }
 

--- a/fluree-db-api/src/view/query.rs
+++ b/fluree-db-api/src/view/query.rs
@@ -20,6 +20,21 @@ use fluree_db_query::ir::{GraphName, Pattern};
 use fluree_db_query::r2rml::{R2rmlProvider, R2rmlTableProvider};
 use serde_json::Value as JsonValue;
 
+fn explain_policy_notice(mut result: JsonValue, view: &GraphDb) -> JsonValue {
+    if view.is_root() {
+        return result;
+    }
+    // Every explain surface emits `plan` as an object; tolerate a different
+    // shape rather than panicking inside a diagnostics path.
+    if let Some(plan) = result.get_mut("plan").and_then(JsonValue::as_object_mut) {
+        plan.insert(
+            "reason".into(),
+            JsonValue::String("Statistics withheld by policy; estimates are heuristic".into()),
+        );
+    }
+    result
+}
+
 /// The content store backing `db`'s binary index, when it participates in
 /// the sync residency tier (exposes a miss register): the handle the
 /// query-entry retry loop drains misses from, fetches through, and holds
@@ -711,26 +726,43 @@ impl Fluree {
         Ok(result)
     }
 
+    /// Explain may show query structure, but a scoped caller must not learn
+    /// unrestricted cardinalities (including annotation-derived counts).
+    /// Keep the normal snapshot on the root path; only governed explains clone.
+    async fn prepare_explain_view(&self, db: &GraphDb) -> Result<GraphDb> {
+        let mut view = self.wrap_policy_defaults(db.clone()).await?;
+        if !view.is_root() {
+            let snapshot = std::sync::Arc::make_mut(&mut view.snapshot);
+            snapshot.stats = None;
+            snapshot.annotation_index = None;
+        }
+        Ok(view)
+    }
+
     /// Explain a JSON-LD query plan against a GraphDb.
     ///
     /// This uses the same default-context behavior as query execution.
     pub async fn explain(&self, db: &GraphDb, query_json: &JsonValue) -> Result<JsonValue> {
+        let db = self.prepare_explain_view(db).await?;
         crate::explain::explain_jsonld_with_default_context(
             &db.snapshot,
             query_json,
             db.default_context.as_ref(),
         )
         .await
+        .map(|result| explain_policy_notice(result, &db))
     }
 
     /// Explain a SPARQL query plan against a GraphDb.
     pub async fn explain_sparql(&self, db: &GraphDb, sparql: &str) -> Result<JsonValue> {
+        let db = self.prepare_explain_view(db).await?;
         crate::explain::explain_sparql_with_default_context(
             &db.snapshot,
             sparql,
             db.default_context.as_ref(),
         )
         .await
+        .map(|result| explain_policy_notice(result, &db))
     }
 
     /// Explain a Cypher query plan against a GraphDb.
@@ -744,8 +776,10 @@ impl Fluree {
         cypher: &str,
         params: Option<&fluree_db_cypher::ParamMap>,
     ) -> Result<JsonValue> {
+        let db = self.prepare_explain_view(db).await?;
         crate::explain::explain_cypher(&db.snapshot, cypher, db.default_context.as_ref(), params)
             .await
+            .map(|result| explain_policy_notice(result, &db))
     }
 
     /// Execute a query with tracking.

--- a/fluree-db-api/src/view/types.rs
+++ b/fluree-db-api/src/view/types.rs
@@ -542,6 +542,12 @@ impl GraphDb {
     pub fn with_graph_id(mut self, graph_id: GraphId) -> Self {
         if self.graph_id != graph_id {
             self.clear_config_resolution();
+            // Only the default graph routes to a virtual source's provider.
+            // Its system graphs read the empty genesis snapshot; dropping the
+            // model config must also drop the virtual-data routing tag.
+            if graph_id != fluree_db_core::DEFAULT_GRAPH_ID {
+                self.graph_source_id = None;
+            }
         }
         self.graph_id = graph_id;
         self

--- a/fluree-db-api/src/view/types.rs
+++ b/fluree-db-api/src/view/types.rs
@@ -196,6 +196,8 @@ pub struct GraphDb {
     /// Carried on `GraphDb` so downstream callers can apply identity gating
     /// at request time without re-reading the config graph.
     pub(crate) resolved_config: Option<ResolvedConfig>,
+    /// Successful resolution found no config; distinct from not yet resolved.
+    pub(crate) config_absent: bool,
 
     // ========================================================================
     // Datalog config (from config graph, applied at query boundary)
@@ -295,6 +297,7 @@ impl GraphDb {
             default_context: None,
             ledger_config: None,
             resolved_config: None,
+            config_absent: false,
             datalog_enabled: true,
             query_time_rules_allowed: true,
             datalog_override_allowed: true,
@@ -517,6 +520,9 @@ impl GraphDb {
     /// let view = view.as_of(50);
     /// ```
     pub fn as_of(mut self, t: i64) -> Self {
+        if self.t != t {
+            self.clear_config_resolution();
+        }
         self.t = t;
         self
     }
@@ -534,6 +540,9 @@ impl GraphDb {
     /// `range_with_overlay()` must ensure the underlying `LedgerSnapshot.range_provider`
     /// is scoped appropriately for the chosen graph.
     pub fn with_graph_id(mut self, graph_id: GraphId) -> Self {
+        if self.graph_id != graph_id {
+            self.clear_config_resolution();
+        }
         self.graph_id = graph_id;
         self
     }
@@ -603,6 +612,17 @@ impl GraphDb {
     pub(crate) fn with_resolved_config(mut self, config: ResolvedConfig) -> Self {
         self.resolved_config = Some(config);
         self
+    }
+
+    fn clear_config_resolution(&mut self) {
+        self.config_absent = false;
+        self.resolved_config = None;
+        self.ledger_config = None;
+        self.rules_source_g_id = None;
+    }
+
+    pub(crate) fn config_is_resolved(&self) -> bool {
+        self.config_absent || self.resolved_config.is_some()
     }
 
     /// Get the full ledger config (if any).

--- a/fluree-db-api/tests/it_config_graph.rs
+++ b/fluree-db-api/tests/it_config_graph.rs
@@ -3432,25 +3432,18 @@ async fn identity_only_without_config_still_denies_all() {
     );
 }
 
-/// Unchanged posture: an anonymous request is wholly unenforced, so a ledger's
-/// configured `f:defaultAllow false` does not close it.
-///
-/// `has_any_policy_inputs()` is false for an anonymous request, so
-/// `apply_source_or_global_policy` never calls `wrap_policy` and no
-/// `PolicyContext` — and therefore no config default — is ever built. Pinned
-/// here as current behavior, not endorsed: see the note in the branch report.
+/// Anonymous connection queries still enforce configured ledger defaults.
 #[tokio::test]
-async fn anonymous_request_unenforced_despite_config_default_allow_false() {
+async fn anonymous_request_enforces_config_default_allow_false() {
     let fluree = FlureeBuilder::memory().build_memory();
     let ledger_id = "it/config-default-allow-anonymous:main";
     seed_default_allow_ledger(&fluree, ledger_id, Some(false)).await;
 
     let names = visible_names(&fluree, ledger_id, serde_json::Value::Null).await;
 
-    assert_eq!(
-        names,
-        vec!["Alice".to_string(), "Bob".to_string()],
-        "anonymous requests remain unenforced regardless of config default-allow"
+    assert!(
+        names.is_empty(),
+        "configured deny must apply to anonymous reads"
     );
 }
 

--- a/fluree-db-api/tests/it_iceberg_policy.rs
+++ b/fluree-db-api/tests/it_iceberg_policy.rs
@@ -1175,7 +1175,7 @@ async fn txn_meta_on_a_governed_source_is_empty_not_an_error() {
     let (sel, wh) = name_query();
     // An identity with no explicit policy-class: the shape the cross-ledger
     // resolver rejects outright.
-    let q = |from: &str| {
+    let q = |from: Value| {
         json!({
             "@context": context(),
             "from": from,
@@ -1185,23 +1185,71 @@ async fn txn_meta_on_a_governed_source_is_empty_not_an_error() {
         })
     };
 
-    let meta = fluree
-        .query_from()
-        .jsonld(&q("local-gov-tm:main#txn-meta"))
-        .execute_formatted()
-        .await
-        .expect("#txn-meta on a governed source must not error");
-    assert_eq!(meta.as_array().map_or(1, Vec::len), 0, "{meta}");
+    for from in [
+        json!("local-gov-tm:main#txn-meta"),
+        json!({"@id": "local-gov-tm:main", "graph": "txn-meta"}),
+        json!({"@id": "local-gov-tm:main", "@graph": "txn-meta"}),
+    ] {
+        let meta = fluree
+            .query_from()
+            .jsonld(&q(from.clone()))
+            .execute_formatted()
+            .await
+            .expect("txn-meta on a governed source must not error");
+        assert_eq!(meta, json!([]), "from={from}");
+    }
 
     // The default graph still resolves the model and denies, so the assertion
     // above is not passing because governance was dropped everywhere.
     let default_graph = fluree
         .query_from()
-        .jsonld(&q("local-gov-tm:main"))
+        .jsonld(&q(json!("local-gov-tm:main")))
         .execute_formatted()
         .await
         .expect("default graph query");
     assert_eq!(default_graph.as_array().map_or(1, Vec::len), 0);
+}
+
+#[tokio::test]
+async fn virtual_source_graph_selectors_preserve_routing_and_defaults() {
+    let fluree = setup().await;
+    for allow in [false, true] {
+        let name = format!("selector-policy-{allow}");
+        let source = format!("{name}:main");
+        let cfg = R2rmlCreateConfig::new_direct(&name, table_location(), PEOPLE_R2RML)
+            .with_mapping_media_type("text/turtle")
+            .with_default_allow(allow);
+        fluree.create_r2rml_graph_source(cfg).await.unwrap();
+
+        for (from, metadata) in [
+            (json!(source), false),
+            (json!({"@id": source, "graph": "default"}), false),
+            (json!({"@id": source, "@graph": "default"}), false),
+            (json!(format!("{source}#txn-meta")), true),
+            (json!({"@id": source, "graph": "txn-meta"}), true),
+            (json!({"@id": source, "@graph": "txn-meta"}), true),
+        ] {
+            for crawl in [false, true] {
+                let (select, wh) = name_query();
+                let query = json!({
+                    "@context": context(), "from": from,
+                    "select": if crawl { json!({"?s": ["*"]}) } else { select },
+                    "where": wh
+                });
+                let result = fluree
+                    .query_from()
+                    .jsonld(&query)
+                    .execute_formatted()
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    result.as_array().unwrap().len(),
+                    if metadata || !allow { 0 } else { 5 },
+                    "allow={allow}, crawl={crawl}, from={from}: {result}"
+                );
+            }
+        }
+    }
 }
 
 #[tokio::test]

--- a/fluree-db-api/tests/it_iceberg_policy.rs
+++ b/fluree-db-api/tests/it_iceberg_policy.rs
@@ -789,14 +789,14 @@ async fn model_ledger_supplies_policies_and_hierarchy() {
     let rows = |v: Value| v.as_array().map_or(0, Vec::len);
     let (sel, wh) = name_query();
 
-    // No policy inputs on the request: unrestricted, as for a native ledger.
+    // Omitted request options still enforce the registered model defaults.
     let r = fluree
         .query_from()
         .jsonld(&query(json!(null), sel.clone(), wh.clone()))
         .execute_formatted()
         .await
         .unwrap();
-    assert_eq!(rows(r), 5);
+    assert_eq!(rows(r), 0);
 
     // Anonymous governed request: the baseline f:AccessPolicy rules apply, and
     // `ex:Agent` reaches `ex:Person` through M's subclass hierarchy.
@@ -1202,4 +1202,80 @@ async fn txn_meta_on_a_governed_source_is_empty_not_an_error() {
         .await
         .expect("default graph query");
     assert_eq!(default_graph.as_array().map_or(1, Vec::len), 0);
+}
+
+#[tokio::test]
+async fn authorization_crawl_preserves_policy_across_formatting_terminals() {
+    use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
+    let fluree = setup().await;
+    for source in virtual_sources(GS) {
+        for deny_all in [true, false] {
+            let auth = PolicyAuthorization::from_trusted_options(if deny_all {
+                GovernanceOptions::default()
+            } else {
+                GovernanceOptions {
+                    policy: Some(json!([deny(
+                        "ex:hideScore",
+                        on_property("http://example.org/score")
+                    )])),
+                    default_allow: Some(true),
+                    ..Default::default()
+                }
+            });
+            let flat = json!({
+                "@context": context(), "from": source, "select": ["?s"],
+                "where": {"@id": "?s", "@type": "ex:Person"}
+            });
+            let flat_result = fluree
+                .query_from()
+                .jsonld(&flat)
+                .authorization(&auth)
+                .execute_formatted()
+                .await
+                .unwrap();
+            assert_eq!(
+                flat_result.as_array().unwrap().len(),
+                if deny_all { 0 } else { 5 }
+            );
+            let crawl = json!({
+                "@context": context(), "from": source, "select": {"?s": ["*"]},
+                "where": {"@id": "?s", "@type": "ex:Person"}
+            });
+            let formatted = fluree
+                .query_from()
+                .jsonld(&crawl)
+                .authorization(&auth)
+                .execute_formatted()
+                .await
+                .unwrap();
+            let string = fluree
+                .query_from()
+                .jsonld(&crawl)
+                .authorization(&auth)
+                .execute_formatted_string()
+                .await
+                .unwrap();
+            let tracked = fluree
+                .query_from()
+                .jsonld(&crawl)
+                .authorization(&auth)
+                .execute_tracked()
+                .await
+                .unwrap()
+                .result;
+            assert_eq!(formatted, serde_json::from_str::<Value>(&string).unwrap());
+            assert_eq!(formatted, tracked);
+            assert_eq!(
+                formatted.as_array().unwrap().len(),
+                if deny_all { 0 } else { 5 }
+            );
+            if !deny_all {
+                assert!(formatted.to_string().contains("alice"));
+                assert!(
+                    !formatted.to_string().contains("score"),
+                    "{source}: {formatted}"
+                );
+            }
+        }
+    }
 }

--- a/fluree-db-api/tests/it_policy_query_connection.rs
+++ b/fluree-db-api/tests/it_policy_query_connection.rs
@@ -637,3 +637,122 @@ async fn jsonld_ask_and_where_together_fails_closed() {
         }
     }
 }
+
+/// Every terminal applies the trusted selection after untrusted JSON/source
+/// options. A positive public-property query prevents deny-all false positives.
+#[tokio::test]
+async fn trusted_authorization_binds_all_builder_terminals() {
+    use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = "policy/trusted:main";
+    seed_people_with_ssn(&fluree, ledger).await;
+    let authorization = PolicyAuthorization::from_trusted_options(GovernanceOptions {
+        policy: Some(json!([{
+            "f:required": true, "f:action": "f:view", "f:allow": false,
+            "f:onProperty": [{"@id": "http://schema.org/ssn"}]
+        }])),
+        default_allow: Some(true),
+        ..Default::default()
+    });
+    let query = json!({
+        "from": {"@id": ledger, "policy": {"default-allow": true}},
+        "opts": {"policy": [{"f:required": true, "f:allow": true}], "default-allow": true},
+        "select": ["?value"],
+        "where": {"@id": "?s", "http://schema.org/ssn": "?value"}
+    });
+    assert_eq!(
+        fluree
+            .query_from()
+            .jsonld(&query)
+            .authorization(&authorization)
+            .execute_formatted()
+            .await
+            .unwrap(),
+        json!([])
+    );
+    let text = fluree
+        .query_from()
+        .authorization(&authorization)
+        .jsonld(&query)
+        .execute_formatted_string()
+        .await
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&text).unwrap(),
+        json!([])
+    );
+    let tracked = fluree
+        .query_from()
+        .jsonld(&query)
+        .authorization(&authorization)
+        .execute_tracked()
+        .await
+        .unwrap();
+    assert_eq!(tracked.result, json!([]));
+    let raw = fluree
+        .query_from()
+        .jsonld(&query)
+        .authorization(&authorization)
+        .execute()
+        .await
+        .unwrap();
+    let loaded = fluree.ledger(ledger).await.unwrap();
+    assert_eq!(raw.to_jsonld(&loaded.snapshot).unwrap(), json!([]));
+    let mut public = query.clone();
+    public["where"] = json!({"@id": "?s", "http://schema.org/name": "?value"});
+    assert!(!fluree
+        .query_from()
+        .jsonld(&public)
+        .authorization(&authorization)
+        .execute_formatted()
+        .await
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .is_empty());
+    let sparql =
+        format!("SELECT ?value FROM <{ledger}> WHERE {{ ?s <http://schema.org/ssn> ?value }}");
+    let result = fluree
+        .query_from()
+        .sparql(&sparql)
+        .authorization(&authorization)
+        .connection_opts(GovernanceOptions {
+            default_allow: Some(true),
+            ..Default::default()
+        })
+        .execute_formatted()
+        .await
+        .unwrap();
+    assert_eq!(result.pointer("/results/bindings").unwrap(), &json!([]));
+    let deny = PolicyAuthorization::from_trusted_options(GovernanceOptions::default());
+    assert_eq!(
+        fluree
+            .query_from()
+            .jsonld(&public)
+            .authorization(&deny)
+            .execute_formatted()
+            .await
+            .unwrap(),
+        json!([])
+    );
+    assert!(fluree
+        .query_from()
+        .jsonld(&query)
+        .authorization(&authorization)
+        .policy(fluree_db_api::PolicyContext::new(
+            fluree_db_api::PolicyWrapper::root(),
+            None
+        ))
+        .validate()
+        .is_err());
+    assert!(fluree
+        .query_from()
+        .jsonld(&query)
+        .policy(fluree_db_api::PolicyContext::new(
+            fluree_db_api::PolicyWrapper::root(),
+            None
+        ))
+        .authorization(&authorization)
+        .validate()
+        .is_err());
+}

--- a/fluree-db-api/tests/it_policy_query_connection.rs
+++ b/fluree-db-api/tests/it_policy_query_connection.rs
@@ -756,3 +756,225 @@ async fn trusted_authorization_binds_all_builder_terminals() {
         .validate()
         .is_err());
 }
+
+/// Solo resolves grants in its router and calls the embedded API without a
+/// server credential. Preserve both its class-selected requests and its
+/// explicit allow for grants without row restrictions. Privileged reads must
+/// also be explicit on configured ledgers: omitted inputs now honor defaults.
+#[tokio::test]
+async fn solo_embedded_policy_selection_and_privileged_read_defaults() {
+    use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "policy/solo-compat:main";
+    let ledger = seed_people_with_ssn(&fluree, ledger_id).await;
+    let mut query = json!({
+        "from": ledger_id,
+        "select": "?name",
+        "where": {"@id": "?s", "http://schema.org/name": "?name"}
+    });
+    let names = json!(["Alice", "John"]);
+    assert_eq!(
+        normalize_rows(
+            &fluree
+                .query_from()
+                .jsonld(&query)
+                .execute_formatted()
+                .await
+                .unwrap()
+        ),
+        normalize_rows(&names),
+        "an unconfigured embedded ledger remains unrestricted"
+    );
+    fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&format!(
+            r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix ex: <http://example.org/ns/> .
+        ex:nameAccess a ex:NameReader ; f:action f:view ;
+            f:onProperty <http://schema.org/name> ; f:allow true .
+        ex:defaultRestriction a ex:DefaultPolicy ; f:action f:view ;
+            f:onProperty <http://schema.org/name> ; f:allow false .
+        GRAPH <urn:fluree:{ledger_id}#config> {{
+            <urn:cfg:main> a f:LedgerConfig ; f:policyDefaults <urn:cfg:policy> .
+            <urn:cfg:policy> f:defaultAllow false ; f:policyClass ex:DefaultPolicy .
+        }}
+    "
+        ))
+        .execute()
+        .await
+        .unwrap();
+
+    // Shapes emitted by Solo's merge_policy_into_opts and privileged paths.
+    for (opts, expected) in [
+        (json!({}), json!([])),
+        (
+            json!({"identity": "http://example.org/ns/alice",
+            "policy-class": ["http://example.org/ns/NameReader"]}),
+            names.clone(),
+        ),
+        (
+            json!({"identity": "http://example.org/ns/alice", "default-allow": true}),
+            names.clone(),
+        ),
+        (json!({"default-allow": true}), names.clone()),
+        (
+            json!({"identity": "http://example.org/ns/alice",
+            "policy-class": [], "default-allow": true}),
+            names.clone(),
+        ),
+    ] {
+        query["opts"] = opts.clone();
+        let result = fluree
+            .query_from()
+            .jsonld(&query)
+            .execute_formatted()
+            .await
+            .unwrap();
+        assert_eq!(
+            normalize_rows(&result),
+            normalize_rows(&expected),
+            "opts: {opts}"
+        );
+
+        let governance = GovernanceOptions::from_json(&query).unwrap();
+        let sparql = format!(
+            "SELECT ?name FROM <{ledger_id}> WHERE {{ ?s <http://schema.org/name> ?name }}"
+        );
+        let result = fluree
+            .query_from()
+            .sparql(&sparql)
+            .connection_opts(governance.clone())
+            .execute_formatted()
+            .await
+            .unwrap();
+        assert_eq!(
+            result["results"]["bindings"].as_array().unwrap().len(),
+            expected.as_array().unwrap().len(),
+            "SPARQL opts: {opts}"
+        );
+
+        // Adopting the new fixed-context helper requires no token/issuer setup.
+        let authorization = PolicyAuthorization::from_trusted_options(governance);
+        let result = fluree
+            .query_from()
+            .jsonld(&query)
+            .authorization(&authorization)
+            .execute_formatted()
+            .await
+            .unwrap();
+        assert_eq!(
+            normalize_rows(&result),
+            normalize_rows(&expected),
+            "authorized opts: {opts}"
+        );
+
+        // Solo's streaming Lambda uses the dataset producer directly.
+        let dataset = fluree.build_stream_dataset(&query).await.unwrap();
+        let plan = fluree
+            .plan_stream_query_dataset(
+                &dataset,
+                &fluree_db_api::OwnedStreamQuery::JsonLd(query.clone()),
+            )
+            .await
+            .unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1024);
+        fluree
+            .run_stream_query_dataset(
+                dataset,
+                plan,
+                fluree_db_api::Tracker::new(fluree_db_api::TrackingOptions::default()),
+                fluree_db_api::QueryExecutionOptions::default(),
+                tx,
+            )
+            .await;
+        let mut bytes = Vec::new();
+        while let Some(chunk) = rx.recv().await {
+            bytes.extend_from_slice(&chunk);
+        }
+        let records: Vec<serde_json::Value> = String::from_utf8(bytes)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(
+            records.last().unwrap()["type"],
+            "end",
+            "stream opts: {opts}"
+        );
+        assert_eq!(
+            records.last().unwrap()["rows"],
+            expected.as_array().unwrap().len(),
+            "stream opts: {opts}"
+        );
+    }
+
+    query["opts"] = json!({"identity": "http://example.org/ns/alice",
+        "policy-class": ["http://example.org/ns/NameReader"]});
+    query["where"] = json!({"@id": "?s", "http://schema.org/ssn": "?name"});
+    assert_eq!(
+        fluree
+            .query_from()
+            .jsonld(&query)
+            .execute_formatted()
+            .await
+            .unwrap(),
+        json!([]),
+        "class-selected access must still hide ungranted properties"
+    );
+
+    // A shared governance model still supplies rules for a default-allow-only
+    // request. Where overrides are allowed, the host can deliberately select
+    // no classes as well as an allow default to express its privileged grant.
+    let model_id = "policy/solo-compat-model:main";
+    fluree
+        .stage_owned(genesis_ledger(&fluree, model_id))
+        .upsert_turtle(
+            r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix ex: <http://example.org/ns/> .
+        GRAPH <http://example.org/model-policy> {
+            ex:deny a ex:DefaultPolicy ; f:action f:view ;
+                f:onProperty <http://schema.org/name> ; f:allow false .
+        }
+    ",
+        )
+        .execute()
+        .await
+        .unwrap();
+    fluree
+        .stage_owned(fluree.ledger(ledger_id).await.unwrap())
+        .upsert_turtle(&format!(
+            r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        GRAPH <urn:fluree:{ledger_id}#config> {{
+            <urn:cfg:policy> f:policySource <urn:cfg:ref> .
+            <urn:cfg:ref> a f:GraphRef ; f:graphSource <urn:cfg:source> .
+            <urn:cfg:source> f:ledger <{model_id}> ;
+                f:graphSelector <http://example.org/model-policy> .
+        }}
+    "
+        ))
+        .execute()
+        .await
+        .unwrap();
+    query["where"] = json!({"@id": "?s", "http://schema.org/name": "?name"});
+    for (opts, expected) in [
+        (json!({"default-allow": true}), json!([])),
+        (json!({"policy-class": [], "default-allow": true}), names),
+    ] {
+        query["opts"] = opts.clone();
+        let result = fluree
+            .query_from()
+            .jsonld(&query)
+            .execute_formatted()
+            .await
+            .unwrap();
+        assert_eq!(
+            normalize_rows(&result),
+            normalize_rows(&expected),
+            "model opts: {opts}"
+        );
+    }
+}

--- a/fluree-db-api/tests/it_policy_query_connection.rs
+++ b/fluree-db-api/tests/it_policy_query_connection.rs
@@ -978,3 +978,162 @@ async fn solo_embedded_policy_selection_and_privileged_read_defaults() {
         );
     }
 }
+
+#[tokio::test]
+async fn policy_defaults_config_read_error_must_fail_closed() {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    struct FailedConfig(Arc<AtomicUsize>);
+    impl fluree_db_core::RangeProvider for FailedConfig {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn range(
+            &self,
+            query: &fluree_db_core::RangeQuery<'_>,
+        ) -> std::io::Result<Vec<fluree_db_core::Flake>> {
+            assert_eq!(query.g_id, 2);
+            self.0.fetch_add(1, Ordering::Relaxed);
+            Err(std::io::Error::other("simulated config index read failure"))
+        }
+    }
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree
+        .create_ledger("review/config-failure:main")
+        .await
+        .unwrap();
+    let count = Arc::new(AtomicUsize::new(0));
+    let mut snapshot = (*ledger.snapshot).clone();
+    snapshot.range_provider = Some(Arc::new(FailedConfig(count.clone())));
+    let db = fluree_db_api::GraphDb::new(
+        Arc::new(snapshot),
+        Arc::new(fluree_db_core::NoOverlay),
+        None,
+        0,
+        "review/config-failure:main",
+    );
+    let result = fluree.wrap_policy_defaults(db).await;
+    assert!(count.load(Ordering::Relaxed) > 0, "fault must be exercised");
+    assert!(
+        result.is_err(),
+        "config read failure returned an unrestricted view: {}",
+        result
+            .as_ref()
+            .map(fluree_db_api::GraphDb::is_root)
+            .unwrap_or(false)
+    );
+}
+
+#[tokio::test]
+async fn absent_config_is_resolved_once_through_wrapping_and_execution() {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    struct EmptyIndex(Arc<AtomicUsize>);
+    impl fluree_db_core::RangeProvider for EmptyIndex {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn range(
+            &self,
+            query: &fluree_db_core::RangeQuery<'_>,
+        ) -> std::io::Result<Vec<fluree_db_core::Flake>> {
+            if query.g_id == 2 {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+            Ok(vec![])
+        }
+    }
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("policy/no-config:main").await.unwrap();
+    let count = Arc::new(AtomicUsize::new(0));
+    let mut snapshot = (*ledger.snapshot).clone();
+    snapshot.range_provider = Some(Arc::new(EmptyIndex(count.clone())));
+    let db = fluree_db_api::GraphDb::new(
+        Arc::new(snapshot),
+        Arc::new(fluree_db_core::NoOverlay),
+        None,
+        0,
+        "policy/no-config:main",
+    );
+    let view = fluree.wrap_policy_defaults(db).await.unwrap();
+    assert_eq!(count.load(Ordering::Relaxed), 1);
+    let query =
+        json!({"select": ["?s"], "where": {"@id": "?s", "@type": "http://example.org/User"}});
+    for _ in 0..2 {
+        let view = fluree.wrap_policy_defaults(view.clone()).await.unwrap();
+        fluree.query(&view, &query).await.unwrap();
+    }
+    assert_eq!(
+        count.load(Ordering::Relaxed),
+        1,
+        "plain execution must reuse absent config"
+    );
+    fluree.wrap_policy_defaults(view.as_of(1)).await.unwrap();
+    assert_eq!(
+        count.load(Ordering::Relaxed),
+        2,
+        "a different snapshot must resolve anew"
+    );
+}
+
+#[tokio::test]
+async fn scoped_explain_withholds_statistics_for_every_language() {
+    use fluree_db_api::{GovernanceOptions, GraphDb};
+    use fluree_db_core::{IndexStats, PropertyStatEntry};
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = seed_people_with_ssn(&fluree, "policy/explain:main").await;
+    let mut view = GraphDb::from_ledger_state(&ledger);
+    let predicate = view.snapshot.encode_iri("http://schema.org/name").unwrap();
+    // Deliberately distinctive stored counts: policy must not disclose them.
+    std::sync::Arc::make_mut(&mut view.snapshot).stats = Some(IndexStats {
+        flakes: 987_654,
+        properties: Some(vec![PropertyStatEntry {
+            sid: (predicate.namespace_code, predicate.name.to_string()),
+            count: 987_654,
+            ndv_values: 987_654,
+            ndv_subjects: 987_654,
+            last_modified_t: 1,
+            datatypes: vec![],
+            observed_datatypes: vec![],
+            historical_datatypes: vec![],
+        }]),
+        ..Default::default()
+    });
+    let scoped = fluree
+        .wrap_policy(
+            view.clone(),
+            &GovernanceOptions {
+                default_allow: Some(false),
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    let jsonld =
+        json!({"select": ["?name"], "where": {"@id": "?s", "http://schema.org/name": "?name"}});
+    let sparql = "SELECT ?name WHERE { ?s <http://schema.org/name> ?name }";
+    let root = fluree.explain(&view, &jsonld).await.unwrap();
+    assert!(root.to_string().contains("987654"), "{root}");
+    for result in [
+        fluree.explain(&scoped, &jsonld).await.unwrap(),
+        fluree.explain_sparql(&scoped, sparql).await.unwrap(),
+        fluree
+            .explain_cypher(
+                &scoped,
+                "MATCH (n:`http://example.org/ns/User`) RETURN n",
+                None,
+            )
+            .await
+            .unwrap(),
+    ] {
+        assert!(result["plan"]["logical"].is_array(), "{result}");
+        assert!(!result.to_string().contains("987654"), "{result}");
+        assert!(result["plan"].get("statistics").is_none(), "{result}");
+    }
+    assert_eq!(view.snapshot.stats.as_ref().unwrap().flakes, 987_654);
+}

--- a/fluree-db-api/tests/it_policy_write_path.rs
+++ b/fluree-db-api/tests/it_policy_write_path.rs
@@ -819,3 +819,67 @@ async fn cross_ledger_identity_binding_drives_fquery_modify_rule() {
         "identity must NOT be able to write another user's email, got: {other:?}"
     );
 }
+
+/// A configured deny default is enforcement even without identity/classes.
+/// Explicit host allow remains available when the config permits overrides.
+#[tokio::test]
+async fn default_only_configuration_governs_embedded_reads_and_writes() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger_id = "policy/default-only:main";
+    let ledger = crate::support::seed_people_with_ssn(&fluree, ledger_id).await;
+    let ledger = fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&format!(
+            r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        GRAPH <urn:fluree:{ledger_id}#config> {{
+            <urn:cfg:main> a f:LedgerConfig ; f:policyDefaults <urn:cfg:policy> .
+            <urn:cfg:policy> f:defaultAllow false .
+        }}
+    "
+        ))
+        .execute()
+        .await
+        .unwrap()
+        .ledger;
+    for (opts, allowed) in [
+        (json!({}), false),
+        (json!({"default-allow": false}), false),
+        (json!({"default-allow": true}), true),
+    ] {
+        let query = json!({"from": ledger_id, "opts": opts, "select": "?name",
+            "where": {"@id": "?s", "http://schema.org/name": "?name"}});
+        let result = fluree
+            .query_from()
+            .jsonld(&query)
+            .execute_formatted()
+            .await
+            .unwrap();
+        assert_eq!(
+            result.as_array().unwrap().len(),
+            if allowed { 2 } else { 0 }
+        );
+        let governance = GovernanceOptions::from_json(&query).unwrap();
+        let policy = build_transact_policy_context(
+            &fluree,
+            &ledger.snapshot,
+            ledger.novelty.as_ref(),
+            Some(ledger.novelty.as_ref()),
+            ledger.t(),
+            &governance,
+        )
+        .await
+        .unwrap();
+        let result = fluree
+            .insert_turtle_with_opts(
+                ledger.clone(),
+                "<http://example.org/new> <http://schema.org/name> \"New\" .",
+                TxnOpts::default(),
+                CommitOpts::default(),
+                &test_index_config(),
+                policy.as_ref(),
+            )
+            .await;
+        assert_eq!(result.is_ok(), allowed, "opts: {opts}, result: {result:?}");
+    }
+}

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -2752,6 +2752,11 @@ pub struct TokenCreateArgs {
     #[arg(long)]
     pub identity: Option<String>,
 
+    /// Allow this backend credential to select request policies (requires --audience
+    /// and a receiving server that trusts the issuer as a policy authority)
+    #[arg(long, requires = "audiences")]
+    pub policy_controller: bool,
+
     /// Grant access to all ledgers (fluree.events.all=true, fluree.storage.all=true)
     #[arg(long)]
     pub all: bool,

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -2755,7 +2755,7 @@ pub struct TokenCreateArgs {
     /// Allow this backend credential to select request policies (requires --audience
     /// and a receiving server that trusts the issuer as a policy authority)
     #[arg(long, requires = "audiences")]
-    pub policy_controller: bool,
+    pub policy_select: bool,
 
     /// Grant access to all ledgers (fluree.events.all=true, fluree.storage.all=true)
     #[arg(long)]

--- a/fluree-db-cli/src/commands/token.rs
+++ b/fluree-db-cli/src/commands/token.rs
@@ -25,7 +25,7 @@ struct TokenClaims<'a> {
 /// Permission settings for the token.
 struct TokenPermissions<'a> {
     /// Allow request policy selection within the data scopes.
-    policy_controller: bool,
+    policy_select: bool,
     /// Grant all permissions.
     all: bool,
     /// Ledgers for events access.
@@ -53,7 +53,7 @@ pub fn run(action: TokenAction) -> CliResult<()> {
                 identity: args.identity.as_deref(),
             };
             let permissions = TokenPermissions {
-                policy_controller: args.policy_controller,
+                policy_select: args.policy_select,
                 all: args.all,
                 events_ledgers: &args.events_ledgers,
                 storage_ledgers: &args.storage_ledgers,
@@ -150,7 +150,7 @@ fn run_create(
         claims["fluree.identity"] = json!(id);
     }
 
-    if permissions.policy_controller {
+    if permissions.policy_select {
         claims["fluree.policy"] = json!("request");
     }
 

--- a/fluree-db-cli/src/commands/token.rs
+++ b/fluree-db-cli/src/commands/token.rs
@@ -24,6 +24,8 @@ struct TokenClaims<'a> {
 
 /// Permission settings for the token.
 struct TokenPermissions<'a> {
+    /// Allow request policy selection within the data scopes.
+    policy_controller: bool,
     /// Grant all permissions.
     all: bool,
     /// Ledgers for events access.
@@ -51,6 +53,7 @@ pub fn run(action: TokenAction) -> CliResult<()> {
                 identity: args.identity.as_deref(),
             };
             let permissions = TokenPermissions {
+                policy_controller: args.policy_controller,
                 all: args.all,
                 events_ledgers: &args.events_ledgers,
                 storage_ledgers: &args.storage_ledgers,
@@ -145,6 +148,10 @@ fn run_create(
 
     if let Some(id) = token_claims.identity {
         claims["fluree.identity"] = json!(id);
+    }
+
+    if permissions.policy_controller {
+        claims["fluree.policy"] = json!("request");
     }
 
     // Events permissions

--- a/fluree-db-cli/tests/token_controller.rs
+++ b/fluree-db-cli/tests/token_controller.rs
@@ -1,0 +1,60 @@
+use assert_cmd::cargo_bin_cmd;
+use fluree_db_credential::{verify_jws, EventsTokenPayload};
+
+#[test]
+fn controller_credential_is_explicit_signed_and_scoped() {
+    // Fixed fixture key, used only to verify the CLI's signed output locally.
+    let key = format!("0x{}", "42".repeat(32));
+    for controller in [false, true] {
+        let mut cmd = cargo_bin_cmd!("fluree");
+        cmd.args([
+            "token",
+            "create",
+            "--private-key",
+            &key,
+            "--audience",
+            "test-db",
+            "--read-ledger",
+            "books:main",
+        ]);
+        if controller {
+            cmd.arg("--policy-controller");
+        }
+        let output = cmd.assert().success().get_output().stdout.clone();
+        let token = String::from_utf8(output).unwrap();
+        let verified = verify_jws(token.trim()).unwrap();
+        let claims: EventsTokenPayload = serde_json::from_str(&verified.payload).unwrap();
+        claims
+            .validate(Some("test-db"), &verified.did, false)
+            .unwrap();
+        assert_eq!(
+            matches!(
+                claims.fluree_policy,
+                Some(fluree_db_credential::jwt_claims::PolicyClaim::Request(_))
+            ),
+            controller
+        );
+        assert_eq!(
+            claims.ledger_read_ledgers,
+            Some(vec!["books:main".to_string()])
+        );
+        assert!(!claims.has_ledger_write_permissions());
+    }
+}
+
+#[test]
+fn controller_creation_requires_an_audience() {
+    cargo_bin_cmd!("fluree")
+        .args([
+            "token",
+            "create",
+            "--private-key",
+            "0x4242424242424242424242424242424242424242424242424242424242424242",
+            "--read-ledger",
+            "books:main",
+            "--policy-controller",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--audience"));
+}

--- a/fluree-db-cli/tests/token_policy_select.rs
+++ b/fluree-db-cli/tests/token_policy_select.rs
@@ -2,10 +2,10 @@ use assert_cmd::cargo_bin_cmd;
 use fluree_db_credential::{verify_jws, EventsTokenPayload};
 
 #[test]
-fn controller_credential_is_explicit_signed_and_scoped() {
+fn request_selection_credential_is_explicit_signed_and_scoped() {
     // Fixed fixture key, used only to verify the CLI's signed output locally.
     let key = format!("0x{}", "42".repeat(32));
-    for controller in [false, true] {
+    for select_policy in [false, true] {
         let mut cmd = cargo_bin_cmd!("fluree");
         cmd.args([
             "token",
@@ -17,8 +17,8 @@ fn controller_credential_is_explicit_signed_and_scoped() {
             "--read-ledger",
             "books:main",
         ]);
-        if controller {
-            cmd.arg("--policy-controller");
+        if select_policy {
+            cmd.arg("--policy-select");
         }
         let output = cmd.assert().success().get_output().stdout.clone();
         let token = String::from_utf8(output).unwrap();
@@ -32,7 +32,7 @@ fn controller_credential_is_explicit_signed_and_scoped() {
                 claims.fluree_policy,
                 Some(fluree_db_credential::jwt_claims::PolicyClaim::Request(_))
             ),
-            controller
+            select_policy
         );
         assert_eq!(
             claims.ledger_read_ledgers,
@@ -43,7 +43,7 @@ fn controller_credential_is_explicit_signed_and_scoped() {
 }
 
 #[test]
-fn controller_creation_requires_an_audience() {
+fn request_selection_creation_requires_an_audience() {
     cargo_bin_cmd!("fluree")
         .args([
             "token",
@@ -52,7 +52,7 @@ fn controller_creation_requires_an_audience() {
             "0x4242424242424242424242424242424242424242424242424242424242424242",
             "--read-ledger",
             "books:main",
-            "--policy-controller",
+            "--policy-select",
         ])
         .assert()
         .failure()

--- a/fluree-db-credential/src/jwt_claims.rs
+++ b/fluree-db-credential/src/jwt_claims.rs
@@ -93,6 +93,39 @@ pub struct EventsTokenPayload {
     /// Identity for policy resolution
     #[serde(rename = "fluree.identity")]
     pub fluree_identity: Option<String>,
+
+    /// Application-selected policies. This claim conveys authority only when
+    /// the receiving server explicitly trusts the verified issuer to select
+    /// policies. Ledger/action scopes, audience and expiry still apply.
+    #[serde(
+        rename = "fluree.policy",
+        default,
+        deserialize_with = "deserialize_delegated_policy"
+    )]
+    pub fluree_policy: Option<DelegatedPolicy>,
+}
+
+/// Signed policy selection for a trusted application gateway.
+/// Identity comes from `fluree.identity` / `sub`; this selection applies uniformly
+/// to the token's authorized ledger/action scopes. Unknown fields are rejected.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct DelegatedPolicy {
+    pub policy_class: Option<Vec<String>>,
+    pub policy: Option<serde_json::Value>,
+    pub policy_values: Option<std::collections::HashMap<String, serde_json::Value>>,
+    pub default_allow: Option<bool>,
+}
+
+// Missing means ordinary authentication; a present null/malformed context must
+// not silently fall back to a scope-only service credential.
+fn deserialize_delegated_policy<'de, D>(
+    deserializer: D,
+) -> Result<Option<DelegatedPolicy>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    DelegatedPolicy::deserialize(deserializer).map(Some)
 }
 
 /// Error type for JWT claims validation
@@ -414,6 +447,7 @@ mod tests {
             ledger_write_all: None,
             ledger_write_ledgers: None,
             fluree_identity: None,
+            fluree_policy: None,
         }
     }
 
@@ -789,6 +823,7 @@ mod tests {
             ledger_write_all: None,
             ledger_write_ledgers: None,
             fluree_identity: Some("did:key:z6MkTest".to_string()),
+            fluree_policy: None,
         }
     }
 

--- a/fluree-db-credential/src/jwt_claims.rs
+++ b/fluree-db-credential/src/jwt_claims.rs
@@ -100,9 +100,24 @@ pub struct EventsTokenPayload {
     #[serde(
         rename = "fluree.policy",
         default,
-        deserialize_with = "deserialize_delegated_policy"
+        deserialize_with = "deserialize_policy_claim"
     )]
-    pub fluree_policy: Option<DelegatedPolicy>,
+    pub fluree_policy: Option<PolicyClaim>,
+}
+
+/// Policy authority carried by one signed claim: a fixed object or "request".
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum PolicyClaim {
+    Fixed(DelegatedPolicy),
+    Request(RequestPolicy),
+}
+
+/// The only accepted string form of `fluree.policy`.
+#[derive(Debug, Clone, Deserialize)]
+pub enum RequestPolicy {
+    #[serde(rename = "request")]
+    Request,
 }
 
 /// Signed policy selection for a trusted application gateway.
@@ -119,13 +134,11 @@ pub struct DelegatedPolicy {
 
 // Missing means ordinary authentication; a present null/malformed context must
 // not silently fall back to a scope-only service credential.
-fn deserialize_delegated_policy<'de, D>(
-    deserializer: D,
-) -> Result<Option<DelegatedPolicy>, D::Error>
+fn deserialize_policy_claim<'de, D>(deserializer: D) -> Result<Option<PolicyClaim>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    DelegatedPolicy::deserialize(deserializer).map(Some)
+    PolicyClaim::deserialize(deserializer).map(Some)
 }
 
 /// Error type for JWT claims validation
@@ -891,5 +904,48 @@ mod tests {
                 false,
             )
             .is_ok());
+    }
+}
+
+#[cfg(test)]
+mod policy_claim_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn policy_claim_has_one_unambiguous_mode() {
+        let base = json!({"iss": "test-issuer", "exp": 1});
+        assert!(serde_json::from_value::<EventsTokenPayload>(base.clone())
+            .unwrap()
+            .fluree_policy
+            .is_none());
+        for (claim, request) in [
+            (json!("request"), true),
+            (json!({}), false),
+            (
+                json!({"policy-class": ["ex:Reader"], "default-allow": false}),
+                false,
+            ),
+        ] {
+            let mut token = base.clone();
+            token["fluree.policy"] = claim;
+            let parsed: EventsTokenPayload = serde_json::from_value(token).unwrap();
+            assert_eq!(
+                matches!(parsed.fluree_policy, Some(PolicyClaim::Request(_))),
+                request
+            );
+        }
+        for claim in [
+            json!(null),
+            json!(true),
+            json!("controller"),
+            json!(["request", {}]),
+            json!({"request": true}),
+            json!({"policy-class": "ex:Reader"}),
+        ] {
+            let mut token = base.clone();
+            token["fluree.policy"] = claim;
+            assert!(serde_json::from_value::<EventsTokenPayload>(token).is_err());
+        }
     }
 }

--- a/fluree-db-server/Cargo.toml
+++ b/fluree-db-server/Cargo.toml
@@ -176,6 +176,7 @@ tokio-util = { version = "0.7", features = ["rt", "io"] }
 http-body-util = { workspace = true }
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["async_tokio"] }
 tokio = { workspace = true, features = ["test-util"] }
 http-body-util = { workspace = true }
 tower = { workspace = true, features = ["util"] }
@@ -188,6 +189,11 @@ fluree-test-support = { path = "../fluree-test-support" }
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "policy_http"
+harness = false
+required-features = ["native", "credential"]
 
 # Integration tests are grouped into grp_* harnesses so the crate links a
 # handful of test binaries instead of one per tests/*.rs file. `autotests =

--- a/fluree-db-server/benches/policy_http.rs
+++ b/fluree-db-server/benches/policy_http.rs
@@ -1,0 +1,176 @@
+//! Warm, in-process HTTP requests, including credential verification, policy
+//! binding, config resolution, execution and response serialization. Socket/TLS
+//! costs are excluded. All modes read the same one-row result from novelty.
+//! Run with `cargo bench -p fluree-db-server --bench policy_http`.
+
+use axum::{body::Body, Router};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use criterion::{criterion_group, criterion_main, Criterion};
+use ed25519_dalek::{Signer, SigningKey};
+use fluree_db_server::{
+    config::DataAuthMode, routes::build_router, AppState, ServerConfig, TelemetryConfig,
+};
+use http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tower::ServiceExt;
+
+const LEDGER: &str = "bench-policy:main";
+const CLASS: &str = "http://example.org/Reader";
+
+fn token(key: &SigningKey, policy: Option<Value>) -> String {
+    let public = key.verifying_key().to_bytes();
+    let mut claims = json!({
+        "iss": fluree_db_credential::did_from_pubkey(&public),
+        "aud": "policy-bench", "sub": "http://example.org/user",
+        "exp": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 3600,
+        "fluree.ledger.read.ledgers": [LEDGER]
+    });
+    if let Some(policy) = policy {
+        claims["fluree.policy"] = policy;
+    }
+    let header = json!({"alg": "EdDSA", "jwk": {
+        "kty": "OKP", "crv": "Ed25519", "x": URL_SAFE_NO_PAD.encode(public)
+    }});
+    let input = format!(
+        "{}.{}",
+        URL_SAFE_NO_PAD.encode(header.to_string()),
+        URL_SAFE_NO_PAD.encode(claims.to_string())
+    );
+    let signature = key.sign(input.as_bytes());
+    format!("{input}.{}", URL_SAFE_NO_PAD.encode(signature.to_bytes()))
+}
+
+async fn app(mode: DataAuthMode, key: &SigningKey) -> (tempfile::TempDir, Router) {
+    let directory = tempfile::tempdir().unwrap();
+    let config = ServerConfig {
+        storage_path: Some(directory.path().to_owned()),
+        indexing_enabled: false,
+        cors_enabled: false,
+        data_auth_mode: mode,
+        data_auth_audience: Some("policy-bench".into()),
+        data_auth_policy_authorities: vec![fluree_db_credential::did_from_pubkey(
+            &key.verifying_key().to_bytes(),
+        )],
+        data_auth_default_policy_class: Some(CLASS.into()),
+        ..Default::default()
+    };
+    let telemetry = TelemetryConfig::with_server_config(&config);
+    let state = Arc::new(AppState::new(config, telemetry).await.unwrap());
+    let ledger = state.fluree.create_ledger(LEDGER).await.unwrap();
+    let mut data: Vec<Value> = (0..256)
+        .map(|i| {
+            json!({
+                "@id": format!("http://example.org/person/{i}"),
+                "http://example.org/name": format!("Person {i}")
+            })
+        })
+        .collect();
+    data.push(json!({
+        "@id": "http://example.org/read", "@type": CLASS,
+        "https://ns.flur.ee/db#action": {"@id": "https://ns.flur.ee/db#view"},
+        "https://ns.flur.ee/db#allow": true
+    }));
+    state
+        .fluree
+        .insert(ledger, &json!({"@graph": data}))
+        .await
+        .unwrap();
+    (directory, build_router(state))
+}
+
+async fn request(app: &Router, token: Option<&str>, body: &str) -> Vec<u8> {
+    let mut request = Request::builder()
+        .method("POST")
+        .uri(format!("/v1/fluree/query/{LEDGER}"))
+        .header("content-type", "application/json");
+    if let Some(token) = token {
+        request = request.header("authorization", format!("Bearer {token}"));
+    }
+    let response = app
+        .clone()
+        .oneshot(request.body(Body::from(body.to_owned())).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec()
+}
+
+fn bench_http(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let key = SigningKey::from_bytes(&[201; 32]);
+    let (_plain_dir, plain) = runtime.block_on(app(DataAuthMode::None, &key));
+    let (_auth_dir, authenticated) = runtime.block_on(app(DataAuthMode::Required, &key));
+    let query = json!({
+        "select": ["?name"],
+        "where": {"@id": "http://example.org/person/0", "http://example.org/name": "?name"}
+    });
+    let mut selected = query.clone();
+    selected["opts"] = json!({"policy-class": [CLASS]});
+    let inline: Vec<_> = (0..32)
+        .map(|i| {
+            json!({
+                "@id": format!("http://example.org/rule/{i}"),
+                "f:action": "f:view", "f:allow": true
+            })
+        })
+        .collect();
+    let cases = [
+        ("no_auth", &plain, None, query.to_string()),
+        (
+            "ordinary",
+            &authenticated,
+            Some(token(&key, None)),
+            query.to_string(),
+        ),
+        (
+            "fixed",
+            &authenticated,
+            Some(token(&key, Some(json!({"policy-class": [CLASS]})))),
+            query.to_string(),
+        ),
+        (
+            "request",
+            &authenticated,
+            Some(token(&key, Some(json!("request")))),
+            selected.to_string(),
+        ),
+        (
+            "fixed_inline_32",
+            &authenticated,
+            Some(token(
+                &key,
+                Some(json!({"policy-class": [CLASS], "policy": inline})),
+            )),
+            query.to_string(),
+        ),
+    ];
+    let mut group = c.benchmark_group("policy_http");
+    for (name, app, token, body) in &cases {
+        // Warm caches and require identical effective access before timing.
+        let bytes = runtime.block_on(request(app, token.as_deref(), body));
+        assert_eq!(
+            serde_json::from_slice::<Value>(&bytes).unwrap(),
+            json!([["Person 0"]]),
+            "{name}"
+        );
+        group.bench_function(*name, |b| {
+            b.to_async(&runtime)
+                .iter(|| request(app, token.as_deref(), body));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_http);
+criterion_main!(benches);

--- a/fluree-db-server/src/bolt.rs
+++ b/fluree-db-server/src/bolt.rs
@@ -94,7 +94,11 @@ impl SessionAuth {
     fn governance(&self) -> fluree_db_api::GovernanceOptions {
         self.principal
             .as_ref()
-            .map(|p| p.policy_authorization.options().clone())
+            .map(|p| {
+                p.policy_authorization
+                    .resolve_options(&Default::default())
+                    .expect("omitted selection is valid for every credential mode")
+            })
             .unwrap_or_default()
     }
 }
@@ -206,6 +210,26 @@ async fn handle_connection(
                     break;
                 }
             };
+            // Until transaction-scoped impersonation is implemented, do not
+            // silently execute an impersonated request as the logged-in user.
+            let impersonated = match &request {
+                Request::Run { extra, .. } | Request::Begin { extra } => extra.get("imp_user"),
+                Request::Route {
+                    extra: Value::Map(extra),
+                    ..
+                } => extra.get("imp_user"),
+                _ => None,
+            }
+            .is_some_and(|value| !matches!(value, Value::Null));
+            if impersonated {
+                write_message(
+                    &Response::failure(CODE_INVALID, "Bolt impersonation is not supported")
+                        .encode(),
+                    &mut out_buf,
+                );
+                close = true;
+                break;
+            }
             match session.on_request(request) {
                 Turn::Reply(replies) => {
                     for reply in replies {
@@ -583,7 +607,11 @@ async fn try_execute_txn_run(
             .await
             .map_err(|e| RunFailure::new(CODE_GENERAL, e.to_string()))?
     } else {
-        view
+        state
+            .fluree
+            .wrap_policy_defaults(view)
+            .await
+            .map_err(|e| RunFailure::new(CODE_GENERAL, e.to_string()))?
     };
     let result = state
         .fluree
@@ -660,7 +688,11 @@ async fn execute_read(
             .await
             .map_err(|e| RunFailure::new(CODE_GENERAL, e.to_string()))?
     } else {
-        view
+        state
+            .fluree
+            .wrap_policy_defaults(view)
+            .await
+            .map_err(|e| RunFailure::new(CODE_GENERAL, e.to_string()))?
     };
     let result = state
         .fluree

--- a/fluree-db-server/src/bolt.rs
+++ b/fluree-db-server/src/bolt.rs
@@ -61,17 +61,12 @@ const CODE_TOKEN_EXPIRED: &str = "Neo.ClientError.Security.TokenExpired";
 /// `principal: None` is an anonymous session (allowed outside Required
 /// mode, mirroring the HTTP extractor); scope checks then allow all.
 struct SessionAuth {
-    /// Policy identity (`fluree.identity ?? sub`) for governance wiring.
-    identity: Option<String>,
     principal: Option<DataPrincipal>,
 }
 
 impl SessionAuth {
     fn anonymous() -> Self {
-        Self {
-            identity: None,
-            principal: None,
-        }
+        Self { principal: None }
     }
 
     /// Bolt sessions outlive the login-time `exp` validation; statements
@@ -94,15 +89,13 @@ impl SessionAuth {
             .is_none_or(|p| p.can_write(ledger_id))
     }
 
-    /// Governance for statements in this session. Bolt has no header
-    /// channel for policy knobs (policy-class, default-allow) by design:
-    /// policy derives entirely from the identity's in-ledger bindings
-    /// (plus the ledger's `#config` defaults, merged downstream).
+    /// Reuse the login-time verified policy selection; statements cannot supply
+    /// policy options. Ledger/action scope and expiry are checked per statement.
     fn governance(&self) -> fluree_db_api::GovernanceOptions {
-        fluree_db_api::GovernanceOptions {
-            identity: self.identity.clone(),
-            ..Default::default()
-        }
+        self.principal
+            .as_ref()
+            .map(|p| p.policy_authorization.options().clone())
+            .unwrap_or_default()
     }
 }
 
@@ -376,7 +369,6 @@ async fn authenticate(state: &AppState, auth: &AuthRequest) -> Result<SessionAut
         .await
         .map_err(|e| RunFailure::new(CODE_UNAUTHORIZED, e.to_string()))?;
     Ok(SessionAuth {
-        identity: principal.identity.clone(),
         principal: Some(principal),
     })
 }

--- a/fluree-db-server/src/config.rs
+++ b/fluree-db-server/src/config.rs
@@ -85,7 +85,7 @@ pub struct DataAuthConfig {
     pub audience: Option<String>,
     /// Trusted issuer did:key identifiers for Bearer tokens
     pub trusted_issuers: Vec<String>,
-    /// Verified issuers allowed to select policies via the signed fluree.policy claim.
+    /// Verified issuers allowed to issue fixed policy selections or controller credentials.
     pub policy_authorities: Vec<String>,
     /// Default policy class IRI for authenticated requests without delegated policies.
     pub default_policy_class: Option<String>,
@@ -105,12 +105,13 @@ impl DataAuthConfig {
         }
         if self.mode == DataAuthMode::Required
             && self.trusted_issuers.is_empty()
+            && self.policy_authorities.is_empty()
             && !self.has_jwks_issuers
             && !self.insecure_accept_any_issuer
         {
             return Err(
                 "data_auth.mode=required requires --data-auth-trusted-issuer, \
-                 --jwks-issuer, or --data-auth-insecure-accept-any-issuer flag"
+                 --data-auth-policy-authority, --jwks-issuer, or --data-auth-insecure-accept-any-issuer flag"
                     .to_string(),
             );
         }
@@ -123,10 +124,10 @@ impl DataAuthConfig {
         if self.insecure_accept_any_issuer {
             return true;
         }
-        if self.trusted_issuers.is_empty() {
-            return false;
-        }
-        self.trusted_issuers.iter().any(|i| i == issuer)
+        self.trusted_issuers
+            .iter()
+            .chain(&self.policy_authorities)
+            .any(|i| i == issuer)
     }
 }
 
@@ -626,8 +627,8 @@ pub struct ServerConfig {
     )]
     pub data_auth_trusted_issuers: Vec<String>,
 
-    /// Issuer allowed to select policies in signed fluree.policy claims (repeatable).
-    /// Also requires ordinary issuer trust and --data-auth-audience.
+    /// Issuer allowed to issue fixed policy selections or controller credentials (repeatable).
+    /// Establishes issuer trust and requires --data-auth-audience.
     #[arg(
         long = "data-auth-policy-authority",
         env = "FLUREE_DATA_AUTH_POLICY_AUTHORITIES"
@@ -1461,6 +1462,19 @@ mod gc_retention_flag_tests {
 #[cfg(test)]
 mod policy_authority_tests {
     use super::*;
+
+    #[test]
+    fn policy_authority_also_establishes_issuer_trust() {
+        let config = DataAuthConfig {
+            mode: DataAuthMode::Required,
+            audience: Some("db".into()),
+            policy_authorities: vec!["did:key:app".into()],
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+        assert!(config.is_issuer_trusted("did:key:app"));
+        assert!(!config.is_issuer_trusted("did:key:other"));
+    }
 
     #[test]
     fn policy_authorities_require_an_audience_even_with_development_issuer_trust() {

--- a/fluree-db-server/src/config.rs
+++ b/fluree-db-server/src/config.rs
@@ -85,7 +85,9 @@ pub struct DataAuthConfig {
     pub audience: Option<String>,
     /// Trusted issuer did:key identifiers for Bearer tokens
     pub trusted_issuers: Vec<String>,
-    /// Default policy class IRI (optional). Applied when request does not specify one.
+    /// Verified issuers allowed to select policies via the signed fluree.policy claim.
+    pub policy_authorities: Vec<String>,
+    /// Default policy class IRI for authenticated requests without delegated policies.
     pub default_policy_class: Option<String>,
     /// DANGEROUS: Accept any valid signature regardless of issuer.
     /// Only for development/testing.
@@ -97,6 +99,10 @@ pub struct DataAuthConfig {
 impl DataAuthConfig {
     /// Validate configuration at startup
     pub fn validate(&self) -> Result<(), String> {
+        if !self.policy_authorities.is_empty() && self.audience.as_deref().is_none_or(str::is_empty)
+        {
+            return Err("data policy authorities require --data-auth-audience".to_string());
+        }
         if self.mode == DataAuthMode::Required
             && self.trusted_issuers.is_empty()
             && !self.has_jwks_issuers
@@ -620,6 +626,14 @@ pub struct ServerConfig {
     )]
     pub data_auth_trusted_issuers: Vec<String>,
 
+    /// Issuer allowed to select policies in signed fluree.policy claims (repeatable).
+    /// Also requires ordinary issuer trust and --data-auth-audience.
+    #[arg(
+        long = "data-auth-policy-authority",
+        env = "FLUREE_DATA_AUTH_POLICY_AUTHORITIES"
+    )]
+    pub data_auth_policy_authorities: Vec<String>,
+
     /// Default policy class IRI for data API requests (optional)
     #[arg(long, env = "FLUREE_DATA_AUTH_DEFAULT_POLICY_CLASS")]
     pub data_auth_default_policy_class: Option<String>,
@@ -908,6 +922,7 @@ impl Default for ServerConfig {
             data_auth_mode: DataAuthMode::None,
             data_auth_audience: None,
             data_auth_trusted_issuers: Vec::new(),
+            data_auth_policy_authorities: Vec::new(),
             data_auth_default_policy_class: None,
             data_auth_insecure_accept_any_issuer: false,
             // JWKS defaults
@@ -1011,6 +1026,7 @@ impl ServerConfig {
             mode: self.data_auth_mode,
             audience: self.data_auth_audience.clone(),
             trusted_issuers: self.data_auth_trusted_issuers.clone(),
+            policy_authorities: self.data_auth_policy_authorities.clone(),
             default_policy_class: self.data_auth_default_policy_class.clone(),
             insecure_accept_any_issuer: self.data_auth_insecure_accept_any_issuer,
             has_jwks_issuers: self.has_jwks_issuers(),
@@ -1439,5 +1455,24 @@ mod gc_retention_flag_tests {
             env_of("gc_hard_max_old_indexes").as_deref(),
             Some("FLUREE_GC_HARD_MAX_OLD_INDEXES")
         );
+    }
+}
+
+#[cfg(test)]
+mod policy_authority_tests {
+    use super::*;
+
+    #[test]
+    fn policy_authorities_require_an_audience_even_with_development_issuer_trust() {
+        let mut config = DataAuthConfig {
+            policy_authorities: vec!["did:key:gateway".into()],
+            insecure_accept_any_issuer: true,
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+        config.audience = Some(String::new());
+        assert!(config.validate().is_err());
+        config.audience = Some("production-data".into());
+        assert!(config.validate().is_ok());
     }
 }

--- a/fluree-db-server/src/config_file.rs
+++ b/fluree-db-server/src/config_file.rs
@@ -1079,6 +1079,51 @@ mod tests {
     use super::*;
 
     #[test]
+    fn policy_authorities_load_from_toml_and_cli_overrides_the_whole_list() {
+        use clap::{CommandFactory, FromArgMatches};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("fluree.toml");
+        std::fs::write(
+            &path,
+            r#"
+            [server.auth.data]
+            mode = "required"
+            audience = "file-audience"
+            trusted_issuers = ["did:key:file"]
+            policy_authorities = ["did:key:file"]
+        "#,
+        )
+        .unwrap();
+        let section = load_config(&path).unwrap().server.unwrap();
+        for (args, authorities, audience) in [
+            (vec!["fluree-server"], vec!["did:key:file"], "file-audience"),
+            (
+                vec![
+                    "fluree-server",
+                    "--data-auth-policy-authority",
+                    "did:key:cli-1",
+                    "--data-auth-policy-authority",
+                    "did:key:cli-2",
+                    "--data-auth-audience",
+                    "cli-audience",
+                ],
+                vec!["did:key:cli-1", "did:key:cli-2"],
+                "cli-audience",
+            ),
+        ] {
+            let matches = ServerConfig::command().try_get_matches_from(args).unwrap();
+            let mut config = ServerConfig::from_arg_matches(&matches).unwrap();
+            apply_to_server_config(&section, &mut config, &matches);
+            let data = config.data_auth();
+            assert_eq!(data.policy_authorities, authorities);
+            assert_eq!(data.audience.as_deref(), Some(audience));
+            assert_eq!(data.trusted_issuers, ["did:key:file"]);
+            assert!(data.validate().is_ok());
+        }
+    }
+
+    #[test]
     fn test_load_toml_with_server_section() {
         let toml = r#"
 [[remotes]]

--- a/fluree-db-server/src/config_file.rs
+++ b/fluree-db-server/src/config_file.rs
@@ -177,6 +177,7 @@ pub struct AuthEndpointFileConfig {
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct DataAuthFileConfig {
+    pub policy_authorities: Option<Vec<String>>,
     pub mode: Option<String>,
     pub audience: Option<String>,
     pub trusted_issuers: Option<Vec<String>>,
@@ -459,6 +460,7 @@ pub const CONFIG_FILE_ARG_IDS: &[&str] = &[
     "data_auth_mode",
     "data_auth_audience",
     "data_auth_trusted_issuers",
+    "data_auth_policy_authorities",
     "data_auth_default_policy_class",
     "admin_auth_mode",
     "admin_auth_trusted_issuers",
@@ -688,6 +690,11 @@ pub fn apply_to_server_config(
             if is_default("data_auth_trusted_issuers") {
                 if let Some(ref v) = data.trusted_issuers {
                     config.data_auth_trusted_issuers = v.clone();
+                }
+            }
+            if is_default("data_auth_policy_authorities") {
+                if let Some(ref v) = data.policy_authorities {
+                    config.data_auth_policy_authorities = v.clone();
                 }
             }
             if is_default("data_auth_default_policy_class") {

--- a/fluree-db-server/src/extract/credential_policy.rs
+++ b/fluree-db-server/src/extract/credential_policy.rs
@@ -1,0 +1,233 @@
+//! Resolve a verified credential into one concrete policy selection per request.
+use fluree_db_api::{ApiError, GovernanceOptions, PolicyAuthorization};
+use serde_json::Value;
+
+use crate::error::{Result, ServerError};
+
+#[derive(Debug, Clone)]
+pub enum CredentialPolicy {
+    Fixed(PolicyAuthorization),
+    Request,
+    ScopeOnly,
+}
+
+impl CredentialPolicy {
+    pub fn mode(&self) -> &'static str {
+        match self {
+            Self::Fixed(_) => "fixed",
+            Self::Request => "request-selected",
+            Self::ScopeOnly => "scope-only",
+        }
+    }
+
+    pub fn fixed_options(&self) -> Option<&GovernanceOptions> {
+        match self {
+            Self::Fixed(auth) => Some(auth.options()),
+            _ => None,
+        }
+    }
+
+    pub fn resolve_options(&self, requested: &GovernanceOptions) -> Result<GovernanceOptions> {
+        match self {
+            Self::Request => Ok(PolicyAuthorization::from_trusted_options(requested.clone())
+                .options()
+                .clone()),
+            Self::Fixed(auth) => {
+                validate_selection(requested, auth.options(), true)?;
+                Ok(auth.constrain_options(requested))
+            }
+            Self::ScopeOnly => {
+                validate_selection(requested, &GovernanceOptions::default(), true)?;
+                Ok(GovernanceOptions {
+                    default_allow: requested.default_allow,
+                    ..Default::default()
+                })
+            }
+        }
+    }
+
+    pub fn apply_to_jsonld(&self, query: &mut Value) -> Result<()> {
+        let requested = GovernanceOptions::from_json(query)
+            .map_err(|e| ServerError::bad_request(e.to_string()))?;
+        let options = self.resolve_options(&requested)?;
+        if !matches!(self, Self::Request) {
+            // Check each spelling, including aliases shadowed by header defaults.
+            let empty = GovernanceOptions::default();
+            let bound = self.fixed_options().unwrap_or(&empty);
+            if let Some(opts) = query.get("opts").and_then(Value::as_object) {
+                for key in [
+                    "identity",
+                    "policy-class",
+                    "policy_class",
+                    "policyClass",
+                    "policy",
+                    "policy-values",
+                    "policy_values",
+                    "policyValues",
+                    "default-allow",
+                    "default_allow",
+                    "defaultAllow",
+                ] {
+                    if let Some(value) = opts.get(key) {
+                        let one = GovernanceOptions::from_json(
+                            &serde_json::json!({"opts": {key: value}}),
+                        )
+                        .map_err(|e| ServerError::bad_request(e.to_string()))?;
+                        validate_selection(&one, bound, true)?;
+                    }
+                }
+            }
+        }
+
+        // One selection applies to all sources. Never silently discard a
+        // source's conflicting selection, including a source-only narrowing.
+        validate_sources(query, &options)?;
+        if !matches!(self, Self::ScopeOnly) || options.has_any_policy_inputs() {
+            PolicyAuthorization::from_trusted_options(options).apply_to_jsonld(query)?;
+        }
+        Ok(())
+    }
+}
+
+fn conflict(field: &str) -> ServerError {
+    ApiError::http(
+        403,
+        format!("Credential does not permit policy selection: conflicting {field}"),
+    )
+    .into()
+}
+
+fn validate_selection(
+    requested: &GovernanceOptions,
+    bound: &GovernanceOptions,
+    narrow: bool,
+) -> Result<()> {
+    if requested.identity.is_some() && requested.identity != bound.identity {
+        return Err(conflict("identity"));
+    }
+    if let Some(classes) = &requested.policy_class {
+        // Class order and duplicates do not change the selected policy set.
+        let equal = bound.policy_class.as_ref().is_some_and(|other| {
+            classes.iter().all(|c| other.contains(c)) && other.iter().all(|c| classes.contains(c))
+        });
+        if !equal {
+            return Err(conflict("policy-class"));
+        }
+    }
+    if requested.policy.as_ref().is_some_and(|p| !p.is_null()) && requested.policy != bound.policy {
+        return Err(conflict("policy"));
+    }
+    if requested.policy_values.is_some() && requested.policy_values != bound.policy_values {
+        return Err(conflict("policy-values"));
+    }
+    if requested.default_allow.is_some()
+        && !(narrow && requested.default_allow == Some(false))
+        && requested.default_allow != bound.default_allow
+    {
+        return Err(conflict("default-allow"));
+    }
+    Ok(())
+}
+
+fn validate_sources(query: &Value, bound: &GovernanceOptions) -> Result<()> {
+    for object in [Some(query), query.get("opts")].into_iter().flatten() {
+        for key in ["from", "ledger", "to"] {
+            if let Some(source) = object.get(key) {
+                validate_source(source, bound)?;
+            }
+        }
+        for key in ["fromNamed", "from-named"] {
+            if let Some(source) = object.get(key) {
+                if let Some(named) = source.as_object() {
+                    for source in named.values() {
+                        validate_source(source, bound)?;
+                    }
+                } else {
+                    validate_source(source, bound)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_source(source: &Value, bound: &GovernanceOptions) -> Result<()> {
+    if let Some(sources) = source.as_array() {
+        for source in sources {
+            validate_source(source, bound)?;
+        }
+    } else if let Some(policy) = source.get("policy") {
+        let opts = GovernanceOptions::from_json(&serde_json::json!({"opts": policy}))
+            .map_err(|e| ServerError::bad_request(e.to_string()))?;
+        validate_selection(&opts, bound, false)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn request_selection_is_explicit_and_scope_only_preserves_defaults() {
+        let empty = GovernanceOptions::default();
+        let selected = CredentialPolicy::Request.resolve_options(&empty).unwrap();
+        assert!(selected.has_any_policy_inputs());
+        assert_eq!(selected.default_allow, Some(false));
+        assert!(!CredentialPolicy::ScopeOnly
+            .resolve_options(&empty)
+            .unwrap()
+            .has_any_policy_inputs());
+        let allow = GovernanceOptions {
+            default_allow: Some(true),
+            ..empty
+        };
+        assert_eq!(
+            CredentialPolicy::Request
+                .resolve_options(&allow)
+                .unwrap()
+                .default_allow,
+            Some(true)
+        );
+        assert!(CredentialPolicy::ScopeOnly.resolve_options(&allow).is_err());
+    }
+
+    #[test]
+    fn fixed_context_accepts_echoes_and_narrowing_but_rejects_conflicts() {
+        let auth = CredentialPolicy::Fixed(PolicyAuthorization::from_trusted_options(
+            GovernanceOptions {
+                identity: Some("https://example.org/user".into()),
+                policy_class: Some(vec![
+                    "https://example.org/A".into(),
+                    "https://example.org/B".into(),
+                ]),
+                default_allow: Some(true),
+                ..Default::default()
+            },
+        ));
+        for opts in [
+            json!({}),
+            json!({"identity": "https://example.org/user"}),
+            json!({"policyClass": ["https://example.org/B", "https://example.org/A"]}),
+            json!({"default-allow": false}),
+        ] {
+            let mut query = json!({"opts": opts});
+            auth.apply_to_jsonld(&mut query).unwrap();
+            assert_eq!(query["opts"]["identity"], "https://example.org/user");
+        }
+        for mut query in [
+            json!({"opts": {"identity": "https://example.org/other"}}),
+            json!({"opts": {"policy-class": ["https://example.org/A", "https://example.org/B"], "policyClass": ["https://example.org/Admin"]}}),
+            json!({"opts": {"policy": [{"f:allow": true}]}}),
+            json!({"opts": {"policy-values": {"?$identity": "someone else"}}}),
+            json!({"from": [{"@id": "db:main", "policy": {"default-allow": false}}]}),
+        ] {
+            let error = auth.apply_to_jsonld(&mut query).unwrap_err();
+            assert!(matches!(
+                error,
+                ServerError::Api(ApiError::Http { status: 403, .. })
+            ));
+        }
+    }
+}

--- a/fluree-db-server/src/extract/data_bearer.rs
+++ b/fluree-db-server/src/extract/data_bearer.rs
@@ -17,10 +17,12 @@ use axum::http::request::Parts;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use super::CredentialPolicy;
 use crate::config::DataAuthMode;
 use crate::error::ServerError;
 use crate::state::AppState;
 use fluree_db_credential::jwt_claims::EventsTokenPayload;
+use fluree_db_credential::jwt_claims::PolicyClaim;
 
 /// Verified principal from a data API Bearer token
 #[derive(Debug, Clone)]
@@ -44,9 +46,7 @@ pub struct DataPrincipal {
     /// before each statement.
     pub expires_unix: u64,
     /// Policy selection constructed from verified claims and server configuration.
-    pub policy_authorization: fluree_db_api::PolicyAuthorization,
-    /// True only when a verified policy authority supplied fluree.policy.
-    pub delegated_policy: bool,
+    pub policy_authorization: CredentialPolicy,
 }
 
 impl DataPrincipal {
@@ -66,20 +66,15 @@ impl DataPrincipal {
     /// check, not a claim that subsequent per-fact policy enforcement allowed
     /// the operation. Disabled unless this tracing target is enabled at DEBUG.
     fn audit_scope(&self, ledger_id: &str, action: &str, allowed: bool) {
-        let opts = self.policy_authorization.options();
-        let mode = if self.delegated_policy {
-            "delegated"
-        } else if opts.policy_class.is_some() {
-            "server-default"
-        } else if self.identity.is_some() {
-            "identity"
-        } else {
-            "scope-only"
-        };
+        let effective_identity = self
+            .policy_authorization
+            .fixed_options()
+            .and_then(|o| o.identity.as_deref());
+        let mode = self.policy_authorization.mode();
         tracing::debug!(
             target: "fluree_db_server::authorization",
             issuer = %self.issuer,
-            effective_identity = ?opts.identity,
+            effective_identity = ?effective_identity,
             authorization_mode = mode,
             ledger = ledger_id,
             action,
@@ -194,49 +189,47 @@ pub(crate) async fn verify_data_principal(
         return Err(ServerError::unauthorized("token authorizes no resources"));
     }
 
-    let options = if let Some(policy) = &payload.fluree_policy {
-        if !config.policy_authorities.contains(&issuer)
-            || config.audience.as_deref().is_none_or(str::is_empty)
-        {
-            return Err(ServerError::unauthorized(
-                "Issuer is not a configured policy authority",
-            ));
-        }
-        fluree_db_api::GovernanceOptions {
-            identity: payload.resolve_identity(),
-            policy_class: policy.policy_class.clone(),
-            policy: policy.policy.clone(),
-            policy_values: policy.policy_values.clone(),
-            default_allow: policy.default_allow,
-        }
+    if payload.fluree_policy.is_some()
+        && (!config.policy_authorities.contains(&issuer)
+            || config.audience.as_deref().is_none_or(str::is_empty))
+    {
+        return Err(ServerError::unauthorized(
+            "Issuer is not a configured policy authority",
+        ));
+    }
+    let authorization = if matches!(payload.fluree_policy, Some(PolicyClaim::Request(_))) {
+        CredentialPolicy::Request
+    } else if let Some(PolicyClaim::Fixed(policy)) = &payload.fluree_policy {
+        CredentialPolicy::Fixed(fluree_db_api::PolicyAuthorization::from_trusted_options(
+            fluree_db_api::GovernanceOptions {
+                identity: payload.resolve_identity(),
+                policy_class: policy.policy_class.clone(),
+                policy: policy.policy.clone(),
+                policy_values: policy.policy_values.clone(),
+                default_allow: policy.default_allow,
+            },
+        ))
+    } else if payload.resolve_identity().is_none() && config.default_policy_class.is_none() {
+        CredentialPolicy::ScopeOnly
     } else {
-        // A trusted issuer can issue a scope-only service credential (no
-        // identity or policy class). Preserve that explicit coarse-access
-        // contract; it still cannot select arbitrary policies via request
-        // options, and mandatory ledger configuration remains authoritative.
-        let scope_only =
-            payload.resolve_identity().is_none() && config.default_policy_class.is_none();
-        fluree_db_api::GovernanceOptions {
-            identity: payload.resolve_identity(),
-            policy_class: config.default_policy_class.map(|c| vec![c]),
-            default_allow: scope_only.then_some(true),
-            ..Default::default()
-        }
+        CredentialPolicy::Fixed(fluree_db_api::PolicyAuthorization::from_trusted_options(
+            fluree_db_api::GovernanceOptions {
+                identity: payload.resolve_identity(),
+                policy_class: config.default_policy_class.map(|c| vec![c]),
+                ..Default::default()
+            },
+        ))
     };
-    Ok(build_principal(
-        &payload,
-        fluree_db_api::PolicyAuthorization::from_trusted_options(options),
-    ))
+    Ok(build_principal(&payload, authorization))
 }
 
 /// Build a `DataPrincipal` from verified claims.
 fn build_principal(
     payload: &EventsTokenPayload,
-    policy_authorization: fluree_db_api::PolicyAuthorization,
+    policy_authorization: CredentialPolicy,
 ) -> DataPrincipal {
     DataPrincipal {
         policy_authorization,
-        delegated_policy: payload.fluree_policy.is_some(),
         issuer: payload.iss.clone(),
         subject: payload.sub.clone(),
         identity: payload.resolve_identity(),

--- a/fluree-db-server/src/extract/data_bearer.rs
+++ b/fluree-db-server/src/extract/data_bearer.rs
@@ -43,6 +43,8 @@ pub struct DataPrincipal {
     /// redundant there; long-lived transports (Bolt sessions) re-check it
     /// before each statement.
     pub expires_unix: u64,
+    /// Policy selection constructed from verified claims and server configuration.
+    pub policy_authorization: fluree_db_api::PolicyAuthorization,
 }
 
 impl DataPrincipal {
@@ -160,12 +162,48 @@ pub(crate) async fn verify_data_principal(
         return Err(ServerError::unauthorized("token authorizes no resources"));
     }
 
-    Ok(build_principal(&payload))
+    let options = if let Some(policy) = &payload.fluree_policy {
+        if !config.policy_authorities.contains(&issuer)
+            || config.audience.as_deref().is_none_or(str::is_empty)
+        {
+            return Err(ServerError::unauthorized(
+                "Issuer is not a configured policy authority",
+            ));
+        }
+        fluree_db_api::GovernanceOptions {
+            identity: payload.resolve_identity(),
+            policy_class: policy.policy_class.clone(),
+            policy: policy.policy.clone(),
+            policy_values: policy.policy_values.clone(),
+            default_allow: policy.default_allow,
+        }
+    } else {
+        // A trusted issuer can issue a scope-only service credential (no
+        // identity or policy class). Preserve that explicit coarse-access
+        // contract; it still cannot select arbitrary policies via request
+        // options, and mandatory ledger configuration remains authoritative.
+        let scope_only =
+            payload.resolve_identity().is_none() && config.default_policy_class.is_none();
+        fluree_db_api::GovernanceOptions {
+            identity: payload.resolve_identity(),
+            policy_class: config.default_policy_class.map(|c| vec![c]),
+            default_allow: scope_only.then_some(true),
+            ..Default::default()
+        }
+    };
+    Ok(build_principal(
+        &payload,
+        fluree_db_api::PolicyAuthorization::from_trusted_options(options),
+    ))
 }
 
 /// Build a `DataPrincipal` from verified claims.
-fn build_principal(payload: &EventsTokenPayload) -> DataPrincipal {
+fn build_principal(
+    payload: &EventsTokenPayload,
+    policy_authorization: fluree_db_api::PolicyAuthorization,
+) -> DataPrincipal {
     DataPrincipal {
+        policy_authorization,
         issuer: payload.iss.clone(),
         subject: payload.sub.clone(),
         identity: payload.resolve_identity(),

--- a/fluree-db-server/src/extract/data_bearer.rs
+++ b/fluree-db-server/src/extract/data_bearer.rs
@@ -45,15 +45,47 @@ pub struct DataPrincipal {
     pub expires_unix: u64,
     /// Policy selection constructed from verified claims and server configuration.
     pub policy_authorization: fluree_db_api::PolicyAuthorization,
+    /// True only when a verified policy authority supplied fluree.policy.
+    pub delegated_policy: bool,
 }
 
 impl DataPrincipal {
     pub fn can_read(&self, ledger_id: &str) -> bool {
-        self.read_all || self.read_ledgers.contains(ledger_id)
+        let allowed = self.read_all || self.read_ledgers.contains(ledger_id);
+        self.audit_scope(ledger_id, "read", allowed);
+        allowed
     }
 
     pub fn can_write(&self, ledger_id: &str) -> bool {
-        self.write_all || self.write_ledgers.contains(ledger_id)
+        let allowed = self.write_all || self.write_ledgers.contains(ledger_id);
+        self.audit_scope(ledger_id, "write", allowed);
+        allowed
+    }
+
+    /// Request/statement-level evidence of the authority used for a scope
+    /// check, not a claim that subsequent per-fact policy enforcement allowed
+    /// the operation. Disabled unless this tracing target is enabled at DEBUG.
+    fn audit_scope(&self, ledger_id: &str, action: &str, allowed: bool) {
+        let opts = self.policy_authorization.options();
+        let mode = if self.delegated_policy {
+            "delegated"
+        } else if opts.policy_class.is_some() {
+            "server-default"
+        } else if self.identity.is_some() {
+            "identity"
+        } else {
+            "scope-only"
+        };
+        tracing::debug!(
+            target: "fluree_db_server::authorization",
+            issuer = %self.issuer,
+            effective_identity = ?opts.identity,
+            authorization_mode = mode,
+            ledger = ledger_id,
+            action,
+            scope_allowed = allowed,
+            "data authorization scope check"
+        );
     }
 }
 
@@ -204,6 +236,7 @@ fn build_principal(
 ) -> DataPrincipal {
     DataPrincipal {
         policy_authorization,
+        delegated_policy: payload.fluree_policy.is_some(),
         issuer: payload.iss.clone(),
         subject: payload.sub.clone(),
         identity: payload.resolve_identity(),

--- a/fluree-db-server/src/extract/headers.rs
+++ b/fluree-db-server/src/extract/headers.rs
@@ -33,7 +33,7 @@ pub struct FlureeHeaders {
     pub raw: HeaderMap,
 
     /// Host-verified policy selection. Never populated by HTTP header parsing.
-    pub policy_authorization: Option<fluree_db_api::PolicyAuthorization>,
+    pub policy_authorization: Option<super::CredentialPolicy>,
 
     /// Ledger alias from header (lower precedence than path)
     pub ledger: Option<String>,
@@ -407,7 +407,11 @@ impl FlureeHeaders {
             opts.insert("policy".to_string(), self.policy.clone().unwrap());
         }
 
-        if !self.policy_class.is_empty() && !opts.contains_key("policy-class") {
+        if !self.policy_class.is_empty()
+            && !["policy-class", "policy_class", "policyClass"]
+                .iter()
+                .any(|key| opts.contains_key(*key))
+        {
             opts.insert(
                 "policy-class".to_string(),
                 JsonValue::Array(
@@ -420,7 +424,11 @@ impl FlureeHeaders {
             );
         }
 
-        if self.policy_values.is_some() && !opts.contains_key("policy-values") {
+        if self.policy_values.is_some()
+            && !["policy-values", "policy_values", "policyValues"]
+                .iter()
+                .any(|key| opts.contains_key(*key))
+        {
             opts.insert(
                 "policy-values".to_string(),
                 self.policy_values.clone().unwrap(),

--- a/fluree-db-server/src/extract/headers.rs
+++ b/fluree-db-server/src/extract/headers.rs
@@ -32,6 +32,9 @@ pub struct FlureeHeaders {
     /// Raw HTTP headers (for telemetry/tracing)
     pub raw: HeaderMap,
 
+    /// Host-verified policy selection. Never populated by HTTP header parsing.
+    pub policy_authorization: Option<fluree_db_api::PolicyAuthorization>,
+
     /// Ledger alias from header (lower precedence than path)
     pub ledger: Option<String>,
 
@@ -86,6 +89,7 @@ impl Default for FlureeHeaders {
     fn default() -> Self {
         Self {
             raw: HeaderMap::new(),
+            policy_authorization: None,
             ledger: None,
             identity: None,
             policy: None,

--- a/fluree-db-server/src/extract/mod.rs
+++ b/fluree-db-server/src/extract/mod.rs
@@ -2,6 +2,7 @@
 
 mod bearer;
 mod credential;
+mod credential_policy;
 mod data_bearer;
 mod headers;
 mod storage_proxy;
@@ -10,6 +11,7 @@ mod tracking;
 pub(crate) use bearer::extract_bearer_token;
 pub use bearer::{EventsPrincipal, MaybeBearer};
 pub use credential::{CredentialPayload, ExtractedCredential, MaybeCredential};
+pub use credential_policy::CredentialPolicy;
 pub(crate) use data_bearer::verify_data_principal;
 pub use data_bearer::{DataPrincipal, MaybeDataBearer};
 pub use headers::FlureeHeaders;

--- a/fluree-db-server/src/extract/storage_proxy.rs
+++ b/fluree-db-server/src/extract/storage_proxy.rs
@@ -107,8 +107,15 @@ impl FromRequestParts<Arc<AppState>> for StorageProxyBearer {
 fn build_principal(
     payload: &fluree_db_credential::jwt_claims::EventsTokenPayload,
     issuer: String,
-) -> StorageProxyPrincipal {
-    StorageProxyPrincipal {
+) -> Result<StorageProxyPrincipal, ServerError> {
+    // This surface does not carry the full authorization context into block
+    // filtering. Never accept a token and silently discard its restrictions.
+    if payload.fluree_policy.is_some() {
+        return Err(ServerError::unauthorized(
+            "Signed policy delegation is not supported by storage proxy endpoints",
+        ));
+    }
+    Ok(StorageProxyPrincipal {
         issuer,
         subject: payload.sub.clone(),
         identity: payload.resolve_identity(),
@@ -119,7 +126,7 @@ fn build_principal(
             .unwrap_or_default()
             .into_iter()
             .collect(),
-    }
+    })
 }
 
 /// Verify token and build principal (embedded JWK only — non-oidc builds)
@@ -159,7 +166,7 @@ fn verify_token(
     }
 
     // 6. Build principal
-    let principal = build_principal(&payload, verified.did);
+    let principal = build_principal(&payload, verified.did)?;
     Ok(StorageProxyBearer(principal))
 }
 
@@ -213,7 +220,7 @@ async fn verify_token(
     }
 
     // 4. Build principal — use verified.issuer as the authoritative identity
-    let principal = build_principal(&verified.payload, verified.issuer);
+    let principal = build_principal(&verified.payload, verified.issuer)?;
     Ok(StorageProxyBearer(principal))
 }
 

--- a/fluree-db-server/src/extract/storage_proxy.rs
+++ b/fluree-db-server/src/extract/storage_proxy.rs
@@ -112,7 +112,7 @@ fn build_principal(
     // filtering. Never accept a token and silently discard its restrictions.
     if payload.fluree_policy.is_some() {
         return Err(ServerError::unauthorized(
-            "Signed policy delegation is not supported by storage proxy endpoints",
+            "Policy delegation and controller credentials are not supported by storage proxy endpoints",
         ));
     }
     Ok(StorageProxyPrincipal {

--- a/fluree-db-server/src/mcp/auth.rs
+++ b/fluree-db-server/src/mcp/auth.rs
@@ -88,6 +88,12 @@ fn verify_mcp_token(
     let payload: EventsTokenPayload = serde_json::from_str(&verified.payload)
         .map_err(|e| ServerError::unauthorized(format!("Invalid claims: {e}")))?;
 
+    if payload.fluree_policy.is_some() {
+        return Err(ServerError::unauthorized(
+            "Policy delegation and controller credentials are not supported by MCP",
+        ));
+    }
+
     // 3. Validate standard claims (exp, iss matches signing key)
     // We don't require specific audience for MCP
     payload

--- a/fluree-db-server/src/routes/graphql.rs
+++ b/fluree-db-server/src/routes/graphql.rs
@@ -53,7 +53,7 @@ pub async fn graphql_ledger_tail(
         &state,
         headers,
         bearer.0.as_ref(),
-        &credential,
+        credential.did(),
     )?;
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
     let trace_id = extract_trace_id(&credential.headers);
@@ -129,7 +129,7 @@ pub async fn graphql_schema_ledger_tail(
         &state,
         headers,
         bearer.0.as_ref(),
-        &credential,
+        credential.did(),
     )?;
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
     let trace_id = extract_trace_id(&credential.headers);
@@ -200,7 +200,8 @@ async fn execute_mutation(
         .map_err(ServerError::Api)?;
     // Bound headers carry the verified selection, including caller default-deny
     // narrowing. The API retains it through schema, writes, and read-back.
-    let governance = crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), headers)?;
+    let governance =
+        crate::routes::policy_auth::bound_governance(headers.identity.as_deref(), headers)?;
     let result = if governance.has_any_policy_inputs() {
         let authorization = fluree_db_api::PolicyAuthorization::from_trusted_options(governance);
         state

--- a/fluree-db-server/src/routes/graphql.rs
+++ b/fluree-db-server/src/routes/graphql.rs
@@ -264,30 +264,8 @@ async fn policy_view(
     ledger: &str,
     headers: &FlureeHeaders,
 ) -> Result<fluree_db_api::GraphDb> {
-    let identity = headers.identity.clone();
-
-    let opts = fluree_db_api::GovernanceOptions {
-        identity,
-        policy_class: (!headers.policy_class.is_empty()).then(|| headers.policy_class.clone()),
-        policy: headers.policy.clone(),
-        policy_values: headers.policy_values_map()?,
-        default_allow: headers.default_allow,
-    };
-
-    let view = state
-        .fluree
-        .db_with_default_context(ledger)
-        .await
-        .map_err(ServerError::Api)?;
-    if opts.has_any_policy_inputs() {
-        state
-            .fluree
-            .wrap_policy(view, &opts, None)
-            .await
-            .map_err(ServerError::Api)
-    } else {
-        Ok(view)
-    }
+    let view = state.fluree.db_with_default_context(ledger).await?;
+    crate::routes::policy_auth::wrap_authorized_view(state, view, headers).await
 }
 
 fn parse_request(

--- a/fluree-db-server/src/routes/graphql.rs
+++ b/fluree-db-server/src/routes/graphql.rs
@@ -49,6 +49,12 @@ pub async fn graphql_ledger_tail(
     bearer: MaybeDataBearer,
     credential: MaybeCredential,
 ) -> Result<Response> {
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.0.as_ref(),
+        &credential,
+    )?;
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
     let trace_id = extract_trace_id(&credential.headers);
     let span = create_request_span(
@@ -94,7 +100,7 @@ pub async fn graphql_ledger_tail(
                 )
                 .await?
             } else {
-                let view = policy_view(&state, &ledger, &headers, &bearer, &credential).await?;
+                let view = policy_view(&state, &ledger, &headers).await?;
                 state
                     .fluree
                     .graphql_with_options(&view, prepared, options)
@@ -119,6 +125,12 @@ pub async fn graphql_schema_ledger_tail(
     bearer: MaybeDataBearer,
     credential: MaybeCredential,
 ) -> Result<Response> {
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.0.as_ref(),
+        &credential,
+    )?;
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
     let trace_id = extract_trace_id(&credential.headers);
     let span = create_request_span(
@@ -132,7 +144,7 @@ pub async fn graphql_schema_ledger_tail(
 
     async move {
         authorize_read(&state, &ledger, &bearer, &credential)?;
-        let view = policy_view(&state, &ledger, &headers, &bearer, &credential).await?;
+        let view = policy_view(&state, &ledger, &headers).await?;
         // Includes mutations when the ledger's `graphql:Schema` enables them,
         // so the SDL matches what this endpoint will actually accept.
         let sdl = fluree_db_api::graphql::schema_sdl_with_mutations(&view)
@@ -167,10 +179,6 @@ async fn execute_mutation(
             return Err(ServerError::not_found("Ledger not found"));
         }
     }
-    // Policy still applies: `wrap_policy` on the read view is what prunes the
-    // schema, and the transaction path enforces write policy itself.
-    let _ = policy_view(state, ledger, headers, bearer, credential).await?;
-
     let loaded = state
         .fluree
         .ledger(ledger)
@@ -181,11 +189,22 @@ async fn execute_mutation(
         .get_default_context(ledger)
         .await
         .map_err(ServerError::Api)?;
-    let (response, _committed) = state
-        .fluree
-        .graphql_transact_with_options(loaded, context, prepared, options)
-        .await
-        .map_err(ServerError::Api)?;
+    // Bound headers carry the verified selection, including caller default-deny
+    // narrowing. The API retains it through schema, writes, and read-back.
+    let governance = crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), headers)?;
+    let result = if governance.has_any_policy_inputs() {
+        let authorization = fluree_db_api::PolicyAuthorization::from_trusted_options(governance);
+        state
+            .fluree
+            .graphql_transact_with_authorization(loaded, context, prepared, options, &authorization)
+            .await
+    } else {
+        state
+            .fluree
+            .graphql_transact_with_options(loaded, context, prepared, options)
+            .await
+    };
+    let (response, _committed) = result.map_err(ServerError::Api)?;
     Ok(response)
 }
 
@@ -235,17 +254,8 @@ async fn policy_view(
     state: &AppState,
     ledger: &str,
     headers: &FlureeHeaders,
-    bearer: &MaybeDataBearer,
-    credential: &MaybeCredential,
 ) -> Result<fluree_db_api::GraphDb> {
-    let bearer_identity = crate::routes::query::effective_identity(credential, bearer);
-    let identity = crate::routes::policy_auth::resolve_sparql_identity(
-        state,
-        ledger,
-        bearer_identity.as_deref(),
-        headers.identity.as_deref(),
-    )
-    .await;
+    let identity = headers.identity.clone();
 
     let opts = fluree_db_api::GovernanceOptions {
         identity,

--- a/fluree-db-server/src/routes/graphql.rs
+++ b/fluree-db-server/src/routes/graphql.rs
@@ -145,8 +145,8 @@ pub async fn graphql_schema_ledger_tail(
     async move {
         authorize_read(&state, &ledger, &bearer, &credential)?;
         let view = policy_view(&state, &ledger, &headers).await?;
-        // Includes mutations when the ledger's `graphql:Schema` enables them,
-        // so the SDL matches what this endpoint will actually accept.
+        // Includes the ledger's configured mutations. Runtime restrictions
+        // (including the Raft mutation gate) still apply when executing them.
         let sdl = fluree_db_api::graphql::schema_sdl_with_mutations(&view)
             .await
             .map_err(ServerError::Api)?;
@@ -178,6 +178,15 @@ async fn execute_mutation(
         if !credential.is_signed() && !p.can_write(ledger) {
             return Err(ServerError::not_found("Ledger not found"));
         }
+    }
+    // The GraphQL executor commits locally. Until it submits through consensus,
+    // reject mutations on every Raft node, including the leader. Forwarding
+    // alone would still permit writes outside the replicated command queue.
+    #[cfg(feature = "raft")]
+    if state.raft.is_some() {
+        return Err(ServerError::not_implemented(
+            "GraphQL mutations are not supported in Raft mode; use the transaction endpoints",
+        ));
     }
     let loaded = state
         .fluree

--- a/fluree-db-server/src/routes/policy_auth.rs
+++ b/fluree-db-server/src/routes/policy_auth.rs
@@ -1,174 +1,81 @@
-//! Shared helpers for applying bearer-authenticated identity and policy class
-//! to incoming requests, with support for **root-identity impersonation**.
+//! Bind caller policy options to authority established by credential verification.
 //!
-//! # Impersonation semantic
-//!
-//! A bearer-authenticated identity that has **no** `f:policyClass` assignments
-//! on the target ledger (i.e. it is unrestricted) may delegate to a body- or
-//! header-supplied target identity for policy-testing purposes. The check is
-//! performed via [`fluree_db_api::identity_has_no_policies`], which returns
-//! true only for the `FoundNoPolicies` case — unknown identities (`NotFound`)
-//! and restricted identities (`FoundWithPolicies`) both fall through to the
-//! non-spoofable "force bearer identity" path.
-//!
-//! # When impersonation is allowed
-//!
-//! - Direct (non-proxy) storage mode only — proxies forward the request
-//!   upstream; the upstream performs its own check.
-//! - The request body / headers explicitly request a target via
-//!   `opts.identity`, `opts.policy-class`, `opts.policy`, or
-//!   `opts.policy-values`. (`opts.default-allow` is intentionally excluded —
-//!   it only governs the absence of matching rules and never widens the
-//!   bearer's resolved policies.)
-//! - The bearer identity resolves to `FoundNoPolicies` on the target ledger.
-//!
-//! When all three hold, the server logs an `info`-level audit line and leaves
-//! the body/header-supplied target in place. Otherwise the bearer identity is
-//! forced into opts (current non-impersonation behavior).
+//! Policy-free identities do not acquire delegation privileges. Embedded hosts
+//! construct `PolicyAuthorization` directly; network hosts use the signed
+//! `fluree.policy` claim from an explicitly configured policy authority. Normal
+//! bearer and signed-request identities use server-selected / ledger policies.
 
+use crate::error::Result;
+use crate::extract::{DataPrincipal, FlureeHeaders, MaybeCredential};
 use crate::state::AppState;
-use serde_json::Value as JsonValue;
+use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
+use serde_json::Value;
 
-/// Returns `true` if the request body explicitly redirects policy evaluation
-/// to a different identity or policy set than the bearer's own.
-///
-/// `default-allow` is intentionally excluded: it only governs the absence of
-/// matching rules and never widens the bearer's resolved policies, so a
-/// request that sets only `default-allow` does not require the impersonation
-/// gate (and shouldn't pay for the ledger lookup).
-pub(crate) fn body_requests_impersonation(query: &JsonValue) -> bool {
-    let Some(opts) = query.get("opts") else {
-        return false;
-    };
-    opts.get("identity").is_some()
-        || opts.get("policy-class").is_some()
-        || opts.get("policy_class").is_some()
-        || opts.get("policyClass").is_some()
-        || opts.get("policy").is_some()
-        || opts.get("policy-values").is_some()
-        || opts.get("policy_values").is_some()
-        || opts.get("policyValues").is_some()
-}
-
-/// Force the bearer's `identity` and `policy-class` into `opts`, overriding any
-/// client-supplied values. This is the non-impersonation path.
-fn force_auth_opts(query: &mut JsonValue, identity: Option<&str>, policy_class: Option<&str>) {
-    let Some(obj) = query.as_object_mut() else {
-        return;
-    };
-    let opts = obj
-        .entry("opts")
-        .or_insert_with(|| JsonValue::Object(serde_json::Map::new()));
-    let Some(opts_obj) = opts.as_object_mut() else {
-        return;
-    };
-
-    if let Some(id) = identity {
-        opts_obj.insert("identity".to_string(), JsonValue::String(id.to_string()));
-    }
-    if let Some(pc) = policy_class {
-        opts_obj.insert(
-            "policy-class".to_string(),
-            JsonValue::String(pc.to_string()),
-        );
-    }
-}
-
-/// Check whether `bearer_identity` is allowed to impersonate on `ledger_id`.
-///
-/// Returns `false` in proxy mode, on lookup errors, and for any identity lookup
-/// result other than `FoundNoPolicies`.
-async fn bearer_can_impersonate(state: &AppState, ledger_id: &str, bearer_identity: &str) -> bool {
-    if state.config.is_proxy_storage_mode() {
-        return false;
-    }
-    let fluree = &state.fluree;
-    let Ok(ledger) = fluree.ledger(ledger_id).await else {
-        return false;
-    };
-    fluree_db_api::identity_has_no_policies(
-        &ledger.snapshot,
-        ledger.novelty.as_ref(),
-        ledger.t(),
-        bearer_identity,
-    )
-    .await
-    .unwrap_or(false)
-}
-
-/// Apply the bearer-authenticated identity to JSON-LD `opts`, honoring the
-/// root-identity impersonation semantic described at module-level.
-///
-/// Use this in place of the legacy `force_query_auth_opts` function on all
-/// JSON-LD query, explain, and transaction routes.
-pub(crate) async fn apply_auth_identity_to_opts(
+/// Resolve once, before header defaults are merged into any query or write.
+/// Signed request credentials take precedence over a bearer token, and cannot
+/// inherit that token's delegated authority. Anonymous private-server requests
+/// retain the direct SDK-style policy option contract.
+pub(crate) fn bind_authorization(
     state: &AppState,
-    ledger_id: &str,
-    query: &mut JsonValue,
-    bearer_identity: Option<&str>,
-    default_policy_class: Option<&str>,
-) {
-    // No authenticated identity → nothing to force; body opts flow through.
-    let Some(bearer_id) = bearer_identity else {
-        return;
-    };
-
-    // If the body isn't trying to impersonate, fast path: force bearer identity
-    // and server-default policy-class.
-    if !body_requests_impersonation(query) {
-        force_auth_opts(query, Some(bearer_id), default_policy_class);
-        return;
-    }
-
-    if bearer_can_impersonate(state, ledger_id, bearer_id).await {
-        let target = query
-            .pointer("/opts/identity")
-            .and_then(|v| v.as_str())
-            .unwrap_or("<unspecified>");
-        tracing::info!(
-            bearer = %bearer_id,
-            target = %target,
-            ledger = %ledger_id,
-            "policy impersonation: bearer delegating to target identity"
-        );
-        // Respect body/header-supplied opts in full. Do not layer the
-        // server-default policy-class on top — an unrestricted bearer that's
-        // explicitly testing policies should get exactly the policies they
-        // asked for.
+    mut headers: FlureeHeaders,
+    principal: Option<&DataPrincipal>,
+    credential: &MaybeCredential,
+) -> Result<FlureeHeaders> {
+    let authorization = if let Some(did) = credential.did() {
+        Some(PolicyAuthorization::from_trusted_options(
+            GovernanceOptions {
+                identity: Some(did.to_owned()),
+                policy_class: state
+                    .config
+                    .data_auth_default_policy_class
+                    .clone()
+                    .map(|c| vec![c]),
+                ..Default::default()
+            },
+        ))
     } else {
-        force_auth_opts(query, Some(bearer_id), default_policy_class);
+        principal.map(|p| p.policy_authorization.clone())
+    };
+    if let Some(authorization) = authorization {
+        let options = authorization.constrain_options(&GovernanceOptions {
+            default_allow: headers.default_allow,
+            ..Default::default()
+        });
+        headers.identity = options.identity;
+        headers.policy_class = options.policy_class.unwrap_or_default();
+        headers.policy = options.policy;
+        headers.policy_values = options
+            .policy_values
+            .map(serde_json::to_value)
+            .transpose()?;
+        headers.default_allow = options.default_allow;
+        headers.policy_authorization = Some(authorization);
     }
+    Ok(headers)
 }
 
-/// Resolve the effective identity for a **SPARQL** request.
-///
-/// Uses the bearer identity unless (1) the bearer can impersonate and (2) a
-/// `fluree-identity` header is supplied, in which case the header value wins.
-/// Returns `None` if no identity is available.
-pub(crate) async fn resolve_sparql_identity(
+/// Apply after all body/header/envelope merges; canonical nulls shadow outer
+/// policy defaults and source overrides cannot replace authenticated selection.
+pub(crate) fn apply_authorization_to_opts(
+    query: &mut Value,
+    headers: &FlureeHeaders,
+) -> Result<()> {
+    if let Some(authorization) = &headers.policy_authorization {
+        authorization.apply_to_jsonld(query)?;
+    }
+    Ok(())
+}
+
+/// Apply the same policy selection when an endpoint builds a view directly.
+pub(crate) async fn wrap_authorized_view(
     state: &AppState,
-    ledger_id: &str,
-    bearer_identity: Option<&str>,
-    header_identity: Option<&str>,
-) -> Option<String> {
-    match (bearer_identity, header_identity) {
-        (Some(bearer), Some(header_id)) => {
-            if bearer_can_impersonate(state, ledger_id, bearer).await {
-                tracing::info!(
-                    bearer = %bearer,
-                    target = %header_id,
-                    ledger = %ledger_id,
-                    "policy impersonation: bearer delegating to target identity (SPARQL)"
-                );
-                Some(header_id.to_string())
-            } else {
-                Some(bearer.to_string())
-            }
-        }
-        (Some(bearer), None) => Some(bearer.to_string()),
-        // No bearer: if a header is set and we're unauthenticated (DataAuthMode::None),
-        // honor it — this matches the legacy root-no-identity behavior.
-        (None, Some(header_id)) => Some(header_id.to_string()),
-        (None, None) => None,
+    view: fluree_db_api::GraphDb,
+    headers: &FlureeHeaders,
+) -> Result<fluree_db_api::GraphDb> {
+    let opts = crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), headers)?;
+    if opts.has_any_policy_inputs() {
+        Ok(state.fluree.wrap_policy(view, &opts, None).await?)
+    } else {
+        Ok(view)
     }
 }

--- a/fluree-db-server/src/routes/policy_auth.rs
+++ b/fluree-db-server/src/routes/policy_auth.rs
@@ -2,11 +2,12 @@
 //!
 //! Policy-free identities do not acquire delegation privileges. Embedded hosts
 //! construct `PolicyAuthorization` directly; network hosts use the signed
-//! `fluree.policy` claim from an explicitly configured policy authority. Normal
+//! `fluree.policy` fixed selection or request-selection capability
+//! from a configured policy authority. Normal
 //! bearer and signed-request identities use server-selected / ledger policies.
 
 use crate::error::Result;
-use crate::extract::{DataPrincipal, FlureeHeaders, MaybeCredential};
+use crate::extract::{CredentialPolicy, DataPrincipal, FlureeHeaders, MaybeCredential};
 use crate::state::AppState;
 use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
 use serde_json::Value;
@@ -22,8 +23,8 @@ pub(crate) fn bind_authorization(
     credential: &MaybeCredential,
 ) -> Result<FlureeHeaders> {
     let authorization = if let Some(did) = credential.did() {
-        Some(PolicyAuthorization::from_trusted_options(
-            GovernanceOptions {
+        Some(CredentialPolicy::Fixed(
+            PolicyAuthorization::from_trusted_options(GovernanceOptions {
                 identity: Some(did.to_owned()),
                 policy_class: state
                     .config
@@ -31,16 +32,20 @@ pub(crate) fn bind_authorization(
                     .clone()
                     .map(|c| vec![c]),
                 ..Default::default()
-            },
+            }),
         ))
     } else {
         principal.map(|p| p.policy_authorization.clone())
     };
     if let Some(authorization) = authorization {
-        let options = authorization.constrain_options(&GovernanceOptions {
-            default_allow: headers.default_allow,
-            ..Default::default()
-        });
+        // Request-selected credentials must wait until body/header merging is complete.
+        if matches!(authorization, CredentialPolicy::Request) {
+            headers.policy_authorization = Some(authorization);
+            return Ok(headers);
+        }
+        let requested =
+            crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), &headers)?;
+        let options = authorization.resolve_options(&requested)?;
         headers.identity = options.identity;
         headers.policy_class = options.policy_class.unwrap_or_default();
         headers.policy = options.policy;
@@ -76,6 +81,6 @@ pub(crate) async fn wrap_authorized_view(
     if opts.has_any_policy_inputs() {
         Ok(state.fluree.wrap_policy(view, &opts, None).await?)
     } else {
-        Ok(view)
+        Ok(state.fluree.wrap_policy_defaults(view).await?)
     }
 }

--- a/fluree-db-server/src/routes/policy_auth.rs
+++ b/fluree-db-server/src/routes/policy_auth.rs
@@ -7,12 +7,13 @@
 //! bearer and signed-request identities use server-selected / ledger policies.
 
 use crate::error::Result;
-use crate::extract::{CredentialPolicy, DataPrincipal, FlureeHeaders, MaybeCredential};
+use crate::extract::{CredentialPolicy, DataPrincipal, FlureeHeaders};
 use crate::state::AppState;
 use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
 use serde_json::Value;
 
-/// Resolve once, before header defaults are merged into any query or write.
+/// Bind verified authority before header defaults are merged into a query or write.
+/// `signed_identity` must come from a verified signed request, never caller headers.
 /// Signed request credentials take precedence over a bearer token, and cannot
 /// inherit that token's delegated authority. Anonymous private-server requests
 /// retain the direct SDK-style policy option contract.
@@ -20,9 +21,9 @@ pub(crate) fn bind_authorization(
     state: &AppState,
     mut headers: FlureeHeaders,
     principal: Option<&DataPrincipal>,
-    credential: &MaybeCredential,
+    signed_identity: Option<&str>,
 ) -> Result<FlureeHeaders> {
-    let authorization = if let Some(did) = credential.did() {
+    let authorization = if let Some(did) = signed_identity {
         Some(CredentialPolicy::Fixed(
             PolicyAuthorization::from_trusted_options(GovernanceOptions {
                 identity: Some(did.to_owned()),
@@ -43,8 +44,7 @@ pub(crate) fn bind_authorization(
             headers.policy_authorization = Some(authorization);
             return Ok(headers);
         }
-        let requested =
-            crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), &headers)?;
+        let requested = governance_from_headers(headers.identity.as_deref(), &headers)?;
         let options = authorization.resolve_options(&requested)?;
         headers.identity = options.identity;
         headers.policy_class = options.policy_class.unwrap_or_default();
@@ -77,10 +77,45 @@ pub(crate) async fn wrap_authorized_view(
     view: fluree_db_api::GraphDb,
     headers: &FlureeHeaders,
 ) -> Result<fluree_db_api::GraphDb> {
-    let opts = crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), headers)?;
+    let opts = bound_governance(headers.identity.as_deref(), headers)?;
     if opts.has_any_policy_inputs() {
         Ok(state.fluree.wrap_policy(view, &opts, None).await?)
     } else {
         Ok(state.fluree.wrap_policy_defaults(view).await?)
     }
+}
+
+/// Resolve header policy options against the authority attached by
+/// `bind_authorization`. Header-only transports call this after binding; JSON
+/// bodies use `apply_authorization_to_opts` after merging their header defaults.
+/// Fixed credentials accept matching selections and deny narrowing; request
+/// credentials resolve their final selection here, including deny when absent.
+pub(crate) fn bound_governance(
+    identity: Option<&str>,
+    headers: &FlureeHeaders,
+) -> Result<GovernanceOptions> {
+    let requested = governance_from_headers(identity, headers)?;
+    match &headers.policy_authorization {
+        Some(authorization) => authorization.resolve_options(&requested),
+        None => Ok(requested),
+    }
+}
+
+/// Parse caller header options without applying credential authorization.
+fn governance_from_headers(
+    identity: Option<&str>,
+    headers: &FlureeHeaders,
+) -> Result<GovernanceOptions> {
+    let policy_values_map = headers.policy_values_map()?;
+    Ok(GovernanceOptions {
+        identity: identity.map(String::from),
+        policy_class: if headers.policy_class.is_empty() {
+            None
+        } else {
+            Some(headers.policy_class.clone())
+        },
+        policy: headers.policy.clone(),
+        policy_values: policy_values_map,
+        default_allow: headers.default_allow,
+    })
 }

--- a/fluree-db-server/src/routes/policy_auth.rs
+++ b/fluree-db-server/src/routes/policy_auth.rs
@@ -78,8 +78,28 @@ pub(crate) async fn wrap_authorized_view(
     headers: &FlureeHeaders,
 ) -> Result<fluree_db_api::GraphDb> {
     let opts = bound_governance(headers.identity.as_deref(), headers)?;
+    wrap_governed_view(state, view, &opts).await
+}
+
+/// JSON routes must use the finalized body selection, including request-selected
+/// credentials and body-level narrowing, after authorization has been applied.
+pub(crate) async fn wrap_jsonld_view(
+    state: &AppState,
+    view: fluree_db_api::GraphDb,
+    query: &Value,
+) -> Result<fluree_db_api::GraphDb> {
+    let opts = GovernanceOptions::from_json(query)
+        .map_err(|e| crate::error::ServerError::bad_request(e.to_string()))?;
+    wrap_governed_view(state, view, &opts).await
+}
+
+async fn wrap_governed_view(
+    state: &AppState,
+    view: fluree_db_api::GraphDb,
+    opts: &GovernanceOptions,
+) -> Result<fluree_db_api::GraphDb> {
     if opts.has_any_policy_inputs() {
-        Ok(state.fluree.wrap_policy(view, &opts, None).await?)
+        Ok(state.fluree.wrap_policy(view, opts, None).await?)
     } else {
         Ok(state.fluree.wrap_policy_defaults(view).await?)
     }

--- a/fluree-db-server/src/routes/push.rs
+++ b/fluree-db-server/src/routes/push.rs
@@ -64,31 +64,23 @@ async fn push_ledger_local(
         }
     }
 
-    // Build policy options.
-    //
-    let mut governance = GovernanceOptions {
-        // Identity is non-spoofable: derived from bearer token (fluree.identity ?? sub).
-        identity: bearer.as_ref().and_then(|p| p.identity.clone()),
-        // Allow client-provided inline policy and policy-values headers.
-        policy: headers.policy.clone(),
-        policy_values: headers.policy_values_map()?,
-        ..Default::default()
+    // Push has no signed body credential; bind its verified bearer exactly as
+    // ordinary writes do, then resolve the complete header selection.
+    let headers =
+        crate::routes::policy_auth::bind_authorization(&state, headers, bearer.as_ref(), None)?;
+    let governance = if bearer.is_some() {
+        crate::routes::policy_auth::bound_governance(headers.identity.as_deref(), &headers)?
+    } else {
+        // Preserve the anonymous push defaults, including the server class.
+        GovernanceOptions {
+            policy_class: data_auth.default_policy_class.map(|c| vec![c]).or_else(|| {
+                (!headers.policy_class.is_empty()).then(|| headers.policy_class.clone())
+            }),
+            policy: headers.policy.clone(),
+            policy_values: headers.policy_values_map()?,
+            ..Default::default()
+        }
     };
-
-    // Force server default policy-class if configured (non-spoofable).
-    if let Some(pc) = data_auth.default_policy_class.as_ref() {
-        governance.policy_class = Some(vec![pc.clone()]);
-    } else if !headers.policy_class.is_empty() {
-        governance.policy_class = Some(headers.policy_class.clone());
-    }
-
-    // Push has no signed body credential. Its verified bearer selects policy;
-    // inline/header grants cannot replace it, just as on ordinary writes.
-    if let Some(principal) = &bearer {
-        governance = principal.policy_authorization.resolve_options(
-            &crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), &headers)?,
-        )?;
-    }
 
     let idempotency_key = extract_idempotency_key(&headers.raw)?;
 

--- a/fluree-db-server/src/routes/push.rs
+++ b/fluree-db-server/src/routes/push.rs
@@ -85,12 +85,9 @@ async fn push_ledger_local(
     // Push has no signed body credential. Its verified bearer selects policy;
     // inline/header grants cannot replace it, just as on ordinary writes.
     if let Some(principal) = &bearer {
-        governance = principal
-            .policy_authorization
-            .constrain_options(&GovernanceOptions {
-                default_allow: headers.default_allow,
-                ..Default::default()
-            });
+        governance = principal.policy_authorization.resolve_options(
+            &crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), &headers)?,
+        )?;
     }
 
     let idempotency_key = extract_idempotency_key(&headers.raw)?;

--- a/fluree-db-server/src/routes/push.rs
+++ b/fluree-db-server/src/routes/push.rs
@@ -82,6 +82,17 @@ async fn push_ledger_local(
         governance.policy_class = Some(headers.policy_class.clone());
     }
 
+    // Push has no signed body credential. Its verified bearer selects policy;
+    // inline/header grants cannot replace it, just as on ordinary writes.
+    if let Some(principal) = &bearer {
+        governance = principal
+            .policy_authorization
+            .constrain_options(&GovernanceOptions {
+                default_allow: headers.default_allow,
+                ..Default::default()
+            });
+    }
+
     let idempotency_key = extract_idempotency_key(&headers.raw)?;
 
     let bytes = axum::body::to_bytes(request.into_body(), 50 * 1024 * 1024)

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -271,21 +271,6 @@ pub(crate) fn is_sparql_request(
 // Data API Auth Helpers
 // ============================================================================
 
-/// Resolve the effective request identity for policy enforcement.
-///
-/// Precedence:
-/// 1) Signed request DID (credential)
-/// 2) Bearer token identity (fluree.identity ?? sub)
-pub(crate) fn effective_identity(
-    credential: &MaybeCredential,
-    bearer: &MaybeDataBearer,
-) -> Option<String> {
-    credential
-        .did()
-        .map(std::string::ToString::to_string)
-        .or_else(|| bearer.0.as_ref().and_then(|p| p.identity.clone()))
-}
-
 /// Check if tracking is requested in query opts
 fn has_tracking_opts(query_json: &JsonValue) -> bool {
     let Some(opts) = query_json.get("opts") else {
@@ -412,21 +397,12 @@ pub(crate) fn enforce_bearer_dataset_scope(
         return Ok(());
     }
 
-    let mut ids: Vec<String> = Vec::new();
-    if let Some(from) = query_json.get("from") {
-        collect_ledger_identifiers(from, &mut ids);
-    }
-    if let Some(named) = query_json
-        .get("fromNamed")
-        .or_else(|| query_json.get("from-named"))
-    {
-        collect_ledger_identifiers(named, &mut ids);
-    }
-
-    for raw in ids {
-        // Strip any `@t:` / `#graph` suffix so a scoped read token still
-        // authorizes time-travel / graph-fragment reads of an in-scope ledger.
-        let base = base_ledger_id(&raw)?;
+    // Use the engine's dataset parser: opts.from / opts.ledger / opts.fromNamed
+    // take precedence over the corresponding top-level fields.
+    let (spec, _) = DatasetSpec::from_query_json(query_json)
+        .map_err(|e| ServerError::bad_request(e.to_string()))?;
+    for source in spec.default_graphs.iter().chain(spec.named_graphs.iter()) {
+        let base = base_ledger_id(&source.identifier)?;
         if !principal.can_read(&base) {
             set_span_error_code(span, "error:Forbidden");
             return Err(ServerError::not_found("Ledger not found"));
@@ -549,6 +525,12 @@ pub async fn query(
     bearer: MaybeDataBearer,
     credential: MaybeCredential,
 ) -> Result<Response> {
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.0.as_ref(),
+        &credential,
+    )?;
     // Create request span with correlation context
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
     let trace_id = extract_trace_id(&credential.headers);
@@ -677,6 +659,8 @@ pub async fn query(
             .await;
         }
 
+        let qc_opts = sparql_qc_opts(headers.identity.as_deref(), &headers)?;
+
         // Parse once and reuse across the format branches below (#1473): the
         // agent-json and plain paths both need the AST, and the advisory header
         // is derived from the same parse rather than a third one.
@@ -727,6 +711,7 @@ pub async fn query(
                     .fluree
                     .query_from()
                     .sparql(&sparql)
+                    .connection_opts(qc_opts.clone())
                     .format(config)
                     .tracking(tracking_opts)
                     .execution_options(query_execution_options(&state))
@@ -773,6 +758,7 @@ pub async fn query(
                 .fluree
                 .query_from()
                 .sparql(&sparql)
+                .connection_opts(qc_opts.clone())
                 .format(config)
                 .execution_options(query_execution_options(&state))
                 .execute_formatted()
@@ -797,12 +783,12 @@ pub async fn query(
             let tracking_opts = headers.to_tracking_options();
             let response = state
                 .fluree
-                .query_connection_sparql_tracked_with_options(
-                    &sparql,
-                    None,
-                    Some(tracking_opts),
-                    query_execution_options(&state),
-                )
+                .query_from()
+                .sparql(&sparql)
+                .connection_opts(qc_opts.clone())
+                .tracking(tracking_opts)
+                .execution_options(query_execution_options(&state))
+                .execute_tracked()
                 .await;
             let response = match response {
                 Ok(r) => r,
@@ -841,6 +827,7 @@ pub async fn query(
             .fluree
             .query_from()
             .sparql(&sparql)
+            .connection_opts(qc_opts.clone())
             .format(fmt_config)
             .execution_options(query_execution_options(&state))
             .execute_formatted()
@@ -905,18 +892,9 @@ pub async fn query(
             collect_jsonld_min_t_requirements(&headers, &query_json, Some(&ledger_id))?;
         await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
-        // Apply bearer identity + server-default policy-class to opts, honoring
-        // the root-identity impersonation semantic (see routes::policy_auth).
-        let identity = effective_identity(&credential, &bearer);
-        let policy_class = data_auth.default_policy_class.as_deref();
-        crate::routes::policy_auth::apply_auth_identity_to_opts(
-            &state,
-            &ledger_id,
-            &mut query_json,
-            identity.as_deref(),
-            policy_class,
-        )
-        .await;
+        // Bind all policy options to verified authority after header merging.
+
+        crate::routes::policy_auth::apply_authorization_to_opts(&mut query_json, &headers)?;
 
         inject_default_context_if_requested(
             &state,
@@ -953,6 +931,12 @@ pub async fn query_ledger(
     bearer: MaybeDataBearer,
     credential: MaybeCredential,
 ) -> Result<Response> {
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.0.as_ref(),
+        &credential,
+    )?;
     // Create request span with correlation context
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
     let trace_id = extract_trace_id(&credential.headers);
@@ -1016,14 +1000,7 @@ pub async fn query_ledger(
             }
         }
 
-        let bearer_identity = effective_identity(&credential, &bearer);
-        let identity = crate::routes::policy_auth::resolve_sparql_identity(
-            &state,
-            &ledger,
-            bearer_identity.as_deref(),
-            headers.identity.as_deref(),
-        )
-        .await;
+        let identity = headers.identity.clone();
         let min_t_requirements =
             collect_sparql_min_t_requirements(headers.min_t, &sparql, Some(&ledger))?;
         await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
@@ -1052,16 +1029,10 @@ pub async fn query_ledger(
         }
         let cypher = credential.body_string()?;
         log_query_text(&cypher, &state.telemetry_config, &span);
-        // Resolve the effective identity (impersonation-aware), same as the
+        // Use the verified effective identity, same as the
         // SPARQL read path, so policy enforcement applies to Cypher too.
-        let bearer_identity = effective_identity(&credential, &bearer);
-        let identity = crate::routes::policy_auth::resolve_sparql_identity(
-            &state,
-            &ledger,
-            bearer_identity.as_deref(),
-            headers.identity.as_deref(),
-        )
-        .await;
+
+        let identity = headers.identity.clone();
         // Honor the `Fluree-Min-T` read-your-writes freshness wait, same as the
         // SPARQL/JSON-LD paths. Cypher has no FROM/dataset clause or `@t:` pin,
         // so the header is the only requirement source, against this one ledger.
@@ -1127,18 +1098,9 @@ pub async fn query_ledger(
         collect_jsonld_min_t_requirements(&headers, &query_json, Some(&ledger_id))?;
     await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
-    // Apply bearer identity + server-default policy-class to opts, honoring
-    // the root-identity impersonation semantic (see routes::policy_auth).
-    let identity = effective_identity(&credential, &bearer);
-    let policy_class = data_auth.default_policy_class.as_deref();
-    crate::routes::policy_auth::apply_auth_identity_to_opts(
-        &state,
-        &ledger_id,
-        &mut query_json,
-        identity.as_deref(),
-        policy_class,
-    )
-    .await;
+    // Apply verified authorization after all caller/header option merges.
+
+    crate::routes::policy_auth::apply_authorization_to_opts(&mut query_json, &headers)?;
 
     inject_default_context_if_requested(
         &state,
@@ -1198,6 +1160,12 @@ pub async fn explain_ledger(
     bearer: MaybeDataBearer,
     credential: MaybeCredential,
 ) -> Result<Json<JsonValue>> {
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.0.as_ref(),
+        &credential,
+    )?;
     // Create request span with correlation context
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
     let trace_id = extract_trace_id(&credential.headers);
@@ -1288,7 +1256,7 @@ pub async fn explain_ledger(
                 // suffix on FROM <ledger@t:N> drives snapshot selection.
                 let result = state
                     .fluree
-                    .explain_connection_sparql(&sparql)
+                    .explain_connection_sparql_with_opts(&sparql, &sparql_qc_opts(headers.identity.as_deref(), &headers)?)
                     .await
                     .map_err(ServerError::Api)?;
                 tracing::info!(
@@ -1310,6 +1278,7 @@ pub async fn explain_ledger(
                 load_ledger_for_query(&state, &ledger_id, &span).await?
             };
             let db = fluree_db_api::GraphDb::from_ledger_state(&loaded);
+            let db = crate::routes::policy_auth::wrap_authorized_view(&state, db, &headers).await?;
             let result = state
                 .fluree
                 .explain_sparql(&db, &sparql)
@@ -1345,6 +1314,7 @@ pub async fn explain_ledger(
                 .db_with_default_context(&ledger)
                 .await
                 .map_err(ServerError::Api)?;
+            let view = crate::routes::policy_auth::wrap_authorized_view(&state, view, &headers).await?;
             let result = state
                 .fluree
                 .explain_cypher(&view, &cypher, cypher_params.as_ref())
@@ -1381,6 +1351,7 @@ pub async fn explain_ledger(
 
         // Inject header values into query opts
         inject_headers_into_query(&mut query_json, &headers);
+        enforce_bearer_dataset_scope(&query_json, &bearer, credential.is_signed(), &span)?;
 
         // Enforce bearer ledger scope for unsigned requests
         if let Some(p) = bearer.0.as_ref() {
@@ -1394,18 +1365,9 @@ pub async fn explain_ledger(
             collect_jsonld_min_t_requirements(&headers, &query_json, Some(&ledger_id))?;
         await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
-        // Apply bearer identity + server-default policy-class to opts, honoring
-        // the root-identity impersonation semantic (see routes::policy_auth).
-        let identity = effective_identity(&credential, &bearer);
-        let policy_class = data_auth.default_policy_class.as_deref();
-        crate::routes::policy_auth::apply_auth_identity_to_opts(
-            &state,
-            &ledger_id,
-            &mut query_json,
-            identity.as_deref(),
-            policy_class,
-        )
-        .await;
+        // Bind all policy options to verified authority after header merging.
+
+        crate::routes::policy_auth::apply_authorization_to_opts(&mut query_json, &headers)?;
 
         // When the body carries a time-travel `from` (or any other dataset
         // feature `normalize_ledger_scoped_from` accepted), delegate to the
@@ -1446,6 +1408,7 @@ pub async fn explain_ledger(
             load_ledger_for_query(&state, &ledger_id, &span).await?
         };
         let db = fluree_db_api::GraphDb::from_ledger_state(&loaded);
+        let db = crate::routes::policy_auth::wrap_authorized_view(&state, db, &headers).await?;
         let result = state
             .fluree
             .explain(&db, &query_json)
@@ -3398,6 +3361,12 @@ pub async fn explain(
     bearer: MaybeDataBearer,
     credential: MaybeCredential,
 ) -> Result<Json<JsonValue>> {
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.0.as_ref(),
+        &credential,
+    )?;
     // Create request span with correlation context
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
     let trace_id = extract_trace_id(&credential.headers);
@@ -3502,7 +3471,7 @@ pub async fn explain(
             if ledger_id_raw != ledger_id {
                 let result = state
                     .fluree
-                    .explain_connection_sparql(&sparql)
+                    .explain_connection_sparql_with_opts(&sparql, &sparql_qc_opts(headers.identity.as_deref(), &headers)?)
                     .await
                     .map_err(ServerError::Api)?;
                 tracing::info!(status = "success", "explain completed (dataset path)");
@@ -3515,6 +3484,7 @@ pub async fn explain(
                 load_ledger_for_query(&state, &ledger_id, &span).await?
             };
             let db = fluree_db_api::GraphDb::from_ledger_state(&loaded);
+            let db = crate::routes::policy_auth::wrap_authorized_view(&state, db, &headers).await?;
             let result = {
                 match state.fluree.explain_sparql(&db, &sparql).await {
                     Ok(result) => {
@@ -3567,6 +3537,7 @@ pub async fn explain(
 
         // Inject header values into query opts
         inject_headers_into_query(&mut query_json, &headers);
+        enforce_bearer_dataset_scope(&query_json, &bearer, credential.is_signed(), &span)?;
 
         // Enforce bearer ledger scope for unsigned requests (base id only).
         if let Some(p) = bearer.0.as_ref() {
@@ -3580,18 +3551,9 @@ pub async fn explain(
             collect_jsonld_min_t_requirements(&headers, &query_json, Some(&ledger_id))?;
         await_query_min_t_requirements(state.as_ref(), min_t_requirements).await?;
 
-        // Apply bearer identity + server-default policy-class to opts, honoring
-        // the root-identity impersonation semantic (see routes::policy_auth).
-        let identity = effective_identity(&credential, &bearer);
-        let policy_class = data_auth.default_policy_class.as_deref();
-        crate::routes::policy_auth::apply_auth_identity_to_opts(
-            &state,
-            &ledger_id,
-            &mut query_json,
-            identity.as_deref(),
-            policy_class,
-        )
-        .await;
+        // Bind all policy options to verified authority after header merging.
+
+        crate::routes::policy_auth::apply_authorization_to_opts(&mut query_json, &headers)?;
 
         // When the body carries time-travel `from` (or any other dataset
         // feature parse_dataset_spec recognizes), route through the
@@ -3620,6 +3582,7 @@ pub async fn explain(
             load_ledger_for_query(&state, &ledger_id, &span).await?
         };
         let db = fluree_db_api::GraphDb::from_ledger_state(&loaded);
+        let db = crate::routes::policy_auth::wrap_authorized_view(&state, db, &headers).await?;
         let result = match state.fluree.explain(&db, &query_json).await {
             Ok(result) => {
                 tracing::info!(status = "success", "explain completed");
@@ -4014,6 +3977,12 @@ pub async fn multi_query(
     bearer: MaybeDataBearer,
     credential: MaybeCredential,
 ) -> Result<Response> {
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.0.as_ref(),
+        &credential,
+    )?;
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
     let trace_id = extract_trace_id(&credential.headers);
     let span = create_request_span(
@@ -4123,57 +4092,29 @@ pub async fn multi_query(
                 .await;
             }
 
-            // Per-sub-query identity / default-policy-class injection runs
-            // here, not inside the api crate. apply_auth_identity_to_opts
-            // depends on the server's impersonation table, which is a
-            // server concern.
-            //
-            // Two security invariants this block enforces:
-            //
-            // 1. The impersonation gate sees the **final** opts.identity
-            //    that would be in effect — including any value set at the
-            //    envelope level or in the sub.opts override. Without the
-            //    pre-merge below, an envelope-level `opts.identity` would
-            //    bypass the gate entirely because
-            //    `body_requests_impersonation` only inspects the query
-            //    body's opts.
-            //
-            // 2. The gate's decision (force bearer identity, or honour body
-            //    opts) is persisted into `sub.query["opts"]`, where the api
-            //    crate's dispatcher gives it precedence over `envelope.opts`
-            //    and `sub.opts`. The dispatcher's merge rule is
-            //    `envelope ⊕ sub.opts ⊕ body opts` with body winning, so
-            //    nothing downstream can clobber the forced identity by
-            //    setting an unrelated key like `meta` at the envelope or
-            //    sub-query level.
+            // Merge first, then bind each alias to the verified request context.
+            // Canonical nulls in the most specific layer also shadow any outer
+            // untrusted defaults when the dispatcher merges again.
             let envelope_opts_owned = envelope.opts.clone();
-            let effective_id = effective_identity(&credential, &bearer);
-            let default_policy_class = data_auth.default_policy_class.clone();
+
             for sub in envelope.queries.values_mut() {
                 if matches!(sub.language, SubqueryLanguage::JsonLd) {
                     premerge_opts_into_subquery_body(envelope_opts_owned.as_ref(), sub);
-                    apply_envelope_subquery_auth(
-                        &state,
-                        sub,
-                        effective_id.as_deref(),
-                        default_policy_class.as_deref(),
-                    )
-                    .await;
+                    enforce_bearer_dataset_scope(
+                        &sub.query,
+                        &bearer,
+                        credential.is_signed(),
+                        &span,
+                    )?;
+                    apply_envelope_subquery_auth(sub, &headers)?;
                 } else if matches!(sub.language, SubqueryLanguage::Sparql) {
                     // SPARQL aliases are policy-enforced too: resolve identity /
-                    // policy-class through the same impersonation gate and stash the
+                    // policy-class through the same authorization binding and stash the
                     // decision in `sub.opts`, which the api crate's SPARQL path reads
                     // (`run_sparql_subquery` → `connection_opts`). Without this a
                     // SPARQL alias would run unrestricted while its JSON-LD twin is
                     // gated.
-                    apply_envelope_sparql_auth(
-                        &state,
-                        sub,
-                        envelope_opts_owned.as_ref(),
-                        effective_id.as_deref(),
-                        default_policy_class.as_deref(),
-                    )
-                    .await;
+                    apply_envelope_sparql_auth(sub, envelope_opts_owned.as_ref(), &headers)?;
                 }
             }
 
@@ -4367,100 +4308,31 @@ fn inject_headers_into_envelope(
     envelope
 }
 
-/// Apply the server's bearer identity / default-policy-class to a
-/// single JSON-LD sub-query's `query` body before handing the envelope
-/// to the api-crate dispatcher.
-///
-/// Per-sub-query application uses the sub-query's primary ledger (first
-/// entry of `from`) as the impersonation-check context. Sub-queries
-/// that span multiple ledgers fall back to the first as a conservative
-/// default — same heuristic the previous server-side dispatcher used.
-async fn apply_envelope_subquery_auth(
-    state: &AppState,
+/// Apply the same verified context after merging each alias's final options.
+fn apply_envelope_subquery_auth(
     sub: &mut MultiQuerySubquery,
-    bearer_identity: Option<&str>,
-    default_policy_class: Option<&str>,
-) {
-    if bearer_identity.is_none() && default_policy_class.is_none() {
-        return;
-    }
-    let primary_ledger = primary_ledger_from_jsonld(&sub.query);
-    crate::routes::policy_auth::apply_auth_identity_to_opts(
-        state,
-        primary_ledger.as_deref().unwrap_or(""),
-        &mut sub.query,
-        bearer_identity,
-        default_policy_class,
-    )
-    .await;
+    headers: &FlureeHeaders,
+) -> Result<()> {
+    crate::routes::policy_auth::apply_authorization_to_opts(&mut sub.query, headers)
 }
 
-/// Run the impersonation gate for a **SPARQL** sub-query alias.
-///
-/// SPARQL bodies carry no `opts` block, so identity / policy inputs ride on the
-/// envelope `opts` (header-injected) and the per-alias `sub.opts` override —
-/// never on the query string. We reuse the **exact** JSON-LD gate
-/// ([`apply_auth_identity_to_opts`]) by feeding it a synthetic
-/// `{ "opts": <merged envelope ⊕ sub opts> }` object, then store the gated opts
-/// back as `sub.opts`. For SPARQL the api dispatcher merges `envelope ⊕ sub.opts`
-/// (there is no body layer), so a forced bearer identity in `sub.opts` wins and
-/// cannot be clobbered by a user-supplied envelope/sub `identity`. The
-/// per-ledger impersonation check uses the alias's first `FROM` ledger.
-///
-/// Reusing the JSON-LD gate (rather than re-deriving the decision) keeps SPARQL
-/// and JSON-LD aliases on identical impersonation semantics by construction.
-async fn apply_envelope_sparql_auth(
-    state: &AppState,
+/// SPARQL carries policy options outside its text. Canonical nulls in sub.opts
+/// prevent the dispatcher from restoring untrusted envelope defaults.
+fn apply_envelope_sparql_auth(
     sub: &mut MultiQuerySubquery,
     envelope_opts: Option<&JsonValue>,
-    bearer_identity: Option<&str>,
-    default_policy_class: Option<&str>,
-) {
-    if bearer_identity.is_none() && default_policy_class.is_none() {
-        return;
-    }
-    let sparql = sub.query.as_str().unwrap_or_default();
-    let ledger = fluree_db_api::sparql_dataset_ledger_ids(sparql)
-        .ok()
-        .and_then(|ids| ids.into_iter().next())
-        .unwrap_or_default();
-
-    // Wrap the merged opts as a synthetic query body so the JSON-LD gate can
-    // inspect/force identity & policy-class exactly as it does for JSON-LD.
+    headers: &FlureeHeaders,
+) -> Result<()> {
     let merged = fluree_db_api::query::multi::merged_opts(envelope_opts, sub.opts.as_ref());
-    let mut synthetic = JsonValue::Object(serde_json::Map::new());
-    if let Some(opts) = merged {
-        if let Some(obj) = synthetic.as_object_mut() {
-            obj.insert("opts".to_string(), opts);
-        }
-    }
-    crate::routes::policy_auth::apply_auth_identity_to_opts(
-        state,
-        &ledger,
-        &mut synthetic,
-        bearer_identity,
-        default_policy_class,
-    )
-    .await;
+    let mut synthetic = serde_json::json!({"opts": merged});
+    crate::routes::policy_auth::apply_authorization_to_opts(&mut synthetic, headers)?;
     sub.opts = synthetic.get("opts").cloned();
+    Ok(())
 }
 
-/// Pre-merge envelope-level `opts` and sub-query `opts` override into
-/// the sub-query body's `opts` BEFORE the impersonation gate runs.
-///
-/// Without this step, an envelope-level `opts.identity` (or one in the
-/// per-sub-query opts override) would never reach
-/// `body_requests_impersonation`, because the gate only inspects
-/// `sub.query["opts"]`. The result would be a silent identity bypass:
-/// the user's "request to impersonate" goes through unchecked because
-/// the gate didn't see it.
-///
-/// Precedence (most specific wins): `sub.query["opts"]` already in the
-/// body beats `sub.opts`, which beats `envelope.opts`. After this
-/// merge, `sub.query["opts"]` holds the final set the gate decides
-/// against. The api crate's dispatcher uses the same priority when it
-/// later merges envelope / sub / body together, so the gate's decision
-/// (written into `sub.query["opts"]`) survives.
+/// Merge envelope, alias, and body options before authorization, using the
+/// dispatcher's precedence. The trusted result is stored in the most specific
+/// layer so subsequent merges preserve it.
 fn premerge_opts_into_subquery_body(
     envelope_opts: Option<&JsonValue>,
     sub: &mut MultiQuerySubquery,
@@ -4479,37 +4351,4 @@ fn premerge_opts_into_subquery_body(
     if let Some(opts) = final_opts {
         body.insert("opts".to_string(), opts);
     }
-}
-
-/// Extract the first ledger identifier (with any temporal suffix and
-/// `#fragment` stripped) from a JSON-LD sub-query body's `from` field.
-/// Used as the impersonation-check context for
-/// [`apply_envelope_subquery_auth`].
-fn primary_ledger_from_jsonld(query: &JsonValue) -> Option<String> {
-    let from = query.as_object()?.get("from")?;
-    let raw = match from {
-        JsonValue::String(s) => s.clone(),
-        JsonValue::Array(arr) => arr.iter().find_map(|v| match v {
-            JsonValue::String(s) => Some(s.clone()),
-            JsonValue::Object(obj) => obj
-                .get("@id")
-                .or_else(|| obj.get("id"))
-                .and_then(JsonValue::as_str)
-                .map(str::to_string),
-            _ => None,
-        })?,
-        JsonValue::Object(obj) => obj
-            .get("@id")
-            .or_else(|| obj.get("id"))
-            .and_then(JsonValue::as_str)?
-            .to_string(),
-        _ => return None,
-    };
-    let bare = raw.split('#').next().unwrap_or(&raw);
-    for marker in ["@t:", "@iso:", "@commit:"] {
-        if let Some(idx) = bare.find(marker) {
-            return Some(bare[..idx].to_string());
-        }
-    }
-    Some(bare.to_string())
 }

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -527,7 +527,7 @@ pub async fn query(
         &state,
         headers,
         bearer.0.as_ref(),
-        &credential,
+        credential.did(),
     )?;
     // Create request span with correlation context
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
@@ -657,7 +657,7 @@ pub async fn query(
             .await;
         }
 
-        let qc_opts = sparql_qc_opts(headers.identity.as_deref(), &headers)?;
+        let qc_opts = crate::routes::policy_auth::bound_governance(headers.identity.as_deref(), &headers)?;
 
         // Parse once and reuse across the format branches below (#1473): the
         // agent-json and plain paths both need the AST, and the advisory header
@@ -933,7 +933,7 @@ pub async fn query_ledger(
         &state,
         headers,
         bearer.0.as_ref(),
-        &credential,
+        credential.did(),
     )?;
     // Create request span with correlation context
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
@@ -1162,7 +1162,7 @@ pub async fn explain_ledger(
         &state,
         headers,
         bearer.0.as_ref(),
-        &credential,
+        credential.did(),
     )?;
     // Create request span with correlation context
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
@@ -1254,7 +1254,7 @@ pub async fn explain_ledger(
                 // suffix on FROM <ledger@t:N> drives snapshot selection.
                 let result = state
                     .fluree
-                    .explain_connection_sparql_with_opts(&sparql, &sparql_qc_opts(headers.identity.as_deref(), &headers)?)
+                    .explain_connection_sparql_with_opts(&sparql, &crate::routes::policy_auth::bound_governance(headers.identity.as_deref(), &headers)?)
                     .await
                     .map_err(ServerError::Api)?;
                 tracing::info!(
@@ -2265,28 +2265,6 @@ async fn execute_query_proxy(
     Ok((HeaderMap::new(), Json(result)).into_response())
 }
 
-pub(crate) fn sparql_qc_opts(
-    identity: Option<&str>,
-    headers: &FlureeHeaders,
-) -> Result<fluree_db_api::GovernanceOptions> {
-    let policy_values_map = headers.policy_values_map()?;
-    let requested = fluree_db_api::GovernanceOptions {
-        identity: identity.map(String::from),
-        policy_class: if headers.policy_class.is_empty() {
-            None
-        } else {
-            Some(headers.policy_class.clone())
-        },
-        policy: headers.policy.clone(),
-        policy_values: policy_values_map,
-        default_allow: headers.default_allow,
-    };
-    match &headers.policy_authorization {
-        Some(authorization) => authorization.resolve_options(&requested),
-        None => Ok(requested),
-    }
-}
-
 /// Build a `DatasetSpec` from a ledger-scoped SPARQL `FROM`/`FROM NAMED` clause.
 ///
 /// FROM/FROM NAMED select named graphs *within this ledger*: a bare graph IRI
@@ -2600,7 +2578,7 @@ async fn execute_cypher_ledger(
     // Build policy options from the resolved identity + headers. Cypher has no
     // body `opts` block, so headers are the only transport for `policy-class`,
     // `policy`, `policy-values`, and `default-allow` (same as SPARQL).
-    let qc_opts = sparql_qc_opts(identity, headers)?;
+    let qc_opts = crate::routes::policy_auth::bound_governance(identity, headers)?;
 
     let view = state
         .fluree
@@ -2699,7 +2677,7 @@ async fn execute_sparql_ledger(
         // Build GovernanceOptions from the resolved identity plus header-supplied
         // policy fields. SPARQL has no body `opts` block, so headers are the only
         // transport for `policy-class`, `policy`, `policy-values`, and `default-allow`.
-        let qc_opts = sparql_qc_opts(identity, headers).inspect_err(|e| {
+        let qc_opts = crate::routes::policy_auth::bound_governance(identity, headers).inspect_err(|e| {
             set_span_error_code(&span, "error:BadRequest");
             tracing::warn!(error = %e, "invalid fluree-policy-values header");
         })?;
@@ -3354,7 +3332,7 @@ pub async fn explain(
         &state,
         headers,
         bearer.0.as_ref(),
-        &credential,
+        credential.did(),
     )?;
     // Create request span with correlation context
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
@@ -3460,7 +3438,7 @@ pub async fn explain(
             if ledger_id_raw != ledger_id {
                 let result = state
                     .fluree
-                    .explain_connection_sparql_with_opts(&sparql, &sparql_qc_opts(headers.identity.as_deref(), &headers)?)
+                    .explain_connection_sparql_with_opts(&sparql, &crate::routes::policy_auth::bound_governance(headers.identity.as_deref(), &headers)?)
                     .await
                     .map_err(ServerError::Api)?;
                 tracing::info!(status = "success", "explain completed (dataset path)");
@@ -3970,7 +3948,7 @@ pub async fn multi_query(
         &state,
         headers,
         bearer.0.as_ref(),
-        &credential,
+        credential.did(),
     )?;
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
     let trace_id = extract_trace_id(&credential.headers);

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -1406,7 +1406,7 @@ pub async fn explain_ledger(
             load_ledger_for_query(&state, &ledger_id, &span).await?
         };
         let db = fluree_db_api::GraphDb::from_ledger_state(&loaded);
-        let db = crate::routes::policy_auth::wrap_authorized_view(&state, db, &headers).await?;
+        let db = crate::routes::policy_auth::wrap_jsonld_view(&state, db, &query_json).await?;
         let result = state
             .fluree
             .explain(&db, &query_json)
@@ -3549,7 +3549,7 @@ pub async fn explain(
             load_ledger_for_query(&state, &ledger_id, &span).await?
         };
         let db = fluree_db_api::GraphDb::from_ledger_state(&loaded);
-        let db = crate::routes::policy_auth::wrap_authorized_view(&state, db, &headers).await?;
+        let db = crate::routes::policy_auth::wrap_jsonld_view(&state, db, &query_json).await?;
         let result = match state.fluree.explain(&db, &query_json).await {
             Ok(result) => {
                 tracing::info!(status = "success", "explain completed");

--- a/fluree-db-server/src/routes/query.rs
+++ b/fluree-db-server/src/routes/query.rs
@@ -302,16 +302,14 @@ fn has_tracking_opts(query_json: &JsonValue) -> bool {
 
 /// Check if the query opts request identity-based policy enforcement.
 ///
-/// Returns true when `opts.identity` or `opts.policy-class` is present.
+/// Returns true when identity, policy class, or inline policy is non-null.
+/// Canonical nulls only shadow outer options; they do not engage enforcement.
 /// These fields trigger policy lookup in the connection execution path;
 /// the plain GraphDb path does not process them.
 pub(crate) fn has_policy_opts(query_json: &JsonValue) -> bool {
-    let Some(opts) = query_json.get("opts") else {
-        return false;
-    };
-    opts.get("identity").is_some()
-        || opts.get("policy-class").is_some()
-        || opts.get("policy").is_some()
+    fluree_db_api::GovernanceOptions::from_json(query_json)
+        .map(|opts| opts.has_any_policy_inputs())
+        .unwrap_or(true)
 }
 
 /// Extract a representative ledger identifier from a `from` / `fromNamed`
@@ -2073,7 +2071,7 @@ async fn execute_query(
             return Err(ServerError::Api(ApiError::NotFound(ledger_id.to_string())));
         }
     };
-    let graph = GraphDb::from_ledger_state(&ledger);
+    let graph = state.fluree.wrap_policy_defaults(GraphDb::from_ledger_state(&ledger)).await?;
     let fluree = &state.fluree;
 
     // Check if tracking is requested
@@ -2195,13 +2193,13 @@ async fn execute_query_proxy(
     query_json: &JsonValue,
     span: &tracing::Span,
 ) -> Result<Response> {
+    let view = state.fluree.db(ledger_id).await?;
+    let view = state.fluree.wrap_policy_defaults(view).await?;
     // Check if tracking is requested
     if has_tracking_opts(query_json) {
         // Execute tracked query
-        let response = match state
-            .fluree
-            .graph(ledger_id)
-            .query()
+        let response = match view
+            .query(state.fluree.as_ref())
             .jsonld(query_json)
             .execution_options(query_execution_options(state))
             .execute_tracked()
@@ -2242,10 +2240,8 @@ async fn execute_query_proxy(
     }
 
     // Execute query
-    let result = match state
-        .fluree
-        .graph(ledger_id)
-        .query()
+    let result = match view
+        .query(state.fluree.as_ref())
         .jsonld(query_json)
         .execution_options(query_execution_options(state))
         .execute_formatted()
@@ -2274,7 +2270,7 @@ pub(crate) fn sparql_qc_opts(
     headers: &FlureeHeaders,
 ) -> Result<fluree_db_api::GovernanceOptions> {
     let policy_values_map = headers.policy_values_map()?;
-    Ok(fluree_db_api::GovernanceOptions {
+    let requested = fluree_db_api::GovernanceOptions {
         identity: identity.map(String::from),
         policy_class: if headers.policy_class.is_empty() {
             None
@@ -2284,7 +2280,11 @@ pub(crate) fn sparql_qc_opts(
         policy: headers.policy.clone(),
         policy_values: policy_values_map,
         default_allow: headers.default_allow,
-    })
+    };
+    match &headers.policy_authorization {
+        Some(authorization) => authorization.resolve_options(&requested),
+        None => Ok(requested),
+    }
 }
 
 /// Build a `DatasetSpec` from a ledger-scoped SPARQL `FROM`/`FROM NAMED` clause.
@@ -2600,20 +2600,7 @@ async fn execute_cypher_ledger(
     // Build policy options from the resolved identity + headers. Cypher has no
     // body `opts` block, so headers are the only transport for `policy-class`,
     // `policy`, `policy-values`, and `default-allow` (same as SPARQL).
-    let policy_values_map = headers.policy_values_map().inspect_err(|_| {
-        set_span_error_code(span, "error:BadRequest");
-    })?;
-    let qc_opts = fluree_db_api::GovernanceOptions {
-        identity: identity.map(String::from),
-        policy_class: if headers.policy_class.is_empty() {
-            None
-        } else {
-            Some(headers.policy_class.clone())
-        },
-        policy: headers.policy.clone(),
-        policy_values: policy_values_map,
-        default_allow: headers.default_allow,
-    };
+    let qc_opts = sparql_qc_opts(identity, headers)?;
 
     let view = state
         .fluree
@@ -2629,7 +2616,7 @@ async fn execute_cypher_ledger(
             .await
             .map_err(ServerError::Api)?
     } else {
-        view
+        state.fluree.wrap_policy_defaults(view).await?
     };
 
     let result = state
@@ -2773,6 +2760,7 @@ async fn execute_sparql_ledger(
                 .inspect_err(|_| {
                     set_span_error_code(&span, "error:QueryFailed");
                 })?;
+                let view = state.fluree.wrap_policy_defaults(view).await?;
                 view.query(state.fluree.as_ref())
                     .sparql(sparql)
                     .format(json_fmt_config.clone())
@@ -3122,6 +3110,7 @@ async fn execute_sparql_ledger(
             use_default_context,
         )
         .await?;
+        let graph = state.fluree.wrap_policy_defaults(graph).await?;
         let fluree = &state.fluree;
 
         // Tracked SPARQL: if tracking headers are present, use tracked execution path

--- a/fluree-db-server/src/routes/show.rs
+++ b/fluree-db-server/src/routes/show.rs
@@ -121,12 +121,19 @@ async fn show_local(
             }
         }
 
-        // Extract identity and policy class for flake-level filtering.
-        // Identity comes from the bearer token; policy_class from server
-        // config. Unlike the query endpoints, show does not accept
-        // per-request policy overrides (no signed body or header injection).
-        let identity = bearer.0.as_ref().and_then(|p| p.identity.clone());
-        let policy_class = data_auth.default_policy_class.as_deref();
+        // Keep the entire verified selection: reconstructing it from identity
+        // alone can widen a delegated view to the identity's local policy set.
+        let governance = match bearer.0.as_ref() {
+            Some(principal) => {
+                let requested =
+                    crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), &headers)?;
+                principal.policy_authorization.resolve_options(&requested)?
+            }
+            None => fluree_db_api::GovernanceOptions {
+                policy_class: data_auth.default_policy_class.map(|c| vec![c]),
+                ..Default::default()
+            },
+        };
 
         // Proxy storage mode cannot decode commits (no local index).
         if state.config.is_proxy_storage_mode() {
@@ -146,8 +153,7 @@ async fn show_local(
             fluree
                 .graph(&alias)
                 .commit_t(t)
-                .identity(identity.as_deref())
-                .policy_class(policy_class)
+                .governance(&governance)
                 .execute()
                 .await
                 .map_err(ServerError::Api)?
@@ -155,8 +161,7 @@ async fn show_local(
             fluree
                 .graph(&alias)
                 .commit_prefix(commit_ref)
-                .identity(identity.as_deref())
-                .policy_class(policy_class)
+                .governance(&governance)
                 .execute()
                 .await
                 .map_err(ServerError::Api)?

--- a/fluree-db-server/src/routes/show.rs
+++ b/fluree-db-server/src/routes/show.rs
@@ -123,16 +123,19 @@ async fn show_local(
 
         // Keep the entire verified selection: reconstructing it from identity
         // alone can widen a delegated view to the identity's local policy set.
-        let governance = match bearer.0.as_ref() {
-            Some(principal) => {
-                let requested =
-                    crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), &headers)?;
-                principal.policy_authorization.resolve_options(&requested)?
-            }
-            None => fluree_db_api::GovernanceOptions {
+        let headers = crate::routes::policy_auth::bind_authorization(
+            &state,
+            headers,
+            bearer.0.as_ref(),
+            None,
+        )?;
+        let governance = if bearer.0.is_some() {
+            crate::routes::policy_auth::bound_governance(headers.identity.as_deref(), &headers)?
+        } else {
+            fluree_db_api::GovernanceOptions {
                 policy_class: data_auth.default_policy_class.map(|c| vec![c]),
                 ..Default::default()
-            },
+            }
         };
 
         // Proxy storage mode cannot decode commits (no local index).

--- a/fluree-db-server/src/routes/stream_query.rs
+++ b/fluree-db-server/src/routes/stream_query.rs
@@ -348,17 +348,8 @@ async fn stream_query_inner(
             // Plain single-ledger SPARQL (no policy, no FROM).
             let input = OwnedStreamQuery::Sparql(sparql);
             let ledger_state = load_ledger_for_query(state.as_ref(), &ledger, &span).await?;
-            let plan = {
-                let graph = GraphDb::from_ledger_state(&ledger_state);
-                fluree
-                    .plan_stream_query(&graph, &input)
-                    .await
-                    .map_err(ServerError::Api)?
-            };
-            (
-                StreamPlan::Single { ledger_state, plan },
-                stream_tracker_from_headers(&headers),
-            )
+            let plan = plan_with_ledger_defaults(&state, ledger_state, &input).await?;
+            (plan, stream_tracker_from_headers(&headers))
         }
     } else {
         let mut query_json: JsonValue = credential.body_json()?;
@@ -428,14 +419,8 @@ async fn stream_query_inner(
         } else {
             let input = OwnedStreamQuery::JsonLd(query_json);
             let ledger_state = load_ledger_for_query(state.as_ref(), &ledger, &span).await?;
-            let plan = {
-                let graph = GraphDb::from_ledger_state(&ledger_state);
-                fluree
-                    .plan_stream_query(&graph, &input)
-                    .await
-                    .map_err(ServerError::Api)?
-            };
-            (StreamPlan::Single { ledger_state, plan }, tracker)
+            let plan = plan_with_ledger_defaults(&state, ledger_state, &input).await?;
+            (plan, tracker)
         }
     };
 
@@ -443,6 +428,28 @@ async fn stream_query_inner(
     let mut response = finish_stream(&state, fluree, stream_plan, tracker);
     response.headers_mut().extend(warn_headers);
     Ok(response)
+}
+
+/// Keep the plain stream path for unconfigured/root views. A configured
+/// filter must travel with the dataset into the producer, not be discarded
+/// when the single-ledger producer reconstructs its view from LedgerState.
+async fn plan_with_ledger_defaults(
+    state: &AppState,
+    ledger_state: LedgerState,
+    input: &OwnedStreamQuery,
+) -> Result<StreamPlan> {
+    let fluree = &state.fluree;
+    let graph = fluree
+        .wrap_policy_defaults(GraphDb::from_ledger_state(&ledger_state))
+        .await?;
+    if graph.is_root() {
+        let plan = fluree.plan_stream_query(&graph, input).await?;
+        Ok(StreamPlan::Single { ledger_state, plan })
+    } else {
+        let dataset = DataSetDb::single(graph);
+        let plan = fluree.plan_stream_query_dataset(&dataset, input).await?;
+        Ok(StreamPlan::Dataset { dataset, plan })
+    }
 }
 
 /// Spawn the producer for a resolved plan and assemble the NDJSON streaming

--- a/fluree-db-server/src/routes/stream_query.rs
+++ b/fluree-db-server/src/routes/stream_query.rs
@@ -41,8 +41,8 @@ use crate::extract::{FlureeHeaders, MaybeCredential, MaybeDataBearer};
 use crate::query_control::QueryDisconnectGuard;
 use crate::routes::query::{
     await_query_min_t_requirements, collect_jsonld_min_t_requirements,
-    collect_sparql_min_t_requirements, effective_identity, enforce_bearer_dataset_scope,
-    get_ledger_id, has_policy_opts, inject_default_context_if_requested, inject_headers_into_query,
+    collect_sparql_min_t_requirements, enforce_bearer_dataset_scope, get_ledger_id,
+    has_policy_opts, inject_default_context_if_requested, inject_headers_into_query,
     is_sparql_request, load_ledger_for_query, normalize_ledger_scoped_from,
     requires_dataset_features, resolve_sparql_text, SparqlParams,
 };
@@ -92,6 +92,12 @@ async fn stream_query_connection_inner(
     bearer: MaybeDataBearer,
     credential: MaybeCredential,
 ) -> Result<Response> {
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.0.as_ref(),
+        &credential,
+    )?;
     let span = tracing::Span::current();
 
     let data_auth = state.config.data_auth();
@@ -118,22 +124,6 @@ async fn stream_query_connection_inner(
     let (stream_plan, tracker) = if is_sparql_request(&headers, &credential, &params) {
         let sparql = resolve_sparql_text(&params, &credential)?;
 
-        // Connection SPARQL has no single ledger to resolve a per-request
-        // identity against, so it cannot enforce identity policy (parity with
-        // /query, which runs connection SPARQL unpoliced). Rather than silently
-        // ignore an *explicit* policy request, refuse the explicit policy
-        // headers (Fluree-Identity / Fluree-Policy* / Fluree-Default-Allow) and
-        // point at the ledger-scoped route (which does enforce SPARQL policy).
-        // A plain bearer token (auth only) and the server `default_policy_class`
-        // are not per-request policy requests and do not apply to SPARQL, so
-        // they do not trigger a refusal here — same as /query.
-        if request_carries_policy(&headers) {
-            return Err(ServerError::bad_request(
-                "policy-scoped SPARQL is not supported on the connection-scoped streaming \
-                 endpoint; use /v1/fluree/stream/query/<ledger> or /v1/fluree/query",
-            ));
-        }
-
         // Bearer scope over every FROM/FROM NAMED ledger.
         if let Some(p) = bearer.0.as_ref() {
             if !credential.is_signed() {
@@ -159,7 +149,10 @@ async fn stream_query_connection_inner(
         );
 
         let dataset = fluree
-            .build_stream_dataset_for_sparql(&sparql, &fluree_db_api::GovernanceOptions::default())
+            .build_stream_dataset_for_sparql(
+                &sparql,
+                &crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), &headers)?,
+            )
             .await
             .map_err(ServerError::Api)?;
         let input = OwnedStreamQuery::Sparql(sparql);
@@ -202,15 +195,8 @@ async fn stream_query_connection_inner(
             }
         }
         enforce_bearer_dataset_scope(&query_json, &bearer, credential.is_signed(), &span)?;
-        let identity = effective_identity(&credential, &bearer);
-        crate::routes::policy_auth::apply_auth_identity_to_opts(
-            state.as_ref(),
-            &ledger_id,
-            &mut query_json,
-            identity.as_deref(),
-            data_auth.default_policy_class.as_deref(),
-        )
-        .await;
+
+        crate::routes::policy_auth::apply_authorization_to_opts(&mut query_json, &headers)?;
         let min_t = collect_jsonld_min_t_requirements(&headers, &query_json, Some(&ledger_id))?;
         await_query_min_t_requirements(state.as_ref(), min_t).await?;
         inject_default_context_if_requested(
@@ -248,6 +234,12 @@ async fn stream_query_inner(
     bearer: MaybeDataBearer,
     credential: MaybeCredential,
 ) -> Result<Response> {
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.0.as_ref(),
+        &credential,
+    )?;
     let span = tracing::Span::current();
 
     // Enforce data auth if configured (Bearer token OR signed request).
@@ -287,14 +279,8 @@ async fn stream_query_inner(
         // SPARQL has no body `opts`, so policy arrives via the resolved identity
         // (bearer/header), the server default policy class, and the
         // `Fluree-Policy*` / `Fluree-Default-Allow` headers.
-        let bearer_identity = effective_identity(&credential, &bearer);
-        let identity = crate::routes::policy_auth::resolve_sparql_identity(
-            state.as_ref(),
-            &ledger,
-            bearer_identity.as_deref(),
-            headers.identity.as_deref(),
-        )
-        .await;
+
+        let identity = headers.identity.clone();
         let qc_opts = crate::routes::query::sparql_qc_opts(identity.as_deref(), &headers)?;
 
         // Detect FROM/FROM NAMED dataset clauses.
@@ -399,15 +385,8 @@ async fn stream_query_inner(
             }
         }
         enforce_bearer_dataset_scope(&query_json, &bearer, credential.is_signed(), &span)?;
-        let identity = effective_identity(&credential, &bearer);
-        crate::routes::policy_auth::apply_auth_identity_to_opts(
-            state.as_ref(),
-            &ledger,
-            &mut query_json,
-            identity.as_deref(),
-            data_auth.default_policy_class.as_deref(),
-        )
-        .await;
+
+        crate::routes::policy_auth::apply_authorization_to_opts(&mut query_json, &headers)?;
 
         // Freshness barrier + stored-default-context injection, before planning,
         // to match /query's request controls.
@@ -523,17 +502,6 @@ enum StreamPlan {
         dataset: DataSetDb,
         plan: StreamDatasetPlan,
     },
-}
-
-/// True if the request carries any policy-scoping signal: `Fluree-Identity`,
-/// `Fluree-Policy`, `Fluree-Policy-Class`, `Fluree-Policy-Values`, or
-/// `Fluree-Default-Allow`.
-fn request_carries_policy(headers: &FlureeHeaders) -> bool {
-    headers.identity.is_some()
-        || headers.policy.is_some()
-        || !headers.policy_class.is_empty()
-        || headers.policy_values.is_some()
-        || headers.default_allow == Some(true)
 }
 
 /// A fuel + time tracker for the streaming endpoint, honoring any `max-fuel`

--- a/fluree-db-server/src/routes/stream_query.rs
+++ b/fluree-db-server/src/routes/stream_query.rs
@@ -96,7 +96,7 @@ async fn stream_query_connection_inner(
         &state,
         headers,
         bearer.0.as_ref(),
-        &credential,
+        credential.did(),
     )?;
     let span = tracing::Span::current();
 
@@ -151,7 +151,10 @@ async fn stream_query_connection_inner(
         let dataset = fluree
             .build_stream_dataset_for_sparql(
                 &sparql,
-                &crate::routes::query::sparql_qc_opts(headers.identity.as_deref(), &headers)?,
+                &crate::routes::policy_auth::bound_governance(
+                    headers.identity.as_deref(),
+                    &headers,
+                )?,
             )
             .await
             .map_err(ServerError::Api)?;
@@ -238,7 +241,7 @@ async fn stream_query_inner(
         &state,
         headers,
         bearer.0.as_ref(),
-        &credential,
+        credential.did(),
     )?;
     let span = tracing::Span::current();
 
@@ -281,7 +284,7 @@ async fn stream_query_inner(
         // `Fluree-Policy*` / `Fluree-Default-Allow` headers.
 
         let identity = headers.identity.clone();
-        let qc_opts = crate::routes::query::sparql_qc_opts(identity.as_deref(), &headers)?;
+        let qc_opts = crate::routes::policy_auth::bound_governance(identity.as_deref(), &headers)?;
 
         // Detect FROM/FROM NAMED dataset clauses.
         let parsed = fluree_db_sparql::parse_sparql(&sparql);

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -234,44 +234,27 @@ struct PreparedTransaction {
 /// Injects header-derived options, applies bearer-identity / policy-class
 /// defaults to the body's opts (which the rest of the pipeline reads),
 /// then extracts the tracking and policy options from the finalized body.
-async fn prepare_transaction_body(
-    state: &AppState,
-    ledger_id: &str,
+fn prepare_transaction_body(
     mut body: JsonValue,
     headers: &FlureeHeaders,
-    author: Option<&str>,
-) -> PreparedTransaction {
+) -> Result<PreparedTransaction> {
     inject_headers_into_txn(&mut body, headers);
 
-    let default_policy_class = state.config.data_auth().default_policy_class.clone();
-    crate::routes::policy_auth::apply_auth_identity_to_opts(
-        state,
-        ledger_id,
-        &mut body,
-        author,
-        default_policy_class.as_deref(),
-    )
-    .await;
+    crate::routes::policy_auth::apply_authorization_to_opts(&mut body, headers)?;
 
     let tracking = tracking_options_from_body(&body);
-    let governance = GovernanceOptions::from_json(&body).unwrap_or_default();
+    let governance =
+        GovernanceOptions::from_json(&body).map_err(|e| ServerError::bad_request(e.to_string()))?;
 
-    PreparedTransaction {
+    Ok(PreparedTransaction {
         body,
         tracking,
         governance,
-    }
+    })
 }
 
-/// Resolve the effective identity for a transaction.
-///
-/// Prefers the (possibly-impersonated) `opts.identity` so the commit records
-/// who the transaction was executed AS; falls back to the bearer-derived
-/// author. The original bearer identity that authorized the request is
-/// captured separately in the impersonation audit log emitted by
-/// `apply_auth_identity_to_opts` — commits stay attributable to the policy
-/// subject responsible for the data change, while the audit trail captures
-/// the operator who performed the action.
+/// Use the policy subject selected by verified authority for commit provenance,
+/// falling back to the authenticated author when no subject was selected.
 fn effective_did<'a>(
     governance: &'a GovernanceOptions,
     author: Option<&'a str>,
@@ -623,6 +606,12 @@ async fn update_local(
 
     // Extract credential (consumes the request body)
     let mut credential = MaybeCredential::extract(request).await?;
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.as_ref(),
+        &credential,
+    )?;
 
     // W3C SPARQL Protocol: rewrite form-encoded `update=...` to sparql-update
     maybe_rewrite_form_encoded_update(&mut credential);
@@ -781,6 +770,12 @@ async fn update_ledger_local(
         Err(e) => return Err(e),
     };
     let mut credential = MaybeCredential::extract(request).await?;
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.as_ref(),
+        &credential,
+    )?;
 
     // W3C SPARQL Protocol: rewrite form-encoded `update=...` to sparql-update
     maybe_rewrite_form_encoded_update(&mut credential);
@@ -931,6 +926,12 @@ async fn insert_local(
         Err(e) => return Err(e),
     };
     let credential = MaybeCredential::extract(request).await?;
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.as_ref(),
+        &credential,
+    )?;
 
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
 
@@ -1078,6 +1079,12 @@ async fn upsert_local(
         Err(e) => return Err(e),
     };
     let credential = MaybeCredential::extract(request).await?;
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.as_ref(),
+        &credential,
+    )?;
 
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
 
@@ -1235,6 +1242,12 @@ async fn sync_local(
     let query_params = extract_query_params(&request);
     let headers = FlureeHeaders::from_headers(request.headers())?;
     let credential = MaybeCredential::extract(request).await?;
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.as_ref(),
+        &credential,
+    )?;
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
 
     let span = create_request_span(
@@ -1296,14 +1309,7 @@ async fn sync_local(
             // state, inline shapes / unique properties), so a restricted
             // writer sees policy-filtered counts and a run that would fail
             // policy / SHACL / uniqueness fails here too.
-            let prepared = prepare_transaction_body(
-                &state,
-                &ledger_id,
-                body_json,
-                &headers,
-                author.as_deref(),
-            )
-            .await;
+            let prepared = prepare_transaction_body(body_json, &headers)?;
             let txn_opts = txn_opts_from_body(&prepared.body, &span)?;
             let handle = state
                 .fluree
@@ -1414,6 +1420,12 @@ async fn insert_ledger_local(
         Err(e) => return Err(e),
     };
     let credential = MaybeCredential::extract(request).await?;
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.as_ref(),
+        &credential,
+    )?;
 
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
 
@@ -1562,6 +1574,12 @@ async fn upsert_ledger_local(
         Err(e) => return Err(e),
     };
     let credential = MaybeCredential::extract(request).await?;
+    let headers = crate::routes::policy_auth::bind_authorization(
+        &state,
+        headers,
+        bearer.as_ref(),
+        &credential,
+    )?;
 
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
 
@@ -1772,8 +1790,7 @@ async fn execute_transaction(
         ));
     }
     let idempotency_key = extract_idempotency_key(&credential.headers)?;
-    let prepared_transaction =
-        prepare_transaction_body(state, ledger_id, body, headers, author).await;
+    let prepared_transaction = prepare_transaction_body(body, headers)?;
 
     let span = tracing::debug_span!(
         "transact_execute",
@@ -1905,7 +1922,7 @@ async fn execute_turtle_transaction(
     turtle: &str,
     credential: &MaybeCredential,
     headers: &FlureeHeaders,
-    author: Option<&str>,
+    _author: Option<&str>,
 ) -> Result<Response> {
     let is_trig = credential.is_trig();
 
@@ -1957,13 +1974,7 @@ async fn execute_turtle_transaction(
         // header-only path the SPARQL UPDATE route uses. The consensus layer
         // builds the PolicyContext from this governance against the staged
         // ledger state and enforces f:modify on the write.
-        let effective_identity = crate::routes::policy_auth::resolve_sparql_identity(
-            state,
-            ledger_id,
-            author,
-            headers.identity.as_deref(),
-        )
-        .await;
+        let effective_identity = headers.identity.clone();
 
         let policy_values_map = match headers.policy_values_map() {
             Ok(v) => v,
@@ -2046,16 +2057,9 @@ async fn execute_cypher_transact(
     let tx_id = compute_tx_id_sparql(body);
     let (cypher, params) = fluree_db_api::extract_cypher_envelope(body);
 
-    // Resolve the effective identity (impersonation-aware) and build policy
+    // Use the verified effective identity and build policy
     // options from headers, same as the SPARQL UPDATE path.
-    let bearer_identity = effective_author(credential, bearer);
-    let effective_identity = crate::routes::policy_auth::resolve_sparql_identity(
-        state,
-        ledger_id,
-        bearer_identity.as_deref(),
-        headers.identity.as_deref(),
-    )
-    .await;
+    let effective_identity = headers.identity.clone();
     let policy_values_map = headers.policy_values_map().inspect_err(|_| {
         set_span_error_code(span, "error:BadRequest");
     })?;
@@ -2287,18 +2291,8 @@ async fn execute_sparql_update_request(
         }
     };
 
-    // Resolve the effective identity honoring the root-impersonation semantic.
-    // For SPARQL UPDATE, impersonation is driven by the `fluree-identity`
-    // header (there is no body-level opts block); the remaining policy inputs
-    // come from the policy-class / policy / policy-values headers.
-    let bearer_identity = effective_author(credential, bearer);
-    let effective_identity = crate::routes::policy_auth::resolve_sparql_identity(
-        state,
-        &ledger_id,
-        bearer_identity.as_deref(),
-        headers.identity.as_deref(),
-    )
-    .await;
+    // Policy headers have already been bound to verified authorization.
+    let effective_identity = headers.identity.clone();
 
     let policy_values_map = match headers.policy_values_map() {
         Ok(v) => v,

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -432,9 +432,6 @@ fn maybe_rewrite_form_encoded_update(credential: &mut MaybeCredential) {
 /// Mirrors the query-side `inject_headers_into_query` pattern: header values act
 /// as defaults that do not override body-level opts.
 fn inject_headers_into_txn(body: &mut JsonValue, headers: &FlureeHeaders) {
-    if !headers.has_tracking() {
-        return;
-    }
     if let Some(obj) = body.as_object_mut() {
         let opts = obj
             .entry("opts")
@@ -1976,25 +1973,8 @@ async fn execute_turtle_transaction(
         // ledger state and enforces f:modify on the write.
         let effective_identity = headers.identity.clone();
 
-        let policy_values_map = match headers.policy_values_map() {
-            Ok(v) => v,
-            Err(e) => {
-                set_span_error_code(&span, "error:BadRequest");
-                tracing::warn!(error = %e, "invalid fluree-policy-values header");
-                return Err(e);
-            }
-        };
-        let governance = GovernanceOptions {
-            identity: effective_identity.clone(),
-            policy_class: if headers.policy_class.is_empty() {
-                None
-            } else {
-                Some(headers.policy_class.clone())
-            },
-            policy: headers.policy.clone(),
-            policy_values: policy_values_map,
-            default_allow: headers.default_allow,
-        };
+        let governance =
+            crate::routes::query::sparql_qc_opts(effective_identity.as_deref(), headers)?;
 
         let commit_opts = build_commit_opts(
             effective_identity.as_deref(),
@@ -2060,20 +2040,7 @@ async fn execute_cypher_transact(
     // Use the verified effective identity and build policy
     // options from headers, same as the SPARQL UPDATE path.
     let effective_identity = headers.identity.clone();
-    let policy_values_map = headers.policy_values_map().inspect_err(|_| {
-        set_span_error_code(span, "error:BadRequest");
-    })?;
-    let qc_opts = fluree_db_api::GovernanceOptions {
-        identity: effective_identity.clone(),
-        policy_class: if headers.policy_class.is_empty() {
-            None
-        } else {
-            Some(headers.policy_class.clone())
-        },
-        policy: headers.policy.clone(),
-        policy_values: policy_values_map,
-        default_allow: headers.default_allow,
-    };
+    let qc_opts = crate::routes::query::sparql_qc_opts(effective_identity.as_deref(), headers)?;
 
     // Submit through consensus, exactly like SPARQL UPDATE: the Cypher statement
     // is lowered to a `Txn` inside the consensus layer under the ledger write
@@ -2294,25 +2261,7 @@ async fn execute_sparql_update_request(
     // Policy headers have already been bound to verified authorization.
     let effective_identity = headers.identity.clone();
 
-    let policy_values_map = match headers.policy_values_map() {
-        Ok(v) => v,
-        Err(e) => {
-            set_span_error_code(parent_span, "error:BadRequest");
-            tracing::warn!(error = %e, "invalid fluree-policy-values header");
-            return Err(e);
-        }
-    };
-    let governance = GovernanceOptions {
-        identity: effective_identity.clone(),
-        policy_class: if headers.policy_class.is_empty() {
-            None
-        } else {
-            Some(headers.policy_class.clone())
-        },
-        policy: headers.policy.clone(),
-        policy_values: policy_values_map,
-        default_allow: headers.default_allow,
-    };
+    let governance = crate::routes::query::sparql_qc_opts(effective_identity.as_deref(), headers)?;
 
     let commit_opts = build_commit_opts(
         effective_identity.as_deref(),

--- a/fluree-db-server/src/routes/transact.rs
+++ b/fluree-db-server/src/routes/transact.rs
@@ -427,10 +427,11 @@ fn maybe_rewrite_form_encoded_update(credential: &mut MaybeCredential) {
     }
 }
 
-/// Inject header-based tracking options into transaction body (modifies in place).
+/// Inject header-based policy and tracking defaults into the transaction body.
 ///
 /// Mirrors the query-side `inject_headers_into_query` pattern: header values act
-/// as defaults that do not override body-level opts.
+/// as defaults that do not override body-level opts. Policy headers apply even
+/// without tracking, including for anonymous requests.
 fn inject_headers_into_txn(body: &mut JsonValue, headers: &FlureeHeaders) {
     if let Some(obj) = body.as_object_mut() {
         let opts = obj
@@ -607,7 +608,7 @@ async fn update_local(
         &state,
         headers,
         bearer.as_ref(),
-        &credential,
+        credential.did(),
     )?;
 
     // W3C SPARQL Protocol: rewrite form-encoded `update=...` to sparql-update
@@ -771,7 +772,7 @@ async fn update_ledger_local(
         &state,
         headers,
         bearer.as_ref(),
-        &credential,
+        credential.did(),
     )?;
 
     // W3C SPARQL Protocol: rewrite form-encoded `update=...` to sparql-update
@@ -927,7 +928,7 @@ async fn insert_local(
         &state,
         headers,
         bearer.as_ref(),
-        &credential,
+        credential.did(),
     )?;
 
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
@@ -1080,7 +1081,7 @@ async fn upsert_local(
         &state,
         headers,
         bearer.as_ref(),
-        &credential,
+        credential.did(),
     )?;
 
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
@@ -1243,7 +1244,7 @@ async fn sync_local(
         &state,
         headers,
         bearer.as_ref(),
-        &credential,
+        credential.did(),
     )?;
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
 
@@ -1421,7 +1422,7 @@ async fn insert_ledger_local(
         &state,
         headers,
         bearer.as_ref(),
-        &credential,
+        credential.did(),
     )?;
 
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
@@ -1575,7 +1576,7 @@ async fn upsert_ledger_local(
         &state,
         headers,
         bearer.as_ref(),
-        &credential,
+        credential.did(),
     )?;
 
     let request_id = extract_request_id(&credential.headers, &state.telemetry_config);
@@ -1974,7 +1975,7 @@ async fn execute_turtle_transaction(
         let effective_identity = headers.identity.clone();
 
         let governance =
-            crate::routes::query::sparql_qc_opts(effective_identity.as_deref(), headers)?;
+            crate::routes::policy_auth::bound_governance(effective_identity.as_deref(), headers)?;
 
         let commit_opts = build_commit_opts(
             effective_identity.as_deref(),
@@ -2040,7 +2041,8 @@ async fn execute_cypher_transact(
     // Use the verified effective identity and build policy
     // options from headers, same as the SPARQL UPDATE path.
     let effective_identity = headers.identity.clone();
-    let qc_opts = crate::routes::query::sparql_qc_opts(effective_identity.as_deref(), headers)?;
+    let qc_opts =
+        crate::routes::policy_auth::bound_governance(effective_identity.as_deref(), headers)?;
 
     // Submit through consensus, exactly like SPARQL UPDATE: the Cypher statement
     // is lowered to a `Txn` inside the consensus layer under the ledger write
@@ -2261,7 +2263,8 @@ async fn execute_sparql_update_request(
     // Policy headers have already been bound to verified authorization.
     let effective_identity = headers.identity.clone();
 
-    let governance = crate::routes::query::sparql_qc_opts(effective_identity.as_deref(), headers)?;
+    let governance =
+        crate::routes::policy_auth::bound_governance(effective_identity.as_deref(), headers)?;
 
     let commit_opts = build_commit_opts(
         effective_identity.as_deref(),

--- a/fluree-db-server/tests/bolt_auth_integration.rs
+++ b/fluree-db-server/tests/bolt_auth_integration.rs
@@ -31,14 +31,23 @@ const BOLT_4_4: [u8; 4] = [0, 0, 4, 4];
 // ---------------------------------------------------------------------
 
 async fn auth_server(mode: DataAuthMode) -> (TempDir, Arc<AppState>, std::net::SocketAddr) {
+    auth_server_with_config(ServerConfig {
+        data_auth_mode: mode,
+        data_auth_insecure_accept_any_issuer: true,
+        ..Default::default()
+    })
+    .await
+}
+
+async fn auth_server_with_config(
+    config: ServerConfig,
+) -> (TempDir, Arc<AppState>, std::net::SocketAddr) {
     let tmp = tempfile::tempdir().expect("tempdir");
     let cfg = ServerConfig {
         cors_enabled: false,
         indexing_enabled: false,
         storage_path: Some(tmp.path().to_path_buf()),
-        data_auth_mode: mode,
-        data_auth_insecure_accept_any_issuer: true,
-        ..Default::default()
+        ..config
     };
     let telemetry = TelemetryConfig::with_server_config(&cfg);
     let state = Arc::new(AppState::new(cfg, telemetry).await.expect("AppState"));
@@ -52,7 +61,7 @@ async fn auth_server(mode: DataAuthMode) -> (TempDir, Arc<AppState>, std::net::S
 async fn http_insert(state: &Arc<AppState>, uri: &str, body: serde_json::Value) {
     // Seeding always presents a write-scoped token: required-mode servers
     // demand it, Optional-mode servers verify-and-allow it.
-    let token = seed_token(uri);
+    let token = seed_token(uri, state.config.data_auth_audience.as_deref());
     let resp = build_router(Arc::clone(state))
         .oneshot(
             Request::builder()
@@ -74,16 +83,19 @@ async fn http_insert(state: &Arc<AppState>, uri: &str, body: serde_json::Value) 
 
 /// A seeding token whose write scope covers the ledger named in `uri`.
 /// No `fluree.identity` claim: seeding must not resolve a policy context.
-fn seed_token(uri: &str) -> String {
+fn seed_token(uri: &str, audience: Option<&str>) -> String {
     let ledger = uri.strip_prefix("/v1/fluree/insert/").unwrap_or("");
     let key = signing_key();
-    let claims = serde_json::json!({
+    let mut claims = serde_json::json!({
         "iss": did_from_pubkey(&key.verifying_key().to_bytes()),
         "exp": now_secs() + 3600,
         "iat": now_secs(),
         "fluree.ledger.read.all": true,
         "fluree.ledger.write.ledgers": [ledger],
     });
+    if let Some(audience) = audience {
+        claims["aud"] = serde_json::json!(audience);
+    }
     create_jws(&claims, &key)
 }
 
@@ -652,4 +664,91 @@ async fn identity_derived_policy_filters_bolt_reads() {
     let mut c = BoltClient::ready_54(addr, auth_map("none", None, None)).await;
     let rows = c.query_rows(q, ledger).await;
     assert_eq!(rows.len(), 3);
+}
+
+#[tokio::test]
+async fn delegated_bolt_sessions_enforce_grants_scopes_and_reauthentication() {
+    let key = signing_key();
+    let issuer = did_from_pubkey(&key.verifying_key().to_bytes());
+    let audience = "bolt-policy-test";
+    let (_tmp, state, addr) = auth_server_with_config(ServerConfig {
+        data_auth_mode: DataAuthMode::Required,
+        data_auth_insecure_accept_any_issuer: true,
+        data_auth_audience: Some(audience.into()),
+        data_auth_policy_authorities: vec![issuer.clone()],
+        ..Default::default()
+    })
+    .await;
+    let ledger = "boltauth:delegation";
+    seed_ledger(&state, ledger).await;
+    http_insert(
+        &state,
+        &format!("/v1/fluree/insert/{ledger}"),
+        serde_json::json!({
+            "@context": {"f": "https://ns.flur.ee/db#"},
+            "insert": [
+                {"@id": "reader", "@type": ["f:AccessPolicy", "http://example.org/ReaderClass"],
+                 "f:action": {"@id": "f:view"}, "f:query": {"@type": "@json", "@value": {
+                    "@context": {}, "where": {"@id": "?$this", "name": "Alice"}
+                 }}},
+                {"@id": "deny-write", "@type": ["f:AccessPolicy", "http://example.org/ReaderClass"],
+                 "f:action": {"@id": "f:modify"}, "f:allow": false,
+                 "f:exMessage": "Delegated reader cannot write."},
+                {"@id": "manager", "@type": ["f:AccessPolicy", "http://example.org/ManagerClass"],
+                 "f:action": [{"@id": "f:view"}, {"@id": "f:modify"}], "f:allow": true}
+            ]
+        }),
+    )
+    .await;
+    let mut claims = serde_json::json!({
+        "iss": issuer, "aud": audience, "exp": now_secs() + 300,
+        "sub": "https://app.example/users/no-local-assignments",
+        "fluree.ledger.read.ledgers": [ledger], "fluree.ledger.write.ledgers": [ledger],
+        "fluree.policy": {"policy-class": ["http://example.org/ReaderClass"], "default-allow": false}
+    });
+    let token = create_jws(&claims, &key);
+    let mut c = BoltClient::ready_54(addr, auth_map("bearer", None, Some(&token))).await;
+    let query = "MATCH (n:Person) RETURN n.name ORDER BY n.name";
+    assert_eq!(
+        c.query_rows(query, ledger).await,
+        vec![vec![Value::from("Alice")]]
+    );
+    let failure = c.run("CREATE (:Person {name: 'Eve'})", ledger).await;
+    failure.assert_failure_code("Neo.DatabaseError.General.UnknownError");
+    assert!(
+        failure
+            .metadata()
+            .get_str("message")
+            .unwrap()
+            .contains("Delegated reader cannot write"),
+        "{failure:?}"
+    );
+    c.send(msg::RESET, vec![]).await;
+    c.recv().await.assert_success();
+    c.send(msg::LOGOFF, vec![]).await;
+    c.recv().await.assert_success();
+
+    claims["fluree.policy"]["policy-class"] =
+        serde_json::json!(["http://example.org/ManagerClass"]);
+    let token = create_jws(&claims, &key);
+    c.logon(auth_map("bearer", None, Some(&token)))
+        .await
+        .assert_success();
+    assert_eq!(c.query_rows(query, ledger).await.len(), 2);
+    c.query_rows("CREATE (:Person {name: 'Eve'})", ledger).await;
+    assert_eq!(c.query_rows(query, ledger).await.len(), 3);
+    c.run(query, "out-of-scope:main")
+        .await
+        .assert_failure_code("Neo.ClientError.Database.DatabaseNotFound");
+
+    // Accept-any-issuer is deliberately insufficient for policy delegation.
+    let other_key = SigningKey::from_bytes(&[8; 32]);
+    claims["iss"] = serde_json::json!(did_from_pubkey(&other_key.verifying_key().to_bytes()));
+    let token = create_jws(&claims, &other_key);
+    let mut invalid = BoltClient::connect(addr, BOLT_5_4).await;
+    invalid.hello(MapValue::new()).await.assert_success();
+    invalid
+        .logon(auth_map("bearer", None, Some(&token)))
+        .await
+        .assert_failure_code("Neo.ClientError.Security.Unauthorized");
 }

--- a/fluree-db-server/tests/bolt_auth_integration.rs
+++ b/fluree-db-server/tests/bolt_auth_integration.rs
@@ -752,3 +752,31 @@ async fn delegated_bolt_sessions_enforce_grants_scopes_and_reauthentication() {
         .await
         .assert_failure_code("Neo.ClientError.Security.Unauthorized");
 }
+
+#[tokio::test]
+async fn bolt_rejects_unsupported_impersonation_instead_of_ignoring_it() {
+    let (_tmp, _state, addr) = auth_server(DataAuthMode::None).await;
+    for signature in [msg::RUN, msg::BEGIN] {
+        let mut client = BoltClient::ready_54(addr, MapValue::new()).await;
+        let mut extra = MapValue::new();
+        extra.insert("imp_user", "https://example.org/another-user");
+        let fields = if signature == msg::RUN {
+            vec![
+                Value::from("RETURN 1"),
+                Value::empty_map(),
+                Value::Map(extra),
+            ]
+        } else {
+            vec![Value::Map(extra)]
+        };
+        client.send(signature, fields).await;
+        let response = client.recv().await;
+        response.assert_failure_code("Neo.ClientError.Request.Invalid");
+        assert!(response
+            .metadata()
+            .get_str("message")
+            .unwrap()
+            .contains("impersonation"));
+        client.assert_closed().await;
+    }
+}

--- a/fluree-db-server/tests/policy_authorization_regression.rs
+++ b/fluree-db-server/tests/policy_authorization_regression.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "policy_transport_regression.rs"]
+mod policy_transport_regression;
+
 async fn post_policy_request(
     app: &axum::Router,
     uri: &str,

--- a/fluree-db-server/tests/policy_authorization_regression.rs
+++ b/fluree-db-server/tests/policy_authorization_regression.rs
@@ -1,0 +1,786 @@
+use super::*;
+
+async fn post_policy_request(
+    app: &axum::Router,
+    uri: &str,
+    token: Option<&str>,
+    content_type: &str,
+    body: String,
+) -> (StatusCode, JsonValue) {
+    let mut request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", content_type);
+    if let Some(token) = token {
+        request = request.header("authorization", format!("Bearer {token}"));
+    }
+    json_body(
+        app.clone()
+            .oneshot(request.body(Body::from(body)).unwrap())
+            .await
+            .unwrap(),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn configured_model_policy_controls_delegated_reads_and_writes() {
+    let (_tmp, state) = policy_test_state().await;
+    let fluree = state.fluree.clone();
+    let model = "authority-model:main";
+    let app = setup_policy_ledger(build_router(state), model).await;
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/upsert/{model}"),
+        None,
+        "application/trig",
+        r#"@prefix f: <https://ns.flur.ee/db#> .
+           @prefix ex: <http://example.org/> .
+           GRAPH <http://example.org/model-policies> {
+               ex:protectContent a f:AccessPolicy, ex:ModelRules ;
+                   f:required true ; f:onProperty ex:content ;
+                   f:action f:view, f:modify ; f:allow false ;
+                   f:exMessage "Model forbids content changes." .
+               ex:manager a f:AccessPolicy, ex:ManagerClass ;
+                   f:action f:view, f:modify ; f:allow true .
+           }"#
+        .into(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+
+    // An explicit policy authority may select grants only where the ledger's
+    // own override control permits it. Exercise both sides of that boundary.
+    for (ledger, control, allowed) in [
+        ("authority-model-locked:main", "OverrideNone", false),
+        ("authority-model-open:main", "OverrideAll", true),
+    ] {
+        let app = setup_policy_ledger(app.clone(), ledger).await;
+        let config = format!(
+            r#"
+            @prefix f: <https://ns.flur.ee/db#> .
+            @prefix ex: <http://example.org/> .
+            GRAPH <urn:fluree:{ledger}#config> {{
+                <urn:cfg:main> a f:LedgerConfig ; f:policyDefaults <urn:cfg:policy> .
+                <urn:cfg:policy> f:defaultAllow true ; f:policyClass ex:ModelRules ;
+                    f:overrideControl f:{control} ; f:policySource <urn:cfg:ref> .
+                <urn:cfg:ref> a f:GraphRef ; f:graphSource <urn:cfg:source> .
+                <urn:cfg:source> f:ledger <{model}> ;
+                    f:graphSelector <http://example.org/model-policies> .
+            }}"#
+        );
+        let (status, result) = post_policy_request(
+            &app,
+            &format!("/v1/fluree/upsert/{ledger}"),
+            None,
+            "application/trig",
+            config,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{result}");
+        let grant = serde_json::json!({
+            "policy-class": ["http://example.org/ManagerClass"],
+            "policy": [{"f:required": true, "f:action": ["f:view", "f:modify"], "f:allow": true}],
+            "policy-values": {"?$identity": {"@id": "http://example.org/manager-user"}},
+            "default-allow": true
+        });
+        let delegated =
+            delegated_token("http://example.org/application-user", ledger, grant.clone());
+        let key = SigningKey::from_bytes(&[205; 32]);
+        let mut tokens = vec![delegated];
+        if !allowed {
+            tokens.push(identity_token_rw(
+                &key,
+                "http://example.org/employee-user",
+                ledger,
+            ));
+            tokens.push(create_jws(
+                &serde_json::json!({
+                    "iss": did_from_pubkey(&key.verifying_key().to_bytes()),
+                    "aud": "fluree-policy-test", "exp": now_secs() + 300,
+                    "fluree.ledger.read.ledgers": [ledger],
+                    "fluree.ledger.write.ledgers": [ledger]
+                }),
+                &key,
+            ));
+        }
+        for token in tokens {
+            for (property, expected) in [
+                ("http://schema.org/name", 1),
+                ("http://example.org/content", usize::from(allowed)),
+            ] {
+                let query = serde_json::json!({
+                    "opts": grant, "select": ["?value"],
+                    "where": {"@id": "http://example.org/doc1", (property): "?value"}
+                });
+                let (status, result) = post_policy_request(
+                    &app,
+                    &format!("/v1/fluree/query/{ledger}"),
+                    Some(&token),
+                    "application/json",
+                    query.to_string(),
+                )
+                .await;
+                assert_eq!(status, StatusCode::OK, "{control}: {result}");
+                assert_eq!(
+                    result.as_array().unwrap().len(),
+                    expected,
+                    "{control}: {result}"
+                );
+            }
+            // An unconditional write reaches modify enforcement even when
+            // the read policy hides content from transaction WHERE matching.
+            let mut body = serde_json::json!({
+                "delete": {"@id": "http://example.org/doc1", "http://example.org/content": "visible to all"},
+                "insert": {"@id": "http://example.org/doc1", "http://example.org/content": "rewritten"}
+            });
+            body["opts"] = grant.clone();
+            let (status, result) = post_policy_request(
+                &app,
+                &format!("/v1/fluree/update/{ledger}"),
+                Some(&token),
+                "application/json",
+                body.to_string(),
+            )
+            .await;
+            assert_eq!(
+                status,
+                if allowed {
+                    StatusCode::OK
+                } else {
+                    StatusCode::BAD_REQUEST
+                },
+                "{control}: {result}"
+            );
+            if !allowed {
+                assert!(
+                    result
+                        .to_string()
+                        .contains("Model forbids content changes."),
+                    "{result}"
+                );
+            }
+        }
+        // A trusted SDK read verifies persisted state independently of the
+        // HTTP filter that intentionally hides content on the locked ledger.
+        let view = fluree.db(ledger).await.unwrap();
+        let query = serde_json::json!({"select": ["?value"], "where": {"@id": "http://example.org/doc1", "http://example.org/content": "?value"}});
+        let result = fluree
+            .query(&view, &query)
+            .await
+            .unwrap()
+            .to_jsonld(&view.snapshot)
+            .unwrap();
+        assert_eq!(
+            result,
+            serde_json::json!([[if allowed {
+                "rewritten"
+            } else {
+                "visible to all"
+            }]])
+        );
+    }
+}
+
+#[cfg(feature = "credential")]
+#[tokio::test]
+async fn signed_request_identity_does_not_inherit_bearer_delegation() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "authority-signed-body:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    let key = SigningKey::from_bytes(&[206; 32]);
+    let identity = did_from_pubkey(&key.verifying_key().to_bytes());
+    let assignment = serde_json::json!({"insert": {
+        "@id": identity,
+        "https://ns.flur.ee/db#policyClass": {"@id": "http://example.org/EmployeeClass"}
+    }});
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/insert/{ledger}"),
+        None,
+        "application/json",
+        assignment.to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    let bearer = delegated_token(
+        "http://example.org/application-user",
+        ledger,
+        serde_json::json!({"policy-class": ["http://example.org/ManagerClass"]}),
+    );
+    let (status, result) = query_docs(app.clone(), ledger, Some(&bearer), false).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(names_from_results(&result).len(), 3);
+    let query = serde_json::json!({
+        "opts": {"identity": "http://example.org/manager-user", "default-allow": true},
+        "select": ["?name", "?class"],
+        "where": {"@id": "?s", "http://schema.org/name": "?name", "http://example.org/classification": "?class"}
+    });
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/query/{ledger}"),
+        Some(&bearer),
+        "application/jwt",
+        create_jws(&query, &key),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert_eq!(names_from_results(&result).len(), 2, "{result}");
+    assert!(!names_from_results(&result).contains(&"Executive Salaries"));
+}
+
+#[cfg(feature = "graphql")]
+#[tokio::test]
+async fn graphql_mutation_preserves_verified_authorization() {
+    let (_tmp, state) = policy_test_state().await;
+    let fluree = state.fluree.clone();
+    let ledger = "authority-graphql:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    add_modify_policies(&app, ledger).await;
+    let context = serde_json::json!({
+        "ex": "http://example.org/", "sh": "http://www.w3.org/ns/shacl#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#", "f": "https://ns.flur.ee/db#",
+        "graphql": "http://datashapes.org/graphql#"
+    });
+    fluree.set_default_context(ledger, &context).await.unwrap();
+    let shapes = serde_json::json!({"@context": context, "insert": [
+        {"@id": "ex:DocumentShape", "@type": "sh:NodeShape",
+         "sh:targetClass": {"@id": "ex:Document"}, "sh:property": [
+            {"sh:path": {"@id": "ex:content"}, "sh:datatype": {"@id": "xsd:string"}, "sh:maxCount": 1},
+            {"sh:path": {"@id": "ex:classification"}, "sh:datatype": {"@id": "xsd:string"}, "sh:maxCount": 1}
+         ]},
+        {"@id": "ex:Api", "@type": "graphql:Schema",
+         "graphql:publicShape": {"@id": "ex:DocumentShape"},
+         "f:graphqlEnableMutations": true, "f:graphqlIriBase": "http://example.org/"}
+    ]});
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/insert/{ledger}"),
+        None,
+        "application/json",
+        shapes.to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    let mutation = serde_json::json!({"query": r#"mutation {
+        create_Document(input: { id: "ex:doc4", content: "new", classification: "public" }) { id content }
+    }"#});
+    let denied = delegated_token(
+        "http://example.org/application-user",
+        ledger,
+        serde_json::json!({"policy-class": ["http://example.org/EmployeeClass"]}),
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/fluree/graphql/{ledger}"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {denied}"))
+                .header("fluree-policy-class", "http://example.org/ManagerClass")
+                .header("fluree-default-allow", "true")
+                .body(Body::from(mutation.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, result) = json_body(resp).await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert!(
+        result.get("errors").is_some(),
+        "restricted mutation must fail: {result}"
+    );
+    assert!(
+        result.to_string().contains("Policy enforcement"),
+        "{result}"
+    );
+    let view = fluree.db(ledger).await.unwrap();
+    let probe = serde_json::json!({"select": ["?v"], "where": {"@id": "http://example.org/doc4", "http://example.org/content": "?v"}});
+    assert_eq!(
+        fluree
+            .query(&view, &probe)
+            .await
+            .unwrap()
+            .to_jsonld(&view.snapshot)
+            .unwrap(),
+        serde_json::json!([])
+    );
+
+    let allowed = delegated_token(
+        "http://example.org/application-user",
+        ledger,
+        serde_json::json!({"policy-class": ["http://example.org/ManagerClass"]}),
+    );
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/graphql/{ledger}"),
+        Some(&allowed),
+        "application/json",
+        mutation.to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert!(result.get("errors").is_none(), "{result}");
+    assert_eq!(
+        result["data"]["create_Document"]["content"], "new",
+        "{result}"
+    );
+
+    // Write authority need not imply read authority. A successful mutation
+    // must not expose a newly created subject that fails the caller's view rule.
+    let write_only = delegated_token(
+        "http://example.org/application-user",
+        ledger,
+        serde_json::json!({"policy": [
+            {"f:action": "f:view", "f:query": {"where": {
+                "@id": "?$this", "http://example.org/classification": "public"
+            }}},
+            {"f:action": "f:modify", "f:allow": true}
+        ], "default-allow": false}),
+    );
+    let mutation = serde_json::json!({"query": r#"mutation {
+        create_Document(input: { id: "ex:doc5", content: "hidden", classification: "confidential" }) { id content }
+    }"#});
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/graphql/{ledger}"),
+        Some(&write_only),
+        "application/json",
+        mutation.to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert!(result.get("errors").is_none(), "{result}");
+    assert_eq!(
+        result["data"]["create_Document"],
+        JsonValue::Null,
+        "{result}"
+    );
+    let view = fluree.db(ledger).await.unwrap();
+    let probe = serde_json::json!({"select": ["?v"], "where": {"@id": "http://example.org/doc5", "http://example.org/content": "?v"}});
+    assert_eq!(
+        fluree
+            .query(&view, &probe)
+            .await
+            .unwrap()
+            .to_jsonld(&view.snapshot)
+            .unwrap(),
+        serde_json::json!([["hidden"]])
+    );
+}
+
+#[tokio::test]
+async fn restricted_bearer_cannot_replace_or_supplement_policy() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "audit-http:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    let signing_key = SigningKey::from_bytes(&[83u8; 32]);
+    let token = identity_token(&signing_key, "http://example.org/employee-user", ledger);
+    let (status, baseline) = query_docs(app.clone(), ledger, Some(&token), false).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(names_from_results(&baseline).len(), 2);
+    for opts in [
+        serde_json::json!({"policy-class": ["http://example.org/ManagerClass"], "default-allow": false}),
+        serde_json::json!({"policy": [{"f:required": true, "f:action": "f:view", "f:allow": true}], "default-allow": false}),
+        serde_json::json!({"policy-class": ["http://example.org/NonexistentClass"], "default-allow": true}),
+        serde_json::json!({"policyClass": ["http://example.org/ManagerClass"], "defaultAllow": true}),
+        serde_json::json!({"policy_class": ["http://example.org/ManagerClass"], "default_allow": true}),
+        serde_json::json!({"policyValues": {"?$identity": {"@id": "http://example.org/manager-user"}}}),
+    ] {
+        let body = serde_json::json!({
+            "opts": opts,
+            "select": ["?name", "?class"],
+            "where": [{"@id": "?doc", "@type": "http://example.org/Document", "http://schema.org/name": "?name", "http://example.org/classification": "?class"}]
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/fluree/query/{ledger}"))
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, result) = json_body(resp).await;
+        assert_eq!(status, StatusCode::OK, "{result}");
+        let names = names_from_results(&result);
+        println!("restricted bearer opts={opts}: {names:?}");
+        assert_eq!(names.len(), 2);
+        assert!(!names.contains(&"Executive Salaries"));
+    }
+    let body = serde_json::json!({
+        "from": {"@id": ledger, "policy": {"identity": "http://example.org/manager-user", "default-allow": false}},
+        "select": ["?name", "?class"],
+        "where": [{"@id": "?doc", "@type": "http://example.org/Document", "http://schema.org/name": "?name", "http://example.org/classification": "?class"}]
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/query")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, result) = json_body(resp).await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    let names = names_from_results(&result);
+    println!("restricted bearer per-source identity override: {names:?}");
+    assert_eq!(names.len(), 2);
+    assert!(!names.contains(&"Executive Salaries"));
+}
+
+#[tokio::test]
+async fn signed_policy_context_requires_authority_scope_and_valid_signature() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "authority-validation:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    let authority = SigningKey::from_bytes(&[200; 32]);
+    let ordinary = SigningKey::from_bytes(&[201; 32]);
+    let claims = serde_json::json!({
+        "iss": did_from_pubkey(&authority.verifying_key().to_bytes()),
+        "aud": "fluree-policy-test", "exp": now_secs() + 300,
+        "fluree.identity": "http://example.org/application-user",
+        "fluree.ledger.read.ledgers": [ledger],
+        "fluree.policy": {"policy-class": ["http://example.org/EmployeeClass"]}
+    });
+    let valid = create_jws(&claims, &authority);
+    let (status, result) = query_docs(app.clone(), ledger, Some(&valid), false).await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert_eq!(
+        names_from_results(&result).len(),
+        2,
+        "grant-derived classes work without local identity assignments"
+    );
+
+    for (label, mut invalid, signer, expected) in [
+        (
+            "issuer",
+            claims.clone(),
+            &ordinary,
+            StatusCode::UNAUTHORIZED,
+        ),
+        (
+            "audience",
+            claims.clone(),
+            &authority,
+            StatusCode::UNAUTHORIZED,
+        ),
+        (
+            "expired",
+            claims.clone(),
+            &authority,
+            StatusCode::UNAUTHORIZED,
+        ),
+        (
+            "future",
+            claims.clone(),
+            &authority,
+            StatusCode::UNAUTHORIZED,
+        ),
+        ("ledger", claims.clone(), &authority, StatusCode::NOT_FOUND),
+        ("action", claims.clone(), &authority, StatusCode::NOT_FOUND),
+        (
+            "unknown-field",
+            claims.clone(),
+            &authority,
+            StatusCode::UNAUTHORIZED,
+        ),
+        (
+            "null-context",
+            claims.clone(),
+            &authority,
+            StatusCode::UNAUTHORIZED,
+        ),
+    ] {
+        match label {
+            "issuer" => {
+                invalid["iss"] =
+                    serde_json::json!(did_from_pubkey(&ordinary.verifying_key().to_bytes()))
+            }
+            "null-context" => invalid["fluree.policy"] = JsonValue::Null,
+            "audience" => invalid["aud"] = serde_json::json!("another-server"),
+            "expired" => invalid["exp"] = serde_json::json!(now_secs() - 120),
+            "future" => invalid["nbf"] = serde_json::json!(now_secs() + 300),
+            "ledger" => {
+                invalid["fluree.ledger.read.ledgers"] = serde_json::json!(["elsewhere:main"])
+            }
+            "action" => {
+                invalid
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("fluree.ledger.read.ledgers");
+                invalid["fluree.ledger.write.ledgers"] = serde_json::json!([ledger]);
+            }
+            _ => invalid["fluree.policy"]["trusted"] = serde_json::json!(true),
+        }
+        let token = create_jws(&invalid, signer);
+        let (status, result) = query_docs(app.clone(), ledger, Some(&token), false).await;
+        assert_eq!(status, expected, "{label}: {result}");
+    }
+    let unrestricted = delegated_token(
+        "http://example.org/new-application-user",
+        ledger,
+        serde_json::json!({"default-allow": true}),
+    );
+    let (status, result) = query_docs(app.clone(), ledger, Some(&unrestricted), true).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(names_from_results(&result).len(), 3);
+    let (status, result) = query_docs(app.clone(), ledger, Some(&unrestricted), false).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        names_from_results(&result).is_empty(),
+        "caller default-deny must narrow signed default-allow"
+    );
+
+    let pieces: Vec<_> = valid.split('.').collect();
+    let mut tampered = claims.clone();
+    tampered["fluree.policy"]["policy-class"] =
+        serde_json::json!(["http://example.org/ManagerClass"]);
+    let token = format!(
+        "{}.{}.{}",
+        pieces[0],
+        URL_SAFE_NO_PAD.encode(tampered.to_string()),
+        pieces[2]
+    );
+    let (status, _) = query_docs(app.clone(), ledger, Some(&token), false).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // A record with no policy assignments is not proof of delegation authority.
+    register_root_identity(&app, ledger, "http://example.org/unassigned").await;
+    let token = identity_token(&ordinary, "http://example.org/unassigned", ledger);
+    let (status, result) =
+        query_docs_as(app, ledger, &token, "http://example.org/manager-user").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(names_from_results(&result).is_empty());
+}
+
+#[tokio::test]
+async fn policy_headers_cannot_widen_sparql_reads() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "authority-text:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    let token = identity_token(
+        &SigningKey::from_bytes(&[202; 32]),
+        "http://example.org/employee-user",
+        ledger,
+    );
+    for (uri, content_type, body, stream) in [
+        (format!("/v1/fluree/query/{ledger}"), "application/sparql-query", "SELECT ?name WHERE { ?doc a <http://example.org/Document>; <http://schema.org/name> ?name }".to_string(), false),
+        ("/v1/fluree/query".into(), "application/sparql-query", format!("SELECT ?name FROM <{ledger}> WHERE {{ ?doc a <http://example.org/Document>; <http://schema.org/name> ?name }}"), false),
+        ("/v1/fluree/stream/query".into(), "application/sparql-query", format!("SELECT ?name FROM <{ledger}> WHERE {{ ?doc a <http://example.org/Document>; <http://schema.org/name> ?name }}"), true),
+        (format!("/v1/fluree/stream/query/{ledger}"), "application/sparql-query", "SELECT ?name WHERE { ?doc a <http://example.org/Document>; <http://schema.org/name> ?name }".to_string(), true),
+    ] {
+        let resp = app.clone().oneshot(Request::builder().method("POST").uri(&uri)
+            .header("content-type", content_type).header("authorization", format!("Bearer {token}"))
+            .header("fluree-identity", "http://example.org/manager-user")
+            .header("fluree-policy-class", "http://example.org/ManagerClass")
+            .header("fluree-policy", r#"[{"f:required":true,"f:action":"f:view","f:allow":true}]"#)
+            .header("fluree-policy-values", r#"{"?$identity":{"@id":"http://example.org/manager-user"}}"#)
+            .header("fluree-default-allow", "true")
+            .body(Body::from(body)).unwrap()).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "{uri}");
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let text = std::str::from_utf8(&bytes).unwrap();
+        assert!(text.contains("Public Post") && text.contains("Internal Memo"), "{uri}: {text}");
+        assert!(!text.contains("Executive Salaries"), "{uri}: {text}");
+        if !stream {
+            assert_eq!(sparql_names(&serde_json::from_str(text).unwrap()).len(), 2);
+        }
+    }
+}
+
+#[tokio::test]
+async fn hostile_policy_selection_cannot_authorize_a_write() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "authority-write:main";
+    let fluree = state.fluree.clone();
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    add_modify_policies(&app, ledger).await;
+    fluree
+        .set_default_context(
+            ledger,
+            &serde_json::json!({"@vocab": "http://example.org/"}),
+        )
+        .await
+        .unwrap();
+    let token = identity_token_rw(
+        &SigningKey::from_bytes(&[203; 32]),
+        "http://example.org/employee-user",
+        ledger,
+    );
+    let hostile = serde_json::json!({
+        "identity": "http://example.org/manager-user",
+        "policyClass": ["http://example.org/ManagerClass"],
+        "policy": [{"f:required": true, "f:action": "f:modify", "f:allow": true}],
+        "defaultAllow": true
+    });
+    let mut body = modify_public_doc_content_body();
+    body["opts"] = hostile;
+    for (route, content_type, body) in [
+        ("update", "application/json", body.to_string()),
+        (
+            "update",
+            "application/sparql-update",
+            r#"PREFIX ex: <http://example.org/>
+            DELETE { ex:doc1 ex:content ?c } INSERT { ex:doc1 ex:content "rewritten" }
+            WHERE { ex:doc1 ex:content ?c }"#
+                .into(),
+        ),
+        (
+            "update",
+            "application/cypher",
+            r#"MATCH (d:Document {classification: "public"}) SET d.content = "rewritten""#.into(),
+        ),
+        (
+            "insert",
+            "text/turtle",
+            r#"<http://example.org/doc1> <http://example.org/content> "rewritten" ."#.into(),
+        ),
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/fluree/{route}/{ledger}"))
+                    .header("content-type", content_type)
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("fluree-identity", "http://example.org/manager-user")
+                    .header("fluree-policy-class", "http://example.org/ManagerClass")
+                    .header(
+                        "fluree-policy",
+                        r#"[{"f:required":true,"f:action":"f:modify","f:allow":true}]"#,
+                    )
+                    .header("fluree-default-allow", "true")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, error) = json_body(resp).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{content_type}: {error}");
+        assert!(error
+            .to_string()
+            .contains("Employees may not modify document content."));
+    }
+    let query = serde_json::json!({"select": ["?content"], "where": {"@id": "http://example.org/doc1", "http://example.org/content": "?content"}});
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/fluree/query/{ledger}"))
+                .header("content-type", "application/json")
+                .body(Body::from(query.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, result) = json_body(resp).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(result, serde_json::json!([["visible to all"]]));
+}
+
+#[tokio::test]
+async fn dataset_options_and_envelope_defaults_cannot_replace_authority() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "authority-dataset:main";
+    let other = "authority-other:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    let app = setup_policy_ledger(app, other).await;
+    let token = identity_token(
+        &SigningKey::from_bytes(&[204; 32]),
+        "http://example.org/employee-user",
+        ledger,
+    );
+    let query = serde_json::json!({
+        "from": ledger,
+        "opts": {"from": {"@id": ledger, "policy": {"identity": "http://example.org/manager-user"}}},
+        "select": ["?name", "?class"],
+        "where": {"@id": "?s", "http://schema.org/name": "?name", "http://example.org/classification": "?class"}
+    });
+    for uri in [
+        "/v1/fluree/query".to_string(),
+        format!("/v1/fluree/query/{ledger}"),
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&uri)
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::from(query.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, rows) = json_body(resp).await;
+        assert_eq!(status, StatusCode::OK, "{uri}: {rows}");
+        assert_eq!(names_from_results(&rows).len(), 2);
+        let mut redirected = query.clone();
+        redirected["opts"]["from"]["@id"] = serde_json::json!(other);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&uri)
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::from(redirected.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+    let envelope = serde_json::json!({
+        "opts": {"policy-class": ["http://example.org/ManagerClass"], "policy": [{"f:required": true, "f:action": "f:view", "f:allow": true}], "default-allow": true},
+        "queries": {
+            "jsonld": {"language": "jsonld", "query": query, "opts": {"policyClass": ["http://example.org/ManagerClass"]}},
+            "sparql": {"language": "sparql", "query": format!("SELECT ?name FROM <{ledger}> WHERE {{ ?s a <http://example.org/Document>; <http://schema.org/name> ?name }}")}
+        }
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/fluree/multi-query")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::from(envelope.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, result) = json_body(resp).await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert!(
+        result
+            .get("errors")
+            .is_none_or(|e| e.as_object().is_some_and(|o| o.is_empty())),
+        "{result}"
+    );
+    assert_eq!(
+        names_from_results(&result["results"]["jsonld"]).len(),
+        2,
+        "{result}"
+    );
+    assert_eq!(
+        sparql_names(&result["results"]["sparql"]).len(),
+        2,
+        "{result}"
+    );
+    assert!(!result.to_string().contains("Executive Salaries"));
+}

--- a/fluree-db-server/tests/policy_authorization_regression.rs
+++ b/fluree-db-server/tests/policy_authorization_regression.rs
@@ -1375,3 +1375,125 @@ async fn authority_alone_authenticates_and_missing_request_context_denies() {
     assert_eq!(status, StatusCode::OK, "{result}");
     assert_eq!(names_from_results(&result).len(), 3);
 }
+
+#[tokio::test]
+async fn missing_controller_selection_with_locked_defaults_denies() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "empty-controller:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    add_modify_policies(&app, ledger).await;
+    let config = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix ex: <http://example.org/> .
+        GRAPH <urn:fluree:{ledger}#config> {{
+            <urn:cfg:main> a f:LedgerConfig ; f:policyDefaults <urn:cfg:policy> .
+            <urn:cfg:policy> f:defaultAllow false ; f:policyClass ex:ManagerClass ;
+                f:overrideControl f:OverrideNone .
+        }}
+    "
+    );
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/upsert/{ledger}"),
+        None,
+        "application/trig",
+        config,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    let token = create_jws(
+        &controller_claims(ledger),
+        &SigningKey::from_bytes(&[200; 32]),
+    );
+    let query = serde_json::json!({
+        "select": ["?value"],
+        "where": {"@id": "http://example.org/doc3", "http://schema.org/name": "?value"}
+    });
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/query/{ledger}"),
+        Some(&token),
+        "application/json",
+        query.to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert_eq!(
+        result,
+        serde_json::json!([]),
+        "missing request selection must deny"
+    );
+
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/insert/{ledger}"),
+        Some(&token),
+        "text/turtle",
+        "<http://example.org/blocked> <http://schema.org/name> \"Blocked\" .".into(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{result}");
+
+    // A fixed empty selection must not acquire the identity's or config's grants.
+    let fixed = delegated_token(
+        "http://example.org/manager-user",
+        ledger,
+        serde_json::json!({"policy-class": []}),
+    );
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/query/{ledger}"),
+        Some(&fixed),
+        "application/json",
+        query.to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert_eq!(result, serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn explain_uses_final_body_policy_selection_on_both_routes() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "explain-selection:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    let token = create_jws(
+        &controller_claims(ledger),
+        &SigningKey::from_bytes(&[200; 32]),
+    );
+    for scoped_route in [true, false] {
+        let uri = if scoped_route {
+            format!("/v1/fluree/explain/{ledger}")
+        } else {
+            "/v1/fluree/explain".into()
+        };
+        for allow in [true, false] {
+            let mut query = serde_json::json!({
+                "opts": {"default-allow": allow},
+                "select": ["?name"],
+                "where": {"@id": "?s", "http://schema.org/name": "?name"}
+            });
+            if !scoped_route {
+                query["from"] = ledger.into();
+            }
+            let (status, result) = post_policy_request(
+                &app,
+                &uri,
+                Some(&token),
+                "application/json",
+                query.to_string(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "{result}");
+            assert_eq!(
+                result["plan"]["reason"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("withheld by policy"),
+                !allow,
+                "{result}"
+            );
+        }
+    }
+}

--- a/fluree-db-server/tests/policy_authorization_regression.rs
+++ b/fluree-db-server/tests/policy_authorization_regression.rs
@@ -90,7 +90,34 @@ async fn configured_model_policy_controls_delegated_reads_and_writes() {
         let delegated =
             delegated_token("http://example.org/application-user", ledger, grant.clone());
         let key = SigningKey::from_bytes(&[205; 32]);
-        let mut tokens = vec![delegated];
+        let controller_key = SigningKey::from_bytes(&[200; 32]);
+        if allowed {
+            let controller = create_jws(&controller_claims(ledger), &controller_key);
+            let empty = serde_json::json!({
+                "opts": {"identity": "http://example.org/manager-user", "policy-class": []},
+                "select": ["?value"],
+                "where": {"@id": "http://example.org/doc1", "http://schema.org/name": "?value"}
+            });
+            let (status, body) = post_policy_request(
+                &app,
+                &format!("/v1/fluree/query/{ledger}"),
+                Some(&controller),
+                "application/json",
+                empty.to_string(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "{body}");
+            assert_eq!(
+                body,
+                serde_json::json!([]),
+                "empty groups must not inherit model defaults"
+            );
+        }
+
+        let mut tokens = vec![
+            delegated,
+            create_jws(&controller_claims(ledger), &controller_key),
+        ];
         if !allowed {
             tokens.push(identity_token_rw(
                 &key,
@@ -107,13 +134,18 @@ async fn configured_model_policy_controls_delegated_reads_and_writes() {
                 &key,
             ));
         }
-        for token in tokens {
+        for (index, token) in tokens.into_iter().enumerate() {
+            let request_opts = if index < 2 {
+                grant.clone()
+            } else {
+                serde_json::json!({})
+            };
             for (property, expected) in [
                 ("http://schema.org/name", 1),
                 ("http://example.org/content", usize::from(allowed)),
             ] {
                 let query = serde_json::json!({
-                    "opts": grant, "select": ["?value"],
+                    "opts": request_opts, "select": ["?value"],
                     "where": {"@id": "http://example.org/doc1", (property): "?value"}
                 });
                 let (status, result) = post_policy_request(
@@ -137,7 +169,7 @@ async fn configured_model_policy_controls_delegated_reads_and_writes() {
                 "delete": {"@id": "http://example.org/doc1", "http://example.org/content": "visible to all"},
                 "insert": {"@id": "http://example.org/doc1", "http://example.org/content": "rewritten"}
             });
-            body["opts"] = grant.clone();
+            body["opts"] = request_opts;
             let (status, result) = post_policy_request(
                 &app,
                 &format!("/v1/fluree/update/{ledger}"),
@@ -227,9 +259,7 @@ async fn signed_request_identity_does_not_inherit_bearer_delegation() {
         create_jws(&query, &key),
     )
     .await;
-    assert_eq!(status, StatusCode::OK, "{result}");
-    assert_eq!(names_from_results(&result).len(), 2, "{result}");
-    assert!(!names_from_results(&result).contains(&"Executive Salaries"));
+    assert_eq!(status, StatusCode::FORBIDDEN, "{result}");
 }
 
 #[cfg(feature = "graphql")]
@@ -281,8 +311,6 @@ async fn graphql_mutation_preserves_verified_authorization() {
                 .uri(format!("/v1/fluree/graphql/{ledger}"))
                 .header("content-type", "application/json")
                 .header("authorization", format!("Bearer {denied}"))
-                .header("fluree-policy-class", "http://example.org/ManagerClass")
-                .header("fluree-default-allow", "true")
                 .body(Body::from(mutation.to_string()))
                 .unwrap(),
         )
@@ -410,11 +438,10 @@ async fn restricted_bearer_cannot_replace_or_supplement_policy() {
             .await
             .unwrap();
         let (status, result) = json_body(resp).await;
-        assert_eq!(status, StatusCode::OK, "{result}");
-        let names = names_from_results(&result);
-        println!("restricted bearer opts={opts}: {names:?}");
-        assert_eq!(names.len(), 2);
-        assert!(!names.contains(&"Executive Salaries"));
+        assert_eq!(status, StatusCode::FORBIDDEN, "{result}");
+        assert!(result
+            .to_string()
+            .contains("Credential does not permit policy selection"));
     }
     let body = serde_json::json!({
         "from": {"@id": ledger, "policy": {"identity": "http://example.org/manager-user", "default-allow": false}},
@@ -435,11 +462,7 @@ async fn restricted_bearer_cannot_replace_or_supplement_policy() {
         .await
         .unwrap();
     let (status, result) = json_body(resp).await;
-    assert_eq!(status, StatusCode::OK, "{result}");
-    let names = names_from_results(&result);
-    println!("restricted bearer per-source identity override: {names:?}");
-    assert_eq!(names.len(), 2);
-    assert!(!names.contains(&"Executive Salaries"));
+    assert_eq!(status, StatusCode::FORBIDDEN, "{result}");
 }
 
 #[tokio::test]
@@ -563,8 +586,7 @@ async fn signed_policy_context_requires_authority_scope_and_valid_signature() {
     let token = identity_token(&ordinary, "http://example.org/unassigned", ledger);
     let (status, result) =
         query_docs_as(app, ledger, &token, "http://example.org/manager-user").await;
-    assert_eq!(status, StatusCode::OK);
-    assert!(names_from_results(&result).is_empty());
+    assert_eq!(status, StatusCode::FORBIDDEN, "{result}");
 }
 
 #[tokio::test]
@@ -577,7 +599,7 @@ async fn policy_headers_cannot_widen_sparql_reads() {
         "http://example.org/employee-user",
         ledger,
     );
-    for (uri, content_type, body, stream) in [
+    for (uri, content_type, body, _stream) in [
         (format!("/v1/fluree/query/{ledger}"), "application/sparql-query", "SELECT ?name WHERE { ?doc a <http://example.org/Document>; <http://schema.org/name> ?name }".to_string(), false),
         ("/v1/fluree/query".into(), "application/sparql-query", format!("SELECT ?name FROM <{ledger}> WHERE {{ ?doc a <http://example.org/Document>; <http://schema.org/name> ?name }}"), false),
         ("/v1/fluree/stream/query".into(), "application/sparql-query", format!("SELECT ?name FROM <{ledger}> WHERE {{ ?doc a <http://example.org/Document>; <http://schema.org/name> ?name }}"), true),
@@ -591,14 +613,7 @@ async fn policy_headers_cannot_widen_sparql_reads() {
             .header("fluree-policy-values", r#"{"?$identity":{"@id":"http://example.org/manager-user"}}"#)
             .header("fluree-default-allow", "true")
             .body(Body::from(body)).unwrap()).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK, "{uri}");
-        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-        let text = std::str::from_utf8(&bytes).unwrap();
-        assert!(text.contains("Public Post") && text.contains("Internal Memo"), "{uri}: {text}");
-        assert!(!text.contains("Executive Salaries"), "{uri}: {text}");
-        if !stream {
-            assert_eq!(sparql_names(&serde_json::from_str(text).unwrap()).len(), 2);
-        }
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN, "{uri}");
     }
 }
 
@@ -671,10 +686,10 @@ async fn hostile_policy_selection_cannot_authorize_a_write() {
             .await
             .unwrap();
         let (status, error) = json_body(resp).await;
-        assert_eq!(status, StatusCode::BAD_REQUEST, "{content_type}: {error}");
+        assert_eq!(status, StatusCode::FORBIDDEN, "{content_type}: {error}");
         assert!(error
             .to_string()
-            .contains("Employees may not modify document content."));
+            .contains("Credential does not permit policy selection"));
     }
     let query = serde_json::json!({"select": ["?content"], "where": {"@id": "http://example.org/doc1", "http://example.org/content": "?content"}});
     let resp = app
@@ -729,10 +744,13 @@ async fn dataset_options_and_envelope_defaults_cannot_replace_authority() {
             .await
             .unwrap();
         let (status, rows) = json_body(resp).await;
-        assert_eq!(status, StatusCode::OK, "{uri}: {rows}");
-        assert_eq!(names_from_results(&rows).len(), 2);
+        assert_eq!(status, StatusCode::FORBIDDEN, "{uri}: {rows}");
         let mut redirected = query.clone();
         redirected["opts"]["from"]["@id"] = serde_json::json!(other);
+        redirected["opts"]["from"]
+            .as_object_mut()
+            .unwrap()
+            .remove("policy");
         let resp = app
             .clone()
             .oneshot(
@@ -768,22 +786,521 @@ async fn dataset_options_and_envelope_defaults_cannot_replace_authority() {
         .await
         .unwrap();
     let (status, result) = json_body(resp).await;
-    assert_eq!(status, StatusCode::OK, "{result}");
+    assert_eq!(status, StatusCode::FORBIDDEN, "{result}");
+    assert!(!result.to_string().contains("Executive Salaries"));
     assert!(
         result
-            .get("errors")
-            .is_none_or(|e| e.as_object().is_some_and(serde_json::Map::is_empty)),
+            .to_string()
+            .contains("Credential does not permit policy selection"),
         "{result}"
     );
+}
+
+#[tokio::test]
+async fn controller_selects_dynamic_policies_without_changing_credential() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "controller:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    add_modify_policies(&app, ledger).await;
+    let key = SigningKey::from_bytes(&[200; 32]);
+    let token = create_jws(&controller_claims(ledger), &key);
+    for (class, count) in [
+        ("PublicClass", 1),
+        ("EmployeeClass", 2),
+        ("ManagerClass", 3),
+    ] {
+        let query = serde_json::json!({
+            "opts": {"identity": "http://example.org/manager-user", "policyClass": [format!("http://example.org/{class}")]},
+            "from": [{"@id": ledger}],
+            "select": ["?name"],
+            "where": {"@id": "?s", "http://schema.org/name": "?name"}
+        });
+        let (status, body) = post_policy_request(
+            &app,
+            &format!("/v1/fluree/query/{ledger}"),
+            Some(&token),
+            "application/json",
+            query.to_string(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body.as_array().unwrap().len(), count, "{body}");
+    }
+    // An empty set of application grants is not the same as omitting policy
+    // selection. Both missing selection and empty grants fail closed.
+    for (opts, expected) in [
+        (serde_json::json!({}), 0),
+        (serde_json::json!({"policy-class": []}), 0),
+        (
+            serde_json::json!({"policy-values": {"?unused": "value"}}),
+            0,
+        ),
+        (
+            serde_json::json!({"identity": "http://example.org/manager-user", "policy-class": []}),
+            0,
+        ),
+        (serde_json::json!({"default-allow": false}), 0),
+    ] {
+        let query = serde_json::json!({"opts": opts, "select": ["?name"],
+            "where": {"@id": "?s", "http://schema.org/name": "?name"}});
+        let (status, body) = post_policy_request(
+            &app,
+            &format!("/v1/fluree/query/{ledger}"),
+            Some(&token),
+            "application/json",
+            query.to_string(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body.as_array().unwrap().len(), expected, "{body}");
+    }
+    // Identity can be chosen dynamically without specifying a class as well.
+    let query = serde_json::json!({"opts": {"identity": "http://example.org/employee-user"},
+        "select": ["?name"], "where": {"@id": "?s", "http://schema.org/name": "?name"}});
+    let (status, body) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/query/{ledger}"),
+        Some(&token),
+        "application/json",
+        query.to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body.as_array().unwrap().len(), 2, "{body}");
+
+    // Inline policy and variable bindings also belong to the app, not to the
+    // credential subject. Reuse the same token to choose another user's data.
+    assign_docs_to_identities(&app, ledger).await;
+    let query = serde_json::json!({
+        "opts": {
+            "policy": [{"@type": "f:AccessPolicy", "f:action": [{"@id": "f:view"}],
+                "f:query": {"@type": "@json", "@value": {
+                    "where": {"@id": "?$this", "http://example.org/assignedTo": "?$identity"}
+                }}
+            }],
+            "policy-values": {"?$identity": {"@id": "http://example.org/employee-user"}},
+            "default-allow": false
+        },
+        "select": ["?name"], "where": {"@id": "?s", "http://schema.org/name": "?name"}
+    });
+    let (status, body) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/query/{ledger}"),
+        Some(&token),
+        "application/json",
+        query.to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body, serde_json::json!([["Internal Memo"]]));
+
+    // SPARQL uses the same selection via existing headers.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/fluree/query/{ledger}"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/sparql-query")
+                .header("fluree-policy-class", "http://example.org/EmployeeClass")
+                .body(Body::from(
+                    "SELECT ?name WHERE { ?s <http://schema.org/name> ?name }",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (status, body) = json_body(response).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
     assert_eq!(
-        names_from_results(&result["results"]["jsonld"]).len(),
+        body["results"]["bindings"].as_array().unwrap().len(),
         2,
-        "{result}"
+        "{body}"
     );
-    assert_eq!(
-        sparql_names(&result["results"]["sparql"]).len(),
-        2,
-        "{result}"
+
+    for (class, expected) in [
+        ("EmployeeClass", StatusCode::BAD_REQUEST),
+        ("ManagerClass", StatusCode::OK),
+    ] {
+        let mut update = modify_public_doc_content_body();
+        update["opts"] = serde_json::json!({"policy-class": [format!("http://example.org/{class}")], "default-allow": true});
+        let (status, body) = post_policy_request(
+            &app,
+            &format!("/v1/fluree/update/{ledger}"),
+            Some(&token),
+            "application/json",
+            update.to_string(),
+        )
+        .await;
+        assert_eq!(status, expected, "{body}");
+    }
+}
+
+#[tokio::test]
+async fn controller_capability_requires_explicit_claim_authority_and_scope() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "controller-gates:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    let key = SigningKey::from_bytes(&[200; 32]);
+    let query = serde_json::json!({"opts": {"policy-class": ["http://example.org/ManagerClass"], "default-allow": true},
+        "select": ["?name"], "where": {"@id": "?s", "http://schema.org/name": "?name"}});
+    let mut ordinary = controller_claims(ledger);
+    ordinary.as_object_mut().unwrap().remove("fluree.policy");
+    let ordinary = create_jws(&ordinary, &key);
+    let (status, body) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/query/{ledger}"),
+        Some(&ordinary),
+        "application/json",
+        query.to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+    for case in [
+        "untrusted-authority",
+        "invalid-policy-mode",
+        "wrong-audience",
+        "expired",
+        "wrong-scope",
+        "null-claim",
+    ] {
+        let mut claims = controller_claims(ledger);
+        let other = SigningKey::from_bytes(&[201; 32]);
+        let signing_key = if case == "untrusted-authority" {
+            &other
+        } else {
+            &key
+        };
+        claims["iss"] = did_from_pubkey(&signing_key.verifying_key().to_bytes()).into();
+        match case {
+            "invalid-policy-mode" => {
+                claims["fluree.policy"] = serde_json::json!(["request", {"default-allow": false}]);
+            }
+            "wrong-audience" => claims["aud"] = "other-server".into(),
+            "expired" => claims["exp"] = 1.into(),
+            "wrong-scope" => {
+                claims["fluree.ledger.read.ledgers"] = serde_json::json!(["other:main"]);
+            }
+            "null-claim" => claims["fluree.policy"] = JsonValue::Null,
+            _ => {}
+        }
+        let token = create_jws(&claims, signing_key);
+        let (status, body) = post_policy_request(
+            &app,
+            &format!("/v1/fluree/query/{ledger}"),
+            Some(&token),
+            "application/json",
+            query.to_string(),
+        )
+        .await;
+        assert_eq!(
+            status,
+            if case == "wrong-scope" {
+                StatusCode::NOT_FOUND
+            } else {
+                StatusCode::UNAUTHORIZED
+            },
+            "{case}: {body}"
+        );
+    }
+    let mut read_only = controller_claims(ledger);
+    read_only
+        .as_object_mut()
+        .unwrap()
+        .remove("fluree.ledger.write.ledgers");
+    let token = create_jws(&read_only, &key);
+    let (status, body) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/update/{ledger}"),
+        Some(&token),
+        "application/json",
+        modify_public_doc_content_body().to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+}
+
+#[tokio::test]
+async fn scope_only_preserves_delimited_output_and_ledger_write_defaults() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "scope-defaults:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    add_modify_policies(&app, ledger).await;
+    let key = SigningKey::from_bytes(&[200; 32]);
+    let mut claims = controller_claims(ledger);
+    claims.as_object_mut().unwrap().remove("fluree.policy");
+    claims.as_object_mut().unwrap().remove("sub");
+    let token = create_jws(&claims, &key);
+    let query = serde_json::json!({
+        "select": ["?name"], "where": {"@id": "?s", "http://schema.org/name": "?name"}});
+    for format in ["text/csv", "text/tab-separated-values"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/fluree/query/{ledger}"))
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .header("accept", format)
+                    .body(Body::from(query.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{format}");
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(
+            text.contains("Executive Salaries"),
+            "scope-only request has no policy selection: {text}"
+        );
+    }
+    let config = format!(
+        r"@prefix f: <https://ns.flur.ee/db#> . @prefix ex: <http://example.org/> .
+        GRAPH <urn:fluree:{ledger}#config> {{
+          <urn:cfg:main> a f:LedgerConfig ; f:policyDefaults <urn:cfg:policy> .
+          <urn:cfg:policy> f:defaultAllow true ; f:policyClass ex:EmployeeClass .
+        }}"
     );
-    assert!(!result.to_string().contains("Executive Salaries"));
+    let (status, body) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/upsert/{ledger}"),
+        None,
+        "application/trig",
+        config,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    // Default governance must survive both the plain and dataset read paths,
+    // including streaming and delimited output after the null-marker fix.
+    for (route, content_type, accept, dataset) in [
+        ("query", "application/json", "application/json", false),
+        ("query", "application/json", "application/json", true),
+        ("query", "application/json", "text/csv", false),
+        (
+            "query",
+            "application/sparql-query",
+            "application/json",
+            false,
+        ),
+        (
+            "stream/query",
+            "application/json",
+            "application/x-ndjson",
+            false,
+        ),
+        (
+            "stream/query",
+            "application/sparql-query",
+            "application/x-ndjson",
+            false,
+        ),
+    ] {
+        let mut query = serde_json::json!({"select": ["?name"],
+            "where": {"@id": "?s", "http://schema.org/name": "?name"}});
+        if dataset {
+            query["from"] = serde_json::json!([ledger]);
+        }
+        let body = if content_type == "application/json" {
+            query.to_string()
+        } else {
+            "SELECT ?name WHERE { ?s <http://schema.org/name> ?name }".into()
+        };
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/fluree/{route}/{ledger}"))
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", content_type)
+                    .header("accept", accept)
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{route}: {content_type}");
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(text.contains("Public Post"), "{route}: {text}");
+        assert!(!text.contains("Executive Salaries"), "{route}: {text}");
+    }
+    for bearer in [None, Some(token.as_str())] {
+        let (status, body) = post_policy_request(
+            &app,
+            &format!("/v1/fluree/update/{ledger}"),
+            bearer,
+            "application/json",
+            modify_public_doc_content_body().to_string(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+        assert!(
+            body.to_string().contains("Employees may not modify"),
+            "{body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn show_preserves_narrowing_delegation_and_controller_headers() {
+    let (_tmp, state) = policy_test_state().await;
+    let ledger = "show-delegation:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    let (status, body) = post_policy_request(&app, &format!("/v1/fluree/insert/{ledger}"), None, "application/json",
+        serde_json::json!({"@context": {"ex": "http://example.org/", "schema": "http://schema.org/"}, "insert": [
+            {"@id": "ex:new-public", "schema:name": "New public", "ex:classification": "public"},
+            {"@id": "ex:new-secret", "schema:name": "New secret", "ex:classification": "confidential"}
+        ]}).to_string()).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let t = body["t"].as_i64().unwrap();
+    let delegated = delegated_token(
+        "http://example.org/manager-user",
+        ledger,
+        serde_json::json!({"policy-class": ["http://example.org/EmployeeClass"]}),
+    );
+    let key = SigningKey::from_bytes(&[200; 32]);
+    let controller = create_jws(&controller_claims(ledger), &key);
+    for (token, class, secret) in [
+        (&delegated, "EmployeeClass", false),
+        (&controller, "EmployeeClass", false),
+        (&controller, "ManagerClass", true),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/v1/fluree/show/{ledger}?commit=t:{t}"))
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("fluree-policy-class", format!("http://example.org/{class}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, body) = json_body(response).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let flakes = body["flakes"].to_string();
+        assert!(flakes.contains("New public"), "{body}");
+        assert_eq!(flakes.contains("New secret"), secret, "{body}");
+    }
+}
+
+#[tokio::test]
+async fn mcp_refuses_policy_credentials_instead_of_discarding_context() {
+    use fluree_db_server::mcp::auth::validate_mcp_token;
+    let key = SigningKey::from_bytes(&[200; 32]);
+    let issuer = did_from_pubkey(&key.verifying_key().to_bytes());
+    let (_tmp, state) = policy_transport_regression::transport_state(ServerConfig {
+        mcp_auth_trusted_issuers: vec![issuer],
+        ..Default::default()
+    })
+    .await;
+    // Use the actual authentication middleware with a sentinel handler, so the
+    // ordinary credential proves that the refusal isn't a missing route.
+    let app = axum::Router::new()
+        .route("/", axum::routing::get(|| async { StatusCode::OK }))
+        .layer(axum::middleware::from_fn_with_state(
+            state,
+            validate_mcp_token,
+        ));
+    for mode in ["ordinary", "delegated", "controller"] {
+        let mut claims = controller_claims("mcp:main");
+        claims.as_object_mut().unwrap().remove("fluree.policy");
+        match mode {
+            "delegated" => {
+                claims["fluree.policy"] =
+                    serde_json::json!({"policy-class": ["http://example.org/EmployeeClass"]});
+            }
+            "controller" => claims["fluree.policy"] = "request".into(),
+            _ => {}
+        }
+        let token = create_jws(&claims, &key);
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            if mode == "ordinary" {
+                StatusCode::OK
+            } else {
+                StatusCode::UNAUTHORIZED
+            },
+            "{mode}"
+        );
+    }
+}
+
+fn controller_claims(ledger: &str) -> JsonValue {
+    let key = SigningKey::from_bytes(&[200; 32]);
+    serde_json::json!({
+        "iss": did_from_pubkey(&key.verifying_key().to_bytes()),
+        "aud": "fluree-policy-test", "sub": "http://example.org/public-user",
+        "exp": now_secs() + 300,
+        "fluree.ledger.read.ledgers": [ledger],
+        "fluree.ledger.write.ledgers": [ledger],
+        "fluree.policy": "request"
+    })
+}
+
+#[tokio::test]
+async fn authority_alone_authenticates_and_missing_request_context_denies() {
+    let key = SigningKey::from_bytes(&[200; 32]);
+    let (_tmp, state) = policy_transport_regression::transport_state(ServerConfig {
+        data_auth_mode: DataAuthMode::Optional,
+        data_auth_audience: Some("fluree-policy-test".into()),
+        data_auth_policy_authorities: vec![did_from_pubkey(&key.verifying_key().to_bytes())],
+        ..Default::default()
+    })
+    .await;
+    let ledger = "authority-alone:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    let token = create_jws(&controller_claims(ledger), &key);
+    for (opts, expected) in [
+        (serde_json::json!({}), 0),
+        (serde_json::json!({"identity": null}), 0),
+        (serde_json::json!({"default-allow": true}), 3),
+    ] {
+        let (status, result) = post_policy_request(
+            &app,
+            &format!("/v1/fluree/query/{ledger}"),
+            Some(&token),
+            "application/json",
+            serde_json::json!({"opts": opts,
+                "select": ["?name"], "where": {"@id": "?s", "http://schema.org/name": "?name"}})
+            .to_string(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{result}");
+        assert_eq!(result.as_array().unwrap().len(), expected, "{result}");
+    }
+    // A headers-only write must resolve the same missing selection to deny.
+    let (status, result) = post_policy_request(
+        &app,
+        &format!("/v1/fluree/insert/{ledger}"),
+        Some(&token),
+        "text/turtle",
+        "<http://example.org/new> <http://schema.org/name> \"New\" .".into(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{result}");
+    // Omitting auth still supports the private-server direct-option contract.
+    let (status, result) = query_docs_tri_state(app, ledger, None, None, None).await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert_eq!(names_from_results(&result).len(), 3);
 }

--- a/fluree-db-server/tests/policy_authorization_regression.rs
+++ b/fluree-db-server/tests/policy_authorization_regression.rs
@@ -1150,6 +1150,53 @@ async fn scope_only_preserves_delimited_output_and_ledger_write_defaults() {
 }
 
 #[tokio::test]
+async fn anonymous_transaction_policy_headers_apply_without_tracking() {
+    for mode in [DataAuthMode::None, DataAuthMode::Optional] {
+        let (_tmp, state) = policy_transport_regression::transport_state(ServerConfig {
+            data_auth_mode: mode,
+            ..Default::default()
+        })
+        .await;
+        let ledger = "anonymous-header-defaults:main";
+        let app = setup_policy_ledger(build_router(state), ledger).await;
+        add_modify_policies(&app, ledger).await;
+
+        // No tracking headers or opts: the employee header must still restrict
+        // this write. A body selection takes precedence over that default.
+        for (body_class, expected) in [
+            (None, StatusCode::BAD_REQUEST),
+            (Some("http://example.org/ManagerClass"), StatusCode::OK),
+        ] {
+            let mut body = modify_public_doc_content_body();
+            if let Some(class) = body_class {
+                body["opts"] = serde_json::json!({"policy-class": [class]});
+            }
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(format!("/v1/fluree/update/{ledger}"))
+                        .header("content-type", "application/json")
+                        .header("fluree-policy-class", "http://example.org/EmployeeClass")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            let (status, body) = json_body(response).await;
+            assert_eq!(status, expected, "{mode:?}: {body}");
+            if expected == StatusCode::BAD_REQUEST {
+                assert!(
+                    body.to_string().contains("Employees may not modify"),
+                    "{body}"
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
 async fn show_preserves_narrowing_delegation_and_controller_headers() {
     let (_tmp, state) = policy_test_state().await;
     let ledger = "show-delegation:main";
@@ -1190,6 +1237,30 @@ async fn show_preserves_narrowing_delegation_and_controller_headers() {
         let flakes = body["flakes"].to_string();
         assert!(flakes.contains("New public"), "{body}");
         assert_eq!(flakes.contains("New secret"), secret, "{body}");
+    }
+    // Binding must reject a conflicting fixed header, and a request-selected
+    // credential with no context must keep the commit flakes hidden.
+    for (token, class, expected) in [
+        (&delegated, Some("ManagerClass"), StatusCode::FORBIDDEN),
+        (&controller, None, StatusCode::OK),
+    ] {
+        let mut request = Request::builder()
+            .uri(format!("/v1/fluree/show/{ledger}?commit=t:{t}"))
+            .header("authorization", format!("Bearer {token}"));
+        if let Some(class) = class {
+            request = request.header("fluree-policy-class", format!("http://example.org/{class}"));
+        }
+        let (status, body) = json_body(
+            app.clone()
+                .oneshot(request.body(Body::empty()).unwrap())
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, expected, "{body}");
+        if expected == StatusCode::OK {
+            assert_eq!(body["flakes"], serde_json::json!([]), "{body}");
+        }
     }
 }
 

--- a/fluree-db-server/tests/policy_authorization_regression.rs
+++ b/fluree-db-server/tests/policy_authorization_regression.rs
@@ -60,7 +60,7 @@ async fn configured_model_policy_controls_delegated_reads_and_writes() {
     ] {
         let app = setup_policy_ledger(app.clone(), ledger).await;
         let config = format!(
-            r#"
+            r"
             @prefix f: <https://ns.flur.ee/db#> .
             @prefix ex: <http://example.org/> .
             GRAPH <urn:fluree:{ledger}#config> {{
@@ -70,7 +70,7 @@ async fn configured_model_policy_controls_delegated_reads_and_writes() {
                 <urn:cfg:ref> a f:GraphRef ; f:graphSource <urn:cfg:source> .
                 <urn:cfg:source> f:ledger <{model}> ;
                     f:graphSelector <http://example.org/model-policies> .
-            }}"#
+            }}"
         );
         let (status, result) = post_policy_request(
             &app,
@@ -508,14 +508,14 @@ async fn signed_policy_context_requires_authority_scope_and_valid_signature() {
         match label {
             "issuer" => {
                 invalid["iss"] =
-                    serde_json::json!(did_from_pubkey(&ordinary.verifying_key().to_bytes()))
+                    serde_json::json!(did_from_pubkey(&ordinary.verifying_key().to_bytes()));
             }
             "null-context" => invalid["fluree.policy"] = JsonValue::Null,
             "audience" => invalid["aud"] = serde_json::json!("another-server"),
             "expired" => invalid["exp"] = serde_json::json!(now_secs() - 120),
             "future" => invalid["nbf"] = serde_json::json!(now_secs() + 300),
             "ledger" => {
-                invalid["fluree.ledger.read.ledgers"] = serde_json::json!(["elsewhere:main"])
+                invalid["fluree.ledger.read.ledgers"] = serde_json::json!(["elsewhere:main"]);
             }
             "action" => {
                 invalid
@@ -772,7 +772,7 @@ async fn dataset_options_and_envelope_defaults_cannot_replace_authority() {
     assert!(
         result
             .get("errors")
-            .is_none_or(|e| e.as_object().is_some_and(|o| o.is_empty())),
+            .is_none_or(|e| e.as_object().is_some_and(serde_json::Map::is_empty)),
         "{result}"
     );
     assert_eq!(

--- a/fluree-db-server/tests/policy_integration.rs
+++ b/fluree-db-server/tests/policy_integration.rs
@@ -60,12 +60,29 @@ fn create_jws(claims: &JsonValue, signing_key: &SigningKey) -> String {
 fn identity_token(signing_key: &SigningKey, identity: &str, ledger: &str) -> String {
     let claims = serde_json::json!({
         "iss": did_from_pubkey(&signing_key.verifying_key().to_bytes()),
+        "aud": "fluree-policy-test",
         "exp": now_secs() + 3600,
         "iat": now_secs(),
         "fluree.identity": identity,
         "fluree.ledger.read.ledgers": [ledger],
     });
     create_jws(&claims, signing_key)
+}
+
+fn delegated_token(identity: &str, ledger: &str, policy: JsonValue) -> String {
+    let key = SigningKey::from_bytes(&[200; 32]);
+    create_jws(
+        &serde_json::json!({
+            "iss": did_from_pubkey(&key.verifying_key().to_bytes()),
+            "aud": "fluree-policy-test",
+            "exp": now_secs() + 300,
+            "fluree.identity": identity,
+            "fluree.ledger.read.ledgers": [ledger],
+            "fluree.ledger.write.ledgers": [ledger],
+            "fluree.policy": policy,
+        }),
+        &key,
+    )
 }
 
 async fn policy_test_state() -> (TempDir, Arc<AppState>) {
@@ -76,6 +93,12 @@ async fn policy_test_state() -> (TempDir, Arc<AppState>) {
         storage_path: Some(tmp.path().to_path_buf()),
         data_auth_mode: DataAuthMode::Optional,
         data_auth_insecure_accept_any_issuer: true,
+        data_auth_audience: Some("fluree-policy-test".into()),
+        data_auth_policy_authorities: vec![did_from_pubkey(
+            &SigningKey::from_bytes(&[200; 32])
+                .verifying_key()
+                .to_bytes(),
+        )],
         ..Default::default()
     };
     let telemetry = TelemetryConfig::with_server_config(&cfg);
@@ -245,7 +268,7 @@ async fn setup_policy_ledger(app: axum::Router, ledger: &str) -> axum::Router {
 ///
 /// The query selects `?name` and `?class` for all `ex:Document` subjects.
 /// `default-allow` is controlled by the caller. No `opts.identity` — the
-/// server injects it from the Bearer token via `force_query_auth_opts`.
+/// server binds it from the verified Bearer token.
 async fn query_docs(
     app: axum::Router,
     ledger: &str,
@@ -414,18 +437,9 @@ async fn identity_without_policy_class_default_allow_false_denies_all() {
     );
 }
 
-/// An identity with no subject node in the ledger must be allowed when
-/// `default-allow: true` is set.
-///
-/// Rationale: `default-allow: true` is an explicit admin opt-in that applies to
-/// every requester not specifically restricted by a policy — including unknown
-/// identities. A common pattern is an application layer in front of the DB that
-/// handles authorization itself and uses credential-signed writes only so that
-/// Fluree records *who* transacted for provenance. In that setup a first-time DID
-/// must be able to transact without being pre-provisioned, and reads must follow
-/// the same opt-in. Callers who want fail-closed behavior set `default-allow: false`.
+/// Caller default-allow cannot give an unknown authenticated identity access.
 #[tokio::test]
-async fn unknown_identity_allowed_with_default_allow_true() {
+async fn unknown_identity_cannot_choose_default_allow_true() {
     let (_tmp, state) = policy_test_state().await;
     let app = setup_policy_ledger(build_router(state), "policy5:main").await;
 
@@ -442,7 +456,7 @@ async fn unknown_identity_allowed_with_default_allow_true() {
     let names = names_from_results(&json);
     assert_eq!(
         names.len(),
-        3,
+        0,
         "unknown identity + default-allow:true must see all documents; got: {names:?}"
     );
 }
@@ -582,19 +596,9 @@ async fn property_level_deny_hides_ex_content_field() {
     );
 }
 
-/// A **known** identity subject (exists in the ledger) with no `f:policyClass` and
-/// `default-allow: true` should see all documents.
-///
-/// This validates the `FoundNoPolicies` path: the identity subject node is present in the
-/// ledger (so it is not `NotFound`), but it carries no policy class binding. With no
-/// restrictions and `default_allow = true`, access is granted to everything.
-///
-/// Contrast with `unknown_identity_allowed_with_default_allow_true` which uses an
-/// identity that has NO subject node at all (`NotFound`) — that path also now honors
-/// `default_allow`, so both tests succeed for the same reason: empty restrictions +
-/// permissive default.
+/// A local identity record with no policies does not confer delegation authority.
 #[tokio::test]
-async fn known_identity_no_policy_class_default_allow_true_allows_all() {
+async fn unassigned_identity_cannot_choose_default_allow_true() {
     let (_tmp, state) = policy_test_state().await;
     let app = setup_policy_ledger(build_router(state), "policy7:main").await;
 
@@ -630,21 +634,12 @@ async fn known_identity_no_policy_class_default_allow_true_allows_all() {
     let names = names_from_results(&json);
     assert_eq!(
         names.len(),
-        3,
-        "known identity with no policyClass + default-allow:true must see all 3 docs; got: {names:?}"
+        0,
+        "known identity with no policyClass + default-allow:true cannot grant itself access; got: {names:?}"
     );
 }
 
-// ── Root-bearer impersonation tests ──────────────────────────────────────────
-//
-// These exercise the "service-account impersonation" pattern: a bearer
-// identity that has no `f:policyClass` on the target ledger may delegate to a
-// body- or header-supplied target identity for policy testing. The check is
-// performed via `fluree_db_api::identity_has_no_policies` — only the
-// `FoundNoPolicies` outcome enables impersonation.
-
-/// Insert a registered identity subject with no `f:policyClass` so it qualifies
-/// as a root-equivalent (FoundNoPolicies) identity for impersonation.
+/// Register an identity without policy assignments to exercise delegation boundaries.
 async fn register_root_identity(app: &axum::Router, ledger: &str, identity_iri: &str) {
     let tx = serde_json::json!({
         "@context": { "ex": "http://example.org/" },
@@ -669,8 +664,8 @@ async fn register_root_identity(app: &axum::Router, ledger: &str, identity_iri: 
     );
 }
 
-/// Query as `bearer_identity`, requesting impersonation as `target_identity`
-/// via body `opts.identity`. Server should honor when bearer is root.
+/// Query with a bearer token and a conflicting body `opts.identity`.
+/// The verified token's policy selection must govern the result.
 async fn query_docs_as(
     app: axum::Router,
     ledger: &str,
@@ -705,16 +700,19 @@ async fn query_docs_as(
     json_body(resp).await
 }
 
-/// A root bearer (no f:policyClass) can impersonate the employee identity and
-/// receives the employee's filtered view (public + internal docs only).
+/// An explicitly trusted issuer can select employee classes for an app identity.
+/// Conflicting request identity is ignored.
 #[tokio::test]
-async fn root_bearer_can_impersonate_employee_via_body_opts() {
+async fn policy_authority_can_delegate_employee_access() {
     let (_tmp, state) = policy_test_state().await;
     let app = setup_policy_ledger(build_router(state), "imp1:main").await;
     register_root_identity(&app, "imp1:main", "http://example.org/svc-bearer").await;
 
-    let signing_key = SigningKey::from_bytes(&[10u8; 32]);
-    let token = identity_token(&signing_key, "http://example.org/svc-bearer", "imp1:main");
+    let token = delegated_token(
+        "http://example.org/svc-bearer",
+        "imp1:main",
+        serde_json::json!({"policy-class": ["http://example.org/EmployeeClass"]}),
+    );
 
     let (status, json) =
         query_docs_as(app, "imp1:main", &token, "http://example.org/employee-user").await;
@@ -724,7 +722,7 @@ async fn root_bearer_can_impersonate_employee_via_body_opts() {
     assert_eq!(
         names.len(),
         2,
-        "impersonating employee should see exactly 2 docs; got: {names:?}"
+        "delegated employee access should see exactly 2 docs; got: {names:?}"
     );
     assert!(names.contains(&"Public Post"));
     assert!(names.contains(&"Internal Memo"));
@@ -760,19 +758,17 @@ async fn restricted_bearer_cannot_impersonate_manager() {
     assert!(!names.contains(&"Executive Salaries"));
 }
 
-/// Root bearer impersonates via the `fluree-identity` HTTP header on a SPARQL
-/// query; result set matches the impersonated identity's policy.
+/// Signed selection also governs SPARQL, regardless of caller identity headers.
 #[tokio::test]
-async fn root_bearer_can_impersonate_via_sparql_header() {
+async fn policy_authority_can_delegate_sparql_access() {
     let (_tmp, state) = policy_test_state().await;
     let app = setup_policy_ledger(build_router(state), "imp3:main").await;
     register_root_identity(&app, "imp3:main", "http://example.org/svc-bearer-sparql").await;
 
-    let signing_key = SigningKey::from_bytes(&[12u8; 32]);
-    let token = identity_token(
-        &signing_key,
+    let token = delegated_token(
         "http://example.org/svc-bearer-sparql",
         "imp3:main",
+        serde_json::json!({"policy-class": ["http://example.org/PublicClass"]}),
     );
 
     let sparql = "PREFIX ex: <http://example.org/> \
@@ -808,7 +804,7 @@ async fn root_bearer_can_impersonate_via_sparql_header() {
     assert_eq!(
         names.len(),
         1,
-        "impersonated public-user should see 1 doc via SPARQL; got: {names:?}"
+        "delegated public access should see 1 doc via SPARQL; got: {names:?}"
     );
     assert_eq!(names[0], "Public Post");
 }
@@ -897,21 +893,12 @@ fn jsonld_select_names(json: &JsonValue) -> Vec<&str> {
         .collect()
 }
 
-/// Helper: build a root bearer token (identity has no f:policyClass on the
-/// ledger, so it qualifies for the impersonation gate when needed).
-async fn root_bearer(app: &axum::Router, ledger: &str, key_byte: u8, identity: &str) -> String {
-    register_root_identity(app, ledger, identity).await;
-    let signing_key = SigningKey::from_bytes(&[key_byte; 32]);
-    identity_token(&signing_key, identity, ledger)
-}
-
 /// Inline JSON-LD policy supplied via `opts.policy` filters results to public
 /// documents only — verifies the `--policy` flag's body-opts transport.
 #[tokio::test]
 async fn inline_policy_via_body_opts_filters_to_public() {
     let (_tmp, state) = policy_test_state().await;
     let app = setup_policy_ledger(build_router(state), "inline1:main").await;
-    let token = root_bearer(&app, "inline1:main", 20, "http://example.org/inline-svc").await;
 
     // Inline policy: only documents with classification = "public" are visible.
     let inline_policy = serde_json::json!([
@@ -938,6 +925,12 @@ async fn inline_policy_via_body_opts_filters_to_public() {
             {"@id": "?doc", "schema:name": "?name"}
         ]
     });
+
+    let token = delegated_token(
+        "http://example.org/inline-svc",
+        "inline1:main",
+        body["opts"].clone(),
+    );
 
     let req = Request::builder()
         .method("POST")
@@ -1237,14 +1230,12 @@ async fn comma_separated_policy_class_header() {
 // ── Write-policy enforcement tests ───────────────────────────────────────────
 //
 // These validate the end-to-end policy path for transactions:
-//   bearer identity → `apply_auth_identity_to_opts`
-//   → `fluree_db_api::build_policy_context`
-//   → `TxBuilder.policy(ctx)` → `Fluree::transact_tracked_with_policy`
+//   verified bearer → authorization binding → consensus governance
+//   → `fluree_db_api::build_transact_policy_context` → policy-enforced commit
 //
-// Covers JSON-LD `/v1/fluree/update`, SPARQL UPDATE, and the impersonation
-// gate's behavior on writes. The setup installs a required `f:modify` gate on
-// the employee class (denies modifying `ex:content` unless the target doc's
-// classification is "internal") and a blanket `f:allow: true` modify policy on
+// Covers JSON-LD `/v1/fluree/update`, SPARQL UPDATE, and explicit delegation
+// on writes. The setup denies employee modifications to `ex:content`
+// and installs a blanket `f:allow: true` modify policy on
 // the manager class, so both the denial and the allow paths exercise real
 // policy evaluation rather than a no-policy fallthrough.
 
@@ -1252,6 +1243,7 @@ async fn comma_separated_policy_class_header() {
 fn identity_token_rw(signing_key: &SigningKey, identity: &str, ledger: &str) -> String {
     let claims = serde_json::json!({
         "iss": did_from_pubkey(&signing_key.verifying_key().to_bytes()),
+        "aud": "fluree-policy-test",
         "exp": now_secs() + 3600,
         "iat": now_secs(),
         "fluree.identity": identity,
@@ -1400,19 +1392,19 @@ async fn manager_bearer_update_allowed() {
     );
 }
 
-/// A root bearer (no `f:policyClass`) impersonating the employee identity via
-/// `opts.identity` is rejected. Policy enforcement follows the impersonated
-/// identity, not the bearer's own unrestricted service-account identity —
-/// impersonation doesn't bypass policy, it tests under the target's view.
+/// Grant-derived employee classes enforce modify restrictions on the write path.
 #[tokio::test]
-async fn root_bearer_impersonating_employee_update_denied() {
+async fn delegated_employee_write_enforces_modify_policy() {
     let (_tmp, state) = policy_test_state().await;
     let app = setup_policy_ledger(build_router(state), "wpol3:main").await;
     add_modify_policies(&app, "wpol3:main").await;
     register_root_identity(&app, "wpol3:main", "http://example.org/svc-writer").await;
 
-    let signing_key = SigningKey::from_bytes(&[32u8; 32]);
-    let token = identity_token_rw(&signing_key, "http://example.org/svc-writer", "wpol3:main");
+    let token = delegated_token(
+        "http://example.org/svc-writer",
+        "wpol3:main",
+        serde_json::json!({"policy-class": ["http://example.org/EmployeeClass"]}),
+    );
 
     let mut body = modify_public_doc_content_body();
     body.as_object_mut().unwrap().insert(
@@ -1435,7 +1427,7 @@ async fn root_bearer_impersonating_employee_update_denied() {
     assert_eq!(
         status,
         StatusCode::BAD_REQUEST,
-        "impersonated employee write must be rejected; got body: {json}"
+        "delegated employee write must be rejected; got body: {json}"
     );
     let err_msg = json
         .get("error")
@@ -2024,7 +2016,7 @@ async fn query_docs_tri_state(
 /// identity the server injects from the Bearer token.
 ///
 /// This is the seam the API-layer tests can't reach — `FlureeHeaders`, the
-/// header→opts injection, and `force_query_auth_opts` all sit between the wire
+/// header→opts injection, and authorization binding all sit between the wire
 /// and `merge_policy_opts`. Before the tri-state change this returned `[]`.
 #[tokio::test]
 async fn config_default_allow_true_applies_to_bearer_identity_over_http() {
@@ -2192,3 +2184,6 @@ async fn enforcement_signal_follows_configured_default_allow() {
         "no policies and no permissive default: no data flake could return; got: {json}"
     );
 }
+
+#[path = "policy_authorization_regression.rs"]
+mod policy_authorization_regression;

--- a/fluree-db-server/tests/policy_integration.rs
+++ b/fluree-db-server/tests/policy_integration.rs
@@ -451,14 +451,10 @@ async fn unknown_identity_cannot_choose_default_allow_true() {
     );
 
     let (status, json) = query_docs(app, "policy5:main", Some(&token), true).await;
-    assert_eq!(status, StatusCode::OK);
-
-    let names = names_from_results(&json);
-    assert_eq!(
-        names.len(),
-        0,
-        "unknown identity + default-allow:true must see all documents; got: {names:?}"
-    );
+    assert_eq!(status, StatusCode::FORBIDDEN, "{json}");
+    assert!(json
+        .to_string()
+        .contains("Credential does not permit policy selection"));
 }
 
 /// A property-level `f:allow: false` on `ex:content` should strip that field
@@ -629,14 +625,10 @@ async fn unassigned_identity_cannot_choose_default_allow_true() {
     );
 
     let (status, json) = query_docs(app, "policy7:main", Some(&token), true).await;
-    assert_eq!(status, StatusCode::OK);
-
-    let names = names_from_results(&json);
-    assert_eq!(
-        names.len(),
-        0,
-        "known identity with no policyClass + default-allow:true cannot grant itself access; got: {names:?}"
-    );
+    assert_eq!(status, StatusCode::FORBIDDEN, "{json}");
+    assert!(json
+        .to_string()
+        .contains("Credential does not permit policy selection"));
 }
 
 /// Register an identity without policy assignments to exercise delegation boundaries.
@@ -701,7 +693,7 @@ async fn query_docs_as(
 }
 
 /// An explicitly trusted issuer can select employee classes for an app identity.
-/// Conflicting request identity is ignored.
+/// Matching request identity is accepted.
 #[tokio::test]
 async fn policy_authority_can_delegate_employee_access() {
     let (_tmp, state) = policy_test_state().await;
@@ -715,7 +707,7 @@ async fn policy_authority_can_delegate_employee_access() {
     );
 
     let (status, json) =
-        query_docs_as(app, "imp1:main", &token, "http://example.org/employee-user").await;
+        query_docs_as(app, "imp1:main", &token, "http://example.org/svc-bearer").await;
     assert_eq!(status, StatusCode::OK);
 
     let names = names_from_results(&json);
@@ -729,9 +721,7 @@ async fn policy_authority_can_delegate_employee_access() {
     assert!(!names.contains(&"Executive Salaries"));
 }
 
-/// A restricted bearer (employee) attempting impersonation has the
-/// `opts.identity` force-overridden by the server back to its own bearer
-/// identity — it sees its own filtered view, NOT the target's.
+/// A restricted bearer receives an explicit refusal for conflicting identity.
 #[tokio::test]
 async fn restricted_bearer_cannot_impersonate_manager() {
     let (_tmp, state) = policy_test_state().await;
@@ -744,21 +734,16 @@ async fn restricted_bearer_cannot_impersonate_manager() {
         "imp2:main",
     );
 
-    // Employee tries to impersonate manager — should be force-overridden.
+    // Employee tries to impersonate manager — reject the conflicting selection.
     let (status, json) =
         query_docs_as(app, "imp2:main", &token, "http://example.org/manager-user").await;
-    assert_eq!(status, StatusCode::OK);
-
-    let names = names_from_results(&json);
-    assert_eq!(
-        names.len(),
-        2,
-        "restricted bearer should see employee view (2 docs), not manager view (3); got: {names:?}"
-    );
-    assert!(!names.contains(&"Executive Salaries"));
+    assert_eq!(status, StatusCode::FORBIDDEN, "{json}");
+    assert!(json
+        .to_string()
+        .contains("Credential does not permit policy selection"));
 }
 
-/// Signed selection also governs SPARQL, regardless of caller identity headers.
+/// Signed selection governs SPARQL when identity headers agree.
 #[tokio::test]
 async fn policy_authority_can_delegate_sparql_access() {
     let (_tmp, state) = policy_test_state().await;
@@ -782,7 +767,7 @@ async fn policy_authority_can_delegate_sparql_access() {
         .uri("/v1/fluree/query/imp3:main")
         .header("content-type", "application/sparql-query")
         .header("authorization", format!("Bearer {token}"))
-        .header("fluree-identity", "http://example.org/public-user");
+        .header("fluree-identity", "http://example.org/svc-bearer-sparql");
 
     let resp = app
         .oneshot(req.body(Body::from(sparql)).unwrap())
@@ -809,7 +794,7 @@ async fn policy_authority_can_delegate_sparql_access() {
     assert_eq!(names[0], "Public Post");
 }
 
-/// Restricted bearer attempting SPARQL impersonation via header is force-overridden.
+/// Restricted bearer attempting SPARQL impersonation via header is rejected.
 #[tokio::test]
 async fn restricted_bearer_cannot_impersonate_via_sparql_header() {
     let (_tmp, state) = policy_test_state().await;
@@ -841,31 +826,11 @@ async fn restricted_bearer_cannot_impersonate_via_sparql_header() {
         .unwrap();
 
     let (status, json) = json_body(resp).await;
-    assert_eq!(status, StatusCode::OK);
-
-    let bindings = json
-        .pointer("/results/bindings")
-        .and_then(|v| v.as_array())
-        .expect("expected SPARQL results.bindings array");
-    let names: Vec<&str> = bindings
-        .iter()
-        .filter_map(|b| b.pointer("/name/value").and_then(|v| v.as_str()))
-        .collect();
-    assert_eq!(
-        names.len(),
-        2,
-        "restricted SPARQL bearer should see employee view (2), not manager (3); got: {names:?}"
-    );
-    assert!(!names.contains(&"Executive Salaries"));
+    assert_eq!(status, StatusCode::FORBIDDEN, "{json}");
+    assert!(json
+        .to_string()
+        .contains("Credential does not permit policy selection"));
 }
-
-// ── Inline policy and policy-values tests ────────────────────────────────────
-//
-// These exercise the ad-hoc policy CLI flags (`--policy` / `--policy-file` and
-// `--policy-values` / `--policy-values-file`) via their on-the-wire forms:
-// body `opts.policy` / `opts.policy-values` for JSON-LD, and
-// `fluree-policy` / `fluree-policy-values` headers for SPARQL. These are the
-// "test policies before persisting them" path.
 
 /// Helper: extract names from SPARQL results bindings.
 fn sparql_names(json: &JsonValue) -> Vec<&str> {
@@ -1409,7 +1374,7 @@ async fn delegated_employee_write_enforces_modify_policy() {
     let mut body = modify_public_doc_content_body();
     body.as_object_mut().unwrap().insert(
         "opts".to_string(),
-        serde_json::json!({"identity": "http://example.org/employee-user"}),
+        serde_json::json!({"identity": "http://example.org/svc-writer"}),
     );
 
     let req = Request::builder()
@@ -1862,11 +1827,9 @@ async fn tracked_read_zero_policy_identity_reports_deny_all() {
     );
 }
 
-/// An anonymous request builds no policy context. Its tracked output must be
-/// exactly what it was before the enforcement record existed: the empty tally,
-/// no enforcement field, and no enforcement header.
+/// An anonymous request explicitly selecting deny must engage enforcement.
 #[tokio::test]
-async fn tracked_read_anonymous_reports_no_enforcement() {
+async fn tracked_read_anonymous_explicit_deny_is_enforced() {
     let (_tmp, state) = policy_test_state().await;
     let app = setup_policy_ledger(build_router(state), "policytrack3:main").await;
 
@@ -1874,23 +1837,16 @@ async fn tracked_read_anonymous_reports_no_enforcement() {
         tracked_query_docs(app, "policytrack3:main", None, false).await;
     assert_eq!(status, StatusCode::OK);
 
+    assert_eq!(json["result"], serde_json::json!([]));
     assert_eq!(
-        json["result"].as_array().map(Vec::len),
-        Some(3),
-        "unenforced request sees every document; got: {json}"
-    );
-    assert_eq!(json["policy"], serde_json::json!({}));
-    assert!(
-        json.get("policy_enforcement").is_none(),
-        "no policy context was built, so no enforcement is claimed; got: {json}"
+        json["policy_enforcement"],
+        serde_json::json!({"enforced": true, "denies_all_data": true})
     );
     assert_eq!(
-        enforcement_header, None,
-        "and no enforcement header is emitted"
+        enforcement_header.as_deref(),
+        Some(r#"{"enforced":true,"denies_all_data":true}"#)
     );
 }
-
-// ── ledger-configured f:defaultAllow over real HTTP ───────────────────────────
 
 /// Creates a ledger with 3 documents, **no policies at all**, and a config graph
 /// declaring `f:defaultAllow <value>`.

--- a/fluree-db-server/tests/policy_transport_regression.rs
+++ b/fluree-db-server/tests/policy_transport_regression.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-async fn transport_state(mut config: ServerConfig) -> (TempDir, Arc<AppState>) {
+pub(super) async fn transport_state(mut config: ServerConfig) -> (TempDir, Arc<AppState>) {
     let tmp = tempfile::tempdir().unwrap();
     config.cors_enabled = false;
     config.indexing_enabled = false;
@@ -26,9 +26,13 @@ async fn storage_proxy_rejects_signed_delegation_without_downgrading_to_scopes()
         "iss": issuer, "exp": now_secs() + 300,
         "fluree.storage.ledgers": [ledger]
     });
-    for delegated in [false, true] {
-        if delegated {
+    for mode in ["ordinary", "delegated", "controller"] {
+        let delegated = mode != "ordinary";
+        claims.as_object_mut().unwrap().remove("fluree.policy");
+        if mode == "delegated" {
             claims["fluree.policy"] = serde_json::json!({"default-allow": false});
+        } else if mode == "controller" {
+            claims["fluree.policy"] = "request".into();
         }
         let token = create_jws(&claims, &key);
         let resp = app
@@ -54,7 +58,8 @@ async fn storage_proxy_rejects_signed_delegation_without_downgrading_to_scopes()
         );
         if delegated {
             assert!(
-                body.to_string().contains("delegation is not supported"),
+                body.to_string()
+                    .contains("not supported by storage proxy endpoints"),
                 "{body}"
             );
             // Block fetch uses the same extractor, before any block lookup.
@@ -135,8 +140,6 @@ async fn push_preserves_signed_policy_and_rejected_commit_can_be_retried_with_a_
                     .uri(format!("/v1/fluree/push/{ledger}"))
                     .header("content-type", "application/json")
                     .header("authorization", format!("Bearer {token}"))
-                    .header("fluree-policy", r#"[{"f:allow":true}]"#)
-                    .header("fluree-policy-class", "http://example.org/ManagerClass")
                     .body(Body::from(request.clone()))
                     .unwrap(),
             )
@@ -212,6 +215,34 @@ async fn oidc_delegation_requires_authority_and_constrains_reads_and_writes() {
             "fluree.storage.ledgers": [ledger],
             "fluree.policy": {"policy-class": ["http://example.org/EmployeeClass"]}
         });
+        let mut controller = claims.clone();
+        controller.as_object_mut().unwrap().remove("fluree.policy");
+        controller["fluree.policy"] = "request".into();
+        let controller = encode(&header, &controller, &key).unwrap();
+        let query = serde_json::json!({
+            "opts": {"policy-class": ["http://example.org/EmployeeClass"]},
+            "select": ["?name"], "where": {"@id": "?s", "http://schema.org/name": "?name"}
+        });
+        let (status, body) = post_policy_request(
+            &app,
+            &format!("/v1/fluree/query/{ledger}"),
+            Some(&controller),
+            "application/json",
+            query.to_string(),
+        )
+        .await;
+        assert_eq!(
+            status,
+            if is_authority {
+                StatusCode::OK
+            } else {
+                StatusCode::UNAUTHORIZED
+            },
+            "{body}"
+        );
+        if is_authority {
+            assert_eq!(body.as_array().unwrap().len(), 2, "{body}");
+        }
         let token = encode(&header, &claims, &key).unwrap();
         let (status, body) = query_docs(app.clone(), ledger, Some(&token), false).await;
         if !is_authority {
@@ -255,7 +286,8 @@ async fn oidc_delegation_requires_authority_and_constrains_reads_and_writes() {
         let (status, body) = json_body(resp).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED, "{body}");
         assert!(
-            body.to_string().contains("delegation is not supported"),
+            body.to_string()
+                .contains("not supported by storage proxy endpoints"),
             "{body}"
         );
 

--- a/fluree-db-server/tests/policy_transport_regression.rs
+++ b/fluree-db-server/tests/policy_transport_regression.rs
@@ -1,0 +1,299 @@
+use super::*;
+
+async fn transport_state(mut config: ServerConfig) -> (TempDir, Arc<AppState>) {
+    let tmp = tempfile::tempdir().unwrap();
+    config.cors_enabled = false;
+    config.indexing_enabled = false;
+    config.storage_path = Some(tmp.path().to_path_buf());
+    let telemetry = TelemetryConfig::with_server_config(&config);
+    let state = Arc::new(AppState::new(config, telemetry).await.unwrap());
+    (tmp, state)
+}
+
+#[tokio::test]
+async fn storage_proxy_rejects_signed_delegation_without_downgrading_to_scopes() {
+    let key = SigningKey::from_bytes(&[200; 32]);
+    let issuer = did_from_pubkey(&key.verifying_key().to_bytes());
+    let (_tmp, state) = transport_state(ServerConfig {
+        storage_proxy_enabled: true,
+        storage_proxy_trusted_issuers: vec![issuer.clone()],
+        ..Default::default()
+    })
+    .await;
+    let ledger = "storage-delegation:main";
+    let app = setup_policy_ledger(build_router(state), ledger).await;
+    let mut claims = serde_json::json!({
+        "iss": issuer, "exp": now_secs() + 300,
+        "fluree.storage.ledgers": [ledger]
+    });
+    for delegated in [false, true] {
+        if delegated {
+            claims["fluree.policy"] = serde_json::json!({"default-allow": false});
+        }
+        let token = create_jws(&claims, &key);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/v1/fluree/storage/ns/{ledger}"))
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, body) = json_body(resp).await;
+        assert_eq!(
+            status,
+            if delegated {
+                StatusCode::UNAUTHORIZED
+            } else {
+                StatusCode::OK
+            },
+            "{body}"
+        );
+        if delegated {
+            assert!(
+                body.to_string().contains("delegation is not supported"),
+                "{body}"
+            );
+            // Block fetch uses the same extractor, before any block lookup.
+            let (status, body) = post_policy_request(
+                &app,
+                "/v1/fluree/storage/block",
+                Some(&token),
+                "application/json",
+                "{}".into(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::UNAUTHORIZED, "{body}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn push_preserves_signed_policy_and_rejected_commit_can_be_retried_with_a_grant() {
+    use fluree_db_api::{Base64Bytes, PushCommitsRequest};
+    use fluree_db_core::{Flake, FlakeValue, Sid};
+    use fluree_db_novelty::Commit;
+    use fluree_vocab::namespaces::{FLUREE_DB, XSD};
+
+    let (_tmp, state) = policy_test_state().await;
+    let app = build_router(state.clone());
+    let ledger = "push-delegation:main";
+    let (status, body) = post_policy_request(
+        &app,
+        "/v1/fluree/create",
+        None,
+        "application/json",
+        serde_json::json!({"ledger": ledger}).to_string(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    let initial = state
+        .fluree
+        .ledger(ledger)
+        .await
+        .unwrap()
+        .head_commit_id
+        .clone();
+    let commit = Commit::new(
+        1,
+        vec![Flake::new(
+            Sid::new(FLUREE_DB, "alice"),
+            Sid::new(FLUREE_DB, "name"),
+            FlakeValue::String("Alice".into()),
+            Sid::new(XSD, "string"),
+            1,
+            true,
+            None,
+        )],
+    );
+    let bytes = fluree_db_core::commit::codec::write_commit(&commit, true, None)
+        .unwrap()
+        .bytes;
+    let request = serde_json::to_string(&PushCommitsRequest {
+        commits: vec![Base64Bytes(bytes)],
+        blobs: Default::default(),
+        missing_blobs: vec![],
+    })
+    .unwrap();
+    for allow in [false, true] {
+        let token = delegated_token(
+            "http://example.org/application-user",
+            ledger,
+            serde_json::json!({
+                "policy": [{"f:action": ["f:view", "f:modify"], "f:allow": allow}],
+                "default-allow": false
+            }),
+        );
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/v1/fluree/push/{ledger}"))
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("fluree-policy", r#"[{"f:allow":true}]"#)
+                    .header("fluree-policy-class", "http://example.org/ManagerClass")
+                    .body(Body::from(request.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, body) = json_body(resp).await;
+        if allow {
+            assert_eq!(status, StatusCode::OK, "{body}");
+            assert_eq!(body["accepted"], 1, "{body}");
+            assert_ne!(
+                state.fluree.ledger(ledger).await.unwrap().head_commit_id,
+                initial
+            );
+        } else {
+            assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+            assert!(body.to_string().to_lowercase().contains("policy"), "{body}");
+            assert_eq!(
+                state.fluree.ledger(ledger).await.unwrap().head_commit_id,
+                initial
+            );
+        }
+    }
+}
+
+#[cfg(feature = "oidc")]
+#[tokio::test]
+async fn oidc_delegation_requires_authority_and_constrains_reads_and_writes() {
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mock = MockServer::start().await;
+    let issuer = "https://policy-issuer.example";
+    let kid = "policy-rsa";
+    let jwks = serde_json::json!({"keys": [{
+        "kty": "RSA", "kid": kid, "use": "sig", "alg": "RS256",
+        "n": "qW0XZx4K2dAqsaNh4CdbaDyl79dtY2Cr7yKTD4lKunXuo1uE84VHRtLIdDw13GjG5fB1P7tjohAeQXYykJd2UaRZQzjiIExcYLnWQ6M1kC2DE4rsxOa2sPuHiKjdpd5XCgmKp-KmyroYn-Suyt3NjxtVeN1ko8bhJaVVR38kl_hmULEHcC8PvMZ5vVfuToxu95NMSU_QnxnHAQOSmoTqoNhqUCVLKxustsKBG-feS1ZvzJ3z0TklU8B_7oSKevuEq1hf8EbxnN2vAHL-uyko47twyc7LUFhufl4BETHmRZlJ4EsiPJ5Mye35d9sInq1VOZ3V2swXKF06kB8Lof2C2w",
+        "e": "AQAB"
+    }]});
+    Mock::given(method("GET"))
+        .and(path("/jwks"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(jwks))
+        .mount(&mock)
+        .await;
+    let key = EncodingKey::from_rsa_pem(include_bytes!(
+        "../../fluree-db-credential/tests/fixtures/test_rsa_private.pem"
+    ))
+    .unwrap();
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some(kid.into());
+    for is_authority in [false, true] {
+        let (_tmp, state) = transport_state(ServerConfig {
+            data_auth_mode: DataAuthMode::Optional,
+            data_auth_audience: Some("fluree-policy-test".into()),
+            data_auth_policy_authorities: if is_authority {
+                vec![issuer.into()]
+            } else {
+                vec![]
+            },
+            jwks_issuers: vec![format!("{issuer}={}/jwks", mock.uri())],
+            storage_proxy_enabled: true,
+            storage_proxy_trusted_issuers: vec![issuer.into()],
+            ..Default::default()
+        })
+        .await;
+        let ledger = "oidc-delegation:main";
+        let app = setup_policy_ledger(build_router(state), ledger).await;
+        add_modify_policies(&app, ledger).await;
+        let mut claims = serde_json::json!({
+            "iss": issuer, "aud": "fluree-policy-test", "exp": now_secs() + 300,
+            "sub": "http://example.org/application-user",
+            "fluree.ledger.read.ledgers": [ledger], "fluree.ledger.write.ledgers": [ledger],
+            "fluree.storage.ledgers": [ledger],
+            "fluree.policy": {"policy-class": ["http://example.org/EmployeeClass"]}
+        });
+        let token = encode(&header, &claims, &key).unwrap();
+        let (status, body) = query_docs(app.clone(), ledger, Some(&token), false).await;
+        if !is_authority {
+            assert_eq!(status, StatusCode::UNAUTHORIZED, "{body}");
+            assert!(body.to_string().contains("policy authority"), "{body}");
+            // Ordinary tokens from this same JWKS issuer still work.
+            claims.as_object_mut().unwrap().remove("fluree.policy");
+            claims["sub"] = serde_json::json!("http://example.org/employee-user");
+            let token = encode(&header, &claims, &key).unwrap();
+            let (status, body) = query_docs(app, ledger, Some(&token), false).await;
+            assert_eq!(status, StatusCode::OK, "{body}");
+            assert_eq!(names_from_results(&body).len(), 2, "{body}");
+            continue;
+        }
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(names_from_results(&body).len(), 2, "{body}");
+        let (status, body) = post_policy_request(
+            &app,
+            &format!("/v1/fluree/update/{ledger}"),
+            Some(&token),
+            "application/json",
+            modify_public_doc_content_body().to_string(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+        assert!(
+            body.to_string().contains("Employees may not modify"),
+            "{body}"
+        );
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/v1/fluree/storage/ns/{ledger}"))
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (status, body) = json_body(resp).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "{body}");
+        assert!(
+            body.to_string().contains("delegation is not supported"),
+            "{body}"
+        );
+
+        let mut wrong_aud = claims.clone();
+        wrong_aud["aud"] = serde_json::json!("another-server");
+        let (status, body) = query_docs(
+            app.clone(),
+            ledger,
+            Some(&encode(&header, &wrong_aud, &key).unwrap()),
+            false,
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "{body}");
+        claims["fluree.policy"]["policy-class"] =
+            serde_json::json!(["http://example.org/ManagerClass"]);
+        let token = encode(&header, &claims, &key).unwrap();
+        let (status, body) = post_policy_request(
+            &app,
+            &format!("/v1/fluree/update/{ledger}"),
+            Some(&token),
+            "application/json",
+            modify_public_doc_content_body().to_string(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        // Even a policy authority's grant cannot widen the signed ledger scopes.
+        claims["fluree.ledger.read.ledgers"] = serde_json::json!(["different:main"]);
+        claims
+            .as_object_mut()
+            .unwrap()
+            .remove("fluree.storage.ledgers");
+        let (status, body) = query_docs(
+            app,
+            ledger,
+            Some(&encode(&header, &claims, &key).unwrap()),
+            false,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    }
+}

--- a/fluree-db-server/tests/raft_multi_node.rs
+++ b/fluree-db-server/tests/raft_multi_node.rs
@@ -675,6 +675,31 @@ async fn delegated_policy_survives_follower_forwarding_and_the_raft_command_queu
                 "@id": "ex:bob", "@type": "ex:Person", "ex:name": "Bob",
                 "opts": {"identity": "http://example.org/manager", "policy": [{"f:allow": true}], "default-allow": true}
             })).send().await.unwrap();
+        // Conflicting caller selections fail at binding, before entering Raft.
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let body: serde_json::Value = response.json().await.unwrap();
+        assert!(
+            body.to_string()
+                .contains("Credential does not permit policy selection"),
+            "{body}"
+        );
+        // A request without conflicts must still carry the token's full policy
+        // through follower forwarding and the replicated transaction queue.
+        let response = cluster
+            .client
+            .post(format!(
+                "{}/v1/fluree/insert/{ledger}",
+                cluster.public_url(follower)
+            ))
+            .bearer_auth(&token)
+            .header("idempotency-key", idempotency_key)
+            .json(&json!({
+                "@context": {"ex": "http://example.org/"},
+                "@id": "ex:bob", "@type": "ex:Person", "ex:name": "Bob"
+            }))
+            .send()
+            .await
+            .unwrap();
         let status = response.status();
         let body: serde_json::Value = response.json().await.unwrap();
         if allow {

--- a/fluree-db-server/tests/raft_multi_node.rs
+++ b/fluree-db-server/tests/raft_multi_node.rs
@@ -22,7 +22,7 @@ use fluree_db_consensus::raft::admin::{
 use fluree_db_consensus::raft::liveness_monitor::LivenessConfig;
 use fluree_db_consensus::NodeId;
 use fluree_db_server::raft::{RaftBootstrapConfig, RaftIntegration};
-use fluree_db_server::{AppState, FlureeServerBuilder};
+use fluree_db_server::{AppState, FlureeServerBuilder, ServerConfig};
 use reqwest::StatusCode;
 use serde_json::json;
 use tempfile::TempDir;
@@ -120,6 +120,14 @@ impl TestCluster {
     /// monitor-driven demotion path pass sub-second thresholds so
     /// the demote / promote windows close inside the test budget.
     async fn spawn_with_liveness(count: u64, liveness_config: LivenessConfig) -> Self {
+        Self::spawn_with_config(count, liveness_config, ServerConfig::default()).await
+    }
+
+    async fn spawn_with_config(
+        count: u64,
+        liveness_config: LivenessConfig,
+        config: ServerConfig,
+    ) -> Self {
         assert!(count >= 1, "cluster must have at least one node");
 
         // Single shared data directory across all nodes — the
@@ -155,6 +163,7 @@ impl TestCluster {
                     raft_listener,
                     shared_data_tmp.path(),
                     liveness_config.clone(),
+                    config.clone(),
                 )
                 .await,
             );
@@ -535,6 +544,7 @@ async fn spawn_node(
     raft_listener: TcpListener,
     shared_data_path: &std::path::Path,
     liveness_config: LivenessConfig,
+    mut config: ServerConfig,
 ) -> TestNode {
     let public_addr = public_listener.local_addr().expect("public local_addr");
     let raft_addr = raft_listener.local_addr().expect("raft local_addr");
@@ -556,7 +566,8 @@ async fn spawn_node(
     // the index roots in shared storage current — the alternative
     // (indexing off) leaves the follower's query path hunting for
     // index roots that nobody has built.
-    let server = FlureeServerBuilder::file(shared_data_path)
+    config.storage_path = Some(shared_data_path.to_path_buf());
+    let server = FlureeServerBuilder::for_config(config)
         .listen_addr(public_addr)
         .cors_enabled(false)
         .with_raft(Arc::clone(&integration), raft_addr)
@@ -599,6 +610,149 @@ async fn spawn_node(
 // ============================================================================
 // Tests
 // ============================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn delegated_policy_survives_follower_forwarding_and_the_raft_command_queue() {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use ed25519_dalek::{Signer, SigningKey};
+
+    let key = SigningKey::from_bytes(&[210; 32]);
+    let issuer = fluree_db_credential::did_from_pubkey(&key.verifying_key().to_bytes());
+    let audience = "raft-policy-test";
+    let cluster = TestCluster::spawn_with_config(
+        3,
+        LivenessConfig::default(),
+        ServerConfig {
+            data_auth_mode: fluree_db_server::config::DataAuthMode::Optional,
+            data_auth_trusted_issuers: vec![issuer.clone()],
+            data_auth_policy_authorities: vec![issuer.clone()],
+            data_auth_audience: Some(audience.into()),
+            ..Default::default()
+        },
+    )
+    .await;
+    cluster.bootstrap().await;
+    let follower = cluster.pick_follower().await;
+    let leader = cluster.current_leader().await.unwrap();
+    let ledger = "raft:delegation";
+    cluster.create_ledger(follower, ledger).await;
+    cluster
+        .insert_subject(follower, ledger, "alice", "Alice")
+        .await;
+    let header = URL_SAFE_NO_PAD.encode(json!({
+        "alg": "EdDSA", "jwk": {"kty": "OKP", "crv": "Ed25519", "x": URL_SAFE_NO_PAD.encode(key.verifying_key().to_bytes())}
+    }).to_string());
+    let exp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 300;
+    for allow in [false, true] {
+        let payload = URL_SAFE_NO_PAD.encode(json!({
+            "iss": issuer, "aud": audience, "exp": exp,
+            "sub": "http://example.org/application-user",
+            "fluree.ledger.read.ledgers": [ledger], "fluree.ledger.write.ledgers": [ledger],
+            "fluree.policy": {"policy": [
+                {"f:action": "f:view", "f:allow": true},
+                {"f:action": "f:modify", "f:allow": allow, "f:exMessage": "Delegated Raft write denied."}
+            ], "default-allow": false}
+        }).to_string());
+        let signing_input = format!("{header}.{payload}");
+        let token = format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(key.sign(signing_input.as_bytes()).to_bytes())
+        );
+        let idempotency_key = if allow {
+            "delegated-raft-allow"
+        } else {
+            "delegated-raft-deny"
+        };
+        let response = cluster.client.post(format!("{}/v1/fluree/insert/{ledger}", cluster.public_url(follower)))
+            .bearer_auth(&token).header("idempotency-key", idempotency_key)
+            .header("fluree-policy", r#"[{"f:allow":true}]"#)
+            .json(&json!({
+                "@context": {"ex": "http://example.org/"},
+                "@id": "ex:bob", "@type": "ex:Person", "ex:name": "Bob",
+                "opts": {"identity": "http://example.org/manager", "policy": [{"f:allow": true}], "default-allow": true}
+            })).send().await.unwrap();
+        let status = response.status();
+        let body: serde_json::Value = response.json().await.unwrap();
+        if allow {
+            assert_eq!(status, StatusCode::OK, "{body}");
+        } else {
+            assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{body}");
+            assert!(
+                body.to_string().contains("Delegated Raft write denied"),
+                "{body}"
+            );
+        }
+        // This route submits a serialized TransactionRequest to the replicated
+        // command queue. Observe its terminal result through a different node.
+        let response = cluster
+            .client
+            .get(format!(
+                "{}/v1/fluree/submissions/{idempotency_key}/{ledger}",
+                cluster.public_url(leader)
+            ))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(
+            body["state"],
+            if allow { "committed" } else { "failed" },
+            "{body}"
+        );
+        for node in &cluster.nodes {
+            cluster
+                .wait_for_names(
+                    node.node_id,
+                    ledger,
+                    if allow { &["Alice", "Bob"] } else { &["Alice"] },
+                    DEFAULT_TIMEOUT,
+                )
+                .await;
+        }
+    }
+
+    #[cfg(feature = "graphql")]
+    for node in [leader, follower] {
+        // The runtime Raft check must protect both ingress nodes, including
+        // anonymous callers on an intentionally optional-auth server.
+        let url = format!("{}/v1/fluree/graphql/{ledger}", cluster.public_url(node));
+        let response = cluster
+            .client
+            .post(&url)
+            .json(&json!({"query": "mutation { createPerson(input: {name: \"Eve\"}) { id } }"}))
+            .send()
+            .await
+            .unwrap();
+        let status = response.status();
+        let body: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "{body}");
+        assert!(
+            body.to_string()
+                .contains("GraphQL mutations are not supported in Raft mode"),
+            "{body}"
+        );
+        let response = cluster
+            .client
+            .post(&url)
+            .json(&json!({"query": "{ __typename }"}))
+            .send()
+            .await
+            .unwrap();
+        let status = response.status();
+        let body: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert!(body.get("errors").is_none(), "{body}");
+        cluster
+            .wait_for_names(node, ledger, &["Alice", "Bob"], DEFAULT_TIMEOUT)
+            .await;
+    }
+}
 
 /// Diagnostic: single-node cluster, post directly to the leader.
 /// Confirms the test harness produces a working HTTP path before the

--- a/fluree-db-server/tests/stream_query_integration.rs
+++ b/fluree-db-server/tests/stream_query_integration.rs
@@ -230,10 +230,9 @@ async fn connection_missing_ledger_spec_rejected() {
     );
 }
 
-/// Connection-scoped SPARQL refuses policy signals (no multi-ledger identity
-/// resolution); use the ledger-scoped route or /query.
+/// Connection SPARQL enforces supplied policies; a missing class grants no rows.
 #[tokio::test]
-async fn connection_sparql_policy_refused() {
+async fn connection_sparql_policy_enforced() {
     let (_tmp, state) = test_state().await;
     let app = build_router(state);
     create_ledger(&app, "strm:cpr").await;
@@ -245,7 +244,9 @@ async fn connection_sparql_policy_refused() {
         Some(("fluree-policy-class", "http://example.org/PublicClass")),
     )
     .await;
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    assert!(!std::str::from_utf8(&bytes).unwrap().contains("Xavier"));
 }
 
 async fn state_no_heartbeat() -> (TempDir, Arc<AppState>) {

--- a/fluree-db-server/tests/telemetry_test.rs
+++ b/fluree-db-server/tests/telemetry_test.rs
@@ -15,6 +15,112 @@ use tracing_subscriber::layer::{Context, Layer};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry::LookupSpan;
 
+#[test]
+fn authorization_events_record_scope_decisions_without_policy_payloads() {
+    use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
+    use fluree_db_server::extract::DataPrincipal;
+
+    type Events = Arc<Mutex<Vec<HashMap<String, String>>>>;
+    struct EventCapture(Events);
+    impl<S: Subscriber> Layer<S> for EventCapture {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            if event.metadata().target() == "fluree_db_server::authorization" {
+                assert_eq!(*event.metadata().level(), tracing::Level::DEBUG);
+                let mut visitor = Vis(HashMap::new());
+                event.record(&mut visitor);
+                self.0.lock().unwrap().push(visitor.0);
+            }
+        }
+    }
+    let events = Events::default();
+    let subscriber = tracing_subscriber::registry().with(EventCapture(events.clone()));
+    tracing::subscriber::with_default(subscriber, || {
+        for mode in ["delegated", "server-default", "identity", "scope-only"] {
+            let identity = (mode != "scope-only").then(|| "https://app.example/user".to_string());
+            let authorization = PolicyAuthorization::from_trusted_options(GovernanceOptions {
+                identity: identity.clone(),
+                policy_class: (mode == "server-default")
+                    .then(|| vec!["https://app.example/Employee".into()]),
+                policy: (mode == "delegated")
+                    .then(|| serde_json::json!({"secret-policy": "never-log-this-policy"})),
+                policy_values: (mode == "delegated").then(|| {
+                    [(
+                        "?secret".into(),
+                        serde_json::json!("never-log-these-values"),
+                    )]
+                    .into()
+                }),
+                default_allow: Some(false),
+            });
+            let principal = DataPrincipal {
+                issuer: "https://issuer.example".into(),
+                subject: Some("user".into()),
+                identity,
+                read_all: false,
+                read_ledgers: ["allowed:main".into()].into(),
+                write_all: false,
+                write_ledgers: ["allowed:main".into()].into(),
+                expires_unix: u64::MAX,
+                policy_authorization: authorization,
+                delegated_policy: mode == "delegated",
+            };
+            assert!(principal.can_read("allowed:main"));
+            assert!(!principal.can_read("denied:main"));
+            assert!(principal.can_write("allowed:main"));
+            assert!(!principal.can_write("denied:main"));
+        }
+    });
+    let events = events.lock().unwrap();
+    assert_eq!(events.len(), 16);
+    for (mode, chunk) in ["delegated", "server-default", "identity", "scope-only"]
+        .into_iter()
+        .zip(events.chunks(4))
+    {
+        for (event, (action, allowed)) in chunk.iter().zip([
+            ("read", true),
+            ("read", false),
+            ("write", true),
+            ("write", false),
+        ]) {
+            assert_eq!(event["issuer"], "https://issuer.example");
+            assert_eq!(event["authorization_mode"], mode);
+            assert_eq!(event["action"], action);
+            assert_eq!(event["scope_allowed"], allowed.to_string());
+            assert_eq!(
+                event["ledger"],
+                if allowed {
+                    "allowed:main"
+                } else {
+                    "denied:main"
+                }
+            );
+            assert_eq!(
+                event["effective_identity"],
+                if mode == "scope-only" {
+                    "None"
+                } else {
+                    "Some(\"https://app.example/user\")"
+                }
+            );
+            let keys: std::collections::BTreeSet<_> = event.keys().map(String::as_str).collect();
+            assert_eq!(
+                keys,
+                [
+                    "issuer",
+                    "effective_identity",
+                    "authorization_mode",
+                    "ledger",
+                    "action",
+                    "scope_allowed",
+                    "message"
+                ]
+                .into()
+            );
+        }
+    }
+    assert!(!format!("{events:?}").contains("never-log-"));
+}
+
 // ---------------------------------------------------------------------------
 // Minimal span capture (self-contained — server tests don't share fluree-db-api test support)
 // ---------------------------------------------------------------------------

--- a/fluree-db-server/tests/telemetry_test.rs
+++ b/fluree-db-server/tests/telemetry_test.rs
@@ -18,7 +18,7 @@ use tracing_subscriber::registry::LookupSpan;
 #[test]
 fn authorization_events_record_scope_decisions_without_policy_payloads() {
     use fluree_db_api::{GovernanceOptions, PolicyAuthorization};
-    use fluree_db_server::extract::DataPrincipal;
+    use fluree_db_server::extract::{CredentialPolicy, DataPrincipal};
 
     type Events = Arc<Mutex<Vec<HashMap<String, String>>>>;
     struct EventCapture(Events);
@@ -35,7 +35,13 @@ fn authorization_events_record_scope_decisions_without_policy_payloads() {
     let events = Events::default();
     let subscriber = tracing_subscriber::registry().with(EventCapture(events.clone()));
     tracing::subscriber::with_default(subscriber, || {
-        for mode in ["delegated", "server-default", "identity", "scope-only"] {
+        for mode in [
+            "controller",
+            "delegated",
+            "server-default",
+            "identity",
+            "scope-only",
+        ] {
             let identity = (mode != "scope-only").then(|| "https://app.example/user".to_string());
             let authorization = PolicyAuthorization::from_trusted_options(GovernanceOptions {
                 identity: identity.clone(),
@@ -52,6 +58,11 @@ fn authorization_events_record_scope_decisions_without_policy_payloads() {
                 }),
                 default_allow: Some(false),
             });
+            let authorization = match mode {
+                "controller" => CredentialPolicy::Request,
+                "scope-only" => CredentialPolicy::ScopeOnly,
+                _ => CredentialPolicy::Fixed(authorization),
+            };
             let principal = DataPrincipal {
                 issuer: "https://issuer.example".into(),
                 subject: Some("user".into()),
@@ -62,7 +73,6 @@ fn authorization_events_record_scope_decisions_without_policy_payloads() {
                 write_ledgers: ["allowed:main".into()].into(),
                 expires_unix: u64::MAX,
                 policy_authorization: authorization,
-                delegated_policy: mode == "delegated",
             };
             assert!(principal.can_read("allowed:main"));
             assert!(!principal.can_read("denied:main"));
@@ -71,10 +81,16 @@ fn authorization_events_record_scope_decisions_without_policy_payloads() {
         }
     });
     let events = events.lock().unwrap();
-    assert_eq!(events.len(), 16);
-    for (mode, chunk) in ["delegated", "server-default", "identity", "scope-only"]
-        .into_iter()
-        .zip(events.chunks(4))
+    assert_eq!(events.len(), 20);
+    for (mode, chunk) in [
+        "controller",
+        "delegated",
+        "server-default",
+        "identity",
+        "scope-only",
+    ]
+    .into_iter()
+    .zip(events.chunks(4))
     {
         for (event, (action, allowed)) in chunk.iter().zip([
             ("read", true),
@@ -83,7 +99,14 @@ fn authorization_events_record_scope_decisions_without_policy_payloads() {
             ("write", false),
         ]) {
             assert_eq!(event["issuer"], "https://issuer.example");
-            assert_eq!(event["authorization_mode"], mode);
+            assert_eq!(
+                event["authorization_mode"],
+                match mode {
+                    "controller" => "request-selected",
+                    "scope-only" => "scope-only",
+                    _ => "fixed",
+                }
+            );
             assert_eq!(event["action"], action);
             assert_eq!(event["scope_allowed"], allowed.to_string());
             assert_eq!(
@@ -96,7 +119,7 @@ fn authorization_events_record_scope_decisions_without_policy_payloads() {
             );
             assert_eq!(
                 event["effective_identity"],
-                if mode == "scope-only" {
+                if mode == "scope-only" || mode == "controller" {
                     "None"
                 } else {
                     "Some(\"https://app.example/user\")"

--- a/regression-budget.json
+++ b/regression-budget.json
@@ -107,6 +107,12 @@
         "small": 5.0
       }
     },
+    "fluree-db-server": {
+      "policy_http": {
+        "tiny": 10.0,
+        "small": 5.0
+      }
+    },
     "fluree-db-query": {
       "vector_math": {
         "small": 3.0

--- a/regression-budget.json
+++ b/regression-budget.json
@@ -4,6 +4,10 @@
   "_comment": "Per-bench, per-scale percentage regression CI accepts. 5.0 means observed time may exceed the committed baseline by up to 5%. Omitted scales fall back to default_budget_pct. Numbers below are placeholders until the first nightly run lands a baseline; tighten them in a follow-up PR once baselines exist. See BENCHMARKING.md and docs/contributing/benches.md.",
   "crates": {
     "fluree-db-api": {
+      "policy_authorization": {
+        "tiny": 10.0,
+        "small": 5.0
+      },
       "insert_formats": {
         "tiny": 10.0,
         "small": 5.0


### PR DESCRIPTION
Introduces an explicit authorization contract for applications and gateways. Embedded applications can supply a typed policy context, while network clients can use signed policy selections from configured delegation authorities.

Applies the selected context consistently across query formats, datasets, transactions, and supported transports. Adds structured authorization logging, expanded integration coverage, and a request-normalization benchmark.

Applications supplying policy selections should adopt the documented authorization contract. See the updated [authorization and migration documentation](https://github.com/fluree/db/blob/fix/trusted-policy-authorization/docs/security/policy-authorization.md) for issuer/audience settings and transport support.

Compatibility notes:

- Application-selected policies use the typed SDK context or signed delegation.
- Storage-proxy access uses separate replication credentials.
- Raft deployments submit writes through transaction endpoints; GraphQL reads remain supported.
- Gateway-side migration and deployment checks remain separate from this database change.

Validation:

- API policy and GraphQL integration suites, plus API/server/credential unit suites, passed.
- Server HTTP, query, policy, storage-proxy, Bolt, configuration, logging, and live Raft-cluster checks passed, including transport checks with and without OIDC.
- Request-normalization latency/allocation benchmark completed using the optimized dev-fast profile. It measures claim parsing and request binding, excluding cryptography, networking, and database policy evaluation.
- Changed-source formatting and whitespace checks passed.
