### PR TITLE
fix(query): match unbound keys in materialized subquery joins

### DIFF
--- a/fluree-db-api/tests/grp_query_sparql.rs
+++ b/fluree-db-api/tests/grp_query_sparql.rs
@@ -35,6 +35,8 @@ mod it_query_sparql_path_literal_object;
 mod it_query_sparql_setop_subselect;
 #[path = "it_query_subquery.rs"]
 mod it_query_subquery;
+#[path = "it_query_subquery_unbound.rs"]
+mod it_query_subquery_unbound;
 #[path = "it_query_subselect_correlation.rs"]
 mod it_query_subselect_correlation;
 #[path = "it_query_ti3.rs"]

--- a/fluree-db-api/tests/it_query_subquery_unbound.rs
+++ b/fluree-db-api/tests/it_query_subquery_unbound.rs
@@ -1,0 +1,197 @@
+//! Materialized subqueries must join compatible mappings, including unbound
+//! outer keys, without discarding duplicate solutions or changing inner slices.
+use crate::support::{assert_index_defaults, genesis_ledger, rebuild_and_publish_index};
+use fluree_db_api::{Fluree, FlureeBuilder};
+use serde_json::{json, Value};
+
+const LEDGER: &str = "subquery-unbound:main";
+
+async fn seed() -> Fluree {
+    assert_index_defaults();
+    let fluree = FlureeBuilder::memory().build_memory();
+    let ledger = genesis_ledger(&fluree, LEDGER);
+    fluree
+        .insert(
+            ledger,
+            &json!({
+                "@context":{"ex":"http://example.org/"},
+                "@graph":[
+                    {"@id":"ex:a", "ex:price":10},
+                    {"@id":"ex:b", "ex:price":20},
+                    {"@id":"ex:left", "ex:selected":{"@id":"ex:a"}}
+                ]
+            }),
+        )
+        .await
+        .unwrap();
+    fluree
+}
+
+async fn check(fluree: &Fluree, query: &str, expected: Value) {
+    // These fixtures use simple SELECT-variable lists. Compare in that order;
+    // the SPARQL JSON renderer may order head.vars differently.
+    let vars: Vec<_> = query
+        .split_once("WHERE")
+        .unwrap()
+        .0
+        .split_whitespace()
+        .skip(1)
+        .map(|var| var.strip_prefix('?').unwrap())
+        .collect();
+    let query = format!("PREFIX ex: <http://example.org/> {query}").replacen(
+        "WHERE",
+        &format!("FROM <{LEDGER}> WHERE"),
+        1,
+    );
+    let response = fluree
+        .query_from()
+        .sparql(&query)
+        .track_all()
+        .execute_tracked()
+        .await
+        .unwrap();
+    assert_eq!(response.status, 200, "{response:?}");
+    let result = response.result;
+    let mut rows: Vec<Vec<String>> = result["results"]["bindings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| {
+            vars.iter()
+                .map(|var| {
+                    let value = row[*var]["value"].as_str().unwrap_or("UNDEF");
+                    value
+                        .strip_prefix("http://example.org/")
+                        .unwrap_or(value)
+                        .to_owned()
+                })
+                .collect()
+        })
+        .collect();
+    rows.sort();
+    assert_eq!(json!(rows), expected, "{query}");
+}
+
+#[tokio::test]
+async fn grouped_subquery_preserves_unbound_keys_and_duplicates() {
+    let fluree = seed().await;
+    for indexed in [false, true] {
+        if indexed {
+            rebuild_and_publish_index(&fluree, LEDGER).await;
+        }
+        check(
+            &fluree,
+            "SELECT ?p ?n WHERE {
+            VALUES ?p { UNDEF ex:a }
+            { SELECT ?p (SUM(?price) AS ?n) WHERE { ?p ex:price ?price } GROUP BY ?p }
+        }",
+            json!([["a", "10"], ["a", "10"], ["b", "20"]]),
+        )
+        .await;
+        check(
+            &fluree,
+            "SELECT ?p ?n WHERE {
+            VALUES ?p { UNDEF UNDEF }
+            { SELECT ?p (SUM(?price) AS ?n) WHERE { ?p ex:price ?price } GROUP BY ?p }
+        }",
+            json!([["a", "10"], ["a", "10"], ["b", "20"], ["b", "20"]]),
+        )
+        .await;
+        check(
+            &fluree,
+            "SELECT ?p ?n WHERE {
+            VALUES ?p { ex:a ex:a ex:missing }
+            { SELECT ?p (SUM(?price) AS ?n) WHERE { ?p ex:price ?price } GROUP BY ?p }
+        }",
+            json!([["a", "10"], ["a", "10"]]),
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn grouped_subquery_restricts_partially_bound_composite_keys() {
+    let fluree = seed().await;
+    for indexed in [false, true] {
+        if indexed {
+            rebuild_and_publish_index(&fluree, LEDGER).await;
+        }
+        check(&fluree, "SELECT ?p ?price ?n WHERE {
+            VALUES (?p ?price) { (UNDEF 10) (ex:a UNDEF) (UNDEF UNDEF) (ex:missing UNDEF) (ex:a 20) }
+            { SELECT ?p ?price (COUNT(*) AS ?n) WHERE { ?p ex:price ?price } GROUP BY ?p ?price }
+        }", json!([["a","10","1"],["a","10","1"],["a","10","1"],["b","20","1"]])).await;
+        // The aggregate output is reconciled after the key lookup. Expanding
+        // an unbound product must still reject a conflicting bound total.
+        check(
+            &fluree,
+            "SELECT ?p ?n WHERE {
+            VALUES (?p ?n) { (UNDEF 10) (ex:a 20) (UNDEF UNDEF) }
+            { SELECT ?p (SUM(?price) AS ?n) WHERE { ?p ex:price ?price } GROUP BY ?p }
+        }",
+            json!([["a", "10"], ["a", "10"], ["b", "20"]]),
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn grouped_subquery_distinguishes_union_unbound_from_optional_poisoned() {
+    let fluree = seed().await;
+    for indexed in [false, true] {
+        if indexed {
+            rebuild_and_publish_index(&fluree, LEDGER).await;
+        }
+        for (outer, expected) in [
+            // Preserve the engine's existing Poisoned contract for failed
+            // OPTIONAL bindings: they must not fan out like an actual UNDEF.
+            (
+                "VALUES ?row { ex:left ex:right } OPTIONAL { ?row ex:selected ?p }",
+                json!([["left", "a", "10"]]),
+            ),
+            (
+                "{ VALUES (?row ?p) { (ex:left ex:a) } } UNION { VALUES ?row { ex:right } }",
+                json!([
+                    ["left", "a", "10"],
+                    ["right", "a", "10"],
+                    ["right", "b", "20"]
+                ]),
+            ),
+        ] {
+            // Materialize the outer solutions independently so this test does
+            // not depend on placement of a bare OPTIONAL relative to the join.
+            check(
+                &fluree,
+                &format!(
+                    "SELECT ?row ?p ?n WHERE {{ {{ SELECT ?row ?p WHERE {{ {outer} }} LIMIT 10 }}
+                {{ SELECT ?p (SUM(?price) AS ?n) WHERE {{ ?p ex:price ?price }} GROUP BY ?p }}
+            }}"
+                ),
+                expected,
+            )
+            .await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn unbound_keys_preserve_inner_slice_and_empty_results() {
+    let fluree = seed().await;
+    for indexed in [false, true] {
+        if indexed {
+            rebuild_and_publish_index(&fluree, LEDGER).await;
+        }
+        check(
+            &fluree,
+            "SELECT ?p WHERE {
+            VALUES ?p { UNDEF ex:a ex:b }
+            { SELECT DISTINCT ?p WHERE { ?p ex:price ?price } ORDER BY ?p LIMIT 1 OFFSET 1 }
+        }",
+            json!([["b"], ["b"]]),
+        )
+        .await;
+        check(&fluree, "SELECT ?p ?n WHERE {
+            VALUES ?p { UNDEF ex:a }
+            { SELECT ?p (COUNT(*) AS ?n) WHERE { ?p ex:price ?price FILTER(?price > 100) } GROUP BY ?p }
+        }", json!([])).await;
+    }
+}

--- a/fluree-db-api/tests/it_query_ti3.rs
+++ b/fluree-db-api/tests/it_query_ti3.rs
@@ -27,7 +27,7 @@ async fn seed(fluree: &Fluree, probe: usize, noise: usize, misses: usize) {
     for i in 0..probe {
         graph.push(
             // Keep p3's average fanout above p2's, matching TI3's join order.
-            json!({"@id":format!("ex:u{i}"), "ex:p3":decimal(if i < 2 {230+i} else {100000+i % (probe / 20).max(1)})}),
+            json!({"@id":format!("ex:u{i}"), "ex:p3":decimal(if i < 2 {230+i} else {100_000+i % (probe / 20).max(1)})}),
         );
     }
     for i in 0..noise {

--- a/fluree-db-query/src/subquery.rs
+++ b/fluree-db-query/src/subquery.rs
@@ -87,11 +87,11 @@ pub struct SubqueryOperator {
     /// reconcile against the parent `?X`. See the merge in `process_parent_batch`.
     reconcile_vars: Vec<VarId>,
     /// Whether the subquery is evaluated ONCE and hash-joined (on `join_keys`)
-    /// rather than re-executed per parent row. Requires no inner `LIMIT`/`OFFSET`
-    /// and that every non-key correlation variable is an unreferenced
-    /// pass-through. Gated by a parent-cardinality check so we only materialize
-    /// when it beats per-row seeding; an uncorrelated subquery always
-    /// materializes. Mirrors `SemijoinOperator`'s hash probe.
+    /// rather than re-executed per parent row. Independent SPARQL subqueries
+    /// with grouping, DISTINCT, or slicing require this mode for correctness.
+    /// Otherwise eligibility and parent cardinality decide whether evaluating
+    /// once beats per-row seeding. Bound outer keys use an exact hash probe;
+    /// unbound outer keys match all compatible materialized rows.
     join_mode: bool,
     /// Lazily materialized subquery result (built once when `join_mode`): all
     /// result rows plus a hash index from the correlation-variable values to the
@@ -445,12 +445,20 @@ impl SubqueryOperator {
                     self.materialized = Some(m);
                 }
                 let mat = self.materialized.as_ref().unwrap();
+                // Track actual Unbound bindings before key normalization:
+                // Poisoned also normalizes to Absent, but must not become a
+                // wildcard. Fully bound rows allocate no extra mask storage.
+                let mut unbound_columns = Vec::new();
                 let parent_key: Vec<GroupKeyOwned> = self
                     .join_keys
                     .iter()
-                    .map(|v| {
-                        parent_batch
-                            .get(row_idx, *v)
+                    .enumerate()
+                    .map(|(col, v)| {
+                        let binding = parent_batch.get(row_idx, *v);
+                        if binding.is_none_or(|b| matches!(b, Binding::Unbound)) {
+                            unbound_columns.push(col);
+                        }
+                        binding
                             .map(|b| {
                                 let (store, gv) = EqualityNorm::parts(&self.norm);
                                 binding_to_group_key_normalized(b, store, gv)
@@ -458,9 +466,31 @@ impl SubqueryOperator {
                             .unwrap_or(GroupKeyOwned::Absent)
                     })
                     .collect();
-                match mat.index.get(&parent_key) {
-                    Some(idxs) => idxs.iter().map(|&i| mat.rows[i].clone()).collect(),
-                    None => Vec::new(),
+                if unbound_columns.is_empty() {
+                    match mat.index.get(&parent_key) {
+                        Some(idxs) => idxs.iter().map(|&i| mat.rows[i].clone()).collect(),
+                        None => Vec::new(),
+                    }
+                } else if unbound_columns.len() == parent_key.len() {
+                    // No restrictions: preserve every inner solution, including
+                    // duplicate keys, and let the existing merge bind the parent.
+                    mat.rows.clone()
+                } else {
+                    let mut matches = Vec::new();
+                    for (bucket, (key, idxs)) in mat.index.iter().enumerate() {
+                        if bucket % 1024 == 0 {
+                            ctx.check_cancelled()?;
+                        }
+                        if parent_key
+                            .iter()
+                            .zip(key)
+                            .enumerate()
+                            .all(|(col, (p, s))| p == s || unbound_columns.contains(&col))
+                        {
+                            matches.extend(idxs.iter().map(|&i| mat.rows[i].clone()));
+                        }
+                    }
+                    matches
                 }
             } else {
                 self.execute_subquery_for_row(ctx, parent_batch, row_idx)
@@ -816,6 +846,83 @@ mod tests {
     use crate::ir::SubqueryPattern;
     use crate::seed::SeedOperator;
     use crate::var_registry::VarId;
+
+    #[tokio::test]
+    async fn materialized_join_matches_partial_keys_without_reviving_poisoned_rows() {
+        use crate::group_aggregate::binding_to_group_key_owned;
+        use crate::ir::FlakeValue;
+        use crate::var_registry::VarRegistry;
+        use fluree_db_core::{LedgerSnapshot, Sid};
+
+        let snapshot = LedgerSnapshot::genesis("test/main");
+        let vars = VarRegistry::new();
+        let ctx = ExecutionContext::new(&snapshot, &vars);
+        let lit = |n| Binding::lit(FlakeValue::Long(n), Sid::xsd_integer());
+        let keys: Arc<[VarId]> = Arc::from(vec![VarId(0), VarId(1)]);
+        let rows = vec![
+            vec![lit(1), lit(10), lit(100)],
+            vec![lit(1), lit(10), lit(101)],
+            vec![lit(2), lit(20), lit(200)],
+        ];
+        let mut index: HashMap<Vec<GroupKeyOwned>, Vec<usize>> = HashMap::new();
+        for (i, row) in rows.iter().enumerate() {
+            index
+                .entry(row[..2].iter().map(binding_to_group_key_owned).collect())
+                .or_default()
+                .push(i);
+        }
+        let child = SeedOperator::from_row(keys.clone(), vec![Binding::Unbound; 2]);
+        let mut op = SubqueryOperator::new(
+            Box::new(child),
+            SubqueryPattern::new(vec![VarId(0), VarId(1), VarId(2)], vec![]),
+            None,
+            PlanningContext::current(),
+        );
+        // Pin the executor path: planner reordering must not hide this case.
+        op.join_mode = true;
+        op.join_keys = keys.to_vec();
+        op.reconcile_vars.clear();
+        op.materialized = Some(MaterializedSubquery {
+            rows: rows.clone(),
+            index,
+        });
+        let parent = Batch::new(
+            keys.clone(),
+            vec![
+                vec![
+                    Binding::Poisoned,
+                    Binding::Unbound,
+                    Binding::Unbound,
+                    lit(1),
+                    lit(1),
+                    Binding::Unbound,
+                ],
+                vec![
+                    Binding::Unbound,
+                    Binding::Poisoned,
+                    lit(10),
+                    Binding::Unbound,
+                    lit(20),
+                    Binding::Unbound,
+                ],
+            ],
+        )
+        .unwrap();
+        op.process_parent_batch(&ctx, &parent).await.unwrap();
+        assert_eq!(op.result_buffer.len(), 7);
+        for (row, copies) in rows.iter().zip([3, 3, 1]) {
+            assert_eq!(
+                op.result_buffer.iter().filter(|r| *r == row).count(),
+                copies
+            );
+        }
+
+        // Reuse the same materialization for a subsequent fully bound batch;
+        // both inner rows sharing its key must survive the exact lookup.
+        let parent = Batch::new(keys, vec![vec![lit(1)], vec![lit(10)]]).unwrap();
+        op.process_parent_batch(&ctx, &parent).await.unwrap();
+        assert_eq!(&op.result_buffer[7..], &rows[..2]);
+    }
 
     /// Verifies that correlation uses SELECT vars, not internal pattern vars.
     ///


### PR DESCRIPTION
Materialized subqueries treated an unbound outer join key as an exact hash key, silently losing compatible rows. For a grouped subquery over products A and B, `VALUES ?p { UNDEF ex:a }` returned only the explicit A match instead of A, A, B. A DISTINCT subquery with LIMIT/OFFSET similarly lost the match from the UNDEF row.

Match actual unbound key positions as wildcards. Fully bound parents retain exact hash lookups; wholly unbound keys broadcast the materialized rows; partially bound keys scan compatible existing buckets. Preserve duplicate inner and outer solutions, reconciliation of non-key variables, and the independent subquery's slice. Track raw Unbound bindings before normalization so Poisoned bindings, which also normalize to Absent, keep their existing blocking behavior.

Stacked on #1826, targeting `perf/ti3-bound-literal-seeks` so the diff contains this correctness fix while retaining the earlier performance improvements for combined testing.

Regression coverage includes indexed and novelty data, composite keys, duplicate rows, empty results, aggregate-output reconciliation, UNION missing columns, existing poisoned OPTIONAL behavior, DISTINCT/LIMIT/OFFSET, and reuse across parent batches. An operator-level test pins the materialized path independently of planner ordering. The grouped-UNDEF and sliced-subquery API regressions were observed failing on the parent implementation.

Validation: 2,912 passing query-engine and API tests across SPARQL, JSON-LD, history, reasoning, policy, and Cypher. Query library/test Clippy and the SPARQL API test target pass with `-D warnings`; formatting and whitespace checks pass. Includes a one-line numeric-literal formatting cleanup in the inherited TI3 fixture exposed by the broader test-target Clippy check.
