### PR TITLE
fix(merge): fast-forward merges land on queue-backed nameservices and keep the target's index root

### DIFF
--- a/docs/guides/cookbook-branching.md
+++ b/docs/guides/cookbook-branching.md
@@ -156,6 +156,28 @@ fluree branch rebase my-branch --strategy abort
 fluree branch rebase my-branch --strategy take-source
 ```
 
+### Fast-forward indexing and transaction ordering
+
+A fast-forward advances the target to the source's commit head while retaining the target's own index. It does not copy or adopt the source's index, because that index's reserved graph names belong to the source branch. Queries replay commits after the target's indexed point until indexing catches up; a target with no index replays from genesis. For a large merged range, run `fluree index mydb:main` to catch up explicitly.
+
+For embedded applications calling `Fluree::merge_branch` directly with a Raft nameservice, the fast-forward ref update goes through consensus but bypasses the per-branch work queue. It can overtake transactions already submitted to that queue. The CAS checks the target head observed during merge preparation; if another writer advances it first, the merge returns `BranchConflict` (409) and should be retried so it recomputes against the new head. Repeating an already-completed fast-forward succeeds without copying commits again.
+
+The server's Raft merge path uses `QueuedTransactor::merge`, which queues the merge alongside transactions and prepares it when the worker reaches it. That path preserves queue ordering and was not affected by the direct API's empty-queue publish failure.
+
+### Repair a target that adopted another branch's index
+
+Older direct fast-forward merges from an indexed source could adopt the source's index root, giving the target the source branch's `#txn-meta` and `#config` graph labels. Ordinary data queries could still work while the target stopped resolving its own governance configuration. Rewriting the config alone does not repair the graph registry.
+
+Run a full rebuild of the affected target:
+
+```bash
+fluree reindex mydb:main
+```
+
+In an embedded application, call `fluree.reindex("mydb:main", ReindexOptions::default()).await?` on the serving instance. After publishing the rebuilt root, reindex evicts that instance's cached ledger so subsequent loads read the corrected registry, even when the index transaction time is unchanged. Existing handles held by callers must be reacquired; other serving instances must also reload their cached ledger. Older versions without this eviction require a cache disconnect or process restart after reindex.
+
+An affected root can also cause `graph_iris[0] must be txn-meta IRI` on the second incremental indexing cycle: the first cycle stamps the target's ledger ID onto the root but retains the source's graph labels. The normal indexer falls back to a full rebuild when this validation fails; it does not permanently stop indexing. Explicit reindex repairs the target without waiting for those cycles.
+
 ### Compare branches
 
 See what's different between two branches:

--- a/docs/indexing-and-search/reindex.md
+++ b/docs/indexing-and-search/reindex.md
@@ -8,6 +8,8 @@ Unlike [background indexing](background-indexing.md) which incrementally updates
 
 Reindex publishes the new index root via `publish_index_allow_equal`, which means a reindex can produce a **new index root CID** even when `index_t` stays the same (same logical snapshot, different physical layout/config).
 
+After a successful publish, reindex evicts the calling instance's cached ledger. Subsequent loads use the rebuilt root and graph registry even when `index_t` is unchanged. Callers holding an existing ledger handle must reacquire it; caches in other serving instances must also reload the ledger.
+
 ## When to Reindex
 
 ### Common Use Cases

--- a/fluree-db-api/src/admin.rs
+++ b/fluree-db-api/src/admin.rs
@@ -1885,6 +1885,7 @@ impl crate::Fluree {
     /// 2. Builds a fresh binary columnar index from the commit chain
     /// 3. Validates ledger hasn't advanced (conflict detection)
     /// 4. Publishes new index (allows same t via AdminPublisher)
+    /// 5. Evicts the cached ledger so subsequent loads use the rebuilt index
     ///
     /// # Errors
     /// - `NotFound` if ledger doesn't exist or has no commits
@@ -2077,6 +2078,12 @@ impl crate::Fluree {
         self.publisher()?
             .publish_index_allow_equal(&ledger_id, index_result.index_t, &index_result.root_id)
             .await?;
+
+        // Reindex can replace a damaged root at the same index t. A cached
+        // handle may otherwise keep its old graph registry indefinitely.
+        if let Some(ref lm) = self.ledger_manager {
+            lm.disconnect(&ledger_id).await;
+        }
 
         info!(
             ledger_id = %ledger_id,

--- a/fluree-db-api/src/merge.rs
+++ b/fluree-db-api/src/merge.rs
@@ -422,10 +422,29 @@ impl crate::Fluree {
             }
         };
 
-        // Best-effort: copy source's index into the target namespace
-        // (and, for fast-forward, publish the index ref too). Errors
-        // here only warn — the target can rebuild from commits.
-        if let Some((index_cid, index_t)) = source_index_for_publish {
+        // Best-effort: copy source's index artifacts into the target
+        // namespace. Errors here only warn — the target can rebuild from
+        // commits.
+        //
+        // The source's index ROOT is deliberately not published as the
+        // target's. A root carries `graph_iris`, the g_id → IRI table the
+        // registry is re-seeded from, and those IRIs are branch-qualified:
+        // slot 1 is `urn:fluree:{ledger}:{branch}#txn-meta` and slot 2
+        // `…#config`. Publishing the source's root therefore relabels the
+        // target's reserved slots with the SOURCE branch's names, and since
+        // the config graph is resolved by slot (`CONFIG_GRAPH_ID = 2`), the
+        // target reads the source's empty config and reports itself
+        // ungoverned — while its real config is displaced to a user slot.
+        // The flakes are untouched (queries resolve by slot, so data and
+        // txn-meta still read correctly); it is the label table that is
+        // wrong, which is worse for being invisible to a data query.
+        //
+        // Leaving the target's own index ref alone costs a rebuild from
+        // commits — the same cost as any un-indexed write — and keeps the
+        // registry the target created for itself. Adopting the root would
+        // need its `graph_iris` rewritten to the target's before publish;
+        // that is the optimisation, not the fix.
+        if let Some((index_cid, _index_t)) = source_index_for_publish {
             if let Err(e) = self
                 .copy_index_to_branch(&source_ledger_id, &target_id, &index_cid)
                 .await
@@ -434,14 +453,6 @@ impl crate::Fluree {
                     %e, source = %source_ledger_id, target = %target_id,
                     "failed to copy index during merge; target will rebuild from commits"
                 );
-            } else if fast_forward {
-                if let Err(e) = self
-                    .publisher()?
-                    .publish_index(&target_id, index_t, &index_cid)
-                    .await
-                {
-                    tracing::warn!(%e, "failed to publish index for merged target");
-                }
             }
         }
 

--- a/fluree-db-api/src/merge.rs
+++ b/fluree-db-api/src/merge.rs
@@ -81,9 +81,9 @@ pub struct StagedMerge {
     /// `None` for fast-forward (the ref just advances to
     /// `new_head_*`).
     pub commit: Option<GuardedStagedCommit>,
-    /// Source's index ref (if any). Best-effort copy after the ref
-    /// advance so the target reuses the source's index. Only set for
-    /// fast-forward — general merge invalidates the source's index.
+    /// Source's index artifacts to copy best-effort after a general merge.
+    /// The root is never published as the target's index. Fast-forward
+    /// merges leave this unset and retain the target's own index.
     pub source_index_for_publish: Option<(ContentId, i64)>,
     /// Source ledger id used as the source for any best-effort
     /// post-apply index copy. Carried through so the apply path can
@@ -120,6 +120,17 @@ impl crate::Fluree {
     ///
     /// If `target_branch` is `None`, the source's parent branch (from its
     /// branch point) is used as the target.
+    ///
+    /// On a queue-backed nameservice, this direct API's fast-forward uses
+    /// a ref CAS through consensus, bypassing the per-branch work queue.
+    /// It can therefore overtake previously queued transactions. Server
+    /// merges submitted through `QueuedTransactor` remain queue-ordered.
+    /// If the target head changes after preparation, re-run the merge on
+    /// `BranchConflict` to recompute against that head.
+    ///
+    /// Fast-forward retains the target's index and replays the merged
+    /// commits on reads until indexing catches up; it does not adopt or
+    /// copy the source's index artifacts.
     pub async fn merge_branch(
         &self,
         ledger_name: &str,
@@ -500,11 +511,6 @@ impl crate::Fluree {
             .await?;
 
         let current_head_t = ancestor.map(|a| a.t).unwrap_or(0);
-        let source_index_for_publish = source_record
-            .index_head_id
-            .as_ref()
-            .map(|cid| (cid.clone(), source_record.index_t));
-
         Ok(StagedMerge {
             target: resolved_target.to_string(),
             source: source_branch.to_string(),
@@ -521,7 +527,7 @@ impl crate::Fluree {
             new_head_t: source_head_t,
             new_head_id: source_head_id,
             commit: None,
-            source_index_for_publish,
+            source_index_for_publish: None,
         })
     }
 

--- a/fluree-db-api/src/merge.rs
+++ b/fluree-db-api/src/merge.rs
@@ -14,11 +14,18 @@ use fluree_db_core::ledger_id::format_ledger_id;
 use fluree_db_core::{collect_dag_cids, load_commit_by_id, CommonAncestor};
 use fluree_db_core::{BranchedContentStore, ConflictKey, ContentId, ContentStore};
 use fluree_db_ledger::{LedgerState, StagedLedger};
-use fluree_db_nameservice::{NsRecord, NsRecordSnapshot};
+use fluree_db_nameservice::{CasResult, NsRecord, NsRecordSnapshot, RefValue};
 use fluree_db_novelty::compute_delta_keys;
 use fluree_db_transact::{CommitOpts, NamespaceRegistry};
 use serde::Serialize;
 use tracing::Instrument;
+
+/// CAS attempts a fast-forward merge makes before reporting contention.
+///
+/// Matches the bulk importer's budget: both are a single ref advance
+/// competing only with other writers to the same branch head, and both would
+/// rather surface contention than spin.
+const FF_MERGE_CAS_RETRIES: usize = 5;
 
 /// Output of [`Fluree::prepare_merge`].
 ///
@@ -353,9 +360,64 @@ impl crate::Fluree {
             },
             None => {
                 // Fast-forward: advance target's HEAD to the source's head.
-                self.publisher()?
-                    .publish_commit(&target_id, new_head_t, &new_head_id)
-                    .await?;
+                //
+                // A ref-level fast-forward, NOT `publish_commit`. On a
+                // queue-backed nameservice (the raft data plane)
+                // `publish_commit`'s contract is "apply the staged queue
+                // front", and a fast-forward stages nothing on the target —
+                // so it failed with "per-branch queue is empty — nothing
+                // staged for this branch" on exactly the merges that need no
+                // work. The general path below stages a merge commit, which
+                // is why a DIVERGENT merge succeeded while a clean
+                // fast-forwardable one did not: the easier the merge, the
+                // surer the failure.
+                //
+                // `fast_forward_commit` carries the same strictly-newer
+                // semantics (`new.t > current.t`) that the file/S3
+                // nameservices give `publish_commit`, and every nameservice
+                // implements it via `RefPublisher` — the same reasoning, and
+                // the same call, that bulk import already uses in
+                // `publish_import_commit_head`.
+                let new_ref = RefValue {
+                    id: Some(new_head_id.clone()),
+                    t: new_head_t,
+                };
+                match self
+                    .publisher()?
+                    .fast_forward_commit(&target_id, &new_ref, FF_MERGE_CAS_RETRIES)
+                    .await?
+                {
+                    CasResult::Updated => {}
+                    // Idempotent re-run: the head is already exactly where
+                    // this merge wanted to put it.
+                    CasResult::Conflict { actual }
+                        if actual.as_ref().is_some_and(|a| {
+                            a.t == new_head_t && a.id.as_ref() == Some(&new_head_id)
+                        }) => {}
+                    CasResult::Conflict { actual } => {
+                        return Err(ApiError::internal(match actual.as_ref() {
+                            // `fast_forward_commit` reports the same
+                            // `Conflict` when its retry budget runs out with
+                            // the fast-forward still valid — contention, not
+                            // divergence.
+                            None => format!(
+                                "fast-forward merge into {target_id} gave up after contended \
+                                 CAS attempts: head is still unborn, wanted t={new_head_t}"
+                            ),
+                            Some(a) if a.t < new_head_t => format!(
+                                "fast-forward merge into {target_id} gave up after contended \
+                                 CAS attempts: head is at t={}, wanted t={new_head_t}",
+                                a.t
+                            ),
+                            Some(a) => format!(
+                                "fast-forward merge into {target_id} found a diverged head: \
+                                 head is t={} id={:?}, wanted t={new_head_t} id={new_head_id} \
+                                 — re-run the merge so it recomputes against the new head",
+                                a.t, a.id
+                            ),
+                        }));
+                    }
+                }
                 (new_head_t, new_head_id)
             }
         };

--- a/fluree-db-api/src/merge.rs
+++ b/fluree-db-api/src/merge.rs
@@ -14,18 +14,11 @@ use fluree_db_core::ledger_id::format_ledger_id;
 use fluree_db_core::{collect_dag_cids, load_commit_by_id, CommonAncestor};
 use fluree_db_core::{BranchedContentStore, ConflictKey, ContentId, ContentStore};
 use fluree_db_ledger::{LedgerState, StagedLedger};
-use fluree_db_nameservice::{CasResult, NsRecord, NsRecordSnapshot, RefValue};
+use fluree_db_nameservice::{CasResult, NsRecord, NsRecordSnapshot, RefKind, RefValue};
 use fluree_db_novelty::compute_delta_keys;
 use fluree_db_transact::{CommitOpts, NamespaceRegistry};
 use serde::Serialize;
 use tracing::Instrument;
-
-/// CAS attempts a fast-forward merge makes before reporting contention.
-///
-/// Matches the bulk importer's budget: both are a single ref advance
-/// competing only with other writers to the same branch head, and both would
-/// rather surface contention than spin.
-const FF_MERGE_CAS_RETRIES: usize = 5;
 
 /// Output of [`Fluree::prepare_merge`].
 ///
@@ -142,10 +135,32 @@ impl crate::Fluree {
             let source_id = staged.source_id.clone();
             let target_id = staged.target_id.clone();
             let target_snapshot = staged.rollback_snapshot.clone();
+            let published_head = staged.new_head_id.clone();
 
             match self.apply_merge(staged).await {
                 Ok(report) => Ok(report),
                 Err(e) => {
+                    // Roll back only a head this merge advanced. A failure
+                    // before the publish — a fast-forward CAS that lost to a
+                    // concurrent writer included — leaves the target's head
+                    // to that writer; forcing the snapshot back over it
+                    // would orphan their commit.
+                    let head_is_ours = self
+                        .nameservice()
+                        .lookup(&target_id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .is_some_and(|r| r.commit_head_id.as_ref() == Some(&published_head));
+                    if !head_is_ours {
+                        tracing::warn!(
+                            source = %source_id,
+                            target = %target_id,
+                            error = %e,
+                            "merge failed before its head was published; nothing to roll back"
+                        );
+                        return Err(e);
+                    }
                     tracing::warn!(
                         source = %source_id,
                         target = %target_id,
@@ -324,8 +339,8 @@ impl crate::Fluree {
             conflict_count,
             strategy,
             commits_copied,
-            current_head_t: _,
-            current_head_id: _,
+            current_head_t,
+            current_head_id,
             new_head_t,
             new_head_id,
             commit,
@@ -361,30 +376,35 @@ impl crate::Fluree {
             None => {
                 // Fast-forward: advance target's HEAD to the source's head.
                 //
-                // A ref-level fast-forward, NOT `publish_commit`. On a
-                // queue-backed nameservice (the raft data plane)
-                // `publish_commit`'s contract is "apply the staged queue
-                // front", and a fast-forward stages nothing on the target —
-                // so it failed with "per-branch queue is empty — nothing
-                // staged for this branch" on exactly the merges that need no
-                // work. The general path below stages a merge commit, which
-                // is why a DIVERGENT merge succeeded while a clean
-                // fast-forwardable one did not: the easier the merge, the
-                // surer the failure.
+                // A ref-level CAS, NOT `publish_commit`. On a queue-backed
+                // nameservice (the raft data plane) `publish_commit`'s
+                // contract is "apply the staged queue front", and a
+                // fast-forward stages nothing on the target — so it failed
+                // with "per-branch queue is empty — nothing staged for this
+                // branch" on exactly the merges that need no work. The
+                // general path above stages a merge commit, which is why a
+                // DIVERGENT merge succeeded while a clean fast-forwardable
+                // one did not: the easier the merge, the surer the failure.
                 //
-                // `fast_forward_commit` carries the same strictly-newer
-                // semantics (`new.t > current.t`) that the file/S3
-                // nameservices give `publish_commit`, and every nameservice
-                // implements it via `RefPublisher` — the same reasoning, and
-                // the same call, that bulk import already uses in
-                // `publish_import_commit_head`.
+                // The CAS expects the head `prepare_merge` computed the
+                // fast-forward against. Fast-forward is an ancestry claim
+                // ("the target head is the common ancestor"), and a retrying
+                // `fast_forward_commit` only checks `t`-ordering: a commit
+                // that landed on the target after preparation would be
+                // silently orphaned by a source head with a larger `t`. The
+                // general path gets the same guard from its write lock and
+                // `expected_head_ref`; this is the fast-forward twin.
+                let expected = RefValue {
+                    id: current_head_id.clone(),
+                    t: current_head_t,
+                };
                 let new_ref = RefValue {
                     id: Some(new_head_id.clone()),
                     t: new_head_t,
                 };
                 match self
                     .publisher()?
-                    .fast_forward_commit(&target_id, &new_ref, FF_MERGE_CAS_RETRIES)
+                    .compare_and_set_ref(&target_id, RefKind::CommitHead, Some(&expected), &new_ref)
                     .await?
                 {
                     CasResult::Updated => {}
@@ -395,27 +415,15 @@ impl crate::Fluree {
                             a.t == new_head_t && a.id.as_ref() == Some(&new_head_id)
                         }) => {}
                     CasResult::Conflict { actual } => {
-                        return Err(ApiError::internal(match actual.as_ref() {
-                            // `fast_forward_commit` reports the same
-                            // `Conflict` when its retry budget runs out with
-                            // the fast-forward still valid — contention, not
-                            // divergence.
-                            None => format!(
-                                "fast-forward merge into {target_id} gave up after contended \
-                                 CAS attempts: head is still unborn, wanted t={new_head_t}"
-                            ),
-                            Some(a) if a.t < new_head_t => format!(
-                                "fast-forward merge into {target_id} gave up after contended \
-                                 CAS attempts: head is at t={}, wanted t={new_head_t}",
-                                a.t
-                            ),
-                            Some(a) => format!(
-                                "fast-forward merge into {target_id} found a diverged head: \
-                                 head is t={} id={:?}, wanted t={new_head_t} id={new_head_id} \
-                                 — re-run the merge so it recomputes against the new head",
-                                a.t, a.id
-                            ),
-                        }));
+                        let moved_to = actual.as_ref().map_or_else(
+                            || "an unknown head".to_string(),
+                            |a| format!("t={} id={:?}", a.t, a.id),
+                        );
+                        return Err(ApiError::BranchConflict(format!(
+                            "fast-forward merge into {target_id} lost a race: the head moved \
+                             from t={current_head_t} to {moved_to} while the merge was being \
+                             prepared — re-run the merge so it recomputes against the new head"
+                        )));
                     }
                 }
                 (new_head_t, new_head_id)

--- a/fluree-db-api/tests/it_cached_handle_cow.rs
+++ b/fluree-db-api/tests/it_cached_handle_cow.rs
@@ -24,7 +24,7 @@
 
 use std::sync::Mutex;
 
-use fluree_db_api::{Fluree, FlureeBuilder, LedgerHandle, RefreshOpts, ReindexOptions};
+use fluree_db_api::{Fluree, FlureeBuilder, LedgerHandle, ReindexOptions};
 use serde_json::json;
 use tracing::field::{Field, Visit};
 use tracing_subscriber::layer::Context;
@@ -179,15 +179,19 @@ async fn cached_handle_commits_uniquely_own_the_dictionaries() {
     assert_eq!(pre_index.len(), 5, "expected one probe per commit");
     assert_uniquely_owned(&pre_index, "before any index");
 
-    // --- Phase 2: publish an index and install it on the cached handle ----
+    // --- Phase 2: publish an index and reload the cached handle -----------
+    // Reindex evicts the cached ledger, including for same-t root repairs.
+    // Existing caller-held handles are not updated by that eviction; drop
+    // ours and reacquire the handle that subsequent cached writes use.
+    drop(handle);
     fluree
         .reindex(ledger_id, ReindexOptions::default())
         .await
         .expect("reindex");
-    fluree
-        .refresh(ledger_id, RefreshOpts::default())
+    let handle = fluree
+        .ledger_cached(ledger_id)
         .await
-        .expect("refresh the cached handle onto the new index");
+        .expect("reload the cached handle from the rebuilt index");
     // Hard assert, not a skip: if the index never reached the cached handle,
     // the phases below would silently re-test the pre-index case.
     assert!(

--- a/fluree-db-api/tests/it_merge.rs
+++ b/fluree-db-api/tests/it_merge.rs
@@ -8,6 +8,9 @@ use crate::support;
 use fluree_db_api::{ConflictStrategy, FlureeBuilder};
 use serde_json::json;
 
+#[path = "support/merge_race.rs"]
+mod race_nameservice;
+
 /// Extract sorted name strings from query result rows.
 fn extract_names(rows: &serde_json::Value) -> Vec<String> {
     let mut names: Vec<String> = rows
@@ -88,9 +91,123 @@ async fn merge_fast_forward() {
     assert_eq!(report.source, "dev");
     assert!(report.commits_copied > 0);
 
+    let repeated = fluree
+        .merge_branch("mydb", "dev", None, ConflictStrategy::default())
+        .await
+        .expect("repeating a completed fast-forward is idempotent");
+    assert!(repeated.fast_forward);
+    assert_eq!(repeated.commits_copied, 0);
+    assert_eq!(repeated.new_head_id, report.new_head_id);
+    assert_eq!(repeated.new_head_t, report.new_head_t);
+    let head = fluree
+        .nameservice()
+        .lookup("mydb:main")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(head.commit_head_id.as_ref(), Some(&report.new_head_id));
+    assert_eq!(head.commit_t, report.new_head_t);
+
     // Main should now see Alice (base) + Bob (from dev)
     let names = query_all_names(&fluree, "mydb:main").await;
     assert_eq!(names, vec!["Alice", "Bob"]);
+}
+
+/// Pause the public merge after preparation and land a real target commit.
+/// A smaller t than the source catches a retry based on t-ordering; equal t
+/// with a different CID catches an idempotency check that ignores identity.
+async fn assert_fast_forward_loses_race(source_commits: usize) {
+    use fluree_db_api::{ApiError, Fluree, NameServiceMode};
+    use std::{sync::Arc, time::Duration};
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    fluree
+        .insert(
+            ledger,
+            &json!({"@id": "urn:base", "http://example.org/ns/name": "Base"}),
+        )
+        .await
+        .unwrap();
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
+    for i in 0..source_commits {
+        let dev = fluree.ledger("mydb:dev").await.unwrap();
+        fluree
+            .insert(
+                dev,
+                &json!({"@id": format!("urn:source:{i}"), "http://example.org/ns/name": "Source"}),
+            )
+            .await
+            .unwrap();
+    }
+    let pause = Arc::new(race_nameservice::PausingNameService::new(
+        fluree.nameservice_mode().publisher_arc().unwrap(),
+    ));
+    let merger = Fluree::from_backend(
+        fluree.config().clone(),
+        fluree.backend().clone(),
+        NameServiceMode::ReadWrite(pause.clone()),
+    );
+    let merging = tokio::spawn(async move {
+        merger
+            .merge_branch("mydb", "dev", None, ConflictStrategy::default())
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(10), pause.entered.notified())
+        .await
+        .expect("merge must reach the prepared-head CAS");
+
+    let main = fluree.ledger("mydb:main").await.unwrap();
+    let winner = fluree
+        .insert(
+            main,
+            &json!({"@id": "urn:winner", "http://example.org/ns/name": "Winner"}),
+        )
+        .await
+        .unwrap();
+    let winner_head = fluree
+        .nameservice()
+        .lookup("mydb:main")
+        .await
+        .unwrap()
+        .unwrap();
+    pause.resume.notify_one();
+    let error = tokio::time::timeout(Duration::from_secs(10), merging)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert!(matches!(error, ApiError::BranchConflict(_)), "{error:?}");
+    assert_eq!(error.status_code(), 409);
+    let after = fluree
+        .nameservice()
+        .lookup("mydb:main")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        after.commit_head_id, winner_head.commit_head_id,
+        "rollback must preserve the concurrent writer's head"
+    );
+    assert_eq!(after.commit_t, winner_head.commit_t);
+    assert_eq!(after.commit_t, winner.ledger.t());
+    assert_eq!(
+        query_all_names(&fluree, "mydb:main").await,
+        vec!["Base", "Winner"]
+    );
+}
+
+#[tokio::test]
+async fn merge_fast_forward_preserves_concurrent_target_commit() {
+    assert_fast_forward_loses_race(2).await;
+}
+
+#[tokio::test]
+async fn merge_fast_forward_rejects_same_t_with_different_head() {
+    assert_fast_forward_loses_race(1).await;
 }
 
 /// Fast-forward merge with multiple commits on the source branch.
@@ -800,6 +917,60 @@ async fn index_branch(fluree: &support::MemoryFluree, ledger_id: &str) {
 /// kept working — the corruption was only visible through the registry.
 #[tokio::test]
 async fn merge_fast_forward_keeps_target_graph_registry_and_config() {
+    let fluree = governed_main_with_indexed_feature().await;
+    let feature_ref = fluree
+        .nameservice()
+        .lookup("mydb:feature")
+        .await
+        .unwrap()
+        .unwrap();
+    let source_root = feature_ref.index_head_id.unwrap();
+    assert!(fluree
+        .content_store("mydb:main")
+        .get(&source_root)
+        .await
+        .is_err());
+
+    let report = fluree
+        .merge_branch("mydb", "feature", None, ConflictStrategy::default())
+        .await
+        .unwrap();
+    assert!(report.fast_forward, "main never advanced: {report:?}");
+
+    let main = fluree.ledger("mydb:main").await.unwrap();
+    assert_eq!(
+        main.snapshot.graph_registry.iri_for_graph_id(1),
+        Some("urn:fluree:mydb:main#txn-meta"),
+        "slot 1 must stay main's txn-meta, not the branch's"
+    );
+    assert_eq!(
+        main.snapshot.graph_registry.iri_for_graph_id(2),
+        Some("urn:fluree:mydb:main#config"),
+        "slot 2 must stay main's config — it is resolved by slot"
+    );
+    assert_eq!(
+        resolved_default_allow(&fluree, "mydb:main").await,
+        Some(false),
+        "main must still resolve its own config after the merge"
+    );
+
+    assert!(
+        fluree
+            .content_store("mydb:main")
+            .get(&source_root)
+            .await
+            .is_err(),
+        "fast-forward must not copy the unreferenced source index root"
+    );
+
+    // And the merge still delivered the data.
+    assert_eq!(
+        query_all_names(&fluree, "mydb:main").await,
+        vec!["Alice", "Bob"]
+    );
+}
+
+async fn governed_main_with_indexed_feature() -> fluree_db_api::Fluree {
     use fluree_db_core::graph_registry::config_graph_iri;
 
     let fluree = FlureeBuilder::memory().build_memory();
@@ -874,32 +1045,185 @@ async fn merge_fast_forward_keeps_target_graph_registry_and_config() {
         Some("urn:fluree:mydb:feature#config")
     );
 
-    let report = fluree
+    fluree
+}
+
+/// Reproduce the old fast-forward's index adoption using real source
+/// artifacts, without changing the merge implementation under test.
+async fn main_with_adopted_feature_index() -> fluree_db_api::Fluree {
+    use fluree_db_binary_index::{collect_root_cas_ids_expanded, format::index_root::IndexRoot};
+    use fluree_db_core::CODEC_FLUREE_DICT_BLOB;
+
+    let fluree = governed_main_with_indexed_feature().await;
+    fluree
         .merge_branch("mydb", "feature", None, ConflictStrategy::default())
         .await
         .unwrap();
-    assert!(report.fast_forward, "main never advanced: {report:?}");
-
-    let main = fluree.ledger("mydb:main").await.unwrap();
+    let source = fluree
+        .nameservice()
+        .lookup("mydb:feature")
+        .await
+        .unwrap()
+        .unwrap();
+    let source_root = source.index_head_id.unwrap();
+    let source_store = fluree.branched_content_store("mydb:feature").await.unwrap();
+    let root_bytes = source_store.get(&source_root).await.unwrap();
+    let root = IndexRoot::decode(&root_bytes).unwrap();
+    let target_store = fluree.content_store("mydb:main");
+    for cid in collect_root_cas_ids_expanded(&source_store, &root)
+        .await
+        .unwrap()
+    {
+        if cid.codec() != CODEC_FLUREE_DICT_BLOB && cid.content_kind().is_some() {
+            target_store
+                .put_with_id(&cid, &source_store.get(&cid).await.unwrap())
+                .await
+                .unwrap();
+        }
+    }
+    target_store
+        .put_with_id(&source_root, &root_bytes)
+        .await
+        .unwrap();
+    fluree
+        .publisher()
+        .unwrap()
+        .publish_index("mydb:main", source.index_t, &source_root)
+        .await
+        .unwrap();
+    fluree
+        .ledger_manager()
+        .unwrap()
+        .disconnect("mydb:main")
+        .await;
+    let cached = fluree
+        .ledger_cached("mydb:main")
+        .await
+        .unwrap()
+        .snapshot()
+        .await;
     assert_eq!(
-        main.snapshot.graph_registry.iri_for_graph_id(1),
-        Some("urn:fluree:mydb:main#txn-meta"),
-        "slot 1 must stay main's txn-meta, not the branch's"
+        cached.snapshot.graph_registry.iri_for_graph_id(1),
+        Some("urn:fluree:mydb:feature#txn-meta")
+    );
+    assert_eq!(resolved_default_allow(&fluree, "mydb:main").await, None);
+    fluree
+}
+
+#[tokio::test]
+async fn reindex_repairs_adopted_branch_registry_in_cached_reads() {
+    let fluree = main_with_adopted_feature_index().await;
+    let before = fluree
+        .nameservice()
+        .lookup("mydb:main")
+        .await
+        .unwrap()
+        .unwrap();
+    fluree
+        .reindex("mydb:main", fluree_db_api::ReindexOptions::default())
+        .await
+        .unwrap();
+    let after = fluree
+        .nameservice()
+        .lookup("mydb:main")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        after.index_t, before.index_t,
+        "repair replaces the root at the same t"
+    );
+    assert_ne!(after.index_head_id, before.index_head_id);
+    assert_eq!(after.commit_head_id, before.commit_head_id);
+
+    // No manual disconnect or new Fluree instance: normal cached reads must
+    // now see the repaired registry, policy, and data.
+    let cached = fluree
+        .ledger_cached("mydb:main")
+        .await
+        .unwrap()
+        .snapshot()
+        .await;
+    assert_eq!(
+        cached.snapshot.graph_registry.iri_for_graph_id(1),
+        Some("urn:fluree:mydb:main#txn-meta")
     );
     assert_eq!(
-        main.snapshot.graph_registry.iri_for_graph_id(2),
-        Some("urn:fluree:mydb:main#config"),
-        "slot 2 must stay main's config — it is resolved by slot"
+        cached.snapshot.graph_registry.iri_for_graph_id(2),
+        Some("urn:fluree:mydb:main#config")
     );
     assert_eq!(
         resolved_default_allow(&fluree, "mydb:main").await,
-        Some(false),
-        "main must still resolve its own config after the merge"
+        Some(false)
     );
-
-    // And the merge still delivered the data.
     assert_eq!(
         query_all_names(&fluree, "mydb:main").await,
         vec!["Alice", "Bob"]
     );
+}
+
+#[tokio::test]
+async fn adopted_branch_index_second_cycle_falls_back_to_rebuild() {
+    use fluree_db_binary_index::format::index_root::IndexRoot;
+    use fluree_db_indexer::run_index::resolve::resolver::SharedResolverState;
+
+    let fluree = main_with_adopted_feature_index().await;
+    for cycle in 1..=2 {
+        let ledger = fluree.ledger("mydb:main").await.unwrap();
+        fluree.insert(ledger, &json!({"@id": format!("urn:cycle:{cycle}"), "http://example.org/ns/name": format!("Cycle {cycle}")})).await.unwrap();
+        let record = fluree
+            .nameservice()
+            .lookup("mydb:main")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(record.commit_t > record.index_t);
+        let config = fluree_db_indexer::IndexerConfig::default();
+        assert!(config.incremental_enabled);
+        assert!(record.commit_t - record.index_t <= config.incremental_max_commits as i64);
+        let result = fluree_db_indexer::build_index_for_record(
+            fluree.content_store("mydb:main"),
+            &record,
+            config,
+        )
+        .await
+        .unwrap();
+        let root = IndexRoot::decode(
+            &fluree
+                .content_store("mydb:main")
+                .get(&result.root_id)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(root.ledger_id, "mydb:main");
+        if cycle == 1 {
+            assert_eq!(
+                root.graph_iris[0], "urn:fluree:mydb:feature#txn-meta",
+                "first incremental cycle preserves the adopted labels"
+            );
+            let error = SharedResolverState::from_index_root(&root)
+                .err()
+                .expect("the next incremental cycle cannot seed from this root");
+            assert!(
+                error
+                    .to_string()
+                    .contains("graph_iris[0] must be txn-meta IRI"),
+                "{error}"
+            );
+        } else {
+            assert_eq!(
+                root.graph_iris[0], "urn:fluree:mydb:main#txn-meta",
+                "second cycle falls back to a full rebuild"
+            );
+            assert_eq!(root.graph_iris[1], "urn:fluree:mydb:main#config");
+            assert!(SharedResolverState::from_index_root(&root).is_ok());
+        }
+        fluree
+            .publisher()
+            .unwrap()
+            .publish_index("mydb:main", result.index_t, &result.root_id)
+            .await
+            .unwrap();
+    }
 }

--- a/fluree-db-api/tests/it_merge.rs
+++ b/fluree-db-api/tests/it_merge.rs
@@ -748,3 +748,158 @@ async fn merge_explicit_target_matches_parent() {
     let names = query_all_names(&fluree, "mydb:main").await;
     assert_eq!(names, vec!["Alice", "Bob"]);
 }
+
+// =============================================================================
+// Fast-forward merge keeps the target's own graph registry
+// =============================================================================
+
+/// The `f:defaultAllow` value a ledger's attached config resolves to, read
+/// the way the engine reads it: by the config graph's fixed slot.
+async fn resolved_default_allow(fluree: &support::MemoryFluree, ledger_id: &str) -> Option<bool> {
+    let view = fluree.db(ledger_id).await.unwrap();
+    view.ledger_config()
+        .and_then(|config| config.policy.as_ref())
+        .and_then(|policy| policy.default_allow)
+}
+
+/// Build and publish a real index root for `ledger_id`. The branch's
+/// pre-fork commits live in its source's namespace, so the rebuild needs
+/// the branch-aware store rather than the flat one the shared helper uses.
+async fn index_branch(fluree: &support::MemoryFluree, ledger_id: &str) {
+    let record = fluree
+        .nameservice()
+        .lookup(ledger_id)
+        .await
+        .unwrap()
+        .expect("branch is registered");
+    let store = fluree.branched_content_store(ledger_id).await.unwrap();
+    let built = fluree_db_indexer::rebuild_index_from_commits(
+        store,
+        ledger_id,
+        &record,
+        fluree_db_indexer::IndexerConfig::default(),
+    )
+    .await
+    .expect("branch index rebuild");
+    fluree
+        .publisher()
+        .unwrap()
+        .publish_index(ledger_id, built.index_t, &built.root_id)
+        .await
+        .unwrap();
+}
+
+/// A fast-forward merge must not publish the source's index root as the
+/// target's. An index root carries `graph_iris`, the slot → IRI table the
+/// registry is re-seeded from, and those IRIs are branch-qualified: slot 1
+/// is `urn:fluree:{ledger}:{branch}#txn-meta`, slot 2 `…#config`. Adopting
+/// the branch's root relabelled main's reserved slots with the branch's
+/// names, and because the config graph is resolved by slot, main read the
+/// branch's empty config and reported itself ungoverned while its real
+/// config sat in a user slot. Data queries resolve by slot too, so they
+/// kept working — the corruption was only visible through the registry.
+#[tokio::test]
+async fn merge_fast_forward_keeps_target_graph_registry_and_config() {
+    use fluree_db_core::graph_registry::config_graph_iri;
+
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    let main_ledger = fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:alice", "ex:name": "Alice"}]
+            }),
+        )
+        .await
+        .unwrap()
+        .ledger;
+
+    // Govern main.
+    let config_iri = config_graph_iri("mydb:main");
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig .
+            <urn:config:main> f:policyDefaults <urn:config:policy> .
+            <urn:config:policy> f:defaultAllow false .
+        }}
+    "
+    );
+    fluree
+        .stage_owned(main_ledger)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("config write");
+    assert_eq!(
+        resolved_default_allow(&fluree, "mydb:main").await,
+        Some(false),
+        "main is governed before the branch exists"
+    );
+
+    // Fork from an unindexed main, so the branch seeds its own registry
+    // under its own name, then give it a commit and a real index root.
+    fluree
+        .create_branch("mydb", "feature", None, None)
+        .await
+        .unwrap();
+    let feature_ledger = fluree.ledger("mydb:feature").await.unwrap();
+    fluree
+        .insert(
+            feature_ledger,
+            &json!({
+                "@context": {"ex": "http://example.org/ns/"},
+                "@graph": [{"@id": "ex:bob", "ex:name": "Bob"}]
+            }),
+        )
+        .await
+        .unwrap();
+    index_branch(&fluree, "mydb:feature").await;
+
+    // Precondition for the regression: the branch's root labels its
+    // reserved slots with the BRANCH's IRIs. Without this the publish
+    // would be harmless and the assertions below vacuous.
+    let feature = fluree.ledger("mydb:feature").await.unwrap();
+    assert_eq!(
+        feature.snapshot.graph_registry.iri_for_graph_id(1),
+        Some("urn:fluree:mydb:feature#txn-meta")
+    );
+    assert_eq!(
+        feature.snapshot.graph_registry.iri_for_graph_id(2),
+        Some("urn:fluree:mydb:feature#config")
+    );
+
+    let report = fluree
+        .merge_branch("mydb", "feature", None, ConflictStrategy::default())
+        .await
+        .unwrap();
+    assert!(report.fast_forward, "main never advanced: {report:?}");
+
+    let main = fluree.ledger("mydb:main").await.unwrap();
+    assert_eq!(
+        main.snapshot.graph_registry.iri_for_graph_id(1),
+        Some("urn:fluree:mydb:main#txn-meta"),
+        "slot 1 must stay main's txn-meta, not the branch's"
+    );
+    assert_eq!(
+        main.snapshot.graph_registry.iri_for_graph_id(2),
+        Some("urn:fluree:mydb:main#config"),
+        "slot 2 must stay main's config — it is resolved by slot"
+    );
+    assert_eq!(
+        resolved_default_allow(&fluree, "mydb:main").await,
+        Some(false),
+        "main must still resolve its own config after the merge"
+    );
+
+    // And the merge still delivered the data.
+    assert_eq!(
+        query_all_names(&fluree, "mydb:main").await,
+        vec!["Alice", "Bob"]
+    );
+}

--- a/fluree-db-api/tests/support/merge_race.rs
+++ b/fluree-db-api/tests/support/merge_race.rs
@@ -1,0 +1,266 @@
+//! A deterministic pause immediately before the merge's ref CAS.
+//! All other operations use the real nameservice, including rollback.
+
+use async_trait::async_trait;
+use fluree_db_core::ContentId;
+use fluree_db_nameservice::{
+    AdminPublisher, BranchLifecycle, CasResult, CommitPublisher, ConfigCasResult, ConfigLookup,
+    ConfigPublisher, ConfigValue, GraphSourceLookup, GraphSourcePublisher, GraphSourceRecord,
+    GraphSourceType, IndexPublisher, LedgerHeads, LedgerLifecycle, NameServiceLookup,
+    NameServicePublisher, NsLookupResult, NsRecord, NsRecordSnapshot, RefKind, RefLookup,
+    RefPublisher, RefValue, Result, StatusCasResult, StatusLookup, StatusPublisher, StatusValue,
+};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use tokio::sync::Notify;
+
+#[derive(Debug)]
+pub(super) struct PausingNameService {
+    inner: Arc<dyn NameServicePublisher>,
+    armed: AtomicBool,
+    pub(super) entered: Notify,
+    pub(super) resume: Notify,
+}
+
+impl PausingNameService {
+    pub(super) fn new(inner: Arc<dyn NameServicePublisher>) -> Self {
+        Self {
+            inner,
+            armed: AtomicBool::new(true),
+            entered: Notify::new(),
+            resume: Notify::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl GraphSourceLookup for PausingNameService {
+    async fn lookup_graph_source(
+        &self,
+        graph_source_id: &str,
+    ) -> Result<Option<GraphSourceRecord>> {
+        self.inner.lookup_graph_source(graph_source_id).await
+    }
+
+    async fn lookup_any(&self, resource_id: &str) -> Result<NsLookupResult> {
+        self.inner.lookup_any(resource_id).await
+    }
+
+    async fn all_graph_source_records(&self) -> Result<Vec<GraphSourceRecord>> {
+        self.inner.all_graph_source_records().await
+    }
+}
+
+#[async_trait]
+impl RefLookup for PausingNameService {
+    async fn get_ref(&self, ledger_id: &str, kind: RefKind) -> Result<Option<RefValue>> {
+        self.inner.get_ref(ledger_id, kind).await
+    }
+}
+
+#[async_trait]
+impl StatusLookup for PausingNameService {
+    async fn get_status(&self, ledger_id: &str) -> Result<Option<StatusValue>> {
+        self.inner.get_status(ledger_id).await
+    }
+}
+
+#[async_trait]
+impl ConfigLookup for PausingNameService {
+    async fn get_config(&self, ledger_id: &str) -> Result<Option<ConfigValue>> {
+        self.inner.get_config(ledger_id).await
+    }
+}
+
+#[async_trait]
+impl NameServiceLookup for PausingNameService {
+    async fn lookup(&self, ledger_id: &str) -> Result<Option<NsRecord>> {
+        self.inner.lookup(ledger_id).await
+    }
+
+    async fn all_records(&self) -> Result<Vec<NsRecord>> {
+        self.inner.all_records().await
+    }
+
+    async fn list_branches(&self, ledger_name: &str) -> Result<Vec<NsRecord>> {
+        self.inner.list_branches(ledger_name).await
+    }
+
+    async fn heads(&self, ledger_id: &str) -> Result<Option<LedgerHeads>> {
+        self.inner.heads(ledger_id).await
+    }
+}
+
+#[async_trait]
+impl BranchLifecycle for PausingNameService {
+    async fn create_branch(
+        &self,
+        ledger_name: &str,
+        new_branch: &str,
+        source_branch: &str,
+        at_commit: Option<(ContentId, i64)>,
+    ) -> Result<()> {
+        self.inner
+            .create_branch(ledger_name, new_branch, source_branch, at_commit)
+            .await
+    }
+
+    async fn drop_branch(&self, ledger_id: &str) -> Result<Option<u32>> {
+        self.inner.drop_branch(ledger_id).await
+    }
+
+    async fn reset_head(&self, ledger_id: &str, snapshot: NsRecordSnapshot) -> Result<()> {
+        self.inner.reset_head(ledger_id, snapshot).await
+    }
+
+    async fn pending_commit_cids(
+        &self,
+        ledger_id: &str,
+        since_t: i64,
+    ) -> Result<Option<Vec<(i64, ContentId)>>> {
+        self.inner.pending_commit_cids(ledger_id, since_t).await
+    }
+
+    async fn prune_commit_index(&self, ledger_id: &str, up_to_t: i64) -> Result<()> {
+        self.inner.prune_commit_index(ledger_id, up_to_t).await
+    }
+}
+
+#[async_trait]
+impl LedgerLifecycle for PausingNameService {
+    async fn init(&self, ledger_id: &str) -> Result<()> {
+        self.inner.init(ledger_id).await
+    }
+
+    async fn retract(&self, ledger_id: &str) -> Result<()> {
+        self.inner.retract(ledger_id).await
+    }
+
+    async fn purge(&self, ledger_id: &str) -> Result<()> {
+        self.inner.purge(ledger_id).await
+    }
+}
+
+#[async_trait]
+impl CommitPublisher for PausingNameService {
+    async fn publish_commit(
+        &self,
+        ledger_id: &str,
+        commit_t: i64,
+        commit_id: &ContentId,
+    ) -> Result<()> {
+        self.inner
+            .publish_commit(ledger_id, commit_t, commit_id)
+            .await
+    }
+
+    fn publishing_ledger_id(&self, ledger_id: &str) -> Option<String> {
+        self.inner.publishing_ledger_id(ledger_id)
+    }
+}
+
+#[async_trait]
+impl IndexPublisher for PausingNameService {
+    async fn publish_index(
+        &self,
+        ledger_id: &str,
+        index_t: i64,
+        index_id: &ContentId,
+    ) -> Result<()> {
+        self.inner.publish_index(ledger_id, index_t, index_id).await
+    }
+}
+
+#[async_trait]
+impl AdminPublisher for PausingNameService {
+    async fn publish_index_allow_equal(
+        &self,
+        ledger_id: &str,
+        index_t: i64,
+        index_id: &ContentId,
+    ) -> Result<()> {
+        self.inner
+            .publish_index_allow_equal(ledger_id, index_t, index_id)
+            .await
+    }
+}
+
+#[async_trait]
+impl RefPublisher for PausingNameService {
+    async fn compare_and_set_ref(
+        &self,
+        ledger_id: &str,
+        kind: RefKind,
+        expected: Option<&RefValue>,
+        new: &RefValue,
+    ) -> Result<CasResult> {
+        if ledger_id == "mydb:main"
+            && kind == RefKind::CommitHead
+            && self.armed.swap(false, Ordering::SeqCst)
+        {
+            self.entered.notify_one();
+            self.resume.notified().await;
+        }
+        self.inner
+            .compare_and_set_ref(ledger_id, kind, expected, new)
+            .await
+    }
+}
+
+#[async_trait]
+impl GraphSourcePublisher for PausingNameService {
+    async fn publish_graph_source(
+        &self,
+        name: &str,
+        branch: &str,
+        source_type: GraphSourceType,
+        config: &str,
+        dependencies: &[String],
+    ) -> Result<()> {
+        self.inner
+            .publish_graph_source(name, branch, source_type, config, dependencies)
+            .await
+    }
+
+    async fn publish_graph_source_index(
+        &self,
+        name: &str,
+        branch: &str,
+        index_id: &ContentId,
+        index_t: i64,
+    ) -> Result<()> {
+        self.inner
+            .publish_graph_source_index(name, branch, index_id, index_t)
+            .await
+    }
+
+    async fn retract_graph_source(&self, name: &str, branch: &str) -> Result<()> {
+        self.inner.retract_graph_source(name, branch).await
+    }
+}
+
+#[async_trait]
+impl StatusPublisher for PausingNameService {
+    async fn push_status(
+        &self,
+        ledger_id: &str,
+        expected: Option<&StatusValue>,
+        new: &StatusValue,
+    ) -> Result<StatusCasResult> {
+        self.inner.push_status(ledger_id, expected, new).await
+    }
+}
+
+#[async_trait]
+impl ConfigPublisher for PausingNameService {
+    async fn push_config(
+        &self,
+        ledger_id: &str,
+        expected: Option<&ConfigValue>,
+        new: &ConfigValue,
+    ) -> Result<ConfigCasResult> {
+        self.inner.push_config(ledger_id, expected, new).await
+    }
+}

--- a/fluree-db-consensus/tests/it_embedded_node.rs
+++ b/fluree-db-consensus/tests/it_embedded_node.rs
@@ -421,3 +421,98 @@ async fn a_probe_that_finds_the_entry_just_popped_still_returns_the_receipt() {
         last_t = receipt.commit.t;
     }
 }
+
+/// A fast-forward merge lands on a queue-backed nameservice.
+///
+/// The regression this pins: `apply_merge`'s fast-forward arm used to call
+/// `publish_commit`, whose contract on the replicated data plane is "apply
+/// the staged queue front". A fast-forward stages nothing on the target —
+/// that is what makes it a fast-forward — so it failed with "per-branch
+/// queue is empty — nothing staged for this branch" on precisely the merges
+/// that need the least work, while a divergent merge (which stages a merge
+/// commit) succeeded.
+///
+/// It has to run here rather than beside the other merge tests: those build
+/// `FlureeBuilder::memory()`, whose `publish_commit` is already a plain ref
+/// write, so every one of them passed throughout.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_fast_forward_merge_lands_through_consensus() {
+    use fluree_db_api::ConflictStrategy;
+
+    let (integration, fluree, node, _dirs) = stand_up(15, |config| config).await;
+    fluree.create_ledger("ffdb").await.expect("create ledger");
+
+    // One commit on main, so the branch has somewhere to fork from.
+    node.committer
+        .transact(TransactionRequest {
+            idempotency_key: None,
+            ledger_id: "ffdb:main".into(),
+            body: TransactionBody::JsonLdInsert(serde_json::json!({
+                "@context": {"ex": "http://example.org/"},
+                "@id": "ex:base", "ex:name": "base"
+            })),
+            txn_opts: Default::default(),
+            commit_opts: Default::default(),
+            tracking: None,
+            governance: Default::default(),
+        })
+        .await
+        .expect("seed main");
+
+    fluree
+        .create_branch("ffdb", "feature", None, None)
+        .await
+        .expect("create branch");
+
+    // Two commits on the branch and NONE on main — the shape that failed.
+    for i in 0..2 {
+        node.committer
+            .transact(TransactionRequest {
+                idempotency_key: None,
+                ledger_id: "ffdb:feature".into(),
+                body: TransactionBody::JsonLdInsert(serde_json::json!({
+                    "@context": {"ex": "http://example.org/"},
+                    "@id": format!("ex:item{i}"), "ex:name": format!("item {i}")
+                })),
+                txn_opts: Default::default(),
+                commit_opts: Default::default(),
+                tracking: None,
+                governance: Default::default(),
+            })
+            .await
+            .expect("commit on branch");
+    }
+
+    let report = fluree
+        .merge_branch("ffdb", "feature", None, ConflictStrategy::default())
+        .await
+        .expect("a fast-forward merge must land on a queue-backed nameservice");
+
+    assert!(
+        report.fast_forward,
+        "main never advanced, so this must be a fast-forward: {report:?}"
+    );
+    assert_eq!(
+        report.conflict_count, 0,
+        "nothing diverged, so nothing can conflict: {report:?}"
+    );
+    assert_eq!(
+        report.commits_copied, 2,
+        "main gains both of the branch's commits: {report:?}"
+    );
+
+    // The head actually moved — a merge that reports success without
+    // advancing the ref would leave the proposal unlanded.
+    let record = integration
+        .nameservice()
+        .lookup("ffdb:main")
+        .await
+        .expect("lookup")
+        .expect("main is registered");
+    assert_eq!(
+        record.commit_t, report.new_head_t,
+        "main's replicated head must be the merged head: {report:?}"
+    );
+
+    node.shutdown().await;
+}


### PR DESCRIPTION
Direct `Fluree::merge_branch` fast-forwards could fail on a queue-backed nameservice with `per-branch queue is empty — nothing staged for this branch`. From an indexed source, the same path could also adopt the source's branch-qualified graph registry, causing the target to stop resolving its own governance configuration while ordinary data queries continued to work.

This PR advances the commit ref against the prepared target head, preserves the target's index, and makes a full reindex repair visible to subsequent cached reads. The branch includes current `origin/main`; #1801 has merged.

## Commit publication and ordering

- Fast-forwards use one `RefPublisher::compare_and_set_ref` with the target head captured during preparation. A concurrent target commit causes `BranchConflict` (409); callers re-run the merge to recompute against the new head. There is no retry based only on transaction-time ordering.
- An already-reached head is idempotent success only when both transaction time and commit ID match. Repeating a completed fast-forward copies zero commits.
- A failed merge rolls back only if the target still has this merge's published head. Losing the CAS preserves the concurrent writer's head instead of resetting it; on Raft, avoiding that reset also avoids clearing the branch queue.
- Direct API fast-forwards go through Raft consensus but bypass the per-branch work queue, so they can overtake previously queued transactions. The server's `QueuedTransactor::merge` → `commit_worker::process_merge` path queues and prepares merges alongside transactions; it was not affected by the empty-queue failure and retains queue ordering.

The queue failure affected direct API callers on queue-backed deployments, including embedded Raft use. It did not prevent every proposal or merge on every replicated deployment. The queue publication contract remains unchanged; fast-forwards neither weaken it nor invent a no-op commit.

## Target index and repair

An index root carries branch-qualified `graph_iris`. Publishing the source root as the target's relabelled the target's reserved txn-meta/config slots. The target now retains its own index ref and reads the merged range from commits until indexing catches up. Fast-forwards also skip copying the source's unreferenced index artifacts, avoiding unnecessary storage reads and writes. Rewriting/adopting source roots is deferred.

For an already-affected target, run a full reindex (`fluree reindex mydb:main`, or the serving instance's `Fluree::reindex`). After successful publication, reindex evicts the calling instance's cached ledger, including when the new root has the same index transaction time. Subsequent loads see the repaired registry and governance configuration. Existing caller-held handles must be reacquired; other serving instances must reload their cached ledger. Rewriting config alone does not repair the registry.

The indexing escalation is now reproduced: the first incremental cycle stamps the target's ledger ID but preserves the adopted branch labels. The next cycle fails the `graph_iris[0] must be txn-meta IRI` validation. The normal indexer then falls back to a full rebuild and restores the target labels; it does not permanently stop indexing. The branching cookbook documents the repair, fallback, index catch-up cost, and queue-ordering distinction.

## Validation

- `cargo test -p fluree-db-api --test grp_ledger`: 170 passed, including deterministic public-API races with a real concurrent target commit at smaller and equal transaction times, idempotent repetition, absence of the copied source root, same-time reindex cache repair, and both indexing cycles on an affected root.
- `cargo test -p fluree-db-api --test grp_index reindex`: 23 passed (67 unrelated tests filtered out).
- `cargo test -p fluree-db-consensus --features raft,testing --test it_embedded_node`: 6 passed, including the real queue-backed fast-forward regression.
- `cargo clippy -p fluree-db-api --all-targets --no-deps -- -D warnings` and the consensus equivalent with `--features raft,testing`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Six mutation checks failed as expected: remove idempotent success, retry CAS against a newer target, ignore commit identity, restore unconditional rollback, restore the unused source-index copy, and remove reindex cache eviction. All mutations were restored before the passing checks above.
