### PR TITLE
indexer: roll up planner-facing property stats after the incremental ndv floor

### DIFF
--- a/fluree-db-api/tests/it_bounded_overlay_translation.rs
+++ b/fluree-db-api/tests/it_bounded_overlay_translation.rs
@@ -916,7 +916,7 @@ async fn warm_whole_product_short_circuits_and_respects_epoch() {
 async fn incoming_reference_seek_keeps_base_overlay_lifecycle() {
     let (fluree, _dir) = new_fluree().await;
     let ledger = fluree.create_ledger(LEDGER).await.expect("create");
-    let ledger = fluree
+    fluree
         .insert(
             ledger,
             &json!({
@@ -929,13 +929,17 @@ async fn incoming_reference_seek_keeps_base_overlay_lifecycle() {
             }),
         )
         .await
-        .expect("seed")
-        .ledger;
+        .expect("seed");
     fluree
         .reindex(LEDGER, ReindexOptions::default())
         .await
         .expect("index");
     let before = indexed_view(&fluree).await;
+    // Commit the overlay on the INDEXED state and query the state that comes
+    // back, so the view is "indexed base + trailing novelty" by construction —
+    // polling `db()` here races the background indexer, which may already have
+    // published the overlay commit.
+    let indexed = fluree.ledger(LEDGER).await.expect("indexed ledger state");
     let mut inserts = (0..80)
         .map(|i| {
             json!({
@@ -944,9 +948,9 @@ async fn incoming_reference_seek_keeps_base_overlay_lifecycle() {
         })
         .collect::<Vec<_>>();
     inserts.push(json!({"@id":"ex:added", "ex:q":{"@id":"ex:target"}}));
-    fluree
+    let updated = fluree
         .update(
-            ledger,
+            indexed,
             &json!({
                 "@context":ctx(),
                 "delete":{"@id":"ex:drop", "ex:p":{"@id":"ex:target"}},
@@ -954,11 +958,14 @@ async fn incoming_reference_seek_keeps_base_overlay_lifecycle() {
             }),
         )
         .await
-        .expect("overlay");
-    let view = indexed_view(&fluree).await;
+        .expect("overlay")
+        .ledger;
+    let view = crate::support::graphdb_from_ledger(&updated);
     assert!(
-        view.t > view.snapshot.t,
-        "fixture must retain trailing novelty"
+        view.snapshot.t > 0 && view.t > view.snapshot.t,
+        "fixture must be an indexed base with trailing novelty (t={}, snapshot.t={})",
+        view.t,
+        view.snapshot.t
     );
     let query = "SELECT ?s ?p WHERE { ?s ?p <http://example.org/target> } ORDER BY ?s ?p";
     let (spans, guard) = span_capture::init_test_tracing();

--- a/fluree-db-api/tests/it_indexing_stats.rs
+++ b/fluree-db-api/tests/it_indexing_stats.rs
@@ -2561,6 +2561,133 @@ async fn ndv_cardinality_estimates_are_accurate() {
         .await;
 }
 
+/// The flat property roll-up the planner reads (`IndexStats::properties`)
+/// must keep its ndv across an incremental build over a base root without
+/// HLL sketches — a bulk import (only a full rebuild uploads sketches). The
+/// incremental seeds such properties with empty registers and clamps their
+/// ndv to the base estimate; the roll-up used to be taken before that clamp,
+/// so every untouched property published ndv 0 and the planner fell back to
+/// its 10-row bound-subject estimate — one write to a bulk-imported BSBM
+/// ledger made Explore Q5 4x slower.
+#[tokio::test]
+async fn flat_property_ndv_survives_incremental_over_sketchless_base() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let data_dir = tempfile::TempDir::new().expect("data tempdir");
+    let mut nt = String::new();
+    for i in 0..20 {
+        nt.push_str(&format!(
+            "<http://example.org/person{i}> <http://example.org/name> \"Person {i}\" .\n\
+             <http://example.org/person{i}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> \
+             <http://example.org/Person> .\n"
+        ));
+    }
+    std::fs::write(data_dir.path().join("00-people.nt"), nt).expect("write nt");
+
+    let mut fluree = FlureeBuilder::file(tmp.path().to_string_lossy().to_string())
+        .build()
+        .expect("build file fluree");
+    let (local, handle) = start_background_indexer_local(
+        fluree.backend().clone(),
+        fluree
+            .nameservice_mode()
+            .publisher_arc()
+            .expect("test setup requires ReadWrite nameservice mode"),
+        fluree_db_indexer::IndexerConfig::small(),
+    );
+    fluree.set_indexing_mode(fluree_db_api::tx::IndexingMode::Background(handle.clone()));
+
+    local
+        .run_until(async move {
+            let ledger_id = "test/ndv-incremental:main";
+            fluree
+                .create(ledger_id)
+                .import(data_dir.path())
+                .threads(1)
+                .memory_budget_mb(256)
+                .cleanup(false)
+                .execute()
+                .await
+                .expect("import");
+            let storage = fluree
+                .backend()
+                .admin_storage_cloned()
+                .expect("test uses managed backend");
+
+            let flat_name_stat = |loaded: &LedgerSnapshot| -> (u64, u64, u64) {
+                loaded
+                    .stats
+                    .as_ref()
+                    .and_then(|s| s.properties.as_ref())
+                    .and_then(|props| {
+                        props.iter().find(|p| {
+                            let sid = fluree_db_core::Sid::new(p.sid.0, &p.sid.1);
+                            loaded
+                                .decode_sid(&sid)
+                                .map(|iri| iri == "http://example.org/name")
+                                .unwrap_or(false)
+                        })
+                    })
+                    .map(|p| (p.count, p.ndv_values, p.ndv_subjects))
+                    .expect("ex:name property should exist in the flat roll-up")
+            };
+
+            let base_view = fluree.db(ledger_id).await.expect("imported view");
+            let (base_count, base_ndv_values, base_ndv_subjects) =
+                flat_name_stat(&base_view.snapshot);
+            assert_eq!(base_count, 20);
+            assert!(
+                (18..=22).contains(&base_ndv_subjects) && (18..=22).contains(&base_ndv_values),
+                "base ndv ~20: values {base_ndv_values}, subjects {base_ndv_subjects}"
+            );
+
+            // One unrelated write, indexed incrementally over the sketchless base.
+            let index_cfg = IndexConfig {
+                reindex_min_bytes: 0,
+                reindex_max_bytes: 10_000_000,
+            };
+            let ledger1 = fluree
+                .ledger(ledger_id)
+                .await
+                .expect("load imported ledger");
+            let delta = fluree
+                .insert_with_opts(
+                    ledger1,
+                    &json!({
+                        "@context": {"ex": "http://example.org/"},
+                        "@id": "ex:note1",
+                        "ex:note": "pending"
+                    }),
+                    TxnOpts::default(),
+                    CommitOpts::default(),
+                    &index_cfg,
+                )
+                .await
+                .expect("insert delta");
+            let outcome =
+                trigger_index_and_wait_outcome(&handle, delta.ledger.ledger_id(), delta.receipt.t)
+                    .await;
+            let fluree_db_api::IndexOutcome::Completed { root_id, .. } = outcome else {
+                unreachable!("helper only returns Completed")
+            };
+            let delta_root = root_id.expect("delta root id");
+            let delta_loaded = load_ledger_snapshot(&storage, &delta_root, ledger_id)
+                .await
+                .expect("load delta root");
+            assert!(
+                delta_loaded.t > base_view.snapshot.t,
+                "the write must publish a newer root"
+            );
+            let (count, ndv_values, ndv_subjects) = flat_name_stat(&delta_loaded);
+            assert_eq!(count, 20, "ex:name count is untouched by the write");
+            assert_eq!(
+                (ndv_values, ndv_subjects),
+                (base_ndv_values, base_ndv_subjects),
+                "ex:name ndv must carry forward through the incremental build"
+            );
+        })
+        .await;
+}
+
 #[tokio::test]
 async fn selectivity_calculation_is_correct() {
     let tmp = tempfile::TempDir::new().expect("tempdir");

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2316,6 +2316,9 @@ pub async fn incremental_index(
             // property (empty registers) published ndv 0 and every
             // bound-subject probe on it was estimated at the 10-row fallback —
             // one write to a bulk-imported ledger made BSBM Q5 4x slower.
+            // The floor preserves the prior NDV estimate without restoring
+            // missing HLL registers. Follow-up: persist sketches during bulk
+            // import so incremental NDV merging includes the imported data.
             let properties = crate::stats::aggregate_property_entries_from_graphs(
                 &final_graphs,
                 &trie,

--- a/fluree-db-indexer/src/build/incremental.rs
+++ b/fluree-db-indexer/src/build/incremental.rs
@@ -2285,18 +2285,6 @@ pub async fn incremental_index(
         let db_stats = {
             use fluree_db_core::index_stats as is;
 
-            let properties = crate::stats::aggregate_property_entries_from_graphs(
-                &id_stats_result.graphs,
-                &trie,
-                |p_id| {
-                    novelty
-                        .shared
-                        .predicates
-                        .resolve(p_id)
-                        .map(ToString::to_string)
-                },
-            );
-
             // Class-property attribution: build full ClassStatEntry with property usage.
             //
             // Strategy:
@@ -2322,6 +2310,23 @@ pub async fn incremental_index(
                     }
                 }
             }
+
+            // The planner reads this roll-up, not the per-graph entries, so it
+            // must be taken AFTER the floor: rolled up before it, a seeded
+            // property (empty registers) published ndv 0 and every
+            // bound-subject probe on it was estimated at the 10-row fallback —
+            // one write to a bulk-imported ledger made BSBM Q5 4x slower.
+            let properties = crate::stats::aggregate_property_entries_from_graphs(
+                &final_graphs,
+                &trie,
+                |p_id| {
+                    novelty
+                        .shared
+                        .predicates
+                        .resolve(p_id)
+                        .map(ToString::to_string)
+                },
+            );
 
             let has_class_changes =
                 !class_count_deltas.is_empty() || !novelty_subject_class_deltas.is_empty();


### PR DESCRIPTION
## Summary

An incremental build over a base root without HLL sketches (a bulk import, or a ledger's first background build) seeds the properties the write did not touch with empty registers and clamps their finalized ndv to the base root's persisted estimate. The flat `IndexStats::properties` roll-up, which is the list the planner's `StatsView` reads, was aggregated from the per-graph entries **before** that clamp, so every untouched property published `ndv_subjects = 0` while the per-graph entries carried the right value.

With ndv 0 the planner estimates a bound-subject probe at its 10-row fallback instead of `count / ndv`, so a star of three probes compounds to 10k → 100k → 1M rows and the constant-subject patterns are scheduled last. One triple written to a bulk-imported 10M BSBM ledger took Explore Q5 from 6.6 ms to 27.9 ms on 4.2.0 and kept it there. Bulk imports never carry a sketch blob (only a full rebuild uploads one), so this hit every imported ledger on its first write.

The fix aggregates the roll-up from the floored per-graph entries instead.

## Test

`flat_property_ndv_survives_incremental_over_sketchless_base` (`fluree-db-api/tests/it_indexing_stats.rs`, run through `grp_index`) bulk-imports 20 subjects, writes one unrelated triple, and asserts the untouched property's count and ndv in the flat roll-up carry through the incremental root. Against the pre-fix code it fails with `(0, 0)` against `(21, 20)`.

End to end on the 10M BSBM ledger with this branch: after one write and the incremental reindex, Q5 runs in 7.1 ms with the original 583-row driving estimate, instead of 27.9 ms.
