### PR TITLE
perf(query): seek bound decimals in TI3 object joins

### DIFF
--- a/fluree-db-api/tests/grp_query_sparql.rs
+++ b/fluree-db-api/tests/grp_query_sparql.rs
@@ -37,6 +37,8 @@ mod it_query_sparql_setop_subselect;
 mod it_query_subquery;
 #[path = "it_query_subselect_correlation.rs"]
 mod it_query_subselect_correlation;
+#[path = "it_query_ti3.rs"]
+mod it_query_ti3;
 #[path = "it_query_unwind.rs"]
 mod it_query_unwind;
 #[path = "it_query_values.rs"]

--- a/fluree-db-api/tests/it_query_ti3.rs
+++ b/fluree-db-api/tests/it_query_ti3.rs
@@ -1,0 +1,321 @@
+//! TI3-style object joins over typed decimals. Dataset setup is outside timings.
+use crate::support::{assert_index_defaults, genesis_ledger, rebuild_and_publish_index};
+use fluree_db_api::{Fluree, FlureeBuilder};
+use serde_json::{json, Value};
+
+const LEDGER: &str = "ti3:main";
+const QUERY: &str = "SELECT * WHERE { ?y <http://example.org/p1> ?x . ?z <http://example.org/p2> ?x . ?u <http://example.org/p3> ?x } LIMIT 1000";
+
+fn decimal(n: usize) -> Value {
+    json!({"@value": format!("{n}.0"), "@type": "http://www.w3.org/2001/XMLSchema#decimal"})
+}
+
+async fn seed(fluree: &Fluree, probe: usize, noise: usize, misses: usize) {
+    let ledger = genesis_ledger(fluree, LEDGER);
+    let mut graph = Vec::new();
+    for i in 0..8 {
+        graph.push(json!({"@id":format!("ex:y{i}"), "ex:p1":decimal(230 + i % 2)}));
+    }
+    if misses > 0 {
+        graph.push(json!({"@id":"ex:missY", "ex:p1":decimal(300)}));
+    }
+    for i in 0..1_000 {
+        graph.push(
+            json!({"@id":format!("ex:z{i}"), "ex:p2":decimal(if i < 2 {230+i} else if i < misses+2 {300} else {1000+i})}),
+        );
+    }
+    for i in 0..probe {
+        graph.push(
+            // Keep p3's average fanout above p2's, matching TI3's join order.
+            json!({"@id":format!("ex:u{i}"), "ex:p3":decimal(if i < 2 {230+i} else {100000+i % (probe / 20).max(1)})}),
+        );
+    }
+    for i in 0..noise {
+        graph.push(json!({"@id":format!("ex:n{i}"), "ex:noise":decimal(i)}));
+    }
+    fluree
+        .insert(
+            ledger,
+            &json!({"@context":{"ex":"http://example.org/"}, "@graph":graph}),
+        )
+        .await
+        .unwrap();
+    rebuild_and_publish_index(fluree, LEDGER).await;
+}
+
+fn assert_join(result: &Value) {
+    let rows = result["results"]["bindings"].as_array().unwrap();
+    assert_eq!(rows.len(), 8, "{result}");
+    let mut seen = Vec::new();
+    for row in rows {
+        let y = row["y"]["value"]
+            .as_str()
+            .unwrap()
+            .strip_prefix("http://example.org/y")
+            .unwrap()
+            .parse::<usize>()
+            .unwrap();
+        assert_eq!(row["z"]["value"], format!("http://example.org/z{}", y % 2));
+        assert_eq!(row["u"]["value"], format!("http://example.org/u{}", y % 2));
+        assert_eq!(
+            row["x"]["value"].as_str().unwrap().parse::<f64>().unwrap(),
+            (230 + y % 2) as f64
+        );
+        seen.push(y);
+    }
+    seen.sort();
+    assert_eq!(seen, (0..8).collect::<Vec<_>>());
+}
+
+#[tokio::test]
+async fn ti3_decimal_join_preserves_multiplicity() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed(&fluree, 50_000, 100, 500).await;
+    let ledger = fluree.ledger(LEDGER).await.unwrap();
+    let db = crate::support::graphdb_from_ledger(&ledger);
+    let result = db
+        .query(&fluree)
+        .sparql(QUERY)
+        .track_all()
+        .execute_tracked()
+        .await
+        .unwrap();
+    assert_eq!(result.status, 200);
+    assert_join(&result.result);
+    // The first join emits 508 rows, 500 of which miss p3. Reopening a broad
+    // p3 scan for every row costs >12 fuel; point lookups stay below 3.
+    assert!(
+        result.fuel.unwrap() < 5.0,
+        "repeated predicate scans: {result:?}"
+    );
+    let from_query = QUERY.replace("WHERE", &format!("FROM <{LEDGER}> WHERE"));
+    let from_result = fluree
+        .query_from()
+        .sparql(&from_query)
+        .track_all()
+        .execute_tracked()
+        .await
+        .unwrap();
+    assert_eq!(from_result.status, 200);
+    assert_join(&from_result.result);
+    assert!(from_result.fuel.unwrap() < 5.0);
+}
+
+async fn subjects(fluree: &Fluree, sparql: &str) -> Vec<String> {
+    let ledger = fluree.ledger(LEDGER).await.unwrap();
+    let db = crate::support::graphdb_from_ledger(&ledger);
+    let result = db
+        .query(fluree)
+        .sparql(sparql)
+        .track_all()
+        .execute_tracked()
+        .await
+        .unwrap();
+    assert_eq!(result.status, 200);
+    let mut ids: Vec<_> = result.result["results"]["bindings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| {
+            row["s"]["value"]
+                .as_str()
+                .unwrap()
+                .strip_prefix("http://example.org/")
+                .unwrap()
+                .to_owned()
+        })
+        .collect();
+    ids.sort();
+    ids
+}
+
+#[tokio::test]
+async fn decimal_seeks_preserve_scales_mixed_types_and_novelty() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, LEDGER);
+    fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context":{"ex":"http://example.org/", "xsd":"http://www.w3.org/2001/XMLSchema#"},
+                "@graph":[
+                    {"@id":"ex:a", "ex:p":{"@value":"22.0", "@type":"xsd:decimal"}},
+                    {"@id":"ex:b", "ex:p":{"@value":"22.000", "@type":"xsd:decimal"}},
+                    {"@id":"ex:unrelated", "ex:other":{"@value":"999.0", "@type":"xsd:decimal"}}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+    let typed = "PREFIX ex: <http://example.org/> PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT ?s WHERE { ?s ex:p \"22.00\"^^xsd:decimal }";
+    let untyped = "PREFIX ex: <http://example.org/> PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT ?s WHERE { VALUES ?v { \"22.00\"^^xsd:decimal \"-1.0\"^^xsd:decimal } ?s ex:p ?v }";
+    let absent = typed.replace("22.00", "999.0");
+    let original_t = fluree.ledger(LEDGER).await.unwrap().t();
+    // Novelty-only and persisted variants; scale-normalized handles must not
+    // collapse distinct subject rows. A handle in another predicate is irrelevant.
+    for indexed in [false, true] {
+        if indexed {
+            rebuild_and_publish_index(&fluree, LEDGER).await;
+        }
+        assert_eq!(subjects(&fluree, typed).await, ["a", "b"]);
+        assert_eq!(subjects(&fluree, untyped).await, ["a", "b"]);
+        assert!(subjects(&fluree, &absent).await.is_empty());
+    }
+    let ledger = fluree.ledger(LEDGER).await.unwrap();
+    fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context":{"ex":"http://example.org/", "xsd":"http://www.w3.org/2001/XMLSchema#"},
+                "@graph":[
+                    {"@id":"ex:integer", "ex:p":22},
+                    {"@id":"ex:double", "ex:p":{"@value":"22.0", "@type":"xsd:double"}},
+                    {"@id":"ex:fresh", "ex:p":{"@value":"999.0", "@type":"xsd:decimal"}}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+    // The mixed observed set must veto untyped decimal narrowing immediately,
+    // before indexing. Explicit decimal constraints still match only decimals.
+    for indexed in [false, true] {
+        if indexed {
+            rebuild_and_publish_index(&fluree, LEDGER).await;
+        }
+        assert_eq!(subjects(&fluree, typed).await, ["a", "b"]);
+        assert_eq!(
+            subjects(&fluree, untyped).await,
+            ["a", "b", "double", "integer"]
+        );
+        assert_eq!(subjects(&fluree, &absent).await, ["fresh"]);
+    }
+    let ledger = fluree.ledger(LEDGER).await.unwrap();
+    fluree
+        .update(
+            ledger,
+            &json!({
+                "@context":{"ex":"http://example.org/", "xsd":"http://www.w3.org/2001/XMLSchema#"},
+                "delete":[{"@id":"ex:a", "ex:p":{"@value":"22.000", "@type":"xsd:decimal"}}]
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(subjects(&fluree, typed).await, ["b"]);
+    assert_eq!(subjects(&fluree, untyped).await, ["b", "double", "integer"]);
+    rebuild_and_publish_index(&fluree, LEDGER).await;
+    let historical = fluree.db(LEDGER).await.unwrap().as_of(original_t);
+    for query in [typed, untyped] {
+        let result = historical
+            .query(&fluree)
+            .sparql(query)
+            .track_all()
+            .execute_tracked()
+            .await
+            .unwrap();
+        assert_eq!(result.status, 200);
+        let json = result.result;
+        let mut ids: Vec<_> = json["results"]["bindings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|row| row["s"]["value"].as_str().unwrap())
+            .collect();
+        ids.sort();
+        assert_eq!(ids, ["http://example.org/a", "http://example.org/b"]);
+    }
+}
+
+#[tokio::test]
+async fn decimal_join_keeps_equal_overflow_integers() {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, LEDGER);
+    fluree.insert(ledger, &json!({
+        "@context":{"ex":"http://example.org/", "xsd":"http://www.w3.org/2001/XMLSchema#"},
+        "@graph":[
+            {"@id":"ex:decimal", "ex:p":{"@value":"100000000000000000000.0", "@type":"xsd:decimal"}},
+            {"@id":"ex:integer", "ex:p":{"@value":"100000000000000000000", "@type":"xsd:integer"}}
+        ]
+    })).await.unwrap();
+    let query = "PREFIX ex: <http://example.org/> PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT ?s WHERE { VALUES ?v { \"100000000000000000000.00\"^^xsd:decimal \"-1.0\"^^xsd:decimal } ?s ex:p ?v }";
+    for indexed in [false, true] {
+        if indexed {
+            rebuild_and_publish_index(&fluree, LEDGER).await;
+        }
+        assert_eq!(subjects(&fluree, query).await, ["decimal", "integer"]);
+    }
+}
+
+/// TI3_PROBE and TI3_NOISE control predicate sizes. FLUREE_HASH_JOIN is the
+/// existing diagnostic override; leave unset for the planner's own decision.
+#[tokio::test]
+#[ignore = "local TI3 scaling probe"]
+async fn ti3_local_scaling() {
+    assert_index_defaults();
+    let read = |name, default| {
+        std::env::var(name)
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(default)
+    };
+    let probe = read("TI3_PROBE", 50_000);
+    let noise = read("TI3_NOISE", 100_000);
+    let misses = read("TI3_MISSES", 0);
+    assert!(probe >= 2 && misses <= 998);
+    let fluree = FlureeBuilder::memory().build_memory();
+    seed(&fluree, probe, noise, misses).await;
+    let ledger = fluree.ledger(LEDGER).await.unwrap();
+    let db = crate::support::graphdb_from_ledger(&ledger);
+    let mut times = Vec::new();
+    let mut fuel = None;
+    let shape = std::env::var("TI3_SHAPE").unwrap_or_default();
+    let sparql = match shape.as_str() {
+        "anchor" => "SELECT * WHERE { ?y <http://example.org/p1> ?x } LIMIT 1000",
+        "first_join" => "SELECT * WHERE { ?y <http://example.org/p1> ?x . ?z <http://example.org/p2> ?x } LIMIT 1000",
+        "point" => "SELECT * WHERE { ?s <http://example.org/p3> \"230.0\"^^<http://www.w3.org/2001/XMLSchema#decimal> } LIMIT 1000",
+        _ => QUERY,
+    };
+    if std::env::var_os("TI3_TRACE").is_some() {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("fluree_db_query=trace")
+            .try_init();
+    }
+    for iteration in 0..6 {
+        let start = std::time::Instant::now();
+        let result = db
+            .query(&fluree)
+            .sparql(sparql)
+            .track_all()
+            .execute_tracked()
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+        assert_eq!(result.status, 200);
+        if sparql == QUERY {
+            assert_join(&result.result);
+        } else {
+            assert_eq!(
+                result.result["results"]["bindings"]
+                    .as_array()
+                    .unwrap()
+                    .len(),
+                match shape.as_str() {
+                    "point" => 1,
+                    "anchor" => 8 + usize::from(misses > 0),
+                    _ => 8 + misses,
+                }
+            );
+        }
+        if iteration > 0 {
+            times.push(elapsed);
+        }
+        fuel = result.fuel;
+    }
+    times.sort();
+    eprintln!(
+        "TI3 probe={probe} noise={noise} misses={misses} shape={shape}: median={:?}, fuel={fuel:?}",
+        times[2]
+    );
+}

--- a/fluree-db-binary-index/src/arena/numbig.rs
+++ b/fluree-db-binary-index/src/arena/numbig.rs
@@ -125,6 +125,8 @@ pub struct NumBigArena {
     dedup: HashMap<NumBigRepr, u32>,
     /// Forward: handle -> stored value.
     values: Vec<StoredBigValue>,
+    /// Monotone summary; NumBig also stores overflow integers.
+    contains_bigint: bool,
     /// True when every stored decimal already has its normalized repr.
     /// Legacy arenas may contain a non-normalized value even without duplicates.
     values_normalized: bool,
@@ -142,6 +144,7 @@ impl NumBigArena {
         Self {
             dedup: HashMap::new(),
             values: Vec::new(),
+            contains_bigint: false,
             values_normalized: true,
             dup_handles: HashMap::new(),
         }
@@ -156,6 +159,7 @@ impl NumBigArena {
         }
         let handle = self.values.len() as u32;
         self.values.push(StoredBigValue::BigInt(bytes));
+        self.contains_bigint = true;
         self.dedup.insert(repr, handle);
         handle
     }
@@ -190,6 +194,7 @@ impl NumBigArena {
     /// tracked as duplicates so value lookups can report every handle.
     fn push_stored(&mut self, value: StoredBigValue, reprs: impl IntoIterator<Item = NumBigRepr>) {
         let handle = self.values.len() as u32;
+        self.contains_bigint |= matches!(value, StoredBigValue::BigInt(_));
         self.values.push(value);
         for repr in reprs {
             match self.dedup.entry(repr) {
@@ -211,6 +216,12 @@ impl NumBigArena {
     /// Look up a stored value by handle.
     pub fn get_by_handle(&self, handle: u32) -> Option<&StoredBigValue> {
         self.values.get(handle as usize)
+    }
+
+    /// Whether this nonempty arena contains exclusively decimal values.
+    /// Includes obsolete handles, so retractions cannot make this proof weaker.
+    pub fn is_decimal_only(&self) -> bool {
+        !self.values.is_empty() && !self.contains_bigint
     }
 
     /// Find a BigInt's handle without inserting (read-only lookup for query path).
@@ -576,6 +587,23 @@ mod tests {
             arena.find_bigdec_handles(&"19.99".parse::<BigDecimal>().unwrap()),
             vec![2]
         );
+    }
+
+    #[test]
+    fn decimal_only_summary_survives_reload_and_integer_insertion() {
+        let mut arena = NumBigArena::new();
+        assert!(!arena.is_decimal_only());
+        arena.get_or_insert_bigdec(&"22.00".parse().unwrap());
+        assert!(arena.is_decimal_only());
+        let mut loaded =
+            read_numbig_arena_from_bytes(&write_numbig_arena_to_bytes(&arena).unwrap()).unwrap();
+        assert!(loaded.is_decimal_only());
+        loaded.get_or_insert_bigint(&BigInt::from(22));
+        loaded.get_or_insert_bigdec(&"23.0".parse().unwrap());
+        assert!(!loaded.is_decimal_only());
+        let reloaded =
+            read_numbig_arena_from_bytes(&write_numbig_arena_to_bytes(&loaded).unwrap()).unwrap();
+        assert!(!reloaded.is_decimal_only());
     }
 
     #[test]

--- a/fluree-db-binary-index/src/read/binary_index_store.rs
+++ b/fluree-db-binary-index/src/read/binary_index_store.rs
@@ -2086,6 +2086,35 @@ impl BinaryIndexStore {
         }
     }
 
+    /// All stored decimal representations of a value under one graph/predicate.
+    /// `None` means no arena is available; an empty vector is a conclusive miss
+    /// in an available arena. Includes legacy scale-variant aliases. This does
+    /// not look up numerically equal integers or floats: callers narrowing a
+    /// scan must independently establish that only decimal rows can match.
+    pub fn find_decimal_handles(
+        &self,
+        g_id: GraphId,
+        p_id: u32,
+        value: &bigdecimal::BigDecimal,
+    ) -> Option<Vec<u32>> {
+        Some(
+            self.graph_indexes
+                .get(&g_id)?
+                .numbig
+                .get(&p_id)?
+                .find_bigdec_handles(value),
+        )
+    }
+
+    /// Whether the predicate's NumBig arena contains only decimals. This says
+    /// nothing about rows stored outside that arena (e.g. inline integers).
+    pub fn numbig_is_decimal_only(&self, g_id: GraphId, p_id: u32) -> bool {
+        self.graph_indexes
+            .get(&g_id)
+            .and_then(|graph| graph.numbig.get(&p_id))
+            .is_some_and(crate::arena::numbig::NumBigArena::is_decimal_only)
+    }
+
     pub fn find_subject_id_by_parts(&self, ns_code: u16, suffix: &str) -> io::Result<Option<u64>> {
         match &self.dicts.subject_reverse_tree {
             Some(tree) => {

--- a/fluree-db-query/src/binary_scan.rs
+++ b/fluree-db-query/src/binary_scan.rs
@@ -690,9 +690,11 @@ impl BinaryScanOperator {
         if object_bounds.is_some() && index == IndexType::Psot {
             index = IndexType::Post;
         }
-        // Generic optimization: if the object is a constant (and can be safely encoded),
-        // prefer the object-leading OPST index when the subject is unbound. This avoids
-        // pathological scans like PSOT(p, *, o_const) that can't narrow by o_key.
+        // A fixed predicate + object already selects POST above. Keep that
+        // predicate-leading range, including when the object cannot be encoded
+        // (e.g. a decimal without a unique arena handle). Overriding it with
+        // OPST would lose the only usable leading bound and walk unrelated
+        // predicates. OPST is useful when only the object is bound.
         //
         // IMPORTANT: plain strings without a datatype constraint are ambiguous (xsd:string
         // vs rdf:langString). In that case we don't force OPST because we may be unable to
@@ -700,6 +702,7 @@ impl BinaryScanOperator {
         if index_hint.is_none()
             && object_bounds.is_none()
             && !s_bound
+            && !p_bound
             && o_bound
             && (pattern.dtc.is_some() || !matches!(&pattern.o, Term::Value(FlakeValue::String(_))))
         {
@@ -2106,7 +2109,7 @@ impl Operator for BinaryScanOperator {
                 // Scan-time datatype narrowing only — never semantic elision.
                 false,
             );
-            let inferred_dt_sid = if dt_sid.is_none() && lang.is_none() {
+            let mut inferred_dt_sid = if dt_sid.is_none() && lang.is_none() {
                 filter.p_id.and_then(|p_id| {
                     infer_exact_datatype_sid_from_stats(
                         stats_view.as_deref(),
@@ -2118,6 +2121,28 @@ impl Operator for BinaryScanOperator {
             } else {
                 None
             };
+
+            // Indexed NumBig statistics deliberately use UNKNOWN: arena handles
+            // can hold either decimals or overflow integers. Prove both the row
+            // encoding and arena contents instead of interpreting UNKNOWN as a
+            // datatype. Limit this additional proof to current, indexed reads;
+            // novelty and historical reads retain the general numeric matcher.
+            if dt_sid.is_none()
+                && inferred_dt_sid.is_none()
+                && lang.is_none()
+                && matches!(bound_o, FlakeValue::Decimal(_))
+                && !self.pattern.s_bound()
+                && !self.mode.is_history()
+                && ctx.to_t >= store_ref.max_t()
+                && !crate::fast_path_common::overlay_has_novelty(ctx)
+                && std::env::var_os("FLUREE_DISABLE_DECIMAL_SEEKS").is_none()
+            {
+                if let Some(p_id) = filter.p_id {
+                    if predicate_is_decimal_only(store_ref, self.g_id, p_id)? {
+                        inferred_dt_sid = Some(Sid::new(namespaces::XSD, xsd_names::DECIMAL));
+                    }
+                }
+            }
 
             // An untyped string that stats couldn't pin to a single datatype:
             // the predicate has langString and/or multiple string-compatible
@@ -2168,7 +2193,41 @@ impl Operator for BinaryScanOperator {
             } else {
                 let encoded = match (dt_sid.or(inferred_dt_sid.as_ref()), lang) {
                     (Some(dt_sid), lang) => {
-                        value_to_otype_okey(bound_o, dt_sid, lang, store_ref, dict_novelty, None)
+                        // Decimal arena handles are local to (graph, predicate).
+                        // Only an explicit decimal constraint or the singleton
+                        // datatype/encoding proof above licenses a point lookup:
+                        // an untyped mixed numeric predicate can also match an
+                        // integer/double representation of the same value.
+                        // Distinguish an absent value from ambiguous legacy
+                        // scale aliases. Only a conclusive miss may skip base
+                        // rows; novelty still goes through the decoded fallback.
+                        if let FlakeValue::Decimal(value) = bound_o {
+                            if *dt_sid == Sid::new(namespaces::XSD, xsd_names::DECIMAL)
+                                && !self.mode.is_history()
+                                && ctx.to_t >= store_ref.max_t()
+                                && std::env::var_os("FLUREE_DISABLE_DECIMAL_SEEKS").is_none()
+                            {
+                                decimal_object_key(store_ref, self.g_id, filter.p_id, value)
+                            } else {
+                                value_to_otype_okey(
+                                    bound_o,
+                                    dt_sid,
+                                    lang,
+                                    store_ref,
+                                    dict_novelty,
+                                    None,
+                                )
+                            }
+                        } else {
+                            value_to_otype_okey(
+                                bound_o,
+                                dt_sid,
+                                lang,
+                                store_ref,
+                                dict_novelty,
+                                None,
+                            )
+                        }
                     }
                     // Refs and untyped strings are handled above; this is reached
                     // for untyped non-string values (numeric/bool/date/…).
@@ -3837,6 +3896,62 @@ pub(crate) fn encode_bound_object_prefilter(
     }
 }
 
+/// A base-only proof. A mixed/unknown leaflet declines, even if the arena itself
+/// contains only decimals: numerically equal inline values must not be missed.
+fn predicate_is_decimal_only(store: &BinaryIndexStore, g_id: GraphId, p_id: u32) -> Result<bool> {
+    use fluree_db_binary_index::format::run_record::RunSortOrder;
+    if !store.numbig_is_decimal_only(g_id, p_id)
+        || store.branch_for_order(g_id, RunSortOrder::Post).is_none()
+    {
+        return Ok(false);
+    }
+    let decimal_type = OType::NUM_BIG_OVERFLOW.as_u16();
+    for leaf in
+        crate::fast_path_common::leaf_entries_for_predicate(store, g_id, RunSortOrder::Post, p_id)
+    {
+        // POST sorts by predicate, then object type. Interior leaf extrema
+        // prove uniformity without opening directories. Only the (at most two)
+        // boundary leaves can require directory reads, even for huge predicates.
+        if leaf.first_key.p_id == p_id && leaf.last_key.p_id == p_id {
+            if leaf.first_key.o_type != decimal_type || leaf.last_key.o_type != decimal_type {
+                return Ok(false);
+            }
+            continue;
+        }
+        let dir = store
+            .open_leaf_dir(&leaf.leaf_cid)
+            .map_err(|e| QueryError::Internal(format!("leaf dir open: {e}")))?;
+        for entry in &dir.entries {
+            if entry.row_count == 0 || entry.p_const.is_some_and(|p| p != p_id) {
+                continue;
+            }
+            if entry.p_const != Some(p_id) || entry.o_type_const != Some(decimal_type) {
+                return Ok(false);
+            }
+        }
+    }
+    Ok(true)
+}
+
+fn decimal_object_key(
+    store: &BinaryIndexStore,
+    g_id: GraphId,
+    p_id: Option<u32>,
+    value: &bigdecimal::BigDecimal,
+) -> std::io::Result<(OType, u64)> {
+    match p_id.and_then(|p| store.find_decimal_handles(g_id, p, value)) {
+        Some(handles) if handles.is_empty() => Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "decimal absent from predicate arena",
+        )),
+        Some(handles) if handles.len() == 1 => Ok((OType::NUM_BIG_OVERFLOW, u64::from(handles[0]))),
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "decimal arena unavailable or has multiple equal-value handles",
+        )),
+    }
+}
+
 fn infer_exact_datatype_sid_from_stats(
     stats_view: Option<&fluree_db_core::StatsView>,
     g_id: GraphId,
@@ -3899,6 +4014,9 @@ fn datatype_sid_for_untyped_value(
     tag: fluree_db_core::ValueTypeTag,
 ) -> Option<Sid> {
     match value {
+        FlakeValue::Decimal(_) if tag == fluree_db_core::ValueTypeTag::DECIMAL => {
+            Some(Sid::new(namespaces::XSD, xsd_names::DECIMAL))
+        }
         FlakeValue::Long(_) => match tag {
             fluree_db_core::ValueTypeTag::INTEGER => {
                 Some(Sid::new(namespaces::XSD, xsd_names::INTEGER))
@@ -4582,6 +4700,71 @@ mod tests {
         .expect("datatype");
         assert_eq!(inferred.namespace_code, namespaces::XSD);
         assert_eq!(inferred.name, xsd_names::INT.into());
+    }
+
+    #[test]
+    fn decimal_seek_inference_requires_a_single_observed_type() {
+        let value = FlakeValue::Decimal(Box::new("230.00".parse().unwrap()));
+        for observed in [
+            vec![ValueTypeTag::DECIMAL],
+            vec![ValueTypeTag::DECIMAL, ValueTypeTag::INTEGER],
+            vec![ValueTypeTag::DECIMAL, ValueTypeTag::DOUBLE],
+            vec![ValueTypeTag::DECIMAL, ValueTypeTag::UNKNOWN],
+            vec![],
+        ] {
+            let singleton = observed == [ValueTypeTag::DECIMAL];
+            // Counts alone can look uniform after no-op retractions.
+            let stats = stats_with(vec![(ValueTypeTag::DECIMAL, 10)], observed);
+            assert_eq!(
+                infer_exact_datatype_sid_from_stats(
+                    Some(&stats),
+                    0,
+                    RuntimePredicateId::from_u32(7),
+                    &value
+                ),
+                singleton.then(|| Sid::new(namespaces::XSD, xsd_names::DECIMAL)),
+            );
+        }
+    }
+
+    #[test]
+    fn bound_predicate_retains_a_leading_index_bound() {
+        for object in [
+            Term::Value(FlakeValue::Decimal(Box::new("230.00".parse().unwrap()))),
+            Term::Value(FlakeValue::Long(230)),
+            Term::Value(FlakeValue::String("value".into())),
+            Term::Sid(Sid::new(100, "target")),
+        ] {
+            let pattern =
+                TriplePattern::new(Ref::Var(VarId(0)), Ref::Sid(Sid::new(100, "p")), object);
+            assert_eq!(
+                BinaryScanOperator::new(pattern.clone(), None, vec![]).index,
+                IndexType::Post
+            );
+            let explicit = BinaryScanOperator::new_with_emit_and_index(
+                pattern.clone(),
+                None,
+                vec![],
+                EmitMask::ALL,
+                Some(IndexType::Opst),
+            );
+            assert_eq!(explicit.index, IndexType::Opst);
+            let mut subject_bound = pattern;
+            subject_bound.s = Ref::Sid(Sid::new(100, "s"));
+            assert_eq!(
+                BinaryScanOperator::new(subject_bound, None, vec![]).index,
+                IndexType::Spot
+            );
+        }
+        let variable_predicate = TriplePattern::new(
+            Ref::Var(VarId(0)),
+            Ref::Var(VarId(1)),
+            Term::Sid(Sid::new(100, "target")),
+        );
+        assert_eq!(
+            BinaryScanOperator::new(variable_predicate, None, vec![]).index,
+            IndexType::Opst
+        );
     }
 
     #[test]


### PR DESCRIPTION
TI3-style joins bind a decimal object while leaving the subject unbound. The scan could override its predicate-leading POST index with OPST, then fail to encode the decimal arena handle and scan broadly for every incoming binding. Keep the predicate bound and resolve eligible decimal bindings to point lookups in the graph/predicate numeric arena; a proven absent value skips persisted rows and checks novelty.

Stacked on #1825, targeting `fix/bi-q4-projected-ratio` so the diff contains only the TI3 work and the branch retains the Q4 improvement for combined testing.

The untyped arena proof requires current indexed data without novelty and verifies both the stored object types and decimal-only arena contents. It uses branch extrema and at most two boundary-directory reads. Mixed numeric representations, historical reads, and ambiguous legacy scale aliases retain the general matcher. Explicit decimal constraints can still check novelty. Subject-bound lookups avoid the extra metadata proof. The existing join plan and cost thresholds are preserved.

Local synthetic measurements (optimized `dev-fast` build, warmup plus five measured executions; eight result rows preserved):

| Final predicate rows | Rejected intermediate bindings | Decimal seeks disabled | Decimal seeks enabled |
| --- | --- | --- | --- |
| 50,000 | 0 | 32.83 ms | 0.46 ms |
| 50,000 | 500 | 2.13 s | 1.49 ms |
| 2,073,472 | 500 | Not measured | 1.60 ms |

The disabled/enabled comparison isolates decimal seeks: both sides already retain the predicate-leading scan bound. These fixtures do not establish that the original full Wikidata timeout is resolved; a matched run on the retained database remains necessary. The ignored `it_query_ti3::ti3_local_scaling` test reproduces the measurements with `TI3_PROBE`, `TI3_NOISE`, `TI3_MISSES`, and `FLUREE_DISABLE_DECIMAL_SEEKS`.

Validation: 2,981 passing tests across query/binary-index unit suites and API query, SPARQL, history, reasoning, numeric identity, VALUES, and scan-narrowing suites; final focused tests and the larger scaling probe also passed. Regression coverage checks multiplicity, graph/dataset execution, scale normalization, mixed integer/double/overflow-integer values, novelty, retractions, historical reads, arena reloads, and a fuel bound against repeated predicate scans. Clippy for the three affected libraries with `-D warnings`, formatting, and whitespace checks passed.

Partially addresses #1328: decimal scan lookups are covered; overflow-integer and other batched prefilter callers remain outside this change.

Follow-up: #1321 — preserve precise NumBig datatype statistics, with indexing-throughput and memory benchmarks. That product change is separate from this PR.
