### PR TITLE
Skip config reasoning defaults on history/changes datasets

### DIFF
--- a/fluree-db-api/src/view/dataset_query.rs
+++ b/fluree-db-api/src/view/dataset_query.rs
@@ -622,20 +622,33 @@ impl Fluree {
     ) -> Result<ExecutableQuery> {
         let mut executable = prepare_for_execution(parsed);
 
-        if let Some(primary) = dataset.primary() {
-            // Server-verified identity for `f:overrideControl`. `None` until
-            // the request boundary threads it through; see
-            // `complete_config_defaults`.
-            self.apply_reasoning_to_executable(
-                primary,
-                &mut executable,
-                dataset.any_non_root_policy(),
-                None,
-            )
-            .await?;
-        } else if dataset.any_non_root_policy() && !executable.reasoning.modes.rules.is_empty() {
-            tracing::debug!("stripping query-time datalog rules under non-root view policy");
-            executable.reasoning.modes.rules.clear();
+        // A history/changes dataset takes no config reasoning defaults: a
+        // from–to range has no single state to derive entailments against,
+        // and `reject_reasoning_in_history_mode` refuses any enabled mode.
+        // Applying `f:reasoningDefaults` here would trip that gate on every
+        // history query against a configured ledger (fluree/db#1806), so only
+        // a mode the query itself supplies reaches it.
+        match dataset.primary() {
+            Some(primary) if !dataset.is_history_mode() => {
+                // Server-verified identity for `f:overrideControl`. `None` until
+                // the request boundary threads it through; see
+                // `complete_config_defaults`.
+                self.apply_reasoning_to_executable(
+                    primary,
+                    &mut executable,
+                    dataset.any_non_root_policy(),
+                    None,
+                )
+                .await?;
+            }
+            _ => {
+                if dataset.any_non_root_policy() && !executable.reasoning.modes.rules.is_empty() {
+                    tracing::debug!(
+                        "stripping query-time datalog rules under non-root view policy"
+                    );
+                    executable.reasoning.modes.rules.clear();
+                }
+            }
         }
 
         Ok(executable)
@@ -1029,9 +1042,10 @@ fn query_error_to_api_error(err: fluree_db_query::QueryError) -> ApiError {
 /// at a single state and never persists them, so the two do not compose — the
 /// derived overlay would be computed against the latest state and silently
 /// dropped rather than applied at any point in the range. Config reasoning
-/// defaults are already not applied in history mode (see the dataset builder),
-/// so this only fires when a query explicitly asks for a mode. Fail loudly
-/// instead of returning results that silently omit entailments.
+/// defaults are not applied to history datasets (see
+/// `build_executable_for_dataset`), so this only fires when a query explicitly
+/// asks for a mode. Fail loudly instead of returning results that silently
+/// omit entailments.
 ///
 /// Mirrors the reasoning gate in `prepare_execution_with_config`
 /// (`executable.reasoning.modes.has_any_enabled()`); `"reasoning": "none"`

--- a/fluree-db-api/tests/grp_query_history.rs
+++ b/fluree-db-api/tests/grp_query_history.rs
@@ -7,6 +7,8 @@ mod it_event_time;
 mod it_query_history_combinations;
 #[path = "it_query_history_range.rs"]
 mod it_query_history_range;
+#[path = "it_query_history_reasoning.rs"]
+mod it_query_history_reasoning;
 #[path = "it_query_history_sparql.rs"]
 mod it_query_history_sparql;
 #[path = "it_query_time_travel.rs"]

--- a/fluree-db-api/tests/it_query_history_reasoning.rs
+++ b/fluree-db-api/tests/it_query_history_reasoning.rs
@@ -1,0 +1,113 @@
+//! Config `f:reasoningDefaults` must not reach a history/changes query.
+//!
+//! Regression for fluree/db#1806: once config defaults moved to the
+//! query-preparation choke point, a history dataset picked up the ledger's
+//! configured reasoning modes and `reject_reasoning_in_history_mode` refused
+//! every from–to query on a configured ledger, even with no `reasoning` key.
+
+use crate::support::MemoryFluree;
+use fluree_db_api::{FlureeBuilder, FormatterConfig};
+use serde_json::{json, Value};
+
+const LEDGER_ID: &str = "it/history-reasoning:main";
+
+/// Ledger with one data triple at t=1 and `f:reasoningModes f:rdfs` in `#config`.
+async fn ledger_with_reasoning_defaults() -> MemoryFluree {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger(LEDGER_ID).await.expect("create");
+
+    let r1 = fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/"},
+                "@id": "ex:alice",
+                "ex:name": "Alice",
+            }),
+        )
+        .await
+        .expect("tx1");
+
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        GRAPH <urn:fluree:{LEDGER_ID}#config> {{
+            <urn:config:main> rdf:type f:LedgerConfig .
+            <urn:config:main> f:reasoningDefaults <urn:cfg:reason> .
+            <urn:cfg:reason> f:reasoningModes f:rdfs .
+        }}
+    "
+    );
+    fluree
+        .stage_owned(r1.ledger)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("config write");
+
+    fluree
+}
+
+fn history_query() -> Value {
+    json!({
+        "@context": {"ex": "http://example.org/"},
+        "from": format!("{LEDGER_ID}@t:1"),
+        "to": format!("{LEDGER_ID}@t:latest"),
+        "select": ["?p", "?v", "?t", "?op"],
+        "where": [{
+            "@id": "ex:alice",
+            "?p": {"@value": "?v", "@t": "?t", "@op": "?op"}
+        }],
+        "orderBy": "?t",
+    })
+}
+
+async fn run(fluree: &MemoryFluree, q: &Value) -> Result<Value, String> {
+    fluree
+        .query_from()
+        .jsonld(q)
+        .format(FormatterConfig::typed_json().with_normalize_arrays())
+        .execute_tracked()
+        .await
+        .map(|r| serde_json::to_value(&r.result).expect("serialize"))
+        .map_err(|e| e.error)
+}
+
+/// No `reasoning` key: the configured default must not be applied, and the
+/// history query returns the t=1 assert.
+#[tokio::test]
+async fn history_query_ignores_config_reasoning_defaults() {
+    let fluree = ledger_with_reasoning_defaults().await;
+
+    let rows = run(&fluree, &history_query())
+        .await
+        .expect("history query on a ledger with f:reasoningDefaults must succeed");
+    let rows = rows.as_array().expect("rows array");
+    assert_eq!(
+        rows.len(),
+        1,
+        "expected the single t=1 assert, got {rows:?}"
+    );
+    let row = &rows[0];
+    assert_eq!(row["?p"]["@id"], json!("ex:name"));
+    assert_eq!(row["?v"]["@value"], json!("Alice"));
+    assert_eq!(row["?t"]["@value"], json!(1));
+    assert_eq!(row["?op"]["@value"], json!(true));
+}
+
+/// The gate still refuses a mode the query itself asks for.
+#[tokio::test]
+async fn history_query_still_rejects_explicit_reasoning_mode() {
+    let fluree = ledger_with_reasoning_defaults().await;
+
+    let mut q = history_query();
+    q["reasoning"] = json!("rdfs");
+    let err = run(&fluree, &q)
+        .await
+        .expect_err("explicit reasoning mode on a history query must be refused");
+    assert!(
+        err.contains("reasoning is not supported for history/changes queries"),
+        "unexpected error: {err}"
+    );
+}

--- a/fluree-db-api/tests/it_query_history_sparql.rs
+++ b/fluree-db-api/tests/it_query_history_sparql.rs
@@ -161,6 +161,54 @@ ORDER BY ?t ?op"
     assert_eq!(got, want, "rows: {rows:#?}");
 }
 
+/// Config reasoning defaults must not reject a SPARQL FROM/TO history query.
+/// Regression for fluree/db#1806 through the SPARQL query surface.
+#[tokio::test]
+async fn sparql_history_ignores_config_reasoning_defaults() {
+    let (_tmp, fluree, ledger_id) = alice_ledger("reasoning-defaults").await;
+    let ledger = fluree.ledger(&ledger_id).await.expect("load ledger");
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        GRAPH <urn:fluree:{ledger_id}#config> {{
+            <urn:config:main> rdf:type f:LedgerConfig .
+            <urn:config:main> f:reasoningDefaults <urn:cfg:reason> .
+            <urn:cfg:reason> f:reasoningModes f:rdfs .
+        }}
+    "
+    );
+    fluree
+        .stage_owned(ledger)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("config write");
+
+    let sparql = format!(
+        r"PREFIX ex: <http://example.org/>
+PREFIX f: <https://ns.flur.ee/db#>
+SELECT ?name ?t ?op
+FROM <{ledger_id}@t:1>
+TO <{ledger_id}@t:latest>
+WHERE {{ << ex:alice ex:name ?name >> f:t ?t ; f:op ?op . }}
+ORDER BY ?t ?op"
+    );
+
+    let rows = run_sparql(&fluree, &sparql).await;
+    let got: Vec<(String, i64, bool)> = rows
+        .as_array()
+        .expect("rows")
+        .iter()
+        .map(row_name_t_op)
+        .collect();
+    let want: Vec<(String, i64, bool)> = EXPECTED
+        .iter()
+        .map(|(n, t, o)| (n.to_string(), *t, *o))
+        .collect();
+    assert_eq!(got, want, "rows: {rows:#?}");
+}
+
 /// The `;`-continued form binds one inner triple, not two. Same results.
 #[tokio::test]
 async fn rdf_star_history_semicolon_form() {


### PR DESCRIPTION
Closes #1806

## Problem

A from–to history query against a ledger whose `#config` graph carries `f:reasoningDefaults` was refused with "reasoning is not supported for history/changes queries", even when the query asked for no reasoning. Every Solo-governed data graph writes `f:reasoningModes ["rdfs"]` into `#config`, so `fluree history --remote` failed on all of them.

## Cause

The history gate (`reject_reasoning_in_history_mode`, added in 22d383ba5) assumed config reasoning defaults were never applied to a history dataset, which was true when the dataset builder applied them only in the non-history branch. 60efa2d02 (#1577) moved config completion to the shared query-preparation choke point, which runs for every dataset including history ones. The configured modes were copied into the executable and the gate then rejected them. Shipped in v4.2.0.

## Fix

`build_executable_for_dataset` skips config reasoning defaults when the dataset is in history mode, so only a query-supplied mode reaches the gate. The non-root-policy rule strip still runs. The gate's doc comment now points at the right place.

## Tests

New `it_query_history_reasoning.rs` in the history test group:
- history query with no `reasoning` key on a ledger with rdfs defaults succeeds and returns the t=1 assert
- explicit `"reasoning": "rdfs"` on the same ledger is still refused

The first test fails with the fix reverted and passes with it restored.
