### PR TITLE
query: index-walk range semi-join for correlated range probes, plus four join-chain fixes (BSBM Explore Q5)

### DIFF
--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -439,6 +439,10 @@ name = "it_query_sparql_indexed"
 path = "tests/it_query_sparql_indexed.rs"
 
 [[test]]
+name = "it_range_semijoin"
+path = "tests/it_range_semijoin.rs"
+
+[[test]]
 name = "it_rebuild_fetch_counts"
 path = "tests/it_rebuild_fetch_counts.rs"
 

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -438,6 +438,7 @@ path = "tests/it_optional_after_union.rs"
 name = "it_query_sparql_indexed"
 path = "tests/it_query_sparql_indexed.rs"
 
+# Keep this binary single-test: its walk-floor override is cached process-wide.
 [[test]]
 name = "it_range_semijoin"
 path = "tests/it_range_semijoin.rs"

--- a/fluree-db-api/benches/query_hot_bsbm.rs
+++ b/fluree-db-api/benches/query_hot_bsbm.rs
@@ -16,6 +16,10 @@
 //! pipelines; this bench stresses the canonical join/filter/aggregate
 //! pipeline on a moderately-sized dataset.
 //!
+//! A separate correlated Explore-Q5 fixture also measures the range semi-join
+//! on indexed data and novelty/policy fallbacks (`support/range_semijoin.rs`).
+//! Filter with `query_range_semijoin` to run that matrix alone.
+//!
 //! ## Setup discipline
 //!
 //! Each scale level builds the dataset once, populates a file-backed
@@ -230,5 +234,12 @@ fn bench_query_hot_bsbm(c: &mut Criterion) {
     drop(fluree);
 }
 
-criterion_group!(benches, bench_query_hot_bsbm);
+#[path = "support/range_semijoin.rs"]
+mod range_semijoin;
+
+criterion_group!(
+    benches,
+    bench_query_hot_bsbm,
+    range_semijoin::bench_range_semijoin
+);
 criterion_main!(benches);

--- a/fluree-db-api/benches/support/range_semijoin.rs
+++ b/fluree-db-api/benches/support/range_semijoin.rs
@@ -1,0 +1,179 @@
+//! Correlated Explore-Q5 windows, separate from the legacy constant-price Q5.
+//! A dedicated fixture keeps the existing Q3/Q5/Q9 baselines unchanged.
+//! Indexed data follows the selected scale; fallback fixtures cap at 1,500
+//! products so large-scale runs still exercise novelty/policy without timing
+//! a pathological unindexed scan. Run with `query_range_semijoin` as filter.
+
+use criterion::{black_box, BenchmarkId, Criterion};
+use fluree_bench_support::{bench_runtime, current_profile, current_scale, next_ledger_alias};
+use fluree_db_api::{
+    CommitOpts, Fluree, FlureeBuilder, GovernanceOptions, GraphDb, IndexConfig, QueryInput, TxnOpts,
+};
+use std::fmt::Write;
+
+// Count the actual execution route in an untimed preflight. Explain uses
+// snapshot-only stats, which can differ from a novelty view's execution stats.
+#[derive(Clone, Default)]
+struct Routes(std::sync::Arc<std::sync::Mutex<(usize, usize)>>);
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Routes {
+    fn on_event(&self, event: &tracing::Event<'_>, _: tracing_subscriber::layer::Context<'_, S>) {
+        #[derive(Default)]
+        struct Fields {
+            semijoin: bool,
+            walked: bool,
+            runtime: bool,
+        }
+        impl tracing::field::Visit for Fields {
+            fn record_debug(&mut self, _: &tracing::field::Field, _: &dyn std::fmt::Debug) {}
+            fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                match field.name() {
+                    "site" => self.semijoin = value == "range-semijoin",
+                    "outcome" => {
+                        self.walked = value == "proceed";
+                        self.runtime = matches!(value, "proceed" | "fallback:gate_declined");
+                    }
+                    _ => {}
+                }
+            }
+        }
+        let mut fields = Fields::default();
+        event.record(&mut fields);
+        if fields.semijoin && fields.runtime {
+            let mut counts = self.0.lock().unwrap();
+            if fields.walked {
+                counts.0 += 1;
+            } else {
+                counts.1 += 1;
+            }
+        }
+    }
+}
+
+const QUERY: &str = r"
+PREFIX ex: <http://example.org/range/>
+SELECT DISTINCT ?product ?label WHERE {
+  ?product ex:label ?label . FILTER (?product != ex:anchor)
+  ex:anchor ex:feature ?f . ?product ex:feature ?f .
+  ex:anchor ex:n1 ?o1 . ?product ex:n1 ?s1 .
+  FILTER (?s1 > ?o1 - 120 && ?s1 < ?o1 + 120)
+  ex:anchor ex:n2 ?o2 . ?product ex:n2 ?s2 .
+  FILTER (?s2 > ?o2 - 170 && ?s2 < ?o2 + 170)
+} ORDER BY ?label
+";
+
+fn fixture(n: usize) -> (String, usize) {
+    let mut ttl = String::from("@prefix ex: <http://example.org/range/> .\nex:anchor ex:feature ex:f0, ex:f1 ; ex:n1 1000 ; ex:n2 1000 ; ex:label \"anchor\" .\n");
+    let mut expected = 0;
+    for i in 0..n {
+        // Dense small fixtures clear the fold's driving-row gate in fallback
+        // contexts; Medium/Large indexed fixtures retain ~12.5% candidates.
+        let (f1, f2) = if n <= 1500 {
+            (0, 1)
+        } else {
+            (i % 32, (i + 5) % 32)
+        };
+        let (n1, n2) = ((i * 811) % 2000, (i * 353 + 211) % 2000);
+        writeln!(
+            ttl,
+            "ex:p{i} ex:feature ex:f{f1}, ex:f{f2} ; ex:n1 {n1} ; ex:n2 {n2} ; ex:label \"p{i}\" ."
+        )
+        .unwrap();
+        if (f1 < 2 || f2 < 2) && n1 > 880 && n1 < 1120 && n2 > 830 && n2 < 1170 {
+            expected += 1;
+        }
+    }
+    (ttl, expected)
+}
+
+async fn setup(n: usize) -> (tempfile::TempDir, Fluree, GraphDb, GraphDb, GraphDb, usize) {
+    let dir = tempfile::tempdir().unwrap();
+    let fluree = FlureeBuilder::file(dir.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let alias = next_ledger_alias("range-semijoin-bench");
+    let ledger = fluree.create_ledger(&alias).await.unwrap();
+    let (ttl, expected) = fixture(n);
+    let inserted = fluree
+        .insert_turtle_with_opts(
+            ledger,
+            &ttl,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &IndexConfig {
+                reindex_min_bytes: 5_000_000_000,
+                reindex_max_bytes: 5_000_000_000,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    let novelty = GraphDb::from_ledger_state(&inserted.ledger);
+    fluree.reindex(&alias, Default::default()).await.unwrap();
+    let indexed = fluree.db(&alias).await.unwrap();
+    // A non-root view that permits the fixture's properties still declines
+    // raw probe lanes. This measures fallback work without an empty result.
+    let policy = fluree.db_with_policy(&alias, &GovernanceOptions {
+        policy: Some(serde_json::json!([
+            {"@id":"ex:denyHidden", "@type":"f:AccessPolicy", "f:action":"f:view",
+             "f:onProperty":[{"@id":"http://example.org/range/hidden"}], "f:allow":false},
+            {"@id":"ex:allow", "@type":"f:AccessPolicy", "f:action":"f:view", "f:allow":true}
+        ])), default_allow: Some(true), ..Default::default()
+    }).await.unwrap();
+    assert!(!policy.is_root());
+    (dir, fluree, indexed, novelty, policy, expected)
+}
+
+pub fn bench_range_semijoin(c: &mut Criterion) {
+    fluree_bench_support::init_tracing_for_bench();
+    let rt = bench_runtime();
+    let scale = current_scale();
+    let n = super::scale_n_products(scale);
+    let (_dir, fluree, indexed, novelty, policy, expected) = rt.block_on(setup(n));
+    let small = (n > 1500).then(|| rt.block_on(setup(1500)));
+    let (fallback_fluree, novelty, policy, fallback_expected) = match &small {
+        Some((_, f, _, novelty, policy, expected)) => (f, novelty, policy, *expected),
+        None => (&fluree, &novelty, &policy, expected),
+    };
+    let mut group = c.benchmark_group("query_range_semijoin");
+    group.sample_size(current_profile().sample_size());
+    group.sampling_mode(criterion::SamplingMode::Flat);
+    for (name, f, view, expected) in [
+        ("indexed", &fluree, &indexed, expected),
+        ("novelty", fallback_fluree, novelty, fallback_expected),
+        ("policy", fallback_fluree, policy, fallback_expected),
+    ] {
+        use tracing_subscriber::prelude::*;
+        let routes = Routes::default();
+        let subscriber = tracing_subscriber::registry().with(routes.clone());
+        let result = tracing::subscriber::with_default(subscriber, || {
+            rt.block_on(f.query(view, QueryInput::Sparql(QUERY)))
+                .unwrap()
+        });
+        let rows = result.to_jsonld(&view.snapshot).unwrap();
+        assert_eq!(
+            rows.as_array().unwrap().len(),
+            expected,
+            "{name} fixture results"
+        );
+        let (walk_batches, probe_batches) = *routes.0.lock().unwrap();
+        let disabled = fluree_db_query::execute::fast_paths_disabled();
+        if n >= 1000 && !disabled {
+            assert!(
+                walk_batches + probe_batches > 0,
+                "{name} must benchmark the fold"
+            );
+        }
+        eprintln!("[range-semijoin] {name}: products={} rows={expected} walk_batches={walk_batches} probe_batches={probe_batches} fast_paths_disabled={disabled}",
+            if name == "indexed" { n } else { n.min(1500) });
+        group.bench_function(BenchmarkId::new(name, scale.as_str()), |b| {
+            b.iter(|| {
+                black_box(
+                    rt.block_on(f.query(view, QueryInput::Sparql(QUERY)))
+                        .unwrap(),
+                )
+            });
+        });
+    }
+    group.finish();
+}

--- a/fluree-db-api/tests/it_query_explain.rs
+++ b/fluree-db-api/tests/it_query_explain.rs
@@ -513,6 +513,49 @@ async fn explain_chain_count_distinct_inserts_early_dedup() {
     );
 }
 
+/// Count `DistinctOperator` nodes strictly below the `ProjectOperator` — the
+/// WHERE-level early-dedup insertions, excluding the outer `SELECT DISTINCT`.
+fn count_early_dedup_nodes(node: &serde_json::Value) -> usize {
+    if node["op"] == "ProjectOperator" {
+        return node["children"]
+            .as_array()
+            .map(|cs| cs.iter().map(|e| count_distinct_nodes(&e["node"])).sum())
+            .unwrap_or(0);
+    }
+    node["children"]
+        .as_array()
+        .map(|cs| cs.iter().map(|e| count_early_dedup_nodes(&e["node"])).sum())
+        .unwrap_or(0)
+}
+
+/// Early dedup is inserted only where a step trims a variable that was still
+/// live before it. The anchored chain plans as `ex:a1 ex:p1 ?b` (nothing dead:
+/// `?b` feeds the next hop), then `?b ex:p2 ?m` (`?b` dies — dedup), then
+/// `?m ex:p3 ?x` (both live and projected — no dedup). A current-state join
+/// step that keeps every variable it produces cannot duplicate an already
+/// distinct stream, so re-deduplicating behind it only re-hashed the whole
+/// intermediate (BSBM Q5's label probe behind its deduplicated candidates).
+#[tokio::test]
+async fn explain_chain_dedups_only_where_a_live_var_dies() {
+    let _env = HashJoinEnv::acquire();
+    let physical = chain_physical_plan(
+        "PREFIX ex: <http://example.org/>\n\
+         SELECT DISTINCT ?m ?x\n\
+         WHERE { ex:a1 ex:p1 ?b . ?b ex:p2 ?m . ?m ex:p3 ?x }",
+    )
+    .await;
+    assert_eq!(
+        count_early_dedup_nodes(&physical),
+        1,
+        "exactly one early dedup (after `?b` dies), none behind the all-live tail step: {physical}"
+    );
+    assert_eq!(
+        count_distinct_nodes(&physical),
+        2,
+        "the outer SELECT DISTINCT is the only other DistinctOperator: {physical}"
+    );
+}
+
 /// `MIN`/`MAX` are duplicate-insensitive without a DISTINCT modifier, so the
 /// same early dedup applies.
 #[tokio::test]

--- a/fluree-db-api/tests/it_range_semijoin.rs
+++ b/fluree-db-api/tests/it_range_semijoin.rs
@@ -1,0 +1,555 @@
+//! `RangeSemiJoinOperator`: a probe whose object feeds a correlated range
+//! FILTER and is otherwise dead is answered as an index-walk semi-join
+//! (`fluree-db-query/src/range_semijoin.rs`). The shape is BSBM Explore Q5.
+//!
+//! Expected rows are computed independently in Rust over the generated data,
+//! so the assertions do not depend on the engine agreeing with itself.
+
+#![cfg(feature = "native")]
+
+mod support;
+
+use fluree_db_api::{FlureeBuilder, QueryInput};
+use serde_json::{json, Value as JsonValue};
+use support::{
+    genesis_ledger, normalize_rows, rebuild_and_publish_index, span_capture, MemoryFluree,
+};
+
+const LEDGER: &str = "range-semijoin:main";
+const ANCHOR_N1: i64 = 100;
+const ANCHOR_N2: i64 = 500;
+
+/// One product: shared features, numeric values (a string stands in for a
+/// non-numeric value), labels.
+struct Product {
+    id: String,
+    features: Vec<&'static str>,
+    n1: Vec<JsonValue>,
+    n2: Vec<JsonValue>,
+    labels: Vec<String>,
+}
+
+fn products() -> Vec<Product> {
+    let p = |id: &str,
+             features: Vec<&'static str>,
+             n1: Vec<JsonValue>,
+             n2: Vec<JsonValue>,
+             labels: Vec<&str>| Product {
+        id: id.to_string(),
+        features,
+        n1,
+        n2,
+        labels: labels.into_iter().map(str::to_string).collect(),
+    };
+    let mut out = vec![
+        // in / in
+        p(
+            "A",
+            vec!["f1"],
+            vec![json!(150)],
+            vec![json!(600)],
+            vec!["a"],
+        ),
+        // n1 out
+        p(
+            "B",
+            vec!["f1"],
+            vec![json!(300)],
+            vec![json!(600)],
+            vec!["b"],
+        ),
+        // both just inside the strict bounds
+        p(
+            "C",
+            vec!["f2"],
+            vec![json!(219)],
+            vec![json!(331)],
+            vec!["c"],
+        ),
+        // n1 exactly on the (exclusive) upper bound
+        p(
+            "D",
+            vec!["f2"],
+            vec![json!(220)],
+            vec![json!(400)],
+            vec!["d"],
+        ),
+        // multi-valued n1: one out, one in
+        p(
+            "E",
+            vec!["f1"],
+            vec![json!(-100), json!(190)],
+            vec![json!(400)],
+            vec!["e"],
+        ),
+        // no n1 at all
+        p("F", vec!["f1"], vec![], vec![json!(400)], vec!["f"]),
+        // shares both features (duplicate candidate) and has two labels
+        p(
+            "G",
+            vec!["f1", "f2"],
+            vec![json!(120)],
+            vec![json!(340)],
+            vec!["g1", "g2"],
+        ),
+        // shares no feature with the anchor
+        p(
+            "H",
+            vec!["f3"],
+            vec![json!(100)],
+            vec![json!(500)],
+            vec!["h"],
+        ),
+        // non-numeric n1
+        p(
+            "I",
+            vec!["f1"],
+            vec![json!("abc")],
+            vec![json!(400)],
+            vec!["i"],
+        ),
+        // n2 exactly on the (exclusive) lower bound
+        p(
+            "J",
+            vec!["f2"],
+            vec![json!(100)],
+            vec![json!(330)],
+            vec!["j"],
+        ),
+        // two in-range n1 values (semi-join keeps the row once)
+        p(
+            "K",
+            vec!["f1"],
+            vec![json!(110), json!(130)],
+            vec![json!(450)],
+            vec!["k"],
+        ),
+        // a rare feature shared by three products only: the capped-walk case
+        p(
+            "R",
+            vec!["f_rare"],
+            vec![json!(100)],
+            vec![json!(500)],
+            vec!["r"],
+        ),
+        p(
+            "R1",
+            vec!["f_rare"],
+            vec![json!(7)],
+            vec![json!(-40)],
+            vec!["r1"],
+        ),
+        p(
+            "R2",
+            vec!["f_rare"],
+            vec![json!(1999)],
+            vec![json!(1999)],
+            vec!["r2"],
+        ),
+    ];
+    // Bulk products so the planner's driving-row estimate clears the lane's
+    // minimum on the indexed ledger; deterministic LCG values, ~12% / ~17%
+    // of them inside each range as in BSBM. Each carries a few features so
+    // `feature` averages several flakes per subject and the anchor's single-
+    // valued numerics win the seed race ahead of its feature list, as at scale.
+    const EXTRA_FEATURES: [&str; 6] = ["f4", "f5", "f6", "f7", "f8", "f9"];
+    let mut seed: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut next = || {
+        seed = seed
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        (seed >> 33) as i64
+    };
+    for i in 0..1500 {
+        let n1 = next() % 2000;
+        let n2 = next() % 2000;
+        let extra_a = EXTRA_FEATURES[(next() as usize) % EXTRA_FEATURES.len()];
+        let mut extra_b = EXTRA_FEATURES[(next() as usize) % EXTRA_FEATURES.len()];
+        if extra_b == extra_a {
+            extra_b = EXTRA_FEATURES[(EXTRA_FEATURES.iter().position(|f| *f == extra_a).unwrap()
+                + 1)
+                % EXTRA_FEATURES.len()];
+        }
+        out.push(p(
+            &format!("bulk{i}"),
+            vec!["f1", extra_a, extra_b],
+            vec![json!(n1)],
+            vec![json!(n2)],
+            vec![],
+        ));
+        out.last_mut().unwrap().labels = vec![format!("bulk-{i:04}")];
+    }
+    out
+}
+
+/// A product's `ex:d` date, derived from its first integer `n1` so the
+/// expected rows need no second fixture: months and days spread over 2024.
+fn date_of(p: &Product) -> Option<String> {
+    let n = p.n1.iter().find_map(JsonValue::as_i64)?;
+    Some(format!(
+        "2024-{:02}-{:02}T00:00:00Z",
+        1 + n.rem_euclid(12),
+        1 + (n / 12).rem_euclid(28)
+    ))
+}
+
+const DATE_LO: &str = "2024-03-15T00:00:00Z";
+const DATE_HI: &str = "2024-09-15T00:00:00Z";
+
+/// (label) rows the date-window query must return, in label order.
+fn expected_date_labels(products: &[Product]) -> Vec<String> {
+    let anchor_features = ["f1", "f2"];
+    let mut labels: Vec<String> = products
+        .iter()
+        .filter(|p| p.features.iter().any(|f| anchor_features.contains(f)))
+        .filter(|p| date_of(p).is_some_and(|d| d.as_str() > DATE_LO && d.as_str() < DATE_HI))
+        .flat_map(|p| p.labels.iter().cloned())
+        .collect();
+    labels.sort();
+    labels
+}
+
+fn in_range(values: &[JsonValue], center: i64, half: i64) -> bool {
+    values.iter().any(|v| {
+        v.as_i64()
+            .is_some_and(|n| n < center + half && n > center - half)
+    })
+}
+
+/// (label) rows the DISTINCT query must return, in label order.
+fn expected_labels(products: &[Product]) -> Vec<String> {
+    let anchor_features = ["f1", "f2"];
+    let mut labels: Vec<String> = products
+        .iter()
+        .filter(|p| p.features.iter().any(|f| anchor_features.contains(f)))
+        .filter(|p| in_range(&p.n1, ANCHOR_N1, 120) && in_range(&p.n2, ANCHOR_N2, 170))
+        .flat_map(|p| p.labels.iter().cloned())
+        .collect();
+    labels.sort();
+    labels
+}
+
+fn graph(products: &[Product]) -> JsonValue {
+    let mut nodes = vec![json!({
+        "@id": "ex:P",
+        "ex:feature": [{"@id": "ex:f1"}, {"@id": "ex:f2"}],
+        "ex:n1": ANCHOR_N1,
+        "ex:n2": ANCHOR_N2,
+        "ex:dlo": {"@value": DATE_LO, "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
+        "ex:dhi": {"@value": DATE_HI, "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
+        "ex:label": "anchor"
+    })];
+    for p in products {
+        let mut node = serde_json::Map::new();
+        node.insert("@id".into(), json!(format!("ex:{}", p.id)));
+        node.insert(
+            "ex:feature".into(),
+            JsonValue::Array(
+                p.features
+                    .iter()
+                    .map(|f| json!({"@id": format!("ex:{f}")}))
+                    .collect(),
+            ),
+        );
+        if !p.n1.is_empty() {
+            node.insert("ex:n1".into(), JsonValue::Array(p.n1.clone()));
+        }
+        if !p.n2.is_empty() {
+            node.insert("ex:n2".into(), JsonValue::Array(p.n2.clone()));
+        }
+        if let Some(d) = date_of(p) {
+            node.insert(
+                "ex:d".into(),
+                json!({"@value": d, "@type": "http://www.w3.org/2001/XMLSchema#dateTime"}),
+            );
+        }
+        node.insert(
+            "ex:label".into(),
+            JsonValue::Array(p.labels.iter().map(|l| json!(l)).collect()),
+        );
+        nodes.push(JsonValue::Object(node));
+    }
+    json!({"@context": {"ex": "http://example.org/ns/"}, "@graph": nodes})
+}
+
+const Q5_SHAPE: &str = "PREFIX ex: <http://example.org/ns/>\n\
+    SELECT DISTINCT ?product ?label WHERE {\n\
+      ?product ex:label ?label .\n\
+      FILTER (ex:P != ?product)\n\
+      ex:P ex:feature ?f .\n\
+      ?product ex:feature ?f .\n\
+      ex:P ex:n1 ?o1 .\n\
+      ?product ex:n1 ?s1 .\n\
+      FILTER (?s1 < (?o1 + 120) && ?s1 > (?o1 - 120))\n\
+      ex:P ex:n2 ?o2 .\n\
+      ?product ex:n2 ?s2 .\n\
+      FILTER (?s2 < (?o2 + 170) && ?s2 > (?o2 - 170))\n\
+    } ORDER BY ?label";
+
+/// Same body, but `?s1` is projected: the value is live, so the probe must
+/// stay a real join (one row per in-range value) and no fold may apply.
+const S1_LIVE: &str = "PREFIX ex: <http://example.org/ns/>\n\
+    SELECT DISTINCT ?label ?s1 WHERE {\n\
+      ?product ex:label ?label .\n\
+      FILTER (ex:P != ?product)\n\
+      ex:P ex:feature ?f .\n\
+      ?product ex:feature ?f .\n\
+      ex:P ex:n1 ?o1 .\n\
+      ?product ex:n1 ?s1 .\n\
+      FILTER (?s1 < (?o1 + 120) && ?s1 > (?o1 - 120))\n\
+      ex:P ex:n2 ?o2 .\n\
+      ?product ex:n2 ?s2 .\n\
+      FILTER (?s2 < (?o2 + 170) && ?s2 > (?o2 - 170))\n\
+      FILTER (?label = \"k\" || ?label = \"e\")\n\
+    } ORDER BY ?label ?s1";
+
+/// Q5 shape anchored on the rare-feature product with a range wide enough
+/// to cover every value: three driving rows against a whole-predicate
+/// envelope, so the walk must cap out and the batch must be answered by probes.
+const WIDE_RANGE_RARE_ANCHOR: &str = "PREFIX ex: <http://example.org/ns/>\n\
+    SELECT DISTINCT ?product ?label WHERE {\n\
+      ?product ex:label ?label .\n\
+      FILTER (ex:R != ?product)\n\
+      ex:R ex:feature ?f .\n\
+      ?product ex:feature ?f .\n\
+      ex:R ex:n1 ?o1 .\n\
+      ?product ex:n1 ?s1 .\n\
+      FILTER (?s1 < (?o1 + 100000) && ?s1 > (?o1 - 100000))\n\
+      ex:R ex:n2 ?o2 .\n\
+      ?product ex:n2 ?s2 .\n\
+      FILTER (?s2 < (?o2 + 100000) && ?s2 > (?o2 - 100000))\n\
+    } ORDER BY ?label";
+
+/// Q5 shape over a date window whose bounds come from the anchor (a constant
+/// bound would be pushed into the probe instead of folded): the fold applies
+/// but the walk keys inline numerics only, so every batch must be answered by
+/// probes with the filter re-evaluated on the decoded dates.
+const DATE_WINDOW: &str = "PREFIX ex: <http://example.org/ns/>\n\
+    SELECT DISTINCT ?product ?label WHERE {\n\
+      ?product ex:label ?label .\n\
+      FILTER (ex:P != ?product)\n\
+      ex:P ex:feature ?f .\n\
+      ?product ex:feature ?f .\n\
+      ex:P ex:dlo ?lo .\n\
+      ex:P ex:dhi ?hi .\n\
+      ?product ex:d ?sd .\n\
+      FILTER (?sd > ?lo && ?sd < ?hi)\n\
+    } ORDER BY ?label";
+
+/// Routing stamps for the semi-join site since `before`, as outcome labels.
+fn semijoin_outcomes(store: &span_capture::SpanStore, before: usize) -> Vec<String> {
+    store.find_events("fast-path outcome")[before..]
+        .iter()
+        .filter(|e| e.fields.get("site").map(String::as_str) == Some("range-semijoin"))
+        .filter_map(|e| e.fields.get("outcome").cloned())
+        .collect()
+}
+
+async fn rows_of(
+    fluree: &MemoryFluree,
+    view: &fluree_db_api::GraphDb,
+    sparql: &str,
+) -> Vec<JsonValue> {
+    let res = fluree
+        .query(view, QueryInput::Sparql(sparql))
+        .await
+        .expect("sparql query");
+    normalize_rows(&res.to_jsonld(&view.snapshot).expect("to_jsonld"))
+}
+
+/// The label column of the Q5-shaped query's rows, sorted.
+async fn labels_of(
+    fluree: &MemoryFluree,
+    view: &fluree_db_api::GraphDb,
+    sparql: &str,
+) -> Vec<String> {
+    let mut labels: Vec<String> = rows_of(fluree, view, sparql)
+        .await
+        .iter()
+        .map(|row| {
+            row.as_array()
+                .and_then(|r| r.last())
+                .and_then(JsonValue::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| row.to_string())
+        })
+        .collect();
+    labels.sort();
+    labels
+}
+
+fn ops(node: &JsonValue, out: &mut Vec<String>) {
+    if let Some(op) = node["op"].as_str() {
+        out.push(match node["details"]["right"].as_str() {
+            Some(right) => format!("{op} {right}"),
+            None => op.to_string(),
+        });
+    }
+    if let Some(children) = node["children"].as_array() {
+        for c in children {
+            ops(&c["node"], out);
+        }
+    }
+}
+
+#[tokio::test]
+async fn correlated_range_probes_fold_into_a_semijoin_with_exact_rows() {
+    // This is the only test in the binary, so the process-wide walk floor is
+    // ours to set before the first walk reads it: a tiny floor makes the
+    // wide-range case cap out (three driving rows against ~1500 in-range
+    // rows) while the Q5 shape stays within 16 rows per driving row.
+    std::env::set_var("FLUREE_RANGE_SEMIJOIN_WALK_FLOOR", "100");
+    let (events, _tracing_guard) = span_capture::init_test_tracing();
+    let products = products();
+    let expected = expected_labels(&products);
+    assert!(
+        expected.iter().any(|l| l == "e") && expected.iter().any(|l| l == "g2"),
+        "fixture sanity: multi-valued and duplicate-candidate cases are in range"
+    );
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger0 = genesis_ledger(&fluree, LEDGER);
+    let ledger = fluree
+        .insert(ledger0, &graph(&products))
+        .await
+        .expect("insert")
+        .ledger;
+
+    // Pure novelty (no statistics): the fold fires on the estimate-free gate.
+    let novelty_view = support::graphdb_from_ledger(&ledger);
+    assert_eq!(labels_of(&fluree, &novelty_view, Q5_SHAPE).await, expected);
+
+    // Binary index: EncodedSid keys, the POST walk, planner statistics.
+    rebuild_and_publish_index(&fluree, LEDGER).await;
+    let view = fluree.db(LEDGER).await.expect("indexed view");
+    let before = events.find_events("fast-path outcome").len();
+    assert_eq!(labels_of(&fluree, &view, Q5_SHAPE).await, expected);
+    let outcomes = semijoin_outcomes(&events, before);
+    assert!(
+        !outcomes.is_empty() && outcomes.iter().all(|o| o == "proceed"),
+        "every batch of the Q5 shape is answered from a built index: {outcomes:?}"
+    );
+
+    // Wide range on a rare anchor: the walk caps out and the batch is
+    // answered by subject probes, with exactly the same rows.
+    let before = events.find_events("fast-path outcome").len();
+    let expected_rare = {
+        let mut labels: Vec<String> = products
+            .iter()
+            .filter(|p| p.features.contains(&"f_rare") && p.id != "R")
+            .flat_map(|p| p.labels.iter().cloned())
+            .collect();
+        labels.sort();
+        labels
+    };
+    assert_eq!(
+        labels_of(&fluree, &view, WIDE_RANGE_RARE_ANCHOR).await,
+        expected_rare,
+        "capped walk falls back to probes with exact rows"
+    );
+    let outcomes = semijoin_outcomes(&events, before);
+    assert!(
+        outcomes.iter().any(|o| o == "fallback:gate_declined"),
+        "the wide range must cap the walk and take the probe fallback: {outcomes:?}"
+    );
+
+    // Date window: non-numeric bounds never build a walked index (which
+    // holds inline numerics only); the batch takes the probe path and the
+    // filter is re-evaluated on the decoded dates.
+    let before = events.find_events("fast-path outcome").len();
+    let expected_dates = expected_date_labels(&products);
+    assert!(
+        expected_dates.len() > 100 && expected_dates.len() < products.len(),
+        "fixture sanity: the date window keeps some but not all products"
+    );
+    assert_eq!(
+        labels_of(&fluree, &view, DATE_WINDOW).await,
+        expected_dates,
+        "date bounds are answered by probes with exact rows"
+    );
+    let outcomes = semijoin_outcomes(&events, before);
+    assert!(
+        !outcomes.is_empty() && outcomes.iter().all(|o| o == "fallback:gate_declined"),
+        "non-numeric bounds must take the probe fallback on every batch: {outcomes:?}"
+    );
+    let plan = fluree
+        .explain_sparql(&view, DATE_WINDOW)
+        .await
+        .expect("explain");
+    let mut names = Vec::new();
+    ops(&plan["plan"]["physical"], &mut names);
+    assert!(
+        names.iter().any(|n| n == "RangeSemiJoinOperator"),
+        "the date probe folds like a numeric one: {names:?}"
+    );
+
+    let plan = fluree
+        .explain_sparql(&view, Q5_SHAPE)
+        .await
+        .expect("explain");
+    let mut names = Vec::new();
+    ops(&plan["plan"]["physical"], &mut names);
+    assert!(
+        names.iter().any(|n| n == "RangeSemiJoinOperator"),
+        "both numeric probes fold into one RangeSemiJoinOperator: {names:?}"
+    );
+    assert!(
+        !names
+            .iter()
+            .any(|n| n.contains("ex:n1>") || n.contains("ns/n1>") || n.contains(":n1> ?")),
+        "the folded probes must not remain as joins: {names:?}"
+    );
+
+    // Novelty on top of the index: a product that exists only in the overlay
+    // (subject id minted after the index) must be found by the overlay-merged
+    // probes the walk declines to, keyed consistently with the driving rows.
+    let ledger2 = fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{
+                    "@id": "ex:N",
+                    "ex:feature": [{"@id": "ex:f1"}],
+                    "ex:n1": 105,
+                    "ex:n2": 505,
+                    "ex:label": "n"
+                }]
+            }),
+        )
+        .await
+        .expect("overlay insert")
+        .ledger;
+    assert!(ledger2.t() > 1, "overlay commit landed");
+    let view2 = fluree.db(LEDGER).await.expect("view with novelty");
+    let mut expected_with_novelty = expected.clone();
+    expected_with_novelty.push("n".to_string());
+    expected_with_novelty.sort();
+    assert_eq!(
+        labels_of(&fluree, &view2, Q5_SHAPE).await,
+        expected_with_novelty,
+        "novelty-only product with in-range values is kept"
+    );
+
+    // A live value var keeps the real join for THAT probe (the still-dead n2
+    // probe may fold on its own): K has two in-range values and yields two
+    // rows, E's out-of-range value yields nothing.
+    let live = rows_of(&fluree, &view, S1_LIVE).await;
+    assert_eq!(
+        live,
+        normalize_rows(&json!([["e", 190], ["k", 110], ["k", 130]])),
+        "one row per in-range value: {live:?}"
+    );
+    let plan = fluree
+        .explain_sparql(&view, S1_LIVE)
+        .await
+        .expect("explain");
+    let mut names = Vec::new();
+    ops(&plan["plan"]["physical"], &mut names);
+    assert!(
+        names
+            .iter()
+            .any(|n| n.starts_with("NestedLoopJoinOperator") && n.contains(":n1> ?")),
+        "the probe whose value is projected must stay a join: {names:?}"
+    );
+}

--- a/fluree-db-api/tests/it_range_semijoin.rs
+++ b/fluree-db-api/tests/it_range_semijoin.rs
@@ -10,7 +10,9 @@
 mod support;
 
 use fluree_db_api::{FlureeBuilder, QueryInput};
+use num_bigdecimal::BigDecimal;
 use serde_json::{json, Value as JsonValue};
+use std::str::FromStr;
 use support::{
     genesis_ledger, normalize_rows, rebuild_and_publish_index, span_capture, MemoryFluree,
 };
@@ -147,6 +149,36 @@ fn products() -> Vec<Product> {
             vec!["r2"],
         ),
     ];
+    let numeric = |value: &str, kind: &str| {
+        json!({
+            "@value": value, "@type": format!("http://www.w3.org/2001/XMLSchema#{kind}")
+        })
+    };
+    for (id, value) in [
+        ("decimal_in", "150.5"),
+        ("decimal_out", "220"),
+        ("decimal_below", "-20.5"),
+    ] {
+        out.push(p(
+            id,
+            vec!["f1"],
+            vec![numeric(value, "decimal")],
+            vec![json!(500)],
+            vec![id],
+        ));
+    }
+    for (id, value) in [
+        ("big_in", "9223372036854776001"),
+        ("big_out", "9223372036854776120"),
+    ] {
+        out.push(p(
+            id,
+            vec!["fbig"],
+            vec![numeric(value, "integer")],
+            vec![json!(500)],
+            vec![id],
+        ));
+    }
     // Bulk products so the planner's driving-row estimate clears the lane's
     // minimum on the indexed ledger; deterministic LCG values, ~12% / ~17%
     // of them inside each range as in BSBM. Each carries a few features so
@@ -209,11 +241,19 @@ fn expected_date_labels(products: &[Product]) -> Vec<String> {
     labels
 }
 
+fn numeric_value(v: &JsonValue) -> Option<BigDecimal> {
+    if let Some(n) = v.as_i64() {
+        Some(n.into())
+    } else {
+        BigDecimal::from_str(v.get("@value")?.as_str()?).ok()
+    }
+}
+
 fn in_range(values: &[JsonValue], center: i64, half: i64) -> bool {
-    values.iter().any(|v| {
-        v.as_i64()
-            .is_some_and(|n| n < center + half && n > center - half)
-    })
+    values
+        .iter()
+        .filter_map(numeric_value)
+        .any(|n| n < center + half && n > center - half)
 }
 
 /// (label) rows the DISTINCT query must return, in label order.
@@ -239,6 +279,11 @@ fn graph(products: &[Product]) -> JsonValue {
         "ex:dhi": {"@value": DATE_HI, "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
         "ex:label": "anchor"
     })];
+    nodes.push(json!({
+        "@id": "ex:BigAnchor", "ex:feature": {"@id": "ex:fbig"},
+        "ex:n1": {"@value": "9223372036854776000", "@type": "http://www.w3.org/2001/XMLSchema#integer"},
+        "ex:n2": 500, "ex:label": "big_anchor"
+    }));
     for p in products {
         let mut node = serde_json::Map::new();
         node.insert("@id".into(), json!(format!("ex:{}", p.id)));
@@ -419,6 +464,9 @@ async fn correlated_range_probes_fold_into_a_semijoin_with_exact_rows() {
     let novelty_view = support::graphdb_from_ledger(&ledger);
     assert_eq!(labels_of(&fluree, &novelty_view, Q5_SHAPE).await, expected);
 
+    check_constant_filter(&fluree, &novelty_view, &products).await;
+    check_fallback_rows(&novelty_view).await;
+
     // Binary index: EncodedSid keys, the POST walk, planner statistics.
     rebuild_and_publish_index(&fluree, LEDGER).await;
     let view = fluree.db(LEDGER).await.expect("indexed view");
@@ -428,6 +476,41 @@ async fn correlated_range_probes_fold_into_a_semijoin_with_exact_rows() {
     assert!(
         !outcomes.is_empty() && outcomes.iter().all(|o| o == "proceed"),
         "every batch of the Q5 shape is answered from a built index: {outcomes:?}"
+    );
+
+    assert_eq!(
+        labels_of(&fluree, &view, &Q5_SHAPE.replace("ex:P", "ex:BigAnchor")).await,
+        vec!["big_in"]
+    );
+    check_constant_filter(&fluree, &view, &products).await;
+    check_growing_envelopes(&view, &events).await;
+
+    // Restricted views must use the generic batch fallback and obey policy.
+    let restricted = fluree.db_with_policy(LEDGER, &fluree_db_api::GovernanceOptions {
+        policy: Some(json!([
+            {"@id":"ex:denyA", "@type":"f:AccessPolicy", "f:action":"f:view",
+             "f:onSubject":[{"@id":"http://example.org/ns/A"}], "f:allow":false},
+            {"@id":"ex:allowAll", "@type":"f:AccessPolicy", "f:action":"f:view", "f:allow":true}
+        ])),
+        default_allow: Some(true),
+        ..Default::default()
+    }).await.expect("restricted view");
+    assert!(!restricted.is_root());
+    let before = events.find_events("range semijoin exhausted").len();
+    let allowed: Vec<String> = expected
+        .iter()
+        .filter(|label| label.as_str() != "a")
+        .cloned()
+        .collect();
+    assert_eq!(labels_of(&fluree, &restricted, Q5_SHAPE).await, allowed);
+    let fallback = events.find_events("range semijoin exhausted");
+    assert!(
+        fallback[before..].iter().any(|event| {
+            let rows: usize = event.fields["fallback"].parse().unwrap();
+            let batches: usize = event.fields["fallback_batches"].parse().unwrap();
+            rows > 0 && batches > 0 && batches < rows
+        }),
+        "restricted results must exercise batch fallback"
     );
 
     // Wide range on a rare anchor: the walk caps out and the batch is
@@ -551,5 +634,203 @@ async fn correlated_range_probes_fold_into_a_semijoin_with_exact_rows() {
             .iter()
             .any(|n| n.starts_with("NestedLoopJoinOperator") && n.contains(":n1> ?")),
         "the probe whose value is projected must stay a join: {names:?}"
+    );
+}
+
+async fn check_constant_filter(
+    fluree: &MemoryFluree,
+    view: &fluree_db_api::GraphDb,
+    products: &[Product],
+) {
+    for (op, bound) in [(">", 150), (">=", 150), ("<", 130), ("<=", 130), ("=", 150)] {
+        let query = Q5_SHAPE.replace(
+            "} ORDER BY",
+            &format!("FILTER (?s1 {op} {bound}) }} ORDER BY"),
+        );
+        let mut expected: Vec<String> = products
+            .iter()
+            .filter(|p| p.features.iter().any(|f| ["f1", "f2"].contains(f)))
+            .filter(|p| in_range(&p.n2, ANCHOR_N2, 170))
+            .filter(|p| {
+                p.n1.iter().filter_map(numeric_value).any(|v| {
+                    v > -20
+                        && v < 220
+                        && match op {
+                            ">" => v > bound,
+                            ">=" => v >= bound,
+                            "<" => v < bound,
+                            "<=" => v <= bound,
+                            _ => v == bound,
+                        }
+                })
+            })
+            .flat_map(|p| p.labels.iter().cloned())
+            .collect();
+        expected.sort();
+        assert_eq!(
+            labels_of(fluree, view, &query).await,
+            expected,
+            "constant + correlated: {op}"
+        );
+    }
+}
+
+// Supply deterministic batch boundaries; a query-level hash join may scramble
+// drifting anchors and hide repeated envelope rebuilds.
+struct Batches {
+    schema: std::sync::Arc<[fluree_db_query::VarId]>,
+    batches: std::collections::VecDeque<fluree_db_query::binding::Batch>,
+}
+
+#[async_trait::async_trait]
+impl fluree_db_query::operator::Operator for Batches {
+    fn schema(&self) -> &[fluree_db_query::VarId] {
+        &self.schema
+    }
+    async fn open(
+        &mut self,
+        _: &fluree_db_query::context::ExecutionContext<'_>,
+    ) -> fluree_db_query::error::Result<()> {
+        Ok(())
+    }
+    async fn next_batch(
+        &mut self,
+        _: &fluree_db_query::context::ExecutionContext<'_>,
+    ) -> fluree_db_query::error::Result<Option<fluree_db_query::binding::Batch>> {
+        Ok(self.batches.pop_front())
+    }
+    fn close(&mut self) {}
+}
+
+async fn run_direct_batches(
+    view: &fluree_db_api::GraphDb,
+    rows: Vec<Vec<(i64, fluree_db_query::binding::Binding, i64, i64)>>,
+) -> Vec<i64> {
+    use fluree_db_core::{FlakeValue, Sid};
+    use fluree_db_query::binding::{Batch, Binding};
+    use fluree_db_query::ir::{Expression, Ref};
+    use fluree_db_query::operator::Operator;
+    use fluree_db_query::range_semijoin::{RangeSemiJoinCondition, RangeSemiJoinOperator};
+    let mut vars = fluree_db_query::VarRegistry::new();
+    let tag = vars.get_or_insert("?tag");
+    let subject = vars.get_or_insert("?s");
+    let lo = vars.get_or_insert("?lo");
+    let hi = vars.get_or_insert("?hi");
+    let value = vars.get_or_insert("?value");
+    let schema: std::sync::Arc<[_]> = vec![tag, subject, lo, hi].into();
+    let lit = |n| Binding::lit(FlakeValue::Long(n), Sid::new(2, "long"));
+    let batches = rows
+        .into_iter()
+        .map(|rows| {
+            let mut columns = vec![Vec::new(); 4];
+            for (tag, s, lo, hi) in rows {
+                columns[0].push(lit(tag));
+                columns[1].push(s);
+                columns[2].push(lit(lo));
+                columns[3].push(lit(hi));
+            }
+            Batch::new(schema.clone(), columns).unwrap()
+        })
+        .collect();
+    let condition = RangeSemiJoinCondition {
+        predicate: Ref::Iri("http://example.org/ns/n1".into()),
+        value_var: value,
+        lower: Some((Expression::Var(lo), false)),
+        upper: Some((Expression::Var(hi), false)),
+        filter: Expression::and(vec![
+            Expression::gt(Expression::Var(value), Expression::Var(lo)),
+            Expression::lt(Expression::Var(value), Expression::Var(hi)),
+        ]),
+    };
+    let mut op = RangeSemiJoinOperator::new(
+        Box::new(Batches { schema, batches }),
+        subject,
+        vec![condition],
+        Some(&[tag]),
+        fluree_db_query::temporal_mode::PlanningContext::current(),
+    );
+    let ctx = fluree_db_query::context::ExecutionContext::from_graph_db_ref(
+        view.as_graph_db_ref(),
+        &vars,
+    );
+    op.open(&ctx).await.unwrap();
+    let mut tags = Vec::new();
+    while let Some(batch) = op.next_batch(&ctx).await.unwrap() {
+        for row in 0..batch.len() {
+            let Some(Binding::Lit {
+                val: FlakeValue::Long(n),
+                ..
+            }) = batch.get(row, tag)
+            else {
+                panic!("missing tag")
+            };
+            tags.push(*n);
+        }
+    }
+    op.close();
+    tags
+}
+
+async fn check_fallback_rows(view: &fluree_db_api::GraphDb) {
+    use fluree_db_query::binding::Binding;
+    let a = Binding::Iri("http://example.org/ns/A".into());
+    assert_eq!(
+        run_direct_batches(
+            view,
+            vec![vec![
+                (10, a.clone(), 100, 160),
+                (20, a, 160, 170),
+                (30, Binding::Unbound, 149, 151),
+                (40, Binding::Unbound, -999, -998),
+                (50, Binding::Poisoned, 100, 160),
+                (
+                    60,
+                    Binding::Iri("http://example.org/ns/missing".into()),
+                    100,
+                    160
+                ),
+            ]]
+        )
+        .await,
+        vec![10, 30],
+        "fallback keeps row identity and unbound-subject semantics"
+    );
+}
+
+async fn check_growing_envelopes(view: &fluree_db_api::GraphDb, events: &span_capture::SpanStore) {
+    use fluree_db_query::binding::Binding;
+    let s_id = view
+        .binary_store()
+        .unwrap()
+        .find_subject_id("http://example.org/ns/A")
+        .unwrap()
+        .unwrap();
+    let a = Binding::EncodedSid {
+        s_id,
+        t: None,
+        op: None,
+    };
+    let before = events
+        .find_events("range semijoin index built by POST walk")
+        .len();
+    assert_eq!(
+        run_direct_batches(
+            view,
+            (1..=10)
+                .map(|i| vec![(i, a.clone(), 0, i * 20); 1000])
+                .collect()
+        )
+        .await,
+        (8..=10)
+            .flat_map(|i| std::iter::repeat_n(i, 1000))
+            .collect::<Vec<_>>()
+    );
+    let walks = events
+        .find_events("range semijoin index built by POST walk")
+        .len()
+        - before;
+    assert_eq!(
+        walks, 4,
+        "drifting bounds have bounded rebuild work; later batches use probes"
     );
 }

--- a/fluree-db-query/src/distinct.rs
+++ b/fluree-db-query/src/distinct.rs
@@ -6,12 +6,13 @@
 use crate::binding::{Batch, Binding};
 use crate::context::ExecutionContext;
 use crate::error::Result;
-use crate::object_binding::{equality_norm, normalize_for_key, EqualityNorm};
+use crate::object_binding::{equality_norm, normalize_for_key_cow, EqualityNorm};
 use crate::operator::{BoxedOperator, Operator, OperatorState};
 use crate::var_registry::VarId;
 use async_trait::async_trait;
 use hashbrown::HashMap;
 use rustc_hash::{FxBuildHasher, FxHasher};
+use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -174,24 +175,32 @@ impl Operator for DistinctOperator {
             }
 
             let mut columns: Vec<Vec<Binding>> = (0..num_cols).map(|_| Vec::new()).collect();
+            // Reused across rows: a duplicate row costs a hash and a probe, no
+            // allocation; only rows that survive are copied into an owned key.
+            let mut scratch: Vec<Cow<'_, Binding>> = Vec::with_capacity(num_cols);
 
             for row_idx in 0..batch.len() {
                 if self.norm.is_some() {
                     let (store, gv) = EqualityNorm::parts(&self.norm);
                     // Normalize decoded bindings to encoded form so mixed
                     // representations of the same value dedup (encoded
-                    // bindings pass through untouched).
-                    let signature: RowSignature = (0..num_cols)
-                        .map(|col| normalize_for_key(batch.get_by_col(row_idx, col), store, gv))
-                        .collect();
+                    // bindings pass through untouched, borrowed).
+                    scratch.clear();
+                    scratch.extend((0..num_cols).map(|col| {
+                        normalize_for_key_cow(batch.get_by_col(row_idx, col), store, gv)
+                    }));
+                    // `Cow` hashes as the binding it wraps, so this equals the
+                    // stored `Vec<Binding>` hash the map recomputes on rehash.
                     let mut h = FxHasher::default();
-                    signature.hash(&mut h);
+                    scratch.hash(&mut h);
                     let hash = h.finish();
-                    let entry = self
-                        .seen
-                        .raw_entry_mut()
-                        .from_hash(hash, |sig| *sig == signature);
+                    let entry = self.seen.raw_entry_mut().from_hash(hash, |sig| {
+                        sig.len() == scratch.len()
+                            && sig.iter().zip(&scratch).all(|(a, b)| a == b.as_ref())
+                    });
                     if let hashbrown::hash_map::RawEntryMut::Vacant(v) = entry {
+                        let signature: RowSignature =
+                            scratch.iter().map(|b| b.as_ref().clone()).collect();
                         v.insert_hashed_nocheck(hash, signature, ());
                         for (col_idx, col) in columns.iter_mut().enumerate() {
                             col.push(batch.get_by_col(row_idx, col_idx).clone());

--- a/fluree-db-query/src/distinct.rs
+++ b/fluree-db-query/src/distinct.rs
@@ -59,6 +59,11 @@ impl DistinctOperator {
         }
     }
 
+    /// Recover the child when a runtime-only dedup wrapper is closed.
+    pub(crate) fn into_child(self) -> BoxedOperator {
+        self.child
+    }
+
     /// Get the number of unique rows seen so far
     pub fn unique_count(&self) -> usize {
         self.seen.len()

--- a/fluree-db-query/src/eval/compare.rs
+++ b/fluree-db-query/src/eval/compare.rs
@@ -38,7 +38,7 @@ pub(super) enum FastEqOutcome {
     OtherUnbound,
 }
 
-fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
+pub(crate) fn fast_eq_ne_for_iri_bindings<R: RowAccess>(
     op: CompareOp,
     args: &[Expression],
     row: &R,

--- a/fluree-db-query/src/eval/helpers.rs
+++ b/fluree-db-query/src/eval/helpers.rs
@@ -6,7 +6,7 @@ use crate::binding::{Binding, RowAccess};
 use crate::context::ExecutionContext;
 use crate::context::WellKnownDatatypes;
 use crate::error::{QueryError, Result};
-use crate::ir::{Expression, Function};
+use crate::ir::{CompareOp, Expression, Function};
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, TimeZone};
 use fluree_db_core::temporal::CalendarField;
 use fluree_db_core::{FlakeValue, ObjKind};
@@ -64,6 +64,13 @@ struct CacheableBoolPredicate {
 pub struct PreparedBoolExpression {
     expr: Expression,
     cache_spec: Option<CacheableBoolPredicate>,
+    /// `?var = <const>` / `!=`: `compare::fast_eq_ne_for_iri_bindings` answers
+    /// this shape with a memoized constant resolution and a `u64` compare,
+    /// which is cheaper than probing the encoded-bool-predicate cache — over
+    /// ~4k distinct products BSBM Q5's `FILTER(<product> != ?product)` spent
+    /// more time thrashing the 256-entry LRU than comparing. Tried first; rows
+    /// it cannot decide still go through the cache.
+    iri_eq_op: Option<CompareOp>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -165,7 +172,12 @@ pub fn build_regex_with_flags(pattern: &str, flags: &str) -> Result<Regex> {
 impl PreparedBoolExpression {
     pub fn new(expr: Expression) -> Self {
         let cache_spec = analyze_cacheable_bool_predicate(&expr);
-        Self { expr, cache_spec }
+        let iri_eq_op = cache_spec.and(var_const_eq_shape(&expr));
+        Self {
+            expr,
+            cache_spec,
+            iri_eq_op,
+        }
     }
 
     pub fn expr(&self) -> &Expression {
@@ -181,6 +193,11 @@ impl PreparedBoolExpression {
         row: &R,
         ctx: Option<&ExecutionContext<'_>>,
     ) -> Result<bool> {
+        if let (Some(op), Expression::Call { args, .. }) = (self.iri_eq_op, &self.expr) {
+            if let Some(pass) = super::compare::fast_eq_ne_for_iri_bindings(op, args, row, ctx)? {
+                return Ok(pass);
+            }
+        }
         if let Some(pass) =
             eval_cached_bool_predicate_with_spec(self.cache_spec.as_ref(), row, ctx, || {
                 self.expr.eval_to_bool_uncached(row, ctx)
@@ -253,6 +270,27 @@ fn eval_cached_bool_predicate_with_spec<R: RowAccess>(
         cache.borrow_mut().put(cache_key, pass);
     });
     Ok(Some(pass))
+}
+
+/// `Eq`/`Ne` between one variable and one variable-free operand — the shape
+/// [`super::compare::fast_eq_ne_for_iri_bindings`] decides for a
+/// resource-valued binding without materializing anything.
+fn var_const_eq_shape(expr: &Expression) -> Option<CompareOp> {
+    let Expression::Call { func, args } = expr else {
+        return None;
+    };
+    let op = match func {
+        Function::Eq => CompareOp::Eq,
+        Function::Ne => CompareOp::Ne,
+        _ => return None,
+    };
+    if args.len() != 2 {
+        return None;
+    }
+    let is_var = |e: &Expression| matches!(e, Expression::Var(_));
+    let is_const = |e: &Expression| !is_var(e) && e.referenced_vars().is_empty();
+    ((is_var(&args[0]) && is_const(&args[1])) || (is_const(&args[0]) && is_var(&args[1])))
+        .then_some(op)
 }
 
 /// Cheap, hash-free variable-usage walk used to pre-filter cacheable predicates.

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -20,7 +20,7 @@ use crate::exists::ExistsOperator;
 use crate::filter::{contains_exists, FilterOperator};
 use crate::hash_join::HashJoinPlanner;
 use crate::ir::triple::{Ref, Term, TriplePattern};
-use crate::ir::{Expression, Pattern};
+use crate::ir::{CompareOp, Expression, Function, Pattern};
 use crate::join::NestedLoopJoinOperator;
 use crate::minus::MinusOperator;
 use crate::operator::inline::InlineOperator;
@@ -29,6 +29,7 @@ use crate::optional::{GroupedPatternOptionalBuilder, OptionalOperator, PlanTreeO
 use crate::planner::{analyze_property_join, is_property_join, reorder_patterns};
 use crate::property_join::PropertyJoinOperator;
 use crate::property_path::PropertyPathOperator;
+use crate::range_semijoin::{RangeSemiJoinCondition, RangeSemiJoinOperator};
 use crate::seed::EmptyOperator;
 use crate::semijoin::SemijoinOperator;
 use crate::subquery::SubqueryOperator;
@@ -1520,11 +1521,46 @@ fn build_sequential_join_block(
     // not 1 — otherwise a large object predicate falsely trips scan-ratio-too-high.
     let mut hash_planner = HashJoinPlanner::new(ctx.stats)
         .with_left_estimate(operator.as_ref().and_then(|o| o.estimated_rows()));
+    let mut dead_before_step = 0usize;
+    let mut folded = vec![false; triples.len()];
     for (k, tp) in triples.iter().enumerate() {
+        if folded[k] {
+            continue;
+        }
         hash_planner.before_step(tp, &bound);
         let mut vars_after: HashSet<VarId> = bound.clone();
         for v in tp.produced_vars() {
             vars_after.insert(v);
+        }
+
+        // Later `?s <p> ?v . FILTER(range on ?v)` pairs answered as a semi-join
+        // behind this step — see `RangeSemiJoinOperator`.
+        let folds = match base_vars.as_ref() {
+            Some(base) => collect_range_semijoin_folds(
+                tp,
+                k,
+                triples,
+                &folded,
+                &bound,
+                &vars_after,
+                base,
+                &pending_binds,
+                &pending_filters,
+                &pushdown.consumed_indices,
+                ctx,
+                hash_planner.step_est(),
+            ),
+            None => Vec::new(),
+        };
+        for fold in &folds {
+            folded[fold.triple_idx] = true;
+        }
+        if !folds.is_empty() {
+            pending_filters.retain(|f| {
+                !folds
+                    .iter()
+                    .any(|x| x.filter_original_idx == f.original_idx)
+            });
         }
 
         // Build interleaved inline operators: eligible filters first, then binds
@@ -1547,7 +1583,9 @@ fn build_sequential_join_block(
             live.extend(
                 triples[k + 1..]
                     .iter()
-                    .flat_map(crate::ir::triple::TriplePattern::referenced_vars),
+                    .zip(&folded[k + 1..])
+                    .filter(|(_, folded)| !**folded)
+                    .flat_map(|(t, _)| t.referenced_vars()),
             );
             live.extend(
                 pending_filters
@@ -1571,18 +1609,45 @@ fn build_sequential_join_block(
             None
         };
 
+        // The join must still carry the folded filters' operands for the
+        // semi-join's re-check; the semi-join then trims them away.
+        let join_live: Option<Vec<VarId>> = live_vars.as_ref().map(|live| {
+            let mut vars = live.clone();
+            for fold in &folds {
+                for v in fold.condition.filter.referenced_vars() {
+                    if v != fold.condition.value_var && !vars.contains(&v) {
+                        vars.push(v);
+                    }
+                }
+            }
+            vars
+        });
+
         let emit = emit_mask_for_triple(tp, ctx.var_counts, ctx.protected_vars);
         let op = build_scan_or_join(
             operator,
             tp,
             &pushdown.object_bounds,
             inline_ops,
-            live_vars.as_deref(),
+            join_live.as_deref(),
             emit,
             ctx.group_by,
             ctx.planning,
             &hash_planner,
         );
+        let op: BoxedOperator = if folds.is_empty() {
+            op
+        } else {
+            let subject_var = folds[0].subject_var;
+            let conditions = folds.into_iter().map(|f| f.condition).collect();
+            Box::new(RangeSemiJoinOperator::new(
+                op,
+                subject_var,
+                conditions,
+                live_vars.as_deref(),
+                *ctx.planning,
+            ))
+        };
         bound.extend(op.schema().iter().copied());
         operator = Some(op);
 
@@ -1597,12 +1662,15 @@ fn build_sequential_join_block(
             );
             pending_binds = new_binds;
             pending_filters = new_filters;
-            operator =
-                if ctx.where_dedup_safe && pruned_vars.as_ref().is_some_and(|s| !s.is_empty()) {
-                    Some(Box::new(DistinctOperator::new(child)))
-                } else {
-                    Some(child)
-                };
+            let dead_after_step = pruned_vars.as_ref().map_or(0, HashSet::len);
+            operator = if ctx.where_dedup_safe
+                && early_dedup_needed(dead_before_step, dead_after_step, ctx.planning)
+            {
+                Some(Box::new(DistinctOperator::new(child)))
+            } else {
+                Some(child)
+            };
+            dead_before_step = dead_before_step.max(dead_after_step);
         }
     }
 
@@ -3136,6 +3204,7 @@ fn build_sequential_triple_chain(
     let mut seen_vars: HashSet<VarId> = bound_vars_from_operator(&operator);
     let mut hash_planner = HashJoinPlanner::new(ctx.stats)
         .with_left_estimate(operator.as_ref().and_then(|o| o.estimated_rows()));
+    let mut dead_before_step = 0usize;
     for (k, pattern) in triples.iter().enumerate() {
         hash_planner.before_step(pattern, &seen_vars);
         seen_vars.extend(pattern.produced_vars());
@@ -3162,8 +3231,8 @@ fn build_sequential_triple_chain(
         ));
 
         // Early dedup (sound because downstream is multiplicity-insensitive —
-        // see `where_dedup_safe`): if any variables seen so far are no longer
-        // live, collapse duplicates early to avoid downstream join blowups.
+        // see `where_dedup_safe`) where this step trimmed a variable that was
+        // still live before it — see `early_dedup_needed`.
         if ctx.where_dedup_safe {
             if let Some(live) = live_vars.as_ref() {
                 let live_set: HashSet<VarId> = live.iter().copied().collect();
@@ -3172,16 +3241,218 @@ fn build_sequential_triple_chain(
                     .copied()
                     .filter(|v| !live_set.contains(v))
                     .count();
-                if dead > 0 {
+                if early_dedup_needed(dead_before_step, dead, ctx.planning) {
                     if let Some(op) = operator.take() {
                         operator = Some(Box::new(DistinctOperator::new(op)));
                     }
                 }
+                dead_before_step = dead_before_step.max(dead);
             }
         }
     }
 
     Ok(operator.unwrap())
+}
+
+/// Whether a join step that leaves `dead_after` variables trimmed (`dead_before`
+/// of them by earlier steps) needs a `DistinctOperator` behind it.
+///
+/// Dead variables only accumulate, so `dead_after > dead_before` means this
+/// step dropped a variable that still distinguished rows — the only way a
+/// current-state step can introduce duplicates, since a step that keeps every
+/// variable it produces extends distinct input rows to distinct output rows
+/// (each fact is unique in the index). Re-deduplicating behind every later
+/// step re-hashed the whole intermediate for nothing (BSBM Q5's `rdfs:label`
+/// probe over its already-deduplicated candidates).
+///
+/// History mode keeps the cumulative rule: a ground step there can match once
+/// per `(t, op)` version, which `Binding` equality ignores.
+fn early_dedup_needed(dead_before: usize, dead_after: usize, planning: &PlanningContext) -> bool {
+    if planning.is_history() {
+        dead_after > 0
+    } else {
+        dead_after > dead_before
+    }
+}
+
+/// A later `?s <p> ?v . FILTER(range on ?v)` pair folded into a
+/// [`RangeSemiJoinOperator`] behind the step that binds `?s`.
+struct RangeSemiJoinFold {
+    triple_idx: usize,
+    filter_original_idx: usize,
+    subject_var: VarId,
+    condition: RangeSemiJoinCondition,
+}
+
+/// Below this many estimated driving rows the per-row probes stay cheaper
+/// than one walk of the predicate's range (as `MEMBERSHIP_JOIN_MIN_DRIVING`).
+const RANGE_SEMIJOIN_MIN_DRIVING: f64 = 256.0;
+
+/// Find the probes after step `k` that can be answered as a range semi-join
+/// behind it: `?s <p> ?v` where `?s` is bound by this step, `?v` is new and
+/// used by exactly one pending FILTER that is a range over `?v` with bounds
+/// computable from variables bound after this step, and nothing else reads
+/// `?v` (so the semi-join's keep/drop equals probe+filter+early-dedup under
+/// `where_dedup_safe`). Every fold shares one subject variable.
+#[allow(clippy::too_many_arguments)]
+fn collect_range_semijoin_folds(
+    step_tp: &TriplePattern,
+    k: usize,
+    triples: &[TriplePattern],
+    folded: &[bool],
+    bound_before: &HashSet<VarId>,
+    vars_after: &HashSet<VarId>,
+    base_vars: &HashSet<VarId>,
+    pending_binds: &[BindPattern],
+    pending_filters: &[FilterPattern],
+    pushdown_consumed: &[usize],
+    ctx: &TriplePlanContext<'_>,
+    driving_est: Option<f64>,
+) -> Vec<RangeSemiJoinFold> {
+    if !ctx.where_dedup_safe || ctx.planning.is_history() {
+        return Vec::new();
+    }
+    if super::fast_paths_disabled() {
+        crate::fast_path_outcome::stamp_fast_path(
+            crate::range_semijoin::RANGE_SEMIJOIN_SITE,
+            crate::fast_path_outcome::FastPathOutcome::Fallback(
+                crate::fast_path_outcome::FastPathFallback::KillSwitch,
+            ),
+        );
+        return Vec::new();
+    }
+    let produced: HashSet<VarId> = step_tp.produced_vars().into_iter().collect();
+    if produced.is_empty() {
+        return Vec::new();
+    }
+    if let (Some(est), Some(stats)) = (driving_est, ctx.stats) {
+        let step_out_est =
+            est * crate::planner::estimate_triple_row_count(step_tp, bound_before, Some(stats));
+        if step_out_est < RANGE_SEMIJOIN_MIN_DRIVING {
+            return Vec::new();
+        }
+    }
+    let mut folds: Vec<RangeSemiJoinFold> = Vec::new();
+    let mut subject: Option<VarId> = None;
+    for (j, tj) in triples.iter().enumerate().skip(k + 1) {
+        if folded[j] || tj.dtc.is_some() || !tj.p_bound() {
+            continue;
+        }
+        let (Ref::Var(s), Term::Var(v)) = (&tj.s, &tj.o) else {
+            continue;
+        };
+        if !produced.contains(s)
+            || subject.is_some_and(|chosen| chosen != *s)
+            || vars_after.contains(v)
+            || base_vars.contains(v)
+        {
+            continue;
+        }
+        let read_elsewhere = triples
+            .iter()
+            .enumerate()
+            .any(|(i, t)| i != j && t.referenced_vars().contains(v))
+            || pending_binds
+                .iter()
+                .any(|b| b.var == *v || b.expr.referenced_vars().contains(v));
+        if read_elsewhere {
+            continue;
+        }
+        let mut readers = pending_filters.iter().filter(|f| {
+            !pushdown_consumed.contains(&f.original_idx) && f.expr.referenced_vars().contains(v)
+        });
+        let (Some(filter), None) = (readers.next(), readers.next()) else {
+            continue;
+        };
+        if !filter
+            .expr
+            .referenced_vars()
+            .iter()
+            .all(|x| x == v || vars_after.contains(x))
+        {
+            continue;
+        }
+        let Some((lower, upper)) = extract_correlated_range(&filter.expr, *v) else {
+            continue;
+        };
+        subject = Some(*s);
+        folds.push(RangeSemiJoinFold {
+            triple_idx: j,
+            filter_original_idx: filter.original_idx,
+            subject_var: *s,
+            condition: RangeSemiJoinCondition {
+                predicate: tj.p.clone(),
+                value_var: *v,
+                lower,
+                upper,
+                filter: filter.expr.clone(),
+            },
+        });
+    }
+    folds
+}
+
+type CorrelatedBound = Option<(Expression, bool)>;
+
+/// `expr` as a range over `v` — an AND of comparisons each between `v` and an
+/// expression not mentioning `v` — oriented as `v op bound`, at most one bound
+/// per side. Anything else (OR, NOT, a conjunct not about `v`, a chained
+/// comparison) is not a range and returns `None`.
+fn extract_correlated_range(
+    expr: &Expression,
+    v: VarId,
+) -> Option<(CorrelatedBound, CorrelatedBound)> {
+    let Expression::Call { func, args } = expr else {
+        return None;
+    };
+    match func {
+        Function::And => {
+            let mut lower: CorrelatedBound = None;
+            let mut upper: CorrelatedBound = None;
+            for arg in args {
+                let (lo, hi) = extract_correlated_range(arg, v)?;
+                if let Some(lo) = lo {
+                    if lower.replace(lo).is_some() {
+                        return None;
+                    }
+                }
+                if let Some(hi) = hi {
+                    if upper.replace(hi).is_some() {
+                        return None;
+                    }
+                }
+            }
+            (lower.is_some() || upper.is_some()).then_some((lower, upper))
+        }
+        Function::Lt | Function::Le | Function::Gt | Function::Ge | Function::Eq => {
+            if args.len() != 2 {
+                return None;
+            }
+            let (var_on_left, other) = match (&args[0], &args[1]) {
+                (Expression::Var(a), other) if *a == v => (true, other),
+                (other, Expression::Var(b)) if *b == v => (false, other),
+                _ => return None,
+            };
+            if other.referenced_vars().contains(&v) {
+                return None;
+            }
+            let op = match (func, var_on_left) {
+                (Function::Lt, true) | (Function::Gt, false) => CompareOp::Lt,
+                (Function::Le, true) | (Function::Ge, false) => CompareOp::Le,
+                (Function::Gt, true) | (Function::Lt, false) => CompareOp::Gt,
+                (Function::Ge, true) | (Function::Le, false) => CompareOp::Ge,
+                _ => CompareOp::Eq,
+            };
+            let inclusive = matches!(op, CompareOp::Le | CompareOp::Ge | CompareOp::Eq);
+            let bound = (other.clone(), inclusive);
+            Some(match op {
+                CompareOp::Lt | CompareOp::Le => (None, Some(bound)),
+                CompareOp::Gt | CompareOp::Ge => (Some(bound), None),
+                _ => (Some(bound.clone()), Some(bound)),
+            })
+        }
+        _ => None,
+    }
 }
 
 /// Build operators for a sequence of triple patterns

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1547,6 +1547,7 @@ fn build_sequential_join_block(
                 &pending_binds,
                 &pending_filters,
                 &pushdown.consumed_indices,
+                &pushdown.object_bounds,
                 ctx,
                 hash_planner.step_est(),
             ),
@@ -3306,6 +3307,7 @@ fn collect_range_semijoin_folds(
     pending_binds: &[BindPattern],
     pending_filters: &[FilterPattern],
     pushdown_consumed: &[usize],
+    pushdown_bounds: &HashMap<VarId, ObjectBounds>,
     ctx: &TriplePlanContext<'_>,
     driving_est: Option<f64>,
 ) -> Vec<RangeSemiJoinFold> {
@@ -3355,7 +3357,9 @@ fn collect_range_semijoin_folds(
             || pending_binds
                 .iter()
                 .any(|b| b.var == *v || b.expr.referenced_vars().contains(v));
-        if read_elsewhere {
+        // Consumed constant filters are enforced by the scan/join we would
+        // remove. Keep that probe unless its bounds are carried by the fold.
+        if read_elsewhere || pushdown_bounds.contains_key(v) {
             continue;
         }
         let mut readers = pending_filters.iter().filter(|f| {

--- a/fluree-db-query/src/join.rs
+++ b/fluree-db-query/src/join.rs
@@ -50,15 +50,15 @@ const ADAPTIVE_FLUSH_GROWTH: usize = 8;
 /// leaf blob, decoded header/dir, the leaf-id hash, and the optional
 /// sidecar bytes — the leaflet loop body destructures this and proceeds
 /// without repeating the fetch+decode dance at each site.
-struct LeafScan {
-    leaf_bytes: fluree_db_binary_index::SharedLeafBytes,
-    header: fluree_db_binary_index::format::leaf::LeafHeaderV3,
-    dir: fluree_db_binary_index::format::leaf::DecodedLeafDirV3,
-    leaf_id: u128,
+pub(crate) struct LeafScan {
+    pub(crate) leaf_bytes: fluree_db_binary_index::SharedLeafBytes,
+    pub(crate) header: fluree_db_binary_index::format::leaf::LeafHeaderV3,
+    pub(crate) dir: fluree_db_binary_index::format::leaf::DecodedLeafDirV3,
+    pub(crate) leaf_id: u128,
     /// Sidecar bytes for time-travel replay. `None` at `max_t` (the base
     /// leaflet alone is authoritative); always fetched when `need_replay`
     /// is true so `replay_leaflet_at_t` can reconstruct historical state.
-    sidecar_bytes: Option<Vec<u8>>,
+    pub(crate) sidecar_bytes: Option<Vec<u8>>,
 }
 
 /// Read-only view of a single joined row — a stored left-batch row plus the
@@ -130,7 +130,7 @@ fn apply_inline_filters_view<R: RowAccess>(
     Ok(true)
 }
 
-fn prepare_leaf_for_scan(
+pub(crate) fn prepare_leaf_for_scan(
     store: &BinaryIndexStore,
     leaf_entry: &fluree_db_binary_index::format::branch::LeafEntry,
     need_replay: bool,

--- a/fluree-db-query/src/lib.rs
+++ b/fluree-db-query/src/lib.rs
@@ -85,6 +85,7 @@ pub mod project;
 pub mod property_join;
 pub mod property_path;
 pub mod r2rml;
+pub mod range_semijoin;
 pub mod reasoning;
 pub mod remote_service;
 pub mod rewrite;

--- a/fluree-db-query/src/object_binding.rs
+++ b/fluree-db-query/src/object_binding.rs
@@ -353,13 +353,25 @@ pub(crate) fn equality_norm(ctx: &crate::context::ExecutionContext<'_>) -> Optio
     })
 }
 
-/// Normalize one binding for use in an equality/hash key (no-op clone-free
-/// path for already-encoded bindings).
+/// Normalize one binding for use in an equality/hash key.
 pub(crate) fn normalize_for_key(
     binding: &Binding,
     store: Option<&BinaryIndexStore>,
     gv: Option<&fluree_db_binary_index::BinaryGraphView>,
 ) -> Binding {
+    normalize_for_key_cow(binding, store, gv).into_owned()
+}
+
+/// [`normalize_for_key`] without the clone: an already-encoded binding (the
+/// common case on the indexed scan path) is returned borrowed, so a hot
+/// equality surface such as `DISTINCT` can hash and probe a row without
+/// copying it and only materializes the key for rows it actually keeps.
+pub(crate) fn normalize_for_key_cow<'a>(
+    binding: &'a Binding,
+    store: Option<&BinaryIndexStore>,
+    gv: Option<&fluree_db_binary_index::BinaryGraphView>,
+) -> std::borrow::Cow<'a, Binding> {
+    use std::borrow::Cow;
     // Arena-keyed NUM_BIG values normalize by DECODING: handles are scoped
     // per (graph, predicate), so the encoded form is not a canonical key for
     // one value across predicates or against decoded rows (VALUES, BIND,
@@ -369,14 +381,15 @@ pub(crate) fn normalize_for_key(
         if let Some(gv) = gv {
             let materialized = crate::group_aggregate::materialize_encoded(binding, Some(gv));
             if !matches!(materialized, Binding::EncodedLit { .. }) {
-                return materialized;
+                return Cow::Owned(materialized);
             }
         }
-        return binding.clone();
+        return Cow::Borrowed(binding);
     }
-    store
-        .and_then(|s| encoded_equivalent(binding, s))
-        .unwrap_or_else(|| binding.clone())
+    match store.and_then(|s| encoded_equivalent(binding, s)) {
+        Some(encoded) => Cow::Owned(encoded),
+        None => Cow::Borrowed(binding),
+    }
 }
 
 /// True if this is an arena-backed (NUM_BIG) encoded literal.

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -1850,6 +1850,7 @@ pub fn reorder_patterns(
             stats,
             &mut result,
             &seed_anchor_vars,
+            &deferred,
             &mut placed_indices,
         ) || try_place_expander(
             &mut expanders,
@@ -2084,11 +2085,15 @@ fn demote_disconnected_class_anchors(
 ///      search source emits its result IDs/IriMatch bindings before plain
 ///      triples consume them;
 ///   2. **estimated cardinality** — the primary signal;
-///   3. **unlocked object→subject hash scan** — among EQUAL-cardinality starts
+///   3. **unlocked deferred FILTER** — among EQUAL-cardinality starts only,
+///      prefer the one whose new variables let a still-pending FILTER run (see
+///      [`unlocks_deferred_filter`]): a filter can only drop rows, so it shrinks
+///      the stream every later probe has to pay for;
+///   4. **unlocked object→subject hash scan** — among EQUAL-cardinality starts
 ///      only, prefer the one that keeps the LARGER predicate hash-able rather
 ///      than forward-joining over a big intermediate (the BSBM-BI bowtie: 46× on
 ///      BI-1's F2);
-///   4. **original position** — stable final tie-break.
+///   5. **original position** — stable final tie-break.
 fn rank_seed_candidates(
     i: usize,
     j: usize,
@@ -2096,6 +2101,7 @@ fn rank_seed_candidates(
     bound_vars: &HashSet<VarId>,
     stats: Option<&StatsView>,
     has_bound: bool,
+    deferred: &[DeferredPattern],
 ) -> std::cmp::Ordering {
     let search_priority = |pattern: &Pattern| match pattern {
         Pattern::IndexSearch(_)
@@ -2120,14 +2126,115 @@ fn rank_seed_candidates(
                 .partial_cmp(&cj.row_count())
                 .unwrap_or(std::cmp::Ordering::Equal)
         })
-        // 3. Equal-cardinality only: keep the larger predicate hash-able.
+        // 3. Equal-cardinality only: let a pending FILTER run as early as possible.
+        .then_with(|| {
+            let fi = unlocks_deferred_filter(&remaining[i], bound_vars, deferred);
+            let fj = unlocks_deferred_filter(&remaining[j], bound_vars, deferred);
+            fj.cmp(&fi)
+        })
+        // 4. Equal-cardinality only: keep the larger predicate hash-able.
         .then_with(|| {
             let bi = unlocked_object_hash_scan(i, remaining, bound_vars, stats);
             let bj = unlocked_object_hash_scan(j, remaining, bound_vars, stats);
             bj.cmp(&bi)
         })
-        // 4. Stable: original position.
+        // 5. Stable: original position.
         .then_with(|| remaining[i].orig_index.cmp(&remaining[j].orig_index))
+}
+
+/// Tie-break signal for join ordering: would placing `candidate` make a
+/// still-deferred FILTER that *pins* one of its new variables ready to run?
+///
+/// Among candidates the cost model cannot separate, the one whose new
+/// variable feeds an equality or a two-sided range filter shrinks the stream
+/// before the remaining probes pay for it. BSBM Explore Q5: the candidate
+/// product's three bound-subject probes all estimate ~1 row, but two of them
+/// feed `±k` windows that discard ~97% of candidates; original position put
+/// the unfiltered `rdfs:label` probe first, so every candidate paid for a label
+/// lookup the filters then threw away (~25% of the query at 10M products).
+///
+/// Only pinning filters qualify (see [`filter_pins_var`]). A one-sided bound
+/// is not a reliable reducer: BSBM Q7's `?date > now` keeps half the offers,
+/// and hoisting its probe ahead of `?offer :vendor ?vendor` delayed the
+/// selective `?vendor :country <DE>` existence check behind it — measured +15%
+/// on Q7 at 100M. BIND, VALUES and the order-sensitive deferred forms never count, and
+/// `candidate` must contribute one of the filter's variables (a filter that
+/// is already ready was drained earlier).
+fn unlocks_deferred_filter(
+    candidate: &RankedPattern,
+    bound_vars: &HashSet<VarId>,
+    deferred: &[DeferredPattern],
+) -> bool {
+    let produced: HashSet<VarId> = candidate.pattern.produced_vars().into_iter().collect();
+    if produced.is_empty() {
+        return false;
+    }
+    deferred.iter().any(|dp| {
+        let Pattern::Filter(expr) = &dp.pattern else {
+            return false;
+        };
+        dp.required_vars
+            .iter()
+            .all(|v| produced.contains(v) || bound_vars.contains(v))
+            && produced
+                .iter()
+                .any(|v| dp.required_vars.contains(v) && filter_pins_var(expr, *v))
+    })
+}
+
+/// Does `expr` pin `v` to a point or a bounded interval — `?v = e`, `?v IN
+/// (...)`, or both a lower and an upper bound on `?v` across the conjuncts of
+/// an AND (a `(lo < ?v < hi)` sandwich included) — with every comparand free
+/// of `v`? One-sided bounds, negations and other predicates do not pin.
+fn filter_pins_var(expr: &Expression, v: VarId) -> bool {
+    fn visit(expr: &Expression, v: VarId, lower: &mut bool, upper: &mut bool, eq: &mut bool) {
+        let Expression::Call { func, args } = expr else {
+            return;
+        };
+        let is_v = |e: &Expression| matches!(e, Expression::Var(x) if *x == v);
+        let free_of_v = |e: &Expression| !e.referenced_vars().contains(&v);
+        match func {
+            Function::And => {
+                for arg in args {
+                    visit(arg, v, lower, upper, eq);
+                }
+            }
+            Function::In if args.first().is_some_and(is_v) && args[1..].iter().all(free_of_v) => {
+                *eq = true;
+            }
+            Function::Eq | Function::Lt | Function::Le | Function::Gt | Function::Ge => {
+                if args.len() == 3 && is_v(&args[1]) && free_of_v(&args[0]) && free_of_v(&args[2]) {
+                    match func {
+                        Function::Eq => *eq = true,
+                        _ => {
+                            *lower = true;
+                            *upper = true;
+                        }
+                    }
+                    return;
+                }
+                if args.len() != 2 {
+                    return;
+                }
+                let var_on_left = match (&args[0], &args[1]) {
+                    (a, other) if is_v(a) && free_of_v(other) => true,
+                    (other, b) if is_v(b) && free_of_v(other) => false,
+                    _ => return,
+                };
+                match (func, var_on_left) {
+                    (Function::Eq, _) => *eq = true,
+                    (Function::Lt | Function::Le, true) | (Function::Gt | Function::Ge, false) => {
+                        *upper = true;
+                    }
+                    _ => *lower = true,
+                }
+            }
+            _ => {}
+        }
+    }
+    let (mut lower, mut upper, mut eq) = (false, false, false);
+    visit(expr, v, &mut lower, &mut upper, &mut eq);
+    eq || (lower && upper)
 }
 
 /// A broad RDF-star annotation *sidecar* triple: `?ann f:reifiesSubject ?s` or
@@ -2192,6 +2299,7 @@ fn try_place_source(
     stats: Option<&StatsView>,
     result: &mut Vec<Pattern>,
     anchor_vars: &HashSet<VarId>,
+    deferred: &[DeferredPattern],
     placed: &mut HashSet<usize>,
 ) -> bool {
     if remaining.is_empty() {
@@ -2202,9 +2310,9 @@ fn try_place_source(
     let base_pool = connected_or_fallback_pool(remaining, bound_vars);
     let pool = demote_disconnected_class_anchors(base_pool, remaining, bound_vars, anchor_vars);
 
-    let best_idx = pool
-        .into_iter()
-        .min_by(|&i, &j| rank_seed_candidates(i, j, remaining, bound_vars, stats, has_bound));
+    let best_idx = pool.into_iter().min_by(|&i, &j| {
+        rank_seed_candidates(i, j, remaining, bound_vars, stats, has_bound, deferred)
+    });
 
     if let Some(idx) = best_idx {
         let rp = remaining.remove(idx);
@@ -2704,6 +2812,172 @@ mod tests {
             matches!(&ordered[1], Pattern::Triple(tp)
                 if matches!(&tp.p, Ref::Sid(sid) if sid.name.as_ref() == "signatureDblpName")),
             "v4.1.2 stats must reorder identically: {ordered:?}"
+        );
+    }
+
+    /// BSBM Explore Q5 after the shared-feature join: three bound-subject
+    /// probes on the candidate product all estimate ~1 row. The two whose
+    /// objects feed a pending range FILTER must run before the unfiltered
+    /// `label` probe, so the filter discards candidates before the label
+    /// lookup pays for them. Original position alone put `label` first.
+    #[test]
+    fn deferred_filter_breaks_bound_subject_probe_ties() {
+        let mut stats = StatsView::default();
+        for name in ["label", "numeric1", "numeric2"] {
+            stats.properties.insert(
+                Sid::new(100, name),
+                PropertyStatData {
+                    count: 10_000,
+                    ndv_values: 2_000,
+                    ndv_subjects: 10_000,
+                },
+            );
+        }
+        let product = VarId(0);
+        let window = |v: VarId, lo: i64, hi: i64| {
+            Expression::and(vec![
+                Expression::gt(Expression::Var(v), Expression::Const(FlakeValue::Long(lo))),
+                Expression::lt(Expression::Var(v), Expression::Const(FlakeValue::Long(hi))),
+            ])
+        };
+        let patterns = vec![
+            Pattern::Triple(make_pattern(product, "label", VarId(1))),
+            Pattern::Triple(make_pattern(product, "numeric1", VarId(2))),
+            Pattern::Filter(window(VarId(2), -120, 120)),
+            Pattern::Triple(make_pattern(product, "numeric2", VarId(3))),
+            Pattern::Filter(window(VarId(3), -170, 170)),
+        ];
+        let bound: HashSet<VarId> = [product].into_iter().collect();
+        let ordered = reorder_patterns(&patterns, Some(&stats), &bound);
+        let shape: Vec<String> = ordered
+            .iter()
+            .map(|p| match p {
+                Pattern::Triple(tp) => match &tp.p {
+                    Ref::Sid(sid) => sid.name.to_string(),
+                    _ => "?".to_string(),
+                },
+                Pattern::Filter(_) => "filter".to_string(),
+                _ => "?".to_string(),
+            })
+            .collect();
+        assert_eq!(
+            shape,
+            ["numeric1", "filter", "numeric2", "filter", "label"],
+            "filter-bearing probes go first among equal-cardinality candidates"
+        );
+    }
+
+    /// A one-sided bound does not pull its probe forward: BSBM Q7's
+    /// `?date > now` keeps half the offers, and hoisting `validTo` ahead of
+    /// the probe that unlocks the selective `?vendor :country <DE>` check cost
+    /// 15% on that query. Original position stands.
+    #[test]
+    fn one_sided_filter_keeps_original_probe_order() {
+        let mut stats = StatsView::default();
+        for name in ["price", "vendor", "validTo"] {
+            stats.properties.insert(
+                Sid::new(100, name),
+                PropertyStatData {
+                    count: 10_000,
+                    ndv_values: 2_000,
+                    ndv_subjects: 10_000,
+                },
+            );
+        }
+        let offer = VarId(0);
+        let patterns = vec![
+            Pattern::Triple(make_pattern(offer, "price", VarId(1))),
+            Pattern::Triple(make_pattern(offer, "vendor", VarId(2))),
+            Pattern::Triple(make_pattern(offer, "validTo", VarId(3))),
+            Pattern::Filter(Expression::gt(
+                Expression::Var(VarId(3)),
+                Expression::Const(FlakeValue::Long(20_080_620)),
+            )),
+        ];
+        let bound: HashSet<VarId> = [offer].into_iter().collect();
+        let ordered = reorder_patterns(&patterns, Some(&stats), &bound);
+        let first = match &ordered[0] {
+            Pattern::Triple(tp) => match &tp.p {
+                Ref::Sid(sid) => sid.name.to_string(),
+                _ => "?".to_string(),
+            },
+            _ => "?".to_string(),
+        };
+        assert_eq!(
+            first, "price",
+            "one-sided filter must not reorder: {ordered:?}"
+        );
+        assert!(filter_pins_var(
+            &Expression::and(vec![
+                Expression::gt(
+                    Expression::Var(VarId(3)),
+                    Expression::Const(FlakeValue::Long(1))
+                ),
+                Expression::lt(
+                    Expression::Var(VarId(3)),
+                    Expression::Const(FlakeValue::Long(9))
+                ),
+            ]),
+            VarId(3)
+        ));
+        assert!(filter_pins_var(
+            &Expression::eq(
+                Expression::Var(VarId(3)),
+                Expression::Const(FlakeValue::Long(1))
+            ),
+            VarId(3)
+        ));
+        assert!(!filter_pins_var(
+            &Expression::gt(
+                Expression::Var(VarId(3)),
+                Expression::Const(FlakeValue::Long(1))
+            ),
+            VarId(3)
+        ));
+    }
+
+    /// The FILTER tie-break is exactly that — a tie-break. A cheaper probe
+    /// still runs before a filtered but more expensive one.
+    #[test]
+    fn deferred_filter_tie_break_never_overrides_cardinality() {
+        let mut stats = StatsView::default();
+        stats.properties.insert(
+            Sid::new(100, "label"),
+            PropertyStatData {
+                count: 10_000,
+                ndv_values: 2_000,
+                ndv_subjects: 10_000,
+            },
+        );
+        stats.properties.insert(
+            Sid::new(100, "tag"),
+            PropertyStatData {
+                count: 50_000,
+                ndv_values: 2_000,
+                ndv_subjects: 10_000,
+            },
+        );
+        let product = VarId(0);
+        let patterns = vec![
+            Pattern::Triple(make_pattern(product, "tag", VarId(2))),
+            Pattern::Filter(Expression::and(vec![
+                Expression::gt(
+                    Expression::Var(VarId(2)),
+                    Expression::Const(FlakeValue::Long(0)),
+                ),
+                Expression::lt(
+                    Expression::Var(VarId(2)),
+                    Expression::Const(FlakeValue::Long(120)),
+                ),
+            ])),
+            Pattern::Triple(make_pattern(product, "label", VarId(1))),
+        ];
+        let bound: HashSet<VarId> = [product].into_iter().collect();
+        let ordered = reorder_patterns(&patterns, Some(&stats), &bound);
+        assert!(
+            matches!(&ordered[0], Pattern::Triple(tp)
+                if matches!(&tp.p, Ref::Sid(sid) if sid.name.as_ref() == "label")),
+            "the ~1-row probe must still run before the ~5-row filtered probe: {ordered:?}"
         );
     }
 

--- a/fluree-db-query/src/planner.rs
+++ b/fluree-db-query/src/planner.rs
@@ -2867,6 +2867,54 @@ mod tests {
         );
     }
 
+    /// Both tie-breaks can fire on the same pair. The filter wins only at
+    /// equal cardinality; absent the filter, the BI bowtie keeps its hash scan.
+    #[test]
+    fn pinned_filter_and_hash_scan_tie_break_precedence() {
+        let stats = stats_with(&[
+            ("vendor", 10_000, 10_000),
+            ("numeric", 10_000, 10_000),
+            ("reviewer", 100_000, 100_000),
+        ]);
+        let product = VarId(0);
+        let vendor = VarId(1);
+        let numeric = VarId(2);
+        let remaining = vec![
+            RankedPattern {
+                orig_index: 0,
+                pattern: Pattern::Triple(make_pattern(product, "vendor", vendor)),
+            },
+            RankedPattern {
+                orig_index: 1,
+                pattern: Pattern::Triple(make_pattern(product, "numeric", numeric)),
+            },
+            RankedPattern {
+                orig_index: 2,
+                pattern: Pattern::Triple(make_pattern(VarId(3), "reviewer", vendor)),
+            },
+        ];
+        let bound = HashSet::from([product]);
+        let deferred = vec![DeferredPattern {
+            orig_index: 3,
+            required_vars: HashSet::from([numeric]),
+            pattern: Pattern::Filter(Expression::eq(
+                Expression::Var(numeric),
+                Expression::Const(FlakeValue::Long(100)),
+            )),
+            nestable: false,
+            after_indices: Vec::new(),
+        }];
+        assert_eq!(
+            unlocked_object_hash_scan(0, &remaining, &bound, Some(&stats)),
+            100_000
+        );
+        assert!(unlocks_deferred_filter(&remaining[1], &bound, &deferred));
+        assert!(
+            rank_seed_candidates(0, 1, &remaining, &bound, Some(&stats), true, &deferred).is_gt()
+        );
+        assert!(rank_seed_candidates(0, 1, &remaining, &bound, Some(&stats), true, &[]).is_lt());
+    }
+
     /// A one-sided bound does not pull its probe forward: BSBM Q7's
     /// `?date > now` keeps half the offers, and hoisting `validTo` ahead of
     /// the probe that unlocks the selective `?vendor :country <DE>` check cost

--- a/fluree-db-query/src/range_semijoin.rs
+++ b/fluree-db-query/src/range_semijoin.rs
@@ -1,0 +1,1185 @@
+//! RangeSemiJoinOperator — keep/drop of a driving row by whether its subject
+//! carries a value of some predicate inside a FILTER range whose bounds are
+//! computed from the row itself.
+//!
+//! The shape it replaces is a probe followed by a correlated range filter on a
+//! variable nothing else needs:
+//!
+//! ```text
+//! ?product bsbm:productPropertyNumeric1 ?sim .
+//! FILTER (?sim < ?orig + 120 && ?sim > ?orig - 120)     # ?sim used nowhere else
+//! ```
+//!
+//! The generic chain probes the predicate once per driving row, materializes a
+//! row per value, evaluates the filter per row, and — because `?sim` is dead
+//! afterwards — deduplicates again. When the driving stream is large and the
+//! range is selective (BSBM Explore Q5: ~13% of all products are candidates, the
+//! range keeps ~12% of them) that is thousands of scattered probes and row
+//! copies to keep a handful of survivors.
+//!
+//! This operator instead reads the predicate's in-range values ONCE per range
+//! envelope — the union of the batch's per-row intervals, inclusive on both
+//! sides — into a map from subject to values, then answers each driving row
+//! with a hash lookup and an exact check of the row's own interval. The
+//! preferred build is an index-level walk of the predicate's POST leaflets
+//! (directory-key pruning, a binary search of the sorted key column, only the
+//! subject and key columns decoded, no bindings for rows outside the
+//! envelope). Whenever the walk cannot answer a batch — leaflets are not
+//! authoritative on their own (novelty overlay, time-travel, a dataset scope,
+//! a restricting policy), a bound is not numeric (the walk keys inline
+//! numerics only), or the envelope would cover too many rows for the driving
+//! stream — the batch is answered by the same batched subject probes the
+//! nested loop would have used, so the lane never costs more than the chain
+//! it replaced.
+//!
+//! Semantics: this is a SEMI-join — a row is kept at most once however many of
+//! its values pass. That equals the probe+filter chain only where downstream
+//! cannot observe row multiplicity (`where_dedup_safe`), which is the same
+//! license the WHERE-level early dedup relies on; the planner folds the probe
+//! only under it, and only when the value variable is dead after its filter.
+//! History mode is excluded at plan time (a ground probe matches once per
+//! version there).
+//!
+//! The per-row check is exact by construction: a range-shaped filter is the
+//! conjunction of its bounds, so a numeric value against the row's evaluated
+//! numeric bounds (with the filter's own strictness) IS the filter; a numeric
+//! value against a non-numeric bound is the type error the filter would raise
+//! (row dropped); anything non-numeric goes back through the original
+//! expression. A driving row whose subject is unbound is answered by an exact
+//! seeded evaluation of the original probe and filter, so a partially-ground
+//! row keeps join semantics.
+
+use crate::binding::{Batch, Binding, RowAccess};
+use crate::context::ExecutionContext;
+use crate::error::{QueryError, Result};
+use crate::eval::PreparedBoolExpression;
+use crate::execute::build_where_operators_seeded;
+use crate::fast_path_common::{
+    leaf_entries_for_predicate, root_or_no_policy, subject_probe_lane_plan, try_normalize_pred_sid,
+    ProbeLanePlan, ProbeOps,
+};
+use crate::group_aggregate::{binding_to_group_key_normalized, GroupKeyOwned};
+use crate::ir::triple::{Ref, Term, TriplePattern};
+use crate::ir::{Expression, Pattern};
+use crate::join::{
+    batched_subject_probe_binary, make_dict_overlay, prepare_leaf_for_scan, LeafScan,
+    SubjectProbeParams,
+};
+use crate::object_binding::{equality_norm, materialized_object_binding, EqualityNorm};
+use crate::operator::{BoxedOperator, Operator, OperatorState};
+use crate::seed::SeedOperator;
+use crate::temporal_mode::PlanningContext;
+use crate::var_registry::VarId;
+use async_trait::async_trait;
+use fluree_db_binary_index::format::column_block::ColumnId;
+use fluree_db_binary_index::format::run_record_v2::read_ordered_key_v2;
+use fluree_db_binary_index::read::column_loader::{
+    load_leaflet_columns, load_leaflet_columns_cached, LeafletDecodeSpec,
+};
+use fluree_db_binary_index::read::column_types::{ColumnData, ColumnProjection, ColumnSet};
+use fluree_db_binary_index::{BinaryIndexStore, ColumnBatch, RunSortOrder};
+use fluree_db_core::o_type::{DecodeKind, OType};
+use fluree_db_core::{FlakeValue, GraphId, ObjKey, ObjKind, ObjectBounds};
+use num_traits::ToPrimitive;
+use rustc_hash::FxHashMap;
+use std::cmp::Ordering;
+use std::sync::Arc;
+
+/// Routing-stamp site for this lane (see `fast_path_outcome`): `Proceed` when
+/// a batch was answered from a built index, `Fallback(GateDeclined)` when it
+/// was answered by probes instead (walk capped or declined, or a non-numeric
+/// bound).
+pub const RANGE_SEMIJOIN_SITE: &str = "range-semijoin";
+
+/// Rows the walk may collect for one envelope: at least this many, or
+/// [`WALK_ROWS_PER_DRIVING_ROW`] per driving row seen so far, whichever is
+/// larger. Beyond it the walk stops paying against per-row probes. The floor
+/// only matters for a small first batch and stays a fraction of one leaflet,
+/// so an inflated driving estimate (a statistics-less root) cannot buy a big
+/// walk for a query that a few probes would answer.
+const WALK_ROW_FLOOR: usize = 4_000;
+const WALK_ROWS_PER_DRIVING_ROW: usize = 16;
+
+fn walk_row_floor() -> usize {
+    static ENV: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *ENV.get_or_init(|| {
+        std::env::var("FLUREE_RANGE_SEMIJOIN_WALK_FLOOR")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(WALK_ROW_FLOOR)
+    })
+}
+
+/// One folded `?s <p> ?v . FILTER(range on ?v)` pair.
+#[derive(Clone, Debug)]
+pub struct RangeSemiJoinCondition {
+    /// The probe's fixed predicate.
+    pub predicate: Ref,
+    /// The probe's object variable — bound only while re-checking `filter`.
+    pub value_var: VarId,
+    /// `?v >[=] lower` — an expression over variables the driving row binds.
+    pub lower: Option<(Expression, bool)>,
+    /// `?v <[=] upper` — likewise.
+    pub upper: Option<(Expression, bool)>,
+    /// The original FILTER, re-evaluated for values the bounds cannot decide.
+    pub filter: Expression,
+}
+
+impl RangeSemiJoinCondition {
+    fn probe(&self, subject_var: VarId) -> TriplePattern {
+        TriplePattern::new(
+            Ref::Var(subject_var),
+            self.predicate.clone(),
+            Term::Var(self.value_var),
+        )
+    }
+
+    fn bound_vars(&self) -> Vec<VarId> {
+        let mut vars: Vec<VarId> = Vec::new();
+        for (expr, _) in self.lower.iter().chain(self.upper.iter()) {
+            for v in expr.referenced_vars() {
+                if !vars.contains(&v) {
+                    vars.push(v);
+                }
+            }
+        }
+        vars
+    }
+}
+
+/// Inclusive envelope of a batch's row intervals. `None` on a side means
+/// unbounded there (the condition has no bound on that side, or a row's bound
+/// was non-numeric so no key range can represent it).
+#[derive(Clone, Debug, Default)]
+struct Envelope {
+    lower: Option<FlakeValue>,
+    upper: Option<FlakeValue>,
+}
+
+impl Envelope {
+    fn covers(&self, other: &Envelope) -> bool {
+        let lower_ok = match (&self.lower, &other.lower) {
+            (None, _) => true,
+            (Some(_), None) => false,
+            (Some(a), Some(b)) => a.cmp(b) != Ordering::Greater,
+        };
+        let upper_ok = match (&self.upper, &other.upper) {
+            (None, _) => true,
+            (Some(_), None) => false,
+            (Some(a), Some(b)) => a.cmp(b) != Ordering::Less,
+        };
+        lower_ok && upper_ok
+    }
+
+    fn union(&self, other: &Envelope) -> Envelope {
+        Envelope {
+            lower: match (&self.lower, &other.lower) {
+                (Some(a), Some(b)) => Some(if a.cmp(b) == Ordering::Greater {
+                    b.clone()
+                } else {
+                    a.clone()
+                }),
+                _ => None,
+            },
+            upper: match (&self.upper, &other.upper) {
+                (Some(a), Some(b)) => Some(if a.cmp(b) == Ordering::Less {
+                    b.clone()
+                } else {
+                    a.clone()
+                }),
+                _ => None,
+            },
+        }
+    }
+}
+
+/// A value of the probed predicate as the semi-join keeps it: inline numerics
+/// stay raw so the row check is a comparison, anything else keeps its binding
+/// for the expression path.
+#[derive(Clone, Debug)]
+enum WalkValue {
+    Int(i64),
+    Float(f64),
+    Other(Binding),
+}
+
+impl WalkValue {
+    fn from_binding(binding: &Binding) -> Self {
+        match binding {
+            Binding::EncodedLit { o_kind, o_key, .. } if *o_kind == ObjKind::NUM_INT.as_u8() => {
+                WalkValue::Int(ObjKey::from_u64(*o_key).decode_i64())
+            }
+            Binding::EncodedLit { o_kind, o_key, .. } if *o_kind == ObjKind::NUM_F64.as_u8() => {
+                WalkValue::Float(ObjKey::from_u64(*o_key).decode_f64())
+            }
+            Binding::Lit {
+                val: FlakeValue::Long(n),
+                ..
+            } => WalkValue::Int(*n),
+            Binding::Lit {
+                val: FlakeValue::Double(d),
+                ..
+            } => WalkValue::Float(*d),
+            other => WalkValue::Other(other.clone()),
+        }
+    }
+
+    fn numeric(&self) -> Option<FlakeValue> {
+        match self {
+            WalkValue::Int(n) => Some(FlakeValue::Long(*n)),
+            WalkValue::Float(f) => Some(FlakeValue::Double(*f)),
+            WalkValue::Other(_) => None,
+        }
+    }
+}
+
+/// Values of one condition's predicate for a set of subjects, in one flat
+/// arena chained per subject (`head` → `next`), so building and dropping cost
+/// two allocations rather than one per subject.
+struct ValueIndex {
+    head: FxHashMap<GroupKeyOwned, u32>,
+    values: Vec<(WalkValue, u32)>,
+}
+
+const NO_NEXT: u32 = u32::MAX;
+
+impl ValueIndex {
+    fn with_capacity(rows: usize) -> Self {
+        Self {
+            head: FxHashMap::with_capacity_and_hasher(rows, Default::default()),
+            values: Vec::with_capacity(rows),
+        }
+    }
+
+    fn push(&mut self, key: GroupKeyOwned, value: WalkValue) {
+        let idx = self.values.len() as u32;
+        let next = self.head.insert(key, idx).unwrap_or(NO_NEXT);
+        self.values.push((value, next));
+    }
+
+    fn values_of(&self, key: &GroupKeyOwned) -> impl Iterator<Item = &WalkValue> {
+        let mut cursor = self.head.get(key).copied();
+        std::iter::from_fn(move || {
+            let idx = cursor?;
+            let (value, next) = &self.values[idx as usize];
+            cursor = (*next != NO_NEXT).then_some(*next);
+            Some(value)
+        })
+    }
+}
+
+/// The in-range values of one condition's predicate over a built envelope.
+struct RangeIndex {
+    envelope: Envelope,
+    values: ValueIndex,
+    rows: usize,
+}
+
+enum WalkOutcome {
+    Built(RangeIndex),
+    /// The envelope covers more rows than the driving stream justifies.
+    Capped,
+    /// Leaflets are not authoritative here (overlay, time-travel, dataset,
+    /// policy) or the predicate cannot be resolved.
+    Declined,
+}
+
+/// A driving row with one extra binding, for re-checking the folded FILTER.
+struct RowWithValue<'a> {
+    batch: &'a Batch,
+    row: usize,
+    value_var: VarId,
+    value: &'a Binding,
+}
+
+impl RowAccess for RowWithValue<'_> {
+    fn get(&self, var: VarId) -> Option<&Binding> {
+        if var == self.value_var {
+            Some(self.value)
+        } else {
+            self.batch.get(self.row, var)
+        }
+    }
+
+    fn for_each_binding(&self, f: &mut dyn FnMut(VarId, &Binding)) {
+        for (col, var) in self.batch.schema().iter().enumerate() {
+            f(*var, self.batch.get_by_col(self.row, col));
+        }
+        f(self.value_var, self.value);
+    }
+}
+
+/// One driving row's own interval: the bounds as the filter evaluates them
+/// (with the filter's strictness) plus their envelope contribution.
+struct RowInterval {
+    exact: ObjectBounds,
+    /// Every present bound is numeric, so a numeric value is decided by
+    /// `exact` alone.
+    numeric: bool,
+    envelope: Envelope,
+}
+
+fn as_f64(v: &FlakeValue) -> Option<f64> {
+    match v {
+        FlakeValue::Long(n) => Some(*n as f64),
+        FlakeValue::Double(d) => Some(*d),
+        FlakeValue::BigInt(b) => b.to_f64(),
+        FlakeValue::Decimal(d) => d.to_f64(),
+        _ => None,
+    }
+}
+
+fn clamp_i64(f: f64) -> i64 {
+    if f <= i64::MIN as f64 {
+        i64::MIN
+    } else if f >= i64::MAX as f64 {
+        i64::MAX
+    } else {
+        f as i64
+    }
+}
+
+/// Inclusive raw-key bounds of `envelope` for one inline numeric kind, widened
+/// (integer ceil/floor, float neighbours) so no borderline row is lost; the
+/// exact check decides them. `None`: the kind is not range-keyed (arena
+/// decimals), so rows are compared by decoded value instead.
+fn key_bounds(envelope: &Envelope, kind: DecodeKind) -> Option<(u64, u64)> {
+    let f = |v: &FlakeValue| as_f64(v).filter(|f| !f.is_nan());
+    match kind {
+        DecodeKind::I64 => {
+            let lo = match &envelope.lower {
+                None => u64::MIN,
+                Some(FlakeValue::Long(n)) => ObjKey::encode_i64(*n).as_u64(),
+                Some(v) => ObjKey::encode_i64(clamp_i64(f(v)?.ceil())).as_u64(),
+            };
+            let hi = match &envelope.upper {
+                None => u64::MAX,
+                Some(FlakeValue::Long(n)) => ObjKey::encode_i64(*n).as_u64(),
+                Some(v) => ObjKey::encode_i64(clamp_i64(f(v)?.floor())).as_u64(),
+            };
+            Some((lo, hi))
+        }
+        DecodeKind::F64 => {
+            let lo = match &envelope.lower {
+                None => u64::MIN,
+                Some(v) => ObjKey::encode_f64(f(v)?.next_down()).map_or(u64::MIN, ObjKey::as_u64),
+            };
+            let hi = match &envelope.upper {
+                None => u64::MAX,
+                Some(v) => ObjKey::encode_f64(f(v)?.next_up()).map_or(u64::MAX, ObjKey::as_u64),
+            };
+            Some((lo, hi))
+        }
+        _ => None,
+    }
+}
+
+/// A leaflet's in-range rows, located by the walk's first pass and collected
+/// by its second once the total is known to be within the cap.
+struct WalkedLeaflet {
+    batch: ColumnBatch,
+    /// `Some((o_type, start, end))` for a homogeneous numeric leaflet whose
+    /// key column was binary-searched; `None` for a mixed leaflet, compared
+    /// row by row against the envelope.
+    keyed: Option<(u16, usize, usize)>,
+    p_const: Option<u32>,
+    o_type_const: Option<u16>,
+}
+
+pub struct RangeSemiJoinOperator {
+    child: BoxedOperator,
+    subject_var: VarId,
+    conditions: Vec<RangeSemiJoinCondition>,
+    filters: Vec<PreparedBoolExpression>,
+    /// Per condition: the driving-row variables its bounds read.
+    bound_vars: Vec<Vec<VarId>>,
+    schema: Arc<[VarId]>,
+    planning: PlanningContext,
+    state: OperatorState,
+    norm: Option<EqualityNorm>,
+    indexes: Vec<Option<RangeIndex>>,
+    /// Per condition: the walk capped out or declined once, so later batches
+    /// go straight to probes instead of re-walking an envelope that only grows
+    /// (the decline conditions hold for the whole query).
+    walk_off: Vec<bool>,
+    probed_rows: usize,
+    kept_rows: usize,
+    fallback_rows: usize,
+    probe_batches: usize,
+}
+
+impl RangeSemiJoinOperator {
+    /// `out_vars` trims the output to the variables still needed downstream:
+    /// the child must carry the bound operands for the re-check, but nothing
+    /// after this operator reads them.
+    pub fn new(
+        child: BoxedOperator,
+        subject_var: VarId,
+        conditions: Vec<RangeSemiJoinCondition>,
+        out_vars: Option<&[VarId]>,
+        planning: PlanningContext,
+    ) -> Self {
+        let schema: Arc<[VarId]> = crate::operator::compute_trimmed_vars(child.schema(), out_vars)
+            .unwrap_or_else(|| Arc::from(child.schema().to_vec().into_boxed_slice()));
+        let filters = conditions
+            .iter()
+            .map(|c| PreparedBoolExpression::new(c.filter.clone()))
+            .collect();
+        let bound_vars = conditions
+            .iter()
+            .map(RangeSemiJoinCondition::bound_vars)
+            .collect();
+        let n = conditions.len();
+        Self {
+            child,
+            subject_var,
+            conditions,
+            filters,
+            bound_vars,
+            schema,
+            planning,
+            state: OperatorState::Created,
+            norm: None,
+            indexes: (0..n).map(|_| None).collect(),
+            walk_off: vec![false; n],
+            probed_rows: 0,
+            kept_rows: 0,
+            fallback_rows: 0,
+            probe_batches: 0,
+        }
+    }
+
+    fn eval_bound<R: RowAccess>(
+        expr: &Expression,
+        row: &R,
+        ctx: &ExecutionContext<'_>,
+    ) -> Option<FlakeValue> {
+        match expr.eval_to_comparable(row, Some(ctx)) {
+            Ok(Some(value)) => Some(FlakeValue::from(&value)),
+            _ => None,
+        }
+    }
+
+    /// The row's own interval for condition `c`, or `None` when a bound cannot
+    /// be evaluated (the filter could not pass either). Memoized against the
+    /// previous row through `memo`: the bound operands rarely change between
+    /// adjacent rows — in BSBM Q5 they are the anchor's values on every row.
+    fn row_interval(
+        &self,
+        c: usize,
+        batch: &Batch,
+        row: usize,
+        ctx: &ExecutionContext<'_>,
+        memo: &mut Option<(usize, Option<u32>)>,
+        distinct: &mut Vec<RowInterval>,
+    ) -> Option<u32> {
+        if let Some((prev_row, prev)) = memo {
+            let same_inputs = self.bound_vars[c]
+                .iter()
+                .all(|v| batch.get(*prev_row, *v) == batch.get(row, *v));
+            if same_inputs {
+                return *prev;
+            }
+        }
+        let cond = &self.conditions[c];
+        let view = batch.row_view(row);
+        let mut exact = ObjectBounds::default();
+        let mut envelope = Envelope::default();
+        let mut numeric = true;
+        let mut dropped = false;
+        if let Some((expr, inclusive)) = &cond.lower {
+            match view.as_ref().and_then(|v| Self::eval_bound(expr, v, ctx)) {
+                Some(value) => {
+                    if value.is_numeric() {
+                        envelope.lower = Some(value.clone());
+                    } else {
+                        numeric = false;
+                    }
+                    exact.lower = Some((value, *inclusive));
+                }
+                None => dropped = true,
+            }
+        }
+        if let Some((expr, inclusive)) = &cond.upper {
+            match view.as_ref().and_then(|v| Self::eval_bound(expr, v, ctx)) {
+                Some(value) => {
+                    if value.is_numeric() {
+                        envelope.upper = Some(value.clone());
+                    } else {
+                        numeric = false;
+                    }
+                    exact.upper = Some((value, *inclusive));
+                }
+                None => dropped = true,
+            }
+        }
+        let out = (!dropped).then(|| {
+            distinct.push(RowInterval {
+                exact,
+                numeric,
+                envelope,
+            });
+            (distinct.len() - 1) as u32
+        });
+        *memo = Some((row, out));
+        out
+    }
+
+    /// Does `value` satisfy the row's interval? A numeric value against
+    /// numeric bounds is the filter itself; against a non-numeric bound it is
+    /// the filter's type error; anything else re-runs the original expression.
+    fn value_passes(
+        &self,
+        c: usize,
+        interval: &RowInterval,
+        batch: &Batch,
+        row: usize,
+        value: &WalkValue,
+        ctx: &ExecutionContext<'_>,
+    ) -> Result<bool> {
+        match value {
+            WalkValue::Other(binding) => {
+                let view = RowWithValue {
+                    batch,
+                    row,
+                    value_var: self.conditions[c].value_var,
+                    value: binding,
+                };
+                self.filters[c].eval_to_bool_non_strict(&view, Some(ctx))
+            }
+            numeric => Ok(interval.numeric
+                && numeric
+                    .numeric()
+                    .is_some_and(|v| interval.exact.matches(&v))),
+        }
+    }
+
+    /// Index-level build: walk the predicate's POST leaflets directly, pruning
+    /// each leaflet on its directory keys, binary-searching the sorted key
+    /// column of a homogeneous numeric leaflet for the envelope's raw-key
+    /// range, and decoding only the subject and key columns. Rows outside the
+    /// envelope never become values. The first pass only counts, so an
+    /// envelope past the cap costs the cached leaflet decodes and nothing more.
+    fn build_index_walk(
+        &self,
+        c: usize,
+        envelope: &Envelope,
+        ctx: &ExecutionContext<'_>,
+    ) -> Result<WalkOutcome> {
+        let Some(store) = ctx.binary_store.as_ref() else {
+            return Ok(WalkOutcome::Declined);
+        };
+        if ctx.is_multi_ledger()
+            || ctx.from_t.is_some()
+            || !ctx.overlay_free_single_graph()
+            || ctx.to_t < store.max_t()
+            || !root_or_no_policy(ctx)
+        {
+            return Ok(WalkOutcome::Declined);
+        }
+        let cond = &self.conditions[c];
+        let Some(pred_sid) = try_normalize_pred_sid(store, &cond.predicate) else {
+            return Ok(WalkOutcome::Declined);
+        };
+        let g_id = ctx.binary_g_id;
+        // Overlay-free and the predicate is not in the index: nothing can match.
+        let Some(p_id) = store.sid_to_p_id(&pred_sid) else {
+            return Ok(WalkOutcome::Built(RangeIndex {
+                envelope: envelope.clone(),
+                values: ValueIndex::with_capacity(0),
+                rows: 0,
+            }));
+        };
+        let bounds = ObjectBounds {
+            lower: envelope.lower.clone().map(|v| (v, true)),
+            upper: envelope.upper.clone().map(|v| (v, true)),
+        };
+        let cache = store.leaflet_cache();
+        let narrow = ColumnSet::single(ColumnId::SId).union(ColumnSet::single(ColumnId::OKey));
+        let mixed = narrow
+            .union(ColumnSet::single(ColumnId::OType))
+            .union(ColumnSet::single(ColumnId::PId));
+        let cap = walk_row_floor().max(WALK_ROWS_PER_DRIVING_ROW * self.probed_rows);
+
+        // Pass 1: locate the in-range rows per leaflet and count them.
+        let mut leaflets: Vec<WalkedLeaflet> = Vec::new();
+        let mut total = 0usize;
+        for leaf in leaf_entries_for_predicate(store, g_id, RunSortOrder::Post, p_id) {
+            ctx.check_cancelled()?;
+            let LeafScan {
+                leaf_bytes,
+                header,
+                dir,
+                leaf_id,
+                ..
+            } = prepare_leaf_for_scan(store, leaf, false)?;
+            for (leaflet_idx, entry) in dir.entries.iter().enumerate() {
+                if entry.row_count == 0 || entry.p_const.is_some_and(|p| p != p_id) {
+                    continue;
+                }
+                // A leaflet homogeneous in predicate and numeric o_type is
+                // sorted by raw key, so the envelope is one contiguous run.
+                let key_range = match (entry.p_const, entry.o_type_const) {
+                    (Some(_), Some(ot)) => {
+                        let o_type = OType::from_u16(ot);
+                        if !o_type.is_numeric() {
+                            continue;
+                        }
+                        match key_bounds(envelope, o_type.decode_kind()) {
+                            Some((lo, hi)) => {
+                                let first =
+                                    read_ordered_key_v2(RunSortOrder::Post, &entry.first_key).o_key;
+                                let last =
+                                    read_ordered_key_v2(RunSortOrder::Post, &entry.last_key).o_key;
+                                if last < lo || first > hi {
+                                    continue;
+                                }
+                                Some((ot, lo, hi))
+                            }
+                            None => None,
+                        }
+                    }
+                    _ => None,
+                };
+                let decode_set = if key_range.is_some() { narrow } else { mixed };
+                let leaflet_idx_u32 = u32::try_from(leaflet_idx)
+                    .map_err(|_| QueryError::Internal("leaflet idx exceeds u32".to_string()))?;
+                let batch = match &cache {
+                    Some(cache) => load_leaflet_columns_cached(
+                        &leaf_bytes,
+                        entry,
+                        dir.payload_base,
+                        cache,
+                        LeafletDecodeSpec {
+                            leaf_id,
+                            leaflet_idx: leaflet_idx_u32,
+                            order: header.order,
+                            decode_set,
+                        },
+                    ),
+                    None => load_leaflet_columns(
+                        &leaf_bytes,
+                        entry,
+                        dir.payload_base,
+                        &ColumnProjection {
+                            output: decode_set,
+                            internal: ColumnSet::EMPTY,
+                        },
+                        header.order,
+                    ),
+                }
+                .map_err(|e| QueryError::Internal(format!("load columns (range walk): {e}")))?;
+
+                let keyed = match key_range {
+                    Some((ot, lo, hi)) => {
+                        let (start, end) = match &batch.o_key {
+                            ColumnData::Block(keys) => {
+                                let keys: &[u64] = keys.as_ref();
+                                (
+                                    keys.partition_point(|k| *k < lo),
+                                    keys.partition_point(|k| *k <= hi),
+                                )
+                            }
+                            // A constant key column is one value: in or out.
+                            _ => {
+                                let k = batch.o_key.get_or(0, 0);
+                                if k >= lo && k <= hi {
+                                    (0, batch.row_count)
+                                } else {
+                                    (0, 0)
+                                }
+                            }
+                        };
+                        total += end - start;
+                        Some((ot, start, end))
+                    }
+                    None => {
+                        total += batch.row_count;
+                        None
+                    }
+                };
+                if total > cap {
+                    charge_rows(ctx, total)?;
+                    return Ok(WalkOutcome::Capped);
+                }
+                leaflets.push(WalkedLeaflet {
+                    batch,
+                    keyed,
+                    p_const: entry.p_const,
+                    o_type_const: entry.o_type_const,
+                });
+            }
+        }
+
+        charge_rows(ctx, total)?;
+
+        // Pass 2: collect.
+        let mut values = ValueIndex::with_capacity(total);
+        let mut rows = 0usize;
+        for leaflet in &leaflets {
+            let batch = &leaflet.batch;
+            match leaflet.keyed {
+                Some((ot, start, end)) => {
+                    let kind = OType::from_u16(ot).decode_kind();
+                    for row in start..end {
+                        let o_key = batch.o_key.get(row);
+                        let value = match kind {
+                            DecodeKind::I64 => WalkValue::Int(ObjKey::from_u64(o_key).decode_i64()),
+                            DecodeKind::F64 => {
+                                WalkValue::Float(ObjKey::from_u64(o_key).decode_f64())
+                            }
+                            _ => WalkValue::Other(decoded_binding(store, g_id, p_id, ot, o_key)?),
+                        };
+                        values.push(GroupKeyOwned::Sid(batch.s_id.get(row)), value);
+                        rows += 1;
+                    }
+                }
+                None => {
+                    for row in 0..batch.row_count {
+                        if leaflet.p_const.is_none() && batch.p_id.get_or(row, 0) != p_id {
+                            continue;
+                        }
+                        let ot = leaflet
+                            .o_type_const
+                            .unwrap_or_else(|| batch.o_type.get_or(row, 0));
+                        if !OType::from_u16(ot).is_numeric() {
+                            continue;
+                        }
+                        let o_key = batch.o_key.get(row);
+                        let val = store.decode_value_v3(ot, o_key, p_id, g_id).map_err(|e| {
+                            QueryError::Internal(format!("decode_value_v3 (range walk): {e}"))
+                        })?;
+                        if !bounds.matches(&val) {
+                            continue;
+                        }
+                        let value = match val {
+                            FlakeValue::Long(n) => WalkValue::Int(n),
+                            FlakeValue::Double(d) => WalkValue::Float(d),
+                            other => WalkValue::Other(materialized_object_binding(
+                                store, ot, p_id, other, None, None,
+                            )),
+                        };
+                        values.push(GroupKeyOwned::Sid(batch.s_id.get(row)), value);
+                        rows += 1;
+                    }
+                }
+            }
+        }
+        tracing::debug!(
+            predicate = ?cond.predicate,
+            lower = ?envelope.lower,
+            upper = ?envelope.upper,
+            rows,
+            subjects = values.head.len(),
+            "range semijoin index built by POST walk"
+        );
+        Ok(WalkOutcome::Built(RangeIndex {
+            envelope: envelope.clone(),
+            values,
+            rows,
+        }))
+    }
+
+    /// Answer one batch's rows for condition `c` by batched subject probes —
+    /// what the nested loop would have done — when no walked index can.
+    async fn probe_batch(
+        &mut self,
+        c: usize,
+        batch: &Batch,
+        keep: &mut [bool],
+        intervals: &[Option<u32>],
+        distinct: &[RowInterval],
+        ctx: &ExecutionContext<'_>,
+    ) -> Result<()> {
+        self.probe_batches += 1;
+        let store = ctx.binary_store.clone();
+        let pred_sid = store
+            .as_ref()
+            .and_then(|s| try_normalize_pred_sid(s, &self.conditions[c].predicate));
+        let lane = match (&store, &pred_sid) {
+            (Some(store), Some(pred_sid)) if !ctx.is_multi_ledger() => {
+                subject_probe_lane_plan(ctx, store, pred_sid)?
+            }
+            _ => ProbeLanePlan::Decline,
+        };
+        let mut probed: Option<ValueIndex> = None;
+        if let (Some(store), Some(pred_sid), false) =
+            (&store, &pred_sid, matches!(lane, ProbeLanePlan::Decline))
+        {
+            let mut subject_ids: Vec<u64> = Vec::new();
+            for (row, keep_row) in keep.iter().enumerate() {
+                if !*keep_row || intervals[row].is_none() {
+                    continue;
+                }
+                if let Some(Binding::EncodedSid { s_id, .. }) = batch.get(row, self.subject_var) {
+                    subject_ids.push(*s_id);
+                }
+            }
+            subject_ids.sort_unstable();
+            subject_ids.dedup();
+            let dict_overlay = make_dict_overlay(ctx, store);
+            let mut probe_ops = match &lane {
+                ProbeLanePlan::Merge(ops) => ProbeOps::new(ops.clone()),
+                _ => None,
+            };
+            let matches = batched_subject_probe_binary(
+                ctx,
+                store,
+                &SubjectProbeParams {
+                    pred_sid,
+                    subject_ids: &subject_ids,
+                    object_bounds: None,
+                    bound_object: None,
+                    emit_object: true,
+                    dict_overlay: dict_overlay.as_ref(),
+                },
+                probe_ops.as_mut(),
+            )?;
+            let mut values = ValueIndex::with_capacity(matches.len());
+            for m in &matches {
+                if let Some(object) = &m.object {
+                    values.push(
+                        GroupKeyOwned::Sid(m.subject_id),
+                        WalkValue::from_binding(object),
+                    );
+                }
+            }
+            probed = Some(values);
+        }
+
+        for (row, keep_row) in keep.iter_mut().enumerate() {
+            if !*keep_row {
+                continue;
+            }
+            let Some(interval) = intervals[row].map(|i| &distinct[i as usize]) else {
+                *keep_row = false;
+                continue;
+            };
+            let passes = match (batch.get(row, self.subject_var), &probed) {
+                (Some(Binding::EncodedSid { s_id, .. }), Some(values)) => {
+                    let mut any = false;
+                    for value in values.values_of(&GroupKeyOwned::Sid(*s_id)) {
+                        if self.value_passes(c, interval, batch, row, value, ctx)? {
+                            any = true;
+                            break;
+                        }
+                    }
+                    any
+                }
+                (Some(Binding::Poisoned), _) => false,
+                _ => {
+                    self.fallback_rows += 1;
+                    self.row_passes_exactly(c, batch, row, ctx).await?
+                }
+            };
+            if !passes {
+                *keep_row = false;
+            }
+        }
+        Ok(())
+    }
+
+    /// Exact evaluation of the original probe + filter seeded with one row,
+    /// for rows no batched path can answer (an unbound or unresolvable
+    /// subject).
+    async fn row_passes_exactly(
+        &self,
+        c: usize,
+        batch: &Batch,
+        row: usize,
+        ctx: &ExecutionContext<'_>,
+    ) -> Result<bool> {
+        let cond = &self.conditions[c];
+        let seed = SeedOperator::from_batch_row(batch, row);
+        let patterns = [
+            Pattern::Triple(cond.probe(self.subject_var)),
+            Pattern::Filter(cond.filter.clone()),
+        ];
+        let mut inner = build_where_operators_seeded(
+            Some(Box::new(seed)),
+            &patterns,
+            None,
+            None,
+            &self.planning,
+        )?;
+        inner.open(ctx).await?;
+        let mut passes = false;
+        while let Some(out) = inner.next_batch(ctx).await? {
+            if !out.is_empty() {
+                passes = true;
+                break;
+            }
+        }
+        inner.close();
+        Ok(passes)
+    }
+}
+
+/// One charge per batch of walked or driving rows, at the same rate as the
+/// nested loop's probes (`charge_probe_rows`), never inside the row loops.
+fn charge_rows(ctx: &ExecutionContext<'_>, rows: usize) -> Result<()> {
+    ctx.tracker
+        .consume_fuel(rows as u64 * fluree_db_core::tracking::schedule::PER_ROW_MICRO_FUEL)?;
+    Ok(())
+}
+
+/// A walked row's value when it is not an inline numeric: decoded through the
+/// store, as the index would deliver it to a scan.
+fn decoded_binding(
+    store: &BinaryIndexStore,
+    g_id: GraphId,
+    p_id: u32,
+    o_type: u16,
+    o_key: u64,
+) -> Result<Binding> {
+    let val = store
+        .decode_value_v3(o_type, o_key, p_id, g_id)
+        .map_err(|e| QueryError::Internal(format!("decode_value_v3 (range walk): {e}")))?;
+    Ok(materialized_object_binding(
+        store, o_type, p_id, val, None, None,
+    ))
+}
+
+#[async_trait]
+impl Operator for RangeSemiJoinOperator {
+    fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
+        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+    }
+
+    fn plan_details(&self) -> serde_json::Map<String, serde_json::Value> {
+        let mut m = serde_json::Map::new();
+        m.insert("subject".into(), format!("?v{}", self.subject_var.0).into());
+        let conditions: Vec<serde_json::Value> = self
+            .conditions
+            .iter()
+            .map(|c| {
+                let side = |b: &Option<(Expression, bool)>, op: &str| {
+                    b.as_ref()
+                        .map(|(e, inclusive)| {
+                            format!("{}{} {:?}", op, if *inclusive { "=" } else { "" }, e)
+                        })
+                        .unwrap_or_default()
+                };
+                let predicate = match &c.predicate {
+                    Ref::Sid(sid) => format!("<{}:{}>", sid.namespace_code, sid.name),
+                    Ref::Iri(iri) => format!("<{iri}>"),
+                    Ref::Var(v) => format!("?v{}", v.0),
+                };
+                format!(
+                    "?v{} {} ?v{} [{} {}]",
+                    self.subject_var.0,
+                    predicate,
+                    c.value_var.0,
+                    side(&c.lower, ">"),
+                    side(&c.upper, "<"),
+                )
+                .into()
+            })
+            .collect();
+        m.insert("conditions".into(), conditions.into());
+        m
+    }
+
+    fn schema(&self) -> &[VarId] {
+        &self.schema
+    }
+
+    async fn open(&mut self, ctx: &ExecutionContext<'_>) -> Result<()> {
+        if self.norm.is_none() {
+            self.norm = equality_norm(ctx);
+        }
+        self.child.open(ctx).await?;
+        for index in &mut self.indexes {
+            *index = None;
+        }
+        for off in &mut self.walk_off {
+            *off = false;
+        }
+        self.state = OperatorState::Open;
+        Ok(())
+    }
+
+    async fn next_batch(&mut self, ctx: &ExecutionContext<'_>) -> Result<Option<Batch>> {
+        if self.state != OperatorState::Open {
+            return Ok(None);
+        }
+        loop {
+            let batch = match self.child.next_batch(ctx).await? {
+                Some(b) if !b.is_empty() => b,
+                Some(_) => continue,
+                None => {
+                    tracing::debug!(
+                        probed = self.probed_rows,
+                        kept = self.kept_rows,
+                        fallback = self.fallback_rows,
+                        probe_batches = self.probe_batches,
+                        walked = self
+                            .indexes
+                            .iter()
+                            .map(|i| i.as_ref().map_or(0, |i| i.rows))
+                            .sum::<usize>(),
+                        "range semijoin exhausted"
+                    );
+                    self.state = OperatorState::Exhausted;
+                    return Ok(None);
+                }
+            };
+            ctx.check_cancelled()?;
+            charge_rows(ctx, batch.len())?;
+            self.probed_rows += batch.len();
+
+            let mut keep = vec![true; batch.len()];
+            for c in 0..self.conditions.len() {
+                // Per-row intervals and the batch envelope they union to.
+                let mut intervals: Vec<Option<u32>> = Vec::with_capacity(batch.len());
+                let mut distinct: Vec<RowInterval> = Vec::new();
+                let mut batch_envelope: Option<Envelope> = None;
+                let mut all_numeric = true;
+                let mut memo = None;
+                for (row, keep_row) in keep.iter_mut().enumerate() {
+                    if !*keep_row {
+                        intervals.push(None);
+                        continue;
+                    }
+                    let interval = self.row_interval(c, &batch, row, ctx, &mut memo, &mut distinct);
+                    match interval {
+                        None => *keep_row = false,
+                        Some(idx) => {
+                            let RowInterval {
+                                numeric, envelope, ..
+                            } = &distinct[idx as usize];
+                            all_numeric &= *numeric;
+                            batch_envelope = Some(match batch_envelope {
+                                None => envelope.clone(),
+                                Some(current) => current.union(envelope),
+                            });
+                        }
+                    }
+                    intervals.push(interval);
+                }
+                let Some(batch_envelope) = batch_envelope else {
+                    continue;
+                };
+
+                // A non-numeric bound has no key range and its rows are not
+                // in a walked index: this batch goes to probes, the index
+                // stays for later numeric batches.
+                let mut use_index = false;
+                if all_numeric {
+                    let covered = self.indexes[c]
+                        .as_ref()
+                        .is_some_and(|index| index.envelope.covers(&batch_envelope));
+                    if !covered && !self.walk_off[c] {
+                        let target = match &self.indexes[c] {
+                            Some(index) => index.envelope.union(&batch_envelope),
+                            None => batch_envelope.clone(),
+                        };
+                        match self.build_index_walk(c, &target, ctx)? {
+                            WalkOutcome::Built(index) => self.indexes[c] = Some(index),
+                            WalkOutcome::Capped | WalkOutcome::Declined => {
+                                self.walk_off[c] = true;
+                                self.indexes[c] = None;
+                            }
+                        }
+                    }
+                    use_index = self.indexes[c].is_some();
+                }
+
+                let Some(index) = self.indexes[c].as_ref().filter(|_| use_index) else {
+                    crate::fast_path_outcome::stamp_fast_path(
+                        RANGE_SEMIJOIN_SITE,
+                        crate::fast_path_outcome::FastPathOutcome::Fallback(
+                            crate::fast_path_outcome::FastPathFallback::GateDeclined,
+                        ),
+                    );
+                    self.probe_batch(c, &batch, &mut keep, &intervals, &distinct, ctx)
+                        .await?;
+                    continue;
+                };
+                crate::fast_path_outcome::stamp_fast_path(
+                    RANGE_SEMIJOIN_SITE,
+                    crate::fast_path_outcome::FastPathOutcome::Proceed,
+                );
+
+                let (store, gv) = EqualityNorm::parts(&self.norm);
+                let mut fallback_rows: Vec<usize> = Vec::new();
+                for (row, keep_row) in keep.iter_mut().enumerate() {
+                    if !*keep_row {
+                        continue;
+                    }
+                    let Some(interval) = intervals[row].map(|i| &distinct[i as usize]) else {
+                        *keep_row = false;
+                        continue;
+                    };
+                    let passes = match batch.get(row, self.subject_var) {
+                        None | Some(Binding::Unbound) => {
+                            fallback_rows.push(row);
+                            continue;
+                        }
+                        Some(Binding::Poisoned) => false,
+                        Some(subject) => {
+                            let key = binding_to_group_key_normalized(subject, store, gv);
+                            let mut any = false;
+                            for value in index.values.values_of(&key) {
+                                if self.value_passes(c, interval, &batch, row, value, ctx)? {
+                                    any = true;
+                                    break;
+                                }
+                            }
+                            any
+                        }
+                    };
+                    if !passes {
+                        *keep_row = false;
+                    }
+                }
+                for row in fallback_rows {
+                    self.fallback_rows += 1;
+                    if !self.row_passes_exactly(c, &batch, row, ctx).await? {
+                        keep[row] = false;
+                    }
+                }
+            }
+
+            let kept = keep.iter().filter(|k| **k).count();
+            if kept == 0 {
+                continue;
+            }
+            self.kept_rows += kept;
+            // Column positions from the batch's own schema, not the child's
+            // declared order (see `MembershipJoinOperator::all_keys_bound`).
+            let source_cols: Vec<Option<usize>> = self
+                .schema
+                .iter()
+                .map(|v| batch.schema().iter().position(|x| x == v))
+                .collect();
+            let mut columns: Vec<Vec<Binding>> = (0..self.schema.len())
+                .map(|_| Vec::with_capacity(kept))
+                .collect();
+            for (row, keep_row) in keep.iter().enumerate() {
+                if !keep_row {
+                    continue;
+                }
+                for (out, source) in columns.iter_mut().zip(&source_cols) {
+                    out.push(match source {
+                        Some(col) => batch.get_by_col(row, *col).clone(),
+                        None => Binding::Unbound,
+                    });
+                }
+            }
+            return Ok(Some(Batch::new(self.schema.clone(), columns)?));
+        }
+    }
+
+    fn close(&mut self) {
+        self.child.close();
+        for index in &mut self.indexes {
+            *index = None;
+        }
+        self.state = OperatorState::Closed;
+    }
+
+    fn estimated_rows(&self) -> Option<usize> {
+        self.child.estimated_rows()
+    }
+}

--- a/fluree-db-query/src/range_semijoin.rs
+++ b/fluree-db-query/src/range_semijoin.rs
@@ -29,8 +29,8 @@
 //! a restricting policy), a bound is not numeric (the walk keys inline
 //! numerics only), or the envelope would cover too many rows for the driving
 //! stream — the batch is answered by the same batched subject probes the
-//! nested loop would have used, so the lane never costs more than the chain
-//! it replaced.
+//! nested loop would have used. If that lane declines too, one seeded
+//! probe/filter plan answers the batch through the generic pipeline.
 //!
 //! Semantics: this is a SEMI-join — a row is kept at most once however many of
 //! its values pass. That equals the probe+filter chain only where downstream
@@ -51,6 +51,7 @@
 
 use crate::binding::{Batch, Binding, RowAccess};
 use crate::context::ExecutionContext;
+use crate::distinct::DistinctOperator;
 use crate::error::{QueryError, Result};
 use crate::eval::PreparedBoolExpression;
 use crate::execute::build_where_operators_seeded;
@@ -67,7 +68,7 @@ use crate::join::{
 };
 use crate::object_binding::{equality_norm, materialized_object_binding, EqualityNorm};
 use crate::operator::{BoxedOperator, Operator, OperatorState};
-use crate::seed::SeedOperator;
+use crate::seed::BatchSeedOperator;
 use crate::temporal_mode::PlanningContext;
 use crate::var_registry::VarId;
 use async_trait::async_trait;
@@ -99,6 +100,13 @@ pub const RANGE_SEMIJOIN_SITE: &str = "range-semijoin";
 /// walk for a query that a few probes would answer.
 const WALK_ROW_FLOOR: usize = 4_000;
 const WALK_ROWS_PER_DRIVING_ROW: usize = 16;
+// A changing anchor must not re-walk an ever-growing envelope per batch.
+// Fixed-anchor queries build once; allow a few expansions, then use probes.
+const MAX_WALKS_PER_CONDITION: usize = 4;
+
+fn walkable_numeric(o_type: OType) -> bool {
+    o_type.is_numeric() || o_type == OType::NUM_BIG_OVERFLOW
+}
 
 fn walk_row_floor() -> usize {
     static ENV: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
@@ -200,7 +208,7 @@ impl Envelope {
 enum WalkValue {
     Int(i64),
     Float(f64),
-    Other(Binding),
+    Other(Box<Binding>),
 }
 
 impl WalkValue {
@@ -220,7 +228,7 @@ impl WalkValue {
                 val: FlakeValue::Double(d),
                 ..
             } => WalkValue::Float(*d),
-            other => WalkValue::Other(other.clone()),
+            other => WalkValue::Other(Box::new(other.clone())),
         }
     }
 
@@ -347,15 +355,17 @@ fn key_bounds(envelope: &Envelope, kind: DecodeKind) -> Option<(u64, u64)> {
     let f = |v: &FlakeValue| as_f64(v).filter(|f| !f.is_nan());
     match kind {
         DecodeKind::I64 => {
+            // Decimal/BigInt -> f64 can round inward above 2^53. Widen
+            // before ceil/floor; the exact value check removes extra rows.
             let lo = match &envelope.lower {
                 None => u64::MIN,
                 Some(FlakeValue::Long(n)) => ObjKey::encode_i64(*n).as_u64(),
-                Some(v) => ObjKey::encode_i64(clamp_i64(f(v)?.ceil())).as_u64(),
+                Some(v) => ObjKey::encode_i64(clamp_i64(f(v)?.next_down().ceil())).as_u64(),
             };
             let hi = match &envelope.upper {
                 None => u64::MAX,
                 Some(FlakeValue::Long(n)) => ObjKey::encode_i64(*n).as_u64(),
-                Some(v) => ObjKey::encode_i64(clamp_i64(f(v)?.floor())).as_u64(),
+                Some(v) => ObjKey::encode_i64(clamp_i64(f(v)?.next_up().floor())).as_u64(),
             };
             Some((lo, hi))
         }
@@ -387,7 +397,8 @@ struct WalkedLeaflet {
 }
 
 pub struct RangeSemiJoinOperator {
-    child: BoxedOperator,
+    child: Option<BoxedOperator>,
+    fallback_dedup: Option<DistinctOperator>,
     subject_var: VarId,
     conditions: Vec<RangeSemiJoinCondition>,
     filters: Vec<PreparedBoolExpression>,
@@ -402,6 +413,8 @@ pub struct RangeSemiJoinOperator {
     /// go straight to probes instead of re-walking an envelope that only grows
     /// (the decline conditions hold for the whole query).
     walk_off: Vec<bool>,
+    walk_attempts: Vec<usize>,
+    fallback_batches: usize,
     probed_rows: usize,
     kept_rows: usize,
     fallback_rows: usize,
@@ -431,7 +444,8 @@ impl RangeSemiJoinOperator {
             .collect();
         let n = conditions.len();
         Self {
-            child,
+            child: Some(child),
+            fallback_dedup: None,
             subject_var,
             conditions,
             filters,
@@ -442,10 +456,32 @@ impl RangeSemiJoinOperator {
             norm: None,
             indexes: (0..n).map(|_| None).collect(),
             walk_off: vec![false; n],
+            walk_attempts: vec![0; n],
+            fallback_batches: 0,
             probed_rows: 0,
             kept_rows: 0,
             fallback_rows: 0,
             probe_batches: 0,
+        }
+    }
+
+    fn input(&self) -> &dyn Operator {
+        match &self.fallback_dedup {
+            Some(dedup) => dedup,
+            None => self.child.as_deref().expect("semi-join child"),
+        }
+    }
+
+    fn input_mut(&mut self) -> &mut dyn Operator {
+        match &mut self.fallback_dedup {
+            Some(dedup) => dedup,
+            None => self.child.as_deref_mut().expect("semi-join child"),
+        }
+    }
+
+    fn restore_child(&mut self) {
+        if let Some(dedup) = self.fallback_dedup.take() {
+            self.child = Some(dedup.into_child());
         }
     }
 
@@ -622,7 +658,7 @@ impl RangeSemiJoinOperator {
                 let key_range = match (entry.p_const, entry.o_type_const) {
                     (Some(_), Some(ot)) => {
                         let o_type = OType::from_u16(ot);
-                        if !o_type.is_numeric() {
+                        if !walkable_numeric(o_type) {
                             continue;
                         }
                         match key_bounds(envelope, o_type.decode_kind()) {
@@ -728,7 +764,9 @@ impl RangeSemiJoinOperator {
                             DecodeKind::F64 => {
                                 WalkValue::Float(ObjKey::from_u64(o_key).decode_f64())
                             }
-                            _ => WalkValue::Other(decoded_binding(store, g_id, p_id, ot, o_key)?),
+                            _ => WalkValue::Other(Box::new(decoded_binding(
+                                store, g_id, p_id, ot, o_key,
+                            )?)),
                         };
                         values.push(GroupKeyOwned::Sid(batch.s_id.get(row)), value);
                         rows += 1;
@@ -742,7 +780,7 @@ impl RangeSemiJoinOperator {
                         let ot = leaflet
                             .o_type_const
                             .unwrap_or_else(|| batch.o_type.get_or(row, 0));
-                        if !OType::from_u16(ot).is_numeric() {
+                        if !walkable_numeric(OType::from_u16(ot)) {
                             continue;
                         }
                         let o_key = batch.o_key.get(row);
@@ -755,9 +793,9 @@ impl RangeSemiJoinOperator {
                         let value = match val {
                             FlakeValue::Long(n) => WalkValue::Int(n),
                             FlakeValue::Double(d) => WalkValue::Float(d),
-                            other => WalkValue::Other(materialized_object_binding(
+                            other => WalkValue::Other(Box::new(materialized_object_binding(
                                 store, ot, p_id, other, None, None,
-                            )),
+                            ))),
                         };
                         values.push(GroupKeyOwned::Sid(batch.s_id.get(row)), value);
                         rows += 1;
@@ -847,6 +885,7 @@ impl RangeSemiJoinOperator {
             probed = Some(values);
         }
 
+        let mut fallback_rows = Vec::new();
         for (row, keep_row) in keep.iter_mut().enumerate() {
             if !*keep_row {
                 continue;
@@ -868,29 +907,70 @@ impl RangeSemiJoinOperator {
                 }
                 (Some(Binding::Poisoned), _) => false,
                 _ => {
-                    self.fallback_rows += 1;
-                    self.row_passes_exactly(c, batch, row, ctx).await?
+                    fallback_rows.push(row);
+                    continue;
                 }
             };
             if !passes {
                 *keep_row = false;
             }
         }
+        self.filter_batch_exactly(c, batch, &fallback_rows, keep, ctx)
+            .await?;
         Ok(())
     }
 
-    /// Exact evaluation of the original probe + filter seeded with one row,
-    /// for rows no batched path can answer (an unbound or unresolvable
-    /// subject).
-    async fn row_passes_exactly(
-        &self,
+    /// Plan the generic probe/filter once for all fallback rows. A private
+    /// row id survives the join: subject identity alone is insufficient when
+    /// two rows have different bounds, or an initially unbound subject binds.
+    async fn filter_batch_exactly(
+        &mut self,
         c: usize,
         batch: &Batch,
-        row: usize,
+        rows: &[usize],
+        keep: &mut [bool],
         ctx: &ExecutionContext<'_>,
-    ) -> Result<bool> {
+    ) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        self.fallback_rows += rows.len();
+        self.fallback_batches += 1;
         let cond = &self.conditions[c];
-        let seed = SeedOperator::from_batch_row(batch, row);
+        let mut used: std::collections::HashSet<VarId> = batch.schema().iter().copied().collect();
+        used.extend(cond.filter.referenced_vars());
+        used.insert(self.subject_var);
+        used.insert(cond.value_var);
+        let row_var = (0..=u16::MAX)
+            .rev()
+            .map(VarId)
+            .find(|v| !used.contains(v))
+            .ok_or_else(|| {
+                QueryError::Internal("no variable available for semi-join row id".into())
+            })?;
+        // Only the subject and filter operands are needed in the inner plan.
+        let mut schema: Vec<VarId> = batch
+            .schema()
+            .iter()
+            .copied()
+            .filter(|v| *v == self.subject_var || self.bound_vars[c].contains(v))
+            .collect();
+        let mut columns: Vec<Vec<Binding>> = schema
+            .iter()
+            .map(|v| {
+                rows.iter()
+                    .map(|r| batch.get(*r, *v).cloned().unwrap_or(Binding::Unbound))
+                    .collect()
+            })
+            .collect();
+        schema.push(row_var);
+        let row_datatype = fluree_db_core::Sid::new(fluree_vocab::namespaces::XSD, "long");
+        columns.push(
+            rows.iter()
+                .map(|r| Binding::lit(FlakeValue::Long(*r as i64), row_datatype.clone()))
+                .collect(),
+        );
+        let seed = BatchSeedOperator::from_batch(Batch::new(schema.into(), columns)?);
         let patterns = [
             Pattern::Triple(cond.probe(self.subject_var)),
             Pattern::Filter(cond.filter.clone()),
@@ -899,19 +979,42 @@ impl RangeSemiJoinOperator {
             Some(Box::new(seed)),
             &patterns,
             None,
-            None,
+            Some(&[row_var]),
             &self.planning,
         )?;
-        inner.open(ctx).await?;
-        let mut passes = false;
-        while let Some(out) = inner.next_batch(ctx).await? {
-            if !out.is_empty() {
-                passes = true;
-                break;
-            }
+        for row in rows {
+            keep[*row] = false;
         }
+        // Close the subtree on errors as well as on exhaustion.
+        let result = async {
+            inner.open(ctx).await?;
+            let mut remaining = rows.len();
+            while let Some(out) = inner.next_batch(ctx).await? {
+                for r in 0..out.len() {
+                    let Some(Binding::Lit {
+                        val: FlakeValue::Long(row),
+                        ..
+                    }) = out.get(r, row_var)
+                    else {
+                        return Err(QueryError::Internal(
+                            "semi-join fallback lost row id".into(),
+                        ));
+                    };
+                    if !keep[*row as usize] {
+                        keep[*row as usize] = true;
+                        remaining -= 1;
+                    }
+                }
+                // A semi-join needs only one witness per driving row.
+                if remaining == 0 {
+                    break;
+                }
+            }
+            Ok(())
+        }
+        .await;
         inner.close();
-        Ok(passes)
+        result
     }
 }
 
@@ -943,7 +1046,7 @@ fn decoded_binding(
 #[async_trait]
 impl Operator for RangeSemiJoinOperator {
     fn plan_children(&self) -> Vec<crate::plan_node::PlanChild<'_>> {
-        vec![crate::plan_node::PlanChild::child(self.child.as_ref())]
+        vec![crate::plan_node::PlanChild::child(self.input())]
     }
 
     fn plan_details(&self) -> serde_json::Map<String, serde_json::Value> {
@@ -988,13 +1091,33 @@ impl Operator for RangeSemiJoinOperator {
         if self.norm.is_none() {
             self.norm = equality_norm(ctx);
         }
-        self.child.open(ctx).await?;
+        self.restore_child();
+        if ctx.binary_store.is_none()
+            || !root_or_no_policy(ctx)
+            || ctx.is_multi_ledger()
+            || ctx.eager_materialization
+        {
+            // The generic plan dedups dead feature variables before probing.
+            // Retain that advantage when probe lanes decline. The fold's
+            // where_dedup_safe license permits this; all child bindings,
+            // including each row's range operands, remain in the dedup key.
+            self.fallback_dedup = Some(DistinctOperator::new(
+                self.child.take().expect("semi-join child"),
+            ));
+        }
+        self.input_mut().open(ctx).await?;
         for index in &mut self.indexes {
             *index = None;
         }
         for off in &mut self.walk_off {
             *off = false;
         }
+        self.walk_attempts.fill(0);
+        self.probed_rows = 0;
+        self.kept_rows = 0;
+        self.fallback_rows = 0;
+        self.fallback_batches = 0;
+        self.probe_batches = 0;
         self.state = OperatorState::Open;
         Ok(())
     }
@@ -1004,7 +1127,7 @@ impl Operator for RangeSemiJoinOperator {
             return Ok(None);
         }
         loop {
-            let batch = match self.child.next_batch(ctx).await? {
+            let batch = match self.input_mut().next_batch(ctx).await? {
                 Some(b) if !b.is_empty() => b,
                 Some(_) => continue,
                 None => {
@@ -1013,6 +1136,8 @@ impl Operator for RangeSemiJoinOperator {
                         kept = self.kept_rows,
                         fallback = self.fallback_rows,
                         probe_batches = self.probe_batches,
+                        fallback_batches = self.fallback_batches,
+                        walk_attempts = ?self.walk_attempts,
                         walked = self
                             .indexes
                             .iter()
@@ -1074,7 +1199,13 @@ impl Operator for RangeSemiJoinOperator {
                             Some(index) => index.envelope.union(&batch_envelope),
                             None => batch_envelope.clone(),
                         };
-                        match self.build_index_walk(c, &target, ctx)? {
+                        let outcome = if self.walk_attempts[c] < MAX_WALKS_PER_CONDITION {
+                            self.walk_attempts[c] += 1;
+                            self.build_index_walk(c, &target, ctx)?
+                        } else {
+                            WalkOutcome::Capped
+                        };
+                        match outcome {
                             WalkOutcome::Built(index) => self.indexes[c] = Some(index),
                             WalkOutcome::Capped | WalkOutcome::Declined => {
                                 self.walk_off[c] = true;
@@ -1133,12 +1264,8 @@ impl Operator for RangeSemiJoinOperator {
                         *keep_row = false;
                     }
                 }
-                for row in fallback_rows {
-                    self.fallback_rows += 1;
-                    if !self.row_passes_exactly(c, &batch, row, ctx).await? {
-                        keep[row] = false;
-                    }
-                }
+                self.filter_batch_exactly(c, &batch, &fallback_rows, &mut keep, ctx)
+                    .await?;
             }
 
             let kept = keep.iter().filter(|k| **k).count();
@@ -1172,7 +1299,8 @@ impl Operator for RangeSemiJoinOperator {
     }
 
     fn close(&mut self) {
-        self.child.close();
+        self.input_mut().close();
+        self.restore_child();
         for index in &mut self.indexes {
             *index = None;
         }
@@ -1180,6 +1308,41 @@ impl Operator for RangeSemiJoinOperator {
     }
 
     fn estimated_rows(&self) -> Option<usize> {
-        self.child.estimated_rows()
+        self.input().estimated_rows()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn integer_walk_bounds_round_outward_above_f64_precision() {
+        for (lower, upper, inside) in [
+            (
+                "18014398509481986.1",
+                "18014398509481987.9",
+                18_014_398_509_481_987,
+            ),
+            (
+                "-18014398509481987.9",
+                "-18014398509481986.1",
+                -18_014_398_509_481_987,
+            ),
+        ] {
+            let decimal =
+                |s| FlakeValue::Decimal(Box::new(bigdecimal::BigDecimal::from_str(s).unwrap()));
+            let envelope = Envelope {
+                lower: Some(decimal(lower)),
+                upper: Some(decimal(upper)),
+            };
+            let (lo, hi) = key_bounds(&envelope, DecodeKind::I64).unwrap();
+            let key = ObjKey::encode_i64(inside).as_u64();
+            assert!(
+                lo <= key && key <= hi,
+                "rounded walk bounds must include {inside}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

BSBM Explore Q5 (products similar to an anchor: a shared feature and two numeric properties within ±k of the anchor's) grew ~65x from 1M to 100M products and was 56–59% of the Explore mix. The cost is per-candidate CPU in the join chain over a candidate set of ~13% of all products, not I/O.

Four generic fixes, on for every query:

- **planner**: among equal-cardinality bound-subject probes, place first the one whose new variable a deferred FILTER *pins* (equality, `IN`, or a two-sided range with comparands free of the variable). Q5 evaluated its two range filters after paying for an `rdfs:label` lookup on every candidate. A one-sided bound does not count: BSBM Q7's `?date > now` keeps half the offers, and hoisting that probe ahead of the selective vendor/country check cost 15% on Q7 at 100M.
- **where_plan**: insert the WHERE-level early Distinct only where a live variable dies at that step, instead of after every step once any has.
- **distinct**: normalize keys through `Cow` and a reused scratch vector, so a duplicate costs a hash probe and no allocation.
- **eval**: try the encoded-IRI equality fast path before the bool-predicate LRU for `?v = / != <iri>` shapes (the 256-entry LRU thrashed over thousands of candidates).

`RangeSemiJoinOperator` (`fluree-db-query/src/range_semijoin.rs`): a probe `?s <p> ?v . FILTER(range on ?v)` whose value has no pushed-down constant bounds and is read by exactly one range filter with bounds computable from earlier-bound variables, and by nothing else, is folded behind the step that binds `?s`, under the same `where_dedup_safe` license the early dedup uses (it is a semi-join), never in history mode, with a 256-row minimum when a driving estimate is available. Per batch it takes the union of the rows' intervals, walks the predicate's POST leaflets for that envelope (directory-key pruning, binary search of the sorted key column of predicate- and type-homogeneous leaflets, only the subject and key columns decoded) into a subject → values map, and keeps a driving row iff one of its values passes the row's own interval exactly. The walk serves numeric-bound batches, using inline range keys where possible and decoding arena-backed decimals/large integers; a batch with a date or string bound, a walk that would cover more than `max(4k, 16 × driving rows)` rows, or a context where raw leaflets are not authoritative (novelty overlay, time-travel, dataset scope, restricting policy) is answered by the batched subject probes the nested loop would have used, and when those probes decline, a single generic probe/filter plan serves each batch with a private row ID preserving per-row bounds. In contexts where the fast probe lane cannot serve, the existing Distinct operator removes duplicate driving rows before fallback work, under the fold's multiplicity-insensitive license. Walked and driving rows are charged fuel per batch. Each condition allows at most four walks before switching to probes, bounding repeated envelope rebuilds; rare materialized values are boxed to keep inline arena entries small. The fold is stamped `range-semijoin` for the routing tests and honours `FLUREE_DISABLE_QUERY_FAST_PATHS`.

## Original measurements (before review fixes)

Result counts identical across every cell; 34 real products byte-identical at 1M and 10M.

| | base | this PR |
|---|---:|---:|
| 10M local, Q5 (Product1) | 6.6 ms | 1.9 ms |
| 100M EC2 m7a.4xlarge, Q5 at c1 | 43.4 ms | 19.1 ms |
| 100M, Q5 at c16 | 50.9 ms | 22.8 ms |
| 100M, Explore mix QMpH at c1 / c16 | 18,848 / 251,224 | 25,227 / 339,313 |

100M is official 4.2.0 vs HEAD-from-source vs this tree, two interleaved rounds; every other Explore query within noise of base after the tie-break was narrowed. At 1M through the BSBM driver (two interleaved rounds) the Explore mix is +1–2% (Q5 0.51 → 0.43 ms from the generic fixes; the fold stays below its driving-row gate) and the BI mix is flat within 2% on all eight queries.

These historical 10M/100M runs have not been repeated after the review fixes; they do not establish which range-semi-join lane ran at those scales. See the local review-validation measurements below.

## Tests

- `fluree-db-api/tests/it_range_semijoin.rs` computes expected rows in Rust over a generated fixture (strict boundaries, multi-valued numerics, a non-numeric value, a missing property, duplicate candidates, a novelty-only product, a projected value that must keep the real join, a wide range that must cap the walk, a date window that must take the probe path) and asserts routing through the stamps.
- Planner tests pin the tie-break, its one-sided exclusion, and the case where filter preference competes with the object-to-subject hash-scan preference. The precedence itself is unchanged by review fixes.
- `it_query_explain` pins the Distinct placement.
- W3C SPARQL suite and the query suites pass; clippy `-D warnings` and fmt clean.


## Review regression coverage

- Indexed decimal and out-of-i64 integer values, including in-range and excluded values.
- Constant comparisons (`>`, `>=`, `<`, `<=`, `=`) combined with correlated ranges on indexed and novelty views.
- Batch fallback with repeated subjects and different bounds, unbound/poisoned/missing subjects, and a non-root policy excluding a subject.
- Deterministic growing-envelope batches: four walks maximum, then probes with the same results.
- Outward integer key bounds for decimal ranges beyond exact f64 integer precision.
- A correlated Q5 matrix in `query_hot_bsbm`, with actual runtime routing checks outside timed iterations; indexed scale plus novelty and policy fallback fixtures. This is separate from the existing constant-price Q5 benchmark.

Both wrong-result regressions were reproduced using the expanded fixture on pre-fix commit `c859037bf`: the constant bound admitted extra rows, and the indexed query omitted `decimal_in`.

## Local measurements after review fixes

Same generated correlated-Q5 fixture and benchmark source in separate builds of pre-fix `c859037bf` and the corrected tree, using optimized `dev-fast` (opt-level 2). Untimed preflights check result counts against an independent calculation and record actual execution routes; timed iterations have tracing disabled. These are local diagnostics, not new production BSBM results.

| Fixture | Before fixes | After fixes |
|---|---:|---:|
| Indexed, 10k products (two rounds) | 0.326–0.423 ms | 0.326–0.331 ms |
| Indexed, 100k products (two longer repeats) | 2.72–2.79 ms | 2.73–2.75 ms |
| Pure novelty, 1,500 products (two rounds) | 29.1–32.6 ms | 6.72–7.56 ms |
| Non-root policy, 1,500 products (two rounds) | 46.3–46.6 ms | 16.3–18.9 ms |

Ranges are Criterion point estimates across runs, not confidence intervals. Initial 2-second 100k runs were 2.32 ms before / 2.58 ms after; the two interleaved 5-second repeats above did not reproduce that slowdown. There is no repeatable indexed regression in this local matrix, but the 10M/100M production workload still needs remeasurement for a production-scale conclusion.

At 10k, routing records four walked condition-batches and no probe condition-batches. At 100k, both versions record 13 walked and 13 probe condition-batches: one range walks, the other hits the conservative first-batch cap and uses probes. We leave that cap unchanged and make no claim that the historical 10M/100M gains came from walks. Novelty and policy cases use the generic fallback; after early input dedup they need four condition-batches rather than eight.

As a diagnostic, disabling **all query shape fast paths** on the corrected 10k fixture gives 0.920 ms indexed, 6.46 ms novelty, and 16.0 ms policy. This is not a fold-only comparison; it shows the corrected fallback is close to the generic pipeline rather than several times slower.

Reproduce with `FLUREE_BENCH_SCALE=medium cargo bench -p fluree-db-api --bench query_hot_bsbm --profile dev-fast -- query_range_semijoin --warm-up-time 0.5 --measurement-time 2 --noplot` (use `large` for 100k indexed products; fallback fixtures remain capped at 1,500).

The constant-bound correctness guard may cost more for those variants because it retains the enforcing join, and arena numeric support performs checks that were previously skipped incorrectly. Neither changes the eligibility of the original integer correlated-Q5 shape. We retain the conservative child cardinality estimate; range selectivity and a fresh large-scale BI-1 tie-break comparison remain follow-up work, not claims made by these fixes.
