### PR TITLE
Validate SHACL rules on merge operations

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -2488,7 +2488,7 @@ Bearer token required when `data_auth.mode = required`; reads are gated on `bear
 
 **URL:**
 ```
-GET /merge-preview/{ledger-name}?source={source}&target={target}&max_commits={n}&max_conflict_keys={n}&include_conflicts={bool}&include_conflict_details={bool}&strategy={strategy}&include_changes={bool}&max_changes={n}&changes_after_subject={iri}
+GET /merge-preview/{ledger-name}?source={source}&target={target}&max_commits={n}&max_conflict_keys={n}&include_conflicts={bool}&include_conflict_details={bool}&strategy={strategy}&include_changes={bool}&max_changes={n}&changes_after_subject={iri}&include_validation={bool}
 ```
 
 **Path / Query Parameters:**
@@ -2506,6 +2506,7 @@ GET /merge-preview/{ledger-name}?source={source}&target={target}&max_commits={n}
 | `include_changes` | bool | No | When true, includes the aggregate **netted** change set the merge would apply (source side, ancestor..source-head) as `changes`. Defaults to false. Costs one full commit load per commit in the source divergence; the walk is shared with the conflict computation when both are requested. |
 | `max_changes` | number | No | Cap on change entries returned, counted in **flakes** and cut at subject boundaries (default 500; server clamps to a hard maximum of 5,000). A single subject larger than the cap is returned whole. `0` is a valid "diff stats" mode: exact counts, no payload. Bounds response size, **not** the replay walk. |
 | `changes_after_subject` | string | No | Pagination cursor: return only subjects whose full IRI sorts strictly after this value. Pass the previous response's `changes.next_cursor`. Each page re-pays the full replay + netting cost. Requires `include_changes=true`. |
+| `include_validation` | bool | No | When true (the default), stages the strategy-resolved change set on the target and validates it against the target's SHACL configuration and shapes exactly as `POST /merge` would, reporting the outcome as `validation` and folding it into `mergeable`. Costs a target-state load plus the validation pass, plus the source replay when `include_changes` is false. Set false for count-only previews. |
 
 **Response body (200 OK):**
 
@@ -2525,6 +2526,7 @@ GET /merge-preview/{ledger-name}?source={source}&target={target}&max_commits={n}
   "behind": { "count": 1, "commits": [...], "truncated": false },
   "fast_forward": false,
   "mergeable": true,
+  "validation": { "conforms": true },
   "conflicts": {
     "count": 1,
     "keys": [{ "s": [100, "alice"], "p": [100, "status"], "g": null }],
@@ -2567,7 +2569,8 @@ GET /merge-preview/{ledger-name}?source={source}&target={target}&max_commits={n}
 | `ahead` | object | Commits on source not on target (`count`, `commits`, `truncated`) |
 | `behind` | object | Commits on target not on source |
 | `fast_forward` | bool | True when target HEAD == ancestor (or both heads absent) |
-| `mergeable` | bool | False only when the selected preview strategy would abort, e.g. `strategy=abort` with conflicts. This is a strategy/conflict signal, not full transaction validation. `mergeable=true` does not guarantee a subsequent `POST /merge` will succeed; it only reflects the conflict/strategy interaction at preview time. |
+| `mergeable` | bool | Whether the merge would go through: the selected strategy can be applied without aborting (false for `strategy=abort` with conflicts) **and**, when `validation` is present, the merged state conforms to the target's shapes. With `include_validation=false` it is the strategy/conflict signal alone. |
+| `validation` | object | Present iff `include_validation=true` (the default) and the merge is not a fast-forward. `{ "conforms": bool, "report"?: string }` — the same SHACL outcome `POST /merge` would produce for this strategy; `report` is present only when `conforms` is false and is the message the merge would fail with. A fast-forward adopts commits already validated when they were authored, so it carries no `validation`. |
 | `conflicts` | object | Overlapping `(s, p, g)` keys touched on both sides since the ancestor. Empty when `fast_forward` or `include_conflicts=false` |
 | `changes` | object | Present iff `include_changes=true`. Aggregate netted change set — see below |
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -2570,7 +2570,7 @@ GET /merge-preview/{ledger-name}?source={source}&target={target}&max_commits={n}
 | `behind` | object | Commits on target not on source |
 | `fast_forward` | bool | True when target HEAD == ancestor (or both heads absent) |
 | `mergeable` | bool | Whether the merge would go through: the selected strategy can be applied without aborting (false for `strategy=abort` with conflicts) **and**, when `validation` is present, the merged state conforms to the target's shapes. With `include_validation=false` it is the strategy/conflict signal alone. |
-| `validation` | object | Present iff `include_validation=true` (the default) and the merge is not a fast-forward. `{ "conforms": bool, "report"?: string }` — the same SHACL outcome `POST /merge` would produce for this strategy; `report` is present only when `conforms` is false and is the message the merge would fail with. A fast-forward adopts commits already validated when they were authored, so it carries no `validation`. |
+| `validation` | object | Present iff `include_validation=true` (the default) and the merge is not a fast-forward. `{ "conforms": bool, "report"?: string }`, the same SHACL outcome `POST /merge` would produce for this strategy; `report` is present only when `conforms` is false and is the message the merge would fail with. A fast-forward adopts commits already validated when they were authored, so it carries no `validation`. |
 | `conflicts` | object | Overlapping `(s, p, g)` keys touched on both sides since the ancestor. Empty when `fast_forward` or `include_conflicts=false` |
 | `changes` | object | Present iff `include_changes=true`. Aggregate netted change set — see below |
 

--- a/docs/cli/branch.md
+++ b/docs/cli/branch.md
@@ -206,6 +206,8 @@ If the branch has no unique commits, a fast-forward rebase is performed — the 
 
 Conflicts occur when both the branch and source have modified the same (subject, predicate, graph) tuples. See [conflict strategies](../concepts/ledgers-and-nameservice.md#rebasing-a-branch) for details.
 
+Each replayed commit is validated against the source branch's SHACL configuration and shapes, exactly as a transaction would be. A commit that conformed on the branch can violate a shape the source installed since the fork; the first such replay aborts the whole rebase with the same violation report a rejected transaction prints, naming the commit it stopped on, and the branch is left as it was.
+
 **Examples:**
 
 ```bash
@@ -260,7 +262,8 @@ fluree branch diff <SOURCE> [OPTIONS]
 | `--max-conflict-keys <N>` | Cap on conflict keys shown (default: 50; pass 0 for unbounded in local mode) |
 | `--no-conflicts` | Skip conflict computation for a cheaper preview |
 | `--conflict-details` | Include source/target flake values for returned conflict keys |
-| `--strategy <STRATEGY>` | Strategy used for conflict detail labels (default: `take-both`). Options: `take-both`, `abort`, `take-source`, `take-branch` |
+| `--strategy <STRATEGY>` | Strategy used for conflict detail labels and for resolving the change set that validation stages (default: `take-both`). Options: `take-both`, `abort`, `take-source`, `take-branch` |
+| `--no-validate` | Skip SHACL validation of the merged state. Validation runs by default and its outcome folds into `mergeable` |
 | `--json` | Emit the raw JSON preview |
 | `-l, --ledger <LEDGER>` | Ledger name (defaults to active ledger) |
 | `--remote <REMOTE>` | Execute against a remote server |
@@ -268,6 +271,8 @@ fluree branch diff <SOURCE> [OPTIONS]
 **Description:**
 
 `branch diff` reports ahead/behind commits, fast-forward eligibility, and conflicting `(subject, predicate, graph)` keys without mutating state. With `--conflict-details`, the preview also shows the source and target values for the returned conflict keys and annotates what the selected strategy would do.
+
+By default the preview also stages the merge's resolved change set on the target and validates it against the target's SHACL configuration and shapes, through the same code path `branch merge` uses. The `validation:` line reports `conforms` or the violation report the merge would fail with, and `mergeable:` is `yes` only when the strategy applies and the result conforms. A preview that says `mergeable: yes` therefore means the merge will go through unless the ledger changes in between. Fast-forward previews carry no validation line: the adopted commits were validated when they were authored. Pass `--no-validate` for a cheaper count-only preview.
 
 **Examples:**
 
@@ -318,6 +323,8 @@ When `--target` is omitted, the merge target is inferred from the source branch'
 
 After a successful merge, the source branch remains intact and can continue to receive new transactions and be merged again. Only the new commits since the last merge (or branch creation) are copied.
 
+A non-fast-forward merge is validated against the target's SHACL configuration and shapes before anything is written, exactly as a transaction producing the merged state would be. This matters most for `take-both`, whose "both values coexist" resolution can breach a `sh:maxCount` on a property both sides changed: the merge is rejected with the same violation report a rejected transaction prints, and the target is left untouched. Warn-mode graphs log and proceed. Shapes referenced through a cross-ledger `f:shapesSource` are resolved and enforced like any other. Use `branch diff` to see the outcome before merging.
+
 **Examples:**
 
 ```bash
@@ -359,6 +366,8 @@ fluree branch revert --from <COMMIT> --to <COMMIT>
 ```
 
 Accepts either positional commit references (cherry-pick style, one or several) or a git-style range. Each commit reference may be a `t:N` transaction number, a hex digest prefix, or a full commit ID — the same forms `branch create --at` accepts.
+
+The revert commit is validated against the branch's SHACL configuration and shapes before it is written. Undoing a commit can remove a value a later shape requires (a `sh:minCount`, say); such a revert is rejected with the same violation report a rejected transaction prints, and the branch is left as it was.
 
 | Option | Description |
 |--------|-------------|

--- a/docs/cli/server-integration.md
+++ b/docs/cli/server-integration.md
@@ -824,6 +824,7 @@ GET {api_base_url}/merge-preview/{ledger}?source={source}&target={target}
    &max_commits={n}&max_conflict_keys={n}&include_conflicts={bool}
    &include_conflict_details={bool}&strategy={strategy}
    &include_changes={bool}&max_changes={n}&changes_after_subject={iri}
+   &include_validation={bool}
 ```
 
 | Parameter | Type | Required | Server default | Description |
@@ -839,6 +840,7 @@ GET {api_base_url}/merge-preview/{ledger}?source={source}&target={target}
 | `include_changes` | bool | No | `false` | When `true`, include the aggregate netted change set as `changes` |
 | `max_changes` | integer | No | `500` | Cap on `changes.entries`, counted in flakes, cut at subject boundaries. `0` = stats-only mode |
 | `changes_after_subject` | string | No | — | Pagination cursor (full subject IRI); requires `include_changes=true` |
+| `include_validation` | bool | No | `true` | When `true`, stage the strategy-resolved change set on the target and validate it against the target's SHACL shapes; report as `validation` and fold into `mergeable` |
 
 Auth follows the same pattern as `GET /branch/*ledger` (read-only): require
 a Bearer when `data_auth.mode == required`; gate on `can_read(ledger)`;
@@ -935,6 +937,22 @@ These rules are not negotiable; the CLI and other clients depend on them:
    `include_changes=true` is a `400`. The source-side commit replay is
    shared with the conflict walk when both are requested; each pagination
    page re-pays the replay cost.
+12. **Validation.** When `include_validation == true` (the default) and
+   `!fast_forward`, stage the change set from rule 11, resolved under
+   `strategy` against the **uncapped** conflict set, onto the target's
+   current state and run the same SHACL validation `POST /merge` runs for
+   that strategy. Report `validation: { conforms, report? }`, where
+   `report` is present only when `conforms == false` and is the message
+   the merge would fail with. `mergeable` is then
+   `strategy-applies && validation.conforms`; with
+   `include_validation=false` it is the strategy signal alone and
+   `validation` is absent. Fast-forward previews carry no `validation`:
+   the adopted commits were validated when authored. Under
+   `strategy=abort` with conflicts the merge never reaches validation, so
+   `validation` is absent there too. This rule is what lets a client
+   trust `mergeable=true`: absent a change to either ledger in between,
+   the merge will go through. Warn-mode graphs log and count as
+   conforming, matching transactions. This is still read-only (rule 9).
 
 ### Response (`200 OK`)
 
@@ -962,6 +980,7 @@ These rules are not negotiable; the CLI and other clients depend on them:
   "behind": { "count": 1, "commits": [], "truncated": false },
   "fast_forward": false,
   "mergeable": true,
+  "validation": { "conforms": true },
   "conflicts": {
     "count": 1,
     "keys": [{ "s": [100, "alice"], "p": [100, "status"], "g": null }],
@@ -1022,11 +1041,12 @@ When `include_conflict_details=false`, `conflicts.details` is omitted. When it
 is true, `source_values` and `target_values` are resolved flake tuples for the
 current asserted values in the same shape returned by `GET /show/*ledger`;
 `resolution` is a label only. `mergeable` is `false` when the chosen strategy
-would abort (currently `strategy=abort` with one or more conflicts). It is not
-full transaction validation for constraints that might fail during the real
-merge commit. `mergeable=true` does not guarantee a subsequent `POST /merge`
-will succeed; it only reflects the conflict/strategy interaction at preview
-time.
+would abort (currently `strategy=abort` with one or more conflicts) or, when
+`validation` is present, when the merged state fails the target's SHACL
+shapes (rule 12). With validation on, `mergeable=true` means a subsequent
+`POST /merge` with the same strategy will succeed unless either branch
+changes in between; with `include_validation=false` it reflects only the
+conflict/strategy interaction.
 
 ### Error responses
 

--- a/docs/getting-started/rust-api.md
+++ b/docs/getting-started/rust-api.md
@@ -1128,9 +1128,24 @@ async fn main() -> Result<()> {
             println!("  - s={} p={}", k.s, k.p);
         }
     }
+
+    // `mergeable` is the answer to "will `merge_branch` go through?": the
+    // strategy applies without aborting AND the merged state conforms to
+    // the target's SHACL shapes. The preview stages the resolved change
+    // set and runs the same validation the merge runs, so the two agree.
+    if let Some(v) = &preview.validation {
+        if !v.conforms {
+            println!("merge would be rejected:\n{}", v.report.as_deref().unwrap_or(""));
+        }
+    }
+    println!("mergeable: {}", preview.mergeable);
     Ok(())
 }
 ```
+
+`validation` is present for every non-fast-forward preview unless
+`MergePreviewOpts::include_validation` is `false`. A fast-forward adopts
+commits that were validated when they were authored, so it carries none.
 
 #### Tuning the preview
 
@@ -1154,6 +1169,7 @@ async fn main() -> Result<()> {
                 max_commits: Some(0),       // counts only — no commit summaries
                 max_conflict_keys: Some(0),
                 include_conflicts: false,
+                include_validation: false,  // skip the target-state load + SHACL pass
                 ..MergePreviewOpts::default()
             },
         )
@@ -1274,12 +1290,15 @@ lists**, not the cost of computing them:
 | `ConflictSummary` | `count` (unbounded), `keys: Vec<ConflictKey>` (sorted, capped), `truncated`, `strategy`, `details` |
 | `ConflictDetail` | `key`, `source_values`, `target_values`, `resolution` (values are the current asserted values at each branch HEAD) |
 | `ConflictKey` | `s: Sid`, `p: Sid`, `g: Option<Sid>` |
+| `ValidationSummary` | `conforms`, `report: Option<String>` (present only when `conforms` is false; the message the merge would fail with) |
 
-`mergeable` only reflects whether the selected strategy would abort due to
-detected conflicts; it is not full validation of every constraint the eventual
-merge commit may encounter. `mergeable=true` does not guarantee a subsequent
-merge will succeed; it only reflects the conflict/strategy interaction at
-preview time.
+`mergeable` is `false` when the selected strategy would abort on detected
+conflicts or, when `validation` is present, when the merged state fails the
+target's SHACL shapes. The preview stages the resolved change set and runs
+the same validation `merge_branch` runs, so with `include_validation` on
+(the default) `mergeable=true` means the merge will succeed unless either
+branch changes first. With it off, `mergeable` reflects only the
+conflict/strategy interaction.
 
 All types derive `Serialize` so the response is wire-stable; the HTTP
 endpoint at `GET /v1/fluree/merge-preview/{ledger...}` returns the same struct.

--- a/docs/guides/cookbook-branching.md
+++ b/docs/guides/cookbook-branching.md
@@ -158,6 +158,18 @@ fluree branch rebase my-branch --strategy take-source
 
 ### Compare branches
 
+Preview what a merge would do before doing it:
+
+```bash
+# Ahead/behind commits, conflicts, whether the merge would go through
+fluree branch diff my-branch --target main
+
+# With the values on each side of every conflict
+fluree branch diff my-branch --target main --conflict-details
+```
+
+The preview stages the merge's resolved change set on the target and validates it against the target's SHACL shapes, through the same code path the merge uses. `mergeable: yes` means the merge will go through unless either branch changes first; otherwise the `validation:` line carries the report the merge would fail with. Pass `--no-validate` for a cheaper count-only preview.
+
 See what's different between two branches:
 
 ```bash

--- a/docs/guides/cookbook-shacl.md
+++ b/docs/guides/cookbook-shacl.md
@@ -735,7 +735,7 @@ SHACL validation runs consistently on every write surface:
 - JSON-LD / SPARQL transactions (`fluree insert`, `fluree upsert`, `fluree update`)
 - Turtle / TriG ingest (`fluree insert-turtle`, `stage_turtle_insert`)
 - Commit replay (`push_commits_with_handle`, followers applying upstream commits)
-- Branch operations (`fluree branch merge`, `rebase`, `revert`) — the merged, replayed, or inverted state is validated against the target branch's shapes before anything is written, and `fluree branch diff` reports the same outcome ahead of time
+- Branch operations (`fluree branch merge`, `rebase`, `revert`): the merged, replayed, or inverted state is validated against the target branch's shapes before anything is written, and `fluree branch diff` reports the same outcome ahead of time
 
 All of these routes go through the same post-stage helper, so the ledger's configured SHACL posture (enable/disable, mode, per-graph, shapes source) applies uniformly. A `take-both` merge whose "both values coexist" resolution would breach a `sh:maxCount`, or a revert that removes a value a `sh:minCount` requires, is rejected with the same report a transaction gets.
 

--- a/docs/guides/cookbook-shacl.md
+++ b/docs/guides/cookbook-shacl.md
@@ -735,8 +735,9 @@ SHACL validation runs consistently on every write surface:
 - JSON-LD / SPARQL transactions (`fluree insert`, `fluree upsert`, `fluree update`)
 - Turtle / TriG ingest (`fluree insert-turtle`, `stage_turtle_insert`)
 - Commit replay (`push_commits_with_handle`, followers applying upstream commits)
+- Branch operations (`fluree branch merge`, `rebase`, `revert`) — the merged, replayed, or inverted state is validated against the target branch's shapes before anything is written, and `fluree branch diff` reports the same outcome ahead of time
 
-All three routes go through the same post-stage helper, so the ledger's configured SHACL posture (enable/disable, mode, per-graph, shapes source) applies uniformly.
+All of these routes go through the same post-stage helper, so the ledger's configured SHACL posture (enable/disable, mode, per-graph, shapes source) applies uniformly. A `take-both` merge whose "both values coexist" resolution would breach a `sh:maxCount`, or a revert that removes a value a `sh:minCount` requires, is rejected with the same report a transaction gets.
 
 ## Validation reports (`fluree validate`)
 

--- a/docs/security/cross-ledger-policy.md
+++ b/docs/security/cross-ledger-policy.md
@@ -466,12 +466,17 @@ Specifics:
   transaction](../guides/cookbook-shacl.md#inline-shapes-per-transaction).
 - **Enforced surfaces**: JSON-LD transactions (insert / upsert /
   update, including TriG upserts), direct-flake Turtle inserts,
+  branch operations (merge, rebase, revert, and merge preview),
   and validation reports (`fluree validate` in ledger mode, the
   HTTP validate endpoint, `Fluree::validate_ledger`). Commit
   replay (graph-sync push) intentionally skips SHACL
   re-validation for cross-ledger sources: the origin already
   validated against M when the commit was authored, and
   re-resolving M at replay time could see a different head.
+  Branch operations are authoring, not replay — the state they
+  stage onto the target is a combination nobody has validated —
+  so they resolve M at operation time and enforce its shapes
+  like any transaction would.
 - **`sh:sparql` constraints travel over the wire** — the query
   text, `sh:prefixes` declarations, and their `owl:imports`
   closure are all projected. At write time the query lowers

--- a/docs/security/cross-ledger-policy.md
+++ b/docs/security/cross-ledger-policy.md
@@ -473,8 +473,8 @@ Specifics:
   re-validation for cross-ledger sources: the origin already
   validated against M when the commit was authored, and
   re-resolving M at replay time could see a different head.
-  Branch operations are authoring, not replay — the state they
-  stage onto the target is a combination nobody has validated —
+  Branch operations are authoring, not replay: the state they
+  stage onto the target is a combination nobody has validated,
   so they resolve M at operation time and enforce its shapes
   like any transaction would.
 - **`sh:sparql` constraints travel over the wire** — the query

--- a/fluree-db-api/src/branch_validation.rs
+++ b/fluree-db-api/src/branch_validation.rs
@@ -38,16 +38,25 @@ impl BranchOpValidation {
     /// Turn a rejected outcome into the error a transaction producing the
     /// same state would return.
     pub(crate) fn into_result(self) -> Result<()> {
+        self.into_result_with(|report| report)
+    }
+
+    /// Like [`Self::into_result`], with `describe` wrapping the report in
+    /// the operation's own context (which commit a rebase stopped on, say).
+    pub(crate) fn into_result_with(self, describe: impl FnOnce(String) -> String) -> Result<()> {
         match self.report {
             None => Ok(()),
             #[cfg(feature = "shacl")]
-            Some(report) => Err(fluree_db_transact::TransactError::ShaclViolation(report).into()),
+            Some(report) => {
+                Err(fluree_db_transact::TransactError::ShaclViolation(describe(report)).into())
+            }
             // Without the feature no validator runs, so no report is ever
             // produced; keep the match total without naming a variant that
             // does not exist in this configuration.
             #[cfg(not(feature = "shacl"))]
             Some(report) => Err(crate::error::ApiError::internal(format!(
-                "SHACL violation reported without the shacl feature: {report}"
+                "SHACL violation reported without the shacl feature: {}",
+                describe(report)
             ))),
         }
     }

--- a/fluree-db-api/src/branch_validation.rs
+++ b/fluree-db-api/src/branch_validation.rs
@@ -10,13 +10,14 @@
 //! A branch operation is authoring, not replay: the combination it stages
 //! onto the target is new state nobody has validated. So, unlike commit
 //! replay, a cross-ledger `f:shapesSource` is resolved and enforced here
-//! rather than skipped. Branch operations carry no request surface — no
-//! requested validation mode, identity, inline shapes, or authoring context
-//! — and run the ledger's configured posture.
+//! rather than skipped. Branch operations carry no request surface (no
+//! requested validation mode, identity, inline shapes, or authoring context)
+//! and run the ledger's configured posture.
 
-use crate::error::Result;
-use fluree_db_core::{GraphId, Sid};
-use fluree_db_ledger::StagedLedger;
+use crate::error::{ApiError, Result};
+use crate::rebase::ConflictStrategy;
+use fluree_db_core::{ConflictKey, Flake, GraphId, Sid};
+use fluree_db_ledger::{LedgerState, StagedLedger};
 use std::collections::HashMap;
 
 /// Outcome of validating a branch operation's staged view.
@@ -63,21 +64,65 @@ impl BranchOpValidation {
 }
 
 impl crate::Fluree {
-    /// Validate a branch operation's staged view against the target ledger's
-    /// SHACL configuration and shapes.
+    /// Stage `flakes` onto `state` and validate the result against the
+    /// ledger's SHACL configuration and shapes.
     ///
-    /// `reverse_graph` is the map the view was built with. `namespace_delta`
-    /// holds the namespace codes the operation introduces, which the snapshot
-    /// will not carry until the commit lands; they make the operation's own
-    /// terms encodable for `sh:sparql` lowering and resolvable in messages.
+    /// This is the one way a branch operation builds a view to commit: the
+    /// staging and the validation travel together so no operation can copy
+    /// one without the other. Returns the validated view and the outcome;
+    /// the caller decides what a rejection means (merge and revert fail,
+    /// rebase names the commit it stopped on, preview reports it).
+    ///
+    /// `namespace_delta` holds the namespace codes the operation introduces,
+    /// which the snapshot will not carry until the commit lands; they make
+    /// the operation's own terms encodable for `sh:sparql` lowering and
+    /// resolvable in messages. `op` names the operation in error messages.
+    pub(crate) async fn stage_validated(
+        &self,
+        state: LedgerState,
+        flakes: Vec<Flake>,
+        namespace_delta: &HashMap<u16, String>,
+        op: &'static str,
+    ) -> Result<(StagedLedger, BranchOpValidation)> {
+        let reverse_graph = state.snapshot.build_reverse_graph().map_err(|e| {
+            ApiError::internal(format!("Failed to build reverse graph during {op}: {e}"))
+        })?;
+        let mut view = StagedLedger::new(state, flakes, &reverse_graph)
+            .map_err(|e| ApiError::internal(format!("Failed to stage flakes during {op}: {e}")))?;
+        let outcome = self
+            .validate_branch_op_view(&mut view, &reverse_graph, namespace_delta)
+            .await?;
+        Ok((view, outcome))
+    }
+
+    /// The merge's staging, shared by the merge itself and its preview:
+    /// resolve `source_flakes` under `strategy` against `target_state`, then
+    /// stage and validate the result.
+    pub(crate) async fn stage_merge(
+        &self,
+        target_state: LedgerState,
+        source_flakes: Vec<Flake>,
+        conflicts: &[ConflictKey],
+        strategy: &ConflictStrategy,
+        namespace_delta: &HashMap<u16, String>,
+    ) -> Result<(StagedLedger, BranchOpValidation)> {
+        let resolved = self
+            .apply_two_way_strategy(source_flakes, conflicts, strategy, &target_state)
+            .await?;
+        self.stage_validated(target_state, resolved, namespace_delta, "merge")
+            .await
+    }
+
+    /// Validate a staged view against the target ledger's SHACL
+    /// configuration and shapes. `reverse_graph` is the map the view was
+    /// built with.
     #[cfg(feature = "shacl")]
-    pub(crate) async fn validate_branch_op_view(
+    async fn validate_branch_op_view(
         &self,
         view: &mut StagedLedger,
         reverse_graph: &HashMap<Sid, GraphId>,
         namespace_delta: &HashMap<u16, String>,
     ) -> Result<BranchOpValidation> {
-        use crate::error::ApiError;
         use crate::tx::{
             apply_shacl_policy_to_staged_view, open_cross_ledger_shapes_model,
             resolve_cross_ledger_schema_for_tx, StagedShaclContext,
@@ -114,12 +159,17 @@ impl crate::Fluree {
 
         // The staged namespace registry: the snapshot's codes plus the ones
         // this operation brings in.
+        // Sibling branches allocate codes independently, so a code or prefix
+        // the source introduced can already mean something else on the
+        // target. The commit builder rejects such a merge too; surfacing it
+        // here, as a conflict rather than an internal error, lets a preview
+        // answer instead of failing.
         let mut staged_ns = NamespaceRegistry::from_db(&base.snapshot);
         staged_ns
             .adopt_delta_for_persistence(namespace_delta)
             .map_err(|e| {
-                ApiError::internal(format!(
-                    "branch-operation namespace delta conflicts with the target registry: {e}"
+                ApiError::BranchConflict(format!(
+                    "the source branch's namespace allocations conflict with the target's: {e}"
                 ))
             })?;
         let cross_ledger_data_ns_map: Option<HashMap<u16, String>> =
@@ -187,7 +237,7 @@ impl crate::Fluree {
 
     /// Without the `shacl` feature there is nothing to validate against.
     #[cfg(not(feature = "shacl"))]
-    pub(crate) async fn validate_branch_op_view(
+    async fn validate_branch_op_view(
         &self,
         _view: &mut StagedLedger,
         _reverse_graph: &HashMap<Sid, GraphId>,

--- a/fluree-db-api/src/branch_validation.rs
+++ b/fluree-db-api/src/branch_validation.rs
@@ -1,0 +1,189 @@
+//! SHACL validation for branch operations.
+//!
+//! Merge, rebase, revert, and merge preview build their commits on a path
+//! parallel to the transaction pipeline, staging flakes straight into a
+//! [`StagedLedger`]. This module runs the same post-stage validation the
+//! transaction path runs (`apply_shacl_policy_to_staged_view`), so a branch
+//! operation whose resulting state the ledger's shapes reject fails exactly
+//! as a transaction producing that state would.
+//!
+//! A branch operation is authoring, not replay: the combination it stages
+//! onto the target is new state nobody has validated. So, unlike commit
+//! replay, a cross-ledger `f:shapesSource` is resolved and enforced here
+//! rather than skipped. Branch operations carry no request surface — no
+//! requested validation mode, identity, inline shapes, or authoring context
+//! — and run the ledger's configured posture.
+
+use crate::error::Result;
+use fluree_db_core::{GraphId, Sid};
+use fluree_db_ledger::StagedLedger;
+use std::collections::HashMap;
+
+/// Outcome of validating a branch operation's staged view.
+///
+/// Warn-mode violations are logged by the validator and never surface here,
+/// matching the transaction path. Only reject-mode violations produce a
+/// report.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct BranchOpValidation {
+    /// Formatted violation report, `None` when the view conforms.
+    pub(crate) report: Option<String>,
+}
+
+impl BranchOpValidation {
+    pub(crate) fn conforms(&self) -> bool {
+        self.report.is_none()
+    }
+
+    /// Turn a rejected outcome into the error a transaction producing the
+    /// same state would return.
+    pub(crate) fn into_result(self) -> Result<()> {
+        match self.report {
+            None => Ok(()),
+            #[cfg(feature = "shacl")]
+            Some(report) => Err(fluree_db_transact::TransactError::ShaclViolation(report).into()),
+            // Without the feature no validator runs, so no report is ever
+            // produced; keep the match total without naming a variant that
+            // does not exist in this configuration.
+            #[cfg(not(feature = "shacl"))]
+            Some(report) => Err(crate::error::ApiError::internal(format!(
+                "SHACL violation reported without the shacl feature: {report}"
+            ))),
+        }
+    }
+}
+
+impl crate::Fluree {
+    /// Validate a branch operation's staged view against the target ledger's
+    /// SHACL configuration and shapes.
+    ///
+    /// `reverse_graph` is the map the view was built with. `namespace_delta`
+    /// holds the namespace codes the operation introduces, which the snapshot
+    /// will not carry until the commit lands; they make the operation's own
+    /// terms encodable for `sh:sparql` lowering and resolvable in messages.
+    #[cfg(feature = "shacl")]
+    pub(crate) async fn validate_branch_op_view(
+        &self,
+        view: &mut StagedLedger,
+        reverse_graph: &HashMap<Sid, GraphId>,
+        namespace_delta: &HashMap<u16, String>,
+    ) -> Result<BranchOpValidation> {
+        use crate::error::ApiError;
+        use crate::tx::{
+            apply_shacl_policy_to_staged_view, open_cross_ledger_shapes_model,
+            resolve_cross_ledger_schema_for_tx, StagedShaclContext,
+        };
+        use fluree_db_transact::{NamespaceRegistry, TransactError};
+
+        if !view.has_staged() {
+            return Ok(BranchOpValidation::default());
+        }
+
+        let base = view.base();
+        let ledger_id = base.snapshot.ledger_id.to_string();
+
+        // Config from the target's pre-operation state, resolved once and
+        // shared by the cross-ledger resolvers and the policy pass.
+        let config = crate::config_resolver::resolve_ledger_config(
+            &base.snapshot,
+            base.novelty.as_ref(),
+            base.t(),
+        )
+        .await
+        .map_err(|e| {
+            ApiError::internal(format!(
+                "failed to load ledger config for branch-operation validation: {e}"
+            ))
+        })?;
+        let tx_config = config.clone().map(std::sync::Arc::new);
+
+        let mut resolve_ctx = crate::cross_ledger::ResolveCtx::new(&ledger_id, self);
+        let cross_ledger_shapes =
+            open_cross_ledger_shapes_model(config.as_ref(), &mut resolve_ctx).await?;
+        let cross_ledger_schema =
+            resolve_cross_ledger_schema_for_tx(base, config.as_ref(), &mut resolve_ctx).await?;
+
+        // The staged namespace registry: the snapshot's codes plus the ones
+        // this operation brings in.
+        let mut staged_ns = NamespaceRegistry::from_db(&base.snapshot);
+        staged_ns
+            .adopt_delta_for_persistence(namespace_delta)
+            .map_err(|e| {
+                ApiError::internal(format!(
+                    "branch-operation namespace delta conflicts with the target registry: {e}"
+                ))
+            })?;
+        let cross_ledger_data_ns_map: Option<HashMap<u16, String>> =
+            cross_ledger_shapes.as_ref().map(|_| {
+                staged_ns
+                    .all_codes()
+                    .into_iter()
+                    .filter_map(|code| staged_ns.get_prefix(code).map(|p| (code, p.to_string())))
+                    .collect()
+            });
+        let cross_ledger_membership = match (&cross_ledger_shapes, &cross_ledger_data_ns_map) {
+            (Some(model), Some(ns_map)) => Some(fluree_db_shacl::CrossLedgerMembership {
+                model_db: fluree_db_core::GraphDbRef::new(
+                    &model.model_db.snapshot,
+                    model.model_g_id,
+                    model.model_db.overlay.as_ref(),
+                    model.model_db.t,
+                ),
+                data_ns_map: ns_map,
+                same_term_space: false,
+            }),
+            _ => None,
+        };
+
+        // Graph routing for the staged flakes: every named graph they touch,
+        // with its IRI for per-graph config resolution. The default graph
+        // always gets the ledger-wide policy.
+        let graph_sids: HashMap<GraphId, Sid> = reverse_graph
+            .iter()
+            .map(|(sid, g_id)| (*g_id, sid.clone()))
+            .collect();
+        let mut graph_delta: rustc_hash::FxHashMap<u16, String> = rustc_hash::FxHashMap::default();
+        for g_sid in view.staged_flakes().iter().filter_map(|f| f.g.as_ref()) {
+            if let Some(&g_id) = reverse_graph.get(g_sid) {
+                if let Some(iri) = base.snapshot.graph_registry.iri_for_graph_id(g_id) {
+                    graph_delta.entry(g_id).or_insert_with(|| iri.to_string());
+                }
+            }
+        }
+
+        let ctx = StagedShaclContext {
+            graph_delta: Some(&graph_delta),
+            graph_sids: Some(&graph_sids),
+            tracker: None,
+            cross_ledger_shapes: cross_ledger_shapes.as_ref().and_then(|m| m.wire()),
+            staged_ns: Some(&staged_ns),
+            uncommitted_namespaces: Some(namespace_delta),
+            txn_context: None,
+            inline_shape_bundle: None,
+            cross_ledger_schema,
+            cross_ledger_membership,
+            requested_validation_mode: None,
+            request_identity: None,
+            origin_validated_replay: false,
+        };
+
+        match apply_shacl_policy_to_staged_view(view, ctx, tx_config).await {
+            Ok(()) => Ok(BranchOpValidation::default()),
+            Err(TransactError::ShaclViolation(report)) => Ok(BranchOpValidation {
+                report: Some(report),
+            }),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Without the `shacl` feature there is nothing to validate against.
+    #[cfg(not(feature = "shacl"))]
+    pub(crate) async fn validate_branch_op_view(
+        &self,
+        _view: &mut StagedLedger,
+        _reverse_graph: &HashMap<Sid, GraphId>,
+        _namespace_delta: &HashMap<u16, String>,
+    ) -> Result<BranchOpValidation> {
+        Ok(BranchOpValidation::default())
+    }
+}

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -38,6 +38,7 @@ pub mod admin;
 pub mod block_fetch;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod bm25_worker;
+mod branch_validation;
 mod commit_data;
 pub mod commit_transfer;
 pub mod config_resolver;

--- a/fluree-db-api/src/lib.rs
+++ b/fluree-db-api/src/lib.rs
@@ -186,7 +186,8 @@ pub use ledger_view::{CommitRef, LedgerView};
 pub use merge::{MergeReport, StagedMerge};
 pub use merge_preview::{
     AncestorRef, BranchDelta, ChangeSummary, ConflictDetail, ConflictResolutionPreview,
-    ConflictSummary, MergePreview, MergePreviewOpts, SubjectChange, DEFAULT_MAX_CHANGES,
+    ConflictSummary, MergePreview, MergePreviewOpts, SubjectChange, ValidationSummary,
+    DEFAULT_MAX_CHANGES,
 };
 pub use pack::{
     compute_missing_index_artifacts, full_ledger_pack_request, validate_pack_request, PackChunk,

--- a/fluree-db-api/src/merge.rs
+++ b/fluree-db-api/src/merge.rs
@@ -539,8 +539,16 @@ impl crate::Fluree {
 
         let current_head_t = target_state.t();
 
-        let view = StagedLedger::new(target_state, resolved_flakes, &reverse_graph)
+        let mut view = StagedLedger::new(target_state, resolved_flakes, &reverse_graph)
             .map_err(|e| ApiError::internal(format!("Failed to stage flakes during merge: {e}")))?;
+
+        // Validate the merged state against the target's shapes before any
+        // side effect: a merge that would leave the ledger in a state its own
+        // shapes reject fails here exactly as a transaction producing that
+        // state would, with nothing written and the target untouched.
+        self.validate_branch_op_view(&mut view, &reverse_graph, &namespace_delta)
+            .await?
+            .into_result()?;
 
         // Create merge commit with the source head as an additional parent,
         // propagating namespace and graph deltas from the source branch.

--- a/fluree-db-api/src/merge.rs
+++ b/fluree-db-api/src/merge.rs
@@ -15,7 +15,7 @@ use fluree_db_core::{
     collect_dag_cids, collect_first_parent_cids, load_commit_by_id, CommonAncestor,
 };
 use fluree_db_core::{BranchedContentStore, ConflictKey, ContentId, ContentStore};
-use fluree_db_ledger::{LedgerState, StagedLedger};
+use fluree_db_ledger::LedgerState;
 use fluree_db_nameservice::{NsRecord, NsRecordSnapshot};
 use fluree_db_novelty::compute_delta_keys;
 use fluree_db_transact::{CommitOpts, NamespaceRegistry};
@@ -500,7 +500,7 @@ impl crate::Fluree {
         let conflict_count = conflicts.len();
 
         // Abort if conflicts exist and strategy is Abort.
-        if strategy == ConflictStrategy::Abort && !conflicts.is_empty() {
+        if strategy.aborts_on(conflicts.len()) {
             return Err(ApiError::BranchConflict(format!(
                 "Merge aborted: {} conflict(s) between {} and {} with abort strategy",
                 conflicts.len(),
@@ -525,30 +525,25 @@ impl crate::Fluree {
             graph_delta,
         } = collect_commit_data(source_store, &source_head_id, ancestor.t).await?;
 
-        // Resolve conflicts via the shared two-way strategy helper.
-        let resolved_flakes = self
-            .apply_two_way_strategy(source_flakes, &conflicts, &strategy, &target_state)
-            .await?;
-
-        // Stage resolved flakes onto target state. An empty flake set is valid
-        // (e.g., TakeBranch drops all source flakes) — we still create the merge
-        // commit to record the parent relationship and prevent future re-merges.
-        let reverse_graph = target_state.snapshot.build_reverse_graph().map_err(|e| {
-            ApiError::internal(format!("Failed to build reverse graph during merge: {e}"))
-        })?;
-
         let current_head_t = target_state.t();
 
-        let mut view = StagedLedger::new(target_state, resolved_flakes, &reverse_graph)
-            .map_err(|e| ApiError::internal(format!("Failed to stage flakes during merge: {e}")))?;
-
-        // Validate the merged state against the target's shapes before any
-        // side effect: a merge that would leave the ledger in a state its own
-        // shapes reject fails here exactly as a transaction producing that
-        // state would, with nothing written and the target untouched.
-        self.validate_branch_op_view(&mut view, &reverse_graph, &namespace_delta)
-            .await?
-            .into_result()?;
+        // Resolve conflicts, stage the result onto the target, and validate
+        // it against the target's shapes before any side effect: a merge
+        // that would leave the ledger in a state its own shapes reject fails
+        // here exactly as a transaction producing that state would, with
+        // nothing written and the target untouched. An empty flake set is
+        // valid (e.g., TakeBranch drops all source flakes): the merge commit
+        // still records the parent relationship and prevents re-merges.
+        let (view, outcome) = self
+            .stage_merge(
+                target_state,
+                source_flakes,
+                &conflicts,
+                &strategy,
+                &namespace_delta,
+            )
+            .await?;
+        outcome.into_result()?;
 
         // Create merge commit with the source head as an additional parent,
         // propagating namespace and graph deltas from the source branch.

--- a/fluree-db-api/src/merge_preview.rs
+++ b/fluree-db-api/src/merge_preview.rs
@@ -20,6 +20,7 @@ use fluree_db_core::{
     ContentId, ContentStore, Flake,
 };
 use fluree_db_ledger::LedgerState;
+use fluree_db_ledger::StagedLedger;
 use fluree_db_novelty::{compute_delta_keys, compute_delta_keys_and_changes};
 use futures::{stream, StreamExt, TryStreamExt};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -101,6 +102,13 @@ pub struct MergePreviewOpts {
     /// previous response's [`ChangeSummary::next_cursor`]. Each page re-pays
     /// the full replay + netting cost. Requires `include_changes`.
     pub changes_after_subject: Option<String>,
+    /// When `true` (the default), stage the strategy-resolved change set on
+    /// the target and validate it against the target's SHACL configuration
+    /// and shapes, exactly as the merge would. The outcome is reported in
+    /// [`MergePreview::validation`] and folded into
+    /// [`MergePreview::mergeable`]. Costs a target-state load plus the
+    /// validation pass; set `false` for count-only previews.
+    pub include_validation: bool,
 }
 
 impl Default for MergePreviewOpts {
@@ -114,8 +122,22 @@ impl Default for MergePreviewOpts {
             include_changes: false,
             max_changes: Some(DEFAULT_MAX_CHANGES),
             changes_after_subject: None,
+            include_validation: true,
         }
     }
+}
+
+/// SHACL outcome of staging the merge's resolved change set on the target.
+#[derive(Clone, Debug, Serialize)]
+pub struct ValidationSummary {
+    /// `true` when the merged state conforms to the target's shapes under
+    /// its configured posture (warn-mode violations are logged, not
+    /// reported, matching the transaction path).
+    pub conforms: bool,
+    /// The violation report the merge would fail with. Present iff
+    /// `conforms` is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub report: Option<String>,
 }
 
 /// Common ancestor of source and target HEADs.
@@ -269,8 +291,17 @@ pub struct MergePreview {
     /// or when the caller opted out via [`MergePreviewOpts::include_conflicts`].
     pub conflicts: ConflictSummary,
 
-    /// Whether the selected strategy can be applied without aborting.
+    /// Whether the merge would go through: the selected strategy can be
+    /// applied without aborting, and the resulting state conforms to the
+    /// target's shapes when validation ran.
     pub mergeable: bool,
+
+    /// SHACL outcome for the resolved change set. Present iff
+    /// [`MergePreviewOpts::include_validation`] was set and the merge is
+    /// not a fast-forward (a fast-forward adopts commits already validated
+    /// when they were authored).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validation: Option<ValidationSummary>,
 
     /// Aggregate netted change set. Present iff
     /// [`MergePreviewOpts::include_changes`] was set.
@@ -480,24 +511,32 @@ impl crate::Fluree {
             && target_head.is_some()
             && ancestor.is_some();
         let need_changes = opts.include_changes;
+        // Validation stages the resolved change set on the target, so it
+        // needs the netted source delta too. A fast-forward adopts commits
+        // already validated when they were authored, so it is skipped.
+        let need_validation = opts.include_validation
+            && !fast_forward
+            && source_head.is_some()
+            && target_head.is_some()
+            && ancestor.is_some();
 
         let source_fut = async {
             match &source_head {
-                Some(s_head) if need_changes => {
-                    let (keys, net) = compute_delta_keys_and_changes(
+                Some(s_head) if need_changes || need_validation => {
+                    let (keys, net, ns_delta) = compute_delta_keys_and_changes(
                         source_store.clone(),
                         s_head.clone(),
                         stop_at_t,
                     )
                     .await?;
-                    Ok::<_, ApiError>((Some(keys), Some(net)))
+                    Ok::<_, ApiError>((Some(keys), Some(net), Some(ns_delta)))
                 }
                 Some(s_head) if need_conflicts => {
                     let keys =
                         compute_delta_keys(source_store.clone(), s_head.clone(), stop_at_t).await?;
-                    Ok((Some(keys), None))
+                    Ok((Some(keys), None, None))
                 }
-                _ => Ok((None, None)),
+                _ => Ok((None, None, None)),
             }
         };
         let target_fut = async {
@@ -510,10 +549,14 @@ impl crate::Fluree {
                 _ => Ok(None),
             }
         };
-        let ((source_delta, net_flakes), target_delta) = tokio::try_join!(source_fut, target_fut)?;
+        let ((source_delta, net_flakes, source_ns_delta), target_delta) =
+            tokio::try_join!(source_fut, target_fut)?;
 
         // ---- Conflicts (only if relevant). --------------------------------
-        let (conflict_keys, conflict_count, conflicts_truncated) =
+        // `all_conflict_keys` is the uncapped set: the cap bounds the
+        // response, not what the strategy resolves when validation stages
+        // the merge.
+        let (conflict_keys, all_conflict_keys, conflict_count, conflicts_truncated) =
             match (need_conflicts, &source_delta, &target_delta) {
                 (true, Some(s_delta), Some(t_delta)) => {
                     // Sort lexicographically by (s, p, g) so capped responses
@@ -522,6 +565,7 @@ impl crate::Fluree {
                     let mut keys: Vec<ConflictKey> =
                         s_delta.intersection(t_delta).cloned().collect();
                     keys.sort();
+                    let all = keys.clone();
                     let count = keys.len();
                     let truncated = match opts.max_conflict_keys {
                         Some(cap) if count > cap => {
@@ -530,9 +574,9 @@ impl crate::Fluree {
                         }
                         _ => false,
                     };
-                    (keys, count, truncated)
+                    (keys, all, count, truncated)
                 }
-                _ => (Vec::new(), 0, false),
+                _ => (Vec::new(), Vec::new(), 0, false),
             };
 
         // ---- Load states needed for IRI resolution. -----------------------
@@ -545,21 +589,28 @@ impl crate::Fluree {
             && net_flakes.as_ref().is_some_and(|n| !n.is_empty())
             && opts.max_changes != Some(0);
 
-        let (source_state, target_state) = if want_details {
-            let source_state_fut =
-                self.load_queryable_state_with_store(source_store.clone(), source_record.clone());
-            let target_state_fut = self
-                .load_queryable_state_with_store(target_branched.clone(), target_record.clone());
-            let (s, t) = tokio::try_join!(source_state_fut, target_state_fut)?;
-            (Some(s), Some(t))
-        } else if want_change_payload {
-            let s = self
-                .load_queryable_state_with_store(source_store.clone(), source_record.clone())
-                .await?;
-            (Some(s), None)
-        } else {
-            (None, None)
+        // Validation stages onto the target, so it needs the target side.
+        let want_source = want_details || want_change_payload;
+        let want_target = want_details || need_validation;
+        let source_state_fut = async {
+            if want_source {
+                self.load_queryable_state_with_store(source_store.clone(), source_record.clone())
+                    .await
+                    .map(Some)
+            } else {
+                Ok::<_, ApiError>(None)
+            }
         };
+        let target_state_fut = async {
+            if want_target {
+                self.load_queryable_state_with_store(target_branched.clone(), target_record.clone())
+                    .await
+                    .map(Some)
+            } else {
+                Ok::<_, ApiError>(None)
+            }
+        };
+        let (source_state, target_state) = tokio::try_join!(source_state_fut, target_state_fut)?;
 
         let conflicts = if !need_conflicts {
             ConflictSummary::empty()
@@ -589,6 +640,45 @@ impl crate::Fluree {
             }
         };
 
+        // ---- Validation (default on; skipped on fast-forward). -------------
+        // The same staging and validation the merge performs, minus the
+        // commit: resolve the netted source delta under the strategy, stage
+        // it on a clone of the target state, and run the branch-operation
+        // validator. Under `Abort` with conflicts the merge never reaches
+        // validation, so neither does the preview.
+        let validation = if need_validation
+            && (opts.conflict_strategy != ConflictStrategy::Abort || conflict_count == 0)
+        {
+            let target_state = target_state.as_ref().expect("loaded for validation");
+            let resolved = self
+                .apply_two_way_strategy(
+                    net_flakes.clone().unwrap_or_default(),
+                    &all_conflict_keys,
+                    &opts.conflict_strategy,
+                    target_state,
+                )
+                .await?;
+            let reverse_graph = target_state.snapshot.build_reverse_graph().map_err(|e| {
+                ApiError::internal(format!(
+                    "Failed to build reverse graph during merge preview: {e}"
+                ))
+            })?;
+            let mut view = StagedLedger::new(target_state.clone(), resolved, &reverse_graph)
+                .map_err(|e| {
+                    ApiError::internal(format!("Failed to stage flakes during merge preview: {e}"))
+                })?;
+            let ns_delta = source_ns_delta.unwrap_or_default();
+            let outcome = self
+                .validate_branch_op_view(&mut view, &reverse_graph, &ns_delta)
+                .await?;
+            Some(ValidationSummary {
+                conforms: outcome.conforms(),
+                report: outcome.report,
+            })
+        } else {
+            None
+        };
+
         // ---- Changes (only if requested). ----------------------------------
         let changes = if need_changes {
             // No compactor in stats-only mode even when conflict details
@@ -614,7 +704,8 @@ impl crate::Fluree {
             None
         };
 
-        let mergeable = opts.conflict_strategy != ConflictStrategy::Abort || conflicts.count == 0;
+        let mergeable = (opts.conflict_strategy != ConflictStrategy::Abort || conflicts.count == 0)
+            && validation.as_ref().is_none_or(|v| v.conforms);
 
         // ---- Invariants (debug-only). -------------------------------------
         debug_assert!(ahead.commits.len() <= ahead.count);
@@ -639,6 +730,7 @@ impl crate::Fluree {
             fast_forward,
             conflicts,
             mergeable,
+            validation,
             changes,
         })
     }

--- a/fluree-db-api/src/merge_preview.rs
+++ b/fluree-db-api/src/merge_preview.rs
@@ -20,7 +20,6 @@ use fluree_db_core::{
     ContentId, ContentStore, Flake,
 };
 use fluree_db_ledger::LedgerState;
-use fluree_db_ledger::StagedLedger;
 use fluree_db_novelty::{compute_delta_keys, compute_delta_keys_and_changes};
 use futures::{stream, StreamExt, TryStreamExt};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -539,9 +538,12 @@ impl crate::Fluree {
                 _ => Ok((None, None, None)),
             }
         };
+        // Validation resolves conflicts the way the merge does, so it needs
+        // the target delta even when the caller asked for no conflict
+        // reporting (`include_conflicts=false`).
         let target_fut = async {
             match (&target_head, &ancestor) {
-                (Some(t_head), Some(anc)) if need_conflicts => {
+                (Some(t_head), Some(anc)) if need_conflicts || need_validation => {
                     let keys =
                         compute_delta_keys(target_branched.clone(), t_head.clone(), anc.t).await?;
                     Ok::<_, ApiError>(Some(keys))
@@ -552,32 +554,37 @@ impl crate::Fluree {
         let ((source_delta, net_flakes, source_ns_delta), target_delta) =
             tokio::try_join!(source_fut, target_fut)?;
 
-        // ---- Conflicts (only if relevant). --------------------------------
-        // `all_conflict_keys` is the uncapped set: the cap bounds the
-        // response, not what the strategy resolves when validation stages
-        // the merge.
-        let (conflict_keys, all_conflict_keys, conflict_count, conflicts_truncated) =
-            match (need_conflicts, &source_delta, &target_delta) {
-                (true, Some(s_delta), Some(t_delta)) => {
-                    // Sort lexicographically by (s, p, g) so capped responses
-                    // are stable across builds and across requests — `HashSet`
-                    // intersection order is otherwise unspecified.
-                    let mut keys: Vec<ConflictKey> =
-                        s_delta.intersection(t_delta).cloned().collect();
-                    keys.sort();
-                    let all = keys.clone();
-                    let count = keys.len();
-                    let truncated = match opts.max_conflict_keys {
-                        Some(cap) if count > cap => {
-                            keys.truncate(cap);
-                            true
-                        }
-                        _ => false,
-                    };
-                    (keys, all, count, truncated)
+        // ---- Conflicts. ----------------------------------------------------
+        // `all_conflict_keys` is the full, uncapped intersection whenever both
+        // deltas were walked: what validation resolves the merge against.
+        // The reported `conflicts` are gated on `include_conflicts` and
+        // capped: the cap bounds the response, not what the strategy
+        // resolves.
+        let all_conflict_keys: Vec<ConflictKey> = match (&source_delta, &target_delta) {
+            (Some(s_delta), Some(t_delta)) => {
+                // Sort lexicographically by (s, p, g) so capped responses
+                // are stable across builds and across requests — `HashSet`
+                // intersection order is otherwise unspecified.
+                let mut keys: Vec<ConflictKey> = s_delta.intersection(t_delta).cloned().collect();
+                keys.sort();
+                keys
+            }
+            _ => Vec::new(),
+        };
+        let (conflict_keys, conflict_count, conflicts_truncated) = if need_conflicts {
+            let mut keys = all_conflict_keys.clone();
+            let count = keys.len();
+            let truncated = match opts.max_conflict_keys {
+                Some(cap) if count > cap => {
+                    keys.truncate(cap);
+                    true
                 }
-                _ => (Vec::new(), Vec::new(), 0, false),
+                _ => false,
             };
+            (keys, count, truncated)
+        } else {
+            (Vec::new(), 0, false)
+        };
 
         // ---- Load states needed for IRI resolution. -----------------------
         // Conflict details need both sides; the change payload needs only the
@@ -646,38 +653,34 @@ impl crate::Fluree {
         // it on a clone of the target state, and run the branch-operation
         // validator. Under `Abort` with conflicts the merge never reaches
         // validation, so neither does the preview.
-        let validation = if need_validation
-            && (opts.conflict_strategy != ConflictStrategy::Abort || conflict_count == 0)
-        {
-            let target_state = target_state.as_ref().expect("loaded for validation");
-            let resolved = self
-                .apply_two_way_strategy(
-                    net_flakes.clone().unwrap_or_default(),
-                    &all_conflict_keys,
-                    &opts.conflict_strategy,
-                    target_state,
-                )
-                .await?;
-            let reverse_graph = target_state.snapshot.build_reverse_graph().map_err(|e| {
-                ApiError::internal(format!(
-                    "Failed to build reverse graph during merge preview: {e}"
-                ))
-            })?;
-            let mut view = StagedLedger::new(target_state.clone(), resolved, &reverse_graph)
-                .map_err(|e| {
-                    ApiError::internal(format!("Failed to stage flakes during merge preview: {e}"))
-                })?;
-            let ns_delta = source_ns_delta.unwrap_or_default();
-            let outcome = self
-                .validate_branch_op_view(&mut view, &reverse_graph, &ns_delta)
-                .await?;
-            Some(ValidationSummary {
-                conforms: outcome.conforms(),
-                report: outcome.report,
-            })
-        } else {
-            None
-        };
+        let mut net_flakes = net_flakes;
+        let validation =
+            if need_validation && !opts.conflict_strategy.aborts_on(all_conflict_keys.len()) {
+                let target_state = target_state.as_ref().expect("loaded for validation");
+                // The change summary below still needs the net set when it was
+                // requested; otherwise hand it over without a copy.
+                let net = if need_changes {
+                    net_flakes.clone()
+                } else {
+                    net_flakes.take()
+                };
+                let ns_delta = source_ns_delta.unwrap_or_default();
+                let (_view, outcome) = self
+                    .stage_merge(
+                        target_state.clone(),
+                        net.unwrap_or_default(),
+                        &all_conflict_keys,
+                        &opts.conflict_strategy,
+                        &ns_delta,
+                    )
+                    .await?;
+                Some(ValidationSummary {
+                    conforms: outcome.conforms(),
+                    report: outcome.report,
+                })
+            } else {
+                None
+            };
 
         // ---- Changes (only if requested). ----------------------------------
         let changes = if need_changes {
@@ -704,7 +707,7 @@ impl crate::Fluree {
             None
         };
 
-        let mergeable = (opts.conflict_strategy != ConflictStrategy::Abort || conflicts.count == 0)
+        let mergeable = !opts.conflict_strategy.aborts_on(conflicts.count)
             && validation.as_ref().is_none_or(|v| v.conforms);
 
         // ---- Invariants (debug-only). -------------------------------------

--- a/fluree-db-api/src/rebase.rs
+++ b/fluree-db-api/src/rebase.rs
@@ -11,7 +11,7 @@ use fluree_db_core::{
     RangeTest, DEFAULT_GRAPH_ID,
 };
 use fluree_db_core::{trace_first_parent_commits_by_id, Commit};
-use fluree_db_ledger::{LedgerState, StagedLedger};
+use fluree_db_ledger::LedgerState;
 use fluree_db_nameservice::NsRecordSnapshot;
 use fluree_db_novelty::{compute_delta_keys, FactKey};
 use fluree_db_transact::{CommitOpts, NamespaceRegistry, StagedCommit};
@@ -42,6 +42,13 @@ pub enum ConflictStrategy {
 }
 
 impl ConflictStrategy {
+    /// Whether this strategy refuses to proceed given `conflict_count`
+    /// conflicting keys. The one shared answer for merge, revert, and merge
+    /// preview, so the preview cannot drift from what the merge does.
+    pub fn aborts_on(&self, conflict_count: usize) -> bool {
+        matches!(self, Self::Abort) && conflict_count > 0
+    }
+
     /// Parse a canonical strategy name from a string.
     ///
     /// Unlike [`Self::from_str_name`], this intentionally rejects aliases such
@@ -654,26 +661,19 @@ impl crate::Fluree {
         flakes: Vec<Flake>,
         original_commit: &Commit,
     ) -> Result<StagedCommit> {
-        let reverse_graph = state.snapshot.build_reverse_graph().map_err(|e| {
-            ApiError::internal(format!("Failed to build reverse graph during rebase: {e}"))
-        })?;
-
-        let mut view = StagedLedger::new(state, flakes, &reverse_graph).map_err(|e| {
-            ApiError::internal(format!("Failed to stage flakes during rebase: {e}"))
-        })?;
-
         // A commit that conformed on the branch can violate a shape the
-        // source installed since the fork. Validate each replay against the
-        // state it lands on; the first violation aborts the whole rebase,
+        // source installed since the fork. Each replay is validated against
+        // the state it lands on; the first violation aborts the whole rebase,
         // which has published nothing yet, naming the commit it stopped on.
-        self.validate_branch_op_view(&mut view, &reverse_graph, &original_commit.namespace_delta)
-            .await?
-            .into_result_with(|report| {
-                format!(
-                    "replaying commit t={} would violate the source branch's shapes:\n{report}",
-                    original_commit.t
-                )
-            })?;
+        let (view, outcome) = self
+            .stage_validated(state, flakes, &original_commit.namespace_delta, "rebase")
+            .await?;
+        outcome.into_result_with(|report| {
+            format!(
+                "replaying commit t={} would violate the source branch's shapes:\n{report}",
+                original_commit.t
+            )
+        })?;
 
         let ns_registry = NamespaceRegistry::from_db(view.db());
         let commit_opts = CommitOpts::default()

--- a/fluree-db-api/src/rebase.rs
+++ b/fluree-db-api/src/rebase.rs
@@ -658,9 +658,22 @@ impl crate::Fluree {
             ApiError::internal(format!("Failed to build reverse graph during rebase: {e}"))
         })?;
 
-        let view = StagedLedger::new(state, flakes, &reverse_graph).map_err(|e| {
+        let mut view = StagedLedger::new(state, flakes, &reverse_graph).map_err(|e| {
             ApiError::internal(format!("Failed to stage flakes during rebase: {e}"))
         })?;
+
+        // A commit that conformed on the branch can violate a shape the
+        // source installed since the fork. Validate each replay against the
+        // state it lands on; the first violation aborts the whole rebase,
+        // which has published nothing yet, naming the commit it stopped on.
+        self.validate_branch_op_view(&mut view, &reverse_graph, &original_commit.namespace_delta)
+            .await?
+            .into_result_with(|report| {
+                format!(
+                    "replaying commit t={} would violate the source branch's shapes:\n{report}",
+                    original_commit.t
+                )
+            })?;
 
         let ns_registry = NamespaceRegistry::from_db(view.db());
         let commit_opts = CommitOpts::default()

--- a/fluree-db-api/src/revert.rs
+++ b/fluree-db-api/src/revert.rs
@@ -491,9 +491,15 @@ impl crate::Fluree {
             ApiError::internal(format!("Failed to build reverse graph during revert: {e}"))
         })?;
 
-        let view = StagedLedger::new(target_state, staged, &reverse_graph).map_err(|e| {
+        let mut view = StagedLedger::new(target_state, staged, &reverse_graph).map_err(|e| {
             ApiError::internal(format!("Failed to stage flakes during revert: {e}"))
         })?;
+
+        // Undoing a commit can remove a value a later shape requires. The
+        // inverted state is validated like any transaction producing it.
+        self.validate_branch_op_view(&mut view, &reverse_graph, &namespace_delta)
+            .await?
+            .into_result()?;
 
         let ns_registry = NamespaceRegistry::from_db(view.db());
         let mut commit_opts = CommitOpts::default().with_txn_meta(txn_meta);

--- a/fluree-db-api/src/revert.rs
+++ b/fluree-db-api/src/revert.rs
@@ -30,7 +30,7 @@ use fluree_db_core::{
     trace_first_parent_commits_by_id, BranchedContentStore, CommitId, ConflictKey, ContentStore,
     NonEmpty,
 };
-use fluree_db_ledger::{LedgerState, StagedLedger};
+use fluree_db_ledger::LedgerState;
 use fluree_db_nameservice::NsRecordSnapshot;
 use fluree_db_transact::{CommitOpts, NamespaceRegistry};
 use fluree_vocab::namespaces::FLUREE_DB;
@@ -212,7 +212,7 @@ impl crate::Fluree {
             .build_revert_context(ledger_name, branch, selection)
             .await?;
 
-        if strategy == ConflictStrategy::Abort && !ctx.conflict_keys.is_empty() {
+        if strategy.aborts_on(ctx.conflict_keys.len()) {
             return Err(ApiError::BranchConflict(format!(
                 "Revert aborted: {} conflict(s) on {} with abort strategy",
                 ctx.conflict_keys.len(),
@@ -487,19 +487,12 @@ impl crate::Fluree {
             })
             .collect();
 
-        let reverse_graph = target_state.snapshot.build_reverse_graph().map_err(|e| {
-            ApiError::internal(format!("Failed to build reverse graph during revert: {e}"))
-        })?;
-
-        let mut view = StagedLedger::new(target_state, staged, &reverse_graph).map_err(|e| {
-            ApiError::internal(format!("Failed to stage flakes during revert: {e}"))
-        })?;
-
         // Undoing a commit can remove a value a later shape requires. The
         // inverted state is validated like any transaction producing it.
-        self.validate_branch_op_view(&mut view, &reverse_graph, &namespace_delta)
-            .await?
-            .into_result()?;
+        let (view, outcome) = self
+            .stage_validated(target_state, staged, &namespace_delta, "revert")
+            .await?;
+        outcome.into_result()?;
 
         let ns_registry = NamespaceRegistry::from_db(view.db());
         let mut commit_opts = CommitOpts::default().with_txn_meta(txn_meta);

--- a/fluree-db-api/src/tx.rs
+++ b/fluree-db-api/src/tx.rs
@@ -793,7 +793,7 @@ pub(crate) async fn open_cross_ledger_shapes_model(
 /// SHACL targeting on D. Resolution is t-cached (GovernanceCache): an
 /// unchanged M head is an Arc clone, not a re-query.
 #[cfg(feature = "shacl")]
-async fn resolve_cross_ledger_schema_for_tx(
+pub(crate) async fn resolve_cross_ledger_schema_for_tx(
     ledger: &LedgerState,
     config: Option<&LedgerConfig>,
     ctx: &mut crate::cross_ledger::ResolveCtx<'_>,

--- a/fluree-db-api/tests/grp_ledger.rs
+++ b/fluree-db-api/tests/grp_ledger.rs
@@ -3,6 +3,8 @@ mod support;
 
 #[path = "it_branch.rs"]
 mod it_branch;
+#[path = "it_branch_shacl.rs"]
+mod it_branch_shacl;
 #[path = "it_branch_time_travel.rs"]
 mod it_branch_time_travel;
 #[path = "it_drop_ledger.rs"]

--- a/fluree-db-api/tests/it_branch_shacl.rs
+++ b/fluree-db-api/tests/it_branch_shacl.rs
@@ -1,0 +1,444 @@
+//! SHACL validation on branch operations (merge, rebase, revert).
+//!
+//! A normal transaction that would violate an attached shape is rejected at
+//! commit time. Merge, rebase, and revert build their commits on a parallel
+//! path, and that path must run the same validation: an operation whose
+//! resulting state the ledger's own shapes reject fails like a transaction
+//! would, leaving the target untouched.
+//!
+//! Regression coverage for #1782.
+
+#![cfg(feature = "shacl")]
+
+use crate::support;
+use fluree_db_api::{ApiError, CommitRef, ConflictStrategy, FlureeBuilder, TransactError};
+use fluree_db_core::graph_registry::config_graph_iri;
+use serde_json::json;
+
+const EX: &str = "http://example.org/ns/";
+
+fn ctx() -> serde_json::Value {
+    json!({"ex": EX, "sh": "http://www.w3.org/ns/shacl#"})
+}
+
+fn insert_name(id: &str, name: &str) -> serde_json::Value {
+    json!({"@context": ctx(), "@graph": [{"@id": id, "ex:name": name}]})
+}
+
+/// Replace-style update on `id`'s `ex:name`.
+fn replace_name(id: &str, name: &str) -> serde_json::Value {
+    json!({
+        "@context": ctx(),
+        "where": {"@id": id, "ex:name": "?old"},
+        "delete": {"@id": id, "ex:name": "?old"},
+        "insert": {"@id": id, "ex:name": name}
+    })
+}
+
+/// `sh:targetNode ex:alice` with `sh:maxCount 1` (and optionally
+/// `sh:minCount 1`) on `ex:name`.
+fn alice_name_shape(min_count: Option<u32>) -> serde_json::Value {
+    let mut property = json!({
+        "@id": "ex:AliceNameShape",
+        "sh:path": {"@id": "ex:name"},
+        "sh:maxCount": 1
+    });
+    if let Some(min) = min_count {
+        property["sh:minCount"] = json!(min);
+    }
+    json!({
+        "@context": ctx(),
+        "@graph": [{
+            "@id": "ex:AliceShape",
+            "@type": "sh:NodeShape",
+            "sh:targetNode": {"@id": "ex:alice"},
+            "sh:property": property
+        }]
+    })
+}
+
+/// All `ex:name` values on `ledger_id`, sorted.
+async fn names(fluree: &fluree_db_api::Fluree, ledger_id: &str) -> Vec<String> {
+    let ledger = fluree.ledger(ledger_id).await.unwrap();
+    let q = json!({
+        "@context": ctx(),
+        "select": ["?name"],
+        "where": {"@id": "?s", "ex:name": "?name"}
+    });
+    let result = support::query_jsonld(fluree, &ledger, &q).await.unwrap();
+    let rows = result.to_jsonld(&ledger.snapshot).unwrap();
+    let mut out: Vec<String> = support::normalize_rows(&rows)
+        .iter()
+        .map(|row| {
+            row.as_array()
+                .and_then(|a| a.first())
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string)
+                .expect("row should be [name]")
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+async fn head_t(fluree: &fluree_db_api::Fluree, ledger_id: &str) -> i64 {
+    fluree.ledger(ledger_id).await.unwrap().t()
+}
+
+fn assert_shacl_violation(err: ApiError, context: &str) {
+    assert!(
+        matches!(err, ApiError::Transact(TransactError::ShaclViolation(_))),
+        "{context}: expected ShaclViolation, got: {err:?}"
+    );
+}
+
+/// Seed `mydb:main` with `ex:alice ex:name "A"` and the maxCount-1 shape,
+/// then fork `dev`. Returns main's state (t=1).
+async fn seed_alice_with_shape(fluree: &fluree_db_api::Fluree) -> fluree_db_api::LedgerState {
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    let mut seed = alice_name_shape(None);
+    seed["@graph"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!({"@id": "ex:alice", "ex:name": "A"}));
+    let main = fluree.insert(ledger, &seed).await.unwrap().ledger;
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
+    main
+}
+
+// =============================================================================
+// Control: the same state via a plain transaction is rejected
+// =============================================================================
+
+#[tokio::test]
+async fn control_plain_insert_of_second_name_is_rejected() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let main = seed_alice_with_shape(&fluree).await;
+
+    let err = fluree
+        .insert(main, &insert_name("ex:alice", "B"))
+        .await
+        .expect_err("second name breaches maxCount 1");
+    assert_shacl_violation(err, "plain insert");
+}
+
+// =============================================================================
+// Merge
+// =============================================================================
+
+/// Take-both on a conflicting key manufactures two values for a
+/// maxCount-1 property. The merge must be rejected and main left as it was.
+#[tokio::test]
+async fn merge_rejected_when_result_violates_shape() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let main = seed_alice_with_shape(&fluree).await;
+
+    let dev = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .update(dev, &replace_name("ex:alice", "B"))
+        .await
+        .unwrap();
+    fluree
+        .update(main, &replace_name("ex:alice", "C"))
+        .await
+        .unwrap();
+    assert_eq!(head_t(&fluree, "mydb:main").await, 2);
+
+    let err = fluree
+        .merge_branch("mydb", "dev", None, ConflictStrategy::TakeBoth)
+        .await
+        .expect_err("merge producing two names must be rejected");
+    assert_shacl_violation(err, "take-both merge");
+
+    // Main is untouched: same head, same value. Dev is untouched too.
+    assert_eq!(head_t(&fluree, "mydb:main").await, 2);
+    assert_eq!(names(&fluree, "mydb:main").await, vec!["C"]);
+    assert_eq!(names(&fluree, "mydb:dev").await, vec!["B"]);
+}
+
+/// A shape being installed does not make conforming merges fail.
+#[tokio::test]
+async fn merge_conforming_result_succeeds_with_shape_installed() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let main = seed_alice_with_shape(&fluree).await;
+
+    let dev = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .update(dev, &replace_name("ex:alice", "B"))
+        .await
+        .unwrap();
+    fluree
+        .insert(main, &insert_name("ex:bob", "Bob"))
+        .await
+        .unwrap();
+
+    let report = fluree
+        .merge_branch("mydb", "dev", None, ConflictStrategy::default())
+        .await
+        .expect("conforming merge");
+    assert!(!report.fast_forward);
+    assert_eq!(report.conflict_count, 0);
+    assert_eq!(names(&fluree, "mydb:main").await, vec!["B", "Bob"]);
+}
+
+/// Under `f:ValidationWarn` the violation is logged and the merge proceeds,
+/// exactly as a warn-mode transaction would.
+#[tokio::test]
+async fn merge_warn_mode_logs_and_succeeds() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    let mut seed = alice_name_shape(None);
+    seed["@graph"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!({"@id": "ex:alice", "ex:name": "A"}));
+    let main = fluree.insert(ledger, &seed).await.unwrap().ledger;
+
+    let config_iri = config_graph_iri("mydb:main");
+    let trig = format!(
+        r"
+        @prefix f: <https://ns.flur.ee/db#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+        GRAPH <{config_iri}> {{
+            <urn:config:main> rdf:type f:LedgerConfig .
+            <urn:config:main> f:shaclDefaults <urn:config:shacl> .
+            <urn:config:shacl> f:shaclEnabled true .
+            <urn:config:shacl> f:validationMode f:ValidationWarn .
+        }}
+        "
+    );
+    let main = fluree
+        .stage_owned(main)
+        .upsert_turtle(&trig)
+        .execute()
+        .await
+        .expect("config write")
+        .ledger;
+
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
+    let dev = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .update(dev, &replace_name("ex:alice", "B"))
+        .await
+        .unwrap();
+    fluree
+        .update(main, &replace_name("ex:alice", "C"))
+        .await
+        .unwrap();
+
+    let report = fluree
+        .merge_branch("mydb", "dev", None, ConflictStrategy::TakeBoth)
+        .await
+        .expect("warn mode lets the merge through");
+    assert_eq!(report.conflict_count, 1);
+    assert_eq!(names(&fluree, "mydb:main").await, vec!["B", "C"]);
+}
+
+/// The originating field case: the shape lives in a model ledger and the
+/// data ledger's `#config` points `f:shapesSource` at it with `f:ledger`.
+/// A merge is authoring, not replay, so the cross-ledger source is
+/// resolved and enforced.
+#[tokio::test]
+async fn merge_rejected_by_cross_ledger_shape() {
+    let fluree = FlureeBuilder::memory().build_memory();
+
+    let model = fluree.create_ledger("shapes-model").await.unwrap();
+    let shapes_graph_iri = "http://example.org/governance/shapes";
+    fluree
+        .stage_owned(model)
+        .upsert_turtle(&format!(
+            r"
+            @prefix sh:  <http://www.w3.org/ns/shacl#> .
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix ex:  <http://example.org/ns/> .
+
+            GRAPH <{shapes_graph_iri}> {{
+                ex:PersonShape
+                    rdf:type        sh:NodeShape ;
+                    sh:targetClass  ex:Person ;
+                    sh:property     ex:pshape_name .
+                ex:pshape_name
+                    sh:path     ex:name ;
+                    sh:maxCount 1 .
+            }}
+            "
+        ))
+        .execute()
+        .await
+        .expect("seed model shapes");
+
+    let data = fluree.create_ledger("mydb").await.unwrap();
+    let config_iri = config_graph_iri("mydb:main");
+    let main = fluree
+        .stage_owned(data)
+        .upsert_turtle(&format!(
+            r"
+            @prefix f:   <https://ns.flur.ee/db#> .
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+            GRAPH <{config_iri}> {{
+                <urn:cfg:main> rdf:type f:LedgerConfig .
+                <urn:cfg:main> f:shaclDefaults <urn:cfg:shacl> .
+                <urn:cfg:shacl> f:shaclEnabled true .
+                <urn:cfg:shacl> f:shapesSource <urn:cfg:shapes-ref> .
+                <urn:cfg:shapes-ref> rdf:type f:GraphRef ;
+                                     f:graphSource <urn:cfg:shapes-src> .
+                <urn:cfg:shapes-src> f:ledger <shapes-model:main> ;
+                                     f:graphSelector <{shapes_graph_iri}> .
+            }}
+            "
+        ))
+        .execute()
+        .await
+        .expect("seed cross-ledger config")
+        .ledger;
+    let main = fluree
+        .insert(
+            main,
+            &json!({
+                "@context": ctx(),
+                "@graph": [{"@id": "ex:alice", "@type": "ex:Person", "ex:name": "A"}]
+            }),
+        )
+        .await
+        .unwrap()
+        .ledger;
+
+    // Control: a second name via a plain insert is rejected by M's shape.
+    let err = fluree
+        .insert(main.clone(), &insert_name("ex:alice", "X"))
+        .await
+        .expect_err("control: second name rejected by cross-ledger shape");
+    assert_shacl_violation(err, "cross-ledger control");
+
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
+    let dev = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .update(dev, &replace_name("ex:alice", "B"))
+        .await
+        .unwrap();
+    fluree
+        .update(main, &replace_name("ex:alice", "C"))
+        .await
+        .unwrap();
+
+    let err = fluree
+        .merge_branch("mydb", "dev", None, ConflictStrategy::TakeBoth)
+        .await
+        .expect_err("merge producing two names must be rejected by the cross-ledger shape");
+    assert_shacl_violation(err, "cross-ledger merge");
+    assert_eq!(names(&fluree, "mydb:main").await, vec!["C"]);
+}
+
+// =============================================================================
+// Rebase
+// =============================================================================
+
+/// A commit that conformed on the branch can violate a shape installed on
+/// the source since the fork. Its replay must be rejected and the branch
+/// left as it was.
+#[tokio::test]
+async fn rebase_rejected_when_replay_violates_shape() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    let main = fluree
+        .insert(ledger, &insert_name("ex:alice", "A"))
+        .await
+        .unwrap()
+        .ledger;
+    fluree
+        .create_branch("mydb", "dev", None, None)
+        .await
+        .unwrap();
+
+    // dev: a second name is fine, there is no shape on dev.
+    let dev = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .insert(dev, &insert_name("ex:alice", "B"))
+        .await
+        .unwrap();
+    assert_eq!(names(&fluree, "mydb:dev").await, vec!["A", "B"]);
+
+    // main: install the maxCount-1 shape (alice has one name, conforms).
+    fluree
+        .insert(main, &alice_name_shape(None))
+        .await
+        .expect("shape install conforms");
+
+    let err = fluree
+        .rebase_branch("mydb", "dev", ConflictStrategy::default())
+        .await
+        .expect_err("replaying the second name onto the shape must be rejected");
+    assert_shacl_violation(err, "rebase replay");
+
+    // dev is untouched.
+    assert_eq!(head_t(&fluree, "mydb:dev").await, 2);
+    assert_eq!(names(&fluree, "mydb:dev").await, vec!["A", "B"]);
+}
+
+// =============================================================================
+// Revert
+// =============================================================================
+
+/// Reverting the commit that asserted a value a later shape requires must
+/// be rejected, exactly as deleting that value in a transaction is.
+#[tokio::test]
+async fn revert_rejected_when_inverse_violates_shape() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    // Genesis cannot be reverted, so seed an unrelated first commit.
+    let r0 = fluree
+        .insert(ledger, &insert_name("ex:carol", "Carol"))
+        .await
+        .unwrap();
+    let r1 = fluree
+        .insert(r0.ledger, &insert_name("ex:alice", "A"))
+        .await
+        .unwrap();
+    let r2 = fluree
+        .insert(r1.ledger, &alice_name_shape(Some(1)))
+        .await
+        .expect("shape install conforms");
+    let r3 = fluree
+        .insert(r2.ledger, &insert_name("ex:bob", "Bob"))
+        .await
+        .unwrap();
+    assert_eq!(r3.receipt.t, 4);
+
+    // Control: deleting the name in a transaction is rejected (minCount 1).
+    let err = fluree
+        .update(
+            r3.ledger,
+            &json!({
+                "@context": ctx(),
+                "delete": {"@id": "ex:alice", "ex:name": "A"}
+            }),
+        )
+        .await
+        .expect_err("control: deleting the only name breaches minCount 1");
+    assert_shacl_violation(err, "plain delete");
+
+    let err = fluree
+        .revert_commit(
+            "mydb",
+            "main",
+            CommitRef::Exact(r1.receipt.commit_id.clone()),
+            ConflictStrategy::TakeSource,
+        )
+        .await
+        .expect_err("reverting the name's commit must be rejected");
+    assert_shacl_violation(err, "revert");
+
+    assert_eq!(head_t(&fluree, "mydb:main").await, 4);
+    assert_eq!(names(&fluree, "mydb:main").await, vec!["A", "Bob", "Carol"]);
+}

--- a/fluree-db-api/tests/it_branch_shacl.rs
+++ b/fluree-db-api/tests/it_branch_shacl.rs
@@ -570,3 +570,93 @@ async fn preview_validation_can_be_skipped() {
         "strategy-only answer when validation is skipped"
     );
 }
+
+/// Validation resolves conflicts the way the merge would even when the
+/// caller asked for no conflict reporting: take-source retracts main's
+/// value, so the staged result has one name and conforms.
+#[tokio::test]
+async fn preview_validation_resolves_conflicts_without_conflict_reporting() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let main = seed_alice_with_shape(&fluree).await;
+
+    let dev = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .update(dev, &replace_name("ex:alice", "B"))
+        .await
+        .unwrap();
+    fluree
+        .update(main, &replace_name("ex:alice", "C"))
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_conflicts: false,
+                conflict_strategy: ConflictStrategy::TakeSource,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .expect("preview");
+    assert_eq!(preview.conflicts.count, 0, "reporting was opted out");
+    let validation = preview.validation.expect("validation still runs");
+    assert!(
+        validation.conforms,
+        "take-source leaves one name: {:?}",
+        validation.report
+    );
+    assert!(preview.mergeable);
+
+    let report = fluree
+        .merge_branch("mydb", "dev", None, ConflictStrategy::TakeSource)
+        .await
+        .expect("merge succeeds as previewed");
+    assert_eq!(report.conflict_count, 1);
+    assert_eq!(names(&fluree, "mydb:main").await, vec!["B"]);
+}
+
+/// Sibling branches allocate namespace codes independently, so the same code
+/// can mean different prefixes on each. Such a merge cannot be built; the
+/// preview reports that as a branch conflict rather than an internal error.
+#[tokio::test]
+async fn preview_reports_conflict_when_sibling_namespaces_collide() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = fluree.create_ledger("mydb").await.unwrap();
+    fluree
+        .insert(ledger, &insert_name("ex:alice", "A"))
+        .await
+        .unwrap();
+    fluree.create_branch("mydb", "a", None, None).await.unwrap();
+    fluree.create_branch("mydb", "b", None, None).await.unwrap();
+
+    // Each branch introduces a fresh prefix; both get the next free code.
+    let a = fluree.ledger("mydb:a").await.unwrap();
+    fluree
+        .insert(
+            a,
+            &json!({"@context": {"foo": "http://foo.example/"}, "@id": "foo:x", "foo:p": "1"}),
+        )
+        .await
+        .unwrap();
+    let b = fluree.ledger("mydb:b").await.unwrap();
+    fluree
+        .insert(
+            b,
+            &json!({"@context": {"bar": "http://bar.example/"}, "@id": "bar:y", "bar:q": "2"}),
+        )
+        .await
+        .unwrap();
+
+    let err = fluree
+        .merge_preview_with("mydb", "b", Some("a"), MergePreviewOpts::default())
+        .await
+        .expect_err("colliding namespace codes cannot be staged");
+    assert!(
+        matches!(err, ApiError::BranchConflict(_)),
+        "expected BranchConflict, got: {err:?}"
+    );
+}

--- a/fluree-db-api/tests/it_branch_shacl.rs
+++ b/fluree-db-api/tests/it_branch_shacl.rs
@@ -11,7 +11,9 @@
 #![cfg(feature = "shacl")]
 
 use crate::support;
-use fluree_db_api::{ApiError, CommitRef, ConflictStrategy, FlureeBuilder, TransactError};
+use fluree_db_api::{
+    ApiError, CommitRef, ConflictStrategy, FlureeBuilder, MergePreviewOpts, TransactError,
+};
 use fluree_db_core::graph_registry::config_graph_iri;
 use serde_json::json;
 
@@ -441,4 +443,130 @@ async fn revert_rejected_when_inverse_violates_shape() {
 
     assert_eq!(head_t(&fluree, "mydb:main").await, 4);
     assert_eq!(names(&fluree, "mydb:main").await, vec!["A", "Bob", "Carol"]);
+}
+
+// =============================================================================
+// Merge preview
+// =============================================================================
+
+/// Preview runs the same validation the merge runs. Where the merge would be
+/// rejected, the preview says so: `mergeable` is false and the report is the
+/// one the merge would fail with.
+#[tokio::test]
+async fn preview_reports_violation_where_merge_would_fail() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let main = seed_alice_with_shape(&fluree).await;
+
+    let dev = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .update(dev, &replace_name("ex:alice", "B"))
+        .await
+        .unwrap();
+    fluree
+        .update(main, &replace_name("ex:alice", "C"))
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                conflict_strategy: ConflictStrategy::TakeBoth,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .expect("preview");
+    assert!(!preview.fast_forward);
+    assert_eq!(preview.conflicts.count, 1);
+    let validation = preview.validation.expect("validation runs by default");
+    assert!(!validation.conforms);
+    let report = validation
+        .report
+        .expect("a rejected preview carries the report");
+    assert!(
+        report.contains("MaxCountConstraintComponent"),
+        "report should name the constraint: {report}"
+    );
+    assert!(
+        !preview.mergeable,
+        "a merge that would be rejected is not mergeable"
+    );
+
+    // The merge agrees with the preview.
+    let err = fluree
+        .merge_branch("mydb", "dev", None, ConflictStrategy::TakeBoth)
+        .await
+        .expect_err("merge is rejected");
+    assert_shacl_violation(err, "merge after preview");
+}
+
+/// Where the merge conforms, the preview says so and stays mergeable.
+#[tokio::test]
+async fn preview_conforms_where_merge_would_succeed() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let main = seed_alice_with_shape(&fluree).await;
+
+    let dev = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .update(dev, &replace_name("ex:alice", "B"))
+        .await
+        .unwrap();
+    fluree
+        .insert(main, &insert_name("ex:bob", "Bob"))
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview_with("mydb", "dev", None, MergePreviewOpts::default())
+        .await
+        .expect("preview");
+    assert!(!preview.fast_forward);
+    let validation = preview.validation.expect("validation runs by default");
+    assert!(validation.conforms);
+    assert!(validation.report.is_none());
+    assert!(preview.mergeable);
+
+    fluree
+        .merge_branch("mydb", "dev", None, ConflictStrategy::default())
+        .await
+        .expect("merge succeeds as previewed");
+}
+
+/// Opting out leaves the field absent and `mergeable` back to the
+/// strategy-only answer, for count-only previews.
+#[tokio::test]
+async fn preview_validation_can_be_skipped() {
+    let fluree = FlureeBuilder::memory().build_memory();
+    let main = seed_alice_with_shape(&fluree).await;
+
+    let dev = fluree.ledger("mydb:dev").await.unwrap();
+    fluree
+        .update(dev, &replace_name("ex:alice", "B"))
+        .await
+        .unwrap();
+    fluree
+        .update(main, &replace_name("ex:alice", "C"))
+        .await
+        .unwrap();
+
+    let preview = fluree
+        .merge_preview_with(
+            "mydb",
+            "dev",
+            None,
+            MergePreviewOpts {
+                include_validation: false,
+                ..MergePreviewOpts::default()
+            },
+        )
+        .await
+        .expect("preview");
+    assert!(preview.validation.is_none());
+    assert!(
+        preview.mergeable,
+        "strategy-only answer when validation is skipped"
+    );
 }

--- a/fluree-db-cli/src/cli.rs
+++ b/fluree-db-cli/src/cli.rs
@@ -1793,6 +1793,11 @@ pub enum BranchAction {
         #[arg(long)]
         changes_after: Option<String>,
 
+        /// Skip SHACL validation of the merged state. Validation runs by
+        /// default and its outcome folds into `mergeable`.
+        #[arg(long)]
+        no_validate: bool,
+
         /// Emit the raw JSON preview instead of a human-readable summary
         #[arg(long)]
         json: bool,

--- a/fluree-db-cli/src/commands/branch.rs
+++ b/fluree-db-cli/src/commands/branch.rs
@@ -107,6 +107,7 @@ pub async fn run(action: BranchAction, dirs: &FlureeDir, direct: bool) -> CliRes
             max_changes,
             stat,
             changes_after,
+            no_validate,
             json,
             ledger,
             remote,
@@ -127,6 +128,7 @@ pub async fn run(action: BranchAction, dirs: &FlureeDir, direct: bool) -> CliRes
                     max_changes,
                     stat,
                     changes_after,
+                    include_validation: !no_validate,
                     json,
                 },
                 ledger.as_deref(),
@@ -1049,6 +1051,8 @@ struct DiffOpts {
     max_changes: Option<usize>,
     stat: bool,
     changes_after: Option<String>,
+    /// SHACL validation of the merged state (on by default; `--no-validate`).
+    include_validation: bool,
     json: bool,
 }
 
@@ -1098,6 +1102,7 @@ async fn run_diff(
     // convention maps to `None` locally and to "omit the param" remotely
     // (the server always enforces its own cap).
     let include_changes = opts.include_changes;
+    let include_validation = opts.include_validation;
     let max_changes = if opts.stat {
         Some(0)
     } else {
@@ -1125,6 +1130,7 @@ async fn run_diff(
                 include_changes.then_some(true),
                 max_changes.filter(|_| include_changes),
                 opts.changes_after.as_deref(),
+                (!include_validation).then_some(false),
             )
             .await?;
 
@@ -1168,6 +1174,7 @@ async fn run_diff(
                     include_changes.then_some(true),
                     max_changes.filter(|_| include_changes),
                     opts.changes_after.as_deref(),
+                    (!include_validation).then_some(false),
                 )
                 .await?;
 
@@ -1190,6 +1197,7 @@ async fn run_diff(
                 include_changes,
                 max_changes,
                 changes_after_subject: opts.changes_after.clone(),
+                include_validation,
             };
 
             let preview = fluree
@@ -1282,6 +1290,18 @@ fn print_preview_local(p: &fluree_db_api::MergePreview) {
             );
         }
     }
+
+    if let Some(v) = &p.validation {
+        if v.conforms {
+            println!("validation: conforms");
+        } else {
+            println!("validation: violations (merge would be rejected)");
+            for line in v.report.as_deref().unwrap_or_default().lines() {
+                println!("  {line}");
+            }
+        }
+    }
+    println!("mergeable: {}", if p.mergeable { "yes" } else { "no" });
 
     if let Some(ch) = &p.changes {
         let shown: usize = ch

--- a/fluree-db-cli/src/commands/branch.rs
+++ b/fluree-db-cli/src/commands/branch.rs
@@ -1291,17 +1291,12 @@ fn print_preview_local(p: &fluree_db_api::MergePreview) {
         }
     }
 
-    if let Some(v) = &p.validation {
-        if v.conforms {
-            println!("validation: conforms");
-        } else {
-            println!("validation: violations (merge would be rejected)");
-            for line in v.report.as_deref().unwrap_or_default().lines() {
-                println!("  {line}");
-            }
-        }
-    }
-    println!("mergeable: {}", if p.mergeable { "yes" } else { "no" });
+    print_validation(
+        p.validation
+            .as_ref()
+            .map(|v| (v.conforms, v.report.as_deref())),
+        p.mergeable,
+    );
 
     if let Some(ch) = &p.changes {
         let shown: usize = ch
@@ -1337,6 +1332,22 @@ fn print_preview_local(p: &fluree_db_api::MergePreview) {
             println!("  next page: --changes-after '{cursor}'");
         }
     }
+}
+
+/// The SHACL outcome and the mergeable verdict, rendered identically by the
+/// local and remote printers so the two cannot drift apart.
+fn print_validation(validation: Option<(bool, Option<&str>)>, mergeable: bool) {
+    if let Some((conforms, report)) = validation {
+        if conforms {
+            println!("validation: conforms");
+        } else {
+            println!("validation: violations (merge would be rejected)");
+            for line in report.unwrap_or_default().lines() {
+                println!("  {line}");
+            }
+        }
+    }
+    println!("mergeable: {}", if mergeable { "yes" } else { "no" });
 }
 
 fn print_delta_local(label: &str, d: &fluree_db_api::BranchDelta) {
@@ -1452,6 +1463,17 @@ fn print_preview_json(v: &serde_json::Value) -> CliResult<()> {
             }
         }
     }
+
+    let validation = v.get("validation").map(|val| {
+        (
+            val.get("conforms")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            val.get("report").and_then(Value::as_str),
+        )
+    });
+    let mergeable = v.get("mergeable").and_then(Value::as_bool).unwrap_or(false);
+    print_validation(validation, mergeable);
 
     if let Some(ch) = v.get("changes").filter(|x| !x.is_null()) {
         let asserts = ch.get("assert_count").and_then(Value::as_u64).unwrap_or(0);

--- a/fluree-db-cli/src/remote_client.rs
+++ b/fluree-db-cli/src/remote_client.rs
@@ -2368,6 +2368,7 @@ impl RemoteLedgerClient {
         include_changes: Option<bool>,
         max_changes: Option<usize>,
         changes_after_subject: Option<&str>,
+        include_validation: Option<bool>,
     ) -> Result<serde_json::Value, RemoteLedgerError> {
         let mut url = self.op_url("merge-preview", ledger);
         let mut sep = '?';
@@ -2430,6 +2431,9 @@ impl RemoteLedgerClient {
                 "changes_after_subject",
                 urlencoding::encode(c).into_owned(),
             );
+        }
+        if let Some(b) = include_validation {
+            push(&mut url, &mut sep, "include_validation", b.to_string());
         }
 
         self.send_json(reqwest::Method::GET, &url, "application/json", None)

--- a/fluree-db-novelty/src/delta.rs
+++ b/fluree-db-novelty/src/delta.rs
@@ -140,7 +140,7 @@ impl NetChangeAccumulator {
 /// One walk serves every output, so callers that need conflict keys *and*
 /// the change set (merge preview) replay the source chain once instead of
 /// twice. The third element is the union of the range's namespace deltas,
-/// earliest commit winning on a code collision — the codes a consumer needs
+/// earliest commit winning on a code collision: the codes a consumer needs
 /// to make the change set's terms encodable before the range is committed.
 pub async fn compute_delta_keys_and_changes<C: ContentStore + Clone + 'static>(
     store: C,

--- a/fluree-db-novelty/src/delta.rs
+++ b/fluree-db-novelty/src/delta.rs
@@ -9,6 +9,7 @@ use fluree_db_core::{ConflictKey, ContentId, ContentStore, Flake, FlakeValue, Si
 use futures::TryStreamExt;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 
 /// Walk the first-parent lineage from `head_id` back to `stop_at_t` and
 /// collect all (subject, predicate, graph) tuples modified in those commits.
@@ -136,21 +137,29 @@ impl NetChangeAccumulator {
 /// into the aggregate change set the range applies (see
 /// [`NetChangeAccumulator`] for the netting contract).
 ///
-/// One walk serves both outputs, so callers that need conflict keys *and*
-/// the change set (merge preview with `include_changes`) replay the source
-/// chain once instead of twice.
+/// One walk serves every output, so callers that need conflict keys *and*
+/// the change set (merge preview) replay the source chain once instead of
+/// twice. The third element is the union of the range's namespace deltas,
+/// earliest commit winning on a code collision — the codes a consumer needs
+/// to make the change set's terms encodable before the range is committed.
 pub async fn compute_delta_keys_and_changes<C: ContentStore + Clone + 'static>(
     store: C,
     head_id: ContentId,
     stop_at_t: i64,
-) -> Result<(FxHashSet<ConflictKey>, Vec<Flake>)> {
+) -> Result<(FxHashSet<ConflictKey>, Vec<Flake>, HashMap<u16, String>)> {
     let stream = trace_first_parent_commits_by_id(store, head_id, stop_at_t);
     futures::pin_mut!(stream);
 
     let mut keys = FxHashSet::default();
     let mut acc = NetChangeAccumulator::default();
+    let mut namespace_delta: HashMap<u16, String> = HashMap::new();
 
     while let Some(commit) = stream.try_next().await? {
+        // Commits stream newest-first, so a plain insert leaves the oldest
+        // commit's prefix in place for a colliding code.
+        for (code, prefix) in commit.namespace_delta {
+            namespace_delta.insert(code, prefix);
+        }
         // Commits stream newest-first; iterate each commit's flakes in
         // reverse so the accumulator sees a strictly reverse-chronological
         // sequence even when one commit touches the same fact twice.
@@ -164,7 +173,7 @@ pub async fn compute_delta_keys_and_changes<C: ContentStore + Clone + 'static>(
         }
     }
 
-    Ok((keys, acc.finish()))
+    Ok((keys, acc.finish(), namespace_delta))
 }
 
 #[cfg(test)]

--- a/fluree-db-server/src/routes/ledger.rs
+++ b/fluree-db-server/src/routes/ledger.rs
@@ -1980,6 +1980,10 @@ pub struct MergePreviewQuery {
     /// full IRI. Pass the previous response's `changes.next_cursor`.
     #[serde(default)]
     pub changes_after_subject: Option<String>,
+    /// Validate the resolved change set against the target's SHACL shapes and
+    /// fold the outcome into `mergeable`. Defaults to true.
+    #[serde(default)]
+    pub include_validation: Option<bool>,
 }
 
 /// Read-only branch merge preview.
@@ -2080,6 +2084,9 @@ pub async fn merge_preview(
             ));
         }
         opts.changes_after_subject = params.changes_after_subject.clone();
+        if let Some(b) = params.include_validation {
+            opts.include_validation = b;
+        }
 
         let preview = state
             .fluree


### PR DESCRIPTION
Fixes #1782

**Stacked on #1818** (`fix/branch-workflow-t`).

## Problem

A transaction that would violate an attached SHACL shape is rejected at commit time. Merge, rebase, and revert build their commits on a parallel path that never consulted the shapes. So a `take-both` merge, whose resolution is "both values coexist", could leave two values on a `sh:maxCount 1` property and report success. The violation sat in the ledger until someone ran `fluree validate`. Rebase replays and revert commits had the same gap.

## Fix

Branch operations now stage and validate through one helper, `stage_validated`. Staging and validation can't be separated, so a future operation can't copy one without the other. It runs the same post-stage validation transactions run, under the ledger's configured posture.

- **Merge** validates the resolved state before copying the source's commits or building the merge commit. A rejection writes nothing and leaves the target untouched. Fast-forward merges are skipped, because the adopted commits were validated when they were authored.
- **Rebase** validates each replayed commit against the state it lands on. The first violation aborts the whole rebase, which has published nothing yet, and the error names the commit it stopped on.
- **Revert** validates the inverted state. For example, undoing the commit that asserted a value a later `sh:minCount` requires is rejected.

A rejection returns the same `ShaclViolation` error and report a rejected transaction does. Warn-mode graphs log and proceed.

**Cross-ledger shapes are enforced, not skipped.** Commit replay skips a cross-ledger `f:shapesSource`, because the origin already validated it. A branch operation is authoring: the state it stages onto the target is a combination nobody has validated. So the model ledger is resolved at operation time, as it is for a transaction. This was the originating field case.

## Merge preview

A preview that says `mergeable` while the merge would be rejected is worse than no preview. The preview now stages the resolved change set on a clone of the target state and runs the merge's own staging (`stage_merge`), so the two can't disagree.

- **New `validation` field.** It carries `conforms` and, when rejected, the report the merge would fail with.
- **`mergeable` now means the merge will go through.** The strategy applies without aborting and the result conforms. The docs previously warned it was not a guarantee.
- **Resolution matches the merge exactly.** It uses the uncapped conflict set, whether or not conflicts are reported, and skips validation exactly where the merge would. The abort decision is shared through `ConflictStrategy::aborts_on`.
- **On by default through `include_validation`.** CLI `fluree branch diff --no-validate`, server query parameter, and remote client. The local and remote text printers show the validation outcome and a `mergeable` line.

## Behavior changes to note

- **Preview cost.** A non-fast-forward preview now loads the target state and runs a validation pass by default. Use `include_validation=false` for count-only previews.
- **Namespace-code collisions.** Sibling branches allocate namespace codes independently. When two siblings give the same code to different prefixes, the merge was already refused at commit build. It now fails earlier as a `BranchConflict` (409), and the preview reports it that way instead of returning an internal error.

## Tests

`it_branch_shacl.rs` adds 12 tests:
- Plain-transaction controls showing each state is one a transaction would refuse.
- Rejected merges, including one through a cross-ledger shape.
- A rejected rebase replay and a rejected revert.
- A conforming merge and warn mode, both passing.
- Preview cases: violation, conforming, opt-out, conflict resolution with reporting off, and a sibling namespace collision.

The branch op tests were observed failing before the fix. Removing validation from the shared helper fails six of them.

## Docs

Updated: `docs/api/endpoints.md`, `docs/cli/server-integration.md` (new rule 12 in the merge preview contract), `docs/cli/branch.md`, `docs/getting-started/rust-api.md`, and the SHACL and branching cookbooks. Also `docs/security/cross-ledger-policy.md`, which lists branch operations among the enforced surfaces and explains why they don't take the replay carve-out.

## Out of scope

- The rebase report's `failures` field is still never populated. A rejected replay aborts the rebase instead.
- Follow-up: Sibling merges can pick a common ancestor on the wrong clock. The namespace-collision behavior above is one symptom of the same topology.