### PR TITLE
fix(query): seed selective object VALUES before star payload joins

### DIFF
--- a/docs/design/performance.md
+++ b/docs/design/performance.md
@@ -235,6 +235,27 @@ ordering and the scan layer work from the narrower form:
   compound patterns are rewrite boundaries because MINUS/EXISTS semantics can
   change when a shared variable disappears before the retained VALUES binds it.
 
+### Multi-row VALUES in stars
+
+A pure, unseeded star with no constant object anchor can start from one small
+object `VALUES` table when predicate statistics predict at least a 16-fold
+reduction over its smallest predicate scan. The table must contain at most 64
+rows of fully bound references. The
+planner probes the associated predicate first, joins other `VALUES` as soon as
+all their variables are available, and visits constrained endpoints before
+unconstrained payload columns. It retains the actual `ValuesOperator` joins, so
+duplicates multiply results, `UNDEF` remains a wildcard, and multi-column
+correlations survive. Independent tables are never multiplied into a seed.
+
+Broad or unsupported seeds, unavailable object NDV, existing subject seeds,
+constant-object anchors, history, and multi-graph default unions retain their
+existing planning paths. In particular, existing fused stars keep their fusion.
+This decision uses the same ordinary scan/join operators as other queries; it
+does not rewrite `VALUES` into `FILTER IN`. The `it_values_object_bounds` tests
+pin the physical plan, scan fuel, and result semantics. The
+`query_hot_values_star` benchmark compares the two spellings at 6k–500k edges
+and includes singleton and broad-set controls.
+
 ### Cost constants are coupled and tested
 
 Estimator constants are not free parameters. `DISTINCT_SUBQUERY_PRODUCER_SELECTIVITY`

--- a/fluree-db-api/Cargo.toml
+++ b/fluree-db-api/Cargo.toml
@@ -587,6 +587,10 @@ name = "query_hot_fanout_star"
 harness = false
 
 [[bench]]
+name = "query_hot_values_star"
+harness = false
+
+[[bench]]
 name = "query_overlay_matrix"
 harness = false
 

--- a/fluree-db-api/benches/query_hot_values_star.rs
+++ b/fluree-db-api/benches/query_hot_values_star.rs
@@ -1,0 +1,111 @@
+//! Two known endpoints in a wide edge star: VALUES must constrain the probes.
+//!
+//! Compare two multi-row VALUES with the FILTER IN workaround. Singleton and
+//! broad-set controls protect existing star plans. Tiny=6k, small=24k,
+//! medium=129k (the report's scale), large=500k edges; 256-byte snapshots.
+//!
+//! cargo bench -p fluree-db-api --bench query_hot_values_star
+//! FLUREE_BENCH_SCALE=medium cargo bench -p fluree-db-api --bench query_hot_values_star
+//! cargo bench -p fluree-db-api --bench query_hot_values_star -- --test
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use fluree_bench_support::{
+    bench_runtime, current_profile, current_scale, init_tracing_for_bench, next_ledger_alias,
+    BenchScale,
+};
+use fluree_db_api::admin::ReindexOptions;
+use fluree_db_api::{CommitOpts, Fluree, FlureeBuilder, IndexConfig, TxnOpts};
+use std::fmt::Write;
+
+async fn setup(n: usize) -> (tempfile::TempDir, Fluree, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let fluree = FlureeBuilder::file(dir.path().to_string_lossy().to_string())
+        .build()
+        .unwrap();
+    let alias = next_ledger_alias("query-hot-values-star");
+    let ledger = fluree.create_ledger(&alias).await.unwrap();
+    let mut ttl = String::from("@prefix ex: <http://example.org/> .\n");
+    let payload = "x".repeat(256);
+    for i in 0..n {
+        let (a, b) = match i {
+            0 => ("A".to_owned(), "B".to_owned()),
+            1 => ("B".to_owned(), "A".to_owned()),
+            2 => ("A".to_owned(), "C".to_owned()),
+            _ => (format!("item{}", i * 2), format!("item{}", i * 2 + 1)),
+        };
+        writeln!(ttl, "ex:edge{i} ex:entity1 ex:{a} ; ex:entity2 ex:{b} ; ex:snap \"{i} {payload}\" ; ex:kind ex:Edge .").unwrap();
+    }
+    fluree
+        .insert_turtle_with_opts(
+            ledger,
+            &ttl,
+            TxnOpts::default(),
+            CommitOpts::default(),
+            &IndexConfig {
+                reindex_min_bytes: 5_000_000_000,
+                reindex_max_bytes: 5_000_000_000,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    fluree
+        .reindex(&alias, ReindexOptions::default())
+        .await
+        .unwrap();
+    (dir, fluree, alias)
+}
+
+fn bench_query_hot_values_star(c: &mut Criterion) {
+    init_tracing_for_bench();
+    let rt = bench_runtime();
+    let scale = current_scale();
+    let profile = current_profile();
+    let n = match scale {
+        BenchScale::Tiny => 6_000,
+        BenchScale::Small => 24_000,
+        BenchScale::Medium => 129_000,
+        BenchScale::Large => 500_000,
+    };
+    let (_dir, fluree, alias) = rt.block_on(setup(n));
+    let graph = rt.block_on(async { fluree.graph(&alias).load().await.unwrap() });
+    let mut group = c.benchmark_group("query_hot_values_star");
+    group.sample_size(profile.sample_size());
+    group.sampling_mode(criterion::SamplingMode::Flat);
+    for (name, constraints, tail) in [
+        (
+            "two_values",
+            "VALUES ?a { ex:A ex:B } VALUES ?b { ex:A ex:B }",
+            "",
+        ),
+        (
+            "filter_in",
+            "VALUES ?a { ex:A ex:B } FILTER(?b IN (ex:A, ex:B))",
+            "",
+        ),
+        (
+            "singleton_anchor",
+            "VALUES ?a { ex:A } VALUES ?b { ex:B ex:C }",
+            "",
+        ),
+        (
+            "broad_values",
+            "VALUES ?kind { ex:Edge ex:Missing } ?ev ex:kind ?kind .",
+            "LIMIT 10",
+        ),
+    ] {
+        let sparql = format!(
+            "PREFIX ex: <http://example.org/> SELECT ?a ?b ?snap WHERE {{
+            {constraints} ?ev ex:snap ?snap ; ex:entity1 ?a ; ex:entity2 ?b . }} {tail}"
+        );
+        group.bench_with_input(BenchmarkId::new(name, scale.as_str()), &sparql, |b, q| {
+            b.iter(|| {
+                rt.block_on(async { black_box(graph.query().sparql(q).execute().await.unwrap()) })
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_query_hot_values_star);
+criterion_main!(benches);

--- a/fluree-db-api/tests/it_values_object_bounds.rs
+++ b/fluree-db-api/tests/it_values_object_bounds.rs
@@ -8,11 +8,10 @@
 //!    (materializing every row, including wide payloads) and the tiny VALUES
 //!    filtered afterwards — measured 1,600x slower than the equivalent
 //!    `FILTER ?v IN (...)` on a 129k-edge two-bound-endpoint join. Such
-//!    VALUES now lower to membership filters (see
-//!    `convert_star_values_to_membership_filters` in fluree-db-query; the
-//!    plan-shape pins live in that crate's unit tests). The tests here pin
-//!    the SEMANTICS the conversion must preserve: identical rows to the
-//!    filter form, duplicate-row multiplicity, and UNDEF match-any.
+//!    Small, selective object VALUES now seed object probes, and the other
+//!    VALUES join before unconstrained payload columns. The plan and fuel pins
+//!    below exercise two MULTI-ROW tables (a singleton uses a separate fold).
+//!    The joins retain duplicate-row multiplicity and UNDEF match-any.
 //!
 //! 2. `FILTER(?v IN (<iri> ...))` matched NOTHING against index-encoded
 //!    bindings: `eval_in` compared an `EncodedSid`/`Sid` row value against a
@@ -93,6 +92,163 @@ async fn run(fluree: &fluree_db_api::Fluree, sparql: &str) -> Vec<JsonValue> {
 fn sorted(mut rows: Vec<JsonValue>) -> Vec<JsonValue> {
     rows.sort_by_key(std::string::ToString::to_string);
     rows
+}
+
+/// The report's two-endpoint shape, including an edge with only its first
+/// endpoint in the set so dropping the second constraint cannot pass.
+async fn seed_endpoint_report(fluree: &fluree_db_api::Fluree, n: usize, indexed: bool) {
+    let ledger = genesis_ledger(fluree, LEDGER_ID);
+    let graph: Vec<_> = (0..n)
+        .map(|i| {
+            let (a, b) = match i {
+                0 => (entity_a(), entity_b()),
+                1 => (entity_b(), entity_a()),
+                2 => (entity_a(), entity_c()),
+                _ => (iri(i * 2), iri(i * 2 + 1)),
+            };
+            json!({
+            "@id": format!("http://example.org/edge/{i}"),
+            "ns:entity1": {"@id": a}, "ns:entity2": {"@id": b},
+            "ns:tag": ["one", "two"],
+            "ns:snap": format!("snapshot {i} {}", "x".repeat(256))
+            })
+        })
+        .collect();
+    fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context": {"ns": "http://example.org/ns#"}, "@graph": graph
+            }),
+        )
+        .await
+        .unwrap();
+    if indexed {
+        rebuild_and_publish_index(fluree, LEDGER_ID).await;
+    }
+}
+
+fn endpoint_query(select: &str, values: &str) -> String {
+    // Payload deliberately first in source order.
+    format!(
+        "PREFIX ns: <http://example.org/ns#> SELECT {select} FROM <{LEDGER_ID}> WHERE {{
+        {values} ?ev ns:snap ?snap ; ns:entity1 ?a ; ns:entity2 ?b . }}"
+    )
+}
+
+fn physical_ops(plan: &JsonValue) -> Vec<String> {
+    let mut ops = vec![plan["op"].as_str().unwrap().to_owned()];
+    if let Some(children) = plan["children"].as_array() {
+        for edge in children {
+            ops.extend(physical_ops(&edge["node"]));
+        }
+    }
+    ops
+}
+
+#[tokio::test]
+async fn multirow_object_values_probe_before_payload_on_both_storage_paths() {
+    assert_index_defaults();
+    for indexed in [false, true] {
+        let fluree = FlureeBuilder::memory().build_memory();
+        seed_endpoint_report(&fluree, 6_000, indexed).await;
+        let (a, b) = (entity_a(), entity_b());
+        let values = format!("VALUES ?a {{ <{a}> <{b}> }} VALUES ?b {{ <{a}> <{b}> }}");
+        let q = endpoint_query("?a ?b ?snap", &values);
+        // EXPLAIN currently reads snapshot stats only; runtime planning also
+        // assembles novelty stats. Pin its tree on the indexed path and actual
+        // execution fuel on BOTH paths.
+        if indexed {
+            let explain = fluree.explain_connection_sparql(&q).await.unwrap();
+            assert_eq!(
+                physical_ops(&explain["plan"]["physical"]),
+                vec![
+                    "ProjectOperator",
+                    "NestedLoopJoinOperator",
+                    "ValuesOperator",
+                    "NestedLoopJoinOperator",
+                    "NestedLoopJoinOperator",
+                    "ValuesOperator",
+                    "EmptyOperator",
+                ],
+                "indexed={indexed}: {explain}"
+            );
+        }
+        let r = fluree
+            .query_from()
+            .sparql(&q)
+            .track_all()
+            .execute_tracked()
+            .await
+            .unwrap();
+        assert_eq!(r.status, 200);
+        let rows = sorted(r.result["results"]["bindings"].as_array().unwrap().clone());
+        assert_eq!(rows.len(), 2);
+        // Per-row charges expose full scans even when everything is cached.
+        assert!(
+            r.fuel.unwrap() < 3.0,
+            "indexed={indexed}: fuel {:?}",
+            r.fuel
+        );
+        let filter = endpoint_query(
+            "?a ?b ?snap",
+            &format!("VALUES ?a {{ <{a}> <{b}> }} FILTER(?b IN (<{a}>, <{b}>))"),
+        );
+        assert_eq!(rows, sorted(run(&fluree, &filter).await));
+        // Projection pruning must keep both endpoint constraints alive.
+        assert_eq!(
+            run(&fluree, &endpoint_query("?snap", &values)).await.len(),
+            2
+        );
+        // An unprojected multi-valued property still multiplies a SELECT bag.
+        let fanout = format!("{values} ?ev ns:tag ?tag .");
+        assert_eq!(
+            run(&fluree, &endpoint_query("?snap", &fanout)).await.len(),
+            4
+        );
+        assert_eq!(
+            run(&fluree, &endpoint_query("DISTINCT ?snap", &fanout))
+                .await
+                .len(),
+            2
+        );
+        let duplicate =
+            format!("VALUES ?a {{ <{a}> <{a}> <{b}> }} VALUES ?b {{ <{a}> <{b}> <{b}> }}");
+        assert_eq!(
+            run(&fluree, &endpoint_query("?a ?b ?snap", &duplicate))
+                .await
+                .len(),
+            5
+        );
+        assert_eq!(
+            run(&fluree, &endpoint_query("DISTINCT ?snap", &duplicate))
+                .await
+                .len(),
+            2
+        );
+        let wildcard = format!("VALUES ?a {{ <{a}> <{b}> }} VALUES ?b {{ <{a}> <{b}> UNDEF }}");
+        assert_eq!(
+            run(&fluree, &endpoint_query("?a ?b ?snap", &wildcard))
+                .await
+                .len(),
+            5
+        );
+        let absent = format!("VALUES ?a {{ <{a}> <{b}> }} VALUES ?b {{ <http://example.org/missing1> <http://example.org/missing2> }}");
+        assert!(run(&fluree, &endpoint_query("?snap", &absent))
+            .await
+            .is_empty());
+        let correlated = format!(
+            "VALUES ?a {{ <{a}> <{b}> }} VALUES (?b ?tag) {{ (<{b}> \"one\") (<{a}> \"two\") }}"
+        );
+        let rows = run(&fluree, &endpoint_query("?b ?tag", &correlated)).await;
+        assert_eq!(rows.len(), 2);
+        for row in rows {
+            assert_eq!(
+                row["tag"]["value"],
+                if row["b"]["value"] == b { "one" } else { "two" }
+            );
+        }
+    }
 }
 
 /// The report's core claim: binding both endpoints of an edge with two

--- a/fluree-db-query/src/execute/where_plan.rs
+++ b/fluree-db-query/src/execute/where_plan.rs
@@ -1049,9 +1049,8 @@ fn apply_values(
 /// rest, which must stay behind the triples.
 ///
 /// A VALUES binding the star's subject constrains every triple in it at once, so
-/// seeding hands the star a bound driving set. Anything else — a VALUES binding
-/// only a leaf object var, or sharing no variable with the star at all — would
-/// seed a cartesian product instead, so it defers.
+/// seeding hands the star a bound driving set. Selective object seeds are handled
+/// separately by `selective_object_values_seed`; everything left here defers.
 ///
 /// The caller only reaches this for a star (`is_property_join`), which guarantees
 /// every triple shares the first triple's subject var.
@@ -1065,6 +1064,88 @@ fn split_values_seeding_star(
     values
         .into_iter()
         .partition(|vp| vp.vars.contains(&subject))
+}
+
+/// Keep large/unknown object sets on the star's scan path. A small, fully bound
+/// resource table can instead drive object probes when measured NDV predicts a
+/// substantial reduction. Seed ONE table: multiplying independent VALUES first
+/// would turn two selective sets into a potentially large cartesian product.
+const OBJECT_VALUES_SEED_MAX_ROWS: usize = 64;
+const OBJECT_VALUES_SEED_MIN_GAIN: f64 = 16.0;
+
+fn object_values_var(values: &ValuesPattern) -> Option<VarId> {
+    let [var] = values.vars.as_slice() else {
+        return None;
+    };
+    if values.rows.is_empty() || values.rows.len() > OBJECT_VALUES_SEED_MAX_ROWS {
+        return None;
+    }
+    values
+        .rows
+        .iter()
+        .all(|row| {
+            matches!(
+                row.as_slice(),
+                [crate::binding::Binding::Sid { .. }
+                    | crate::binding::Binding::Iri(_)
+                    | crate::binding::Binding::IriMatch { .. }]
+            )
+        })
+        .then_some(*var)
+}
+
+/// Called only for an unseeded, pure inner-join star. Returns the VALUES and
+/// triple to drive from; no pattern is replaced or deduplicated. In particular,
+/// duplicate VALUES rows still multiply solutions and UNDEF tables stay joins.
+fn selective_object_values_seed(
+    values: &[ValuesPattern],
+    triples: &[TriplePattern],
+    stats: Option<&StatsView>,
+) -> Option<(usize, usize)> {
+    let stats = stats?;
+    let subject = triples.first()?.s.as_var()?;
+    // A constant object can anchor the fused PropertyJoinOperator. Leave that
+    // entire family alone: this optimization repairs unanchored stars only.
+    if triples.iter().any(TriplePattern::o_bound) {
+        return None;
+    }
+    if values.iter().any(|vp| vp.vars.contains(&subject)) {
+        return None; // Preserve the existing subject-seeding path.
+    }
+    let unbound = HashSet::new();
+    // Compare against the smallest predicate scan the old plan could drive.
+    let baseline = triples
+        .iter()
+        .map(|tp| crate::planner::estimate_triple_row_count(tp, &unbound, Some(stats)))
+        .fold(f64::INFINITY, f64::min);
+    let mut best = None;
+    let mut best_work = baseline / OBJECT_VALUES_SEED_MIN_GAIN;
+    for (vi, vp) in values.iter().enumerate() {
+        let Some(var) = object_values_var(vp) else {
+            continue;
+        };
+        for (ti, tp) in triples.iter().enumerate() {
+            if tp.o.as_var() != Some(var) {
+                continue;
+            }
+            let prop = match &tp.p {
+                Ref::Sid(sid) => stats.get_property(sid),
+                Ref::Iri(iri) => stats.get_property_by_iri(iri),
+                Ref::Var(_) => None,
+            };
+            let Some(prop) = prop.filter(|p| p.ndv_values > 0) else {
+                continue;
+            };
+            let fanout = (prop.count as f64 / prop.ndv_values as f64).max(1.0);
+            // Count duplicate seed rows too, and charge one seek per row.
+            let work = vp.rows.len() as f64 * (1.0 + fanout);
+            if work < best_work {
+                best_work = work;
+                best = Some((vi, ti));
+            }
+        }
+    }
+    best
 }
 
 /// Partition filters into those eligible for inline evaluation and those still waiting.
@@ -2211,6 +2292,51 @@ pub fn build_where_operators_seeded_with_needed(
                 if block.binds.is_empty() && block.filters.is_empty() {
                     let mut augmented_rwv = augmented_at(end);
 
+                    if operator.is_none()
+                        && !block.values.is_empty()
+                        && is_property_join(&block.triples)
+                        && !planning.multi_default_graph
+                        && !planning.is_history()
+                    {
+                        if let Some((vi, ti)) = selective_object_values_seed(
+                            &block.values,
+                            &block.triples,
+                            stats.as_deref(),
+                        ) {
+                            let mut values = block.values;
+                            let seed = values.remove(vi);
+                            let mut triples = block.triples;
+                            let driver = triples.remove(ti);
+                            // Test the other endpoints before fetching unrestrained
+                            // payload columns. Stable sort preserves other ties.
+                            triples.sort_by_key(|tp| {
+                                !(tp.o_bound()
+                                    || values.iter().any(|vp| {
+                                        object_values_var(vp)
+                                            .is_some_and(|v| tp.o.as_var() == Some(v))
+                                    }))
+                            });
+                            triples.insert(0, driver);
+                            let ctx = TriplePlanContext {
+                                required_where_vars: augmented_rwv.as_deref(),
+                                var_counts: &var_counts,
+                                protected_vars: &protected_vars,
+                                group_by,
+                                where_dedup_safe,
+                                planning,
+                                stats: stats.as_deref(),
+                            };
+                            operator = Some(build_sequential_triple_chain(
+                                apply_values(None, vec![seed]),
+                                &triples,
+                                &HashMap::new(),
+                                &ctx,
+                                values,
+                            )?);
+                            continue;
+                        }
+                    }
+
                     // Preserve property-join eligibility when a top-level VALUES precedes
                     // a pure star block. Wrapping VALUES first seeds the schema/operator and
                     // prevents `build_triple_operators()` from taking the property-join path.
@@ -3190,6 +3316,7 @@ fn build_sequential_triple_chain(
     triples: &[TriplePattern],
     object_bounds: &HashMap<VarId, ObjectBounds>,
     ctx: &TriplePlanContext<'_>,
+    mut pending_values: Vec<ValuesPattern>,
 ) -> Result<BoxedOperator> {
     let mut operator = existing;
     let rwv_set: Option<HashSet<VarId>> =
@@ -3215,7 +3342,13 @@ fn build_sequential_triple_chain(
                 .iter()
                 .flat_map(crate::ir::triple::TriplePattern::referenced_vars)
                 .collect();
-            base.union(&suffix_vars).copied().collect::<Vec<VarId>>()
+            let mut live = base.union(&suffix_vars).copied().collect::<Vec<VarId>>();
+            for var in pending_values.iter().flat_map(|vp| &vp.vars) {
+                if !live.contains(var) {
+                    live.push(*var);
+                }
+            }
+            live
         });
 
         let emit = emit_mask_for_triple(pattern, ctx.var_counts, ctx.protected_vars);
@@ -3230,6 +3363,17 @@ fn build_sequential_triple_chain(
             ctx.planning,
             &hash_planner,
         ));
+
+        // Retain the real VALUES join, including duplicates and wildcard cells.
+        // Only move it past required triples, once ALL its variables are bound;
+        // disconnected/correlated-column tables remain deferred to the end.
+        if !pending_values.is_empty() {
+            let (ready, pending) = pending_values
+                .into_iter()
+                .partition(|vp| vp.vars.iter().all(|v| seen_vars.contains(v)));
+            operator = apply_values(operator, ready);
+            pending_values = pending;
+        }
 
         // Early dedup (sound because downstream is multiplicity-insensitive —
         // see `where_dedup_safe`) where this step trimmed a variable that was
@@ -3252,7 +3396,7 @@ fn build_sequential_triple_chain(
         }
     }
 
-    Ok(operator.unwrap())
+    Ok(apply_values(operator, pending_values).unwrap())
 }
 
 /// Whether a join step that leaves `dead_after` variables trimmed (`dead_before`
@@ -3518,8 +3662,13 @@ pub fn build_triple_operators(
 
     if existing.is_none() && object_bounds.is_empty() {
         if let Some(cyclic_plan) = analyze_cyclic_bgp(&triples_for_exec, ctx.stats) {
-            let fallback =
-                build_sequential_triple_chain(None, &triples_for_exec, object_bounds, ctx)?;
+            let fallback = build_sequential_triple_chain(
+                None,
+                &triples_for_exec,
+                object_bounds,
+                ctx,
+                Vec::new(),
+            )?;
             return Ok(Box::new(CyclicBgpOperator::new(
                 cyclic_plan,
                 ctx.required_where_vars,
@@ -3529,7 +3678,7 @@ pub fn build_triple_operators(
         }
     }
 
-    build_sequential_triple_chain(existing, &triples_for_exec, object_bounds, ctx)
+    build_sequential_triple_chain(existing, &triples_for_exec, object_bounds, ctx, Vec::new())
 }
 
 #[cfg(test)]
@@ -3821,6 +3970,145 @@ mod tests {
             ops.extend(plan_ops(&edge.node));
         }
         ops
+    }
+
+    fn object_seed_fixture() -> (Vec<ValuesPattern>, Vec<TriplePattern>, StatsView) {
+        use crate::binding::Binding;
+        let values = [VarId(1), VarId(2)]
+            .into_iter()
+            .map(|v| {
+                ValuesPattern::new(
+                    vec![v],
+                    vec![vec![Binding::iri("ex:a")], vec![Binding::iri("ex:b")]],
+                )
+            })
+            .collect();
+        // Payload deliberately first: the object seed must reorder the driver.
+        let triples = vec![
+            make_pattern(VarId(0), "payload", VarId(3)),
+            make_pattern(VarId(0), "left", VarId(1)),
+            make_pattern(VarId(0), "right", VarId(2)),
+        ];
+        let mut stats = StatsView::default();
+        for p in ["payload", "left", "right"] {
+            stats.properties.insert(
+                Sid::new(100, p),
+                PropertyStatData {
+                    count: 100_000,
+                    ndv_values: 100_000,
+                    ndv_subjects: 100_000,
+                },
+            );
+        }
+        (values, triples, stats)
+    }
+
+    #[test]
+    fn object_values_seed_uses_selectivity_and_keeps_existing_anchors() {
+        let (values, triples, mut stats) = object_seed_fixture();
+        assert_eq!(
+            selective_object_values_seed(&values, &triples, Some(&stats)),
+            Some((0, 1))
+        );
+        // The first endpoint is a hub: seed from the second instead.
+        stats
+            .properties
+            .get_mut(&Sid::new(100, "left"))
+            .unwrap()
+            .ndv_values = 1;
+        assert_eq!(
+            selective_object_values_seed(&values, &triples, Some(&stats)),
+            Some((1, 2))
+        );
+        stats
+            .properties
+            .get_mut(&Sid::new(100, "right"))
+            .unwrap()
+            .ndv_values = 1;
+        assert!(selective_object_values_seed(&values, &triples, Some(&stats)).is_none());
+        let (values, mut triples, stats) = object_seed_fixture();
+        triples[0].o = Term::Iri(Arc::from("ex:unique-payload"));
+        assert!(selective_object_values_seed(&values, &triples, Some(&stats)).is_none());
+        // Even a broad constant anchor keeps its fused-star eligibility.
+        let mut broad_anchor_stats = stats.clone();
+        broad_anchor_stats
+            .properties
+            .get_mut(&Sid::new(100, "payload"))
+            .unwrap()
+            .ndv_values = 1;
+        assert!(
+            selective_object_values_seed(&values, &triples, Some(&broad_anchor_stats)).is_none()
+        );
+        assert!(selective_object_values_seed(&values, &triples, None).is_none());
+    }
+
+    #[test]
+    fn object_values_seed_declines_unknown_broad_and_non_resource_sets() {
+        use crate::binding::Binding;
+        let (mut values, triples, mut stats) = object_seed_fixture();
+        values.truncate(1);
+        for rows in [
+            vec![],
+            vec![vec![Binding::Unbound]],
+            vec![vec![Binding::iri("ex:a")], vec![Binding::Unbound]],
+            vec![vec![Binding::lit(
+                FlakeValue::Long(1),
+                Sid::new(2, "integer"),
+            )]],
+            vec![vec![Binding::iri("ex:a")]; OBJECT_VALUES_SEED_MAX_ROWS + 1],
+        ] {
+            let candidate = [ValuesPattern::new(vec![VarId(1)], rows)];
+            assert!(selective_object_values_seed(&candidate, &triples, Some(&stats)).is_none());
+        }
+        // Multi-column correlation, disconnected sets, and subject seeds retain
+        // their existing plans even when another object table could seed.
+        values[0].vars = vec![VarId(1), VarId(2)];
+        assert!(selective_object_values_seed(&values, &triples, Some(&stats)).is_none());
+        values[0].vars = vec![VarId(9)];
+        assert!(selective_object_values_seed(&values, &triples, Some(&stats)).is_none());
+        let (mut values, _, _) = object_seed_fixture();
+        values.push(ValuesPattern::new(
+            vec![VarId(0)],
+            vec![vec![Binding::iri("ex:s")]],
+        ));
+        assert!(selective_object_values_seed(&values, &triples, Some(&stats)).is_none());
+        values.pop();
+        for p in stats.properties.values_mut() {
+            p.ndv_values = 0;
+        }
+        assert!(selective_object_values_seed(&values, &triples, Some(&stats)).is_none());
+    }
+
+    #[test]
+    fn object_values_seed_plan_probes_before_payload_and_preserves_duplicates() {
+        let (mut values, triples, stats) = object_seed_fixture();
+        let duplicate = values[0].rows[0].clone();
+        values[0].rows.push(duplicate);
+        assert_eq!(
+            selective_object_values_seed(&values, &triples, Some(&stats)),
+            Some((1, 2))
+        );
+        let mut patterns: Vec<_> = values
+            .into_iter()
+            .map(|vp| Pattern::Values {
+                vars: vp.vars,
+                rows: vp.rows,
+            })
+            .collect();
+        patterns.extend(triples.into_iter().map(Pattern::Triple));
+        let op = build_where_operators(&patterns, Some(Arc::new(stats))).unwrap();
+        let plan = op.describe();
+        assert_eq!(
+            plan_ops(&plan),
+            vec![
+                "NestedLoopJoinOperator", // payload AFTER the second VALUES join
+                "ValuesOperator",
+                "NestedLoopJoinOperator",
+                "NestedLoopJoinOperator",
+                "ValuesOperator", // one seed, never a cartesian product of tables
+                "EmptyOperator",
+            ]
+        );
     }
 
     /// Regression (#51): a VALUES sharing a variable with the star must seed it.

--- a/regression-budget.json
+++ b/regression-budget.json
@@ -98,6 +98,11 @@
         "small": 5.0,
         "medium": 3.0
       },
+      "query_hot_values_star": {
+        "tiny": 10.0,
+        "small": 5.0,
+        "medium": 3.0
+      },
       "query_overlay_matrix": {
         "tiny": 10.0,
         "small": 5.0,


### PR DESCRIPTION
Two multi-row `VALUES` clauses binding the endpoints of an edge star were applied after the triple joins, scanning the predicate extent and materializing snapshot payloads before reducing the result to two edges. This change seeds one small reference table, probes its matching predicate, and joins the other `VALUES` as soon as their variables are available, before unconstrained payload columns.

The optimization requires at most 64 fully bound reference rows and a predicted reduction greater than 16× over the smallest predicate scan. It retains real `VALUES` joins to preserve duplicates, `UNDEF`, and multi-column correlations. Constant-object anchors, existing subject seeds, history, and multi-graph default unions retain their existing paths; existing fused stars keep their fusion.

Adds physical-plan and scan-fuel regression coverage on indexed and novelty data, semantic and admission tests, documentation, and a registered benchmark with singleton and broad-set controls. The regression test fails against the original planner on excessive scan fuel. On 129,000 synthetic indexed edges, the optimized in-process benchmark improved from 139 ms to 0.121 ms (approximately 1,150×), matching the `FILTER IN` workaround. Repeated optimized control runs showed no reproducible slowdown.

Validation on the `perf/wal-group-commit` base:

- `cargo fmt --all -- --check`
- `cargo test -p fluree-db-query --lib object_values_seed` — 3 passed
- `cargo test -p fluree-db-api --test it_values_object_bounds` — 10 passed
- `cargo test -p fluree-bench-support --test workspace_reconcile` — 1 passed

The benchmark is `query_hot_values_star`; its medium scale reproduces the report's approximate corpus size.


Follow-up: #1834 (repeated-object-var stars fall to the generic planner, which can fetch a functional payload before an existence check)
